### PR TITLE
Connection Configuration: Changes in indirect key format

### DIFF
--- a/src/EntityFramework.Core/Properties/Strings.Designer.cs
+++ b/src/EntityFramework.Core/Properties/Strings.Designer.cs
@@ -29,14 +29,6 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
-        /// The value for the configuration entry '{configurationKey}' is '{invalidValue}', but an integer is expected.
-        /// </summary>
-        public static string IntegerConfigurationValueFormatError([CanBeNull] object configurationKey, [CanBeNull] object invalidValue)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("IntegerConfigurationValueFormatError", "configurationKey", "invalidValue"), configurationKey, invalidValue);
-        }
-
-        /// <summary>
         /// The value provided for argument '{argumentName}' must be a valid value of enum type '{enumType}'.
         /// </summary>
         public static string InvalidEnumValue([CanBeNull] object argumentName, [CanBeNull] object enumType)
@@ -818,6 +810,22 @@ namespace Microsoft.Data.Entity.Internal
         public static string InvalidEntityType([CanBeNull] object type, [CanBeNull] object argumentName)
         {
             return string.Format(CultureInfo.CurrentCulture, GetString("InvalidEntityType", "type", "argumentName"), type, argumentName);
+        }
+
+        /// <summary>
+        /// The value for the configuration entry '{configurationKey}' is '{invalidValue}', but an integer is expected.
+        /// </summary>
+        public static string IntegerConfigurationValueFormatError([CanBeNull] object configurationKey, [CanBeNull] object invalidValue)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("IntegerConfigurationValueFormatError", "configurationKey", "invalidValue"), configurationKey, invalidValue);
+        }
+
+        /// <summary>
+        /// No connection string named '{connectionString}' could be found in configuration.
+        /// </summary>
+        public static string ConnectionStringNotFound([CanBeNull] object connectionString)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("ConnectionStringNotFound", "connectionString"), connectionString);
         }
 
         private static string GetString(string name, params string[] formatterNames)

--- a/src/EntityFramework.Core/Properties/Strings.resx
+++ b/src/EntityFramework.Core/Properties/Strings.resx
@@ -420,4 +420,7 @@
   <data name="IntegerConfigurationValueFormatError" xml:space="preserve">
     <value>The value for the configuration entry '{configurationKey}' is '{invalidValue}', but an integer is expected.</value>
   </data>
+  <data name="ConnectionStringNotFound" xml:space="preserve">
+    <value>No connection string named '{connectionString}' could be found in configuration.</value>
+  </data>
 </root>

--- a/test/EntityFramework.Core.Tests/DbContextTest.cs
+++ b/test/EntityFramework.Core.Tests/DbContextTest.cs
@@ -2063,7 +2063,7 @@ namespace Microsoft.Data.Entity.Tests
             where ContextT : DbContext
         {
             var configSource = new MemoryConfigurationSource();
-            configSource.Add(string.Concat("EntityFramework:", contextKeyFunc(typeof(ContextT)), ":ConnectionString"), "MyConnectionString");
+            configSource.Add(string.Concat("EntityFramework:", contextKeyFunc(typeof(ContextT)), ":ConnectionString"), "Data Source=MyConnectionString");
 
             var config = new Configuration();
             config.Add(configSource);
@@ -2085,7 +2085,7 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.NotNull(contextOptions);
                 var rawOptions = ((IDbContextOptions)contextOptions).RawOptions;
                 Assert.Equal(1, rawOptions.Count);
-                Assert.Equal("MyConnectionString", rawOptions["ConnectionString"]);
+                Assert.Equal("Data Source=MyConnectionString", rawOptions["ConnectionString"]);
                 Assert.Equal(1, ((IDbContextOptions)contextOptions).Extensions.Count);
                 Assert.Same(contextOptionsExtension, ((IDbContextOptions)contextOptions).Extensions[0]);
             }
@@ -2095,8 +2095,8 @@ namespace Microsoft.Data.Entity.Tests
         public void Context_activation_reads_options_from_configuration_with_key_redirection()
         {
             var configSource = new MemoryConfigurationSource();
-            configSource.Add("Data:DefaultConnection:ConnectionString", "MyConnectionString");
-            configSource.Add("EntityFramework:ContextWithDefaults:ConnectionStringKey", "Data:DefaultConnection:ConnectionString");
+            configSource.Add("Data:DefaultConnection:ConnectionString", "Data Source=MyConnectionString");
+            configSource.Add("EntityFramework:ContextWithDefaults:ConnectionString", "Name=Data:DefaultConnection:ConnectionString");
 
             var config = new Configuration();
             config.Add(configSource);
@@ -2117,7 +2117,7 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.NotNull(contextOptions);
                 var rawOptions = ((IDbContextOptions)contextOptions).RawOptions;
                 Assert.Equal(1, rawOptions.Count);
-                Assert.Equal("MyConnectionString", rawOptions["ConnectionString"]);
+                Assert.Equal("Data Source=MyConnectionString", rawOptions["ConnectionString"]);
             }
         }
 
@@ -2125,7 +2125,7 @@ namespace Microsoft.Data.Entity.Tests
         public void Context_activation_reads_options_from_configuration_case_insensitively()
         {
             var configSource = new MemoryConfigurationSource();
-            configSource.Add("entityFramework:contextWithDefaults:connectionString", "MyConnectionString");
+            configSource.Add("entityFramework:contextWithDefaults:connectionString", "Data Source=MyConnectionString");
 
             var config = new Configuration();
             config.Add(configSource);
@@ -2146,7 +2146,7 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.NotNull(contextOptions);
                 var rawOptions = ((IDbContextOptions)contextOptions).RawOptions;
                 Assert.Equal(1, rawOptions.Count);
-                Assert.Equal("MyConnectionString", rawOptions["ConnectionString"]);
+                Assert.Equal("Data Source=MyConnectionString", rawOptions["ConnectionString"]);
             }
         }
 

--- a/test/EntityFramework.SqlServer.FunctionalTests/ConnectionSpecificationTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/ConnectionSpecificationTest.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                                 "Data:DefaultConnection:ConnectionString", SqlServerNorthwindContext.ConnectionString
                             },
                             {
-                                "EntityFramework:" + typeof(StringInConfigContext).Name + ":ConnectionStringKey", "Data:DefaultConnection:ConnectionString"
+                                "EntityFramework:" + typeof(StringInConfigContext).Name + ":ConnectionString", "Name=Data:DefaultConnection:ConnectionString"
                             }
                         }
                 };
@@ -247,7 +247,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                                 "Data:DefaultConnection:ConnectionString", SqlServerNorthwindContext.ConnectionString
                             },
                             {
-                                "EntityFramework:" + typeof(NoUseSqlServerContext).Name + ":ConnectionStringKey", "Data:DefaultConnection:ConnectionString"
+                                "EntityFramework:" + typeof(NoUseSqlServerContext).Name + ":ConnectionString", "Name=Data:DefaultConnection:ConnectionString"
                             }
                         }
                 };


### PR DESCRIPTION
#1391 - Removed 2 different key names and added "name=xyz" syntax.
#1395 - Added test to verify that priority given to full name