### PR TITLE
Update handling of snapshots and ensure DetectChanges is only used when required (Issue #731)

### DIFF
--- a/src/EntityFramework.Core/ChangeTracking/ChangeTracker.cs
+++ b/src/EntityFramework.Core/ChangeTracking/ChangeTracker.cs
@@ -77,12 +77,12 @@ namespace Microsoft.Data.Entity.ChangeTracking
 
         public virtual DbContext Context => _context.Service;
 
-        public virtual bool DetectChanges()
+        public virtual void DetectChanges()
         {
-            return _changeDetector.DetectChanges(StateManager);
+            _changeDetector.DetectChanges(StateManager);
         }
 
-        public virtual Task<bool> DetectChangesAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task DetectChangesAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return _changeDetector.DetectChangesAsync(StateManager, cancellationToken);
         }

--- a/src/EntityFramework.Core/Metadata/EntityTypeExtensions.cs
+++ b/src/EntityFramework.Core/Metadata/EntityTypeExtensions.cs
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
+using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Utilities;
 
@@ -21,6 +23,18 @@ namespace Microsoft.Data.Entity.Metadata
         public static IEnumerable<IForeignKey> GetReferencingForeignKeys([NotNull] this IEntityType entityType)
         {
             return entityType.Model.GetReferencingForeignKeys(entityType);
+        }
+
+        public static bool HasPropertyChangingNotifications([NotNull] this IEntityType entityType)
+        {
+            return entityType.Type == null
+                   || typeof(INotifyPropertyChanging).GetTypeInfo().IsAssignableFrom(entityType.Type.GetTypeInfo());
+        }
+
+        public static bool HasPropertyChangedNotifications([NotNull] this IEntityType entityType)
+        {
+            return entityType.Type == null
+                   || typeof(INotifyPropertyChanged).GetTypeInfo().IsAssignableFrom(entityType.Type.GetTypeInfo());
         }
     }
 }

--- a/src/EntityFramework.Core/Metadata/IEntityType.cs
+++ b/src/EntityFramework.Core/Metadata/IEntityType.cs
@@ -44,6 +44,6 @@ namespace Microsoft.Data.Entity.Metadata
         int ShadowPropertyCount { get; }
         int OriginalValueCount { get; }
         bool HasClrType { get; }
-        bool UseLazyOriginalValues { get; }
+        bool UseEagerSnapshots { get; }
     }
 }

--- a/src/EntityFramework.Core/Metadata/NavigationExtensions.cs
+++ b/src/EntityFramework.Core/Metadata/NavigationExtensions.cs
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Specialized;
+using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Metadata
@@ -49,6 +52,29 @@ namespace Microsoft.Data.Entity.Metadata
             return navigation.PointsToPrincipal
                 ? navigation.ForeignKey.ReferencedEntityType
                 : navigation.ForeignKey.EntityType;
+        }
+
+        public static bool IsNonNotifyingCollection([NotNull] this INavigation navigation, [NotNull] StateEntry entry)
+        {
+            Check.NotNull(navigation, "navigation");
+            Check.NotNull(entry, "entry");
+
+            if (!navigation.IsCollection())
+            {
+                return false;
+            }
+
+            // TODO: Returning true until INotifyCollectionChanged (Issue #445) is supported.
+            return true;
+
+            //if (typeof(INotifyCollectionChanged).GetTypeInfo().IsAssignableFrom(navigation.GetType().GetTypeInfo()))
+            //{
+            //    return false;
+            //}
+
+            //var collectionInstance = entry[navigation];
+
+            //return collectionInstance != null && !(collectionInstance is INotifyCollectionChanged);
         }
     }
 }

--- a/src/EntityFramework.Core/Query/QueryBuffer.cs
+++ b/src/EntityFramework.Core/Query/QueryBuffer.cs
@@ -188,7 +188,7 @@ namespace Microsoft.Data.Entity.Query
                     {
                         Include(e, navigationPath, relatedValueReaders, currentNavigationIndex + 1);
 
-                        return Task.FromResult(0);
+                        return Task.FromResult(false);
                     },
                 currentNavigationIndex,
                 relatedValueReaders[currentNavigationIndex](primaryKey, relatedKeyFactory)

--- a/test/EntityFramework.Core.FunctionalTests/ChangeTrackingTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/ChangeTrackingTestBase.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Linq;
 using Microsoft.Data.Entity.FunctionalTests.TestModels.Northwind;
 using Xunit;
@@ -14,10 +13,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
         [Fact]
         public virtual void Entity_reverts_when_state_set_to_unchanged()
         {
-            Console.WriteLine("Entity_reverts_when_state_set_to_unchanged started");
             using (var context = CreateContext())
             {
-                Console.WriteLine("Context Created");
                 var customer = context.Customers.First();
                 var firstTrackedEntity = context.ChangeTracker.Entries<Customer>().Single();
                 var originalPhoneNumber = customer.Phone;

--- a/test/EntityFramework.Core.FunctionalTests/Metadata/Compiled/CompiledEntityType.cs
+++ b/test/EntityFramework.Core.FunctionalTests/Metadata/Compiled/CompiledEntityType.cs
@@ -128,20 +128,20 @@ namespace Microsoft.Data.Entity.Metadata.Compiled
 
         public int ShadowPropertyCount
         {
-            // TODO:
+            // TODO: Implement this appropriately rather than always just returning 0.
             get { return 0; }
         }
 
         public int OriginalValueCount
         {
-            // TODO:
+            // TODO: Implement this appropriately rather than always just returning 0.
             get { return 0; }
         }
 
-        public bool UseLazyOriginalValues
+        public bool UseEagerSnapshots
         {
-            // TODO:
-            get { return true; }
+            // TODO: Implement this appropriately rather than always just returning false.
+            get { return false; }
         }
 
         public bool HasClrType

--- a/test/EntityFramework.Core.FunctionalTests/MonsterFixupTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/MonsterFixupTestBase.cs
@@ -131,14 +131,14 @@ namespace Microsoft.Data.Entity.FunctionalTests
             Can_build_monster_model_and_seed_data_using_principal_navigations_test(p => CreateSnapshotMonsterContext(p, databaseName), databaseName);
         }
 
-        //[Fact] TODO: Support INotifyCollectionChanging so that collection change detection without DetectChanges works
+        //[Fact] TODO: Support INotifyCollectionChanged (Issue #445) so that collection change detection without DetectChanges works
         public virtual void Can_build_monster_model_with_full_notification_entities_and_seed_data_using_principal_navigations()
         {
             const string databaseName = FullNotifyDatabaseName + "_PrincipalNavs";
             Can_build_monster_model_and_seed_data_using_principal_navigations_test(p => CreateChangedChangingMonsterContext(p, databaseName), databaseName);
         }
 
-        //[Fact] TODO: Support INotifyCollectionChanging so that collection change detection without DetectChanges works
+        //[Fact] TODO: Support INotifyCollectionChanged (Issue #445) so that collection change detection without DetectChanges works
         public virtual void Can_build_monster_model_with_changed_only_notification_entities_and_seed_data_using_principal_navigations()
         {
             const string databaseName = ChangedOnlyDatabaseName + "_PrincipalNavs";
@@ -472,13 +472,13 @@ namespace Microsoft.Data.Entity.FunctionalTests
             await One_to_many_fixup_happens_when_collection_changes_test(p => CreateSnapshotMonsterContext(p), SnapshotDatabaseName, useDetectChanges: true);
         }
 
-        //[Fact] TODO: Support INotifyCollectionChanging so that collection change detection without DetectChanges works
+        //[Fact] TODO: Support INotifyCollectionChanged (Issue #445) so that collection change detection without DetectChanges works
         public virtual async Task One_to_many_fixup_happens_when_collection_changes_for_full_notification_entities()
         {
             await One_to_many_fixup_happens_when_collection_changes_test(p => CreateChangedChangingMonsterContext(p), FullNotifyDatabaseName, useDetectChanges: false);
         }
 
-        //[Fact] TODO: Support INotifyCollectionChanging so that collection change detection without DetectChanges works
+        //[Fact] TODO: Support INotifyCollectionChanged (Issue #445) so that collection change detection without DetectChanges works
         public virtual async Task One_to_many_fixup_happens_when_collection_changes_for_changed_only_notification_entities()
         {
             await One_to_many_fixup_happens_when_collection_changes_test(p => CreateChangedOnlyMonsterContext(p), ChangedOnlyDatabaseName, useDetectChanges: false);
@@ -893,13 +893,13 @@ namespace Microsoft.Data.Entity.FunctionalTests
             await Fixup_with_binary_keys_happens_when_FKs_or_navigations_change_test(p => CreateSnapshotMonsterContext(p), SnapshotDatabaseName, useDetectChanges: true);
         }
 
-        //[Fact] TODO: Support INotifyCollectionChanging so that collection change detection without DetectChanges works
+        //[Fact] TODO: Support INotifyCollectionChanged (Issue #445) so that collection change detection without DetectChanges works
         public virtual async Task Fixup_with_binary_keys_happens_when_FKs_or_navigations_change_for_full_notification_entities()
         {
             await Fixup_with_binary_keys_happens_when_FKs_or_navigations_change_test(p => CreateChangedChangingMonsterContext(p), FullNotifyDatabaseName, useDetectChanges: false);
         }
 
-        //[Fact] TODO: Support INotifyCollectionChanging so that collection change detection without DetectChanges works
+        //[Fact] TODO: Support INotifyCollectionChanged (Issue #445) so that collection change detection without DetectChanges works
         public virtual async Task Fixup_with_binary_keys_happens_when_FKs_or_navigations_change_for_changed_only_notification_entities()
         {
             await Fixup_with_binary_keys_happens_when_FKs_or_navigations_change_test(p => CreateChangedOnlyMonsterContext(p), ChangedOnlyDatabaseName, useDetectChanges: false);

--- a/test/EntityFramework.Core.Tests/ChangeTracking/ChangeDetectorTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/ChangeDetectorTest.cs
@@ -2,10 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.DependencyInjection;
 using Moq;
 using Xunit;
@@ -14,6 +16,159 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 {
     public class ChangeDetectorTest
     {
+        [Fact]
+        public void PropertyChanging_does_not_snapshot_if_eager_snapshots_are_in_use()
+        {
+            var contextServices = TestHelpers.CreateContextServices(BuildModel());
+            var entry = CreateStateEntry<Product>(contextServices);
+
+            Assert.True(entry.EntityType.UseEagerSnapshots);
+            Assert.Null(entry.TryGetSidecar(Sidecar.WellKnownNames.OriginalValues));
+            Assert.Null(entry.TryGetSidecar(Sidecar.WellKnownNames.RelationshipsSnapshot));
+
+            contextServices
+                .GetRequiredService<ChangeDetector>()
+                .PropertyChanging(entry, entry.EntityType.GetProperty("DependentId"));
+
+            Assert.Null(entry.TryGetSidecar(Sidecar.WellKnownNames.OriginalValues));
+            Assert.Null(entry.TryGetSidecar(Sidecar.WellKnownNames.RelationshipsSnapshot));
+        }
+
+        [Fact]
+        public void PropertyChanging_snapshots_original_and_FK_value_if_lazy_snapshots_are_in_use()
+        {
+            var contextServices = TestHelpers.CreateContextServices(BuildModelWithChanging());
+            var entry = CreateStateEntry(contextServices, new ProductWithChanging { DependentId = 77 });
+
+            Assert.False(entry.EntityType.UseEagerSnapshots);
+            Assert.Null(entry.TryGetSidecar(Sidecar.WellKnownNames.OriginalValues));
+            Assert.Null(entry.TryGetSidecar(Sidecar.WellKnownNames.RelationshipsSnapshot));
+
+            var property = entry.EntityType.GetProperty("DependentId");
+
+            contextServices
+                .GetRequiredService<ChangeDetector>()
+                .PropertyChanging(entry, property);
+
+            Assert.Equal(77, entry.TryGetSidecar(Sidecar.WellKnownNames.OriginalValues)[property]);
+            Assert.True(entry.TryGetSidecar(Sidecar.WellKnownNames.OriginalValues).HasValue(property));
+            Assert.Equal(77, entry.TryGetSidecar(Sidecar.WellKnownNames.RelationshipsSnapshot)[property]);
+            Assert.True(entry.TryGetSidecar(Sidecar.WellKnownNames.RelationshipsSnapshot).HasValue(property));
+        }
+
+        [Fact]
+        public void PropertyChanging_does_not_snapshot_original_values_for_properties_with_no_original_value_tracking()
+        {
+            var contextServices = TestHelpers.CreateContextServices(BuildModelWithChanging());
+            var entry = CreateStateEntry<ProductWithChanging>(contextServices);
+
+            Assert.False(entry.EntityType.UseEagerSnapshots);
+            Assert.Null(entry.TryGetSidecar(Sidecar.WellKnownNames.OriginalValues));
+            Assert.Null(entry.TryGetSidecar(Sidecar.WellKnownNames.RelationshipsSnapshot));
+
+            contextServices
+                .GetRequiredService<ChangeDetector>()
+                .PropertyChanging(entry, entry.EntityType.GetProperty("Name"));
+
+            Assert.Null(entry.TryGetSidecar(Sidecar.WellKnownNames.OriginalValues));
+            Assert.Null(entry.TryGetSidecar(Sidecar.WellKnownNames.RelationshipsSnapshot));
+        }
+
+        [Fact]
+        public void PropertyChanging_snapshots_reference_navigations_if_lazy_snapshots_are_in_use()
+        {
+            var contextServices = TestHelpers.CreateContextServices(BuildModelWithChanging());
+            var category = new CategoryWithChanging();
+            var entry = CreateStateEntry(contextServices, new ProductWithChanging { Category = category });
+
+            Assert.False(entry.EntityType.UseEagerSnapshots);
+            Assert.Null(entry.TryGetSidecar(Sidecar.WellKnownNames.OriginalValues));
+            Assert.Null(entry.TryGetSidecar(Sidecar.WellKnownNames.RelationshipsSnapshot));
+
+            var navigation = entry.EntityType.GetNavigation("Category");
+
+            contextServices
+                .GetRequiredService<ChangeDetector>()
+                .PropertyChanging(entry, navigation);
+
+            Assert.Null(entry.TryGetSidecar(Sidecar.WellKnownNames.OriginalValues));
+            Assert.True(entry.TryGetSidecar(Sidecar.WellKnownNames.RelationshipsSnapshot).HasValue(navigation));
+            Assert.Same(category, entry.TryGetSidecar(Sidecar.WellKnownNames.RelationshipsSnapshot)[navigation]);
+        }
+
+        [Fact]
+        public void PropertyChanging_snapshots_PK_for_relationships_if_lazy_snapshots_are_in_use()
+        {
+            var contextServices = TestHelpers.CreateContextServices(BuildModelWithChanging());
+            var entry = CreateStateEntry(contextServices, new ProductWithChanging { Id = 77 });
+
+            Assert.False(entry.EntityType.UseEagerSnapshots);
+            Assert.Null(entry.TryGetSidecar(Sidecar.WellKnownNames.OriginalValues));
+            Assert.Null(entry.TryGetSidecar(Sidecar.WellKnownNames.RelationshipsSnapshot));
+
+            var property = entry.EntityType.GetProperty("Id");
+
+            contextServices
+                .GetRequiredService<ChangeDetector>()
+                .PropertyChanging(entry, property);
+
+            Assert.Null(entry.TryGetSidecar(Sidecar.WellKnownNames.OriginalValues));
+            Assert.True(entry.TryGetSidecar(Sidecar.WellKnownNames.RelationshipsSnapshot).HasValue(property));
+            Assert.Equal(77, entry.TryGetSidecar(Sidecar.WellKnownNames.RelationshipsSnapshot)[property]);
+        }
+
+        [Fact]
+        public void PropertyChanging_does_not_snapshot_notification_collections()
+        {
+            var contextServices = TestHelpers.CreateContextServices(BuildModelWithChanging());
+            var entry = CreateStateEntry<CategoryWithChanging>(contextServices);
+
+            Assert.False(entry.EntityType.UseEagerSnapshots);
+            Assert.Null(entry.TryGetSidecar(Sidecar.WellKnownNames.OriginalValues));
+            Assert.Null(entry.TryGetSidecar(Sidecar.WellKnownNames.RelationshipsSnapshot));
+
+            contextServices
+                .GetRequiredService<ChangeDetector>()
+                .PropertyChanging(entry, entry.EntityType.GetNavigation("Products"));
+
+            Assert.Null(entry.TryGetSidecar(Sidecar.WellKnownNames.OriginalValues));
+            Assert.Null(entry.TryGetSidecar(Sidecar.WellKnownNames.RelationshipsSnapshot));
+        }
+
+        [Fact]
+        public void PropertyChanged_entities_do_not_require_DetectChanges()
+        {
+            var contextServices = TestHelpers.CreateContextServices(BuildModelWithChanged());
+            var entry = CreateStateEntry<CategoryWithChanged>(contextServices);
+
+            // TODO: The following assert should be changed to False once INotifyCollectionChanged is supported (Issue #445)
+            Assert.True(contextServices
+                .GetRequiredService<ChangeDetector>()
+                .RequiresDetectChanges(entry));
+        }
+
+        [Fact]
+        public void Non_PropertyChanged_entities_do_require_DetectChanges()
+        {
+            var contextServices = TestHelpers.CreateContextServices(BuildModelWithChanging());
+            var entry = CreateStateEntry<CategoryWithChanging>(contextServices);
+
+            Assert.True(contextServices
+                .GetRequiredService<ChangeDetector>()
+                .RequiresDetectChanges(entry));
+        }
+
+        [Fact]
+        public void PropertyChanged_entities_with_non_notifying_collections_require_DetectChanges()
+        {
+            var contextServices = TestHelpers.CreateContextServices(BuildModelWithChanged());
+            var entry = CreateStateEntry(contextServices, new CategoryWithChanged { Products = new List<ProductWithChanged>()});
+
+            Assert.True(contextServices
+                .GetRequiredService<ChangeDetector>()
+                .RequiresDetectChanges(entry));
+        }
+
         [Fact]
         public void Detects_principal_key_change()
         {
@@ -254,6 +409,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             public int Id { get; set; }
             public int? PrincipalId { get; set; }
             public string Name { get; set; }
+
+            public virtual ICollection<Product> Products { get; } = new List<Product>();
         }
 
         private class Product
@@ -261,27 +418,121 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             public Guid Id { get; set; }
             public int? DependentId { get; set; }
             public string Name { get; set; }
+
+            public virtual Category Category { get; set; }
         }
 
         private static IModel BuildModel()
         {
-            var model = new Model();
-            var builder = new ModelBuilder(model);
+            var builder = new ModelBuilder();
 
             builder.Entity<Product>();
-            builder.Entity<Category>().Property(e => e.Id).GenerateValueOnAdd(false);
+            builder.Entity<Category>(b =>
+                {
+                    b.Property(e => e.Id).GenerateValueOnAdd(false);
 
-            var productType = model.GetEntityType(typeof(Product));
-            var categoryType = model.GetEntityType(typeof(Category));
+                    b.OneToMany(e => e.Products, e => e.Category)
+                        .ForeignKey(e => e.DependentId)
+                        .ReferencedKey(e => e.PrincipalId);
+                });
 
-            productType.GetOrAddForeignKey(productType.GetProperty("DependentId"), new Key(new[] { categoryType.GetProperty("PrincipalId") }));
+            return builder.Model;
+        }
 
-            return model;
+        private class CategoryWithChanging : INotifyPropertyChanging
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+
+            public virtual ICollection<ProductWithChanging> Products { get; } = new ObservableCollection<ProductWithChanging>();
+
+            // Actual implementation not needed for tests
+#pragma warning disable 67
+            public event PropertyChangingEventHandler PropertyChanging;
+#pragma warning restore 67
+        }
+
+        private class ProductWithChanging : INotifyPropertyChanging
+        {
+            public int Id { get; set; }
+            public int? DependentId { get; set; }
+            public string Name { get; set; }
+
+            public virtual CategoryWithChanging Category { get; set; }
+
+            // Actual implementation not needed for tests
+#pragma warning disable 67
+            public event PropertyChangingEventHandler PropertyChanging;
+#pragma warning restore 67
+        }
+
+        private static IModel BuildModelWithChanging()
+        {
+            var builder = new ModelBuilder();
+
+            builder.Entity<ProductWithChanging>();
+            builder.Entity<CategoryWithChanging>(b =>
+                {
+                    b.Property(e => e.Id).GenerateValueOnAdd(false);
+                    b.OneToMany(e => e.Products, e => e.Category).ForeignKey(e => e.DependentId);
+                });
+
+            return builder.Model;
+        }
+
+        private class CategoryWithChanged : INotifyPropertyChanged
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+
+            public virtual ICollection<ProductWithChanged> Products { get; set; } = new ObservableCollection<ProductWithChanged>();
+
+            // Actual implementation not needed for tests
+#pragma warning disable 67
+            public event PropertyChangedEventHandler PropertyChanged;
+#pragma warning restore 67
+        }
+
+        private class ProductWithChanged : INotifyPropertyChanged
+        {
+            public int Id { get; set; }
+            public int? DependentId { get; set; }
+            public string Name { get; set; }
+
+            public virtual CategoryWithChanged Category { get; set; }
+
+            // Actual implementation not needed for tests
+#pragma warning disable 67
+            public event PropertyChangedEventHandler PropertyChanged;
+#pragma warning restore 67
+        }
+
+        private static IModel BuildModelWithChanged()
+        {
+            var builder = new ModelBuilder();
+
+            builder.Entity<ProductWithChanged>();
+            builder.Entity<CategoryWithChanged>(b =>
+                {
+                    b.Property(e => e.Id).GenerateValueOnAdd(false);
+                    b.OneToMany(e => e.Products, e => e.Category).ForeignKey(e => e.DependentId);
+                });
+
+            return builder.Model;
         }
 
         private static IServiceProvider CreateContextServices(StateEntryNotifier notifier, IModel model)
         {
             return TestHelpers.CreateContextServices(new ServiceCollection().AddInstance(notifier), model);
+        }
+
+        private static ClrStateEntry CreateStateEntry<TEntity>(IServiceProvider contextServices, TEntity entity = null)
+            where TEntity : class, new()
+        {
+            return new ClrStateEntry(
+                contextServices.GetRequiredService<StateManager>(),
+                contextServices.GetRequiredService<DbContextService<IModel>>().Service.GetEntityType(typeof(TEntity)),
+                contextServices.GetRequiredService<StateEntryMetadataServices>(), entity ?? new TEntity());
         }
     }
 }

--- a/test/EntityFramework.Core.Tests/ChangeTracking/MixedStateEntryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/MixedStateEntryTest.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var model = BuildModel();
             var entityType = model.GetEntityType(typeof(ChangedOnlyEntity).FullName);
-            entityType.UseLazyOriginalValues = false;
+            entityType.UseEagerSnapshots = true;
 
             AllOriginalValuesTest(model, entityType);
         }

--- a/test/EntityFramework.Core.Tests/ChangeTracking/StateEntryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/StateEntryTest.cs
@@ -634,7 +634,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var model = BuildModel();
             var entityType = model.GetEntityType(typeof(FullNotificationEntity).FullName);
-            entityType.UseLazyOriginalValues = false;
+            entityType.UseEagerSnapshots = true;
 
             AllOriginalValuesTest(model, entityType);
         }

--- a/test/EntityFramework.Core.Tests/ChangeTracking/StateManagerTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/StateManagerTest.cs
@@ -295,13 +295,13 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var changeDetector = new FakeChangeDetector();
 
-            Assert.False(changeDetector.DetectChanges(stateManager));
+            changeDetector.DetectChanges(stateManager);
 
             Assert.Equal(new[] { 77, 78, 79 }, changeDetector.Entries.Select(e => ((Category)e.Entity).Id).ToArray());
 
             ((Category)entry2.Entity).Name = "Snacks";
 
-            Assert.True(changeDetector.DetectChanges(stateManager));
+            changeDetector.DetectChanges(stateManager);
 
             Assert.Equal(new[] { 77, 78, 79, 77, 78, 79 }, changeDetector.Entries.Select(e => ((Category)e.Entity).Id).ToArray());
         }
@@ -315,11 +315,11 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
                 get { return _entries; }
             }
 
-            public override bool DetectChanges(StateEntry entry)
+            public override void DetectChanges(StateEntry entry)
             {
                 _entries.Add(entry);
 
-                return base.DetectChanges(entry);
+                base.DetectChanges(entry);
             }
         }
 

--- a/test/EntityFramework.Core.Tests/DbContextTest.cs
+++ b/test/EntityFramework.Core.Tests/DbContextTest.cs
@@ -244,10 +244,9 @@ namespace Microsoft.Data.Entity.Tests
         {
             public bool DetectChangesCalled { get; set; }
 
-            public override bool DetectChanges(StateManager stateManager)
+            public override void DetectChanges(StateManager stateManager)
             {
                 DetectChangesCalled = true;
-                return false;
             }
         }
 

--- a/test/EntityFramework.Core.Tests/Metadata/EntityTypeTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/EntityTypeTest.cs
@@ -1085,49 +1085,49 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         [Fact]
         public void Lazy_original_values_are_used_for_full_notification_and_shadow_enties()
         {
-            Assert.True(new EntityType(typeof(FullNotificationEntity), new Model()).UseLazyOriginalValues);
+            Assert.False(new EntityType(typeof(FullNotificationEntity), new Model()).UseEagerSnapshots);
         }
 
         [Fact]
         public void Lazy_original_values_are_used_for_shadow_enties()
         {
-            Assert.True(new EntityType("Z'ha'dum", new Model()).UseLazyOriginalValues);
+            Assert.False(new EntityType("Z'ha'dum", new Model()).UseEagerSnapshots);
         }
 
         [Fact]
         public void Eager_original_values_are_used_for_enties_that_only_implement_INotifyPropertyChanged()
         {
-            Assert.False(new EntityType(typeof(ChangedOnlyEntity), new Model()).UseLazyOriginalValues);
+            Assert.True(new EntityType(typeof(ChangedOnlyEntity), new Model()).UseEagerSnapshots);
         }
 
         [Fact]
         public void Eager_original_values_are_used_for_enties_that_do_no_notification()
         {
-            Assert.False(new EntityType(typeof(Customer), new Model()).UseLazyOriginalValues);
+            Assert.True(new EntityType(typeof(Customer), new Model()).UseEagerSnapshots);
         }
 
         [Fact]
         public void Lazy_original_values_can_be_switched_off()
         {
-            Assert.False(new EntityType(typeof(FullNotificationEntity), new Model()) { UseLazyOriginalValues = false }.UseLazyOriginalValues);
+            Assert.False(new EntityType(typeof(FullNotificationEntity), new Model()) { UseEagerSnapshots = false }.UseEagerSnapshots);
         }
 
         [Fact]
         public void Lazy_original_values_can_be_switched_on_but_only_if_entity_does_not_require_eager_values()
         {
-            var entityType = new EntityType(typeof(FullNotificationEntity), new Model()) { UseLazyOriginalValues = false };
-            entityType.UseLazyOriginalValues = true;
-            Assert.True(entityType.UseLazyOriginalValues);
+            var entityType = new EntityType(typeof(FullNotificationEntity), new Model()) { UseEagerSnapshots = true };
+            entityType.UseEagerSnapshots = false;
+            Assert.False(entityType.UseEagerSnapshots);
 
             Assert.Equal(
                 Strings.EagerOriginalValuesRequired(typeof(ChangedOnlyEntity).FullName),
-                Assert.Throws<InvalidOperationException>(() => new EntityType(typeof(ChangedOnlyEntity), new Model()) { UseLazyOriginalValues = true }).Message);
+                Assert.Throws<InvalidOperationException>(() => new EntityType(typeof(ChangedOnlyEntity), new Model()) { UseEagerSnapshots = false }).Message);
         }
 
         [Fact]
         public void All_properties_have_original_value_indexes_when_using_eager_original_values()
         {
-            var entityType = new EntityType(typeof(FullNotificationEntity), new Model()) { UseLazyOriginalValues = false };
+            var entityType = new EntityType(typeof(FullNotificationEntity), new Model()) { UseEagerSnapshots = true };
 
             entityType.GetOrAddProperty("Name", typeof(string));
             entityType.GetOrAddProperty("Id", typeof(int));


### PR DESCRIPTION
The logic around when to snapshot original values was written before a lot of the relationship fixup and DetectChanges code. These changes revisit that code to improve and test the logic for determined if and when snapshots are required.

We make eager snapshots (as soon as the entity is tracked) for original values and relationship properties and navigations when the entity does not implement INotifyPropertyChanging. In addition, we take a collection snapshot for any collection that does not implement INotifyCollectionChanged. However, since INotifyCollectionChanged is not actually supported yet we currently treat all collections as if they do not implement this interface. See issue #445.

DetectChanges is needed for any entity that does not implement INotifyPropertyChanged, and also if an entity has a collection that does not implement INotifyCollectionChanged. As above, it is currently assumed that no collection does because of issue #445.