### PR TITLE
fixing issue 1294 - Aliases are not uniquified for some queries with SelectMany - may produce invalid sql

### DIFF
--- a/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/RelationalEntityQueryableExpressionTreeVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/RelationalEntityQueryableExpressionTreeVisitor.cs
@@ -81,14 +81,18 @@ namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
             var selectExpression = new SelectExpression();
             var tableName = QueryModelVisitor.QueryCompilationContext.GetTableName(entityType);
 
+            var preferredAlias = _querySource.ItemName.StartsWith("<generated>_")
+                            ? tableName.First().ToString().ToLower()
+                            : _querySource.ItemName;
+
+            var alias = QueryModelVisitor.CreateUniqueAlias(preferredAlias);
+
             selectExpression
                 .AddTable(
                     new TableExpression(
                         tableName,
                         QueryModelVisitor.QueryCompilationContext.GetSchema(entityType),
-                        _querySource.ItemName.StartsWith("<generated>_")
-                            ? tableName.First().ToString().ToLower()
-                            : _querySource.ItemName,
+                        alias,
                         _querySource));
 
             QueryModelVisitor.AddQuery(_querySource, selectExpression);

--- a/src/EntityFramework.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EntityFramework.Relational/Query/RelationalQueryModelVisitor.cs
@@ -112,9 +112,7 @@ namespace Microsoft.Data.Entity.Relational.Query
             var targetTableExpression = selectExpression.FindTableForQuerySource(querySource);
             var targetEntityType = navigation.GetTargetType();
             var targetTableName = QueryCompilationContext.GetTableName(targetEntityType);
-
-            var targetTableAlias
-               = CreateUniqueAlias(selectExpression, targetTableName.First().ToString().ToLower());
+            var targetTableAlias = CreateUniqueAlias(targetTableName.First().ToString().ToLower());
 
             var joinedTableExpression
                 = new TableExpression(
@@ -198,11 +196,7 @@ namespace Microsoft.Data.Entity.Relational.Query
 
             var targetEntityType = navigation.GetTargetType();
             var targetTableName = QueryCompilationContext.GetTableName(targetEntityType);
-
-            var targetSelectExpression = new SelectExpression();
-
-            var targetTableAlias
-                = CreateUniqueAlias(selectExpression, targetTableName.First().ToString().ToLower());
+            var targetTableAlias = CreateUniqueAlias(targetTableName.First().ToString().ToLower());
 
             var targetTableExpression
                 = new TableExpression(
@@ -211,6 +205,7 @@ namespace Microsoft.Data.Entity.Relational.Query
                     targetTableAlias,
                     querySource);
 
+            var targetSelectExpression = new SelectExpression();
             targetSelectExpression.AddTable(targetTableExpression);
 
             foreach (var property in targetEntityType.Properties)
@@ -282,13 +277,15 @@ namespace Microsoft.Data.Entity.Relational.Query
             return ((RelationalQueryContext)queryContext).ValueReaderFactory.Create(dataReader);
         }
 
-        private static string CreateUniqueAlias(SelectExpression selectExpression, string preferredAlias)
+        public virtual string CreateUniqueAlias([NotNull]string preferredAlias)
         {
+            Check.NotNull(preferredAlias, "preferredAlias");
+
             var alias = preferredAlias;
             var counter = 0;
 
-            while (selectExpression.Projection
-                .Any(c => string.Equals(c.TableAlias, alias, StringComparison.OrdinalIgnoreCase)))
+            while (_queriesBySource.Values.SelectMany(c => c.Tables)
+                .Any(c => string.Equals(c.Alias, alias, StringComparison.OrdinalIgnoreCase)))
             {
                 alias = preferredAlias + counter++;
             }

--- a/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
@@ -1906,6 +1906,20 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
+        public virtual void Select_many_cross_join_same_collection()
+        {
+            AssertQuery<Customer, Customer>((cs1, cs2) =>
+                cs1.SelectMany(c => cs2));
+        }
+
+        [Fact]
+        public virtual void Join_same_collection_multiple()
+        {
+            AssertQuery<Customer, Customer, Customer>((cs1, cs2, cs3) =>
+                cs1.Join(cs2, o => o.CustomerID, i => i.CustomerID, (c1, c2) => new { c1, c2 }).Join(cs3, o => o.c1.CustomerID, i => i.CustomerID, (c12, c3) => c3));
+        }
+
+        [Fact]
         public void Contains_with_subquery()
         {
             AssertQuery<Customer, Order>((cs, os) =>

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerIncludeTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerIncludeTest.cs
@@ -237,14 +237,14 @@ INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 WHERE [c].[CustomerID] = @p0
 ORDER BY [c].[CustomerID]
 
-SELECT [o].[CustomerID], [o].[OrderDate], [o].[OrderID]
-FROM [Orders] AS [o]
+SELECT [o0].[CustomerID], [o0].[OrderDate], [o0].[OrderID]
+FROM [Orders] AS [o0]
 INNER JOIN (
     SELECT DISTINCT [c].[CustomerID]
     FROM [Customers] AS [c]
     INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
     WHERE [c].[CustomerID] = @p0
-) AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+) AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
 ORDER BY [c].[CustomerID]",
                 Sql);
         }
@@ -396,14 +396,14 @@ INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 WHERE [c].[CustomerID] = @p0
 ORDER BY [c].[City], [c].[CustomerID]
 
-SELECT [o].[CustomerID], [o].[OrderDate], [o].[OrderID]
-FROM [Orders] AS [o]
+SELECT [o0].[CustomerID], [o0].[OrderDate], [o0].[OrderID]
+FROM [Orders] AS [o0]
 INNER JOIN (
     SELECT DISTINCT [c].[City], [c].[CustomerID]
     FROM [Customers] AS [c]
     INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
     WHERE [c].[CustomerID] = @p0
-) AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+) AS [c] ON [o0].[CustomerID] = [c].[CustomerID]
 ORDER BY [c].[City], [c].[CustomerID]",
                 Sql);
         }

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerQueryTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerQueryTest.cs
@@ -1323,6 +1323,29 @@ FROM [Orders] AS [o]
                 Sql);
         }
 
+        public override void Select_many_cross_join_same_collection()
+        {
+            base.Select_many_cross_join_same_collection();
+
+            Assert.Equal(
+                @"SELECT [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[CustomerID], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+FROM [Customers] AS [c]
+CROSS JOIN [Customers] AS [c0]",
+                Sql);
+        }
+
+        public override void Join_same_collection_multiple()
+        {
+            base.Join_same_collection_multiple();
+
+            Assert.Equal(
+                @"SELECT [c3].[Address], [c3].[City], [c3].[CompanyName], [c3].[ContactName], [c3].[ContactTitle], [c3].[Country], [c3].[CustomerID], [c3].[Fax], [c3].[Phone], [c3].[PostalCode], [c3].[Region]
+FROM [Customers] AS [o]
+INNER JOIN [Customers] AS [c2] ON [o].[CustomerID] = [c2].[CustomerID]
+INNER JOIN [Customers] AS [c3] ON [o].[CustomerID] = [c3].[CustomerID]",
+                Sql);
+        }
+
         public SqlServerQueryTest(SqlServerNorthwindQueryFixture fixture)
             : base(fixture)
         {


### PR DESCRIPTION
Before we were only generating unique aliases for Include. However name clashes may also appear in case of join/cross join queries. Fix is to check the list of tracked query sources (and their table aliases) before introducing a new table alias to the query, uniquefying if necessary. This should preserve the aliases specified by user as long as they are unique already.