### PR TITLE
Changing relationship configuration API to separate calls for each end.

### DIFF
--- a/src/EntityFramework.Core/Metadata/ForeignKeyExtensions.cs
+++ b/src/EntityFramework.Core/Metadata/ForeignKeyExtensions.cs
@@ -40,13 +40,13 @@ namespace Microsoft.Data.Entity.Metadata
             [NotNull] this ForeignKey foreignKey,
             [NotNull] EntityType principalType,
             [NotNull] EntityType dependentType,
-            bool isUnique)
+            bool? isUnique)
         {
             Check.NotNull(foreignKey, "foreignKey");
             Check.NotNull(principalType, "principalType");
             Check.NotNull(dependentType, "dependentType");
 
-            return ((IForeignKey)foreignKey).IsUnique == isUnique
+            return (isUnique == null || ((IForeignKey)foreignKey).IsUnique == isUnique)
                    && foreignKey.ReferencedEntityType == principalType
                    && foreignKey.EntityType == dependentType;
         }

--- a/src/EntityFramework.Core/Metadata/ModelConventions/ForeignKeyConvention.cs
+++ b/src/EntityFramework.Core/Metadata/ModelConventions/ForeignKeyConvention.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
             [CanBeNull] string navigationToPrincipal,
             [CanBeNull] IReadOnlyList<Property> foreignKeyProperties,
             [CanBeNull] IReadOnlyList<Property> referencedProperties,
-            bool isUnique)
+            bool? isUnique)
         {
             Check.NotNull(principalType, "principalType");
             Check.NotNull(dependentType, "dependentType");
@@ -142,7 +142,7 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
             [CanBeNull] string navigationToPrincipal,
             [CanBeNull] IReadOnlyList<Property> foreignKeyProperties,
             [CanBeNull] IReadOnlyList<Property> referencedProperties,
-            bool isUnique)
+            bool? isUnique)
         {
             foreignKeyProperties = foreignKeyProperties ?? ImmutableList<Property>.Empty;
 
@@ -174,7 +174,7 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
             // Create foreign key properties in shadow state if no properties are specified
             if (!foreignKeyProperties.Any())
             {
-                var baseName = (navigationToPrincipal ?? principalType.SimpleName) + "Id";
+                var baseName = (string.IsNullOrEmpty(navigationToPrincipal) ? principalType.SimpleName : navigationToPrincipal) + "Id";
                 var isComposite = principalKey.Properties.Count > 1;
 
                 var fkProperties = new List<Property>();
@@ -202,7 +202,7 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
         }
 
         private IReadOnlyList<IReadOnlyList<Property>> GetCandidateForeignKeyProperties(
-            EntityType principalType, EntityType dependentType, string navigationToPrincipal, bool isUnique)
+            EntityType principalType, EntityType dependentType, string navigationToPrincipal, bool? isUnique)
         {
             var pk = principalType.TryGetPrimaryKey();
             if (pk == null)
@@ -242,7 +242,7 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
                 }
             }
 
-            if (isUnique)
+            if (isUnique.HasValue && isUnique.Value)
             {
                 var dependentPk = dependentType.TryGetPrimaryKey();
                 if (dependentPk != null)

--- a/src/EntityFramework.Core/Metadata/ModelConventions/RelationshipDiscoveryConvention.cs
+++ b/src/EntityFramework.Core/Metadata/ModelConventions/RelationshipDiscoveryConvention.cs
@@ -115,8 +115,7 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
                     targetBuilder,
                     navigationToSource?.Name,
                     navigationToTarget.Name,
-                    /*oneToOne:*/ false,
-                    ConfigurationSource.Convention);
+                    configurationSource: ConfigurationSource.Convention, oneToOne: false, strictPrincipal: true);
             }
             else
             {
@@ -126,9 +125,8 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
                         targetBuilder,
                         sourceBuilder,
                         navigationToTarget.Name,
-                        /*navNameToDependent:*/ null,
-                        /*oneToOne:*/ false,
-                        ConfigurationSource.Convention);
+                        navigationToDependentName: null,
+                        configurationSource: ConfigurationSource.Convention, oneToOne: null, strictPrincipal: false);
                 }
                 else
                 {
@@ -139,8 +137,7 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
                             targetBuilder,
                             navigationToSource.Name,
                             navigationToTarget.Name,
-                            /*oneToOne:*/ true,
-                            ConfigurationSource.Convention);
+                            configurationSource: ConfigurationSource.Convention, oneToOne: true, strictPrincipal: false);
                     }
                 }
             }

--- a/src/EntityFramework.Core/Metadata/NavigationExtensions.cs
+++ b/src/EntityFramework.Core/Metadata/NavigationExtensions.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Specialized;
-using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Utilities;
@@ -52,6 +50,32 @@ namespace Microsoft.Data.Entity.Metadata
             return navigation.PointsToPrincipal
                 ? navigation.ForeignKey.ReferencedEntityType
                 : navigation.ForeignKey.EntityType;
+        }
+
+        public static bool IsCompatible(
+            [NotNull] this Navigation navigation,
+            [NotNull] EntityType principalType,
+            [NotNull] EntityType dependentType,
+            bool? shouldPointToPrincipal,
+            bool? oneToOne)
+        {
+            Check.NotNull(navigation, "navigation");
+            Check.NotNull(principalType, "principalType");
+            Check.NotNull(dependentType, "dependentType");
+
+            if ((!shouldPointToPrincipal.HasValue || navigation.PointsToPrincipal == shouldPointToPrincipal.Value)
+                && navigation.ForeignKey.IsCompatible(principalType, dependentType, oneToOne))
+            {
+                return true;
+            }
+
+            if (!shouldPointToPrincipal.HasValue
+                && navigation.ForeignKey.IsCompatible(dependentType, principalType, oneToOne))
+            {
+                return true;
+            }
+
+            return false;
         }
 
         public static bool IsNonNotifyingCollection([NotNull] this INavigation navigation, [NotNull] StateEntry entry)

--- a/test/EntityFramework.Core.FunctionalTests/F1FixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/F1FixtureBase.cs
@@ -45,8 +45,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
             {
                 b.Property(e => e.EngineSupplierId).ConcurrencyToken();
                 b.Property(e => e.Name).ConcurrencyToken();
-                b.OneToMany(e => e.Teams, e => e.Engine);
-                b.OneToMany(e => e.Gearboxes);
+                b.HasMany(e => e.Teams).WithOne(e => e.Engine);
+                b.HasMany(e => e.Gearboxes).WithOne();
             });
 
             // TODO: Complex type
@@ -56,7 +56,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             modelBuilder.Entity<EngineSupplier>(b =>
             {
                 b.Property(e => e.Name);
-                b.OneToMany(e => e.Engines, e => e.EngineSupplier);
+                b.HasMany(e => e.Engines).WithOne(e => e.EngineSupplier);
             });
 
             modelBuilder.Entity<Gearbox>(b =>
@@ -100,8 +100,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     .StoreComputed()
                     .ConcurrencyToken();
 
-                b.OneToMany(e => e.Drivers, e => e.Team);
-                b.OneToOne(e => e.Gearbox).ForeignKey<Team>(e => e.GearboxId);
+                b.HasMany(e => e.Drivers).WithOne(e => e.Team);
+                b.HasOne(e => e.Gearbox).WithOne().ForeignKey<Team>(e => e.GearboxId);
             });
 
             modelBuilder.Entity<TestDriver>();

--- a/test/EntityFramework.Core.FunctionalTests/FixupTest.cs
+++ b/test/EntityFramework.Core.FunctionalTests/FixupTest.cs
@@ -246,13 +246,13 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 modelBuilder.Entity<Product>(b =>
                     {
                         b.Property(e => e.Id).GenerateValueOnAdd(false);
-                        b.OneToMany(e => e.SpecialOffers, e => e.Product);
+                        b.HasMany(e => e.SpecialOffers).WithOne(e => e.Product);
                     });
 
                 modelBuilder.Entity<Category>(b =>
                     {
                         b.Property(e => e.Id).GenerateValueOnAdd(false);
-                        b.OneToMany(e => e.Products, e => e.Category);
+                        b.HasMany(e => e.Products).WithOne(e => e.Category);
                     });
 
                 modelBuilder.Entity<SpecialOffer>()

--- a/test/EntityFramework.Core.FunctionalTests/GearsOfWarQueryFixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/GearsOfWarQueryFixtureBase.cs
@@ -16,14 +16,14 @@ namespace Microsoft.Data.Entity.FunctionalTests
         protected virtual void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder.Entity<City>().Key(c => c.Name);
-            modelBuilder.Entity<City>().OneToMany(c => c.StationedGears, g => g.AssignedCity).Required(false);
 
             modelBuilder.Entity<Gear>(b =>
             {
                 b.Key(g => new { g.Nickname, g.SquadId });
-                b.ManyToOne(g => g.CityOfBirth, c => c.BornGears).ForeignKey(g => g.CityOrBirthName).Required(true);
-                b.OneToMany(g => g.Reports).ForeignKey(g => new { g.LeaderNickname, g.LeaderSquadId });
-                b.OneToOne(g => g.Tag, t => t.Gear).ForeignKey<CogTag>(t => new { t.GearNickName, t.GearSquadId });
+                b.HasOne(g => g.CityOfBirth).WithMany(c => c.BornGears).ForeignKey(g => g.CityOrBirthName).Required();
+                b.HasMany(g => g.Reports).WithOne().ForeignKey(g => new { g.LeaderNickname, g.LeaderSquadId });
+                b.HasOne(g => g.Tag).WithOne(t => t.Gear).ForeignKey<CogTag>(t => new { t.GearNickName, t.GearSquadId });
+                b.HasOne(g => g.AssignedCity).WithMany(c => c.StationedGears).Required(false);
             });
 
             modelBuilder.Entity<CogTag>(b =>
@@ -35,14 +35,14 @@ namespace Microsoft.Data.Entity.FunctionalTests
             modelBuilder.Entity<Squad>(b =>
             {
                 b.Key(s => s.Id);
-                b.OneToMany(s => s.Members, g => g.Squad).ForeignKey(g => g.SquadId);
+                b.HasMany(s => s.Members).WithOne(g => g.Squad).ForeignKey(g => g.SquadId);
                 b.Property(t => t.Id).GenerateValueOnAdd();
             });
 
             modelBuilder.Entity<Weapon>(b =>
             {
-                b.OneToOne(w => w.SynergyWith).ForeignKey<Weapon>(w => w.SynergyWithId);
-                b.ManyToOne(w => w.Owner, g => g.Weapons).ForeignKey(w => new { w.OwnerNickname, w.OwnerSquadId });
+                b.HasOne(w => w.SynergyWith).WithOne().ForeignKey<Weapon>(w => w.SynergyWithId);
+                b.HasOne(w => w.Owner).WithMany(g => g.Weapons).ForeignKey(w => new { w.OwnerNickname, w.OwnerSquadId });
             });
         }
     }

--- a/test/EntityFramework.Core.FunctionalTests/NullKeysTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/NullKeysTestBase.cs
@@ -146,15 +146,17 @@ namespace Microsoft.Data.Entity.FunctionalTests
             public virtual void OnModelCreating(ModelBuilder modelBuilder)
             {
                 modelBuilder.Entity<WithStringKey>()
-                    .OneToMany(e => e.Dependents, e => e.Principal)
+                    .HasMany(e => e.Dependents).WithOne(e => e.Principal)
                     .ForeignKey(e => e.Fk);
 
                 modelBuilder.Entity<WithStringFk>()
-                    .OneToOne(e => e.Self)
+                    .HasOne(e => e.Self)
+                    .WithOne()
                     .ForeignKey<WithStringFk>(e => e.SelfFk);
 
                 modelBuilder.Entity<WithIntKey>()
-                    .OneToMany(e => e.Dependents, e => e.Principal)
+                    .HasMany(e => e.Dependents)
+                    .WithOne(e => e.Principal)
                     .ForeignKey(e => e.Fk);
             }
 

--- a/test/EntityFramework.Core.FunctionalTests/OneToOneQueryFixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/OneToOneQueryFixtureBase.cs
@@ -13,8 +13,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             var modelBuilder = new ModelBuilder(model);
 
             modelBuilder
-                .Entity<Person>(
-                    e => e.OneToOne(p => p.Address, a => a.Resident));
+                .Entity<Address>(e => e.HasOne(a => a.Resident).WithOne(p => p.Address));
 
             // TODO: Bug #1116
             modelBuilder.Entity<Address>().Property(a => a.Id).GenerateValueOnAdd(false);
@@ -23,7 +22,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
             modelBuilder
                 .Entity<Person2>(
-                    e => e.OneToOne(p => p.Address, a => a.Resident)
+                    e => e.HasOne(p => p.Address).WithOne(a => a.Resident)
                         .ForeignKey(typeof(Address2), "PersonId"));
 
             return model;

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/GearsOfWarModel/GearsOfWarContext.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/GearsOfWarModel/GearsOfWarContext.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/test/EntityFramework.Core.Tests/ChangeTracking/ChangeDetectorTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/ChangeDetectorTest.cs
@@ -431,7 +431,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
                 {
                     b.Property(e => e.Id).GenerateValueOnAdd(false);
 
-                    b.OneToMany(e => e.Products, e => e.Category)
+                    b.HasMany(e => e.Products).WithOne(e => e.Category)
                         .ForeignKey(e => e.DependentId)
                         .ReferencedKey(e => e.PrincipalId);
                 });
@@ -474,7 +474,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             builder.Entity<CategoryWithChanging>(b =>
                 {
                     b.Property(e => e.Id).GenerateValueOnAdd(false);
-                    b.OneToMany(e => e.Products, e => e.Category).ForeignKey(e => e.DependentId);
+                    b.HasMany(e => e.Products).WithOne(e => e.Category).ForeignKey(e => e.DependentId);
                 });
 
             return builder.Model;
@@ -515,7 +515,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             builder.Entity<CategoryWithChanged>(b =>
                 {
                     b.Property(e => e.Id).GenerateValueOnAdd(false);
-                    b.OneToMany(e => e.Products, e => e.Category).ForeignKey(e => e.DependentId);
+                    b.HasMany(e => e.Products).WithOne(e => e.Category).ForeignKey(e => e.DependentId);
                 });
 
             return builder.Model;

--- a/test/EntityFramework.Core.Tests/ChangeTracking/ChangeTrackerTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/ChangeTrackerTest.cs
@@ -1190,29 +1190,25 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             protected internal override void OnModelCreating(ModelBuilder modelBuilder)
             {
                 modelBuilder
-                    .Entity<Category>()
-                    .OneToMany(e => e.Products, e => e.Category);
+                    .Entity<Category>().HasMany(e => e.Products).WithOne(e => e.Category);
 
                 modelBuilder
-                    .Entity<ProductDetailsTag>()
-                    .OneToOne(e => e.TagDetails, e => e.Tag)
+                    .Entity<ProductDetailsTag>().HasOne(e => e.TagDetails).WithOne(e => e.Tag)
                     .ForeignKey<ProductDetailsTagDetails>(e => e.Id);
 
                 modelBuilder
-                    .Entity<ProductDetails>()
-                    .OneToOne(e => e.Tag, e => e.Details)
+                    .Entity<ProductDetails>().HasOne(e => e.Tag).WithOne(e => e.Details)
                     .ForeignKey<ProductDetailsTag>(e => e.Id);
 
                 modelBuilder
-                    .Entity<Product>()
-                    .OneToOne(e => e.Details, e => e.Product)
+                    .Entity<Product>().HasOne(e => e.Details).WithOne(e => e.Product)
                     .ForeignKey<ProductDetails>(e => e.Id);
 
                 modelBuilder.Entity<OrderDetails>(b =>
                     {
                         b.Key(e => new { e.OrderId, e.ProductId });
-                        b.ManyToOne(e => e.Order, e => e.OrderDetails).ForeignKey(e => e.OrderId);
-                        b.ManyToOne(e => e.Product, e => e.OrderDetails).ForeignKey(e => e.ProductId);
+                        b.HasOne(e => e.Order).WithMany(e => e.OrderDetails).ForeignKey(e => e.OrderId);
+                        b.HasOne(e => e.Product).WithMany(e => e.OrderDetails).ForeignKey(e => e.ProductId);
                     });
             }
         }

--- a/test/EntityFramework.Core.Tests/ChangeTracking/NavigationFixerTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/NavigationFixerTest.cs
@@ -957,28 +957,29 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var builder = new ModelBuilder(model);
 
             builder.Entity<Product>(b =>
-            {
-                b.OneToOne(e => e.OriginalProduct, e => e.AlternateProduct)
-                    .ForeignKey<Product>(e => e.AlternateProductId);
+                {
+                    b.HasOne(e => e.AlternateProduct).WithOne(e => e.OriginalProduct)
+                        .ForeignKey<Product>(e => e.AlternateProductId);
 
-                b.OneToOne(e => e.Detail, e => e.Product);
+                b.HasOne(e => e.Detail).WithOne(e => e.Product)
+                    .ForeignKey<ProductDetail>(e => e.Id);
             });
 
-            builder.Entity<Category>().OneToMany(e => e.Products, e => e.Category);
+            builder.Entity<Category>().HasMany(e => e.Products).WithOne(e => e.Category);
 
             builder.Entity<ProductDetail>();
 
             builder.Entity<ProductPhoto>(b =>
             {
                 b.Key(e => new { e.ProductId, e.PhotoId });
-                b.OneToMany(e => e.ProductTags, e => e.Photo)
+                b.HasMany(e => e.ProductTags).WithOne(e => e.Photo)
                     .ForeignKey(e => new { e.ProductId, e.PhotoId });
             });
 
             builder.Entity<ProductReview>(b =>
             {
                 b.Key(e => new { e.ProductId, e.ReviewId });
-                b.OneToMany(e => e.ProductTags, e => e.Review)
+                b.HasMany(e => e.ProductTags).WithOne(e => e.Review)
                     .ForeignKey(e => new { e.ProductId, e.ReviewId });
             });
 

--- a/test/EntityFramework.Core.Tests/ChangeTracking/StateEntrySubscriberTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/StateEntrySubscriberTest.cs
@@ -169,7 +169,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             builder.Entity<FullNotificationEntity>(b =>
                 {
                     b.Ignore(e => e.NotMapped);
-                    b.OneToMany(e => e.RelatedCollection, e => e.Related).ForeignKey(e => e.Fk);
+                    b.HasMany(e => e.RelatedCollection).WithOne(e => e.Related).ForeignKey(e => e.Fk);
                 });
 
             return builder.Model;

--- a/test/EntityFramework.Core.Tests/ChangeTracking/StateEntryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/StateEntryTest.cs
@@ -1313,12 +1313,14 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             modelBuilder
                 .Entity<FirstDependent>()
-                .OneToOne(e => e.Second, e => e.First)
+                .HasOne(e => e.Second)
+                .WithOne(e => e.First)
                 .ForeignKey<SecondDependent>(e => e.Id);
 
             modelBuilder
                 .Entity<Root>()
-                .OneToOne(e => e.First, e => e.Root)
+                .HasOne(e => e.First)
+                .WithOne(e => e.Root)
                 .ForeignKey<FirstDependent>(e => e.Id);
 
             modelBuilder.Entity<Root>().Property(e => e.Id).GenerateValueOnAdd();

--- a/test/EntityFramework.Core.Tests/DbContextTest.cs
+++ b/test/EntityFramework.Core.Tests/DbContextTest.cs
@@ -1920,8 +1920,7 @@ namespace Microsoft.Data.Entity.Tests
             protected internal override void OnModelCreating(ModelBuilder modelBuilder)
             {
                 modelBuilder
-                    .Entity<Category>()
-                    .OneToMany(e => e.Products, e => e.Category);
+                    .Entity<Category>().HasMany(e => e.Products).WithOne(e => e.Category);
             }
         }
 

--- a/test/EntityFramework.Core.Tests/Extensions/ForeignKeyExtensionsTest.cs
+++ b/test/EntityFramework.Core.Tests/Extensions/ForeignKeyExtensionsTest.cs
@@ -114,13 +114,15 @@ namespace Microsoft.Data.Entity.Tests
 
             modelBuilder
                 .Entity<Category>()
-                .OneToMany(e => e.Products, e => e.Category);
+                .HasMany(e => e.Products)
+                .WithOne(e => e.Category);
 
             modelBuilder
                 .Entity<ProductDetailsTag>(b =>
                     {
                         b.Key(e => new { e.Id1, e.Id2 });
-                        b.OneToOne(e => e.TagDetails, e => e.Tag)
+                        b.HasOne(e => e.TagDetails)
+                            .WithOne(e => e.Tag)
                             .ReferencedKey<ProductDetailsTag>(e => e.Id2)
                             .ForeignKey<ProductDetailsTagDetails>(e => e.Id);
                     });
@@ -129,20 +131,26 @@ namespace Microsoft.Data.Entity.Tests
                 .Entity<ProductDetails>(b =>
                     {
                         b.Key(e => new { e.Id1, e.Id2 });
-                        b.OneToOne(e => e.Tag, e => e.Details)
+                        b.HasOne(e => e.Tag)
+                            .WithOne(e => e.Details)
                             .ForeignKey<ProductDetailsTag>(e => new { e.Id1, e.Id2 });
                     });
 
             modelBuilder
                 .Entity<Product>()
-                .OneToOne(e => e.Details, e => e.Product)
+                .HasOne(e => e.Details)
+                .WithOne(e => e.Product)
                 .ForeignKey<ProductDetails>(e => new { e.Id1 });
 
             modelBuilder.Entity<OrderDetails>(b =>
                 {
                     b.Key(e => new { e.OrderId, e.ProductId });
-                    b.ManyToOne(e => e.Order, e => e.OrderDetails).ForeignKey(e => e.OrderId);
-                    b.ManyToOne(e => e.Product, e => e.OrderDetails).ForeignKey(e => e.ProductId);
+                    b.HasOne(e => e.Order)
+                        .WithMany(e => e.OrderDetails)
+                        .ForeignKey(e => e.OrderId);
+                    b.HasOne(e => e.Product)
+                        .WithMany(e => e.OrderDetails)
+                        .ForeignKey(e => e.ProductId);
                 });
 
             return modelBuilder.Model;

--- a/test/EntityFramework.Core.Tests/Identity/ForeignKeyValuePropagatorTest.cs
+++ b/test/EntityFramework.Core.Tests/Identity/ForeignKeyValuePropagatorTest.cs
@@ -276,22 +276,22 @@ namespace Microsoft.Data.Entity.Tests.Identity
 
             builder.Entity<Product>(b =>
             {
-                b.OneToMany(e => e.OrderLines, e => e.Product);
-                b.OneToOne(e => e.Detail, e => e.Product);
+                b.HasMany(e => e.OrderLines).WithOne(e => e.Product);
+                b.HasOne(e => e.Detail).WithOne(e => e.Product).ForeignKey<ProductDetail>(e => e.Id);
             });
 
-            builder.Entity<Category>().OneToMany(e => e.Products, e => e.Category);
+            builder.Entity<Category>().HasMany(e => e.Products).WithOne(e => e.Category);
 
             builder.Entity<ProductDetail>();
 
-            builder.Entity<Order>().OneToMany(e => e.OrderLines, e => e.Order);
+            builder.Entity<Order>().HasMany(e => e.OrderLines).WithOne(e => e.Order);
 
             builder.Entity<OrderLineDetail>().Key(e => new { e.OrderId, e.ProductId });
 
             builder.Entity<OrderLine>(b =>
             {
                 b.Key(e => new { e.OrderId, e.ProductId });
-                b.OneToOne(e => e.Detail, e => e.OrderLine)
+                b.HasOne(e => e.Detail).WithOne(e => e.OrderLine)
                 // TODO: Remove this line when ForeignKeyConvention handles composite fks
                 .ForeignKey<OrderLineDetail>(e => new {e.OrderId, e.ProductId});
             });

--- a/test/EntityFramework.Core.Tests/Metadata/Internal/InternalEntityBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/Internal/InternalEntityBuilderTest.cs
@@ -688,10 +688,10 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             customerEntityBuilder.Key(new[] { Customer.IdProperty, Customer.UniqueProperty }, ConfigurationSource.Explicit);
             var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
-            var relationshipBuilder = orderEntityBuilder.Relationship(typeof(Customer), typeof(Order), Order.CustomerProperty.Name, null, /*oneToOne:*/ true, ConfigurationSource.Convention);
+            var relationshipBuilder = orderEntityBuilder.Relationship(typeof(Customer), typeof(Order), Order.CustomerProperty.Name, null, ConfigurationSource.Convention, true, true);
 
             Assert.NotNull(relationshipBuilder);
-            Assert.Same(relationshipBuilder, customerEntityBuilder.Relationship(customerEntityBuilder.Metadata, orderEntityBuilder.Metadata, Order.CustomerProperty.Name, null, /*oneToOne:*/ true, ConfigurationSource.Convention));
+            Assert.Same(relationshipBuilder, customerEntityBuilder.Relationship(customerEntityBuilder.Metadata, orderEntityBuilder.Metadata, Order.CustomerProperty.Name, null, ConfigurationSource.Convention, true, true));
         }
 
         [Fact]
@@ -702,10 +702,10 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             customerEntityBuilder.Key(new[] { Customer.IdProperty, Customer.UniqueProperty }, ConfigurationSource.Explicit);
             var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
-            var relationshipBuilder = orderEntityBuilder.Relationship(customerEntityBuilder.Metadata, orderEntityBuilder.Metadata, null, Customer.OrdersProperty.Name, /*oneToOne:*/ false, ConfigurationSource.Explicit);
+            var relationshipBuilder = orderEntityBuilder.Relationship(customerEntityBuilder.Metadata, orderEntityBuilder.Metadata, null, Customer.OrdersProperty.Name, ConfigurationSource.Explicit, false, true);
 
             Assert.NotNull(relationshipBuilder);
-            Assert.Same(relationshipBuilder, customerEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, Customer.OrdersProperty.Name, /*oneToOne:*/ false, ConfigurationSource.DataAnnotation));
+            Assert.Same(relationshipBuilder, customerEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, Customer.OrdersProperty.Name, ConfigurationSource.DataAnnotation, false, true));
         }
 
         [Fact]
@@ -716,10 +716,10 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             customerEntityBuilder.Key(new[] { Customer.IdProperty, Customer.UniqueProperty }, ConfigurationSource.Explicit);
             var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
-            var relationshipBuilder = orderEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, null, /*oneToOne:*/ true, ConfigurationSource.Convention);
+            var relationshipBuilder = orderEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, null, ConfigurationSource.Convention, true, true);
 
             Assert.NotNull(relationshipBuilder);
-            Assert.NotSame(relationshipBuilder, customerEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, null, /*oneToOne:*/ true, ConfigurationSource.Convention));
+            Assert.NotSame(relationshipBuilder, customerEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, null, ConfigurationSource.Convention, true, true));
         }
 
         [Fact]
@@ -728,16 +728,16 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var modelBuilder = new InternalModelBuilder(new Model(), null);
             var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
             principalEntityBuilder.Key(new[] { Customer.IdProperty, Customer.UniqueProperty }, ConfigurationSource.Explicit);
-            Assert.NotNull(principalEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, null, /*oneToOne:*/ true, ConfigurationSource.Convention));
+            Assert.NotNull(principalEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, null, ConfigurationSource.Convention, true, true));
 
             Assert.True(modelBuilder.Ignore(typeof(Order), ConfigurationSource.Explicit));
 
             Assert.Equal(typeof(Customer).FullName, modelBuilder.Metadata.EntityTypes.Single().Name);
             Assert.True(modelBuilder.Ignore(typeof(Order), ConfigurationSource.Convention));
-            Assert.Null(principalEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, null, /*oneToOne:*/ true, ConfigurationSource.Convention));
+            Assert.Null(principalEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, null, ConfigurationSource.Convention, true, true));
             Assert.Equal(Strings.EntityIgnoredExplicitly(typeof(Order).FullName),
                 Assert.Throws<InvalidOperationException>(() => 
-                principalEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, null, /*oneToOne:*/ true, ConfigurationSource.Explicit)).Message);
+                principalEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, null, ConfigurationSource.Explicit, true, true)).Message);
         }
 
         [Fact]
@@ -747,16 +747,16 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Convention);
             principalEntityBuilder.Key(new[] { Customer.IdProperty, Customer.UniqueProperty }, ConfigurationSource.Convention);
             modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-            Assert.NotNull(principalEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, null, /*oneToOne:*/ true, ConfigurationSource.Convention));
+            Assert.NotNull(principalEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, null, ConfigurationSource.Convention, true, true));
 
             Assert.True(modelBuilder.Ignore(typeof(Customer), ConfigurationSource.Explicit));
 
             Assert.Equal(typeof(Order).FullName, modelBuilder.Metadata.EntityTypes.Single().Name);
             Assert.True(modelBuilder.Ignore(typeof(Customer), ConfigurationSource.Convention));
-            Assert.Null(principalEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, null, /*oneToOne:*/ true, ConfigurationSource.Convention));
+            Assert.Null(principalEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, null, ConfigurationSource.Convention, true, true));
             Assert.Equal(Strings.EntityIgnoredExplicitly(typeof(Customer).FullName),
                 Assert.Throws<InvalidOperationException>(() =>
-                principalEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, null, /*oneToOne:*/ true, ConfigurationSource.Explicit)).Message);
+                principalEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, null, ConfigurationSource.Explicit, true, true)).Message);
         }
 
         [Fact]
@@ -767,17 +767,17 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             principalEntityBuilder.Key(new[] { Customer.IdProperty, Customer.UniqueProperty }, ConfigurationSource.Explicit);
             var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
-            Assert.NotNull(dependentEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, Customer.OrdersProperty.Name, /*oneToOne:*/ false, ConfigurationSource.Convention));
+            Assert.NotNull(dependentEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, Customer.OrdersProperty.Name, ConfigurationSource.Convention, false, true));
 
             Assert.True(principalEntityBuilder.Ignore(Customer.OrdersProperty.Name, ConfigurationSource.Explicit));
 
             Assert.Empty(dependentEntityBuilder.Metadata.ForeignKeys);
             Assert.Empty(principalEntityBuilder.Metadata.ForeignKeys);
             Assert.True(principalEntityBuilder.Ignore(Customer.OrdersProperty.Name, ConfigurationSource.Convention));
-            Assert.Null(dependentEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, Customer.OrdersProperty.Name, /*oneToOne:*/ false, ConfigurationSource.Convention));
+            Assert.Null(dependentEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, Customer.OrdersProperty.Name, ConfigurationSource.Convention, false, true));
             Assert.Equal(Strings.NavigationIgnoredExplicitly(Customer.OrdersProperty.Name, typeof(Customer).FullName),
                 Assert.Throws<InvalidOperationException>(() =>
-                dependentEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, Customer.OrdersProperty.Name, /*oneToOne:*/ false, ConfigurationSource.Explicit)).Message);
+                dependentEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, Customer.OrdersProperty.Name, ConfigurationSource.Explicit, false, true)).Message);
         }
 
         [Fact]
@@ -788,17 +788,17 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             principalEntityBuilder.Key(new[] { Customer.IdProperty, Customer.UniqueProperty }, ConfigurationSource.Explicit);
             var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
-            Assert.NotNull(dependentEntityBuilder.Relationship(typeof(Customer), typeof(Order), Order.CustomerProperty.Name, null, /*oneToOne:*/ false, ConfigurationSource.Convention));
+            Assert.NotNull(dependentEntityBuilder.Relationship(typeof(Customer), typeof(Order), Order.CustomerProperty.Name, null, ConfigurationSource.Convention, false, true));
 
             Assert.True(dependentEntityBuilder.Ignore(Order.CustomerProperty.Name, ConfigurationSource.Explicit));
 
             Assert.Empty(dependentEntityBuilder.Metadata.ForeignKeys);
             Assert.Empty(principalEntityBuilder.Metadata.ForeignKeys);
             Assert.True(dependentEntityBuilder.Ignore(Order.CustomerProperty.Name, ConfigurationSource.Convention));
-            Assert.Null(dependentEntityBuilder.Relationship(typeof(Customer), typeof(Order), Order.CustomerProperty.Name, null, /*oneToOne:*/ false, ConfigurationSource.Convention));
+            Assert.Null(dependentEntityBuilder.Relationship(typeof(Customer), typeof(Order), Order.CustomerProperty.Name, null, ConfigurationSource.Convention, false, true));
             Assert.Equal(Strings.NavigationIgnoredExplicitly(Order.CustomerProperty.Name, typeof(Order).FullName),
                 Assert.Throws<InvalidOperationException>(() =>
-                dependentEntityBuilder.Relationship(typeof(Customer), typeof(Order), Order.CustomerProperty.Name, null, /*oneToOne:*/ false, ConfigurationSource.Explicit)).Message);
+                dependentEntityBuilder.Relationship(typeof(Customer), typeof(Order), Order.CustomerProperty.Name, null, ConfigurationSource.Explicit, false, true)).Message);
         }
 
         [Fact]
@@ -808,9 +808,9 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
             principalEntityBuilder.Key(new[] { Customer.IdProperty, Customer.UniqueProperty }, ConfigurationSource.Explicit);
             var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-            Assert.NotNull(dependentEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, Customer.OrdersProperty.Name, /*oneToOne:*/ false, ConfigurationSource.Explicit));
+            Assert.NotNull(dependentEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, Customer.OrdersProperty.Name, ConfigurationSource.Explicit, false, true));
 
-            Assert.Null(dependentEntityBuilder.Relationship(typeof(Customer), typeof(Order), Order.CustomerProperty.Name, Customer.OrdersProperty.Name, /*oneToOne:*/ false, ConfigurationSource.Convention));
+            Assert.Null(dependentEntityBuilder.Relationship(typeof(Customer), typeof(Order), Order.CustomerProperty.Name, Customer.OrdersProperty.Name, ConfigurationSource.Convention, false, true));
 
             Assert.Empty(principalEntityBuilder.Metadata.ForeignKeys);
             var fk = dependentEntityBuilder.Metadata.ForeignKeys.Single();
@@ -825,9 +825,9 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
             principalEntityBuilder.Key(new[] { Customer.IdProperty, Customer.UniqueProperty }, ConfigurationSource.Explicit);
             var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-            Assert.NotNull(dependentEntityBuilder.Relationship(typeof(Customer), typeof(Order), Order.CustomerProperty.Name, null, /*oneToOne:*/ false, ConfigurationSource.Explicit));
+            Assert.NotNull(dependentEntityBuilder.Relationship(typeof(Customer), typeof(Order), Order.CustomerProperty.Name, null, ConfigurationSource.Explicit, false, true));
 
-            Assert.Null(dependentEntityBuilder.Relationship(typeof(Customer), typeof(Order), Order.CustomerProperty.Name, Customer.OrdersProperty.Name, /*oneToOne:*/ false, ConfigurationSource.Convention));
+            Assert.Null(dependentEntityBuilder.Relationship(typeof(Customer), typeof(Order), Order.CustomerProperty.Name, Customer.OrdersProperty.Name, ConfigurationSource.Convention, false, true));
 
             Assert.Empty(principalEntityBuilder.Metadata.ForeignKeys);
             var fk = dependentEntityBuilder.Metadata.ForeignKeys.Single();
@@ -843,12 +843,12 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             customerEntityBuilder.Key(new[] { Customer.IdProperty, Customer.UniqueProperty }, ConfigurationSource.Explicit);
             var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
-            var orderRelationship = orderEntityBuilder.Relationship(typeof(Customer), typeof(Order), Order.CustomerProperty.Name, null, /*oneToOne:*/ true, ConfigurationSource.DataAnnotation);
+            var orderRelationship = orderEntityBuilder.Relationship(typeof(Customer), typeof(Order), Order.CustomerProperty.Name, null, ConfigurationSource.DataAnnotation, true, true);
             Assert.NotNull(orderRelationship);
-            var customerRelationship = orderEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, "NotCollectionOrders", /*oneToOne:*/ true, ConfigurationSource.Convention);
+            var customerRelationship = orderEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, "NotCollectionOrders", ConfigurationSource.Convention, true, true);
             Assert.NotNull(customerRelationship);
 
-            Assert.Null(orderEntityBuilder.Relationship(typeof(Order), typeof(Customer), "NotCollectionOrders", Order.CustomerProperty.Name, /*oneToOne:*/ true, ConfigurationSource.Convention));
+            Assert.Null(orderEntityBuilder.Relationship(typeof(Order), typeof(Customer), "NotCollectionOrders", Order.CustomerProperty.Name, ConfigurationSource.Convention, true, true));
 
             Assert.Null(orderRelationship.Metadata.GetNavigationToDependent());
             Assert.Equal(Order.CustomerProperty.Name, orderRelationship.Metadata.GetNavigationToPrincipal().Name);
@@ -864,12 +864,12 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             customerEntityBuilder.Key(new[] { Customer.IdProperty, Customer.UniqueProperty }, ConfigurationSource.Explicit);
             var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
-            var orderRelationship = orderEntityBuilder.Relationship(typeof(Customer), typeof(Order), Order.CustomerProperty.Name, null, /*oneToOne:*/ true, ConfigurationSource.Convention);
+            var orderRelationship = orderEntityBuilder.Relationship(typeof(Customer), typeof(Order), Order.CustomerProperty.Name, null, ConfigurationSource.Convention, true, true);
             Assert.NotNull(orderRelationship);
-            var customerRelationship = orderEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, "NotCollectionOrders", /*oneToOne:*/ true, ConfigurationSource.DataAnnotation);
+            var customerRelationship = orderEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, "NotCollectionOrders", ConfigurationSource.DataAnnotation, true, true);
             Assert.NotNull(customerRelationship);
 
-            Assert.Null(orderEntityBuilder.Relationship(typeof(Order), typeof(Customer), "NotCollectionOrders", Order.CustomerProperty.Name, /*oneToOne:*/ true, ConfigurationSource.Convention));
+            Assert.Null(orderEntityBuilder.Relationship(typeof(Order), typeof(Customer), "NotCollectionOrders", Order.CustomerProperty.Name, ConfigurationSource.Convention, true, true));
 
             Assert.Null(orderRelationship.Metadata.GetNavigationToDependent());
             Assert.Equal(Order.CustomerProperty.Name, orderRelationship.Metadata.GetNavigationToPrincipal().Name);

--- a/test/EntityFramework.Core.Tests/Metadata/Internal/InternalRelationshipBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/Internal/InternalRelationshipBuilderTest.cs
@@ -21,13 +21,13 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Internal
             var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
             orderEntityBuilder.Key(new[] { Order.IdProperty }, ConfigurationSource.Explicit);
 
-            var relationshipBuilder = orderEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, null, /*oneToOne:*/ true, ConfigurationSource.Convention)
+            var relationshipBuilder = orderEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, null, ConfigurationSource.Convention, true, true)
                 .ForeignKey(typeof(Order), new[] { Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name }, ConfigurationSource.DataAnnotation);
 
             Assert.NotNull(relationshipBuilder);
-            Assert.Same(relationshipBuilder, customerEntityBuilder.Relationship(typeof(Order), typeof(Customer), null, null, /*oneToOne:*/ true, ConfigurationSource.Convention)
+            Assert.Same(relationshipBuilder, customerEntityBuilder.Relationship(typeof(Order), typeof(Customer), null, null, ConfigurationSource.Convention, true, true)
                 .ForeignKey(typeof(Order), new[] { Order.CustomerIdProperty, Order.CustomerUniqueProperty }, ConfigurationSource.DataAnnotation));
-            Assert.Null(customerEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, null, /*oneToOne:*/ false, ConfigurationSource.Convention)
+            Assert.Null(customerEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, null, ConfigurationSource.Convention, false, true)
                 .ForeignKey(typeof(Order).FullName, new[] { Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name }, ConfigurationSource.Convention));
         }
 
@@ -40,13 +40,13 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Internal
             var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
             orderEntityBuilder.Key(new[] { Order.IdProperty }, ConfigurationSource.Explicit);
 
-            var relationshipBuilder = orderEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, null, /*oneToOne:*/ true, ConfigurationSource.DataAnnotation)
+            var relationshipBuilder = orderEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, null, ConfigurationSource.DataAnnotation, true, true)
                 .ReferencedKey(typeof(Order), new[] { Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name }, ConfigurationSource.DataAnnotation);
 
             Assert.NotNull(relationshipBuilder);
             Assert.Same(relationshipBuilder,
                 relationshipBuilder.ReferencedKey(typeof(Order), new[] { Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name }, ConfigurationSource.DataAnnotation));
-            Assert.NotSame(relationshipBuilder, customerEntityBuilder.Relationship(typeof(Order), typeof(Customer), null, null, /*oneToOne:*/ true, ConfigurationSource.DataAnnotation)
+            Assert.NotSame(relationshipBuilder, customerEntityBuilder.Relationship(typeof(Order), typeof(Customer), null, null, ConfigurationSource.DataAnnotation, true, true)
                 .ReferencedKey(typeof(Order).FullName, new[] { Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name }, ConfigurationSource.Convention));
             Assert.Null(relationshipBuilder.ReferencedKey(typeof(Order), new[] { Order.CustomerIdProperty }, ConfigurationSource.Convention));
 
@@ -61,7 +61,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Internal
             customerEntityBuilder.Key(new[] { Customer.IdProperty, Customer.UniqueProperty }, ConfigurationSource.Explicit);
             var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
-            var relationshipBuilder = orderEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, null, /*oneToOne:*/ true, ConfigurationSource.Convention);
+            var relationshipBuilder = orderEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, null, ConfigurationSource.Convention, true, true);
             Assert.True(relationshipBuilder.Metadata.IsUnique.Value);
             Assert.True(((IForeignKey)relationshipBuilder.Metadata).IsUnique);
 
@@ -117,7 +117,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Internal
             customerEntityBuilder.Key(new[] { Customer.IdProperty, Customer.UniqueProperty }, ConfigurationSource.Explicit);
             var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
-            var relationshipBuilder = orderEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, null, /*oneToOne:*/ true, ConfigurationSource.Convention);
+            var relationshipBuilder = orderEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, null, ConfigurationSource.Convention, true, true);
             Assert.Null(relationshipBuilder.Metadata.IsRequired);
             Assert.False(((IForeignKey)relationshipBuilder.Metadata).IsRequired);
 
@@ -142,7 +142,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Internal
             var customerUniqueProperty = orderEntityBuilder.Property(Order.CustomerUniqueProperty, ConfigurationSource.Convention).Metadata;
             customerUniqueProperty.IsNullable = false;
 
-            var relationshipBuilder = orderEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, null, /*oneToOne:*/ true, ConfigurationSource.Convention)
+            var relationshipBuilder = orderEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, null, ConfigurationSource.Convention, true, true)
                 .ForeignKey(typeof(Order), new[] { Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name }, ConfigurationSource.DataAnnotation);
             Assert.True(((IForeignKey)relationshipBuilder.Metadata).IsRequired);
 

--- a/test/EntityFramework.Core.Tests/Metadata/MetadataBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/MetadataBuilderTest.cs
@@ -342,8 +342,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var builder = new ModelBuilder();
 
             var returnedBuilder = builder
-                .Entity<Gunter>()
-                .OneToMany(e => e.Gates, e => e.Gunter)
+                .Entity<Gunter>().HasMany(e => e.Gates).WithOne(e => e.Gunter)
                 .OneToManyBuilderExtension("V1")
                 .OneToManyBuilderExtension("V2");
 
@@ -363,8 +362,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var builder = new ModelBuilder();
 
             var returnedBuilder = builder
-                .Entity<Gate>()
-                .ManyToOne(e => e.Gunter, e => e.Gates)
+                .Entity<Gate>().HasOne(e => e.Gunter).WithMany(e => e.Gates)
                 .ManyToOneBuilderExtension("V1")
                 .ManyToOneBuilderExtension("V2");
 
@@ -384,8 +382,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var builder = new ModelBuilder();
 
             var returnedBuilder = builder
-                .Entity<Gunter>()
-                .OneToOne<Avatar>(e => e.Avatar, e => e.Gunter)
+                .Entity<Avatar>().HasOne(e => e.Gunter).WithOne(e => e.Avatar)
                 .OneToOneBuilderExtension("V1")
                 .OneToOneBuilderExtension("V2");
 
@@ -731,8 +728,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var builder = new ModelBuilder();
 
             var returnedBuilder = builder
-                .Entity<Gunter>()
-                .OneToMany(e => e.Gates, e => e.Gunter)
+                .Entity<Gunter>().HasMany(e => e.Gates).WithOne(e => e.Gunter)
                 .SharedNameExtension("V1")
                 .SharedNameExtension("V2");
 
@@ -752,8 +748,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var builder = new ModelBuilder();
 
             var returnedBuilder = builder
-                .Entity<Gate>()
-                .ManyToOne(e => e.Gunter, e => e.Gates)
+                .Entity<Gate>().HasOne(e => e.Gunter).WithMany(e => e.Gates)
                 .SharedNameExtension("V1")
                 .SharedNameExtension("V2");
 
@@ -773,8 +768,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var builder = new ModelBuilder();
 
             var returnedBuilder = builder
-                .Entity<Gunter>()
-                .OneToOne<Avatar>(e => e.Avatar, e => e.Gunter)
+                .Entity<Avatar>().HasOne(e => e.Gunter).WithOne(e => e.Avatar)
                 .SharedNameExtension("V1")
                 .SharedNameExtension("V2");
 

--- a/test/EntityFramework.Core.Tests/Metadata/ModelBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelBuilderTest.cs
@@ -1039,8 +1039,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var modelBuilder = new ModelBuilder(model);
             modelBuilder.Entity<Customer>();
             modelBuilder
-                .Entity<Order>()
-                .ManyToOne(o => o.Customer, c => c.Orders)
+                .Entity<Order>().HasOne(o => o.Customer).WithMany(c => c.Orders)
                 .ForeignKey(c => c.CustomerId);
             modelBuilder.Ignore<OrderDetails>();
             modelBuilder.Ignore<CustomerDetails>();
@@ -1055,10 +1054,10 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity<Customer>().OneToMany(e => e.Orders, e => e.Customer);
+            modelBuilder.Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer);
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
-            Assert.Same(navToPrincipal, dependentType.Navigations.Single());
+            Assert.Equal(navToPrincipal.Name, dependentType.Navigations.Single().Name);
             Assert.Same(navToDependent, principalType.Navigations.Single());
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
@@ -1078,8 +1077,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var modelBuilder = new ModelBuilder(model);
             modelBuilder.Entity<Customer>();
             modelBuilder
-                .Entity<Order>()
-                .ManyToOne(c => c.Customer)
+                .Entity<Order>().HasOne(c => c.Customer).WithMany()
                 .ForeignKey(c => c.CustomerId);
             modelBuilder.Ignore<OrderDetails>();
             modelBuilder.Ignore<CustomerDetails>();
@@ -1093,7 +1091,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity<Customer>().OneToMany(e => e.Orders, e => e.Customer);
+            modelBuilder.Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer);
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
             Assert.Same(navigation, dependentType.Navigations.Single());
@@ -1130,7 +1128,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity<Customer>().OneToMany(e => e.Orders, e => e.Customer);
+            modelBuilder.Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer);
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -1153,8 +1151,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var modelBuilder = new ModelBuilder(model);
             modelBuilder.Entity<Customer>();
             modelBuilder
-                .Entity<Order>()
-                .ManyToOne(e => e.Customer, e => e.Orders)
+                .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                 .ForeignKey(c => c.CustomerId);
             modelBuilder.Ignore<OrderDetails>();
             modelBuilder.Ignore<CustomerDetails>();
@@ -1166,7 +1163,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity<Customer>().OneToMany(e => e.Orders, e => e.Customer);
+            modelBuilder.Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer);
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -1200,7 +1197,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity<Customer>().OneToMany(e => e.Orders, e => e.Customer);
+            modelBuilder.Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer);
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -1236,7 +1233,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity<Customer>().OneToMany(e => e.Orders);
+            modelBuilder.Entity<Customer>().HasMany(e => e.Orders).WithOne();
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -1272,7 +1269,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             // Passing null as the first arg is not super-compelling, but it is consistent
-            modelBuilder.Entity<Customer>().OneToMany<Order>(null, e => e.Customer);
+            modelBuilder.Entity<Customer>().HasMany<Order>().WithOne(e => e.Customer);
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -1309,7 +1306,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity<Customer>().OneToMany<Order>();
+            modelBuilder.Entity<Customer>().HasMany<Order>().WithOne();
 
             var newFk = dependentType.ForeignKeys.Single(foreignKey => foreignKey != fk);
 
@@ -1345,8 +1342,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Customer>()
-                .OneToMany(e => e.Orders, e => e.Customer)
+                .Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer)
                 .ForeignKey(e => e.CustomerId);
 
             var fk = dependentType.ForeignKeys.Single();
@@ -1372,21 +1368,20 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var modelBuilder = new ModelBuilder(model);
             modelBuilder.Entity<BigMak>();
             modelBuilder
-                .Entity<Pickle>()
-                .ManyToOne<BigMak>()
+                .Entity<Pickle>().HasOne(e => e.BigMak).WithMany()
                 .ForeignKey(c => c.BurgerId);
             modelBuilder.Ignore<Bun>();
 
             var dependentType = model.GetEntityType(typeof(Pickle));
             var principalType = model.GetEntityType(typeof(BigMak));
             var fk = dependentType.ForeignKeys.Single(foreignKey => foreignKey.Properties.Single().Name == "BurgerId");
+            dependentType.RemoveNavigation(fk.GetNavigationToPrincipal());
 
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<BigMak>()
-                .OneToMany(e => e.Pickles, e => e.BigMak)
+                .Entity<BigMak>().HasMany(e => e.Pickles).WithOne(e => e.BigMak)
                 .ForeignKey(e => e.BurgerId);
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
@@ -1421,8 +1416,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<BigMak>()
-                .OneToMany(e => e.Pickles, e => e.BigMak)
+                .Entity<BigMak>().HasMany(e => e.Pickles).WithOne(e => e.BigMak)
                 .ForeignKey(e => e.BurgerId);
 
             var fk = dependentType.ForeignKeys.Single();
@@ -1459,8 +1453,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<BigMak>()
-                .OneToMany(e => e.Pickles)
+                .Entity<BigMak>().HasMany(e => e.Pickles).WithOne()
                 .ForeignKey(e => e.BurgerId);
 
             var fk = dependentType.ForeignKeys.Single();
@@ -1496,8 +1489,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<BigMak>()
-                .OneToMany<Pickle>(null, e => e.BigMak)
+                .Entity<BigMak>().HasMany<Pickle>().WithOne(e => e.BigMak)
                 .ForeignKey(e => e.BurgerId);
 
             var fk = dependentType.ForeignKeys.Single();
@@ -1534,8 +1526,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<BigMak>()
-                .OneToMany<Pickle>()
+                .Entity<BigMak>().HasMany<Pickle>().WithOne()
                 .ForeignKey(e => e.BurgerId);
 
             var newFk = dependentType.ForeignKeys.Single(foreignKey => foreignKey != fk);
@@ -1567,7 +1558,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity<BigMak>().OneToMany(e => e.Pickles, e => e.BigMak);
+            modelBuilder.Entity<BigMak>().HasMany(e => e.Pickles).WithOne(e => e.BigMak);
 
             var fk = dependentType.ForeignKeys.Single();
             var fkProperty = fk.Properties.Single();
@@ -1605,7 +1596,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity<BigMak>().OneToMany(e => e.Pickles);
+            modelBuilder.Entity<BigMak>().HasMany(e => e.Pickles).WithOne();
 
             var fk = dependentType.ForeignKeys.Single();
             var fkProperty = fk.Properties.Single();
@@ -1642,7 +1633,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity<BigMak>().OneToMany<Pickle>(null, e => e.BigMak);
+            modelBuilder.Entity<BigMak>().HasMany<Pickle>().WithOne(e => e.BigMak);
 
             var fk = dependentType.ForeignKeys.Single();
             var fkProperty = fk.Properties.Single();
@@ -1680,7 +1671,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
             var existingFk = dependentType.ForeignKeys.Single();
 
-            modelBuilder.Entity<BigMak>().OneToMany<Pickle>();
+            modelBuilder.Entity<BigMak>().HasMany<Pickle>().WithOne();
 
             var foreignKey = dependentType.ForeignKeys.Single(fk => fk != existingFk);
             var fkProperty = foreignKey.Properties.Single();
@@ -1719,7 +1710,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty = dependentType.GetProperty("BigMakId");
 
-            modelBuilder.Entity<BigMak>().OneToMany(e => e.Pickles, e => e.BigMak);
+            modelBuilder.Entity<BigMak>().HasMany(e => e.Pickles).WithOne(e => e.BigMak);
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -1744,26 +1735,24 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var model = new Model();
             var modelBuilder = new ModelBuilder(model);
             modelBuilder.Entity<BigMak>();
-            modelBuilder
-                .Entity<Pickle>()
-                .OneToOne<BigMak>()
-                .ForeignKey<Pickle>(c => c.BurgerId);
+            modelBuilder.Entity<Pickle>();
             modelBuilder.Ignore<Bun>();
 
-            var dependentType = (IEntityType)model.GetEntityType(typeof(Pickle));
+            var dependentType = model.GetEntityType(typeof(Pickle));
             var principalType = model.GetEntityType(typeof(BigMak));
-            var fk = dependentType.ForeignKeys.Single(foreignKey => foreignKey.IsUnique);
 
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
+            var fk = dependentType.AddForeignKey(dependentType.GetOrAddProperty("BurgerId", typeof(int)), principalKey);
+            fk.IsUnique = true;
+
             modelBuilder
-                .Entity<BigMak>()
-                .OneToMany(e => e.Pickles, e => e.BigMak)
+                .Entity<BigMak>().HasMany(e => e.Pickles).WithOne(e => e.BigMak)
                 .ForeignKey(e => e.BurgerId);
 
             Assert.Equal(1, dependentType.ForeignKeys.Count);
-            var newFk = dependentType.ForeignKeys.Single(k => k != fk);
+            var newFk = (IForeignKey)dependentType.ForeignKeys.Single(k => k != fk);
 
             Assert.False(newFk.IsUnique);
 
@@ -1802,8 +1791,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Customer>()
-                .OneToMany(e => e.Orders, e => e.Customer)
+                .Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer)
                 .ReferencedKey(e => e.Id);
 
             var fk = dependentType.ForeignKeys.Single();
@@ -1843,8 +1831,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Customer>()
-                .OneToMany(e => e.Orders, e => e.Customer)
+                .Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer)
                 .ReferencedKey(e => e.AlternateKey);
 
             var fk = dependentType.ForeignKeys.Single();
@@ -1889,8 +1876,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Customer>()
-                .OneToMany(e => e.Orders, e => e.Customer)
+                .Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer)
                 .ForeignKey(e => e.CustomerId)
                 .ReferencedKey(e => e.Id);
 
@@ -1931,8 +1917,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Customer>()
-                .OneToMany(e => e.Orders, e => e.Customer)
+                .Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer)
                 .ReferencedKey(e => e.Id)
                 .ForeignKey(e => e.CustomerId);
 
@@ -1973,8 +1958,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Customer>()
-                .OneToMany(e => e.Orders, e => e.Customer)
+                .Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer)
                 .ForeignKey(e => e.CustomerId)
                 .ReferencedKey(e => e.AlternateKey);
 
@@ -2020,8 +2004,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Customer>()
-                .OneToMany(e => e.Orders, e => e.Customer)
+                .Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer)
                 .ReferencedKey(e => e.AlternateKey)
                 .ForeignKey(e => e.CustomerId);
 
@@ -2066,8 +2049,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<BigMak>()
-                .OneToMany(e => e.Pickles, e => e.BigMak)
+                .Entity<BigMak>().HasMany(e => e.Pickles).WithOne(e => e.BigMak)
                 .ForeignKey(e => e.BurgerId)
                 .ReferencedKey(e => e.AlternateKey);
 
@@ -2112,8 +2094,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<BigMak>()
-                .OneToMany(e => e.Pickles, e => e.BigMak)
+                .Entity<BigMak>().HasMany(e => e.Pickles).WithOne(e => e.BigMak)
                 .ReferencedKey(e => e.AlternateKey)
                 .ForeignKey(e => e.BurgerId);
 
@@ -2161,7 +2142,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity<Order>().ManyToOne(e => e.Customer, e => e.Orders);
+            modelBuilder.Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders);
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
             Assert.Same(navToPrincipal, dependentType.Navigations.Single());
@@ -2184,8 +2165,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var modelBuilder = new ModelBuilder(model);
             modelBuilder.Entity<Customer>();
             modelBuilder
-                .Entity<Order>()
-                .ManyToOne(o => o.Customer)
+                .Entity<Order>().HasOne(o => o.Customer).WithMany()
                 .ForeignKey(c => c.CustomerId);
             modelBuilder.Ignore<OrderDetails>();
             modelBuilder.Ignore<CustomerDetails>();
@@ -2199,7 +2179,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity<Order>().ManyToOne(e => e.Customer, e => e.Orders);
+            modelBuilder.Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders);
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
             Assert.Same(navigation, dependentType.Navigations.Single());
@@ -2220,23 +2200,22 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             var model = new Model();
             var modelBuilder = new ModelBuilder(model);
-            modelBuilder.Entity<Customer>();
-            modelBuilder
-                .Entity<Order>()
-                .ForeignKey<Customer>(c => c.CustomerId);
+            modelBuilder.Entity<Customer>()
+                .HasMany(e => e.Orders)
+                .WithOne()
+                .ForeignKey(c => c.CustomerId);
             modelBuilder.Ignore<OrderDetails>();
             modelBuilder.Ignore<CustomerDetails>();
 
             var dependentType = model.GetEntityType(typeof(Order));
             var principalType = model.GetEntityType(typeof(Customer));
             var fk = dependentType.ForeignKeys.Single();
-
-            var navigation = principalType.GetOrAddNavigation("Orders", fk, pointsToPrincipal: false);
+            var navigation = fk.GetNavigationToDependent();
 
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity<Order>().ManyToOne(e => e.Customer, e => e.Orders);
+            modelBuilder.Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders);
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -2271,7 +2250,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity<Order>().ManyToOne(e => e.Customer, e => e.Orders);
+            modelBuilder.Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders);
             var newFk = dependentType.ForeignKeys.Single(foreignKey => foreignKey != fk);
 
             Assert.NotSame(fk, newFk);
@@ -2306,7 +2285,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity<Order>().ManyToOne(e => e.Customer, e => e.Orders);
+            modelBuilder.Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders);
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -2342,15 +2321,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            // Passing null as the first arg is not super-compelling, but it is consistent
-            modelBuilder.Entity<Order>().ManyToOne<Customer>(null, e => e.Orders);
+            modelBuilder.Entity<Order>().HasOne(e => e.Customer).WithMany();
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
-            Assert.Empty(dependentType.Navigations);
-            Assert.Equal("Orders", principalType.Navigations.Single().Name);
-            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
+            Assert.Equal("Customer", dependentType.Navigations.Single().Name);
+            Assert.Empty(principalType.Navigations);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Equal(new[] { "AlternateKey", principalKey.Properties.Single().Name, Customer.NameProperty.Name }, principalType.Properties.Select(p => p.Name));
             Assert.Equal(new[] { "AnotherCustomerId", fk.Properties.Single().Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
             Assert.Empty(principalType.ForeignKeys);
@@ -2375,19 +2353,17 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty = dependentType.GetProperty("CustomerId");
 
-            var principalPropertyCount = principalType.Properties.Count;
-            var dependentPropertyCount = dependentType.Properties.Count;
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity<Order>().ManyToOne(e => e.Customer);
+            modelBuilder.Entity<Order>().HasOne<Customer>().WithMany(e => e.Orders);
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
-            Assert.Equal("Customer", dependentType.Navigations.Single().Name);
-            Assert.Empty(principalType.Navigations);
-            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Empty(dependentType.Navigations);
+            Assert.Equal("Orders", principalType.Navigations.Single().Name);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(new[] { "AlternateKey", principalKey.Properties.Single().Name, Customer.NameProperty.Name }, principalType.Properties.Select(p => p.Name));
             Assert.Equal(new[] { "AnotherCustomerId", fk.Properties.Single().Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
             Assert.Empty(principalType.ForeignKeys);
@@ -2417,7 +2393,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity<Order>().ManyToOne<Customer>();
+            modelBuilder.Entity<Order>().HasOne<Customer>().WithMany();
 
             var newFk = dependentType.ForeignKeys.Single(foreignKey => foreignKey != fk);
 
@@ -2452,8 +2428,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Order>()
-                .ManyToOne(e => e.Customer, e => e.Orders)
+                .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                 .ForeignKey(e => e.CustomerId);
 
             var fk = dependentType.ForeignKeys.Single();
@@ -2478,22 +2453,20 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var model = new Model();
             var modelBuilder = new ModelBuilder(model);
             modelBuilder.Entity<BigMak>();
-            modelBuilder
-                .Entity<Pickle>()
-                .ManyToOne<BigMak>()
-                .ForeignKey(c => c.BurgerId);
+            modelBuilder.Entity<Pickle>();
             modelBuilder.Ignore<Bun>();
 
             var dependentType = model.GetEntityType(typeof(Pickle));
             var principalType = model.GetEntityType(typeof(BigMak));
-            var fk = dependentType.ForeignKeys.Single(foreignKey => foreignKey.Properties.Single().Name == "BurgerId");
 
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
+            var fk = dependentType.AddForeignKey(dependentType.GetOrAddProperty("BurgerId", typeof(int)), principalKey);
+            fk.IsUnique = false;
+
             modelBuilder
-                .Entity<Pickle>()
-                .ManyToOne(e => e.BigMak, e => e.Pickles)
+                .Entity<Pickle>().HasOne(e => e.BigMak).WithMany(e => e.Pickles)
                 .ForeignKey(e => e.BurgerId);
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
@@ -2528,8 +2501,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Pickle>()
-                .ManyToOne(e => e.BigMak, e => e.Pickles)
+                .Entity<Pickle>().HasOne(e => e.BigMak).WithMany(e => e.Pickles)
                 .ForeignKey(e => e.BurgerId);
 
             var fk = dependentType.ForeignKeys.Single();
@@ -2566,16 +2538,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Pickle>()
-                .ManyToOne<BigMak>(null, e => e.Pickles)
+                .Entity<Pickle>().HasOne(e => e.BigMak).WithMany(null)
                 .ForeignKey(e => e.BurgerId);
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
-            Assert.Empty(dependentType.Navigations);
-            Assert.Equal("Pickles", principalType.Navigations.Single().Name);
-            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
+            Assert.Equal("BigMak", dependentType.Navigations.Single().Name);
+            Assert.Empty(principalType.Navigations);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Equal(new[] { "AlternateKey", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             Assert.Equal(new[] { fkProperty.Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
             Assert.Empty(principalType.ForeignKeys);
@@ -2603,16 +2574,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Pickle>()
-                .ManyToOne(e => e.BigMak)
+                .Entity<Pickle>().HasOne<BigMak>().WithMany(e => e.Pickles)
                 .ForeignKey(e => e.BurgerId);
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
-            Assert.Equal("BigMak", dependentType.Navigations.Single().Name);
-            Assert.Empty(principalType.Navigations);
-            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Empty(dependentType.Navigations);
+            Assert.Equal("Pickles", principalType.Navigations.Single().Name);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(new[] { "AlternateKey", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             Assert.Equal(new[] { fkProperty.Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
             Assert.Empty(principalType.ForeignKeys);
@@ -2641,8 +2611,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Pickle>()
-                .ManyToOne<BigMak>()
+                .Entity<Pickle>().HasOne<BigMak>().WithMany()
                 .ForeignKey(e => e.BurgerId);
 
             var newFk = dependentType.ForeignKeys.Single(foreignKey => foreignKey != fk);
@@ -2674,7 +2643,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity<Pickle>().ManyToOne(e => e.BigMak, e => e.Pickles);
+            modelBuilder.Entity<Pickle>().HasOne(e => e.BigMak).WithMany(e => e.Pickles);
 
             var fk = dependentType.ForeignKeys.Single();
             var fkProperty = fk.Properties.Single();
@@ -2712,7 +2681,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity<Pickle>().ManyToOne<BigMak>(null, e => e.Pickles);
+            modelBuilder.Entity<Pickle>().HasOne(e => e.BigMak).WithMany();
 
             var fk = dependentType.ForeignKeys.Single();
             var fkProperty = fk.Properties.Single();
@@ -2722,9 +2691,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(typeof(int?), fkProperty.PropertyType);
             Assert.Same(dependentType, fkProperty.EntityType);
 
-            Assert.Empty(dependentType.Navigations);
-            Assert.Equal("Pickles", principalType.Navigations.Single().Name);
-            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
+            Assert.Equal("BigMak", dependentType.Navigations.Single().Name);
+            Assert.Empty(principalType.Navigations);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Equal(new[] { "AlternateKey", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             Assert.Equal(new[] { fkProperty.Name, "BurgerId", dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
             Assert.Empty(principalType.ForeignKeys);
@@ -2749,7 +2718,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity<Pickle>().ManyToOne(e => e.BigMak);
+            modelBuilder.Entity<Pickle>().HasOne<BigMak>().WithMany(e => e.Pickles);
 
             var fk = dependentType.ForeignKeys.Single();
             var fkProperty = fk.Properties.Single();
@@ -2759,9 +2728,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(typeof(int?), fkProperty.PropertyType);
             Assert.Same(dependentType, fkProperty.EntityType);
 
-            Assert.Equal("BigMak", dependentType.Navigations.Single().Name);
-            Assert.Empty(principalType.Navigations);
-            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Empty(dependentType.Navigations);
+            Assert.Equal("Pickles", principalType.Navigations.Single().Name);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(new[] { "AlternateKey", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             Assert.Equal(new[] { fkProperty.Name, "BurgerId", dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
             Assert.Empty(principalType.ForeignKeys);
@@ -2788,7 +2757,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fk = dependentType.ForeignKeys.SingleOrDefault();
 
-            modelBuilder.Entity<Pickle>().ManyToOne<BigMak>();
+            modelBuilder.Entity<Pickle>().HasOne<BigMak>().WithMany();
 
             var newFk = dependentType.ForeignKeys.Single(foreignKey => foreignKey != fk);
             var fkProperty = newFk.Properties.Single();
@@ -2825,7 +2794,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty = dependentType.GetProperty("BigMakId");
 
-            modelBuilder.Entity<Pickle>().ManyToOne(e => e.BigMak, e => e.Pickles);
+            modelBuilder.Entity<Pickle>().HasOne(e => e.BigMak).WithMany(e => e.Pickles);
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -2848,28 +2817,26 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             var model = new Model();
             var modelBuilder = new ModelBuilder(model);
-            modelBuilder.Entity<BigMak>();
             modelBuilder
-                .Entity<Pickle>()
-                .OneToOne<BigMak>()
+                .Entity<Pickle>().HasOne(e => e.BigMak).WithOne()
                 .ForeignKey<Pickle>(c => c.BurgerId);
             modelBuilder.Ignore<Bun>();
 
-            var dependentType = (IEntityType)model.GetEntityType(typeof(Pickle));
+            var dependentType = model.GetEntityType(typeof(Pickle));
             var principalType = model.GetEntityType(typeof(BigMak));
             var fk = dependentType.ForeignKeys.Single(foreignKey => foreignKey.Properties.Single().Name == "BurgerId");
-            Assert.True(fk.IsUnique);
+            Assert.True(((IForeignKey)fk).IsUnique);
+            dependentType.RemoveNavigation(fk.GetNavigationToPrincipal());
 
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Pickle>()
-                .ManyToOne(e => e.BigMak, e => e.Pickles)
+                .Entity<Pickle>().HasOne(e => e.BigMak).WithMany(e => e.Pickles)
                 .ForeignKey(e => e.BurgerId);
 
             Assert.Equal(1, dependentType.ForeignKeys.Count);
-            var newFk = dependentType.ForeignKeys.Single();
+            var newFk = (IForeignKey)dependentType.ForeignKeys.Single();
 
             Assert.False(newFk.IsUnique);
             Assert.NotSame(fk, newFk);
@@ -2907,8 +2874,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Order>()
-                .ManyToOne(e => e.Customer, e => e.Orders)
+                .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                 .ReferencedKey(e => e.Id);
 
             var fk = dependentType.ForeignKeys.Single();
@@ -2948,8 +2914,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Order>()
-                .ManyToOne(e => e.Customer, e => e.Orders)
+                .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                 .ReferencedKey(e => e.AlternateKey);
 
             var fk = dependentType.ForeignKeys.Single();
@@ -2994,8 +2959,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Order>()
-                .ManyToOne(e => e.Customer, e => e.Orders)
+                .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                 .ForeignKey(e => e.CustomerId)
                 .ReferencedKey(e => e.Id);
 
@@ -3036,8 +3000,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Order>()
-                .ManyToOne(e => e.Customer, e => e.Orders)
+                .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                 .ReferencedKey(e => e.Id)
                 .ForeignKey(e => e.CustomerId);
 
@@ -3078,8 +3041,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Order>()
-                .ManyToOne(e => e.Customer, e => e.Orders)
+                .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                 .ForeignKey(e => e.CustomerId)
                 .ReferencedKey(e => e.AlternateKey);
 
@@ -3125,8 +3087,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Order>()
-                .ManyToOne(e => e.Customer, e => e.Orders)
+                .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                 .ReferencedKey(e => e.AlternateKey)
                 .ForeignKey(e => e.CustomerId);
 
@@ -3171,8 +3132,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Pickle>()
-                .ManyToOne(e => e.BigMak, e => e.Pickles)
+                .Entity<Pickle>().HasOne(e => e.BigMak).WithMany(e => e.Pickles)
                 .ForeignKey(e => e.BurgerId)
                 .ReferencedKey(e => e.AlternateKey);
 
@@ -3217,8 +3177,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Pickle>()
-                .ManyToOne(e => e.BigMak, e => e.Pickles)
+                .Entity<Pickle>().HasOne(e => e.BigMak).WithMany(e => e.Pickles)
                 .ReferencedKey(e => e.AlternateKey)
                 .ForeignKey(e => e.BurgerId);
 
@@ -3251,8 +3210,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var modelBuilder = new ModelBuilder(model);
             modelBuilder.Entity<Customer>();
             modelBuilder
-                .Entity<CustomerDetails>()
-                .OneToOne(d => d.Customer, c => c.Details)
+                .Entity<CustomerDetails>().HasOne(d => d.Customer).WithOne(c => c.Details)
                 .ForeignKey<CustomerDetails>(c => c.Id);
             modelBuilder.Ignore<Order>();
 
@@ -3266,7 +3224,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity<Customer>().OneToOne(e => e.Details, e => e.Customer);
+            modelBuilder.Entity<Customer>().HasOne(e => e.Details).WithOne(e => e.Customer);
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
             Assert.Same(navToPrincipal, dependentType.Navigations.Single());
@@ -3287,9 +3245,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             var model = new Model();
             var modelBuilder = new ModelBuilder(model);
-            modelBuilder.Entity<Customer>()
-                .OneToOne<CustomerDetails>(null, c => c.Customer);
-            modelBuilder.Entity<CustomerDetails>();
+            modelBuilder.Entity<CustomerDetails>().HasOne(c => c.Customer).WithOne();
             modelBuilder.Ignore<Order>();
 
             var dependentType = model.GetEntityType(typeof(CustomerDetails));
@@ -3301,7 +3257,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity<Customer>().OneToOne(e => e.Details, e => e.Customer);
+            modelBuilder.Entity<Customer>().HasOne(e => e.Details).WithOne(e => e.Customer);
 
             var newFk = dependentType.ForeignKeys.Single();
             Assert.Equal(fk.Properties, newFk.Properties);
@@ -3324,11 +3280,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             var model = new Model();
             var modelBuilder = new ModelBuilder(model);
-            modelBuilder.Entity<Customer>();
-            modelBuilder
-                .Entity<CustomerDetails>()
-                .OneToOne<Customer>(null, c => c.Details)
+            modelBuilder.Entity<Customer>().HasOne(c => c.Details).WithOne()
                 .ForeignKey<CustomerDetails>(c => c.Id);
+            modelBuilder.Entity<CustomerDetails>();
             modelBuilder.Ignore<Order>();
 
             var dependentType = model.GetEntityType(typeof(CustomerDetails));
@@ -3340,7 +3294,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity<Customer>().OneToOne(e => e.Details, e => e.Customer);
+            modelBuilder.Entity<Customer>().HasOne(e => e.Details).WithOne(e => e.Customer);
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -3361,25 +3315,24 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             var model = new Model();
             var modelBuilder = new ModelBuilder(model);
-            modelBuilder.Entity<Customer>();
-            modelBuilder.Entity<CustomerDetails>();
-            modelBuilder
-                .Entity<CustomerDetails>()
-                .ForeignKey<Customer>(c => c.Id)
-                .IsUnique();
+            modelBuilder.Entity<Customer>()
+                .HasOne(e => e.Details)
+                .WithOne()
+                .ForeignKey<CustomerDetails>(e => e.Id);
             modelBuilder.Ignore<Order>();
 
             var dependentType = model.GetEntityType(typeof(CustomerDetails));
             var principalType = model.GetEntityType(typeof(Customer));
             var fk = dependentType.ForeignKeys.Single();
             Assert.True(((IForeignKey)fk).IsUnique);
+            principalType.RemoveNavigation(fk.GetNavigationToDependent());
 
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity<Customer>().OneToOne(e => e.Details, e => e.Customer);
-            var newFk = dependentType.ForeignKeys.Single(foreignKey => foreignKey!=fk);
-            
+            modelBuilder.Entity<CustomerDetails>().HasOne(e => e.Customer).WithOne(e => e.Details);
+            var newFk = dependentType.ForeignKeys.Single(foreignKey => foreignKey != fk);
+
             Assert.NotSame(fk, newFk);
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
             Assert.Equal("Details", principalType.Navigations.Single().Name);
@@ -3399,8 +3352,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             var model = new Model();
             var modelBuilder = new ModelBuilder(model);
-            modelBuilder.Entity<Customer>();
             modelBuilder.Entity<CustomerDetails>();
+            modelBuilder.Entity<Customer>();
             modelBuilder.Ignore<Order>();
 
             var dependentType = model.GetEntityType(typeof(CustomerDetails));
@@ -3411,7 +3364,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity<Customer>().OneToOne(e => e.Details, e => e.Customer);
+            modelBuilder.Entity<CustomerDetails>().HasOne(e => e.Customer).WithOne(e => e.Details);
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -3437,19 +3390,21 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             modelBuilder.Entity<Order>();
             modelBuilder.Entity<OrderDetails>();
             modelBuilder
-                .Entity<OrderDetails>()
-                .ForeignKey<Order>(c => c.Id);
+                .Entity<Order>()
+                .HasOne(e => e.Details)
+                .WithOne()
+                .ForeignKey<OrderDetails>(c => c.Id);
             modelBuilder.Ignore<Customer>();
 
             var dependentType = model.GetEntityType(typeof(OrderDetails));
             var principalType = model.GetEntityType(typeof(Order));
-            var fk = dependentType.ForeignKeys.Single();
-            fk.IsUnique = true;
+            var fk = dependentType.ForeignKeys.Single(foreignKey => ((IForeignKey)foreignKey).IsUnique);
+            principalType.RemoveNavigation(fk.GetNavigationToDependent());
 
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity<Order>().OneToOne(e => e.Details, e => e.Order);
+            modelBuilder.Entity<OrderDetails>().HasOne(e => e.Order).WithOne(e => e.Details);
 
             var newFk = dependentType.ForeignKeys.Single(foreignKey => foreignKey != fk);
             Assert.NotSame(fk, newFk);
@@ -3472,8 +3427,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             var model = new Model();
             var modelBuilder = new ModelBuilder(model);
-            modelBuilder.Entity<Order>();
             modelBuilder.Entity<OrderDetails>();
+            modelBuilder.Entity<Order>();
             modelBuilder.Ignore<Customer>();
 
             var dependentType = model.GetEntityType(typeof(OrderDetails));
@@ -3484,7 +3439,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity<Order>().OneToOne(e => e.Details, e => e.Order);
+            modelBuilder.Entity<OrderDetails>().HasOne(e => e.Order).WithOne(e => e.Details);
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -3511,24 +3466,24 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             modelBuilder.Entity<CustomerDetails>();
             modelBuilder.Ignore<Order>();
 
-            var dependentType = model.GetEntityType(typeof(CustomerDetails));
-            var principalType = model.GetEntityType(typeof(Customer));
+            var dependentType = model.GetEntityType(typeof(Customer));
+            var principalType = model.GetEntityType(typeof(CustomerDetails));
 
             var fkProperty = dependentType.GetProperty(Customer.IdProperty.Name);
 
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity<Customer>().OneToOne(e => e.Details);
+            modelBuilder.Entity<Customer>().HasOne(e => e.Details).WithOne();
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
-            Assert.Empty(dependentType.Navigations);
-            Assert.Equal("Details", principalType.Navigations.Single().Name);
-            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
-            Assert.Equal(new[] { "AlternateKey", principalKey.Properties.Single().Name, Customer.NameProperty.Name }, principalType.Properties.Select(p => p.Name));
-            Assert.Equal(new[] { dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
+            Assert.Empty(principalType.Navigations);
+            Assert.Equal("Details", dependentType.Navigations.Single().Name);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Equal(new[] { principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
+            Assert.Equal(new[] { "AlternateKey", dependentKey.Properties.Single().Name, Customer.NameProperty.Name }, dependentType.Properties.Select(p => p.Name));
             Assert.Empty(principalType.ForeignKeys);
             Assert.Same(principalKey, principalType.Keys.Single());
             Assert.Same(dependentKey, dependentType.Keys.Single());
@@ -3548,20 +3503,29 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentType = model.GetEntityType(typeof(CustomerDetails));
             var principalType = model.GetEntityType(typeof(Customer));
 
+            foreach (var navigation in principalType.Navigations.ToList())
+            {
+                var inverse = navigation.TryGetInverse();
+                inverse?.EntityType.RemoveNavigation(inverse);
+                principalType.RemoveNavigation(navigation);
+
+                var foreignKey = navigation.ForeignKey;
+                foreignKey.EntityType.RemoveForeignKey(foreignKey);
+            }
+
             var fkProperty = dependentType.GetProperty(Customer.IdProperty.Name);
 
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            // Passing null as the first arg is not super-compelling, but it is consistent
-            modelBuilder.Entity<Customer>().OneToOne<CustomerDetails>(null, e => e.Customer);
+            modelBuilder.Entity<CustomerDetails>().HasOne<Customer>().WithOne(e => e.Details);
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
-            Assert.Equal("Customer", dependentType.Navigations.Single().Name);
-            Assert.Empty(principalType.Navigations);
-            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Equal("Details", principalType.Navigations.Single().Name);
+            Assert.Empty(dependentType.Navigations);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(new[] { "AlternateKey", principalKey.Properties.Single().Name, "Name" }, principalType.Properties.Select(p => p.Name));
             Assert.Equal(new[] { dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
             Assert.Empty(principalType.ForeignKeys);
@@ -3586,14 +3550,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            var fk = principalType.ForeignKeys.Single();
+            modelBuilder.Entity<CustomerDetails>().HasOne<Customer>().WithOne();
 
-            modelBuilder.Entity<Customer>().OneToOne<CustomerDetails>();
+            var fk = dependentType.ForeignKeys.Single();
 
-            var newFk = dependentType.ForeignKeys.Single();
-
-            Assert.Empty(dependentType.Navigations.Where(nav => nav.ForeignKey == newFk));
-            Assert.Empty(principalType.Navigations.Where(nav => nav.ForeignKey == newFk));
+            Assert.Empty(dependentType.Navigations.Where(nav => nav.ForeignKey == fk));
+            Assert.Empty(principalType.Navigations.Where(nav => nav.ForeignKey == fk));
             Assert.Equal(new[] { "AlternateKey", principalKey.Properties.Single().Name, Customer.NameProperty.Name }, principalType.Properties.Select(p => p.Name));
             Assert.Equal(new[] { dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
             Assert.Same(principalKey, principalType.Keys.Single());
@@ -3620,8 +3582,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Order>()
-                .OneToOne(e => e.Details, e => e.Order)
+                .Entity<Order>().HasOne(e => e.Details).WithOne(e => e.Order)
                 .ForeignKey<OrderDetails>(e => e.OrderId);
 
             var fk = dependentType.ForeignKeys.Single();
@@ -3658,8 +3619,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Customer>()
-                .OneToOne(e => e.Details, e => e.Customer)
+                .Entity<Customer>().HasOne(e => e.Details).WithOne(e => e.Customer)
                 .ForeignKey<CustomerDetails>(e => e.Id);
 
             var fk = dependentType.ForeignKeys.Single();
@@ -3698,8 +3658,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<BigMak>()
-                .OneToOne(e => e.Bun, e => e.BigMak)
+                .Entity<BigMak>().HasOne(e => e.Bun).WithOne(e => e.BigMak)
                 .ForeignKey<Bun>(e => e.BurgerId);
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
@@ -3734,8 +3693,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<BigMak>()
-                .OneToOne(e => e.Bun, e => e.BigMak)
+                .Entity<BigMak>().HasOne(e => e.Bun).WithOne(e => e.BigMak)
                 .ForeignKey<Bun>(e => e.BurgerId);
 
             var fk = dependentType.ForeignKeys.Single();
@@ -3772,8 +3730,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<BigMak>()
-                .OneToOne(e => e.Bun)
+                .Entity<BigMak>().HasOne(e => e.Bun).WithOne()
                 .ForeignKey<Bun>(e => e.BurgerId);
 
             var fk = dependentType.ForeignKeys.Single();
@@ -3809,8 +3766,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<BigMak>()
-                .OneToOne<Bun>(null, e => e.BigMak)
+                .Entity<BigMak>().HasOne<Bun>().WithOne(e => e.BigMak)
                 .ForeignKey<Bun>(e => e.BurgerId);
 
             var fk = dependentType.ForeignKeys.Single();
@@ -3843,11 +3799,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            var fk = principalType.ForeignKeys.Single();
-
             modelBuilder
-                .Entity<BigMak>()
-                .OneToOne<Bun>()
+                .Entity<BigMak>().HasOne<Bun>().WithOne()
                 .ForeignKey<Bun>(e => e.BurgerId);
 
             var newFk = dependentType.ForeignKeys.Single();
@@ -3881,8 +3834,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<BigMak>()
-                .OneToOne(e => e.Bun, e => e.BigMak)
+                .Entity<BigMak>().HasOne(e => e.Bun).WithOne(e => e.BigMak)
                 .ForeignKey<Bun>(e => e.BurgerId);
 
             Assert.Equal(1, dependentType.ForeignKeys.Count);
@@ -3913,8 +3865,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             modelBuilder.Entity<Order>();
             modelBuilder.Entity<OrderDetails>();
             modelBuilder
-                .Entity<OrderDetails>()
-                .OneToOne(e => e.Order)
+                .Entity<OrderDetails>().HasOne(e => e.Order).WithOne()
                 .ForeignKey<OrderDetails>(c => c.Id);
             modelBuilder.Ignore<Customer>();
 
@@ -3926,8 +3877,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<OrderDetails>()
-                .OneToOne(e => e.Order, e => e.Details)
+                .Entity<OrderDetails>().HasOne(e => e.Order).WithOne(e => e.Details)
                 .ForeignKey<OrderDetails>(e => e.Id);
 
             var newFk = dependentType.ForeignKeys.Single();
@@ -3964,8 +3914,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<OrderDetails>()
-                .OneToOne(e => e.Order, e => e.Details)
+                .Entity<OrderDetails>().HasOne(e => e.Order).WithOne(e => e.Details)
                 .ForeignKey<OrderDetails>(e => e.OrderId);
 
             var fk = dependentType.ForeignKeys.Single();
@@ -3977,43 +3926,6 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(new[] { "AnotherCustomerId", "CustomerId", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             Assert.Equal(new[] { dependentKey.Properties.Single().Name, fk.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
-            Assert.Same(principalKey, principalType.GetPrimaryKey());
-            Assert.Same(dependentKey, dependentType.GetPrimaryKey());
-        }
-
-        [Fact]
-        public void Unidirectional_from_other_end_OneToOne_principal_and_dependent_can_be_flipped()
-        {
-            var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
-            modelBuilder.Entity<Customer>();
-            modelBuilder.Entity<CustomerDetails>();
-            modelBuilder.Ignore<Order>();
-
-            var dependentType = model.GetEntityType(typeof(CustomerDetails));
-            var principalType = model.GetEntityType(typeof(Customer));
-
-            var fkProperty = dependentType.GetProperty(Customer.IdProperty.Name);
-
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
-
-            modelBuilder
-                .Entity<CustomerDetails>()
-                .OneToOne(e => e.Customer)
-                .ForeignKey<CustomerDetails>(e => e.Id);
-
-            var fk = dependentType.ForeignKeys.Single();
-            Assert.Same(fkProperty, fk.Properties.Single());
-
-            Assert.Equal("Customer", dependentType.Navigations.Single().Name);
-            Assert.Empty(principalType.Navigations);
-            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
-            Assert.Equal(new[] { "AlternateKey", principalKey.Properties.Single().Name, "Name" }, principalType.Properties.Select(p => p.Name));
-            Assert.Equal(new[] { dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
             Assert.Empty(principalType.ForeignKeys);
             Assert.Same(principalKey, principalType.Keys.Single());
             Assert.Same(dependentKey, dependentType.Keys.Single());
@@ -4039,8 +3951,43 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<CustomerDetails>()
-                .OneToOne<Customer>(null, e => e.Details)
+                .Entity<CustomerDetails>().HasOne(e => e.Customer).WithOne()
+                .ForeignKey<CustomerDetails>(e => e.Id);
+
+            var fk = dependentType.ForeignKeys.Single();
+            Assert.Same(fkProperty, fk.Properties.Single());
+
+            Assert.Equal("Customer", dependentType.Navigations.Single().Name);
+            Assert.Empty(principalType.Navigations);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Equal(new[] { "AlternateKey", principalKey.Properties.Single().Name, "Name" }, principalType.Properties.Select(p => p.Name));
+            Assert.Equal(new[] { dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
+            Assert.Empty(principalType.ForeignKeys);
+            Assert.Same(principalKey, principalType.Keys.Single());
+            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Same(principalKey, principalType.GetPrimaryKey());
+            Assert.Same(dependentKey, dependentType.GetPrimaryKey());
+        }
+
+        [Fact]
+        public void Unidirectional_from_other_end_OneToOne_principal_and_dependent_can_be_flipped()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+            modelBuilder.Entity<Customer>();
+            modelBuilder.Entity<CustomerDetails>();
+            modelBuilder.Ignore<Order>();
+
+            var dependentType = model.GetEntityType(typeof(CustomerDetails));
+            var principalType = model.GetEntityType(typeof(Customer));
+
+            var fkProperty = dependentType.GetProperty(Customer.IdProperty.Name);
+
+            var principalKey = principalType.Keys.Single();
+            var dependentKey = dependentType.Keys.Single();
+
+            modelBuilder
+                .Entity<CustomerDetails>().HasOne<Customer>().WithOne(e => e.Details)
                 .ForeignKey<CustomerDetails>(e => e.Id);
 
             var fk = dependentType.ForeignKeys.Single();
@@ -4078,8 +4025,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var existingFk = principalType.ForeignKeys.SingleOrDefault();
 
             modelBuilder
-                .Entity<CustomerDetails>()
-                .OneToOne<Customer>()
+                .Entity<CustomerDetails>().HasOne<Customer>().WithOne()
                 .ForeignKey<CustomerDetails>(e => e.Id);
 
             var fk = dependentType.ForeignKeys.Single();
@@ -4114,8 +4060,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<CustomerDetails>()
-                .OneToOne(e => e.Customer, e => e.Details)
+                .Entity<CustomerDetails>().HasOne(e => e.Customer).WithOne(e => e.Details)
                 .ForeignKey<CustomerDetails>(e => e.Id);
 
             var fk = dependentType.ForeignKeys.Single();
@@ -4153,8 +4098,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Customer>()
-                .OneToOne(e => e.Details, e => e.Customer)
+                .Entity<Customer>().HasOne(e => e.Details).WithOne(e => e.Customer)
                 .ReferencedKey<Customer>(e => e.Id);
 
             var fk = dependentType.ForeignKeys.Single();
@@ -4193,8 +4137,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Customer>()
-                .OneToOne(e => e.Details, e => e.Customer)
+                .Entity<Customer>().HasOne(e => e.Details).WithOne(e => e.Customer)
                 .ReferencedKey<Customer>(e => e.AlternateKey);
 
             var fk = dependentType.ForeignKeys.Single();
@@ -4240,8 +4183,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Order>()
-                .OneToOne(e => e.Details, e => e.Order)
+                .Entity<Order>().HasOne(e => e.Details).WithOne(e => e.Order)
                 .ForeignKey<OrderDetails>(e => e.OrderId)
                 .ReferencedKey<Order>(e => e.OrderId);
 
@@ -4283,8 +4225,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Order>()
-                .OneToOne(e => e.Details, e => e.Order)
+                .Entity<Order>().HasOne(e => e.Details).WithOne(e => e.Order)
                 .ReferencedKey<Order>(e => e.OrderId)
                 .ForeignKey<OrderDetails>(e => e.OrderId);
 
@@ -4324,8 +4265,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<BigMak>()
-                .OneToOne(e => e.Bun, e => e.BigMak)
+                .Entity<BigMak>().HasOne(e => e.Bun).WithOne(e => e.BigMak)
                 .ForeignKey<Bun>(e => e.BurgerId)
                 .ReferencedKey<BigMak>(e => e.AlternateKey);
 
@@ -4370,8 +4310,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<BigMak>()
-                .OneToOne(e => e.Bun, e => e.BigMak)
+                .Entity<BigMak>().HasOne(e => e.Bun).WithOne(e => e.BigMak)
                 .ReferencedKey<BigMak>(e => e.AlternateKey)
                 .ForeignKey<Bun>(e => e.BurgerId);
 
@@ -4419,8 +4358,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<OrderDetails>()
-                .OneToOne(e => e.Order, e => e.Details)
+                .Entity<OrderDetails>().HasOne(e => e.Order).WithOne(e => e.Details)
                 .ReferencedKey<Order>(e => e.OrderId);
 
             var newFk = dependentType.ForeignKeys.Single(foreignKey => foreignKey != fk);
@@ -4457,8 +4395,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<OrderDetails>()
-                .OneToOne(e => e.Order, e => e.Details)
+                .Entity<OrderDetails>().HasOne(e => e.Order).WithOne(e => e.Details)
                 .ReferencedKey<Order>(e => e.OrderId);
 
             var fk = dependentType.ForeignKeys.Single();
@@ -4496,8 +4433,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<OrderDetails>()
-                .OneToOne(e => e.Order, e => e.Details)
+                .Entity<OrderDetails>().HasOne(e => e.Order).WithOne(e => e.Details)
                 .ForeignKey<OrderDetails>(e => e.OrderId)
                 .ReferencedKey<Order>(e => e.OrderId);
 
@@ -4536,8 +4472,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<OrderDetails>()
-                .OneToOne(e => e.Order, e => e.Details)
+                .Entity<OrderDetails>().HasOne(e => e.Order).WithOne(e => e.Details)
                 .ReferencedKey<Order>(e => e.OrderId)
                 .ForeignKey<OrderDetails>(e => e.OrderId);
 
@@ -4550,43 +4485,6 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(new[] { "AnotherCustomerId", "CustomerId", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             Assert.Equal(new[] { dependentKey.Properties.Single().Name, fkProperty.Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
-            Assert.Same(principalKey, principalType.GetPrimaryKey());
-            Assert.Same(dependentKey, dependentType.GetPrimaryKey());
-        }
-
-        [Fact]
-        public void Unidirectional_from_other_end_OneToOne_principal_and_dependent_can_be_flipped_using_principal()
-        {
-            var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
-            modelBuilder.Entity<Customer>();
-            modelBuilder.Entity<CustomerDetails>();
-            modelBuilder.Ignore<Order>();
-
-            var dependentType = model.GetEntityType(typeof(CustomerDetails));
-            var principalType = model.GetEntityType(typeof(Customer));
-
-            var fkProperty = dependentType.GetProperty(Customer.IdProperty.Name);
-
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
-
-            modelBuilder
-                .Entity<CustomerDetails>()
-                .OneToOne(e => e.Customer)
-                .ReferencedKey<Customer>(e => e.Id);
-
-            var fk = dependentType.ForeignKeys.Single();
-            Assert.Same(fkProperty, fk.Properties.Single());
-
-            Assert.Equal("Customer", dependentType.Navigations.Single().Name);
-            Assert.Empty(principalType.Navigations);
-            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
-            Assert.Equal(new[] { "AlternateKey", principalKey.Properties.Single().Name, "Name" }, principalType.Properties.Select(p => p.Name));
-            Assert.Equal(new[] { dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
             Assert.Empty(principalType.ForeignKeys);
             Assert.Same(principalKey, principalType.Keys.Single());
             Assert.Same(dependentKey, dependentType.Keys.Single());
@@ -4612,8 +4510,43 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<CustomerDetails>()
-                .OneToOne<Customer>(null, e => e.Details)
+                .Entity<CustomerDetails>().HasOne(e => e.Customer).WithOne()
+                .ReferencedKey<Customer>(e => e.Id);
+
+            var fk = dependentType.ForeignKeys.Single();
+            Assert.Same(fkProperty, fk.Properties.Single());
+
+            Assert.Equal("Customer", dependentType.Navigations.Single().Name);
+            Assert.Empty(principalType.Navigations);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Equal(new[] { "AlternateKey", principalKey.Properties.Single().Name, "Name" }, principalType.Properties.Select(p => p.Name));
+            Assert.Equal(new[] { dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
+            Assert.Empty(principalType.ForeignKeys);
+            Assert.Same(principalKey, principalType.Keys.Single());
+            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Same(principalKey, principalType.GetPrimaryKey());
+            Assert.Same(dependentKey, dependentType.GetPrimaryKey());
+        }
+
+        [Fact]
+        public void Unidirectional_from_other_end_OneToOne_principal_and_dependent_can_be_flipped_using_principal()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+            modelBuilder.Entity<Customer>();
+            modelBuilder.Entity<CustomerDetails>();
+            modelBuilder.Ignore<Order>();
+
+            var dependentType = model.GetEntityType(typeof(CustomerDetails));
+            var principalType = model.GetEntityType(typeof(Customer));
+
+            var fkProperty = dependentType.GetProperty(Customer.IdProperty.Name);
+
+            var principalKey = principalType.Keys.Single();
+            var dependentKey = dependentType.Keys.Single();
+
+            modelBuilder
+                .Entity<CustomerDetails>().HasOne<Customer>().WithOne(e => e.Details)
                 .ReferencedKey<Customer>(e => e.Id);
 
             var fk = dependentType.ForeignKeys.Single();
@@ -4650,8 +4583,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalForeignKeyCount = principalType.ForeignKeys.Count;
 
             modelBuilder
-                .Entity<CustomerDetails>()
-                .OneToOne<Customer>()
+                .Entity<CustomerDetails>().HasOne<Customer>().WithOne()
                 .ReferencedKey<Customer>(e => e.Id);
 
             var fk = dependentType.ForeignKeys.Single();
@@ -4701,8 +4633,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var modelBuilder = new ModelBuilder(model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             modelBuilder
-                .Entity<Tomato>()
-                .ManyToOne(e => e.Whoopper)
+                .Entity<Tomato>().HasOne(e => e.Whoopper).WithMany()
                 .ForeignKey(c => new { c.BurgerId1, c.BurgerId2 });
             modelBuilder.Ignore<ToastedBun>();
             modelBuilder.Ignore<Moostard>();
@@ -4715,8 +4646,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Whoopper>()
-                .OneToMany(e => e.Tomatoes, e => e.Whoopper)
+                .Entity<Whoopper>().HasMany(e => e.Tomatoes).WithOne(e => e.Whoopper)
                 .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
@@ -4753,8 +4683,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Whoopper>()
-                .OneToMany(e => e.Tomatoes, e => e.Whoopper)
+                .Entity<Whoopper>().HasMany(e => e.Tomatoes).WithOne(e => e.Whoopper)
                 .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
 
             var fk = dependentType.ForeignKeys.Single();
@@ -4796,8 +4725,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Whoopper>()
-                .OneToMany(e => e.Tomatoes, e => e.Whoopper)
+                .Entity<Whoopper>().HasMany(e => e.Tomatoes).WithOne(e => e.Whoopper)
                 .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 })
                 .ReferencedKey(e => new { e.AlternateKey1, e.AlternateKey2 });
 
@@ -4847,8 +4775,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Whoopper>()
-                .OneToMany(e => e.Tomatoes, e => e.Whoopper)
+                .Entity<Whoopper>().HasMany(e => e.Tomatoes).WithOne(e => e.Whoopper)
                 .ReferencedKey(e => new { e.AlternateKey1, e.AlternateKey2 })
                 .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
 
@@ -4900,8 +4827,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Whoopper>()
-                .OneToMany(e => e.Tomatoes)
+                .Entity<Whoopper>().HasMany(e => e.Tomatoes).WithOne()
                 .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
 
             var fk = dependentType.ForeignKeys.Single();
@@ -4940,8 +4866,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Whoopper>()
-                .OneToMany<Tomato>(null, e => e.Whoopper)
+                .Entity<Whoopper>().HasMany<Tomato>().WithOne(e => e.Whoopper)
                 .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
 
             var fk = dependentType.ForeignKeys.Single();
@@ -4967,8 +4892,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var modelBuilder = new ModelBuilder(model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             // TODO: Remove this line when configuring a key triggers conventions
-            modelBuilder.Entity<Whoopper>()
-                .OneToMany(w => w.Tomatoes, t => t.Whoopper);
+            modelBuilder.Entity<Whoopper>().HasMany(w => w.Tomatoes).WithOne(t => t.Whoopper);
             modelBuilder.Entity<Tomato>();
             modelBuilder.Ignore<Moostard>();
             modelBuilder.Ignore<ToastedBun>();
@@ -4984,8 +4908,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.GetPrimaryKey();
 
             modelBuilder
-                .Entity<Whoopper>()
-                .OneToMany<Tomato>()
+                .Entity<Whoopper>().HasMany<Tomato>().WithOne()
                 .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
 
             var newFk = dependentType.ForeignKeys.Single(foreignKey => foreignKey != fk);
@@ -5010,8 +4933,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var modelBuilder = new ModelBuilder(model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             modelBuilder
-                .Entity<Tomato>()
-                .ManyToOne<Whoopper>()
+                .Entity<Tomato>().HasOne(e => e.Whoopper).WithMany()
                 .ForeignKey(c => new { c.BurgerId1, c.BurgerId2 });
             modelBuilder.Ignore<ToastedBun>();
             modelBuilder.Ignore<Moostard>();
@@ -5019,13 +4941,13 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentType = model.GetEntityType(typeof(Tomato));
             var principalType = model.GetEntityType(typeof(Whoopper));
             var fk = dependentType.ForeignKeys.Single(foreignKey => foreignKey.Properties.First().Name == "BurgerId1");
+            dependentType.RemoveNavigation(fk.GetNavigationToPrincipal());
 
             var principalKey = principalType.GetPrimaryKey();
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Tomato>()
-                .ManyToOne(e => e.Whoopper, e => e.Tomatoes)
+                .Entity<Tomato>().HasOne(e => e.Whoopper).WithMany(e => e.Tomatoes)
                 .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
@@ -5062,8 +4984,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.GetPrimaryKey();
 
             modelBuilder
-                .Entity<Tomato>()
-                .ManyToOne(e => e.Whoopper, e => e.Tomatoes)
+                .Entity<Tomato>().HasOne(e => e.Whoopper).WithMany(e => e.Tomatoes)
                 .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
 
             var fk = dependentType.ForeignKeys.Single();
@@ -5105,8 +5026,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Tomato>()
-                .ManyToOne(e => e.Whoopper, e => e.Tomatoes)
+                .Entity<Tomato>().HasOne(e => e.Whoopper).WithMany(e => e.Tomatoes)
                 .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 })
                 .ReferencedKey(e => new { e.AlternateKey1, e.AlternateKey2 });
 
@@ -5156,8 +5076,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.GetPrimaryKey();
 
             modelBuilder
-                .Entity<Tomato>()
-                .ManyToOne(e => e.Whoopper, e => e.Tomatoes)
+                .Entity<Tomato>().HasOne(e => e.Whoopper).WithMany(e => e.Tomatoes)
                 .ReferencedKey(e => new { e.AlternateKey1, e.AlternateKey2 })
                 .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
 
@@ -5205,17 +5124,16 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Tomato>()
-                .ManyToOne<Whoopper>(null, e => e.Tomatoes)
+                .Entity<Tomato>().HasOne(e => e.Whoopper).WithMany()
                 .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
 
-            Assert.Empty(dependentType.Navigations);
-            Assert.Equal("Tomatoes", principalType.Navigations.Single().Name);
-            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
+            Assert.Equal("Whoopper", dependentType.Navigations.Single().Name);
+            Assert.Empty(principalType.Navigations);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Equal(new[] { "AlternateKey1", "AlternateKey2", principalKey.Properties[0].Name, principalKey.Properties[1].Name }, principalType.Properties.Select(p => p.Name));
             Assert.Equal(new[] { fk.Properties[0].Name, fk.Properties[1].Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
             Assert.Empty(principalType.ForeignKeys);
@@ -5245,17 +5163,16 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Tomato>()
-                .ManyToOne(e => e.Whoopper)
+                .Entity<Tomato>().HasOne<Whoopper>().WithMany(e => e.Tomatoes)
                 .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
 
-            Assert.Equal("Whoopper", dependentType.Navigations.Single().Name);
-            Assert.Empty(principalType.Navigations);
-            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Empty(dependentType.Navigations);
+            Assert.Equal("Tomatoes", principalType.Navigations.Single().Name);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(new[] { "AlternateKey1", "AlternateKey2", principalKey.Properties[0].Name, principalKey.Properties[1].Name }, principalType.Properties.Select(p => p.Name));
             Assert.Equal(new[] { fk.Properties[0].Name, fk.Properties[1].Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
             Assert.Empty(principalType.ForeignKeys);
@@ -5272,8 +5189,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var modelBuilder = new ModelBuilder(model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             // TODO: Remove this line when configuring a key triggers conventions
-            modelBuilder.Entity<Whoopper>()
-                .OneToMany(w => w.Tomatoes, t => t.Whoopper);
+            modelBuilder.Entity<Whoopper>().HasMany(w => w.Tomatoes).WithOne(t => t.Whoopper);
             modelBuilder.Entity<Tomato>();
             modelBuilder.Ignore<ToastedBun>();
             modelBuilder.Ignore<Moostard>();
@@ -5289,8 +5205,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Tomato>()
-                .ManyToOne<Whoopper>()
+                .Entity<Tomato>().HasOne<Whoopper>().WithMany()
                 .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
 
             var newFk = dependentType.ForeignKeys.Single(foreignKey => foreignKey != fk);
@@ -5303,7 +5218,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 principalType.Properties.Select(p => p.Name));
             Assert.Equal(new[] { fkProperty1.Name, fkProperty2.Name, dependentKey.Properties.Single().Name, fk.Properties[0].Name, fk.Properties[1].Name }, dependentType.Properties.Select(p => p.Name));
             Assert.Empty(principalType.ForeignKeys);
-            //Assert.Same(principalKey, principalType.Keys.Single());
+            Assert.Same(principalKey, principalType.Keys.Single()); //
             Assert.Same(dependentKey, dependentType.Keys.Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
@@ -5330,8 +5245,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.GetPrimaryKey();
 
             modelBuilder
-                .Entity<Whoopper>()
-                .OneToOne(e => e.ToastedBun, e => e.Whoopper)
+                .Entity<Whoopper>().HasOne(e => e.ToastedBun).WithOne(e => e.Whoopper)
                 .ForeignKey<ToastedBun>(e => new { e.BurgerId1, e.BurgerId2 });
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
@@ -5368,8 +5282,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Whoopper>()
-                .OneToOne(e => e.ToastedBun, e => e.Whoopper)
+                .Entity<Whoopper>().HasOne(e => e.ToastedBun).WithOne(e => e.Whoopper)
                 .ForeignKey<ToastedBun>(e => new { e.BurgerId1, e.BurgerId2 });
 
             var fk = dependentType.ForeignKeys.Single();
@@ -5411,8 +5324,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Whoopper>()
-                .OneToOne(e => e.ToastedBun, e => e.Whoopper)
+                .Entity<Whoopper>().HasOne(e => e.ToastedBun).WithOne(e => e.Whoopper)
                 .ForeignKey<ToastedBun>(e => new { e.BurgerId1, e.BurgerId2 })
                 .ReferencedKey<Whoopper>(e => new { e.AlternateKey1, e.AlternateKey2 });
 
@@ -5462,8 +5374,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Whoopper>()
-                .OneToOne(e => e.ToastedBun, e => e.Whoopper)
+                .Entity<Whoopper>().HasOne(e => e.ToastedBun).WithOne(e => e.Whoopper)
                 .ReferencedKey<Whoopper>(e => new { e.AlternateKey1, e.AlternateKey2 })
                 .ForeignKey<ToastedBun>(e => new { e.BurgerId1, e.BurgerId2 });
 
@@ -5504,15 +5415,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentType = model.GetEntityType(typeof(Moostard));
             var principalType = model.GetEntityType(typeof(Whoopper));
 
-            var fkProperty1 = dependentType.GetProperty("Id1");
-            var fkProperty2 = dependentType.GetProperty("Id2");
+            //var fkProperty1 = dependentType.GetProperty("Id1");
+            //var fkProperty2 = dependentType.GetProperty("Id2");
 
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.GetPrimaryKey();
 
             modelBuilder
-                .Entity<Whoopper>()
-                .OneToOne(e => e.Moostard, e => e.Whoopper);
+                .Entity<Moostard>().HasOne(e => e.Whoopper).WithOne(e => e.Moostard);
 
             var fk = dependentType.ForeignKeys.Single();
             //TODO: Reenable when ForeignKeyConvention handles composite fks
@@ -5552,8 +5462,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.GetPrimaryKey();
 
             modelBuilder
-                .Entity<Moostard>()
-                .OneToOne(e => e.Whoopper, e => e.Moostard)
+                .Entity<Moostard>().HasOne(e => e.Whoopper).WithOne(e => e.Moostard)
                 .ForeignKey<Moostard>(e => new { e.Id1, e.Id2 });
 
             var fk = dependentType.ForeignKeys.Single();
@@ -5593,8 +5502,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.GetPrimaryKey();
 
             modelBuilder
-                .Entity<Moostard>()
-                .OneToOne(e => e.Whoopper, e => e.Moostard)
+                .Entity<Moostard>().HasOne(e => e.Whoopper).WithOne(e => e.Moostard)
                 .ReferencedKey<Whoopper>(e => new { e.Id1, e.Id2 });
 
             var fk = dependentType.ForeignKeys.Single();
@@ -5634,8 +5542,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Whoopper>()
-                .OneToOne(e => e.ToastedBun)
+                .Entity<Whoopper>().HasOne(e => e.ToastedBun).WithOne()
                 .ForeignKey<ToastedBun>(e => new { e.BurgerId1, e.BurgerId2 });
 
             var fk = dependentType.ForeignKeys.Single();
@@ -5674,8 +5581,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Whoopper>()
-                .OneToOne<ToastedBun>(null, e => e.Whoopper)
+                .Entity<Whoopper>().HasOne<ToastedBun>().WithOne(e => e.Whoopper)
                 .ForeignKey<ToastedBun>(e => new { e.BurgerId1, e.BurgerId2 });
 
             var fk = dependentType.ForeignKeys.Single();
@@ -5714,8 +5620,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<Whoopper>()
-                .OneToOne<ToastedBun>()
+                .Entity<Whoopper>().HasOne<ToastedBun>().WithOne()
                 .ForeignKey<ToastedBun>(e => new { e.BurgerId1, e.BurgerId2 });
 
             var fk = dependentType.ForeignKeys.Single();
@@ -5741,12 +5646,11 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             modelBuilder.Entity<Customer>();
             modelBuilder.Entity<CustomerDetails>().Property<Guid>("GuidProperty");
             modelBuilder.Ignore<Order>();
-            
+
             Assert.Equal(Strings.ForeignKeyTypeMismatch("'GuidProperty'", typeof(CustomerDetails).FullName, typeof(Customer).FullName),
                 Assert.Throws<InvalidOperationException>(() =>
                     modelBuilder
-                        .Entity<Customer>()
-                        .OneToOne(c => c.Details, d => d.Customer)
+                        .Entity<Customer>().HasOne(c => c.Details).WithOne(d => d.Customer)
                         .ForeignKey(typeof(CustomerDetails), "GuidProperty")).Message);
         }
 
@@ -5758,12 +5662,11 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             modelBuilder.Entity<Customer>();
             modelBuilder.Entity<CustomerDetails>().Property<Guid>("GuidProperty");
             modelBuilder.Ignore<Order>();
-            
+
             Assert.Equal(Strings.ForeignKeyCountMismatch("'Id', 'GuidProperty'", typeof(CustomerDetails).FullName, "'Id'", typeof(Customer).FullName),
                 Assert.Throws<InvalidOperationException>(() =>
                     modelBuilder
-                        .Entity<Customer>()
-                        .OneToOne(c => c.Details, d => d.Customer)
+                        .Entity<Customer>().HasOne(c => c.Details).WithOne(d => d.Customer)
                         .ForeignKey(typeof(CustomerDetails), "Id", "GuidProperty")).Message);
         }
 
@@ -5795,8 +5698,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Equal(Strings.PrincipalEntityTypeRequiresKey(principalType.Name),
                 Assert.Throws<InvalidOperationException>(() =>
                     modelBuilder
-                        .Entity<Customer>()
-                        .OneToOne(c => c.Details, d => d.Customer)).Message);
+                        .Entity<CustomerDetails>().HasOne(d => d.Customer).WithOne(c => c.Details)).Message);
         }
 
         [Fact]
@@ -5912,8 +5814,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var modelBuilder = HobNobBuilder();
 
             modelBuilder
-                .Entity<Hob>()
-                .OneToMany(e => e.Nobs, e => e.Hob)
+                .Entity<Hob>().HasMany(e => e.Nobs).WithOne(e => e.Hob)
                 .ForeignKey(e => new { e.HobId1, e.HobId2 });
 
             var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob));
@@ -5929,8 +5830,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var modelBuilder = HobNobBuilder();
 
             modelBuilder
-                .Entity<Nob>()
-                .OneToMany(e => e.Hobs, e => e.Nob)
+                .Entity<Nob>().HasMany(e => e.Hobs).WithOne(e => e.Nob)
                 .ForeignKey(e => new { e.NobId1, e.NobId2 });
 
             var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Hob));
@@ -5946,8 +5846,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var modelBuilder = HobNobBuilder();
 
             modelBuilder
-                .Entity<Nob>()
-                .ManyToOne(e => e.Hob, e => e.Nobs)
+                .Entity<Nob>().HasOne(e => e.Hob).WithMany(e => e.Nobs)
                 .ForeignKey(e => new { e.HobId1, e.HobId2 });
 
             var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob));
@@ -5963,8 +5862,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var modelBuilder = HobNobBuilder();
 
             modelBuilder
-                .Entity<Hob>()
-                .ManyToOne(e => e.Nob, e => e.Hobs)
+                .Entity<Hob>().HasOne(e => e.Nob).WithMany(e => e.Hobs)
                 .ForeignKey(e => new { e.NobId1, e.NobId2 });
 
             var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Hob));
@@ -5980,8 +5878,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var modelBuilder = HobNobBuilder();
 
             modelBuilder
-                .Entity<Hob>()
-                .OneToOne(e => e.Nob, e => e.Hob)
+                .Entity<Hob>().HasOne(e => e.Nob).WithOne(e => e.Hob)
                 .ForeignKey<Nob>(e => new { e.HobId1, e.HobId2 });
 
             var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob));
@@ -5997,8 +5894,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var modelBuilder = HobNobBuilder();
 
             modelBuilder
-                .Entity<Nob>()
-                .OneToOne(e => e.Hob, e => e.Nob)
+                .Entity<Nob>().HasOne(e => e.Hob).WithOne(e => e.Nob)
                 .ForeignKey<Hob>(e => new { e.NobId1, e.NobId2 });
 
             var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Hob));
@@ -6014,8 +5910,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var modelBuilder = HobNobBuilder();
 
             modelBuilder
-                .Entity<Hob>()
-                .OneToMany(e => e.Nobs, e => e.Hob)
+                .Entity<Hob>().HasMany(e => e.Nobs).WithOne(e => e.Hob)
                 .ForeignKey(e => new { e.HobId1, e.HobId2 })
                 .Required();
 
@@ -6034,8 +5929,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Equal(
                 Strings.CannotBeNullable("NobId1", "Hob", "Int32"),
                 Assert.Throws<InvalidOperationException>(() => modelBuilder
-                    .Entity<Nob>()
-                    .OneToMany(e => e.Hobs, e => e.Nob)
+                    .Entity<Nob>().HasMany(e => e.Hobs).WithOne(e => e.Nob)
                     .ForeignKey(e => new { e.NobId1, e.NobId2 })
                     .Required(false)).Message);
 
@@ -6052,8 +5946,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var modelBuilder = HobNobBuilder();
 
             modelBuilder
-                .Entity<Nob>()
-                .ManyToOne(e => e.Hob, e => e.Nobs)
+                .Entity<Nob>().HasOne(e => e.Hob).WithMany(e => e.Nobs)
                 .ForeignKey(e => new { e.HobId1, e.HobId2 })
                 .Required();
 
@@ -6072,8 +5965,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Equal(
                 Strings.CannotBeNullable("NobId1", "Hob", "Int32"),
                 Assert.Throws<InvalidOperationException>(() => modelBuilder
-                    .Entity<Hob>()
-                    .ManyToOne(e => e.Nob, e => e.Hobs)
+                    .Entity<Hob>().HasOne(e => e.Nob).WithMany(e => e.Hobs)
                     .ForeignKey(e => new { e.NobId1, e.NobId2 })
                     .Required(false)).Message);
 
@@ -6090,8 +5982,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var modelBuilder = HobNobBuilder();
 
             modelBuilder
-                .Entity<Hob>()
-                .OneToOne(e => e.Nob, e => e.Hob)
+                .Entity<Hob>().HasOne(e => e.Nob).WithOne(e => e.Hob)
                 .ForeignKey<Nob>(e => new { e.HobId1, e.HobId2 })
                 .Required();
 
@@ -6110,8 +6001,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Equal(
                 Strings.CannotBeNullable("NobId1", "Hob", "Int32"),
                 Assert.Throws<InvalidOperationException>(() => modelBuilder
-                    .Entity<Nob>()
-                    .OneToOne(e => e.Hob, e => e.Nob)
+                    .Entity<Nob>().HasOne(e => e.Hob).WithOne(e => e.Nob)
                     .ForeignKey<Hob>(e => new { e.NobId1, e.NobId2 })
                     .Required(false)).Message);
 
@@ -6163,8 +6053,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             modelBuilder.Ignore<OrderDetails>();
 
             AssertIsGenericOneToMany(modelBuilder
-                .Entity<Customer>()
-                .OneToMany(e => e.Orders, e => e.Customer)
+                .Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer)
                 .Annotation("X", "Y"));
 
             var entityType = modelBuilder.Model.GetEntityType(typeof(Order));
@@ -6178,8 +6067,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             modelBuilder.Ignore<OrderDetails>();
 
             AssertIsGenericOneToMany(modelBuilder
-                .Entity<Customer>()
-                .OneToMany(e => e.Orders, e => e.Customer)
+                .Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer)
                 .ForeignKey("AnotherCustomerId"));
 
             var entityType = modelBuilder.Model.GetEntityType(typeof(Order));
@@ -6193,8 +6081,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             modelBuilder.Ignore<OrderDetails>();
 
             AssertIsGenericOneToMany(modelBuilder
-                .Entity<Customer>()
-                .OneToMany(e => e.Orders, e => e.Customer)
+                .Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer)
                 .ReferencedKey("AlternateKey"));
 
             var entityType = modelBuilder.Model.GetEntityType(typeof(Order));
@@ -6209,8 +6096,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             modelBuilder.Ignore<OrderDetails>();
 
             AssertIsGenericOneToMany(modelBuilder
-                .Entity<Customer>()
-                .OneToMany(e => e.Orders, e => e.Customer)
+                .Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer)
                 .Required(false));
 
             var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Order));
@@ -6228,8 +6114,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             modelBuilder.Ignore<OrderDetails>();
 
             AssertIsGenericManyToOne(modelBuilder
-                .Entity<Order>()
-                .ManyToOne(e => e.Customer, e => e.Orders)
+                .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                 .Annotation("X", "Y"));
 
             var entityType = modelBuilder.Model.GetEntityType(typeof(Order));
@@ -6243,8 +6128,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             modelBuilder.Ignore<OrderDetails>();
 
             AssertIsGenericManyToOne(modelBuilder
-                .Entity<Order>()
-                .ManyToOne(e => e.Customer, e => e.Orders)
+                .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                 .ForeignKey("AnotherCustomerId"));
 
             var entityType = modelBuilder.Model.GetEntityType(typeof(Order));
@@ -6258,8 +6142,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             modelBuilder.Ignore<OrderDetails>();
 
             AssertIsGenericManyToOne(modelBuilder
-                .Entity<Order>()
-                .ManyToOne(e => e.Customer, e => e.Orders)
+                .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                 .ReferencedKey("AlternateKey"));
 
             var entityType = modelBuilder.Model.GetEntityType(typeof(Order));
@@ -6273,8 +6156,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             modelBuilder.Ignore<OrderDetails>();
 
             AssertIsGenericManyToOne(modelBuilder
-                .Entity<Order>()
-                .ManyToOne(e => e.Customer, e => e.Orders)
+                .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                 .Required(false));
 
             var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Order));
@@ -6286,12 +6168,11 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         }
 
         [Fact]
-        public void Self_referencing_one_to_one_can_be_flipped()
+        public void Self_referencing_one_to_one_does_not_flip_implicitly()
         {
             var modelBuilder = new ModelBuilder();
             modelBuilder
-                .Entity<SelfRef>()
-                .OneToOne(e => e.SelfRef1, e => e.SelfRef2);
+                .Entity<SelfRef>().HasOne(e => e.SelfRef1).WithOne(e => e.SelfRef2);
 
             var entityType = modelBuilder.Model.GetEntityType(typeof(SelfRef));
             var fk = entityType.ForeignKeys.Single();
@@ -6300,8 +6181,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var navigationToDependent = fk.GetNavigationToDependent();
 
             modelBuilder
-                .Entity<SelfRef>()
-                .OneToOne(e => e.SelfRef1, e => e.SelfRef2);
+                .Entity<SelfRef>().HasOne(e => e.SelfRef1).WithOne(e => e.SelfRef2);
 
             Assert.Same(fk, entityType.ForeignKeys.Single());
             Assert.Equal(navigationToDependent.Name, fk.GetNavigationToDependent().Name);
@@ -6309,15 +6189,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.True(((IForeignKey)fk).IsRequired);
 
             modelBuilder
-                .Entity<SelfRef>()
-                .OneToOne(e => e.SelfRef2, e => e.SelfRef1);
+                .Entity<SelfRef>().HasOne(e => e.SelfRef2).WithOne(e => e.SelfRef1);
 
             var newFk = entityType.ForeignKeys.Single();
 
             Assert.Equal(fk.Properties, newFk.Properties);
             Assert.Equal(fk.ReferencedKey, newFk.ReferencedKey);
-            Assert.Equal(navigationToPrincipal.Name, newFk.GetNavigationToDependent().Name);
-            Assert.Equal(navigationToDependent.Name, newFk.GetNavigationToPrincipal().Name);
+            Assert.Equal(navigationToDependent.Name, newFk.GetNavigationToDependent().Name);
+            Assert.Equal(navigationToPrincipal.Name, newFk.GetNavigationToPrincipal().Name);
             Assert.True(((IForeignKey)newFk).IsRequired);
         }
 

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/RelationshipDiscoveryConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/RelationshipDiscoveryConventionTest.cs
@@ -112,16 +112,16 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             var entityType = entityBuilder.Metadata;
             var fk = entityType.ForeignKeys.Single();
             Assert.Null(fk.IsRequired);
-            Assert.False(fk.IsUnique.Value);
+            Assert.False(((IForeignKey)fk).IsUnique);
 
             fk.IsRequired = true;
             fk.IsUnique = true;
 
             new RelationshipDiscoveryConvention().Apply(entityBuilder);
 
-            var newFk = entityType.ForeignKeys.Single();
-            Assert.True(newFk.IsRequired.Value);
-            Assert.True(newFk.IsUnique.Value);
+            var newFk = (IForeignKey)entityType.ForeignKeys.Single();
+            Assert.True(newFk.IsRequired);
+            Assert.True(newFk.IsUnique);
         }
 
         [Fact]

--- a/test/EntityFramework.Core.Tests/Metadata/NavigationExtensionsTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/NavigationExtensionsTest.cs
@@ -181,8 +181,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             var builder = new ModelBuilder();
 
-            builder.Entity<Principal>().OneToMany(e => e.Dependents1, e => e.Principal1);
-            builder.Entity<Principal>().OneToMany(e => e.Dependents2, e => e.Principal2);
+            builder.Entity<Principal>().HasMany(e => e.Dependents1).WithOne(e => e.Principal1);
+            builder.Entity<Principal>().HasMany(e => e.Dependents2).WithOne(e => e.Principal2);
 
             return builder.Model;
         }

--- a/test/EntityFramework.Core.Tests/Metadata/NonGenericRelationshipBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/NonGenericRelationshipBuilderTest.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Customer)).OneToMany(typeof(Order), "Orders", "Customer");
+            modelBuilder.Entity(typeof(Customer)).HasMany(typeof(Order), "Orders").WithOne("Customer");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
             Assert.Same(navToPrincipal, dependentType.Navigations.Single());
@@ -74,7 +74,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Customer)).OneToMany(typeof(Order), "Orders", "Customer");
+            modelBuilder.Entity(typeof(Customer)).HasMany(typeof(Order), "Orders").WithOne("Customer");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
             Assert.Same(navigation, dependentType.Navigations.Single());
@@ -111,7 +111,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Customer)).OneToMany(typeof(Order), "Orders", "Customer");
+            modelBuilder.Entity(typeof(Customer)).HasMany(typeof(Order), "Orders").WithOne("Customer");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -146,7 +146,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Customer)).OneToMany(typeof(Order), "Orders", "Customer");
+            modelBuilder.Entity(typeof(Customer)).HasMany(typeof(Order), "Orders").WithOne("Customer");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -180,7 +180,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Customer)).OneToMany(typeof(Order), "Orders", "Customer");
+            modelBuilder.Entity(typeof(Customer)).HasMany(typeof(Order), "Orders").WithOne("Customer");
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -216,7 +216,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Customer)).OneToMany(typeof(Order), "Orders");
+            modelBuilder.Entity(typeof(Customer)).HasMany(typeof(Order), "Orders").WithOne(null);
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -252,7 +252,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             // Passing null as the first arg is not super-compelling, but it is consistent
-            modelBuilder.Entity(typeof(Customer)).OneToMany(typeof(Order), null, "Customer");
+            modelBuilder.Entity(typeof(Customer)).HasMany(typeof(Order), null).WithOne("Customer");
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -287,7 +287,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Customer)).OneToMany(typeof(Order));
+            modelBuilder.Entity(typeof(Customer)).HasMany(typeof(Order), null).WithOne(null);
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -322,8 +322,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Customer))
-                .OneToMany(typeof(Order), "Orders", "Customer")
+                .Entity(typeof(Customer)).HasMany(typeof(Order), "Orders").WithOne("Customer")
                 .ForeignKey("CustomerId");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -362,8 +361,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(BigMak))
-                .OneToMany(typeof(Pickle), "Pickles", "BigMak")
+                .Entity(typeof(BigMak)).HasMany(typeof(Pickle), "Pickles").WithOne("BigMak")
                 .ForeignKey("BurgerId");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
@@ -399,8 +397,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(BigMak))
-                .OneToMany(typeof(Pickle), "Pickles", "BigMak")
+                .Entity(typeof(BigMak)).HasMany(typeof(Pickle), "Pickles").WithOne("BigMak")
                 .ForeignKey("BurgerId");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -438,8 +435,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(BigMak))
-                .OneToMany(typeof(Pickle), "Pickles")
+                .Entity(typeof(BigMak)).HasMany(typeof(Pickle), "Pickles").WithOne(null)
                 .ForeignKey("BurgerId");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -476,8 +472,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(BigMak))
-                .OneToMany(typeof(Pickle), null, "BigMak")
+                .Entity(typeof(BigMak)).HasMany(typeof(Pickle), null).WithOne("BigMak")
                 .ForeignKey("BurgerId");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -514,8 +509,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(BigMak))
-                .OneToMany(typeof(Pickle))
+                .Entity(typeof(BigMak)).HasMany(typeof(Pickle), null).WithOne(null)
                 .ForeignKey("BurgerId");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -548,7 +542,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(BigMak)).OneToMany(typeof(Pickle), "Pickles", "BigMak");
+            modelBuilder.Entity(typeof(BigMak)).HasMany(typeof(Pickle), "Pickles").WithOne("BigMak");
 
             var fk = dependentType.ForeignKeys.Single();
             var fkProperty = fk.Properties.Single();
@@ -587,7 +581,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(BigMak)).OneToMany(typeof(Pickle), "Pickles");
+            modelBuilder.Entity(typeof(BigMak)).HasMany(typeof(Pickle), "Pickles").WithOne(null);
 
             var fk = dependentType.ForeignKeys.Single();
             var fkProperty = fk.Properties.Single();
@@ -625,7 +619,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(BigMak)).OneToMany(typeof(Pickle), null, "BigMak");
+            modelBuilder.Entity(typeof(BigMak)).HasMany(typeof(Pickle), null).WithOne("BigMak");
 
             var fk = dependentType.ForeignKeys.Single();
             var fkProperty = fk.Properties.Single();
@@ -663,7 +657,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(BigMak)).OneToMany(typeof(Pickle));
+            modelBuilder.Entity(typeof(BigMak)).HasMany(typeof(Pickle), null).WithOne(null);
 
             var fk = dependentType.ForeignKeys.Single();
             var fkProperty = fk.Properties.Single();
@@ -702,7 +696,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty = dependentType.GetProperty("BigMakId");
 
-            modelBuilder.Entity(typeof(BigMak)).OneToMany(typeof(Pickle), "Pickles", "BigMak");
+            modelBuilder.Entity(typeof(BigMak)).HasMany(typeof(Pickle), "Pickles").WithOne("BigMak");
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -741,8 +735,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(BigMak))
-                .OneToMany(typeof(Pickle), "Pickles", "BigMak")
+                .Entity(typeof(BigMak)).HasMany(typeof(Pickle), "Pickles").WithOne("BigMak")
                 .ForeignKey("BurgerId");
 
             Assert.Equal(2, dependentType.ForeignKeys.Count);
@@ -784,8 +777,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Customer))
-                .OneToMany(typeof(Order), "Orders", "Customer")
+                .Entity(typeof(Customer)).HasMany(typeof(Order), "Orders").WithOne("Customer")
                 .ReferencedKey("Id");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -829,8 +821,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Customer))
-                .OneToMany(typeof(Order), "Orders", "Customer")
+                .Entity(typeof(Customer)).HasMany(typeof(Order), "Orders").WithOne("Customer")
                 .ReferencedKey("AlternateKey");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -879,8 +870,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Customer))
-                .OneToMany(typeof(Order), "Orders", "Customer")
+                .Entity(typeof(Customer)).HasMany(typeof(Order), "Orders").WithOne("Customer")
                 .ForeignKey("CustomerId")
                 .ReferencedKey("Id");
 
@@ -925,8 +915,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Customer))
-                .OneToMany(typeof(Order), "Orders", "Customer")
+                .Entity(typeof(Customer)).HasMany(typeof(Order), "Orders").WithOne("Customer")
                 .ReferencedKey("Id")
                 .ForeignKey("CustomerId");
 
@@ -971,8 +960,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Customer))
-                .OneToMany(typeof(Order), "Orders", "Customer")
+                .Entity(typeof(Customer)).HasMany(typeof(Order), "Orders").WithOne("Customer")
                 .ForeignKey("CustomerId")
                 .ReferencedKey("AlternateKey");
 
@@ -1022,8 +1010,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Customer))
-                .OneToMany(typeof(Order), "Orders", "Customer")
+                .Entity(typeof(Customer)).HasMany(typeof(Order), "Orders").WithOne("Customer")
                 .ReferencedKey("AlternateKey")
                 .ForeignKey("CustomerId");
 
@@ -1073,8 +1060,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(BigMak))
-                .OneToMany(typeof(Pickle), "Pickles", "BigMak")
+                .Entity(typeof(BigMak)).HasMany(typeof(Pickle), "Pickles").WithOne("BigMak")
                 .ForeignKey("BurgerId")
                 .ReferencedKey("AlternateKey");
 
@@ -1124,8 +1110,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(BigMak))
-                .OneToMany(typeof(Pickle), "Pickles", "BigMak")
+                .Entity(typeof(BigMak)).HasMany(typeof(Pickle), "Pickles").WithOne("BigMak")
                 .ReferencedKey("AlternateKey")
                 .ForeignKey("BurgerId");
 
@@ -1173,7 +1158,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Order)).ManyToOne(typeof(Customer), "Customer", "Orders");
+            modelBuilder.Entity(typeof(Order)).HasOne(typeof(Customer), "Customer").WithMany("Orders");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
             Assert.Same(navToPrincipal, dependentType.Navigations.Single());
@@ -1210,7 +1195,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Order)).ManyToOne(typeof(Customer), "Customer", "Orders");
+            modelBuilder.Entity(typeof(Order)).HasOne(typeof(Customer), "Customer").WithMany("Orders");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
             Assert.Same(navigation, dependentType.Navigations.Single());
@@ -1247,7 +1232,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Order)).ManyToOne(typeof(Customer), "Customer", "Orders");
+            modelBuilder.Entity(typeof(Order)).HasOne(typeof(Customer), "Customer").WithMany("Orders");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -1282,7 +1267,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Order)).ManyToOne(typeof(Customer), "Customer", "Orders");
+            modelBuilder.Entity(typeof(Order)).HasOne(typeof(Customer), "Customer").WithMany("Orders");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -1316,7 +1301,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Order)).ManyToOne(typeof(Customer), "Customer", "Orders");
+            modelBuilder.Entity(typeof(Order)).HasOne(typeof(Customer), "Customer").WithMany("Orders");
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -1353,7 +1338,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             // Passing null as the first arg is not super-compelling, but it is consistent
-            modelBuilder.Entity(typeof(Order)).ManyToOne(typeof(Customer), null, "Orders");
+            modelBuilder.Entity(typeof(Order)).HasOne(typeof(Customer), null).WithMany("Orders");
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -1388,7 +1373,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Order)).ManyToOne(typeof(Customer), "Customer");
+            modelBuilder.Entity(typeof(Order)).HasOne(typeof(Customer), "Customer").WithMany(null);
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -1423,7 +1408,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Order)).ManyToOne(typeof(Customer));
+            modelBuilder.Entity(typeof(Order)).HasOne(typeof(Customer), null).WithMany(null);
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -1458,8 +1443,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Order))
-                .ManyToOne(typeof(Customer), "Customer", "Orders")
+                .Entity(typeof(Order)).HasOne(typeof(Customer), "Customer").WithMany("Orders")
                 .ForeignKey("CustomerId");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -1498,8 +1482,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Pickle))
-                .ManyToOne(typeof(BigMak), "BigMak", "Pickles")
+                .Entity(typeof(Pickle)).HasOne(typeof(BigMak), "BigMak").WithMany("Pickles")
                 .ForeignKey("BurgerId");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
@@ -1535,8 +1518,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Pickle))
-                .ManyToOne(typeof(BigMak), "BigMak", "Pickles")
+                .Entity(typeof(Pickle)).HasOne(typeof(BigMak), "BigMak").WithMany("Pickles")
                 .ForeignKey("BurgerId");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -1574,8 +1556,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Pickle))
-                .ManyToOne(typeof(BigMak), null, "Pickles")
+                .Entity(typeof(Pickle)).HasOne(typeof(BigMak), null).WithMany("Pickles")
                 .ForeignKey("BurgerId");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -1612,8 +1593,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Pickle))
-                .ManyToOne(typeof(BigMak), "BigMak")
+                .Entity(typeof(Pickle)).HasOne(typeof(BigMak), "BigMak").WithMany(null)
                 .ForeignKey("BurgerId");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -1650,8 +1630,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Pickle))
-                .ManyToOne(typeof(BigMak))
+                .Entity(typeof(Pickle)).HasOne(typeof(BigMak), null).WithMany(null)
                 .ForeignKey("BurgerId");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -1684,7 +1663,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Pickle)).ManyToOne(typeof(BigMak), "BigMak", "Pickles");
+            modelBuilder.Entity(typeof(Pickle)).HasOne(typeof(BigMak), "BigMak").WithMany("Pickles");
 
             var fk = dependentType.ForeignKeys.Single();
             var fkProperty = fk.Properties.Single();
@@ -1723,7 +1702,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Pickle)).ManyToOne(typeof(BigMak), null, "Pickles");
+            modelBuilder.Entity(typeof(Pickle)).HasOne(typeof(BigMak), null).WithMany("Pickles");
 
             var fk = dependentType.ForeignKeys.Single();
             var fkProperty = fk.Properties.Single();
@@ -1761,7 +1740,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Pickle)).ManyToOne(typeof(BigMak), "BigMak");
+            modelBuilder.Entity(typeof(Pickle)).HasOne(typeof(BigMak), "BigMak").WithMany(null);
 
             var fk = dependentType.ForeignKeys.Single();
             var fkProperty = fk.Properties.Single();
@@ -1799,7 +1778,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Pickle)).ManyToOne(typeof(BigMak));
+            modelBuilder.Entity(typeof(Pickle)).HasOne(typeof(BigMak), null).WithMany(null);
 
             var fk = dependentType.ForeignKeys.Single();
             var fkProperty = fk.Properties.Single();
@@ -1838,7 +1817,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty = dependentType.GetProperty("BigMakId");
 
-            modelBuilder.Entity(typeof(Pickle)).ManyToOne(typeof(BigMak), "BigMak", "Pickles");
+            modelBuilder.Entity(typeof(Pickle)).HasOne(typeof(BigMak), "BigMak").WithMany("Pickles");
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -1877,8 +1856,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Pickle))
-                .ManyToOne(typeof(BigMak), "BigMak", "Pickles")
+                .Entity(typeof(Pickle)).HasOne(typeof(BigMak), "BigMak").WithMany("Pickles")
                 .ForeignKey("BurgerId");
 
             Assert.Equal(2, dependentType.ForeignKeys.Count);
@@ -1920,8 +1898,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Order))
-                .ManyToOne(typeof(Customer), "Customer", "Orders")
+                .Entity(typeof(Order)).HasOne(typeof(Customer), "Customer").WithMany("Orders")
                 .ReferencedKey("Id");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -1965,8 +1942,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Order))
-                .ManyToOne(typeof(Customer), "Customer", "Orders")
+                .Entity(typeof(Order)).HasOne(typeof(Customer), "Customer").WithMany("Orders")
                 .ReferencedKey("AlternateKey");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -2015,8 +1991,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Order))
-                .ManyToOne(typeof(Customer), "Customer", "Orders")
+                .Entity(typeof(Order)).HasOne(typeof(Customer), "Customer").WithMany("Orders")
                 .ForeignKey("CustomerId")
                 .ReferencedKey("Id");
 
@@ -2061,8 +2036,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Order))
-                .ManyToOne(typeof(Customer), "Customer", "Orders")
+                .Entity(typeof(Order)).HasOne(typeof(Customer), "Customer").WithMany("Orders")
                 .ReferencedKey("Id")
                 .ForeignKey("CustomerId");
 
@@ -2107,8 +2081,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Order))
-                .ManyToOne(typeof(Customer), "Customer", "Orders")
+                .Entity(typeof(Order)).HasOne(typeof(Customer), "Customer").WithMany("Orders")
                 .ForeignKey("CustomerId")
                 .ReferencedKey("AlternateKey");
 
@@ -2158,8 +2131,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Order))
-                .ManyToOne(typeof(Customer), "Customer", "Orders")
+                .Entity(typeof(Order)).HasOne(typeof(Customer), "Customer").WithMany("Orders")
                 .ReferencedKey("AlternateKey")
                 .ForeignKey("CustomerId");
 
@@ -2209,8 +2181,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Pickle))
-                .ManyToOne(typeof(BigMak), "BigMak", "Pickles")
+                .Entity(typeof(Pickle)).HasOne(typeof(BigMak), "BigMak").WithMany("Pickles")
                 .ForeignKey("BurgerId")
                 .ReferencedKey("AlternateKey");
 
@@ -2260,8 +2231,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Pickle))
-                .ManyToOne(typeof(BigMak), "BigMak", "Pickles")
+                .Entity(typeof(Pickle)).HasOne(typeof(BigMak), "BigMak").WithMany("Pickles")
                 .ReferencedKey("AlternateKey")
                 .ForeignKey("BurgerId");
 
@@ -2310,7 +2280,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Customer)).OneToOne(typeof(CustomerDetails), "Details", "Customer");
+            modelBuilder.Entity(typeof(Customer)).HasOne(typeof(CustomerDetails), "Details").WithOne("Customer");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
             Assert.Same(navToPrincipal, dependentType.Navigations.Single());
@@ -2348,7 +2318,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Customer)).OneToOne(typeof(CustomerDetails), "Details", "Customer");
+            modelBuilder.Entity(typeof(Customer)).HasOne(typeof(CustomerDetails), "Details").WithOne("Customer");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
             Assert.Same(navigation, dependentType.Navigations.Single());
@@ -2386,7 +2356,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Customer)).OneToOne(typeof(CustomerDetails), "Details", "Customer");
+            modelBuilder.Entity(typeof(Customer)).HasOne(typeof(CustomerDetails), "Details").WithOne("Customer");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -2423,7 +2393,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Customer)).OneToOne(typeof(CustomerDetails), "Details", "Customer");
+            modelBuilder.Entity(typeof(Customer)).HasOne(typeof(CustomerDetails), "Details").WithOne("Customer");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -2457,7 +2427,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Customer)).OneToOne(typeof(CustomerDetails), "Details", "Customer");
+            modelBuilder.Entity(typeof(Customer)).HasOne(typeof(CustomerDetails), "Details").WithOne("Customer");
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -2496,7 +2466,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Order)).OneToOne(typeof(OrderDetails), "Details", "Order");
+            modelBuilder.Entity(typeof(Order)).HasOne(typeof(OrderDetails), "Details").WithOne("Order");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
             Assert.Equal("Order", dependentType.Navigations.Single().Name);
@@ -2534,7 +2504,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Order)).OneToOne(typeof(OrderDetails), "Details", "Order");
+            modelBuilder.Entity(typeof(Order)).HasOne(typeof(OrderDetails), "Details").WithOne("Order");
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -2570,7 +2540,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Customer)).OneToOne(typeof(CustomerDetails), "Details");
+            modelBuilder.Entity(typeof(Customer)).HasOne(typeof(CustomerDetails), "Details").WithOne(null);
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -2606,7 +2576,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             // Passing null as the first arg is not super-compelling, but it is consistent
-            modelBuilder.Entity(typeof(Customer)).OneToOne(typeof(CustomerDetails), null, "Customer");
+            modelBuilder.Entity(typeof(Customer)).HasOne(typeof(CustomerDetails), null).WithOne("Customer");
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -2641,7 +2611,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Customer)).OneToOne(typeof(CustomerDetails));
+            modelBuilder.Entity(typeof(Customer)).HasOne(typeof(CustomerDetails), null).WithOne(null);
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -2680,8 +2650,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Order))
-                .OneToOne(typeof(OrderDetails), "Details", "Order")
+                .Entity(typeof(Order)).HasOne(typeof(OrderDetails), "Details").WithOne("Order")
                 .ForeignKey(typeof(OrderDetails), "OrderId");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -2719,8 +2688,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Customer))
-                .OneToOne(typeof(CustomerDetails), "Details", "Customer")
+                .Entity(typeof(Customer)).HasOne(typeof(CustomerDetails), "Details").WithOne("Customer")
                 .ForeignKey(typeof(CustomerDetails), "Id");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -2760,8 +2728,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(BigMak))
-                .OneToOne(typeof(Bun), "Bun", "BigMak")
+                .Entity(typeof(BigMak)).HasOne(typeof(Bun), "Bun").WithOne("BigMak")
                 .ForeignKey(typeof(Bun), "BurgerId");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
@@ -2797,8 +2764,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(BigMak))
-                .OneToOne(typeof(Bun), "Bun", "BigMak")
+                .Entity(typeof(BigMak)).HasOne(typeof(Bun), "Bun").WithOne("BigMak")
                 .ForeignKey(typeof(Bun), "BurgerId");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -2836,8 +2802,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(BigMak))
-                .OneToOne(typeof(Bun), "Bun")
+                .Entity(typeof(BigMak)).HasOne(typeof(Bun), "Bun").WithOne(null)
                 .ForeignKey(typeof(Bun), "BurgerId");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -2874,8 +2839,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(BigMak))
-                .OneToOne(typeof(Bun), null, "BigMak")
+                .Entity(typeof(BigMak)).HasOne(typeof(Bun), null).WithOne("BigMak")
                 .ForeignKey(typeof(Bun), "BurgerId");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -2912,8 +2876,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(BigMak))
-                .OneToOne(typeof(Bun))
+                .Entity(typeof(BigMak)).HasOne(typeof(Bun), null).WithOne(null)
                 .ForeignKey(typeof(Bun), "BurgerId");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -2950,8 +2913,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(BigMak))
-                .OneToOne(typeof(Bun), "Bun", "BigMak")
+                .Entity(typeof(BigMak)).HasOne(typeof(Bun), "Bun").WithOne("BigMak")
                 .ForeignKey(typeof(Bun), "BurgerId");
 
             Assert.Equal(2, dependentType.ForeignKeys.Count);
@@ -2995,8 +2957,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(OrderDetails))
-                .OneToOne(typeof(Order), "Order", "Details")
+                .Entity(typeof(OrderDetails)).HasOne(typeof(Order), "Order").WithOne("Details")
                 .ForeignKey(typeof(OrderDetails), "Id");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
@@ -3036,8 +2997,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(OrderDetails))
-                .OneToOne(typeof(Order), "Order", "Details")
+                .Entity(typeof(OrderDetails)).HasOne(typeof(Order), "Order").WithOne("Details")
                 .ForeignKey(typeof(OrderDetails), "OrderId");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -3075,8 +3035,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<CustomerDetails>()
-                .OneToOne(typeof(Customer), "Customer")
+                .Entity<CustomerDetails>().HasOne(typeof(Customer), "Customer").WithOne(null)
                 .ForeignKey(typeof(CustomerDetails), "Id");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -3113,8 +3072,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<CustomerDetails>()
-                .OneToOne(typeof(Customer), null, "Details")
+                .Entity<CustomerDetails>().HasOne(typeof(Customer), null).WithOne("Details")
                 .ForeignKey(typeof(CustomerDetails), "Id");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -3151,8 +3109,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<CustomerDetails>()
-                .OneToOne(typeof(Customer))
+                .Entity<CustomerDetails>().HasOne(typeof(Customer), null).WithOne(null)
                 .ForeignKey(typeof(CustomerDetails), "Id");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -3188,8 +3145,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<CustomerDetails>()
-                .OneToOne(typeof(Customer), "Customer", "Details")
+                .Entity<CustomerDetails>().HasOne(typeof(Customer), "Customer").WithOne("Details")
                 .ForeignKey(typeof(CustomerDetails), "Id");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -3228,8 +3184,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Customer))
-                .OneToOne(typeof(CustomerDetails), "Details", "Customer")
+                .Entity(typeof(Customer)).HasOne(typeof(CustomerDetails), "Details").WithOne("Customer")
                 .ReferencedKey(typeof(Customer), "Id");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -3273,8 +3228,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Customer))
-                .OneToOne(typeof(CustomerDetails), "Details", "Customer")
+                .Entity(typeof(Customer)).HasOne(typeof(CustomerDetails), "Details").WithOne("Customer")
                 .ReferencedKey(typeof(Customer), "AlternateKey");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -3323,8 +3277,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Order))
-                .OneToOne(typeof(OrderDetails), "Details", "Order")
+                .Entity(typeof(Order)).HasOne(typeof(OrderDetails), "Details").WithOne("Order")
                 .ForeignKey(typeof(OrderDetails), "OrderId")
                 .ReferencedKey(typeof(Order), "OrderId");
 
@@ -3369,8 +3322,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Order))
-                .OneToOne(typeof(OrderDetails), "Details", "Order")
+                .Entity(typeof(Order)).HasOne(typeof(OrderDetails), "Details").WithOne("Order")
                 .ReferencedKey(typeof(Order), "OrderId")
                 .ForeignKey(typeof(OrderDetails), "OrderId");
 
@@ -3415,8 +3367,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(BigMak))
-                .OneToOne(typeof(Bun), "Bun", "BigMak")
+                .Entity(typeof(BigMak)).HasOne(typeof(Bun), "Bun").WithOne("BigMak")
                 .ForeignKey(typeof(Bun), "BurgerId")
                 .ReferencedKey(typeof(BigMak), "AlternateKey");
 
@@ -3466,8 +3417,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(BigMak))
-                .OneToOne(typeof(Bun), "Bun", "BigMak")
+                .Entity(typeof(BigMak)).HasOne(typeof(Bun), "Bun").WithOne("BigMak")
                 .ReferencedKey(typeof(BigMak), "AlternateKey")
                 .ForeignKey(typeof(Bun), "BurgerId");
 
@@ -3515,8 +3465,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(OrderDetails))
-                .OneToOne(typeof(Order), "Order", "Details")
+                .Entity(typeof(OrderDetails)).HasOne(typeof(Order), "Order").WithOne("Details")
                 .ReferencedKey(typeof(Order), "OrderId");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
@@ -3556,8 +3505,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(OrderDetails))
-                .OneToOne(typeof(Order), "Order", "Details")
+                .Entity(typeof(OrderDetails)).HasOne(typeof(Order), "Order").WithOne("Details")
                 .ReferencedKey(typeof(Order), "OrderId");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -3599,8 +3547,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(OrderDetails))
-                .OneToOne(typeof(Order), "Order", "Details")
+                .Entity(typeof(OrderDetails)).HasOne(typeof(Order), "Order").WithOne("Details")
                 .ForeignKey(typeof(OrderDetails), "OrderId")
                 .ReferencedKey(typeof(Order), "OrderId");
 
@@ -3643,8 +3590,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(OrderDetails))
-                .OneToOne(typeof(Order), "Order", "Details")
+                .Entity(typeof(OrderDetails)).HasOne(typeof(Order), "Order").WithOne("Details")
                 .ReferencedKey(typeof(Order), "OrderId")
                 .ForeignKey(typeof(OrderDetails), "OrderId");
 
@@ -3683,8 +3629,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<CustomerDetails>()
-                .OneToOne(typeof(Customer), "Customer")
+                .Entity<CustomerDetails>().HasOne(typeof(Customer), "Customer").WithOne(null)
                 .ReferencedKey(typeof(Customer), "Id");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -3721,8 +3666,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<CustomerDetails>()
-                .OneToOne(typeof(Customer), null, "Details")
+                .Entity<CustomerDetails>().HasOne(typeof(Customer), null).WithOne("Details")
                 .ReferencedKey(typeof(Customer), "Id");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -3759,8 +3703,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<CustomerDetails>()
-                .OneToOne(typeof(Customer))
+                .Entity<CustomerDetails>().HasOne(typeof(Customer), null).WithOne(null)
                 .ReferencedKey(typeof(Customer), "Id");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -3823,8 +3766,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Whoopper))
-                .OneToMany(typeof(Tomato), "Tomatoes", "Whoopper")
+                .Entity(typeof(Whoopper)).HasMany(typeof(Tomato), "Tomatoes").WithOne("Whoopper")
                 .ForeignKey("BurgerId1", "BurgerId2");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
@@ -3865,8 +3807,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Whoopper))
-                .OneToMany(typeof(Tomato), "Tomatoes", "Whoopper")
+                .Entity(typeof(Whoopper)).HasMany(typeof(Tomato), "Tomatoes").WithOne("Whoopper")
                 .ForeignKey("BurgerId1", "BurgerId2");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -3917,8 +3858,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Whoopper))
-                .OneToMany(typeof(Tomato), "Tomatoes", "Whoopper")
+                .Entity(typeof(Whoopper)).HasMany(typeof(Tomato), "Tomatoes").WithOne("Whoopper")
                 .ForeignKey("BurgerId1", "BurgerId2")
                 .ReferencedKey("AlternateKey1", "AlternateKey2");
 
@@ -3977,8 +3917,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Whoopper))
-                .OneToMany(typeof(Tomato), "Tomatoes", "Whoopper")
+                .Entity(typeof(Whoopper)).HasMany(typeof(Tomato), "Tomatoes").WithOne("Whoopper")
                 .ReferencedKey("AlternateKey1", "AlternateKey2")
                 .ForeignKey("BurgerId1", "BurgerId2");
 
@@ -4030,8 +3969,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Whoopper))
-                .OneToMany(typeof(Tomato), "Tomatoes")
+                .Entity(typeof(Whoopper)).HasMany(typeof(Tomato), "Tomatoes").WithOne(null)
                 .ForeignKey("BurgerId1", "BurgerId2");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -4074,8 +4012,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Whoopper))
-                .OneToMany(typeof(Tomato), null, "Whoopper")
+                .Entity(typeof(Whoopper)).HasMany(typeof(Tomato), null).WithOne("Whoopper")
                 .ForeignKey("BurgerId1", "BurgerId2");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -4118,8 +4055,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Whoopper))
-                .OneToMany(typeof(Tomato))
+                .Entity(typeof(Whoopper)).HasMany(typeof(Tomato), null).WithOne(null)
                 .ForeignKey("BurgerId1", "BurgerId2");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -4157,8 +4093,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Tomato))
-                .ManyToOne(typeof(Whoopper), "Whoopper", "Tomatoes")
+                .Entity(typeof(Tomato)).HasOne(typeof(Whoopper), "Whoopper").WithMany("Tomatoes")
                 .ForeignKey("BurgerId1", "BurgerId2");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
@@ -4199,8 +4134,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Tomato))
-                .ManyToOne(typeof(Whoopper), "Whoopper", "Tomatoes")
+                .Entity(typeof(Tomato)).HasOne(typeof(Whoopper), "Whoopper").WithMany("Tomatoes")
                 .ForeignKey("BurgerId1", "BurgerId2");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -4251,8 +4185,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Tomato))
-                .ManyToOne(typeof(Whoopper), "Whoopper", "Tomatoes")
+                .Entity(typeof(Tomato)).HasOne(typeof(Whoopper), "Whoopper").WithMany("Tomatoes")
                 .ForeignKey("BurgerId1", "BurgerId2")
                 .ReferencedKey("AlternateKey1", "AlternateKey2");
 
@@ -4311,8 +4244,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Tomato))
-                .ManyToOne(typeof(Whoopper), "Whoopper", "Tomatoes")
+                .Entity(typeof(Tomato)).HasOne(typeof(Whoopper), "Whoopper").WithMany("Tomatoes")
                 .ReferencedKey("AlternateKey1", "AlternateKey2")
                 .ForeignKey("BurgerId1", "BurgerId2");
 
@@ -4364,8 +4296,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Tomato))
-                .ManyToOne(typeof(Whoopper), null, "Tomatoes")
+                .Entity(typeof(Tomato)).HasOne(typeof(Whoopper), null).WithMany("Tomatoes")
                 .ForeignKey("BurgerId1", "BurgerId2");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -4408,8 +4339,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Tomato))
-                .ManyToOne(typeof(Whoopper), "Whoopper")
+                .Entity(typeof(Tomato)).HasOne(typeof(Whoopper), "Whoopper").WithMany(null)
                 .ForeignKey("BurgerId1", "BurgerId2");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -4452,8 +4382,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Tomato))
-                .ManyToOne(typeof(Whoopper))
+                .Entity(typeof(Tomato)).HasOne(typeof(Whoopper), null).WithMany(null)
                 .ForeignKey("BurgerId1", "BurgerId2");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -4492,8 +4421,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Whoopper))
-                .OneToOne(typeof(ToastedBun), "ToastedBun", "Whoopper")
+                .Entity(typeof(Whoopper)).HasOne(typeof(ToastedBun), "ToastedBun").WithOne("Whoopper")
                 .ForeignKey(typeof(ToastedBun), "BurgerId1", "BurgerId2");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
@@ -4534,8 +4462,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Whoopper))
-                .OneToOne(typeof(ToastedBun), "ToastedBun", "Whoopper")
+                .Entity(typeof(Whoopper)).HasOne(typeof(ToastedBun), "ToastedBun").WithOne("Whoopper")
                 .ForeignKey(typeof(ToastedBun), "BurgerId1", "BurgerId2");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -4586,8 +4513,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Whoopper))
-                .OneToOne(typeof(ToastedBun), "ToastedBun", "Whoopper")
+                .Entity(typeof(Whoopper)).HasOne(typeof(ToastedBun), "ToastedBun").WithOne("Whoopper")
                 .ForeignKey(typeof(ToastedBun), "BurgerId1", "BurgerId2")
                 .ReferencedKey(typeof(Whoopper), "AlternateKey1", "AlternateKey2");
 
@@ -4646,8 +4572,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Whoopper))
-                .OneToOne(typeof(ToastedBun), "ToastedBun", "Whoopper")
+                .Entity(typeof(Whoopper)).HasOne(typeof(ToastedBun), "ToastedBun").WithOne("Whoopper")
                 .ReferencedKey(typeof(Whoopper), "AlternateKey1", "AlternateKey2")
                 .ForeignKey(typeof(ToastedBun), "BurgerId1", "BurgerId2");
 
@@ -4695,8 +4620,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Whoopper))
-                .OneToOne(typeof(Moostard), "Moostard", "Whoopper");
+                .Entity(typeof(Whoopper)).HasOne(typeof(Moostard), "Moostard").WithOne("Whoopper");
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
@@ -4735,8 +4659,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Moostard))
-                .OneToOne(typeof(Whoopper), "Whoopper", "Moostard")
+                .Entity(typeof(Moostard)).HasOne(typeof(Whoopper), "Whoopper").WithOne("Moostard")
                 .ForeignKey(typeof(Moostard), "Id1", "Id2");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -4776,8 +4699,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Moostard))
-                .OneToOne(typeof(Whoopper), "Whoopper", "Moostard")
+                .Entity(typeof(Moostard)).HasOne(typeof(Whoopper), "Whoopper").WithOne("Moostard")
                 .ReferencedKey(typeof(Whoopper), "Id1", "Id2");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -4821,8 +4743,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Whoopper))
-                .OneToOne(typeof(ToastedBun), "ToastedBun")
+                .Entity(typeof(Whoopper)).HasOne(typeof(ToastedBun), "ToastedBun").WithOne(null)
                 .ForeignKey(typeof(ToastedBun), "BurgerId1", "BurgerId2");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -4865,8 +4786,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Whoopper))
-                .OneToOne(typeof(ToastedBun), null, "Whoopper")
+                .Entity(typeof(Whoopper)).HasOne(typeof(ToastedBun), null).WithOne("Whoopper")
                 .ForeignKey(typeof(ToastedBun), "BurgerId1", "BurgerId2");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -4909,8 +4829,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Whoopper))
-                .OneToOne(typeof(ToastedBun))
+                .Entity(typeof(Whoopper)).HasOne(typeof(ToastedBun), null).WithOne(null)
                 .ForeignKey(typeof(ToastedBun), "BurgerId1", "BurgerId2");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -5030,8 +4949,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var modelBuilder = HobNobBuilder();
 
             modelBuilder
-                .Entity(typeof(Hob))
-                .OneToMany(typeof(Nob), "Nobs", "Hob")
+                .Entity(typeof(Hob)).HasMany(typeof(Nob), "Nobs").WithOne("Hob")
                 .ForeignKey("HobId1", "HobId2");
 
             var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob));
@@ -5047,8 +4965,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var modelBuilder = HobNobBuilder();
 
             modelBuilder
-                .Entity(typeof(Nob))
-                .OneToMany(typeof(Hob), "Hobs", "Nob")
+                .Entity(typeof(Nob)).HasMany(typeof(Hob), "Hobs").WithOne("Nob")
                 .ForeignKey("NobId1", "NobId2");
 
             var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Hob));
@@ -5064,8 +4981,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var modelBuilder = HobNobBuilder();
 
             modelBuilder
-                .Entity(typeof(Nob))
-                .ManyToOne(typeof(Hob), "Hob", "Nobs")
+                .Entity(typeof(Nob)).HasOne(typeof(Hob), "Hob").WithMany("Nobs")
                 .ForeignKey("HobId1", "HobId2");
 
             var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob));
@@ -5081,8 +4997,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var modelBuilder = HobNobBuilder();
 
             modelBuilder
-                .Entity<Hob>()
-                .ManyToOne(typeof(Nob), "Nob", "Hobs")
+                .Entity<Hob>().HasOne(typeof(Nob), "Nob").WithMany("Hobs")
                 .ForeignKey("NobId1", "NobId2");
 
             var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Hob));
@@ -5098,8 +5013,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var modelBuilder = HobNobBuilder();
 
             modelBuilder
-                .Entity(typeof(Hob))
-                .OneToOne(typeof(Nob), "Nob", "Hob")
+                .Entity(typeof(Hob)).HasOne(typeof(Nob), "Nob").WithOne("Hob")
                 .ForeignKey(typeof(Nob), "HobId1", "HobId2");
 
             var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob));
@@ -5115,8 +5029,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var modelBuilder = HobNobBuilder();
 
             modelBuilder
-                .Entity(typeof(Nob))
-                .OneToOne(typeof(Hob), "Hob", "Nob")
+                .Entity(typeof(Nob)).HasOne(typeof(Hob), "Hob").WithOne("Nob")
                 .ForeignKey(typeof(Hob), "NobId1", "NobId2");
 
             var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Hob));
@@ -5132,8 +5045,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var modelBuilder = HobNobBuilder();
 
             modelBuilder
-                .Entity(typeof(Hob))
-                .OneToMany(typeof(Nob), "Nobs", "Hob")
+                .Entity(typeof(Hob)).HasMany(typeof(Nob), "Nobs").WithOne("Hob")
                 .ForeignKey("HobId1", "HobId2")
                 .Required();
 
@@ -5152,8 +5064,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Equal(
                 Strings.CannotBeNullable("NobId1", "Hob", "Int32"),
                 Assert.Throws<InvalidOperationException>(() => modelBuilder
-                    .Entity(typeof(Nob))
-                    .OneToMany(typeof(Hob), "Hobs", "Nob")
+                    .Entity(typeof(Nob)).HasMany(typeof(Hob), "Hobs").WithOne("Nob")
                     .ForeignKey("NobId1", "NobId2")
                     .Required(false)).Message);
 
@@ -5170,8 +5081,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var modelBuilder = HobNobBuilder();
 
             modelBuilder
-                .Entity(typeof(Nob))
-                .ManyToOne(typeof(Hob), "Hob", "Nobs")
+                .Entity(typeof(Nob)).HasOne(typeof(Hob), "Hob").WithMany("Nobs")
                 .ForeignKey("HobId1", "HobId2")
                 .Required();
 
@@ -5190,8 +5100,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Equal(
                 Strings.CannotBeNullable("NobId1", "Hob", "Int32"),
                 Assert.Throws<InvalidOperationException>(() => modelBuilder
-                    .Entity(typeof(Hob))
-                    .ManyToOne(typeof(Nob), "Nob", "Hobs")
+                    .Entity(typeof(Hob)).HasOne(typeof(Nob), "Nob").WithMany("Hobs")
                     .ForeignKey("NobId1", "NobId2")
                     .Required(false)).Message);
 
@@ -5208,8 +5117,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var modelBuilder = HobNobBuilder();
 
             modelBuilder
-                .Entity(typeof(Hob))
-                .OneToOne(typeof(Nob), "Nob", "Hob")
+                .Entity(typeof(Hob)).HasOne(typeof(Nob), "Nob").WithOne("Hob")
                 .ForeignKey(typeof(Nob), "HobId1", "HobId2")
                 .Required();
 
@@ -5228,8 +5136,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Equal(
                 Strings.CannotBeNullable("NobId1", "Hob", "Int32"),
                 Assert.Throws<InvalidOperationException>(() => modelBuilder
-                    .Entity(typeof(Nob))
-                    .OneToOne(typeof(Hob), "Hob", "Nob")
+                    .Entity(typeof(Nob)).HasOne(typeof(Hob), "Hob").WithOne("Nob")
                     .ForeignKey(typeof(Hob), "NobId1", "NobId2")
                     .Required(false)).Message);
 

--- a/test/EntityFramework.Core.Tests/Metadata/StringRelationshipBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/StringRelationshipBuilderTest.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Customer).FullName).OneToMany(typeof(Order).FullName, "Orders", "Customer");
+            modelBuilder.Entity(typeof(Customer).FullName).HasMany(typeof(Order).FullName, "Orders").WithOne("Customer");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
             Assert.Same(navToPrincipal, dependentType.Navigations.Single());
@@ -74,7 +74,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Customer).FullName).OneToMany(typeof(Order).FullName, "Orders", "Customer");
+            modelBuilder.Entity(typeof(Customer).FullName).HasMany(typeof(Order).FullName, "Orders").WithOne("Customer");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
             Assert.Same(navigation, dependentType.Navigations.Single());
@@ -111,7 +111,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Customer).FullName).OneToMany(typeof(Order).FullName, "Orders", "Customer");
+            modelBuilder.Entity(typeof(Customer).FullName).HasMany(typeof(Order).FullName, "Orders").WithOne("Customer");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -146,7 +146,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Customer).FullName).OneToMany(typeof(Order).FullName, "Orders", "Customer");
+            modelBuilder.Entity(typeof(Customer).FullName).HasMany(typeof(Order).FullName, "Orders").WithOne("Customer");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -180,7 +180,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Customer).FullName).OneToMany(typeof(Order).FullName, "Orders", "Customer");
+            modelBuilder.Entity(typeof(Customer).FullName).HasMany(typeof(Order).FullName, "Orders").WithOne("Customer");
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -216,7 +216,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Customer).FullName).OneToMany(typeof(Order).FullName, "Orders");
+            modelBuilder.Entity(typeof(Customer).FullName).HasMany(typeof(Order).FullName, "Orders").WithOne(null);
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -252,7 +252,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             // Passing null as the first arg is not super-compelling, but it is consistent
-            modelBuilder.Entity(typeof(Customer).FullName).OneToMany(typeof(Order).FullName, null, "Customer");
+            modelBuilder.Entity(typeof(Customer).FullName).HasMany(typeof(Order).FullName, null).WithOne("Customer");
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -287,7 +287,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Customer).FullName).OneToMany(typeof(Order).FullName);
+            modelBuilder.Entity(typeof(Customer).FullName).HasMany(typeof(Order).FullName, null).WithOne(null);
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -322,8 +322,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Customer).FullName)
-                .OneToMany(typeof(Order).FullName, "Orders", "Customer")
+                .Entity(typeof(Customer).FullName).HasMany(typeof(Order).FullName, "Orders").WithOne("Customer")
                 .ForeignKey("CustomerId");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -362,8 +361,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(BigMak).FullName)
-                .OneToMany(typeof(Pickle).FullName, "Pickles", "BigMak")
+                .Entity(typeof(BigMak).FullName).HasMany(typeof(Pickle).FullName, "Pickles").WithOne("BigMak")
                 .ForeignKey("BurgerId");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
@@ -399,8 +397,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(BigMak).FullName)
-                .OneToMany(typeof(Pickle).FullName, "Pickles", "BigMak")
+                .Entity(typeof(BigMak).FullName).HasMany(typeof(Pickle).FullName, "Pickles").WithOne("BigMak")
                 .ForeignKey("BurgerId");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -438,8 +435,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(BigMak).FullName)
-                .OneToMany(typeof(Pickle).FullName, "Pickles")
+                .Entity(typeof(BigMak).FullName).HasMany(typeof(Pickle).FullName, "Pickles").WithOne(null)
                 .ForeignKey("BurgerId");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -476,8 +472,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(BigMak).FullName)
-                .OneToMany(typeof(Pickle).FullName, null, "BigMak")
+                .Entity(typeof(BigMak).FullName).HasMany(typeof(Pickle).FullName, null).WithOne("BigMak")
                 .ForeignKey("BurgerId");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -514,8 +509,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(BigMak).FullName)
-                .OneToMany(typeof(Pickle).FullName)
+                .Entity(typeof(BigMak).FullName).HasMany(typeof(Pickle).FullName, null).WithOne(null)
                 .ForeignKey("BurgerId");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -548,7 +542,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(BigMak).FullName).OneToMany(typeof(Pickle).FullName, "Pickles", "BigMak");
+            modelBuilder.Entity(typeof(BigMak).FullName).HasMany(typeof(Pickle).FullName, "Pickles").WithOne("BigMak");
 
             var fk = dependentType.ForeignKeys.Single();
             var fkProperty = fk.Properties.Single();
@@ -587,7 +581,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(BigMak).FullName).OneToMany(typeof(Pickle).FullName, "Pickles");
+            modelBuilder.Entity(typeof(BigMak).FullName).HasMany(typeof(Pickle).FullName, "Pickles").WithOne(null);
 
             var fk = dependentType.ForeignKeys.Single();
             var fkProperty = fk.Properties.Single();
@@ -625,7 +619,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(BigMak).FullName).OneToMany(typeof(Pickle).FullName, null, "BigMak");
+            modelBuilder.Entity(typeof(BigMak).FullName).HasMany(typeof(Pickle).FullName, null).WithOne("BigMak");
 
             var fk = dependentType.ForeignKeys.Single();
             var fkProperty = fk.Properties.Single();
@@ -663,7 +657,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(BigMak).FullName).OneToMany(typeof(Pickle).FullName);
+            modelBuilder.Entity(typeof(BigMak).FullName).HasMany(typeof(Pickle).FullName, null).WithOne(null);
 
             var fk = dependentType.ForeignKeys.Single();
             var fkProperty = fk.Properties.Single();
@@ -702,7 +696,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty = dependentType.GetProperty("BigMakId");
 
-            modelBuilder.Entity(typeof(BigMak).FullName).OneToMany(typeof(Pickle).FullName, "Pickles", "BigMak");
+            modelBuilder.Entity(typeof(BigMak).FullName).HasMany(typeof(Pickle).FullName, "Pickles").WithOne("BigMak");
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -741,8 +735,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(BigMak).FullName)
-                .OneToMany(typeof(Pickle).FullName, "Pickles", "BigMak")
+                .Entity(typeof(BigMak).FullName).HasMany(typeof(Pickle).FullName, "Pickles").WithOne("BigMak")
                 .ForeignKey("BurgerId");
 
             Assert.Equal(2, dependentType.ForeignKeys.Count);
@@ -784,8 +777,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Customer).FullName)
-                .OneToMany(typeof(Order).FullName, "Orders", "Customer")
+                .Entity(typeof(Customer).FullName).HasMany(typeof(Order).FullName, "Orders").WithOne("Customer")
                 .ReferencedKey("Id");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -829,8 +821,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Customer).FullName)
-                .OneToMany(typeof(Order).FullName, "Orders", "Customer")
+                .Entity(typeof(Customer).FullName).HasMany(typeof(Order).FullName, "Orders").WithOne("Customer")
                 .ReferencedKey("AlternateKey");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -879,8 +870,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Customer).FullName)
-                .OneToMany(typeof(Order).FullName, "Orders", "Customer")
+                .Entity(typeof(Customer).FullName).HasMany(typeof(Order).FullName, "Orders").WithOne("Customer")
                 .ForeignKey("CustomerId")
                 .ReferencedKey("Id");
 
@@ -925,8 +915,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Customer).FullName)
-                .OneToMany(typeof(Order).FullName, "Orders", "Customer")
+                .Entity(typeof(Customer).FullName).HasMany(typeof(Order).FullName, "Orders").WithOne("Customer")
                 .ReferencedKey("Id")
                 .ForeignKey("CustomerId");
 
@@ -971,8 +960,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Customer).FullName)
-                .OneToMany(typeof(Order).FullName, "Orders", "Customer")
+                .Entity(typeof(Customer).FullName).HasMany(typeof(Order).FullName, "Orders").WithOne("Customer")
                 .ForeignKey("CustomerId")
                 .ReferencedKey("AlternateKey");
 
@@ -1022,8 +1010,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Customer).FullName)
-                .OneToMany(typeof(Order).FullName, "Orders", "Customer")
+                .Entity(typeof(Customer).FullName).HasMany(typeof(Order).FullName, "Orders").WithOne("Customer")
                 .ReferencedKey("AlternateKey")
                 .ForeignKey("CustomerId");
 
@@ -1073,8 +1060,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(BigMak).FullName)
-                .OneToMany(typeof(Pickle).FullName, "Pickles", "BigMak")
+                .Entity(typeof(BigMak).FullName).HasMany(typeof(Pickle).FullName, "Pickles").WithOne("BigMak")
                 .ForeignKey("BurgerId")
                 .ReferencedKey("AlternateKey");
 
@@ -1124,8 +1110,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(BigMak).FullName)
-                .OneToMany(typeof(Pickle).FullName, "Pickles", "BigMak")
+                .Entity(typeof(BigMak).FullName).HasMany(typeof(Pickle).FullName, "Pickles").WithOne("BigMak")
                 .ReferencedKey("AlternateKey")
                 .ForeignKey("BurgerId");
 
@@ -1173,7 +1158,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Order).FullName).ManyToOne(typeof(Customer).FullName, "Customer", "Orders");
+            modelBuilder.Entity(typeof(Order).FullName).HasOne(typeof(Customer).FullName, "Customer").WithMany("Orders");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
             Assert.Same(navToPrincipal, dependentType.Navigations.Single());
@@ -1210,7 +1195,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Order).FullName).ManyToOne(typeof(Customer).FullName, "Customer", "Orders");
+            modelBuilder.Entity(typeof(Order).FullName).HasOne(typeof(Customer).FullName, "Customer").WithMany("Orders");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
             Assert.Same(navigation, dependentType.Navigations.Single());
@@ -1247,7 +1232,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Order).FullName).ManyToOne(typeof(Customer).FullName, "Customer", "Orders");
+            modelBuilder.Entity(typeof(Order).FullName).HasOne(typeof(Customer).FullName, "Customer").WithMany("Orders");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -1282,7 +1267,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Order).FullName).ManyToOne(typeof(Customer).FullName, "Customer", "Orders");
+            modelBuilder.Entity(typeof(Order).FullName).HasOne(typeof(Customer).FullName, "Customer").WithMany("Orders");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -1316,7 +1301,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Order).FullName).ManyToOne(typeof(Customer).FullName, "Customer", "Orders");
+            modelBuilder.Entity(typeof(Order).FullName).HasOne(typeof(Customer).FullName, "Customer").WithMany("Orders");
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -1353,7 +1338,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             // Passing null as the first arg is not super-compelling, but it is consistent
-            modelBuilder.Entity(typeof(Order).FullName).ManyToOne(typeof(Customer).FullName, null, "Orders");
+            modelBuilder.Entity(typeof(Order).FullName).HasOne(typeof(Customer).FullName, null).WithMany("Orders");
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -1388,7 +1373,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Order).FullName).ManyToOne(typeof(Customer).FullName, "Customer");
+            modelBuilder.Entity(typeof(Order).FullName).HasOne(typeof(Customer).FullName, "Customer").WithMany(null);
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -1423,7 +1408,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Order).FullName).ManyToOne(typeof(Customer).FullName);
+            modelBuilder.Entity(typeof(Order).FullName).HasOne(typeof(Customer).FullName, null).WithMany(null);
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -1458,8 +1443,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Order).FullName)
-                .ManyToOne(typeof(Customer).FullName, "Customer", "Orders")
+                .Entity(typeof(Order).FullName).HasOne(typeof(Customer).FullName, "Customer").WithMany("Orders")
                 .ForeignKey("CustomerId");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -1498,8 +1482,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Pickle).FullName)
-                .ManyToOne(typeof(BigMak).FullName, "BigMak", "Pickles")
+                .Entity(typeof(Pickle).FullName).HasOne(typeof(BigMak).FullName, "BigMak").WithMany("Pickles")
                 .ForeignKey("BurgerId");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
@@ -1535,8 +1518,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Pickle).FullName)
-                .ManyToOne(typeof(BigMak).FullName, "BigMak", "Pickles")
+                .Entity(typeof(Pickle).FullName).HasOne(typeof(BigMak).FullName, "BigMak").WithMany("Pickles")
                 .ForeignKey("BurgerId");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -1574,8 +1556,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Pickle).FullName)
-                .ManyToOne(typeof(BigMak).FullName, null, "Pickles")
+                .Entity(typeof(Pickle).FullName).HasOne(typeof(BigMak).FullName, null).WithMany("Pickles")
                 .ForeignKey("BurgerId");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -1612,8 +1593,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Pickle).FullName)
-                .ManyToOne(typeof(BigMak).FullName, "BigMak")
+                .Entity(typeof(Pickle).FullName).HasOne(typeof(BigMak).FullName, "BigMak").WithMany(null)
                 .ForeignKey("BurgerId");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -1650,8 +1630,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Pickle).FullName)
-                .ManyToOne(typeof(BigMak).FullName)
+                .Entity(typeof(Pickle).FullName).HasOne(typeof(BigMak).FullName, null).WithMany(null)
                 .ForeignKey("BurgerId");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -1684,7 +1663,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Pickle).FullName).ManyToOne(typeof(BigMak).FullName, "BigMak", "Pickles");
+            modelBuilder.Entity(typeof(Pickle).FullName).HasOne(typeof(BigMak).FullName, "BigMak").WithMany("Pickles");
 
             var fk = dependentType.ForeignKeys.Single();
             var fkProperty = fk.Properties.Single();
@@ -1723,7 +1702,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Pickle).FullName).ManyToOne(typeof(BigMak).FullName, null, "Pickles");
+            modelBuilder.Entity(typeof(Pickle).FullName).HasOne(typeof(BigMak).FullName, null).WithMany("Pickles");
 
             var fk = dependentType.ForeignKeys.Single();
             var fkProperty = fk.Properties.Single();
@@ -1761,7 +1740,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Pickle).FullName).ManyToOne(typeof(BigMak).FullName, "BigMak");
+            modelBuilder.Entity(typeof(Pickle).FullName).HasOne(typeof(BigMak).FullName, "BigMak").WithMany(null);
 
             var fk = dependentType.ForeignKeys.Single();
             var fkProperty = fk.Properties.Single();
@@ -1799,7 +1778,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Pickle).FullName).ManyToOne(typeof(BigMak).FullName);
+            modelBuilder.Entity(typeof(Pickle).FullName).HasOne(typeof(BigMak).FullName, null).WithMany(null);
 
             var fk = dependentType.ForeignKeys.Single();
             var fkProperty = fk.Properties.Single();
@@ -1838,7 +1817,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty = dependentType.GetProperty("BigMakId");
 
-            modelBuilder.Entity(typeof(Pickle).FullName).ManyToOne(typeof(BigMak).FullName, "BigMak", "Pickles");
+            modelBuilder.Entity(typeof(Pickle).FullName).HasOne(typeof(BigMak).FullName, "BigMak").WithMany("Pickles");
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -1877,8 +1856,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Pickle).FullName)
-                .ManyToOne(typeof(BigMak).FullName, "BigMak", "Pickles")
+                .Entity(typeof(Pickle).FullName).HasOne(typeof(BigMak).FullName, "BigMak").WithMany("Pickles")
                 .ForeignKey("BurgerId");
 
             Assert.Equal(2, dependentType.ForeignKeys.Count);
@@ -1920,8 +1898,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Order).FullName)
-                .ManyToOne(typeof(Customer).FullName, "Customer", "Orders")
+                .Entity(typeof(Order).FullName).HasOne(typeof(Customer).FullName, "Customer").WithMany("Orders")
                 .ReferencedKey("Id");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -1965,8 +1942,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Order).FullName)
-                .ManyToOne(typeof(Customer).FullName, "Customer", "Orders")
+                .Entity(typeof(Order).FullName).HasOne(typeof(Customer).FullName, "Customer").WithMany("Orders")
                 .ReferencedKey("AlternateKey");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -2015,8 +1991,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Order).FullName)
-                .ManyToOne(typeof(Customer).FullName, "Customer", "Orders")
+                .Entity(typeof(Order).FullName).HasOne(typeof(Customer).FullName, "Customer").WithMany("Orders")
                 .ForeignKey("CustomerId")
                 .ReferencedKey("Id");
 
@@ -2061,8 +2036,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Order).FullName)
-                .ManyToOne(typeof(Customer).FullName, "Customer", "Orders")
+                .Entity(typeof(Order).FullName).HasOne(typeof(Customer).FullName, "Customer").WithMany("Orders")
                 .ReferencedKey("Id")
                 .ForeignKey("CustomerId");
 
@@ -2107,8 +2081,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Order).FullName)
-                .ManyToOne(typeof(Customer).FullName, "Customer", "Orders")
+                .Entity(typeof(Order).FullName).HasOne(typeof(Customer).FullName, "Customer").WithMany("Orders")
                 .ForeignKey("CustomerId")
                 .ReferencedKey("AlternateKey");
 
@@ -2158,8 +2131,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Order).FullName)
-                .ManyToOne(typeof(Customer).FullName, "Customer", "Orders")
+                .Entity(typeof(Order).FullName).HasOne(typeof(Customer).FullName, "Customer").WithMany("Orders")
                 .ReferencedKey("AlternateKey")
                 .ForeignKey("CustomerId");
 
@@ -2209,8 +2181,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Pickle).FullName)
-                .ManyToOne(typeof(BigMak).FullName, "BigMak", "Pickles")
+                .Entity(typeof(Pickle).FullName).HasOne(typeof(BigMak).FullName, "BigMak").WithMany("Pickles")
                 .ForeignKey("BurgerId")
                 .ReferencedKey("AlternateKey");
 
@@ -2260,8 +2231,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Pickle).FullName)
-                .ManyToOne(typeof(BigMak).FullName, "BigMak", "Pickles")
+                .Entity(typeof(Pickle).FullName).HasOne(typeof(BigMak).FullName, "BigMak").WithMany("Pickles")
                 .ReferencedKey("AlternateKey")
                 .ForeignKey("BurgerId");
 
@@ -2310,7 +2280,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Customer).FullName).OneToOne(typeof(CustomerDetails).FullName, "Details", "Customer");
+            modelBuilder.Entity(typeof(Customer).FullName).HasOne(typeof(CustomerDetails).FullName, "Details").WithOne("Customer");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
             Assert.Same(navToPrincipal, dependentType.Navigations.Single());
@@ -2348,7 +2318,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Customer).FullName).OneToOne(typeof(CustomerDetails).FullName, "Details", "Customer");
+            modelBuilder.Entity(typeof(Customer).FullName).HasOne(typeof(CustomerDetails).FullName, "Details").WithOne("Customer");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
             Assert.Same(navigation, dependentType.Navigations.Single());
@@ -2386,7 +2356,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Customer).FullName).OneToOne(typeof(CustomerDetails).FullName, "Details", "Customer");
+            modelBuilder.Entity(typeof(Customer).FullName).HasOne(typeof(CustomerDetails).FullName, "Details").WithOne("Customer");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -2423,7 +2393,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Customer).FullName).OneToOne(typeof(CustomerDetails).FullName, "Details", "Customer");
+            modelBuilder.Entity(typeof(Customer).FullName).HasOne(typeof(CustomerDetails).FullName, "Details").WithOne("Customer");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -2457,7 +2427,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Customer).FullName).OneToOne(typeof(CustomerDetails).FullName, "Details", "Customer");
+            modelBuilder.Entity(typeof(Customer).FullName).HasOne(typeof(CustomerDetails).FullName, "Details").WithOne("Customer");
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -2496,7 +2466,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Order).FullName).OneToOne(typeof(OrderDetails).FullName, "Details", "Order");
+            modelBuilder.Entity(typeof(Order).FullName).HasOne(typeof(OrderDetails).FullName, "Details").WithOne("Order");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
             Assert.Equal("Order", dependentType.Navigations.Single().Name);
@@ -2534,7 +2504,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Order).FullName).OneToOne(typeof(OrderDetails).FullName, "Details", "Order");
+            modelBuilder.Entity(typeof(Order).FullName).HasOne(typeof(OrderDetails).FullName, "Details").WithOne("Order");
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -2570,7 +2540,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Customer).FullName).OneToOne(typeof(CustomerDetails).FullName, "Details");
+            modelBuilder.Entity(typeof(Customer).FullName).HasOne(typeof(CustomerDetails).FullName, "Details").WithOne(null);
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -2606,7 +2576,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             // Passing null as the first arg is not super-compelling, but it is consistent
-            modelBuilder.Entity(typeof(Customer).FullName).OneToOne(typeof(CustomerDetails).FullName, null, "Customer");
+            modelBuilder.Entity(typeof(Customer).FullName).HasOne(typeof(CustomerDetails).FullName, null).WithOne("Customer");
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -2641,7 +2611,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalKey = principalType.Keys.Single();
             var dependentKey = dependentType.Keys.Single();
 
-            modelBuilder.Entity(typeof(Customer).FullName).OneToOne(typeof(CustomerDetails).FullName);
+            modelBuilder.Entity(typeof(Customer).FullName).HasOne(typeof(CustomerDetails).FullName, null).WithOne(null);
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -2680,8 +2650,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Order).FullName)
-                .OneToOne(typeof(OrderDetails).FullName, "Details", "Order")
+                .Entity(typeof(Order).FullName).HasOne(typeof(OrderDetails).FullName, "Details").WithOne("Order")
                 .ForeignKey(typeof(OrderDetails).FullName, "OrderId");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -2719,8 +2688,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Customer).FullName)
-                .OneToOne(typeof(CustomerDetails).FullName, "Details", "Customer")
+                .Entity(typeof(Customer).FullName).HasOne(typeof(CustomerDetails).FullName, "Details").WithOne("Customer")
                 .ForeignKey(typeof(CustomerDetails).FullName, "Id");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -2760,8 +2728,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(BigMak).FullName)
-                .OneToOne(typeof(Bun).FullName, "Bun", "BigMak")
+                .Entity(typeof(BigMak).FullName).HasOne(typeof(Bun).FullName, "Bun").WithOne("BigMak")
                 .ForeignKey(typeof(Bun).FullName, "BurgerId");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
@@ -2797,8 +2764,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(BigMak).FullName)
-                .OneToOne(typeof(Bun).FullName, "Bun", "BigMak")
+                .Entity(typeof(BigMak).FullName).HasOne(typeof(Bun).FullName, "Bun").WithOne("BigMak")
                 .ForeignKey(typeof(Bun).FullName, "BurgerId");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -2836,8 +2802,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(BigMak).FullName)
-                .OneToOne(typeof(Bun).FullName, "Bun")
+                .Entity(typeof(BigMak).FullName).HasOne(typeof(Bun).FullName, "Bun").WithOne(null)
                 .ForeignKey(typeof(Bun).FullName, "BurgerId");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -2874,8 +2839,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(BigMak).FullName)
-                .OneToOne(typeof(Bun).FullName, null, "BigMak")
+                .Entity(typeof(BigMak).FullName).HasOne(typeof(Bun).FullName, null).WithOne("BigMak")
                 .ForeignKey(typeof(Bun).FullName, "BurgerId");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -2912,8 +2876,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(BigMak).FullName)
-                .OneToOne(typeof(Bun).FullName)
+                .Entity(typeof(BigMak).FullName).HasOne(typeof(Bun).FullName, null).WithOne(null)
                 .ForeignKey(typeof(Bun).FullName, "BurgerId");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -2950,8 +2913,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(BigMak).FullName)
-                .OneToOne(typeof(Bun).FullName, "Bun", "BigMak")
+                .Entity(typeof(BigMak).FullName).HasOne(typeof(Bun).FullName, "Bun").WithOne("BigMak")
                 .ForeignKey(typeof(Bun).FullName, "BurgerId");
 
             Assert.Equal(2, dependentType.ForeignKeys.Count);
@@ -2995,8 +2957,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(OrderDetails).FullName)
-                .OneToOne(typeof(Order).FullName, "Order", "Details")
+                .Entity(typeof(OrderDetails).FullName).HasOne(typeof(Order).FullName, "Order").WithOne("Details")
                 .ForeignKey(typeof(OrderDetails).FullName, "Id");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
@@ -3036,8 +2997,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(OrderDetails).FullName)
-                .OneToOne(typeof(Order).FullName, "Order", "Details")
+                .Entity(typeof(OrderDetails).FullName).HasOne(typeof(Order).FullName, "Order").WithOne("Details")
                 .ForeignKey(typeof(OrderDetails).FullName, "OrderId");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -3075,8 +3035,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<CustomerDetails>()
-                .OneToOne(typeof(Customer).FullName, "Customer")
+                .Entity<CustomerDetails>().HasOne(typeof(Customer).FullName, "Customer").WithOne(null)
                 .ForeignKey(typeof(CustomerDetails).FullName, "Id");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -3113,8 +3072,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<CustomerDetails>()
-                .OneToOne(typeof(Customer).FullName, null, "Details")
+                .Entity<CustomerDetails>().HasOne(typeof(Customer).FullName, null).WithOne("Details")
                 .ForeignKey(typeof(CustomerDetails).FullName, "Id");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -3151,8 +3109,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<CustomerDetails>()
-                .OneToOne(typeof(Customer).FullName)
+                .Entity<CustomerDetails>().HasOne(typeof(Customer).FullName, null).WithOne(null)
                 .ForeignKey(typeof(CustomerDetails).FullName, "Id");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -3188,8 +3145,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<CustomerDetails>()
-                .OneToOne(typeof(Customer).FullName, "Customer", "Details")
+                .Entity<CustomerDetails>().HasOne(typeof(Customer).FullName, "Customer").WithOne("Details")
                 .ForeignKey(typeof(CustomerDetails).FullName, "Id");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -3228,8 +3184,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Customer).FullName)
-                .OneToOne(typeof(CustomerDetails).FullName, "Details", "Customer")
+                .Entity(typeof(Customer).FullName).HasOne(typeof(CustomerDetails).FullName, "Details").WithOne("Customer")
                 .ReferencedKey(typeof(Customer).FullName, "Id");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -3273,8 +3228,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Customer).FullName)
-                .OneToOne(typeof(CustomerDetails).FullName, "Details", "Customer")
+                .Entity(typeof(Customer).FullName).HasOne(typeof(CustomerDetails).FullName, "Details").WithOne("Customer")
                 .ReferencedKey(typeof(Customer).FullName, "AlternateKey");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -3323,8 +3277,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Order).FullName)
-                .OneToOne(typeof(OrderDetails).FullName, "Details", "Order")
+                .Entity(typeof(Order).FullName).HasOne(typeof(OrderDetails).FullName, "Details").WithOne("Order")
                 .ForeignKey(typeof(OrderDetails).FullName, "OrderId")
                 .ReferencedKey(typeof(Order).FullName, "OrderId");
 
@@ -3369,8 +3322,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Order).FullName)
-                .OneToOne(typeof(OrderDetails).FullName, "Details", "Order")
+                .Entity(typeof(Order).FullName).HasOne(typeof(OrderDetails).FullName, "Details").WithOne("Order")
                 .ReferencedKey(typeof(Order).FullName, "OrderId")
                 .ForeignKey(typeof(OrderDetails).FullName, "OrderId");
 
@@ -3415,8 +3367,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(BigMak).FullName)
-                .OneToOne(typeof(Bun).FullName, "Bun", "BigMak")
+                .Entity(typeof(BigMak).FullName).HasOne(typeof(Bun).FullName, "Bun").WithOne("BigMak")
                 .ForeignKey(typeof(Bun).FullName, "BurgerId")
                 .ReferencedKey(typeof(BigMak).FullName, "AlternateKey");
 
@@ -3466,8 +3417,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(BigMak).FullName)
-                .OneToOne(typeof(Bun).FullName, "Bun", "BigMak")
+                .Entity(typeof(BigMak).FullName).HasOne(typeof(Bun).FullName, "Bun").WithOne("BigMak")
                 .ReferencedKey(typeof(BigMak).FullName, "AlternateKey")
                 .ForeignKey(typeof(Bun).FullName, "BurgerId");
 
@@ -3515,8 +3465,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(OrderDetails).FullName)
-                .OneToOne(typeof(Order).FullName, "Order", "Details")
+                .Entity(typeof(OrderDetails).FullName).HasOne(typeof(Order).FullName, "Order").WithOne("Details")
                 .ReferencedKey(typeof(Order).FullName, "OrderId");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
@@ -3556,8 +3505,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(OrderDetails).FullName)
-                .OneToOne(typeof(Order).FullName, "Order", "Details")
+                .Entity(typeof(OrderDetails).FullName).HasOne(typeof(Order).FullName, "Order").WithOne("Details")
                 .ReferencedKey(typeof(Order).FullName, "OrderId");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -3599,8 +3547,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(OrderDetails).FullName)
-                .OneToOne(typeof(Order).FullName, "Order", "Details")
+                .Entity(typeof(OrderDetails).FullName).HasOne(typeof(Order).FullName, "Order").WithOne("Details")
                 .ForeignKey(typeof(OrderDetails).FullName, "OrderId")
                 .ReferencedKey(typeof(Order).FullName, "OrderId");
 
@@ -3643,8 +3590,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(OrderDetails).FullName)
-                .OneToOne(typeof(Order).FullName, "Order", "Details")
+                .Entity(typeof(OrderDetails).FullName).HasOne(typeof(Order).FullName, "Order").WithOne("Details")
                 .ReferencedKey(typeof(Order).FullName, "OrderId")
                 .ForeignKey(typeof(OrderDetails).FullName, "OrderId");
 
@@ -3683,8 +3629,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<CustomerDetails>()
-                .OneToOne(typeof(Customer).FullName, "Customer")
+                .Entity<CustomerDetails>().HasOne(typeof(Customer).FullName, "Customer").WithOne(null)
                 .ReferencedKey(typeof(Customer).FullName, "Id");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -3721,8 +3666,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<CustomerDetails>()
-                .OneToOne(typeof(Customer).FullName, null, "Details")
+                .Entity<CustomerDetails>().HasOne(typeof(Customer).FullName, null).WithOne("Details")
                 .ReferencedKey(typeof(Customer).FullName, "Id");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -3759,8 +3703,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity<CustomerDetails>()
-                .OneToOne(typeof(Customer).FullName)
+                .Entity<CustomerDetails>().HasOne(typeof(Customer).FullName, null).WithOne(null)
                 .ReferencedKey(typeof(Customer).FullName, "Id");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -3823,8 +3766,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Whoopper).FullName)
-                .OneToMany(typeof(Tomato).FullName, "Tomatoes", "Whoopper")
+                .Entity(typeof(Whoopper).FullName).HasMany(typeof(Tomato).FullName, "Tomatoes").WithOne("Whoopper")
                 .ForeignKey("BurgerId1", "BurgerId2");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
@@ -3865,8 +3807,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Whoopper).FullName)
-                .OneToMany(typeof(Tomato).FullName, "Tomatoes", "Whoopper")
+                .Entity(typeof(Whoopper).FullName).HasMany(typeof(Tomato).FullName, "Tomatoes").WithOne("Whoopper")
                 .ForeignKey("BurgerId1", "BurgerId2");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -3917,8 +3858,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Whoopper).FullName)
-                .OneToMany(typeof(Tomato).FullName, "Tomatoes", "Whoopper")
+                .Entity(typeof(Whoopper).FullName).HasMany(typeof(Tomato).FullName, "Tomatoes").WithOne("Whoopper")
                 .ForeignKey("BurgerId1", "BurgerId2")
                 .ReferencedKey("AlternateKey1", "AlternateKey2");
 
@@ -3977,8 +3917,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Whoopper).FullName)
-                .OneToMany(typeof(Tomato).FullName, "Tomatoes", "Whoopper")
+                .Entity(typeof(Whoopper).FullName).HasMany(typeof(Tomato).FullName, "Tomatoes").WithOne("Whoopper")
                 .ReferencedKey("AlternateKey1", "AlternateKey2")
                 .ForeignKey("BurgerId1", "BurgerId2");
 
@@ -4030,8 +3969,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Whoopper).FullName)
-                .OneToMany(typeof(Tomato).FullName, "Tomatoes")
+                .Entity(typeof(Whoopper).FullName).HasMany(typeof(Tomato).FullName, "Tomatoes").WithOne(null)
                 .ForeignKey("BurgerId1", "BurgerId2");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -4074,8 +4012,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Whoopper).FullName)
-                .OneToMany(typeof(Tomato).FullName, null, "Whoopper")
+                .Entity(typeof(Whoopper).FullName).HasMany(typeof(Tomato).FullName, null).WithOne("Whoopper")
                 .ForeignKey("BurgerId1", "BurgerId2");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -4118,8 +4055,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Whoopper).FullName)
-                .OneToMany(typeof(Tomato).FullName)
+                .Entity(typeof(Whoopper).FullName).HasMany(typeof(Tomato).FullName, null).WithOne(null)
                 .ForeignKey("BurgerId1", "BurgerId2");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -4157,8 +4093,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Tomato).FullName)
-                .ManyToOne(typeof(Whoopper).FullName, "Whoopper", "Tomatoes")
+                .Entity(typeof(Tomato).FullName).HasOne(typeof(Whoopper).FullName, "Whoopper").WithMany("Tomatoes")
                 .ForeignKey("BurgerId1", "BurgerId2");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
@@ -4199,8 +4134,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Tomato).FullName)
-                .ManyToOne(typeof(Whoopper).FullName, "Whoopper", "Tomatoes")
+                .Entity(typeof(Tomato).FullName).HasOne(typeof(Whoopper).FullName, "Whoopper").WithMany("Tomatoes")
                 .ForeignKey("BurgerId1", "BurgerId2");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -4251,8 +4185,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Tomato).FullName)
-                .ManyToOne(typeof(Whoopper).FullName, "Whoopper", "Tomatoes")
+                .Entity(typeof(Tomato).FullName).HasOne(typeof(Whoopper).FullName, "Whoopper").WithMany("Tomatoes")
                 .ForeignKey("BurgerId1", "BurgerId2")
                 .ReferencedKey("AlternateKey1", "AlternateKey2");
 
@@ -4311,8 +4244,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Tomato).FullName)
-                .ManyToOne(typeof(Whoopper).FullName, "Whoopper", "Tomatoes")
+                .Entity(typeof(Tomato).FullName).HasOne(typeof(Whoopper).FullName, "Whoopper").WithMany("Tomatoes")
                 .ReferencedKey("AlternateKey1", "AlternateKey2")
                 .ForeignKey("BurgerId1", "BurgerId2");
 
@@ -4364,8 +4296,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Tomato).FullName)
-                .ManyToOne(typeof(Whoopper).FullName, null, "Tomatoes")
+                .Entity(typeof(Tomato).FullName).HasOne(typeof(Whoopper).FullName, null).WithMany("Tomatoes")
                 .ForeignKey("BurgerId1", "BurgerId2");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -4408,8 +4339,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Tomato).FullName)
-                .ManyToOne(typeof(Whoopper).FullName, "Whoopper")
+                .Entity(typeof(Tomato).FullName).HasOne(typeof(Whoopper).FullName, "Whoopper").WithMany(null)
                 .ForeignKey("BurgerId1", "BurgerId2");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -4452,8 +4382,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Tomato).FullName)
-                .ManyToOne(typeof(Whoopper).FullName)
+                .Entity(typeof(Tomato).FullName).HasOne(typeof(Whoopper).FullName, null).WithMany(null)
                 .ForeignKey("BurgerId1", "BurgerId2");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -4492,8 +4421,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Whoopper).FullName)
-                .OneToOne(typeof(ToastedBun).FullName, "ToastedBun", "Whoopper")
+                .Entity(typeof(Whoopper).FullName).HasOne(typeof(ToastedBun).FullName, "ToastedBun").WithOne("Whoopper")
                 .ForeignKey(typeof(ToastedBun).FullName, "BurgerId1", "BurgerId2");
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
@@ -4534,8 +4462,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Whoopper).FullName)
-                .OneToOne(typeof(ToastedBun).FullName, "ToastedBun", "Whoopper")
+                .Entity(typeof(Whoopper).FullName).HasOne(typeof(ToastedBun).FullName, "ToastedBun").WithOne("Whoopper")
                 .ForeignKey(typeof(ToastedBun).FullName, "BurgerId1", "BurgerId2");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -4586,8 +4513,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Whoopper).FullName)
-                .OneToOne(typeof(ToastedBun).FullName, "ToastedBun", "Whoopper")
+                .Entity(typeof(Whoopper).FullName).HasOne(typeof(ToastedBun).FullName, "ToastedBun").WithOne("Whoopper")
                 .ForeignKey(typeof(ToastedBun).FullName, "BurgerId1", "BurgerId2")
                 .ReferencedKey(typeof(Whoopper).FullName, "AlternateKey1", "AlternateKey2");
 
@@ -4646,8 +4572,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Whoopper).FullName)
-                .OneToOne(typeof(ToastedBun).FullName, "ToastedBun", "Whoopper")
+                .Entity(typeof(Whoopper).FullName).HasOne(typeof(ToastedBun).FullName, "ToastedBun").WithOne("Whoopper")
                 .ReferencedKey(typeof(Whoopper).FullName, "AlternateKey1", "AlternateKey2")
                 .ForeignKey(typeof(ToastedBun).FullName, "BurgerId1", "BurgerId2");
 
@@ -4695,8 +4620,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Whoopper).FullName)
-                .OneToOne(typeof(Moostard).FullName, "Moostard", "Whoopper");
+                .Entity(typeof(Whoopper).FullName).HasOne(typeof(Moostard).FullName, "Moostard").WithOne("Whoopper");
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
@@ -4735,8 +4659,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Moostard).FullName)
-                .OneToOne(typeof(Whoopper).FullName, "Whoopper", "Moostard")
+                .Entity(typeof(Moostard).FullName).HasOne(typeof(Whoopper).FullName, "Whoopper").WithOne("Moostard")
                 .ForeignKey(typeof(Moostard).FullName, "Id1", "Id2");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -4776,8 +4699,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Moostard).FullName)
-                .OneToOne(typeof(Whoopper).FullName, "Whoopper", "Moostard")
+                .Entity(typeof(Moostard).FullName).HasOne(typeof(Whoopper).FullName, "Whoopper").WithOne("Moostard")
                 .ReferencedKey(typeof(Whoopper).FullName, "Id1", "Id2");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -4821,8 +4743,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Whoopper).FullName)
-                .OneToOne(typeof(ToastedBun).FullName, "ToastedBun")
+                .Entity(typeof(Whoopper).FullName).HasOne(typeof(ToastedBun).FullName, "ToastedBun").WithOne(null)
                 .ForeignKey(typeof(ToastedBun).FullName, "BurgerId1", "BurgerId2");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -4865,8 +4786,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Whoopper).FullName)
-                .OneToOne(typeof(ToastedBun).FullName, null, "Whoopper")
+                .Entity(typeof(Whoopper).FullName).HasOne(typeof(ToastedBun).FullName, null).WithOne("Whoopper")
                 .ForeignKey(typeof(ToastedBun).FullName, "BurgerId1", "BurgerId2");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -4909,8 +4829,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentKey = dependentType.Keys.Single();
 
             modelBuilder
-                .Entity(typeof(Whoopper).FullName)
-                .OneToOne(typeof(ToastedBun).FullName)
+                .Entity(typeof(Whoopper).FullName).HasOne(typeof(ToastedBun).FullName, null).WithOne(null)
                 .ForeignKey(typeof(ToastedBun).FullName, "BurgerId1", "BurgerId2");
 
             var fk = dependentType.ForeignKeys.Single();
@@ -5029,8 +4948,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var modelBuilder = HobNobBuilder();
 
             modelBuilder
-                .Entity(typeof(Hob).FullName)
-                .OneToMany(typeof(Nob).FullName, "Nobs", "Hob")
+                .Entity(typeof(Hob).FullName).HasMany(typeof(Nob).FullName, "Nobs").WithOne("Hob")
                 .ForeignKey("HobId1", "HobId2");
 
             var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob).FullName);
@@ -5046,8 +4964,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var modelBuilder = HobNobBuilder();
 
             modelBuilder
-                .Entity(typeof(Nob).FullName)
-                .OneToMany(typeof(Hob).FullName, "Hobs", "Nob")
+                .Entity(typeof(Nob).FullName).HasMany(typeof(Hob).FullName, "Hobs").WithOne("Nob")
                 .ForeignKey("NobId1", "NobId2");
 
             var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Hob).FullName);
@@ -5063,8 +4980,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var modelBuilder = HobNobBuilder();
 
             modelBuilder
-                .Entity(typeof(Nob).FullName)
-                .ManyToOne(typeof(Hob).FullName, "Hob", "Nobs")
+                .Entity(typeof(Nob).FullName).HasOne(typeof(Hob).FullName, "Hob").WithMany("Nobs")
                 .ForeignKey("HobId1", "HobId2");
 
             var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob).FullName);
@@ -5080,8 +4996,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var modelBuilder = HobNobBuilder();
 
             modelBuilder
-                .Entity<Hob>()
-                .ManyToOne(typeof(Nob).FullName, "Nob", "Hobs")
+                .Entity<Hob>().HasOne(typeof(Nob).FullName, "Nob").WithMany("Hobs")
                 .ForeignKey("NobId1", "NobId2");
 
             var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Hob).FullName);
@@ -5097,8 +5012,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var modelBuilder = HobNobBuilder();
 
             modelBuilder
-                .Entity(typeof(Hob).FullName)
-                .OneToOne(typeof(Nob).FullName, "Nob", "Hob")
+                .Entity(typeof(Hob).FullName).HasOne(typeof(Nob).FullName, "Nob").WithOne("Hob")
                 .ForeignKey(typeof(Nob).FullName, "HobId1", "HobId2");
 
             var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob).FullName);
@@ -5114,8 +5028,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var modelBuilder = HobNobBuilder();
 
             modelBuilder
-                .Entity(typeof(Nob).FullName)
-                .OneToOne(typeof(Hob).FullName, "Hob", "Nob")
+                .Entity(typeof(Nob).FullName).HasOne(typeof(Hob).FullName, "Hob").WithOne("Nob")
                 .ForeignKey(typeof(Hob).FullName, "NobId1", "NobId2");
 
             var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Hob).FullName);
@@ -5131,8 +5044,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var modelBuilder = HobNobBuilder();
 
             modelBuilder
-                .Entity(typeof(Hob).FullName)
-                .OneToMany(typeof(Nob).FullName, "Nobs", "Hob")
+                .Entity(typeof(Hob).FullName).HasMany(typeof(Nob).FullName, "Nobs").WithOne("Hob")
                 .ForeignKey("HobId1", "HobId2")
                 .Required();
 
@@ -5151,8 +5063,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Equal(
                 Strings.CannotBeNullable("NobId1", "Hob", "Int32"),
                 Assert.Throws<InvalidOperationException>(() => modelBuilder
-                    .Entity(typeof(Nob).FullName)
-                    .OneToMany(typeof(Hob).FullName, "Hobs", "Nob")
+                    .Entity(typeof(Nob).FullName).HasMany(typeof(Hob).FullName, "Hobs").WithOne("Nob")
                     .ForeignKey("NobId1", "NobId2")
                     .Required(false)).Message);
 
@@ -5169,8 +5080,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var modelBuilder = HobNobBuilder();
 
             modelBuilder
-                .Entity(typeof(Nob).FullName)
-                .ManyToOne(typeof(Hob).FullName, "Hob", "Nobs")
+                .Entity(typeof(Nob).FullName).HasOne(typeof(Hob).FullName, "Hob").WithMany("Nobs")
                 .ForeignKey("HobId1", "HobId2")
                 .Required();
 
@@ -5189,8 +5099,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Equal(
                 Strings.CannotBeNullable("NobId1", "Hob", "Int32"),
                 Assert.Throws<InvalidOperationException>(() => modelBuilder
-                    .Entity(typeof(Hob).FullName)
-                    .ManyToOne(typeof(Nob).FullName, "Nob", "Hobs")
+                    .Entity(typeof(Hob).FullName).HasOne(typeof(Nob).FullName, "Nob").WithMany("Hobs")
                     .ForeignKey("NobId1", "NobId2")
                     .Required(false)).Message);
 
@@ -5207,8 +5116,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var modelBuilder = HobNobBuilder();
 
             modelBuilder
-                .Entity(typeof(Hob).FullName)
-                .OneToOne(typeof(Nob).FullName, "Nob", "Hob")
+                .Entity(typeof(Hob).FullName).HasOne(typeof(Nob).FullName, "Nob").WithOne("Hob")
                 .ForeignKey(typeof(Nob).FullName, "HobId1", "HobId2")
                 .Required();
 
@@ -5227,8 +5135,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Equal(
                 Strings.CannotBeNullable("NobId1", "Hob", "Int32"),
                 Assert.Throws<InvalidOperationException>(() => modelBuilder
-                    .Entity(typeof(Nob).FullName)
-                    .OneToOne(typeof(Hob).FullName, "Hob", "Nob")
+                    .Entity(typeof(Nob).FullName).HasOne(typeof(Hob).FullName, "Hob").WithOne("Nob")
                     .ForeignKey(typeof(Hob).FullName, "NobId1", "NobId2")
                     .Required(false)).Message);
 

--- a/test/EntityFramework.Microbenchmarks/Models/Orders/OrdersContext.cs
+++ b/test/EntityFramework.Microbenchmarks/Models/Orders/OrdersContext.cs
@@ -35,16 +35,13 @@ namespace EntityFramework.Microbenchmarks.Models.Orders
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.Entity<Customer>()
-                .OneToMany(c => c.Orders, o => o.Customer)
+            modelBuilder.Entity<Customer>().HasMany(c => c.Orders).WithOne(o => o.Customer)
                 .ForeignKey(o => o.CustomerId);
 
-            modelBuilder.Entity<Order>()
-                .OneToMany(o => o.OrderLines, ol => ol.Order)
+            modelBuilder.Entity<Order>().HasMany(o => o.OrderLines).WithOne(ol => ol.Order)
                 .ForeignKey(ol => ol.OrderId);
 
-            modelBuilder.Entity<Product>()
-                .OneToMany(p => p.OrderLines, ol => ol.Product)
+            modelBuilder.Entity<Product>().HasMany(p => p.OrderLines).WithOne(ol => ol.Product)
                 .ForeignKey(ol => ol.ProductId);
         }
     }

--- a/test/EntityFramework.Relational.FunctionalTests/RelationalF1Fixture.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/RelationalF1Fixture.cs
@@ -76,8 +76,7 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
                 .Table("TitleSponsors");
 
             modelBuilder
-                .Entity<Team>()
-                .OneToOne(e => e.Chassis, e => e.Team);
+                .Entity<Team>().HasOne(e => e.Chassis).WithOne(e => e.Team);
         }
     }
 }

--- a/test/EntityFramework.Relational.Tests/Metadata/RelationalBuilderExtensionsTest.cs
+++ b/test/EntityFramework.Relational.Tests/Metadata/RelationalBuilderExtensionsTest.cs
@@ -422,8 +422,7 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
             var modelBuilder = new ModelBuilder();
 
             modelBuilder
-                .Entity<Customer>()
-                .OneToMany(e => e.Orders, e => e.Customer)
+                .Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer)
                 .ForRelational()
                 .Name("LemonSupreme");
 
@@ -432,8 +431,7 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
             Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
 
             modelBuilder
-                .Entity<Customer>()
-                .OneToMany(e => e.Orders, e => e.Customer)
+                .Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer)
                 .ForRelational()
                 .Name(null);
 
@@ -446,8 +444,7 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
             var modelBuilder = new ModelBuilder();
 
             modelBuilder
-                .Entity<Customer>()
-                .OneToMany(e => e.Orders, e => e.Customer)
+                .Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer)
                 .ForeignKey(e => e.CustomerId)
                 .ForRelational()
                 .Name("LemonSupreme");
@@ -463,8 +460,7 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
             var modelBuilder = new ModelBuilder();
 
             modelBuilder
-                .Entity<Customer>()
-                .OneToMany(e => e.Orders, e => e.Customer)
+                .Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer)
                 .ForRelational(b => { b.Name("LemonSupreme"); });
 
             var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).ForeignKeys.Single(fk => fk.ReferencedEntityType.Type == typeof(Customer));
@@ -478,8 +474,7 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
             var modelBuilder = new ModelBuilder();
 
             modelBuilder
-                .Entity<Customer>()
-                .OneToMany(e => e.Orders, e => e.Customer)
+                .Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer)
                 .ForeignKey(e => e.CustomerId)
                 .ForRelational(b => { b.Name("LemonSupreme"); });
 
@@ -494,8 +489,7 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
             var modelBuilder = new ModelBuilder();
 
             modelBuilder
-                .Entity<Order>()
-                .ManyToOne(e => e.Customer, e => e.Orders)
+                .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                 .ForRelational()
                 .Name("LemonSupreme");
 
@@ -504,8 +498,7 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
             Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
 
             modelBuilder
-                .Entity<Order>()
-                .ManyToOne(e => e.Customer, e => e.Orders)
+                .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                 .ForRelational()
                 .Name(null);
 
@@ -518,8 +511,7 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
             var modelBuilder = new ModelBuilder();
 
             modelBuilder
-                .Entity<Order>()
-                .ManyToOne(e => e.Customer, e => e.Orders)
+                .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                 .ForeignKey(e => e.CustomerId)
                 .ForRelational()
                 .Name("LemonSupreme");
@@ -535,8 +527,7 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
             var modelBuilder = new ModelBuilder();
 
             modelBuilder
-                .Entity<Order>()
-                .ManyToOne(e => e.Customer, e => e.Orders)
+                .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                 .ForRelational(b => { b.Name("LemonSupreme"); });
 
             var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).ForeignKeys.Single(fk => fk.ReferencedEntityType.Type == typeof(Customer));
@@ -550,8 +541,7 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
             var modelBuilder = new ModelBuilder();
 
             modelBuilder
-                .Entity<Order>()
-                .ManyToOne(e => e.Customer, e => e.Orders)
+                .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                 .ForeignKey(e => e.CustomerId)
                 .ForRelational(b => { b.Name("LemonSupreme"); });
 
@@ -566,8 +556,8 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
             var modelBuilder = new ModelBuilder();
 
             modelBuilder
-                .Entity<Order>()
-                .OneToOne(e => e.Details, e => e.Order)
+                .Entity<Order>().HasOne(e => e.Details).WithOne(e => e.Order)
+                .ReferencedKey<Order>(e => e.OrderId)
                 .ForRelational()
                 .Name("LemonSupreme");
 
@@ -576,8 +566,7 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
             Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
 
             modelBuilder
-                .Entity<Order>()
-                .OneToOne(e => e.Details, e => e.Order)
+                .Entity<Order>().HasOne(e => e.Details).WithOne(e => e.Order)
                 .ForRelational()
                 .Name(null);
 
@@ -590,8 +579,7 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
             var modelBuilder = new ModelBuilder();
 
             modelBuilder
-                .Entity<Order>()
-                .OneToOne(e => e.Details, e => e.Order)
+                .Entity<Order>().HasOne(e => e.Details).WithOne(e => e.Order)
                 .ForeignKey<OrderDetails>(e => e.Id)
                 .ForRelational()
                 .Name("LemonSupreme");
@@ -607,8 +595,8 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
             var modelBuilder = new ModelBuilder();
 
             modelBuilder
-                .Entity<Order>()
-                .OneToOne(e => e.Details, e => e.Order)
+                .Entity<Order>().HasOne(e => e.Details).WithOne(e => e.Order)
+                .ReferencedKey<Order>(e => e.OrderId)
                 .ForRelational(b => { b.Name("LemonSupreme"); });
 
             var foreignKey = modelBuilder.Model.GetEntityType(typeof(OrderDetails)).ForeignKeys.Single();
@@ -622,8 +610,7 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
             var modelBuilder = new ModelBuilder();
 
             modelBuilder
-                .Entity<Order>()
-                .OneToOne(e => e.Details, e => e.Order)
+                .Entity<Order>().HasOne(e => e.Details).WithOne(e => e.Order)
                 .ForeignKey<OrderDetails>(e => e.Id)
                 .ForRelational(b => { b.Name("LemonSupreme"); });
 

--- a/test/EntityFramework.SqlServer.FunctionalTests/QueryBugsTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/QueryBugsTest.cs
@@ -208,7 +208,7 @@ LEFT JOIN [Customer] AS [c] ON ([o].[CustomerId0] = [c].[FirstName] AND [o].[Cus
                 modelBuilder.Entity<Customer>(m =>
                     {
                         m.Key(c => new { c.FirstName, c.LastName });
-                        m.OneToMany(c => c.Orders, o => o.Customer);
+                        m.HasMany(c => c.Orders).WithOne(o => o.Customer);
                     });
             }
         }
@@ -345,8 +345,8 @@ Queen of the Andals and the Rhoynar and the First Men, Khaleesi of the Great Gra
                 modelBuilder.Entity<Targaryen>(m =>
                     {
                         m.Key(t => t.Id);
-                        m.OneToMany(t => t.Dragons, d => d.Mother).ForeignKey(d => d.MotherId);
-                        m.OneToOne(t => t.Details, d => d.Targaryen).ForeignKey<Details>(d => d.TargaryenId);
+                        m.HasMany(t => t.Dragons).WithOne(d => d.Mother).ForeignKey(d => d.MotherId);
+                        m.HasOne(t => t.Details).WithOne(d => d.Targaryen).ForeignKey<Details>(d => d.TargaryenId);
                     });
             }
         }

--- a/test/EntityFramework.SqlServer.Tests/Metadata/SqlServerBuilderExtensionsTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/Metadata/SqlServerBuilderExtensionsTest.cs
@@ -526,14 +526,12 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             var modelBuilder = new ModelBuilder();
 
             modelBuilder
-                .Entity<Customer>()
-                .OneToMany(e => e.Orders, e => e.Customer)
+                .Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer)
                 .ForRelational()
                 .Name("LemonSupreme");
 
             modelBuilder
-                .Entity<Customer>()
-                .OneToMany(e => e.Orders, e => e.Customer)
+                .Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer)
                 .ForSqlServer()
                 .Name("ChocolateLimes");
 
@@ -543,8 +541,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             Assert.Equal("ChocolateLimes", foreignKey.SqlServer().Name);
 
             modelBuilder
-                .Entity<Customer>()
-                .OneToMany(e => e.Orders, e => e.Customer)
+                .Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer)
                 .ForSqlServer()
                 .Name(null);
 
@@ -558,15 +555,13 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             var modelBuilder = new ModelBuilder();
 
             modelBuilder
-                .Entity<Customer>()
-                .OneToMany(e => e.Orders, e => e.Customer)
+                .Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer)
                 .ForeignKey(e => e.CustomerId)
                 .ForRelational()
                 .Name("LemonSupreme");
 
             modelBuilder
-                .Entity<Customer>()
-                .OneToMany(e => e.Orders, e => e.Customer)
+                .Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer)
                 .ForeignKey(e => e.CustomerId)
                 .ForSqlServer()
                 .Name("ChocolateLimes");
@@ -583,8 +578,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             var modelBuilder = new ModelBuilder();
 
             modelBuilder
-                .Entity<Customer>()
-                .OneToMany(e => e.Orders, e => e.Customer)
+                .Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer)
                 .ForRelational(b => { b.Name("LemonSupreme"); })
                 .ForSqlServer(b => { b.Name("ChocolateLimes"); });
 
@@ -600,8 +594,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             var modelBuilder = new ModelBuilder();
 
             modelBuilder
-                .Entity<Customer>()
-                .OneToMany(e => e.Orders, e => e.Customer)
+                .Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer)
                 .ForeignKey(e => e.CustomerId)
                 .ForRelational(b => { b.Name("LemonSupreme"); })
                 .ForSqlServer(b => { b.Name("ChocolateLimes"); });
@@ -618,14 +611,12 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             var modelBuilder = new ModelBuilder();
 
             modelBuilder
-                .Entity<Order>()
-                .ManyToOne(e => e.Customer, e => e.Orders)
+                .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                 .ForRelational()
                 .Name("LemonSupreme");
 
             modelBuilder
-                .Entity<Order>()
-                .ManyToOne(e => e.Customer, e => e.Orders)
+                .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                 .ForSqlServer()
                 .Name("ChocolateLimes");
 
@@ -635,8 +626,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             Assert.Equal("ChocolateLimes", foreignKey.SqlServer().Name);
 
             modelBuilder
-                .Entity<Order>()
-                .ManyToOne(e => e.Customer, e => e.Orders)
+                .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                 .ForSqlServer()
                 .Name(null);
 
@@ -650,15 +640,13 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             var modelBuilder = new ModelBuilder();
 
             modelBuilder
-                .Entity<Order>()
-                .ManyToOne(e => e.Customer, e => e.Orders)
+                .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                 .ForeignKey(e => e.CustomerId)
                 .ForRelational()
                 .Name("LemonSupreme");
 
             modelBuilder
-                .Entity<Order>()
-                .ManyToOne(e => e.Customer, e => e.Orders)
+                .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                 .ForeignKey(e => e.CustomerId)
                 .ForSqlServer()
                 .Name("ChocolateLimes");
@@ -675,8 +663,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             var modelBuilder = new ModelBuilder();
 
             modelBuilder
-                .Entity<Order>()
-                .ManyToOne(e => e.Customer, e => e.Orders)
+                .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                 .ForRelational(b => { b.Name("LemonSupreme"); })
                 .ForSqlServer(b => { b.Name("ChocolateLimes"); });
 
@@ -692,8 +679,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             var modelBuilder = new ModelBuilder();
 
             modelBuilder
-                .Entity<Order>()
-                .ManyToOne(e => e.Customer, e => e.Orders)
+                .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                 .ForeignKey(e => e.CustomerId)
                 .ForRelational(b => { b.Name("LemonSupreme"); })
                 .ForSqlServer(b => { b.Name("ChocolateLimes"); });
@@ -710,14 +696,13 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             var modelBuilder = new ModelBuilder();
 
             modelBuilder
-                .Entity<Order>()
-                .OneToOne(e => e.Details, e => e.Order)
+                .Entity<Order>().HasOne(e => e.Details).WithOne(e => e.Order)
+                .ReferencedKey<Order>(e => e.OrderId)
                 .ForRelational()
                 .Name("LemonSupreme");
 
             modelBuilder
-                .Entity<Order>()
-                .OneToOne(e => e.Details, e => e.Order)
+                .Entity<Order>().HasOne(e => e.Details).WithOne(e => e.Order)
                 .ForSqlServer()
                 .Name("ChocolateLimes");
 
@@ -727,8 +712,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             Assert.Equal("ChocolateLimes", foreignKey.SqlServer().Name);
 
             modelBuilder
-                .Entity<Order>()
-                .OneToOne(e => e.Details, e => e.Order)
+                .Entity<Order>().HasOne(e => e.Details).WithOne(e => e.Order)
                 .ForSqlServer()
                 .Name(null);
 
@@ -742,15 +726,13 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             var modelBuilder = new ModelBuilder();
 
             modelBuilder
-                .Entity<Order>()
-                .OneToOne(e => e.Details, e => e.Order)
+                .Entity<Order>().HasOne(e => e.Details).WithOne(e => e.Order)
                 .ForeignKey<OrderDetails>(e => e.Id)
                 .ForRelational()
                 .Name("LemonSupreme");
 
             modelBuilder
-                .Entity<Order>()
-                .OneToOne(e => e.Details, e => e.Order)
+                .Entity<Order>().HasOne(e => e.Details).WithOne(e => e.Order)
                 .ForeignKey<OrderDetails>(e => e.Id)
                 .ForSqlServer()
                 .Name("ChocolateLimes");
@@ -767,8 +749,8 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             var modelBuilder = new ModelBuilder();
 
             modelBuilder
-                .Entity<Order>()
-                .OneToOne(e => e.Details, e => e.Order)
+                .Entity<Order>().HasOne(e => e.Details).WithOne(e => e.Order)
+                .ReferencedKey<Order>(e => e.OrderId)
                 .ForRelational(b => { b.Name("LemonSupreme"); })
                 .ForSqlServer(b => { b.Name("ChocolateLimes"); });
 
@@ -784,8 +766,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             var modelBuilder = new ModelBuilder();
 
             modelBuilder
-                .Entity<Order>()
-                .OneToOne(e => e.Details, e => e.Order)
+                .Entity<Order>().HasOne(e => e.Details).WithOne(e => e.Order)
                 .ForeignKey<OrderDetails>(e => e.Id)
                 .ForRelational(b => { b.Name("LemonSupreme"); })
                 .ForSqlServer(b => { b.Name("ChocolateLimes"); });


### PR DESCRIPTION
The new API will also avoid overriding existing configuration implicitly. E.g. calling Entity<Order>.HasOne(e => e.Details); will by default configure the relationship as one to many with Order as the dependent end. However If there was already a one to one relationship involving the "Details" navigation then the existing relationship and the associated FK will not be changed as no conflicting configuration has been explicitly specified.

Fixes #1383, #1152