### PR TITLE
Apples

### DIFF
--- a/test/EntityFramework.Microbenchmarks.EF6/ChangeTracker/DbSetOperationTests.cs
+++ b/test/EntityFramework.Microbenchmarks.EF6/ChangeTracker/DbSetOperationTests.cs
@@ -23,26 +23,41 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
                 TestName = "ChangeTracker_DbSetOperation_Add_EF6",
                 IterationCount = 100,
                 WarmupCount = 5,
-                Run = harness =>
-                {
-                    using (var context = new OrdersContext(_connectionString))
-                    {
-                        var customers = new Customer[1000];
-                        for (int i = 0; i < customers.Length; i++)
-                        {
-                            customers[i] = new Customer { Name = "Customer " + i };
-                        }
+                Run = harness => Add(harness, true)
+            }.RunTest();
+        }
 
-                        using (harness.StartCollection())
-                        {
-                            foreach (var customer in customers)
-                            {
-                                context.Customers.Add(customer);
-                            }
-                        }
+        [Fact]
+        public void Add_AutoDetectChangesDisabled()
+        {
+            new TestDefinition
+            {
+                TestName = "ChangeTracker_DbSetOperation_Add_AutoDetectChangesDisabled_EF6",
+                IterationCount = 100,
+                WarmupCount = 5,
+                Run = harness => Add(harness, false)
+            }.RunTest();
+        }
+
+        public void Add(TestHarness harness, bool autoDetectChanges)
+        {
+            using (var context = new OrdersContext(_connectionString))
+            {
+                var customers = new Customer[1000];
+                for (int i = 0; i < customers.Length; i++)
+                {
+                    customers[i] = new Customer { Name = "Customer " + i };
+                }
+
+                context.Configuration.AutoDetectChangesEnabled = autoDetectChanges;
+                using (harness.StartCollection())
+                {
+                    foreach (var customer in customers)
+                    {
+                        context.Customers.Add(customer);
                     }
                 }
-            }.RunTest();
+            }
         }
 
         [Fact]
@@ -81,23 +96,39 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
                 IterationCount = 100,
                 WarmupCount = 5,
                 Setup = EnsureDatabaseSetup,
-                Run = harness =>
-                {
-                    using (var context = new OrdersContext(_connectionString))
-                    {
-                        var customers = GetAllCustomersFromDatabase();
-                        Assert.Equal(1000, customers.Length);
+                Run = harness => Attach(harness, true)
+            }.RunTest();
+        }
 
-                        using (harness.StartCollection())
-                        {
-                            foreach (var customer in customers)
-                            {
-                                context.Customers.Attach(customer);
-                            }
-                        }
+        [Fact]
+        public void Attach_AutoDetectChangesDisabled()
+        {
+            new TestDefinition
+            {
+                TestName = "ChangeTracker_DbSetOperation_Attach_AutoDetectChangesDisabled_EF6",
+                IterationCount = 100,
+                WarmupCount = 5,
+                Setup = EnsureDatabaseSetup,
+                Run = harness => Attach(harness, false)
+            }.RunTest();
+        }
+
+        public void Attach(TestHarness harness, bool autoDetectChanges)
+        {
+            using (var context = new OrdersContext(_connectionString))
+            {
+                var customers = GetAllCustomersFromDatabase();
+                Assert.Equal(1000, customers.Length);
+
+                context.Configuration.AutoDetectChangesEnabled = autoDetectChanges;
+                using (harness.StartCollection())
+                {
+                    foreach (var customer in customers)
+                    {
+                        context.Customers.Attach(customer);
                     }
                 }
-            }.RunTest();
+            }
         }
 
         // Note: AttachCollection() not implemented because there is no
@@ -112,23 +143,39 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
                 IterationCount = 100,
                 WarmupCount = 5,
                 Setup = EnsureDatabaseSetup,
-                Run = harness =>
-                {
-                    using (var context = new OrdersContext(_connectionString))
-                    {
-                        var customers = context.Customers.ToArray();
-                        Assert.Equal(1000, customers.Length);
+                Run = harness => Remove(harness, true)
+            }.RunTest();
+        }
 
-                        using (harness.StartCollection())
-                        {
-                            foreach (var customer in customers)
-                            {
-                                context.Customers.Remove(customer);
-                            }
-                        }
+        [Fact]
+        public void Remove_AutoDetectChangesDisabled()
+        {
+            new TestDefinition
+            {
+                TestName = "ChangeTracker_DbSetOperation_Remove_AutoDetectChangesDisabled_EF6",
+                IterationCount = 100,
+                WarmupCount = 5,
+                Setup = EnsureDatabaseSetup,
+                Run = harness => Remove(harness, false)
+            }.RunTest();
+        }
+
+        public void Remove(TestHarness harness, bool autoDetectChanges)
+        {
+            using (var context = new OrdersContext(_connectionString))
+            {
+                var customers = context.Customers.ToArray();
+                Assert.Equal(1000, customers.Length);
+
+                context.Configuration.AutoDetectChangesEnabled = autoDetectChanges;
+                using (harness.StartCollection())
+                {
+                    foreach (var customer in customers)
+                    {
+                        context.Customers.Remove(customer);
                     }
                 }
-            }.RunTest();
+            }
         }
 
         [Fact]
@@ -165,23 +212,39 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
                 IterationCount = 100,
                 WarmupCount = 5,
                 Setup = EnsureDatabaseSetup,
-                Run = harness =>
-                {
-                    using (var context = new OrdersContext(_connectionString))
-                    {
-                        var customers = GetAllCustomersFromDatabase();
-                        Assert.Equal(1000, customers.Length);
+                Run = harness => Update(harness, true)
+            }.RunTest();
+        }
 
-                        using (harness.StartCollection())
-                        {
-                            foreach (var customer in customers)
-                            {
-                                context.Entry(customer).State = EntityState.Modified;
-                            }
-                        }
+        [Fact]
+        public void Update_AutoDetectChangesDisabled()
+        {
+            new TestDefinition
+            {
+                TestName = "ChangeTracker_DbSetOperation_Update_AutoDetectChangesDisabled_EF6",
+                IterationCount = 100,
+                WarmupCount = 5,
+                Setup = EnsureDatabaseSetup,
+                Run = harness => Update(harness, false)
+            }.RunTest();
+        }
+
+        public void Update(TestHarness harness, bool autoDetectChanges)
+        {
+            using (var context = new OrdersContext(_connectionString))
+            {
+                var customers = GetAllCustomersFromDatabase();
+                Assert.Equal(1000, customers.Length);
+
+                context.Configuration.AutoDetectChangesEnabled = autoDetectChanges;
+                using (harness.StartCollection())
+                {
+                    foreach (var customer in customers)
+                    {
+                        context.Entry(customer).State = EntityState.Modified;
                     }
                 }
-            }.RunTest();
+            }
         }
 
         // Note: UpdateCollection() not implemented because there is no

--- a/test/EntityFramework.Microbenchmarks.EF6/Properties/AssemblyInfo.cs
+++ b/test/EntityFramework.Microbenchmarks.EF6/Properties/AssemblyInfo.cs
@@ -37,4 +37,5 @@ using Xunit;
 [assembly: AssemblyFileVersion("1.0.0.0")]
 
 [assembly: TestFramework("EntityFramework.Microbenchmarks.Core.PerfTestFramework", "EntityFramework.Microbenchmarks.Core")]
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
 

--- a/test/EntityFramework.Microbenchmarks/Models/Orders/OrdersContext.cs
+++ b/test/EntityFramework.Microbenchmarks/Models/Orders/OrdersContext.cs
@@ -1,20 +1,21 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
+using EntityFramework.Microbenchmarks.Core.Models.Orders;
 using Microsoft.Data.Entity;
 using Microsoft.Data.Entity.Metadata;
-using EntityFramework.Microbenchmarks.Core.Models.Orders;
 
 namespace EntityFramework.Microbenchmarks.Models.Orders
 {
     public class OrdersContext : DbContext
     {
         private readonly string _connectionString;
+        private readonly bool _disableBatching;
 
-        public OrdersContext(string connectionString)
+        public OrdersContext(string connectionString, bool disableBatching = false)
         {
             _connectionString = connectionString;
+            _disableBatching = disableBatching;
         }
 
         public DbSet<Customer> Customers { get; set; }
@@ -24,7 +25,12 @@ namespace EntityFramework.Microbenchmarks.Models.Orders
 
         protected override void OnConfiguring(DbContextOptions builder)
         {
-            builder.UseSqlServer(_connectionString);
+            var sqlBuilder = builder.UseSqlServer(_connectionString);
+
+            if (_disableBatching)
+            {
+                sqlBuilder.MaxBatchSize(1);
+            }
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/test/EntityFramework.Microbenchmarks/Properties/AssemblyInfo.cs
+++ b/test/EntityFramework.Microbenchmarks/Properties/AssemblyInfo.cs
@@ -40,4 +40,5 @@ using Xunit;
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 [assembly: TestFramework("EntityFramework.Microbenchmarks.Core.PerfTestFramework", "EntityFramework.Microbenchmarks.Core")]
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
 

--- a/test/EntityFramework.Microbenchmarks/UpdatePipeline/SimpleUpdatePipelineTests.cs
+++ b/test/EntityFramework.Microbenchmarks/UpdatePipeline/SimpleUpdatePipelineTests.cs
@@ -6,7 +6,6 @@ using EntityFramework.Microbenchmarks.Core.Models.Orders;
 using EntityFramework.Microbenchmarks.Models.Orders;
 using Microsoft.Data.Entity;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
@@ -24,14 +23,27 @@ namespace EntityFramework.Microbenchmarks.UpdatePipeline
                 TestName = "UpdatePipeline_Simple_Insert",
                 IterationCount = 100,
                 WarmupCount = 5,
-                Run = Insert,
+                Run = harness => Insert(harness, false),
                 Setup = EnsureDatabaseSetup
             }.RunTest();
         }
 
-        private static void Insert(TestHarness harness)
+        [Fact]
+        public void Insert_WithoutBatching()
         {
-            using (var context = new OrdersContext(_connectionString))
+            new TestDefinition
+            {
+                TestName = "UpdatePipeline_Simple_Insert_WithoutBatching",
+                IterationCount = 100,
+                WarmupCount = 5,
+                Run = harness => Insert(harness, true),
+                Setup = EnsureDatabaseSetup
+            }.RunTest();
+        }
+
+        private static void Insert(TestHarness harness, bool disableBatching)
+        {
+            using (var context = new OrdersContext(_connectionString, disableBatching))
             {
                 using (context.Database.AsRelational().Connection.BeginTransaction())
                 {
@@ -57,14 +69,27 @@ namespace EntityFramework.Microbenchmarks.UpdatePipeline
                 TestName = "UpdatePipeline_Simple_Update",
                 IterationCount = 100,
                 WarmupCount = 5,
-                Run = Update,
+                Run = harness => Insert(harness, false),
                 Setup = EnsureDatabaseSetup
             }.RunTest();
         }
 
-        private static void Update(TestHarness harness)
+        [Fact]
+        public void Update_WithoutBatching()
         {
-            using (var context = new OrdersContext(_connectionString))
+            new TestDefinition
+            {
+                TestName = "UpdatePipeline_Simple_Update_WithoutBatching",
+                IterationCount = 100,
+                WarmupCount = 5,
+                Run = harness => Insert(harness, true),
+                Setup = EnsureDatabaseSetup
+            }.RunTest();
+        }
+
+        private static void Update(TestHarness harness, bool disableBatching)
+        {
+            using (var context = new OrdersContext(_connectionString, disableBatching))
             {
                 using (context.Database.AsRelational().Connection.BeginTransaction())
                 {
@@ -90,14 +115,27 @@ namespace EntityFramework.Microbenchmarks.UpdatePipeline
                 TestName = "UpdatePipeline_Simple_Delete",
                 IterationCount = 100,
                 WarmupCount = 5,
-                Run = Delete,
+                Run = harness => Insert(harness, false),
                 Setup = EnsureDatabaseSetup
             }.RunTest();
         }
 
-        private static void Delete(TestHarness harness)
+        [Fact]
+        public void Delete_WithoutBatching()
         {
-            using (var context = new OrdersContext(_connectionString))
+            new TestDefinition
+            {
+                TestName = "UpdatePipeline_Simple_Delete_WithoutBatching",
+                IterationCount = 100,
+                WarmupCount = 5,
+                Run = harness => Insert(harness, true),
+                Setup = EnsureDatabaseSetup
+            }.RunTest();
+        }
+
+        private static void Delete(TestHarness harness, bool disableBatching)
+        {
+            using (var context = new OrdersContext(_connectionString, disableBatching))
             {
                 using (context.Database.AsRelational().Connection.BeginTransaction())
                 {
@@ -123,14 +161,27 @@ namespace EntityFramework.Microbenchmarks.UpdatePipeline
                 TestName = "UpdatePipeline_Simple_Mixed",
                 IterationCount = 100,
                 WarmupCount = 5,
-                Run = Mixed,
+                Run = harness => Insert(harness, false),
                 Setup = EnsureDatabaseSetup
             }.RunTest();
         }
 
-        private static void Mixed(TestHarness harness)
+        [Fact]
+        public void Mixed_WithoutBatching()
         {
-            using (var context = new OrdersContext(_connectionString))
+            new TestDefinition
+            {
+                TestName = "UpdatePipeline_Simple__WithoutBatching",
+                IterationCount = 100,
+                WarmupCount = 5,
+                Run = harness => Insert(harness, true),
+                Setup = EnsureDatabaseSetup
+            }.RunTest();
+        }
+
+        private static void Mixed(TestHarness harness, bool disableBatching)
+        {
+            using (var context = new OrdersContext(_connectionString, disableBatching))
             {
                 using (context.Database.AsRelational().Connection.BeginTransaction())
                 {


### PR DESCRIPTION
More perf test variations 
* Variations withput batching for EF7 Update Pipeling
* Variations with AutoDetectChanges off for EF7 DbSet Operations

Also disabling parallel execution of perf tests