### PR TITLE
Fix bugs in ChangeTracker perf tests

### DIFF
--- a/test/EntityFramework.Microbenchmarks.EF6/ChangeTracker/DbSetOperationTests.cs
+++ b/test/EntityFramework.Microbenchmarks.EF6/ChangeTracker/DbSetOperationTests.cs
@@ -13,7 +13,7 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
 {
     public class DbSetOperationTests
     {
-        private static string _connectionString = String.Format(@"Server={0};Database=Perf_ChangeTracker_DbSetOperation;Integrated Security=True;MultipleActiveResultSets=true;", TestConfig.Instance.DataSource);
+        private static string _connectionString = String.Format(@"Server={0};Database=Perf_ChangeTracker_DbSetOperation_EF6;Integrated Security=True;MultipleActiveResultSets=true;", TestConfig.Instance.DataSource);
 
         [Fact]
         public void Add()

--- a/test/EntityFramework.Microbenchmarks.EF6/ChangeTracker/FixupTests.cs
+++ b/test/EntityFramework.Microbenchmarks.EF6/ChangeTracker/FixupTests.cs
@@ -58,6 +58,7 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
                 TestName = "ChangeTracker_Fixup_AttachChildren_EF6",
                 IterationCount = 10,
                 WarmupCount = 5,
+                Setup = EnsureDatabaseSetup,
                 Run = harness =>
                 {
                     List<Order> orders;
@@ -94,6 +95,7 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
                 TestName = "ChangeTracker_Fixup_AttachParents_EF6",
                 IterationCount = 10,
                 WarmupCount = 5,
+                Setup = EnsureDatabaseSetup,
                 Run = harness =>
                 {
                     List<Customer> customers;

--- a/test/EntityFramework.Microbenchmarks/ChangeTracker/FixupTests.cs
+++ b/test/EntityFramework.Microbenchmarks/ChangeTracker/FixupTests.cs
@@ -88,6 +88,7 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
                 TestName = "ChangeTracker_Fixup_AttachChildren",
                 IterationCount = 10,
                 WarmupCount = 5,
+                Setup = EnsureDatabaseSetup,
                 Run = harness =>
                 {
                     List<Order> orders;
@@ -124,6 +125,7 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
                 TestName = "ChangeTracker_Fixup_AttachParents",
                 IterationCount = 10,
                 WarmupCount = 5,
+                Setup = EnsureDatabaseSetup,
                 Run = harness =>
                 {
                     List<Customer> customers;


### PR DESCRIPTION
Some tests that use a database didn't have Setup specified to create the database if it wasn't present
EF6 tests were missing the EF6 postfix on the database name