### PR TITLE
[SMALL] Allow SQL Specific config after UseSqlServer

### DIFF
--- a/src/EntityFramework.Relational/EntityFramework.Relational.csproj
+++ b/src/EntityFramework.Relational/EntityFramework.Relational.csproj
@@ -204,6 +204,7 @@
     <Compile Include="RelationalDatabase.cs" />
     <Compile Include="RelationalDatabaseExtensions.cs" />
     <Compile Include="RelationalDataStoreCreator.cs" />
+    <Compile Include="RelationalDbContextOptions.cs" />
     <Compile Include="RelationalMetadataExtensions.cs" />
     <Compile Include="RelationalOptionsExtension.cs" />
     <Compile Include="RelationalConnection.cs" />

--- a/src/EntityFramework.Relational/RelationalDbContextOptions.cs
+++ b/src/EntityFramework.Relational/RelationalDbContextOptions.cs
@@ -1,0 +1,26 @@
+﻿// Copyright(c) Microsoft Open Technologies, Inc.All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.SqlServer.Extensions
+{
+    public class RelationalDbContextOptions
+    {
+        private readonly DbContextOptions _options;
+
+        public RelationalDbContextOptions([NotNull] DbContextOptions options)
+        {
+            Check.NotNull(options, "options");
+
+            _options = options;
+        }
+
+        protected DbContextOptions Options
+        {
+            get { return _options; }
+        }
+    }
+}

--- a/src/EntityFramework.SqlServer/EntityFramework.SqlServer.csproj
+++ b/src/EntityFramework.SqlServer/EntityFramework.SqlServer.csproj
@@ -59,6 +59,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.tt</DependentUpon>
     </Compile>
+    <Compile Include="Extensions\SqlServerDbContextOptions.cs" />
     <Compile Include="Metadata\ISqlServerEntityTypeExtensions.cs" />
     <Compile Include="Metadata\ISqlServerForeignKeyExtensions.cs" />
     <Compile Include="Metadata\ISqlServerIndexExtensions.cs" />

--- a/src/EntityFramework.SqlServer/Extensions/SqlServerDbContextOptions.cs
+++ b/src/EntityFramework.SqlServer/Extensions/SqlServerDbContextOptions.cs
@@ -1,0 +1,23 @@
+﻿// Copyright(c) Microsoft Open Technologies, Inc.All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
+
+namespace Microsoft.Data.Entity.SqlServer.Extensions
+{
+    public class SqlServerDbContextOptions : RelationalDbContextOptions
+    {
+        public SqlServerDbContextOptions([NotNull] DbContextOptions options)
+            : base(options)
+        { }
+
+        public virtual SqlServerDbContextOptions MaxBatchSize(int maxBatchSize)
+        {
+            ((IDbContextOptions)Options)
+                .AddOrUpdateExtension<SqlServerOptionsExtension>(x => x.MaxBatchSize = maxBatchSize);
+
+            return this;
+        }
+    }
+}

--- a/src/EntityFramework.SqlServer/Extensions/SqlServerDbContextOptionsExtensions.cs
+++ b/src/EntityFramework.SqlServer/Extensions/SqlServerDbContextOptionsExtensions.cs
@@ -6,6 +6,7 @@ using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.SqlServer;
 using Microsoft.Data.Entity.Utilities;
+using Microsoft.Data.Entity.SqlServer.Extensions;
 
 // ReSharper disable once CheckNamespace
 
@@ -13,42 +14,48 @@ namespace Microsoft.Data.Entity
 {
     public static class SqlServerDbContextOptionsExtensions
     {
-        public static void UseSqlServer([NotNull] this DbContextOptions options)
+        public static SqlServerDbContextOptions UseSqlServer([NotNull] this DbContextOptions options)
         {
             Check.NotNull(options, "options");
 
             ((IDbContextOptions)options)
                 .AddOrUpdateExtension<SqlServerOptionsExtension>(x => { });
+
+            return new SqlServerDbContextOptions(options);
         }
 
-        public static void UseSqlServer([NotNull] this DbContextOptions options, [NotNull] string connectionString)
+        public static SqlServerDbContextOptions UseSqlServer([NotNull] this DbContextOptions options, [NotNull] string connectionString)
         {
             Check.NotNull(options, "options");
             Check.NotEmpty(connectionString, "connectionString");
 
             ((IDbContextOptions)options)
                 .AddOrUpdateExtension<SqlServerOptionsExtension>(x => x.ConnectionString = connectionString);
+
+            return new SqlServerDbContextOptions(options);
         }
 
-        public static void UseSqlServer<T>([NotNull] this DbContextOptions<T> options, [NotNull] string connectionString)
+        public static SqlServerDbContextOptions UseSqlServer<T>([NotNull] this DbContextOptions<T> options, [NotNull] string connectionString)
         {
-            UseSqlServer((DbContextOptions)options, connectionString);
+            return UseSqlServer((DbContextOptions)options, connectionString);
         }
 
         // Note: Decision made to use DbConnection not SqlConnection: Issue #772
-        public static void UseSqlServer([NotNull] this DbContextOptions options, [NotNull] DbConnection connection)
+        public static SqlServerDbContextOptions UseSqlServer([NotNull] this DbContextOptions options, [NotNull] DbConnection connection)
         {
             Check.NotNull(options, "options");
             Check.NotNull(connection, "connection");
 
             ((IDbContextOptions)options)
                 .AddOrUpdateExtension<SqlServerOptionsExtension>(x => x.Connection = connection);
+
+            return new SqlServerDbContextOptions(options);
         }
 
         // Note: Decision made to use DbConnection not SqlConnection: Issue #772
-        public static void UseSqlServer<T>([NotNull] this DbContextOptions<T> options, [NotNull] DbConnection connection)
+        public static SqlServerDbContextOptions UseSqlServer<T>([NotNull] this DbContextOptions<T> options, [NotNull] DbConnection connection)
         {
-            UseSqlServer((DbContextOptions)options, connection);
+            return UseSqlServer((DbContextOptions)options, connection);
         }
     }
 }

--- a/test/EntityFramework.SqlServer.Tests/EntityFramework.SqlServer.Tests.csproj
+++ b/test/EntityFramework.SqlServer.Tests/EntityFramework.SqlServer.Tests.csproj
@@ -81,6 +81,7 @@
     <Compile Include="SqlServerDataStoreCreatorTest.cs" />
     <Compile Include="SqlServerDbContextOptionsExtensionsTest.cs" />
     <Compile Include="SqlServerDatabaseExtensionsTest.cs" />
+    <Compile Include="SqlServerDbContextOptionsTest.cs" />
     <Compile Include="SqlServerMigrationOperationPreProcessorTest.cs" />
     <Compile Include="SqlServerModelDifferTest.cs" />
     <Compile Include="SqlServerOptionsExtensionTest.cs" />

--- a/test/EntityFramework.SqlServer.Tests/SqlServerDbContextOptionsTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerDbContextOptionsTest.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Linq;
+using Microsoft.Data.Entity.Infrastructure;
+using Xunit;
+
+namespace Microsoft.Data.Entity.SqlServer.Tests
+{
+    public class SqlServerDbContextOptionsTest
+    {
+        [Fact]
+        public void Can_add_extension_with_max_batch_size()
+        {
+            var options = new DbContextOptions();
+            options.UseSqlServer().MaxBatchSize(123);
+
+            var extension = ((IDbContextOptions)options).Extensions.OfType<SqlServerOptionsExtension>().Single();
+
+            Assert.Equal(123, extension.MaxBatchSize);
+        }
+    }
+}


### PR DESCRIPTION
Adding a SQL Server specific return type from UseSqlServer that allows setting things specific to SqlServerOptionsExtension
Introducing a relational base class that isn't used yet but will be used for CommandTimeout shortly