### PR TITLE
supported "Contains" method of string in Where clause.

### DIFF
--- a/src/EntityFramework.Relational/EntityFramework.Relational.csproj
+++ b/src/EntityFramework.Relational/EntityFramework.Relational.csproj
@@ -169,6 +169,7 @@
     <Compile Include="Query\IncludeCollectionIterator.cs" />
     <Compile Include="Query\ExpressionTreeVisitors\QueryFlatteningExpressionTreeVisitor.cs" />
     <Compile Include="Query\ExpressionTreeVisitors\IncludeReferenceExpressionTreeVisitor.cs" />
+    <Compile Include="Query\Methods\ContainsTranslator.cs" />
     <Compile Include="Query\OffsetValueReaderDecorator.cs" />
     <Compile Include="Query\QueryingEnumerable.cs" />
     <Compile Include="Query\QueryMethodProvider.cs" />

--- a/src/EntityFramework.Relational/Query/Methods/CompositeMethodCallTranslator.cs
+++ b/src/EntityFramework.Relational/Query/Methods/CompositeMethodCallTranslator.cs
@@ -11,7 +11,8 @@ namespace Microsoft.Data.Entity.Relational.Query.Methods
         {
             return new EqualsTranslator().Translate(methodCallExpression)
                    ?? new StartsWithTranslator().Translate(methodCallExpression)
-                   ?? new EndsWithTranslator().Translate(methodCallExpression);
-        }
+                   ?? new EndsWithTranslator().Translate(methodCallExpression)
+                   ?? new ContainsTranslator().Translate(methodCallExpression);
+		}
     }
 }

--- a/src/EntityFramework.Relational/Query/Methods/ContainsTranslator.cs
+++ b/src/EntityFramework.Relational/Query/Methods/ContainsTranslator.cs
@@ -1,0 +1,27 @@
+﻿using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.Data.Entity.Relational.Query.Expressions;
+
+namespace Microsoft.Data.Entity.Relational.Query.Methods
+{
+    public class ContainsTranslator : IMethodCallTranslator
+    {
+        private static readonly MethodInfo _methodInfo
+            = typeof(string).GetRuntimeMethod("Contains", new[] { typeof(string) });
+
+        private static readonly MethodInfo _concat
+            = typeof(string).GetRuntimeMethod("Concat", new[] { typeof(string), typeof(string) });
+
+        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        {
+            if (ReferenceEquals(methodCallExpression.Method, _methodInfo))
+            {
+                var pattern = Expression.Add(new LiteralExpression("%"), methodCallExpression.Arguments[0], _concat);
+                pattern = Expression.Add(pattern, new LiteralExpression("%"), _concat);
+                return new LikeExpression(methodCallExpression.Object, pattern);
+            }
+
+            return null;
+        }
+    }
+}

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerQueryTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerQueryTest.cs
@@ -1275,6 +1275,60 @@ WHERE [c].[ContactName] LIKE '%' + @p0",
                 Sql);
         }
 
+        public override void String_Contains_Literal()
+        {
+            //base.String_Contains_Literal();
+
+            AssertQuery<Customer>(
+                cs => cs.Where(c => c.ContactName.Contains("M")), // case-insensitive
+                cs => cs.Where(c => c.ContactName.Contains("M") || c.ContactName.Contains("m")), // case-sensitive
+                stateEntryCount: 34);
+
+            Assert.Equal(
+                @"SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[ContactName] LIKE '%' + @p0 + '%'",
+                Sql);
+        }
+
+        public override void String_Contains_Identity()
+        {
+            base.String_Contains_Identity();
+
+            Assert.Equal(
+                @"SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[ContactName] LIKE '%' + [c].[ContactName] + '%'",
+                Sql);
+        }
+
+        public override void String_Contains_Column()
+        {
+            base.String_Contains_Column();
+
+            Assert.Equal(
+                @"SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[ContactName] LIKE '%' + [c].[ContactName] + '%'",
+                Sql);
+        }
+
+        public override void String_Contains_MethodCall()
+        {
+            //base.String_Contains_MethodCall();
+
+            AssertQuery<Customer>(
+                cs => cs.Where(c => c.ContactName.Contains(LocalMethod1())), // case-insensitive
+                cs => cs.Where(c => c.ContactName.Contains(LocalMethod1()) || c.ContactName.Contains(LocalMethod2())), // case-sensitive
+                stateEntryCount: 34);
+
+            Assert.Equal(
+                @"SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[ContactName] LIKE '%' + @p0 + '%'",
+                Sql);
+        }
+
         public override void Select_nested_collection()
         {
             base.Select_nested_collection();


### PR DESCRIPTION
This is the pull request for #1353.

now we can get all customers whose contact name contains "M" in Northwind database.
We can write `var query = northwindDbContext.Customers.Where(c => c.ContactName.Contains("M"));` and EF will generate SQL statement ` WHERE ContactName LIKE '%' + 'M' + '%'`

@maumar - In order to minimize the modifications of test classes, I added the overload of AssertQuery you mentioned as well as overriding test methods in SqlServerQueryTest class. Please let me know if the modifications of test classes are acceptable. Thank you.