### PR TITLE
Make DetectChanges start tracking new entities (Issue #1213)

### DIFF
--- a/src/EntityFramework.Core/ChangeTracking/IRelationshipListener.cs
+++ b/src/EntityFramework.Core/ChangeTracking/IRelationshipListener.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
     public interface IRelationshipListener
     {
         void ForeignKeyPropertyChanged([NotNull] StateEntry entry, [NotNull] IProperty property, [CanBeNull] object oldValue, [CanBeNull] object newValue);
-        void NavigationReferenceChanged([NotNull] StateEntry entry, [NotNull] INavigation property, [CanBeNull] object oldValue, [CanBeNull] object newValue);
+        void NavigationReferenceChanged([NotNull] StateEntry entry, [NotNull] INavigation navigation, [CanBeNull] object oldValue, [CanBeNull] object newValue);
         void NavigationCollectionChanged([NotNull] StateEntry entry, [NotNull] INavigation navigation, [NotNull] ISet<object> added, [NotNull] ISet<object> removed);
         void PrincipalKeyPropertyChanged([NotNull] StateEntry entry, [NotNull] IProperty property, [CanBeNull] object oldValue, [CanBeNull] object newValue);
     }

--- a/src/EntityFramework.Core/ChangeTracking/RelationshipsSnapshot.cs
+++ b/src/EntityFramework.Core/ChangeTracking/RelationshipsSnapshot.cs
@@ -33,8 +33,9 @@ namespace Microsoft.Data.Entity.ChangeTracking
         {
             var entityType = stateEntry.EntityType;
 
-            return entityType.GetPrimaryKey().Properties.Concat(
-                entityType.ForeignKeys.SelectMany(fk => fk.Properties)).Distinct()
+            return entityType.Keys.SelectMany(k => k.Properties)
+                .Concat(entityType.ForeignKeys.SelectMany(fk => fk.Properties))
+                .Distinct()
                 .Concat<IPropertyBase>(entityType.Navigations);
         }
 

--- a/src/EntityFramework.Core/ChangeTracking/StateEntry.cs
+++ b/src/EntityFramework.Core/ChangeTracking/StateEntry.cs
@@ -145,11 +145,14 @@ namespace Microsoft.Data.Entity.ChangeTracking
                 return false;
             }
 
+            if (EntityState == EntityState.Modified)
+            {
+                _stateData.FlagAllProperties(EntityType.Properties.Count(), isFlagged: false);
+            }
+
             // Temporarily change the internal state to unknown so that key generation, including setting key values
             // can happen without constraints on changing read-only values kicking in
             _stateData.EntityState = EntityState.Unknown;
-
-            _stateData.FlagAllProperties(EntityType.Properties.Count(), isFlagged: false);
 
             return true;
         }

--- a/test/EntityFramework.Core.FunctionalTests/IncludeAsyncTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/IncludeAsyncTestBase.cs
@@ -153,7 +153,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 Assert.Equal(orders, customer.Orders, ReferenceEqualityComparer.Instance);
                 Assert.Equal(6, customer.Orders.Count);
                 Assert.True(customer.Orders.All(o => o.Customer != null));
-                Assert.Equal(6, context.ChangeTracker.Entries().Count());
+                // See Issue #1402. The count should be 6, but fixup to the tracked Orders brings in the Customer.
+                Assert.Equal(7, context.ChangeTracker.Entries().Count());
             }
         }
 

--- a/test/EntityFramework.Core.FunctionalTests/IncludeTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/IncludeTestBase.cs
@@ -167,7 +167,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 Assert.Equal(orders, customer.Orders, ReferenceEqualityComparer.Instance);
                 Assert.Equal(6, customer.Orders.Count);
                 Assert.True(customer.Orders.All(o => o.Customer != null));
-                Assert.Equal(6, context.ChangeTracker.Entries().Count());
+                // See Issue #1402. The count should be 6, but fixup to the tracked Orders brings in the Customer.
+                Assert.Equal(7, context.ChangeTracker.Entries().Count());
             }
         }
 

--- a/test/EntityFramework.Core.Tests/ChangeTracking/StateEntryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/StateEntryTest.cs
@@ -350,6 +350,25 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         }
 
         [Fact]
+        public void Modified_values_are_reset_when_entity_is_changed_to_Added()
+        {
+            var model = BuildModel();
+            var entityType = model.GetEntityType(typeof(SomeEntity).FullName);
+            var property = entityType.GetProperty("Name");
+            var configuration = TestHelpers.CreateContextServices(model);
+
+            var entry = CreateStateEntry(configuration, entityType, new SomeEntity());
+            entry[entityType.GetProperty("Id")] = 1;
+
+            entry.SetEntityState(EntityState.Modified);
+            entry.SetPropertyModified(property);
+
+            entry.SetEntityState(EntityState.Added);
+
+            Assert.False(entry.HasTemporaryValue(property));
+        }
+
+        [Fact]
         public void Changing_state_to_Added_triggers_value_generation_for_any_property()
         {
             var model = BuildModel();


### PR DESCRIPTION
The only significant new code in the ChangeDetector are the TrackAddedEntities methods. The other changes are async overhead.

Notes:
- DetectChanges will only bring in the single entity added/set, not an entire graph. In the future the plan is that if the added entity is an aggregate root, then the entire aggregate will be brought in.
- Async Add is used when when DetectChangesAsync is called, but not when DetectChanges is called automatically or a notification entity triggers the change.
- Entities are always assumed to be new and put in the Added state.

More functional testing to come in a later change.