### PR TITLE
Databases are now only created if explicitly specified in the initial migration

### DIFF
--- a/src/EntityFramework.Commands/Migrations/CSharpMigrationCodeGenerator.cs
+++ b/src/EntityFramework.Commands/Migrations/CSharpMigrationCodeGenerator.cs
@@ -238,7 +238,7 @@ namespace Microsoft.Data.Entity.Commands.Migrations
             Check.NotNull(stringBuilder, "stringBuilder");
 
             stringBuilder
-                .Append("CreateDatabaseIfNotExists()");
+                .Append("CreateDatabase()");
         }
 
         public override void Generate(DropDatabaseOperation dropDatabaseOperation, IndentedStringBuilder stringBuilder)

--- a/src/EntityFramework.Commands/Migrations/CSharpMigrationCodeGenerator.cs
+++ b/src/EntityFramework.Commands/Migrations/CSharpMigrationCodeGenerator.cs
@@ -238,9 +238,7 @@ namespace Microsoft.Data.Entity.Commands.Migrations
             Check.NotNull(stringBuilder, "stringBuilder");
 
             stringBuilder
-                .Append("CreateDatabase(")
-                .Append(GenerateLiteral(createDatabaseOperation.DatabaseName))
-                .Append(")");
+                .Append("CreateDatabaseIfNotExists()");
         }
 
         public override void Generate(DropDatabaseOperation dropDatabaseOperation, IndentedStringBuilder stringBuilder)

--- a/src/EntityFramework.Commands/Migrations/MigrationScaffolder.cs
+++ b/src/EntityFramework.Commands/Migrations/MigrationScaffolder.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Data.Entity.Commands.Migrations
             }
             else
             {
-                upgradeOperations = ModelDiffer.CreateSchema(targetModel);
+                upgradeOperations = ModelDiffer.CreateSchema(targetModel, initialMigration: true);
                 downgradeOperations = ModelDiffer.DropSchema(targetModel);
             }
 

--- a/src/EntityFramework.Migrations/Builders/MigrationBuilder.cs
+++ b/src/EntityFramework.Migrations/Builders/MigrationBuilder.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Data.Entity.Migrations.Builders
         }
 
 
-        public virtual void CreateDatabaseIfNotExists()
+        public virtual void CreateDatabase()
         {
             AddOperation(new CreateDatabaseOperation());
         }

--- a/src/EntityFramework.Migrations/Builders/MigrationBuilder.cs
+++ b/src/EntityFramework.Migrations/Builders/MigrationBuilder.cs
@@ -29,11 +29,10 @@ namespace Microsoft.Data.Entity.Migrations.Builders
             _operations.Add(operation);
         }
 
-        public virtual void CreateDatabase([NotNull] string databaseName)
-        {
-            Check.NotEmpty(databaseName, "databaseName");
 
-            AddOperation(new CreateDatabaseOperation(databaseName));
+        public virtual void CreateDatabaseIfNotExists()
+        {
+            AddOperation(new CreateDatabaseOperation());
         }
 
         public virtual void DropDatabase([NotNull] string databaseName)

--- a/src/EntityFramework.Migrations/EntityFramework.Migrations.csproj
+++ b/src/EntityFramework.Migrations/EntityFramework.Migrations.csproj
@@ -119,8 +119,8 @@
     </Compile>
     <Compile Include="MigrationsOptionsExtension.cs" />
     <Compile Include="Utilities\AssemblyExtensions.cs" />
-    <Compile Include="..\Shared\Check.cs" >
-        <Link>Utilities\Check.cs</Link>
+    <Compile Include="..\Shared\Check.cs">
+      <Link>Utilities\Check.cs</Link>
     </Compile>
     <Compile Include="Utilities\EnumerableExtensions.cs" />
     <Compile Include="Utilities\MigrationExtensions.cs" />

--- a/src/EntityFramework.Migrations/Infrastructure/MigratorLoggerEventIds.cs
+++ b/src/EntityFramework.Migrations/Infrastructure/MigratorLoggerEventIds.cs
@@ -10,5 +10,6 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
         public static readonly int ApplyingMigration = 102;
         public static readonly int RevertingMigration = 103;
         public static readonly int UpToDate = 104;
+        public static readonly int CreatingDatabases = 105;
     }
 }

--- a/src/EntityFramework.Migrations/Infrastructure/MigratorLoggerExtensions.cs
+++ b/src/EntityFramework.Migrations/Infrastructure/MigratorLoggerExtensions.cs
@@ -55,5 +55,14 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
                 MigratorLoggerEventIds.UpToDate,
                 () => Strings.MigratorLoggerUpToDate);
         }
+
+        public static void CreatingDatabases([NotNull] this ILogger logger)
+        {
+            Check.NotNull(logger, "logger");
+
+            logger.WriteInformation(
+                MigratorLoggerEventIds.CreatingDatabases,
+                () => Strings.MigratorLoggerCreatingHistoryTable);
+        }
     }
 }

--- a/src/EntityFramework.Migrations/MigrationOperationCollection.cs
+++ b/src/EntityFramework.Migrations/MigrationOperationCollection.cs
@@ -89,7 +89,8 @@ namespace Microsoft.Data.Entity.Migrations
         public virtual IReadOnlyList<MigrationOperation> GetAll()
         {
             return
-                ((IEnumerable<MigrationOperation>)Get<DropSequenceOperation>())
+                ((IEnumerable<MigrationOperation>)Get<CreateDatabaseOperation>())
+                    .Concat(Get<DropSequenceOperation>())
                     .Concat(Get<MoveSequenceOperation>())
                     .Concat(Get<RenameSequenceOperation>())
                     .Concat(Get<AlterSequenceOperation>())

--- a/src/EntityFramework.Migrations/MigrationOperationSqlGenerator.cs
+++ b/src/EntityFramework.Migrations/MigrationOperationSqlGenerator.cs
@@ -10,8 +10,10 @@ using JetBrains.Annotations;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Migrations.Model;
 using Microsoft.Data.Entity.Migrations.Utilities;
+using Microsoft.Data.Entity.Query;
 using Microsoft.Data.Entity.Relational;
 using Microsoft.Data.Entity.Relational.Metadata;
+using Microsoft.Data.Entity.Relational.Query.Sql;
 using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Migrations
@@ -117,9 +119,7 @@ namespace Microsoft.Data.Entity.Migrations
             Check.NotNull(createDatabaseOperation, "createDatabaseOperation");
             Check.NotNull(batchBuilder, "batchBuilder");
 
-            batchBuilder
-                .Append("CREATE DATABASE ")
-                .Append(DelimitIdentifier(createDatabaseOperation.DatabaseName));
+            // noop
         }
 
         public virtual void Generate([NotNull] DropDatabaseOperation dropDatabaseOperation, [NotNull] SqlBatchBuilder batchBuilder)

--- a/src/EntityFramework.Migrations/Model/CreateDatabaseOperation.cs
+++ b/src/EntityFramework.Migrations/Model/CreateDatabaseOperation.cs
@@ -9,18 +9,8 @@ namespace Microsoft.Data.Entity.Migrations.Model
 {
     public class CreateDatabaseOperation : MigrationOperation
     {
-        private readonly string _databaseName;
-
-        public CreateDatabaseOperation([NotNull] string databaseName)
+        public CreateDatabaseOperation()
         {
-            Check.NotEmpty(databaseName, "databaseName");
-
-            _databaseName = databaseName;
-        }
-
-        public virtual string DatabaseName
-        {
-            get { return _databaseName; }
         }
 
         public override void Accept<TVisitor, TContext>(TVisitor visitor, TContext context)

--- a/src/EntityFramework.Migrations/ModelDiffer.cs
+++ b/src/EntityFramework.Migrations/ModelDiffer.cs
@@ -64,11 +64,16 @@ namespace Microsoft.Data.Entity.Migrations
             get { return _operationProcessor; }
         }
 
-        public virtual IReadOnlyList<MigrationOperation> CreateSchema([NotNull] IModel model)
+        public virtual IReadOnlyList<MigrationOperation> CreateSchema([NotNull] IModel model, bool initialMigration = false)
         {
             Check.NotNull(model, "model");
 
             _operations = new MigrationOperationCollection();
+
+            if (initialMigration)
+            {
+                _operations.Add(new CreateDatabaseOperation());
+            }
 
             _operations.AddRange(GetSequences(model)
                 .Select(s => OperationFactory.CreateSequenceOperation(s)));

--- a/src/EntityFramework.Migrations/Properties/Strings.Designer.cs
+++ b/src/EntityFramework.Migrations/Properties/Strings.Designer.cs
@@ -100,6 +100,12 @@ namespace Microsoft.Data.Entity.Migrations
             get { return GetString("MigratorLoggerUpToDate"); }
         }
 
+        public static string MigratorCreatingDatabases
+        {
+            //TODO add resource
+            get { return "CreatingDatabases";  }
+        }
+
         /// <summary>
         /// Migrations-specific methods can only be used when the context is using a migrations-enabled data store.
         /// </summary>

--- a/src/EntityFramework.SqlServer/SqlServerMigrationOperationSqlGenerator.cs
+++ b/src/EntityFramework.SqlServer/SqlServerMigrationOperationSqlGenerator.cs
@@ -30,25 +30,7 @@ namespace Microsoft.Data.Entity.SqlServer
         {
             get { return _generatedSchemas; }
         }
-
-        public override void Generate(CreateDatabaseOperation createDatabaseOperation, SqlBatchBuilder batchBuilder)
-        {
-            base.Generate(createDatabaseOperation, batchBuilder);
-
-            batchBuilder.EndBatch();
-
-            batchBuilder
-                .Append("IF SERVERPROPERTY('EngineEdition') <> 5 EXECUTE sp_executesql N")
-                .Append(
-                    GenerateLiteral(
-                        string.Concat(
-                            "ALTER DATABASE ",
-                            DelimitIdentifier(createDatabaseOperation.DatabaseName),
-                            " SET READ_COMMITTED_SNAPSHOT ON")));
-
-            batchBuilder.EndBatch();
-        }
-
+        
         public override void Generate(DropDatabaseOperation dropDatabaseOperation, SqlBatchBuilder batchBuilder)
         {
             batchBuilder

--- a/test/EntityFramework.Commands.Tests/Migrations/CSharpMigrationCodeGeneratorTest.cs
+++ b/test/EntityFramework.Commands.Tests/Migrations/CSharpMigrationCodeGeneratorTest.cs
@@ -20,10 +20,10 @@ namespace Microsoft.Data.Entity.Commands.Tests.Migrations
         [Fact]
         public void Generate_when_create_database_operation()
         {
-            var operation = new CreateDatabaseOperation("MyDatabase");
+            var operation = new CreateDatabaseOperation();
 
             Assert.Equal(
-                @"CreateDatabase(""MyDatabase"")",
+                @"CreateDatabaseIfNotExists()",
                 CSharpMigrationCodeGenerator.Generate(operation));
 
             GenerateAndValidateCode(operation);

--- a/test/EntityFramework.Commands.Tests/Migrations/CSharpMigrationCodeGeneratorTest.cs
+++ b/test/EntityFramework.Commands.Tests/Migrations/CSharpMigrationCodeGeneratorTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Data.Entity.Commands.Tests.Migrations
             var operation = new CreateDatabaseOperation();
 
             Assert.Equal(
-                @"CreateDatabaseIfNotExists()",
+                @"CreateDatabase()",
                 CSharpMigrationCodeGenerator.Generate(operation));
 
             GenerateAndValidateCode(operation);

--- a/test/EntityFramework.Commands.Tests/Migrations/MigrationScaffolderTest.cs
+++ b/test/EntityFramework.Commands.Tests/Migrations/MigrationScaffolderTest.cs
@@ -165,7 +165,7 @@ namespace MyNamespace.Migrations
     {
         public override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.CreateDatabaseIfNotExists();
+            migrationBuilder.CreateDatabase();
         }
         
         public override void Down(MigrationBuilder migrationBuilder)
@@ -262,7 +262,7 @@ namespace MyNamespace.Migrations
     {
         public override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.CreateDatabaseIfNotExists();
+            migrationBuilder.CreateDatabase();
             
             migrationBuilder.CreateTable(""dbo.MyTable"",
                 c => new
@@ -384,7 +384,7 @@ namespace MyNamespace.Migrations
     {
         public override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.CreateDatabaseIfNotExists();
+            migrationBuilder.CreateDatabase();
             
             migrationBuilder.CreateTable(""[Ho!use[]]]"",
                 c => new
@@ -602,7 +602,7 @@ namespace MyNamespace.Migrations
     {
         public override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.CreateDatabaseIfNotExists();
+            migrationBuilder.CreateDatabase();
             
             migrationBuilder.CreateTable(""EntityWithNamedKey"",
                 c => new

--- a/test/EntityFramework.Commands.Tests/Migrations/MigrationScaffolderTest.cs
+++ b/test/EntityFramework.Commands.Tests/Migrations/MigrationScaffolderTest.cs
@@ -165,6 +165,7 @@ namespace MyNamespace.Migrations
     {
         public override void Up(MigrationBuilder migrationBuilder)
         {
+            migrationBuilder.CreateDatabaseIfNotExists();
         }
         
         public override void Down(MigrationBuilder migrationBuilder)
@@ -261,6 +262,8 @@ namespace MyNamespace.Migrations
     {
         public override void Up(MigrationBuilder migrationBuilder)
         {
+            migrationBuilder.CreateDatabaseIfNotExists();
+            
             migrationBuilder.CreateTable(""dbo.MyTable"",
                 c => new
                     {
@@ -381,6 +384,8 @@ namespace MyNamespace.Migrations
     {
         public override void Up(MigrationBuilder migrationBuilder)
         {
+            migrationBuilder.CreateDatabaseIfNotExists();
+            
             migrationBuilder.CreateTable(""[Ho!use[]]]"",
                 c => new
                     {
@@ -597,6 +602,8 @@ namespace MyNamespace.Migrations
     {
         public override void Up(MigrationBuilder migrationBuilder)
         {
+            migrationBuilder.CreateDatabaseIfNotExists();
+            
             migrationBuilder.CreateTable(""EntityWithNamedKey"",
                 c => new
                     {

--- a/test/EntityFramework.Core.FunctionalTests/ChangeTrackingTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/ChangeTrackingTestBase.cs
@@ -14,10 +14,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
         [Fact]
         public virtual void Entity_reverts_when_state_set_to_unchanged()
         {
-            Console.WriteLine("Entity_reverts_when_state_set_to_unchanged started");
             using (var context = CreateContext())
             {
-                Console.WriteLine("Context Created");
                 var customer = context.Customers.First();
                 var firstTrackedEntity = context.ChangeTracker.Entries<Customer>().Single();
                 var originalPhoneNumber = customer.Phone;

--- a/test/EntityFramework.Migrations.Tests/Builders/MigrationBuilderTest.cs
+++ b/test/EntityFramework.Migrations.Tests/Builders/MigrationBuilderTest.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Builders
         {
             var builder = new MigrationBuilder();
 
-            builder.CreateDatabaseIfNotExists();
+            builder.CreateDatabase();
 
             Assert.Equal(1, builder.Operations.Count);
             Assert.IsType<CreateDatabaseOperation>(builder.Operations[0]);

--- a/test/EntityFramework.Migrations.Tests/Builders/MigrationBuilderTest.cs
+++ b/test/EntityFramework.Migrations.Tests/Builders/MigrationBuilderTest.cs
@@ -31,14 +31,10 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Builders
         {
             var builder = new MigrationBuilder();
 
-            builder.CreateDatabase("MyDb");
+            builder.CreateDatabaseIfNotExists();
 
             Assert.Equal(1, builder.Operations.Count);
             Assert.IsType<CreateDatabaseOperation>(builder.Operations[0]);
-
-            var operation = (CreateDatabaseOperation)builder.Operations[0];
-
-            Assert.Equal("MyDb", operation.DatabaseName);
         }
 
         [Fact]

--- a/test/EntityFramework.Migrations.Tests/Infrastructure/MigratorTest.cs
+++ b/test/EntityFramework.Migrations.Tests/Infrastructure/MigratorTest.cs
@@ -666,7 +666,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
                     {
                         new MigrationInfo("000000000000001_Migration1")
                             {
-                                UpgradeOperations = new[] { new SqlOperation("SomeSql") },
+                                UpgradeOperations = new MigrationOperation[] { new CreateDatabaseOperation(),  new SqlOperation("SomeSql") },
                                 TargetModel = new Metadata.Model()
                             }
                     };
@@ -684,6 +684,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
                 new[]
                     {
                         "Create__MigrationHistorySql",
+                        "CreateDatabaseOperationSql",
                         "SomeSql",
                         "Migration1InsertSql",
                     },
@@ -877,7 +878,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
         }
 
         [Fact]
-        public void ApplyMigrations_creates_database_if_no_migrations()
+        public void ApplyMigrations_does_not_create_database_if_no_migrations()
         {
             var contextServices = CreateContextServices(new MigrationInfo[0], new MigrationInfo[0], historyRepositoryExists: false);
             var migrator = contextServices.GetRequiredService<TestMigrator>();
@@ -889,8 +890,8 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
             migrator.ApplyMigrations();
 
             Assert.Empty(executor.NonQueries);
-            Assert.True(creator.Created);
-            Assert.True(creator.ExistsState);
+            Assert.False(creator.Created);
+            Assert.False(creator.ExistsState);
 
             creator.ExistsState = false;
             creator.Created = false;
@@ -898,8 +899,8 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
             migrator.ApplyMigrations(Migrator.InitialDatabase);
 
             Assert.Empty(executor.NonQueries);
-            Assert.True(creator.Created);
-            Assert.True(creator.ExistsState);
+            Assert.False(creator.Created);
+            Assert.False(creator.ExistsState);
         }
 
         [Fact]

--- a/test/EntityFramework.Migrations.Tests/MigrationOperationSqlGeneratorTest.cs
+++ b/test/EntityFramework.Migrations.Tests/MigrationOperationSqlGeneratorTest.cs
@@ -18,8 +18,8 @@ namespace Microsoft.Data.Entity.Migrations.Tests
         public void Generate_when_create_database_operation()
         {
             Assert.Equal(
-                @"CREATE DATABASE ""MyDatabase""",
-                Generate(new CreateDatabaseOperation("MyDatabase")));
+                string.Empty,
+                Generate(new CreateDatabaseOperation()));
         }
 
         [Fact]
@@ -353,7 +353,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests
 
             var operations = new List<MigrationOperation>
             {
-                new CreateDatabaseOperation("CustomeOrderDb"),
+                new CreateDatabaseOperation(),
                 OperationFactory().CreateTableOperation(model.GetEntityType("Customer")),
                 OperationFactory().CreateTableOperation(model.GetEntityType("Order")),
                 new DropDatabaseOperation("CustomeOrderDb"),
@@ -363,7 +363,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests
 
             Assert.Equal(1, batches.Count);
             Assert.Equal(
-@"CREATE DATABASE ""CustomeOrderDb"";
+@";
 CREATE TABLE ""dbo"".""Customers"" (
     ""FirstName"" varchar(4000),
     ""LastName"" varchar(4000),

--- a/test/EntityFramework.Migrations.Tests/Model/CreateDatabaseOperationTest.cs
+++ b/test/EntityFramework.Migrations.Tests/Model/CreateDatabaseOperationTest.cs
@@ -13,16 +13,15 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Model
         [Fact]
         public void Create_and_initialize_operation()
         {
-            var createDatabaseOperation = new CreateDatabaseOperation("MyDatabase");
+            var createDatabaseOperation = new CreateDatabaseOperation();
 
-            Assert.Equal("MyDatabase", createDatabaseOperation.DatabaseName);
             Assert.False(createDatabaseOperation.IsDestructiveChange);
         }
 
         [Fact]
         public void Dispatches_visitor()
         {
-            var createDatabaseOperation = new CreateDatabaseOperation("MyDatabase");
+            var createDatabaseOperation = new CreateDatabaseOperation();
             var mockVisitor = MigrationsTestHelpers.MockSqlGenerator();
             var builder = new Mock<SqlBatchBuilder>();
             createDatabaseOperation.GenerateSql(mockVisitor.Object, builder.Object);

--- a/test/EntityFramework.Migrations.Tests/ModelDifferTest.cs
+++ b/test/EntityFramework.Migrations.Tests/ModelDifferTest.cs
@@ -710,6 +710,22 @@ namespace Microsoft.Data.Entity.Migrations.Tests
             Assert.Equal("RenamedIndex", renameIndexOperation.NewIndexName);
         }
 
+
+
+        [Fact]
+        public void Initial_migration_scaffolds_create_database_command()
+        {
+            var targetModelBuilder = new BasicModelBuilder();
+            targetModelBuilder.Entity("A",
+                b =>
+                {
+                    b.Property<int>("Id");
+                    b.Key("Id");
+                });
+
+
+        }
+
         #endregion
 
         #region Transitive renames

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerMigrationsTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerMigrationsTest.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         {
             public override void Up(MigrationBuilder migrationBuilder)
             {
-                migrationBuilder.CreateDatabaseIfNotExists();
+                migrationBuilder.CreateDatabase();
             }
 
             public override void Down(MigrationBuilder migrationBuilder)

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerMigrationsTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerMigrationsTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Data.SqlClient;
 using System.Threading.Tasks;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Migrations;
@@ -15,21 +16,24 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 {
     public class SqlServerMigrationsTest
     {
+        #region Empty Migration
         [Fact]
-        public async Task Empty_Migration_Creates_Database()
+        public async Task Empty_Migration_Does_Not_Create_Database()
         {
             using (var testDatabase = await SqlServerTestStore.CreateScratchAsync(createDatabase: false))
             {
-                using (var context = CreateContext(testDatabase))
+                using (var context = CreateEmptyContext(testDatabase))
                 {
-                    context.Database.AsMigrationsEnabled().ApplyMigrations();
+                    context.Database.EnsureDeleted();
 
-                    Assert.True(context.Database.AsRelational().Exists());
+                    Assert.Throws<SqlException>(() => context.Database.AsMigrationsEnabled().ApplyMigrations());
+
+                    Assert.False(context.Database.AsRelational().Exists());
                 }
             }
         }
 
-        private static BloggingContext CreateContext(SqlServerTestStore testStore)
+        private static BloggingContext CreateEmptyContext(SqlServerTestStore testStore)
         {
             var serviceProvider =
                 new ServiceCollection()
@@ -38,7 +42,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                     .ServiceCollection
                     .BuildServiceProvider();
 
-            var options =new DbContextOptions();
+            var options = new DbContextOptions();
             options.UseSqlServer(testStore.Connection.ConnectionString);
 
             return new BloggingContext(
@@ -88,5 +92,97 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 get { return new Model(); }
             }
         }
+
+
+        #endregion
+
+        #region Create Database Migration
+
+        [Fact]
+        public async Task Create_Database_Command_Creates_Database()
+        {
+            using (var testDatabase = await SqlServerTestStore.CreateScratchAsync(createDatabase: false))
+            {
+                using (var context = CreateDatabaseContext(testDatabase))
+                {
+                    context.Database.EnsureDeleted();
+
+                    context.Database.AsMigrationsEnabled().ApplyMigrations();
+
+                    Assert.True(context.Database.AsRelational().Exists());
+                }
+            }
+        }
+
+        [Fact]
+        public async Task Create_Database_Command_is_Idempotent()
+        {
+            using (var testDatabase = await SqlServerTestStore.CreateScratchAsync(createDatabase: false))
+            {
+                using (var context = CreateDatabaseContext(testDatabase))
+                {
+                    context.Database.EnsureCreated();
+
+                    context.Database.AsMigrationsEnabled().ApplyMigrations();
+
+                    Assert.True(context.Database.AsRelational().Exists());
+                }
+            }
+        }
+
+        private static CreateDatabaseBloggingContext CreateDatabaseContext(SqlServerTestStore testStore)
+        {
+            var serviceProvider =
+                new ServiceCollection()
+                    .AddEntityFramework()
+                    .AddSqlServer()
+                    .ServiceCollection
+                    .BuildServiceProvider();
+
+            var options = new DbContextOptions();
+            options.UseSqlServer(testStore.Connection.ConnectionString);
+
+            return new CreateDatabaseBloggingContext(
+                serviceProvider,
+                options);
+        }
+
+        private class CreateDatabaseBloggingContext : BloggingContext
+        {
+            public CreateDatabaseBloggingContext(IServiceProvider serviceProvider, DbContextOptions options)
+                : base(serviceProvider, options)
+            {
+            }
+        }
+
+        [ContextType(typeof(CreateDatabaseBloggingContext))]
+        public class CreateDatabaseMigration : Migration, IMigrationMetadata
+        {
+            public override void Up(MigrationBuilder migrationBuilder)
+            {
+                migrationBuilder.CreateDatabaseIfNotExists();
+            }
+
+            public override void Down(MigrationBuilder migrationBuilder)
+            {
+            }
+
+            public string MigrationId
+            {
+                get { return "CreateDatabase"; }
+            }
+
+            public string ProductVersion
+            {
+                get { return "EF7"; }
+            }
+
+            public IModel TargetModel
+            {
+                get { return new Model(); }
+            }
+        }
+
+        #endregion
     }
 }

--- a/test/EntityFramework.SqlServer.Tests/SqlServerMigrationOperationSqlGeneratorTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerMigrationOperationSqlGeneratorTest.cs
@@ -17,16 +17,6 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
     public class SqlServerMigrationOperationSqlGeneratorTest
     {
         [Fact]
-        public void Generate_when_create_database_operation()
-        {
-            var batches = SqlGenerator().Generate(new CreateDatabaseOperation("MyDatabase")).ToList();
-
-            Assert.Equal(2, batches.Count);
-            Assert.Equal(@"CREATE DATABASE [MyDatabase]", batches[0].Sql);
-            Assert.Equal(@"IF SERVERPROPERTY('EngineEdition') <> 5 EXECUTE sp_executesql N'ALTER DATABASE [MyDatabase] SET READ_COMMITTED_SNAPSHOT ON'", batches[1].Sql);
-        }
-
-        [Fact]
         public void Generate_when_drop_database_operation()
         {
             Assert.Equal(


### PR DESCRIPTION
 EF now scripts idempotent database creation code for migrations and only executes database creation when the line is present in the initial migration.