### PR TITLE
fixing issue 1294 - Aliases are not uniquified for some queries with SelectMany - may produce invalid sql

### DIFF
--- a/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/RelationalEntityQueryableExpressionTreeVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/RelationalEntityQueryableExpressionTreeVisitor.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Data.Common;
-using System.Linq;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Query;
@@ -80,15 +79,14 @@ namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
 
             var selectExpression = new SelectExpression();
             var tableName = QueryModelVisitor.QueryCompilationContext.GetTableName(entityType);
+            var tableAlias = QueryModelVisitor.QueryCompilationContext.CreateUniqueAlias(tableName);
 
             selectExpression
                 .AddTable(
                     new TableExpression(
                         tableName,
                         QueryModelVisitor.QueryCompilationContext.GetSchema(entityType),
-                        _querySource.ItemName.StartsWith("<generated>_")
-                            ? tableName.First().ToString().ToLower()
-                            : _querySource.ItemName,
+                        tableAlias,
                         _querySource));
 
             QueryModelVisitor.AddQuery(_querySource, selectExpression);

--- a/src/EntityFramework.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/EntityFramework.Relational/Query/Expressions/SelectExpression.cs
@@ -4,10 +4,10 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using JetBrains.Annotations;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Relational.Query.Sql;
 using Microsoft.Data.Entity.Utilities;
+using JetBrains.Annotations;
 using Remotion.Linq.Clauses;
 using Remotion.Linq.Parsing;
 

--- a/src/EntityFramework.Relational/Query/RelationalQueryCompilationContext.cs
+++ b/src/EntityFramework.Relational/Query/RelationalQueryCompilationContext.cs
@@ -3,15 +3,14 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using JetBrains.Annotations;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Query;
 using Microsoft.Data.Entity.Relational.Query.Expressions;
 using Microsoft.Data.Entity.Relational.Query.Methods;
 using Microsoft.Data.Entity.Relational.Query.Sql;
-using Microsoft.Data.Entity.Relational.Utilities;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
+using JetBrains.Annotations;
 using Remotion.Linq.Clauses;
 
 namespace Microsoft.Data.Entity.Relational.Query
@@ -23,6 +22,8 @@ namespace Microsoft.Data.Entity.Relational.Query
 
         private readonly List<RelationalQueryModelVisitor> _relationalQueryModelVisitors
             = new List<RelationalQueryModelVisitor>();
+
+        private Dictionary<char, int> _queryAliasesDictionary = new Dictionary<char, int>(); 
 
         public RelationalQueryCompilationContext(
             [NotNull] IModel model,
@@ -104,6 +105,26 @@ namespace Microsoft.Data.Entity.Relational.Query
             Check.NotNull(property, "property");
 
             return property.Relational().Column;
+        }
+
+        public virtual string CreateUniqueAlias([NotNull]string tableName)
+        {
+            Check.NotEmpty(tableName, "tableName");
+
+            var alias = tableName.ToLower().First();
+            int ordinal;
+            if (_queryAliasesDictionary.TryGetValue(alias, out ordinal))
+            {
+                _queryAliasesDictionary[alias]++;
+
+                return alias.ToString() + ordinal;
+            }
+            else
+            {
+                _queryAliasesDictionary[alias] = 0;
+
+                return alias.ToString();
+            }
         }
     }
 }

--- a/src/EntityFramework.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EntityFramework.Relational/Query/RelationalQueryModelVisitor.cs
@@ -112,9 +112,7 @@ namespace Microsoft.Data.Entity.Relational.Query
             var targetTableExpression = selectExpression.FindTableForQuerySource(querySource);
             var targetEntityType = navigation.GetTargetType();
             var targetTableName = QueryCompilationContext.GetTableName(targetEntityType);
-
-            var targetTableAlias
-               = CreateUniqueAlias(selectExpression, targetTableName.First().ToString().ToLower());
+            var targetTableAlias = QueryCompilationContext.CreateUniqueAlias(targetTableName);
 
             var joinedTableExpression
                 = new TableExpression(
@@ -198,11 +196,7 @@ namespace Microsoft.Data.Entity.Relational.Query
 
             var targetEntityType = navigation.GetTargetType();
             var targetTableName = QueryCompilationContext.GetTableName(targetEntityType);
-
-            var targetSelectExpression = new SelectExpression();
-
-            var targetTableAlias
-                = CreateUniqueAlias(selectExpression, targetTableName.First().ToString().ToLower());
+            var targetTableAlias = QueryCompilationContext.CreateUniqueAlias(targetTableName);
 
             var targetTableExpression
                 = new TableExpression(
@@ -211,6 +205,7 @@ namespace Microsoft.Data.Entity.Relational.Query
                     targetTableAlias,
                     querySource);
 
+            var targetSelectExpression = new SelectExpression();
             targetSelectExpression.AddTable(targetTableExpression);
 
             foreach (var property in targetEntityType.Properties)
@@ -280,20 +275,6 @@ namespace Microsoft.Data.Entity.Relational.Query
             QueryContext queryContext, DbDataReader dataReader, IEntityType entityType)
         {
             return ((RelationalQueryContext)queryContext).ValueReaderFactory.Create(dataReader);
-        }
-
-        private static string CreateUniqueAlias(SelectExpression selectExpression, string preferredAlias)
-        {
-            var alias = preferredAlias;
-            var counter = 0;
-
-            while (selectExpression.Projection
-                .Any(c => string.Equals(c.TableAlias, alias, StringComparison.OrdinalIgnoreCase)))
-            {
-                alias = preferredAlias + counter++;
-            }
-
-            return alias;
         }
 
         private Expression BuildJoinEqualityExpression(

--- a/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
@@ -1905,6 +1905,20 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c.ContactName, o });
         }
 
+        [Fact]
+        public virtual void Select_many_cross_join_same_collection()
+        {
+            AssertQuery<Customer, Customer>((cs1, cs2) =>
+                cs1.SelectMany(c => cs2));
+        }
+
+        [Fact]
+        public virtual void Join_same_collection_multiple()
+        {
+            AssertQuery<Customer, Customer, Customer>((cs1, cs2, cs3) =>
+                cs1.Join(cs2, o => o.CustomerID, i => i.CustomerID, (c1, c2) => new { c1, c2 }).Join(cs3, o => o.c1.CustomerID, i => i.CustomerID, (c12, c3) => c3 ));
+        }
+
         protected NorthwindContext CreateContext()
         {
             return Fixture.CreateContext();

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerIncludeTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerIncludeTest.cs
@@ -237,14 +237,14 @@ INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 WHERE [c].[CustomerID] = @p0
 ORDER BY [c].[CustomerID]
 
-SELECT [o].[CustomerID], [o].[OrderDate], [o].[OrderID]
-FROM [Orders] AS [o]
+SELECT [o0].[CustomerID], [o0].[OrderDate], [o0].[OrderID]
+FROM [Orders] AS [o0]
 INNER JOIN (
     SELECT DISTINCT [c].[CustomerID]
     FROM [Customers] AS [c]
     INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
     WHERE [c].[CustomerID] = @p0
-) AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+) AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
 ORDER BY [c].[CustomerID]",
                 Sql);
         }
@@ -254,21 +254,21 @@ ORDER BY [c].[CustomerID]",
             base.Include_collection_on_additional_from_clause_with_filter();
 
             Assert.Equal(
-                @"SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c1]
-CROSS JOIN [Customers] AS [c]
-WHERE [c].[CustomerID] = @p0
-ORDER BY [c].[CustomerID]
+                @"SELECT [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[CustomerID], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+FROM [Customers] AS [c]
+CROSS JOIN [Customers] AS [c0]
+WHERE [c0].[CustomerID] = @p0
+ORDER BY [c0].[CustomerID]
 
 SELECT [o].[CustomerID], [o].[OrderDate], [o].[OrderID]
 FROM [Orders] AS [o]
 INNER JOIN (
-    SELECT DISTINCT [c].[CustomerID]
-    FROM [Customers] AS [c1]
-    CROSS JOIN [Customers] AS [c]
-    WHERE [c].[CustomerID] = @p0
-) AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-ORDER BY [c].[CustomerID]",
+    SELECT DISTINCT [c0].[CustomerID]
+    FROM [Customers] AS [c]
+    CROSS JOIN [Customers] AS [c0]
+    WHERE [c0].[CustomerID] = @p0
+) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
+ORDER BY [c0].[CustomerID]",
                 Sql);
         }
 
@@ -281,33 +281,33 @@ ORDER BY [c].[CustomerID]",
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 
-SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]
-ORDER BY [c].[CustomerID]
+SELECT [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[CustomerID], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+FROM [Customers] AS [c0]
+ORDER BY [c0].[CustomerID]
 
 SELECT [o].[CustomerID], [o].[OrderDate], [o].[OrderID]
 FROM [Orders] AS [o]
 INNER JOIN (
-    SELECT DISTINCT [c].[CustomerID]
-    FROM [Customers] AS [c]
-) AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-ORDER BY [c].[CustomerID]
+    SELECT DISTINCT [c0].[CustomerID]
+    FROM [Customers] AS [c0]
+) AS [c0] ON [o].[CustomerID] = [c0].[CustomerID]
+ORDER BY [c0].[CustomerID]
 
-SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]
-ORDER BY [c].[CustomerID]
+SELECT [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[CustomerID], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+FROM [Customers] AS [c0]
+ORDER BY [c0].[CustomerID]
 
-SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]
-ORDER BY [c].[CustomerID]
+SELECT [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[CustomerID], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+FROM [Customers] AS [c0]
+ORDER BY [c0].[CustomerID]
 
-SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]
-ORDER BY [c].[CustomerID]
+SELECT [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[CustomerID], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+FROM [Customers] AS [c0]
+ORDER BY [c0].[CustomerID]
 
-SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]
-ORDER BY [c].[CustomerID]",
+SELECT [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[CustomerID], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+FROM [Customers] AS [c0]
+ORDER BY [c0].[CustomerID]",
                 Sql);
         }
 
@@ -320,9 +320,9 @@ ORDER BY [c].[CustomerID]",
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 
-SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]
-ORDER BY [c].[CustomerID] OFFSET @p0 ROWS FETCH NEXT @p0 ROWS ONLY
+SELECT [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[CustomerID], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+FROM [Customers] AS [c0]
+ORDER BY [c0].[CustomerID] OFFSET @p0 ROWS FETCH NEXT @p0 ROWS ONLY
 
 SELECT [o].[CustomerID], [o].[OrderDate], [o].[OrderID]
 FROM [Orders] AS [o]
@@ -332,21 +332,21 @@ INNER JOIN (
 ) AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 ORDER BY [c].[CustomerID]
 
-SELECT [o].[CustomerID], [o].[OrderDate], [o].[OrderID]
-FROM [Orders] AS [o]
+SELECT [o0].[CustomerID], [o0].[OrderDate], [o0].[OrderID]
+FROM [Orders] AS [o0]
 INNER JOIN (
     SELECT DISTINCT [t0].*
     FROM (
-        SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-        FROM [Customers] AS [c]
-        ORDER BY [c].[CustomerID] OFFSET @p0 ROWS FETCH NEXT @p0 ROWS ONLY
+        SELECT [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[CustomerID], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+        FROM [Customers] AS [c0]
+        ORDER BY [c0].[CustomerID] OFFSET @p0 ROWS FETCH NEXT @p0 ROWS ONLY
     ) AS [t0]
-) AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-ORDER BY [c].[CustomerID]
+) AS [c0] ON [o0].[CustomerID] = [c0].[CustomerID]
+ORDER BY [c0].[CustomerID]
 
-SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]
-ORDER BY [c].[CustomerID] OFFSET @p0 ROWS FETCH NEXT @p0 ROWS ONLY",
+SELECT [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[CustomerID], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+FROM [Customers] AS [c0]
+ORDER BY [c0].[CustomerID] OFFSET @p0 ROWS FETCH NEXT @p0 ROWS ONLY",
                 Sql);
         }
 
@@ -359,9 +359,9 @@ ORDER BY [c].[CustomerID] OFFSET @p0 ROWS FETCH NEXT @p0 ROWS ONLY",
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 
-SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]
-ORDER BY [c].[CustomerID] OFFSET @p0 ROWS FETCH NEXT @p0 ROWS ONLY
+SELECT [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[CustomerID], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+FROM [Customers] AS [c0]
+ORDER BY [c0].[CustomerID] OFFSET @p0 ROWS FETCH NEXT @p0 ROWS ONLY
 
 SELECT [o].[CustomerID], [o].[OrderDate], [o].[OrderID]
 FROM [Orders] AS [o]
@@ -371,17 +371,17 @@ INNER JOIN (
 ) AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 ORDER BY [c].[CustomerID]
 
-SELECT [o].[CustomerID], [o].[OrderDate], [o].[OrderID]
-FROM [Orders] AS [o]
+SELECT [o0].[CustomerID], [o0].[OrderDate], [o0].[OrderID]
+FROM [Orders] AS [o0]
 INNER JOIN (
     SELECT DISTINCT [t0].*
     FROM (
-        SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-        FROM [Customers] AS [c]
-        ORDER BY [c].[CustomerID] OFFSET @p0 ROWS FETCH NEXT @p0 ROWS ONLY
+        SELECT [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[CustomerID], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+        FROM [Customers] AS [c0]
+        ORDER BY [c0].[CustomerID] OFFSET @p0 ROWS FETCH NEXT @p0 ROWS ONLY
     ) AS [t0]
-) AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-ORDER BY [c].[CustomerID]",
+) AS [c0] ON [o0].[CustomerID] = [c0].[CustomerID]
+ORDER BY [c0].[CustomerID]",
                 Sql);
         }
 
@@ -396,14 +396,14 @@ INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 WHERE [c].[CustomerID] = @p0
 ORDER BY [c].[City], [c].[CustomerID]
 
-SELECT [o].[CustomerID], [o].[OrderDate], [o].[OrderID]
-FROM [Orders] AS [o]
+SELECT [o0].[CustomerID], [o0].[OrderDate], [o0].[OrderID]
+FROM [Orders] AS [o0]
 INNER JOIN (
     SELECT DISTINCT [c].[City], [c].[CustomerID]
     FROM [Customers] AS [c]
     INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
     WHERE [c].[CustomerID] = @p0
-) AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+) AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
 ORDER BY [c].[City], [c].[CustomerID]",
                 Sql);
         }
@@ -418,19 +418,19 @@ FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 
 SELECT 1
-FROM [Customers] AS [c]
+FROM [Customers] AS [c0]
 
 SELECT 1
-FROM [Customers] AS [c]
+FROM [Customers] AS [c0]
 
 SELECT 1
-FROM [Customers] AS [c]
+FROM [Customers] AS [c0]
 
 SELECT 1
-FROM [Customers] AS [c]
+FROM [Customers] AS [c0]
 
 SELECT 1
-FROM [Customers] AS [c]",
+FROM [Customers] AS [c0]",
                 Sql);
         }
 
@@ -443,9 +443,9 @@ FROM [Customers] AS [c]",
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 
-SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]
-ORDER BY [c].[CustomerID] OFFSET @p0 ROWS FETCH NEXT @p0 ROWS ONLY
+SELECT [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[CustomerID], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+FROM [Customers] AS [c0]
+ORDER BY [c0].[CustomerID] OFFSET @p0 ROWS FETCH NEXT @p0 ROWS ONLY
 
 SELECT [o].[CustomerID], [o].[OrderDate], [o].[OrderID]
 FROM [Orders] AS [o]
@@ -501,15 +501,15 @@ FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 ORDER BY [o].[CustomerID]
 
-SELECT [o].[CustomerID], [o].[OrderDate], [o].[OrderID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Orders] AS [o]
-LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-ORDER BY [o].[CustomerID] OFFSET @p0 ROWS FETCH NEXT @p0 ROWS ONLY
+SELECT [o0].[CustomerID], [o0].[OrderDate], [o0].[OrderID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[CustomerID], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+FROM [Orders] AS [o0]
+LEFT JOIN [Customers] AS [c0] ON [o0].[CustomerID] = [c0].[CustomerID]
+ORDER BY [o0].[CustomerID] OFFSET @p0 ROWS FETCH NEXT @p0 ROWS ONLY
 
-SELECT [o].[CustomerID], [o].[OrderDate], [o].[OrderID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Orders] AS [o]
-LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-ORDER BY [o].[CustomerID] OFFSET @p0 ROWS FETCH NEXT @p0 ROWS ONLY",
+SELECT [o0].[CustomerID], [o0].[OrderDate], [o0].[OrderID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[CustomerID], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+FROM [Orders] AS [o0]
+LEFT JOIN [Customers] AS [c0] ON [o0].[CustomerID] = [c0].[CustomerID]
+ORDER BY [o0].[CustomerID] OFFSET @p0 ROWS FETCH NEXT @p0 ROWS ONLY",
                 Sql);
         }
 
@@ -523,13 +523,13 @@ FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 ORDER BY [o].[OrderID]
 
-SELECT [o].[CustomerID], [o].[OrderDate], [o].[OrderID]
-FROM [Orders] AS [o]
-ORDER BY [o].[OrderID] OFFSET @p0 ROWS FETCH NEXT @p0 ROWS ONLY
+SELECT [o0].[CustomerID], [o0].[OrderDate], [o0].[OrderID]
+FROM [Orders] AS [o0]
+ORDER BY [o0].[OrderID] OFFSET @p0 ROWS FETCH NEXT @p0 ROWS ONLY
 
-SELECT [o].[CustomerID], [o].[OrderDate], [o].[OrderID]
-FROM [Orders] AS [o]
-ORDER BY [o].[OrderID] OFFSET @p0 ROWS FETCH NEXT @p0 ROWS ONLY",
+SELECT [o0].[CustomerID], [o0].[OrderDate], [o0].[OrderID]
+FROM [Orders] AS [o0]
+ORDER BY [o0].[OrderID] OFFSET @p0 ROWS FETCH NEXT @p0 ROWS ONLY",
                 Sql);
         }
 
@@ -542,15 +542,15 @@ ORDER BY [o].[OrderID] OFFSET @p0 ROWS FETCH NEXT @p0 ROWS ONLY",
 FROM [Orders] AS [o]
 ORDER BY [o].[OrderID]
 
-SELECT [o].[CustomerID], [o].[OrderDate], [o].[OrderID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Orders] AS [o]
-LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-ORDER BY [o].[OrderID] OFFSET @p0 ROWS FETCH NEXT @p0 ROWS ONLY
+SELECT [o0].[CustomerID], [o0].[OrderDate], [o0].[OrderID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Orders] AS [o0]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+ORDER BY [o0].[OrderID] OFFSET @p0 ROWS FETCH NEXT @p0 ROWS ONLY
 
-SELECT [o].[CustomerID], [o].[OrderDate], [o].[OrderID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Orders] AS [o]
-LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-ORDER BY [o].[OrderID] OFFSET @p0 ROWS FETCH NEXT @p0 ROWS ONLY",
+SELECT [o0].[CustomerID], [o0].[OrderDate], [o0].[OrderID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Orders] AS [o0]
+LEFT JOIN [Customers] AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
+ORDER BY [o0].[OrderID] OFFSET @p0 ROWS FETCH NEXT @p0 ROWS ONLY",
                 Sql);
         }
 

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerQueryTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerQueryTest.cs
@@ -1323,6 +1323,29 @@ FROM [Orders] AS [o]
                 Sql);
         }
 
+        public override void Select_many_cross_join_same_collection()
+        {
+            base.Select_many_cross_join_same_collection();
+
+            Assert.Equal(
+                @"SELECT [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[CustomerID], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+FROM [Customers] AS [c]
+CROSS JOIN [Customers] AS [c0]",
+                Sql);
+        }
+
+        public override void Join_same_collection_multiple()
+        {
+            base.Join_same_collection_multiple();
+
+            Assert.Equal(
+                @"SELECT [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[CustomerID], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
+FROM [Customers] AS [c]
+INNER JOIN [Customers] AS [c0] ON [c].[CustomerID] = [c0].[CustomerID]
+INNER JOIN [Customers] AS [c1] ON [c].[CustomerID] = [c1].[CustomerID]",
+                Sql);
+        }
+
         public SqlServerQueryTest(SqlServerNorthwindQueryFixture fixture)
             : base(fixture)
         {

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerQueryTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerQueryTest.cs
@@ -223,8 +223,8 @@ FROM [Customers] AS [c]",
             base.Queryable_nested_simple();
 
             Assert.Equal(
-                @"SELECT [c3].[Address], [c3].[City], [c3].[CompanyName], [c3].[ContactName], [c3].[ContactTitle], [c3].[Country], [c3].[CustomerID], [c3].[Fax], [c3].[Phone], [c3].[PostalCode], [c3].[Region]
-FROM [Customers] AS [c3]",
+                @"SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]",
                 Sql);
         }
 
@@ -653,10 +653,10 @@ WHERE [c].[City] = @p0",
         {
             base.SelectMany_mixed();
 
-            Assert.Equal(3873, Sql.Length);
+            Assert.Equal(3866, Sql.Length);
             Assert.StartsWith(
-                @"SELECT [e1].[City], [e1].[Country], [e1].[EmployeeID], [e1].[FirstName], [e1].[ReportsTo], [e1].[Title]
-FROM [Employees] AS [e1]
+                @"SELECT [e].[City], [e].[Country], [e].[EmployeeID], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Employees] AS [e]
 
 SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
@@ -682,10 +682,10 @@ CROSS JOIN [Customers] AS [c]",
             base.SelectMany_simple2();
 
             Assert.Equal(
-                @"SELECT [e1].[City], [e1].[Country], [e1].[EmployeeID], [e1].[FirstName], [e1].[ReportsTo], [e1].[Title], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [e2].[FirstName]
-FROM [Employees] AS [e1]
+                @"SELECT [e].[City], [e].[Country], [e].[EmployeeID], [e].[FirstName], [e].[ReportsTo], [e].[Title], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [e0].[FirstName]
+FROM [Employees] AS [e]
 CROSS JOIN [Customers] AS [c]
-CROSS JOIN [Employees] AS [e2]",
+CROSS JOIN [Employees] AS [e0]",
                 Sql);
         }
 
@@ -694,10 +694,10 @@ CROSS JOIN [Employees] AS [e2]",
             base.SelectMany_entity_deep();
 
             Assert.Equal(
-                @"SELECT [e1].[City], [e1].[Country], [e1].[EmployeeID], [e1].[FirstName], [e1].[ReportsTo], [e1].[Title], [e2].[City], [e2].[Country], [e2].[EmployeeID], [e2].[FirstName], [e2].[ReportsTo], [e2].[Title], [e3].[City], [e3].[Country], [e3].[EmployeeID], [e3].[FirstName], [e3].[ReportsTo], [e3].[Title]
-FROM [Employees] AS [e1]
-CROSS JOIN [Employees] AS [e2]
-CROSS JOIN [Employees] AS [e3]",
+                @"SELECT [e].[City], [e].[Country], [e].[EmployeeID], [e].[FirstName], [e].[ReportsTo], [e].[Title], [e0].[City], [e0].[Country], [e0].[EmployeeID], [e0].[FirstName], [e0].[ReportsTo], [e0].[Title], [e1].[City], [e1].[Country], [e1].[EmployeeID], [e1].[FirstName], [e1].[ReportsTo], [e1].[Title]
+FROM [Employees] AS [e]
+CROSS JOIN [Employees] AS [e0]
+CROSS JOIN [Employees] AS [e1]",
                 Sql);
         }
 
@@ -706,9 +706,9 @@ CROSS JOIN [Employees] AS [e3]",
             base.SelectMany_projection1();
 
             Assert.Equal(
-                @"SELECT [e1].[City], [e2].[Country]
-FROM [Employees] AS [e1]
-CROSS JOIN [Employees] AS [e2]",
+                @"SELECT [e].[City], [e0].[Country]
+FROM [Employees] AS [e]
+CROSS JOIN [Employees] AS [e0]",
                 Sql);
         }
 
@@ -717,10 +717,10 @@ CROSS JOIN [Employees] AS [e2]",
             base.SelectMany_projection2();
 
             Assert.Equal(
-                @"SELECT [e1].[City], [e2].[Country], [e3].[FirstName]
-FROM [Employees] AS [e1]
-CROSS JOIN [Employees] AS [e2]
-CROSS JOIN [Employees] AS [e3]",
+                @"SELECT [e].[City], [e0].[Country], [e1].[FirstName]
+FROM [Employees] AS [e]
+CROSS JOIN [Employees] AS [e0]
+CROSS JOIN [Employees] AS [e1]",
                 Sql);
         }
 
@@ -832,8 +832,8 @@ WHERE [c].[CustomerID] = @p0", Sql);
     EXISTS (
         SELECT 1
         FROM [Customers] AS [c]
-        INNER JOIN [Orders] AS [or] ON [c].[CustomerID] = [or].[CustomerID]
-        INNER JOIN [Order Details] AS [od] ON [or].[OrderID] = [od].[OrderID]
+        INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+        INNER JOIN [Order Details] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
         WHERE [c].[City] = @p0
     )
 ) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END", Sql);
@@ -1018,24 +1018,24 @@ ORDER BY [c].[Country], [c].[CustomerID]",
         {
             base.Where_subquery_recursive_trivial();
 
-            Assert.Equal(2632, Sql.Length);
+            Assert.Equal(2624, Sql.Length);
             Assert.StartsWith(
-                @"SELECT [e1].[City], [e1].[Country], [e1].[EmployeeID], [e1].[FirstName], [e1].[ReportsTo], [e1].[Title]
-FROM [Employees] AS [e1]
-ORDER BY [e1].[EmployeeID]
+                @"SELECT [e].[City], [e].[Country], [e].[EmployeeID], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Employees] AS [e]
+ORDER BY [e].[EmployeeID]
 
-SELECT [e2].[City], [e2].[Country], [e2].[EmployeeID], [e2].[FirstName], [e2].[ReportsTo], [e2].[Title]
-FROM [Employees] AS [e2]
+SELECT [e0].[City], [e0].[Country], [e0].[EmployeeID], [e0].[FirstName], [e0].[ReportsTo], [e0].[Title]
+FROM [Employees] AS [e0]
 
 SELECT CASE WHEN (
     EXISTS (
         SELECT 1
-        FROM [Employees] AS [e3]
+        FROM [Employees] AS [e1]
     )
 ) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END
 
-SELECT [e2].[City], [e2].[Country], [e2].[EmployeeID], [e2].[FirstName], [e2].[ReportsTo], [e2].[Title]
-FROM [Employees] AS [e2]",
+SELECT [e0].[City], [e0].[Country], [e0].[EmployeeID], [e0].[FirstName], [e0].[ReportsTo], [e0].[Title]
+FROM [Employees] AS [e0]",
                 Sql);
         }
 


### PR DESCRIPTION
Before we were only generating unique aliases for Include. However name clashes may also appear in case of join/cross join queries. Fix is to store a list of all table aliases used so far in the RelationalQueryCompilationContext and generate them there so we keep track of all the places aliases get generated.