### PR TITLE
Additional testing and cleanup of ChangeDetector

### DIFF
--- a/src/EntityFramework.Core/ChangeTracking/IRelationshipListener.cs
+++ b/src/EntityFramework.Core/ChangeTracking/IRelationshipListener.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
     public interface IRelationshipListener
     {
         void ForeignKeyPropertyChanged([NotNull] StateEntry entry, [NotNull] IProperty property, [CanBeNull] object oldValue, [CanBeNull] object newValue);
-        void NavigationReferenceChanged([NotNull] StateEntry entry, [NotNull] INavigation property, [CanBeNull] object oldValue, [CanBeNull] object newValue);
+        void NavigationReferenceChanged([NotNull] StateEntry entry, [NotNull] INavigation navigation, [CanBeNull] object oldValue, [CanBeNull] object newValue);
         void NavigationCollectionChanged([NotNull] StateEntry entry, [NotNull] INavigation navigation, [NotNull] ISet<object> added, [NotNull] ISet<object> removed);
         void PrincipalKeyPropertyChanged([NotNull] StateEntry entry, [NotNull] IProperty property, [CanBeNull] object oldValue, [CanBeNull] object newValue);
     }

--- a/src/EntityFramework.Core/ChangeTracking/RelationshipsSnapshot.cs
+++ b/src/EntityFramework.Core/ChangeTracking/RelationshipsSnapshot.cs
@@ -33,8 +33,9 @@ namespace Microsoft.Data.Entity.ChangeTracking
         {
             var entityType = stateEntry.EntityType;
 
-            return entityType.GetPrimaryKey().Properties.Concat(
-                entityType.ForeignKeys.SelectMany(fk => fk.Properties)).Distinct()
+            return entityType.Keys.SelectMany(k => k.Properties)
+                .Concat(entityType.ForeignKeys.SelectMany(fk => fk.Properties))
+                .Distinct()
                 .Concat<IPropertyBase>(entityType.Navigations);
         }
 


### PR DESCRIPTION
The interaction between the ChangeDetector and property/relationship listeners was simplified as part of the state manager DI refactorings done some time ago. This change cleans up the ChangeDetector based on the now simpler and more robust interactions.