### PR TITLE
Remove unintentional call of DetectChanges in Add/Attach/etc.

### DIFF
--- a/src/EntityFramework.Core/ChangeTracking/EntityEntryGraphIterator.cs
+++ b/src/EntityFramework.Core/ChangeTracking/EntityEntryGraphIterator.cs
@@ -13,20 +13,24 @@ namespace Microsoft.Data.Entity.ChangeTracking
     public class EntityEntryGraphIterator
     {
         private readonly DbContextService<DbContext> _context;
+        private readonly StateManager _stateManager;
 
         public EntityEntryGraphIterator(
-            [NotNull] DbContextService<DbContext> context)
+            [NotNull] DbContextService<DbContext> context,
+            [NotNull] StateManager stateManager)
         {
             Check.NotNull(context, "context");
+            Check.NotNull(stateManager, "stateManager");
 
             _context = context;
+            _stateManager = stateManager;
         }
 
         public virtual IEnumerable<EntityEntry> TraverseGraph([NotNull] object entity)
         {
             Check.NotNull(entity, "entity");
 
-            var entry = _context.Service.Entry(entity);
+            var entry = new EntityEntry(_context.Service, _stateManager.GetOrCreateEntry(entity));
 
             if (entry.State != EntityState.Unknown)
             {

--- a/src/EntityFramework.Core/DbContext.cs
+++ b/src/EntityFramework.Core/DbContext.cs
@@ -260,22 +260,32 @@ namespace Microsoft.Data.Entity
         {
             Check.NotNull(entity, "entity");
 
-            var stateManager = GetStateManager();
+            TryDetectChanges(GetStateManager());
 
-            TryDetectChanges(stateManager);
+            return EntryWithoutDetectChanges(entity);
+        }
 
-            return new EntityEntry<TEntity>(this, stateManager.GetOrCreateEntry(entity));
+        private EntityEntry<TEntity> EntryWithoutDetectChanges<TEntity>([NotNull] TEntity entity) where TEntity : class
+        {
+            Check.NotNull(entity, "entity");
+
+            return new EntityEntry<TEntity>(this, GetStateManager().GetOrCreateEntry(entity));
         }
 
         public virtual EntityEntry Entry([NotNull] object entity)
         {
             Check.NotNull(entity, "entity");
 
-            var stateManager = GetStateManager();
+            TryDetectChanges(GetStateManager());
 
-            TryDetectChanges(stateManager);
+            return EntryWithoutDetectChanges(entity);
+        }
 
-            return new EntityEntry(this, stateManager.GetOrCreateEntry(entity));
+        private EntityEntry EntryWithoutDetectChanges([NotNull] object entity)
+        {
+            Check.NotNull(entity, "entity");
+
+            return new EntityEntry(this, GetStateManager().GetOrCreateEntry(entity));
         }
 
         public virtual EntityEntry<TEntity> Add<TEntity>([NotNull] TEntity entity) where TEntity : class
@@ -291,7 +301,7 @@ namespace Microsoft.Data.Entity
         {
             Check.NotNull(entity, "entity");
 
-            var entry = Entry(entity);
+            var entry = EntryWithoutDetectChanges(entity);
 
             await entry.StateEntry
                 .SetEntityStateAsync(EntityState.Added, true, cancellationToken)
@@ -321,14 +331,14 @@ namespace Microsoft.Data.Entity
             // An Added entity does not yet exist in the database. If it is then marked as deleted there is
             // nothing to delete because it was not yet inserted, so just make sure it doesn't get inserted.
             return SetEntityState(
-                entity, Entry(entity).State == EntityState.Added
+                entity, EntryWithoutDetectChanges(entity).State == EntityState.Added
                     ? EntityState.Unknown
                     : EntityState.Deleted);
         }
 
         private EntityEntry<TEntity> SetEntityState<TEntity>(TEntity entity, EntityState entityState) where TEntity : class
         {
-            var entry = Entry(entity);
+            var entry = EntryWithoutDetectChanges(entity);
 
             entry.SetState(entityState);
 
@@ -347,7 +357,7 @@ namespace Microsoft.Data.Entity
         {
             Check.NotNull(entity, "entity");
 
-            var entry = Entry(entity);
+            var entry = EntryWithoutDetectChanges(entity);
 
             await entry.StateEntry
                 .SetEntityStateAsync(EntityState.Added, true, cancellationToken)
@@ -377,14 +387,14 @@ namespace Microsoft.Data.Entity
             // An Added entity does not yet exist in the database. If it is then marked as deleted there is
             // nothing to delete because it was not yet inserted, so just make sure it doesn't get inserted.
             return SetEntityState(
-                entity, Entry(entity).State == EntityState.Added
+                entity, EntryWithoutDetectChanges(entity).State == EntityState.Added
                     ? EntityState.Unknown
                     : EntityState.Deleted);
         }
 
         private EntityEntry SetEntityState(object entity, EntityState entityState)
         {
-            var entry = Entry(entity);
+            var entry = EntryWithoutDetectChanges(entity);
 
             entry.SetState(entityState);
 


### PR DESCRIPTION
/cc @HaoK @divega 

This seems to break Identity and should not be happening anyway. It started happening because the Entry methods call DetectChanges, and these are used by Add/Attach/Remove/Update since these methods now return EntityEntry objects. This fix is to not call the public surface method.

Writing some tests, but wanted to get this checked in as soon as possible since the Identity build is broken.