### PR TITLE
Auto-DetectChanges (Issue #745)

### DIFF
--- a/src/EntityFramework.Core/ChangeTracking/ChangeTracker.cs
+++ b/src/EntityFramework.Core/ChangeTracking/ChangeTracker.cs
@@ -51,14 +51,26 @@ namespace Microsoft.Data.Entity.ChangeTracking
 
         public virtual IEnumerable<EntityEntry> Entries()
         {
+            TryDetectChanges();
+
             return StateManager.StateEntries.Select(e => new EntityEntry(_context.Service, e));
         }
 
         public virtual IEnumerable<EntityEntry<TEntity>> Entries<TEntity>() where TEntity : class
         {
+            TryDetectChanges();
+
             return StateManager.StateEntries
                 .Where(e => e.Entity is TEntity)
                 .Select(e => new EntityEntry<TEntity>(_context.Service, e));
+        }
+
+        private void TryDetectChanges()
+        {
+            if (_context.Service.Configuration.AutoDetectChangesEnabled)
+            {
+                DetectChanges();
+            }
         }
 
         public virtual StateManager StateManager { get; }
@@ -68,6 +80,11 @@ namespace Microsoft.Data.Entity.ChangeTracking
         public virtual bool DetectChanges()
         {
             return _changeDetector.DetectChanges(StateManager);
+        }
+
+        public virtual Task<bool> DetectChangesAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return _changeDetector.DetectChangesAsync(StateManager, cancellationToken);
         }
 
         public virtual void AttachGraph([NotNull] object rootEntity, [NotNull] Action<EntityEntry> callback)

--- a/src/EntityFramework.Core/DbContextConfiguration.cs
+++ b/src/EntityFramework.Core/DbContextConfiguration.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Data.Entity
+{
+    public class DbContextConfiguration
+    {
+        public virtual bool AutoDetectChangesEnabled { get; set; } = true;
+    }
+}

--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -82,6 +82,7 @@
     <Compile Include="ChangeTracking\ValueGenerationManager.cs" />
     <Compile Include="DbContext.cs" />
     <Compile Include="Identity\GeneratedValue.cs" />
+    <Compile Include="DbContextConfiguration.cs" />
     <Compile Include="Identity\TemporaryBinaryValueGenerator.cs" />
     <Compile Include="Identity\TemporaryStringValueGenerator.cs" />
     <Compile Include="Infrastructure\DbContextService.cs" />

--- a/test/EntityFramework.Core.Tests/ChangeTracking/ChangeTrackerTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/ChangeTrackerTest.cs
@@ -957,6 +957,89 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             Assert.Contains(orderDetails2b, orderDetails1b.Product.OrderDetails);
         }
 
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Entries_calls_DetectChanges_by_default(bool useGenericOverload)
+        {
+            using (var context = new EarlyLearningCenter())
+            {
+                var entry = context.Attach(new Product { Id = 1, CategoryId = 66 });
+
+                entry.Entity.CategoryId = 77;
+
+                Assert.Equal(EntityState.Unchanged, entry.State);
+
+                if (useGenericOverload)
+                {
+                    context.ChangeTracker.Entries<Product>();
+                }
+                else
+                {
+                    context.ChangeTracker.Entries();
+                }
+
+                Assert.Equal(EntityState.Modified, entry.State);
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Auto_DetectChanges_for_Entries_can_be_switched_off(bool useGenericOverload)
+        {
+            using (var context = new EarlyLearningCenter())
+            {
+                context.Configuration.AutoDetectChangesEnabled = false;
+
+                var entry = context.Attach(new Product { Id = 1, CategoryId = 66 });
+
+                entry.Entity.CategoryId = 77;
+
+                Assert.Equal(EntityState.Unchanged, entry.State);
+
+                if (useGenericOverload)
+                {
+                    context.ChangeTracker.Entries<Product>();
+                }
+                else
+                {
+                    context.ChangeTracker.Entries();
+                }
+
+                Assert.Equal(EntityState.Unchanged, entry.State);
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task Explicitly_calling_DetectChanges_works_even_if_auto_DetectChanges_is_switched_off(bool async)
+        {
+            using (var context = new EarlyLearningCenter())
+            {
+                context.Configuration.AutoDetectChangesEnabled = false;
+
+                var entry = context.Attach(new Product { Id = 1, CategoryId = 66 });
+
+                entry.Entity.CategoryId = 77;
+
+                Assert.Equal(EntityState.Unchanged, entry.State);
+
+                if (async)
+                {
+                    await context.ChangeTracker.DetectChangesAsync();
+                }
+                else
+                {
+                    context.ChangeTracker.DetectChanges();
+                }
+
+                Assert.Equal(EntityState.Modified, entry.State);
+            }
+        }
+
         private class Category
         {
             public int Id { get; set; }


### PR DESCRIPTION
- Allow auto-DetectChanges to be switched off
- Call DetectChanges automatically from SaveChanges, Entry, and Entries, unless it has been switched off
- Create async version so that async Add can be called when needed. Note that as discussed, the async version is never called from Entry or Entries to avoid even more async API. Guidance will be to call DetectChangesAsync manually before Entry or Entries if it may add new objects and if it is important that this happen asynchronously.