### PR TITLE
Fix to issue 1362 - multi level include may produce invalid SQL

### DIFF
--- a/test/EntityFramework.Core.FunctionalTests/EntityFramework.Core.FunctionalTests.csproj
+++ b/test/EntityFramework.Core.FunctionalTests/EntityFramework.Core.FunctionalTests.csproj
@@ -78,6 +78,8 @@
     <Compile Include="BuiltInDataTypesFixtureBase.cs" />
     <Compile Include="BuiltInDataTypesTestBase.cs" />
     <Compile Include="FixupTest.cs" />
+    <Compile Include="GearsOfWarQueryFixtureBase.cs" />
+    <Compile Include="GearsOfWarQueryTestBase.cs" />
     <Compile Include="IncludeAsyncTestBase.cs" />
     <Compile Include="IncludeOneToOneTestBase.cs" />
     <Compile Include="IncludeTestBase.cs" />

--- a/test/EntityFramework.Core.FunctionalTests/GearsOfWarQueryFixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/GearsOfWarQueryFixtureBase.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel;
+
+namespace Microsoft.Data.Entity.FunctionalTests
+{
+    public abstract class GearsOfWarQueryFixtureBase<TTestStore>
+            where TTestStore : TestStore
+    {
+        public abstract TTestStore CreateTestStore();
+
+        public abstract GearsOfWarContext CreateContext(TTestStore testStore);
+
+        protected virtual void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<City>().Key(c => c.Name);
+            modelBuilder.Entity<City>().OneToMany(c => c.StationedGears, g => g.AssignedCity).Required(false);
+
+            modelBuilder.Entity<Gear>(b =>
+            {
+                b.Key(g => new { g.Nickname, g.SquadId });
+                b.ManyToOne(g => g.CityOfBirth, c => c.BornGears).ForeignKey(g => g.CityOrBirthName).Required(true);
+                b.OneToMany(g => g.Reports).ForeignKey(g => new { g.LeaderNickname, g.LeaderSquadId });
+                b.OneToOne(g => g.Tag, t => t.Gear).ForeignKey<CogTag>(t => new { t.GearNickName, t.GearSquadId });
+            });
+
+            modelBuilder.Entity<CogTag>(b =>
+            {
+                b.Key(t => t.Id);
+                b.Property(t => t.Id).GenerateValueOnAdd();
+            });
+
+            modelBuilder.Entity<Squad>(b =>
+            {
+                b.Key(s => s.Id);
+                b.OneToMany(s => s.Members, g => g.Squad).ForeignKey(g => g.SquadId);
+                b.Property(t => t.Id).GenerateValueOnAdd();
+            });
+
+            modelBuilder.Entity<Weapon>(b =>
+            {
+                b.OneToOne(w => w.SynergyWith).ForeignKey<Weapon>(w => w.SynergyWithId);
+                b.ManyToOne(w => w.Owner, g => g.Weapons).ForeignKey(w => new { w.OwnerNickname, w.OwnerSquadId });
+            });
+        }
+    }
+}

--- a/test/EntityFramework.Core.FunctionalTests/GearsOfWarQueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/GearsOfWarQueryTestBase.cs
@@ -1,0 +1,127 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel;
+using Xunit;
+
+namespace Microsoft.Data.Entity.FunctionalTests
+{
+    public abstract class GearsOfWarQueryTestBase<TTestStore, TFixture> : IClassFixture<TFixture>, IDisposable
+        where TTestStore : TestStore
+        where TFixture : GearsOfWarQueryFixtureBase<TTestStore>, new()
+    {
+        protected GearsOfWarContext CreateContext()
+        {
+            return Fixture.CreateContext(TestStore);
+        }
+
+        protected GearsOfWarQueryTestBase(TFixture fixture)
+        {
+            Fixture = fixture;
+
+            TestStore = Fixture.CreateTestStore();
+        }
+
+        protected TFixture Fixture { get; private set; }
+
+        protected TTestStore TestStore { get; private set; }
+
+        public void Dispose()
+        {
+            TestStore.Dispose();
+        }
+
+        [Fact]
+        public virtual void Include_multiple_one_to_one_and_one_to_many()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Tags.Include(t => t.Gear.Weapons);
+                var result = query.ToList();
+
+                Assert.Equal(6, result.Count);
+
+                var gears = result.Select(t => t.Gear).Where(g => g != null).ToList();
+                Assert.Equal(5, gears.Count);
+
+                Assert.True(gears.All(g => g.Weapons.Any()));
+            }
+        }
+
+        [Fact]
+        public virtual void Include_multiple_one_to_one_and_one_to_many_self_reference()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Tags.Include(t => t.Gear.Reports);
+                var result = query.ToList();
+
+                Assert.Equal(6, result.Count);
+
+                var gears = result.Select(t => t.Gear).Where(g => g != null).ToList();
+                Assert.Equal(5, gears.Count);
+
+                Assert.True(gears.All(g => g.Reports != null));
+            }
+        }
+
+        // blocked by issue #1393
+        ////[Fact]
+        public virtual void Include_multiple_one_to_one_optional_and_one_to_one_required()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Tags.Include(t => t.Gear.Squad);
+                var result = query.ToList();
+
+                Assert.Equal(6, result.Count);
+            }
+        }
+
+        // blocked by issue #1393
+        ////[Fact]
+        public virtual void Include_multiple_one_to_one_and_one_to_one_and_one_to_many()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Tags.Include(t => t.Gear.Squad.Members);
+                var result = query.ToList();
+
+                Assert.Equal(6, result.Count);
+            }
+        }
+
+
+        [Fact]
+        public virtual void Include_multiple_circular()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Gears.Include(g => g.CityOfBirth.StationedGears);
+                var result = query.ToList();
+
+                Assert.Equal(5, result.Count);
+
+                var cities = result.Select(g => g.CityOfBirth);
+                Assert.True(cities.All(c => c != null));
+                Assert.True(cities.All(c => c.BornGears != null));
+            }
+        }
+
+        [Fact]
+        public virtual void Include_multiple_circular_with_filter()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Gears.Include(g => g.CityOfBirth.StationedGears).Where(g => g.Nickname == "Marcus");
+                var result = query.ToList();
+
+                Assert.Equal(1, result.Count);
+                Assert.Equal("Jacinto", result.Single().CityOfBirth.Name);
+                Assert.Equal(2, result.Single().CityOfBirth.StationedGears.Count);
+            }
+        }
+    }
+}

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/GearsOfWarModel/City.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/GearsOfWarModel/City.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+
 namespace Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel
 {
     public class City
@@ -8,5 +10,8 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel
         // non-integer key with not conventional name
         public string Name { get; set; }
         public string Location { get; set; }
+
+        public List<Gear> BornGears { get; set; }
+        public List<Gear> StationedGears { get; set; }
     }
 }

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/GearsOfWarModel/Gear.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/GearsOfWarModel/Gear.cs
@@ -22,6 +22,8 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel
         public string CityOrBirthName { get; set; }
         public virtual City CityOfBirth { get; set; }
 
+        public virtual City AssignedCity { get; set; }
+
         public MilitaryRank Rank { get; set; }
 
         public virtual CogTag Tag { get; set; }

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/GearsOfWarModel/GearsOfWarContext.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/GearsOfWarModel/GearsOfWarContext.cs
@@ -8,6 +8,8 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel
 {
     public class GearsOfWarContext : DbContext
     {
+        public static readonly string StoreName = "GearsOfWar";
+
         public GearsOfWarContext(IServiceProvider serviceProvider, DbContextOptions options)
             : base(serviceProvider, options)
         {
@@ -18,37 +20,5 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel
         public DbSet<CogTag> Tags { get; set; }
         public DbSet<Weapon> Weapons { get; set; }
         public DbSet<City> Cities { get; set; }
-
-        protected override void OnModelCreating(ModelBuilder builder)
-        {
-            builder.Entity<City>().Key(c => c.Name);
-
-            builder.Entity<Gear>(b =>
-                {
-                    b.Key(g => new { g.Nickname, g.SquadId });
-                    b.ManyToOne(g => g.CityOfBirth).ForeignKey(g => g.CityOrBirthName);
-                    b.OneToMany(g => g.Reports).ForeignKey(g => new { g.LeaderNickname, g.LeaderSquadId });
-                    b.OneToOne(g => g.Tag, t => t.Gear).ForeignKey<CogTag>(t => new { t.GearNickName, t.GearSquadId });
-                });
-
-            builder.Entity<CogTag>(b =>
-                {
-                    b.Key(t => t.Id);
-                    b.Property(t => t.Id).GenerateValueOnAdd();
-                });
-
-            builder.Entity<Squad>(b =>
-                {
-                    b.Key(s => s.Id);
-                    b.OneToMany(s => s.Members, g => g.Squad).ForeignKey(g => g.SquadId);
-                    b.Property(t => t.Id).GenerateValueOnAdd();
-                });
-
-            builder.Entity<Weapon>(b =>
-                {
-                    b.OneToOne(w => w.SynergyWith).ForeignKey<Weapon>(w => w.SynergyWithId);
-                    b.ManyToOne(w => w.Owner, g => g.Weapons).ForeignKey(w => new { w.OwnerNickname, w.OwnerSquadId });
-                });
-        }
     }
 }

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/GearsOfWarModel/GearsOfWarModelInitializer.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/GearsOfWarModel/GearsOfWarModelInitializer.cs
@@ -53,9 +53,16 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel
                     Name = "Hanover",
                 };
 
+                var unknown = new City
+                {
+                    Location = "Unknown",
+                    Name = "Unknown",
+                };
+
                 await context.Cities.AddAsync(jacinto);
                 await context.Cities.AddAsync(ephyra);
                 await context.Cities.AddAsync(hanover);
+                await context.Cities.AddAsync(unknown);
 
                 await context.SaveChangesAsync();
 
@@ -166,6 +173,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel
                     FullName = "Dominic Santiago",
                     SquadId = deltaSquad.Id,
                     Rank = MilitaryRank.Corporal,
+                    AssignedCity = ephyra,
                     CityOrBirthName = ephyra.Name,
                     Tag = domsTag,
                     Reports = new List<Gear>(),
@@ -179,6 +187,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel
                     SquadId = deltaSquad.Id,
                     Rank = MilitaryRank.Private,
                     CityOrBirthName = hanover.Name,
+                    AssignedCity = jacinto,
                     Tag = colesTag,
                     Reports = new List<Gear>(),
                     Weapons = new List<Weapon> { colesGnasher, colesMulcher }
@@ -190,6 +199,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel
                     FullName = "Garron Paduk",
                     SquadId = kiloSquad.Id,
                     Rank = MilitaryRank.Private,
+                    CityOrBirthName = unknown.Name,
                     Tag = paduksTag,
                     Reports = new List<Gear>(),
                     Weapons = new List<Weapon> { paduksMarkza },
@@ -201,6 +211,8 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel
                     FullName = "Damon Baird",
                     SquadId = deltaSquad.Id,
                     Rank = MilitaryRank.Corporal,
+                    CityOrBirthName = unknown.Name,
+                    AssignedCity = jacinto,
                     Tag = bairdsTag,
                     Reports = new List<Gear>() { paduk },
                     Weapons = new List<Weapon> { bairdsLancer, bairdsGnasher }

--- a/test/EntityFramework.Relational.FunctionalTests/EntityFramework.Relational.FunctionalTests.csproj
+++ b/test/EntityFramework.Relational.FunctionalTests/EntityFramework.Relational.FunctionalTests.csproj
@@ -71,6 +71,7 @@
     <Compile Include="MappingQueryTestBase.cs" />
     <Compile Include="MappingQueryFixtureBase.cs" />
     <Compile Include="RelationalF1Fixture.cs" />
+    <Compile Include="RelationalGearsOfWarQueryFixture.cs" />
     <Compile Include="RelationalNorthwindQueryFixture.cs" />
     <Compile Include="RelationalTestStore.cs" />
     <Compile Include="TestSqlLoggerFactory.cs" />

--- a/test/EntityFramework.Relational.FunctionalTests/RelationalGearsOfWarQueryFixture.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/RelationalGearsOfWarQueryFixture.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Data.Entity.Metadata;
+
+namespace Microsoft.Data.Entity.Relational.FunctionalTests
+{
+    public abstract class RelationalGearsOfWarQueryFixture<TTestStore> : GearsOfWarQueryFixtureBase<TTestStore>
+        where TTestStore : TestStore
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+        }
+    }
+}

--- a/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
+++ b/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
@@ -87,6 +87,8 @@
     <Compile Include="SqlServerChangeTrackingTest.cs" />
     <Compile Include="SqlServerF1Fixture.cs" />
     <Compile Include="SqlServerFixture.cs" />
+    <Compile Include="SqlServerGearsOfWarQueryFixture.cs" />
+    <Compile Include="SqlServerGearsOfWarQueryTest.cs" />
     <Compile Include="SqlServerIncludeAsyncTest.cs" />
     <Compile Include="SqlServerIncludeOneToOneTest.cs" />
     <Compile Include="SqlServerIncludeTest.cs" />

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerGearsOfWarQueryFixture.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerGearsOfWarQueryFixture.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Relational.FunctionalTests;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.DependencyInjection.Fallback;
+using Microsoft.Framework.Logging;
+
+namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
+{
+    public class SqlServerGearsOfWarQueryFixture : RelationalGearsOfWarQueryFixture<SqlServerTestStore>
+    {
+        public static readonly string DatabaseName = "GearsOfWarQueryTest";
+
+        private readonly IServiceProvider _serviceProvider;
+
+        private readonly string _connectionString = SqlServerTestStore.CreateConnectionString(DatabaseName);
+
+        public SqlServerGearsOfWarQueryFixture()
+        {
+            _serviceProvider = new ServiceCollection()
+                .AddEntityFramework()
+                .AddSqlServer()
+                .ServiceCollection
+                .AddTestModelSource(OnModelCreating)
+                .AddInstance<ILoggerFactory>(new TestSqlLoggerFactory())
+                .BuildServiceProvider();
+        }
+
+        public override SqlServerTestStore CreateTestStore()
+        {
+            return SqlServerTestStore.GetOrCreateSharedAsync(DatabaseName, async () =>
+            {
+                var options = new DbContextOptions();
+                options.UseSqlServer(_connectionString);
+
+                using (var context = new GearsOfWarContext(_serviceProvider, options))
+                {
+                    if (await context.Database.EnsureCreatedAsync())
+                    {
+                        await GearsOfWarModelInitializer.SeedAsync(context);
+                    }
+                }
+            }).Result;
+        }
+
+        public override GearsOfWarContext CreateContext(SqlServerTestStore testStore)
+        {
+            var options = new DbContextOptions();
+            options.UseSqlServer(testStore.Connection);
+
+            var context = new GearsOfWarContext(_serviceProvider, options);
+            context.Database.AsRelational().Connection.UseTransaction(testStore.Transaction);
+            return context;
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.ForSqlServer().UseSequence();
+        }
+    }
+}
+

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerGearsOfWarQueryTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerGearsOfWarQueryTest.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Data.Entity.Relational.FunctionalTests;
+using Xunit;
+
+namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
+{
+    public class SqlServerGearsOfWarQueryTest : GearsOfWarQueryTestBase<SqlServerTestStore, SqlServerGearsOfWarQueryFixture>
+    {
+        public SqlServerGearsOfWarQueryTest(SqlServerGearsOfWarQueryFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        public override void Include_multiple_one_to_one_and_one_to_many()
+        {
+            base.Include_multiple_one_to_one_and_one_to_many();
+
+            Assert.EndsWith(
+@"SELECT [w].[Id], [w].[Name], [w].[OwnerNickname], [w].[OwnerSquadId], [w].[SynergyWithId]
+FROM [Weapon] AS [w]
+INNER JOIN (
+    SELECT DISTINCT [t].[Id], [g].[Nickname], [g].[SquadId]
+    FROM [CogTag] AS [t]
+    LEFT JOIN [Gear] AS [g] ON ([t].[GearNickName] = [g].[Nickname] AND [t].[GearSquadId] = [g].[SquadId])
+) AS [t] ON ([w].[OwnerNickname] = [t].[Nickname] AND [w].[OwnerSquadId] = [t].[SquadId])
+ORDER BY [t].[Id]", Sql);
+        }
+
+        public override void Include_multiple_one_to_one_and_one_to_many_self_reference()
+        {
+            base.Include_multiple_one_to_one_and_one_to_many_self_reference();
+
+            Assert.EndsWith(
+@"SELECT [g].[AssignedCityId], [g].[CityOrBirthName], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Nickname], [g].[Rank], [g].[SquadId]
+FROM [Gear] AS [g]
+INNER JOIN (
+    SELECT DISTINCT [t].[Id], [g].[Nickname], [g].[SquadId]
+    FROM [CogTag] AS [t]
+    LEFT JOIN [Gear] AS [g] ON ([t].[GearNickName] = [g].[Nickname] AND [t].[GearSquadId] = [g].[SquadId])
+) AS [t] ON ([g].[LeaderNickname] = [t].[Nickname] AND [g].[LeaderSquadId] = [t].[SquadId])
+ORDER BY [t].[Id]", Sql);
+        }
+
+        public override void Include_multiple_one_to_one_and_one_to_one_and_one_to_many()
+        {
+            base.Include_multiple_one_to_one_and_one_to_one_and_one_to_many();
+
+            Assert.EndsWith(
+@"SELECT [g].[AssignedCityId], [g].[CityOrBirthName], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Nickname], [g].[Rank], [g].[SquadId]
+FROM [Gear] AS [g]
+INNER JOIN (
+    SELECT DISTINCT [t].[Id], [s].[Id] AS [Id0]
+    FROM [CogTag] AS [t]
+    LEFT JOIN [Gear] AS [g] ON ([t].[GearNickName] = [g].[Nickname] AND [t].[GearSquadId] = [g].[SquadId])
+    INNER JOIN [Squad] AS [s] ON [g].[SquadId] = [s].[Id]
+) AS [t] ON [g].[SquadId] = [t].[Id0]
+ORDER BY [t].[Id]", Sql);
+        }
+
+        public override void Include_multiple_circular()
+        {
+            base.Include_multiple_circular();
+
+            Assert.EndsWith(
+@"TBD", Sql);
+        }
+
+        public override void Include_multiple_circular_with_filter()
+        {
+            base.Include_multiple_circular_with_filter();
+
+            Assert.EndsWith(
+@"TBD", Sql);
+        }
+
+        private static string Sql
+        {
+            get { return TestSqlLoggerFactory.Sql; }
+        }
+    }
+}


### PR DESCRIPTION
In some cases of multi level include we would try to project columns from two tables, which may lead to invalid queries if those properties happen to have the same name. Fix is to uniquefy the columns using projection aliases where necessary (if the affected subquery it itself aliased).

Also, in case of aliasing we can no longer rely on column names when building join equality expressions - instead we extract the projected columns and use their alias when applicable, rather than original column name.

@anpete 