### PR TITLE
Loading CommandTimeout from Configuration, enhanced OptionsExtensions tests

### DIFF
--- a/src/EntityFramework.Core/Infrastructure/DbContextOptionsExtension.cs
+++ b/src/EntityFramework.Core/Infrastructure/DbContextOptionsExtension.cs
@@ -1,15 +1,51 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Internal;
+using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Infrastructure
 {
     public abstract class DbContextOptionsExtension
     {
+        private static readonly Dictionary<Type, Func<string, string, object>> _conversionFuncs = new Dictionary<Type, Func<string, string, object>>
+            {
+                {
+                    typeof(int), (valueKey, valueString) =>
+                        {
+                            int valueInt;
+                            if (!Int32.TryParse(valueString, out valueInt))
+                            {
+                                throw new InvalidOperationException(Strings.IntegerConfigurationValueFormatError(valueKey, valueString));
+                            }
+                            return valueInt;
+                        }
+                },
+                {
+                    typeof(string), (valueKey, valueString) => valueString
+                }
+            };
+
+        protected IReadOnlyDictionary<string, string> RawOptions;
+
         protected internal virtual void Configure([NotNull] IReadOnlyDictionary<string, string> rawOptions)
         {
+            Check.NotNull(rawOptions, "rawOptions");
+
+            RawOptions = rawOptions;
+        }
+
+        protected T GetSetting<T>(string key)
+        {
+            string valueString;
+            if (RawOptions.TryGetValue(key, out valueString))
+            {
+                return (T)_conversionFuncs[typeof(T).UnwrapNullableType()].Invoke(key, valueString);
+            }
+            return default(T);
         }
 
         protected internal abstract void ApplyServices([NotNull] EntityServicesBuilder builder);

--- a/src/EntityFramework.Core/Properties/Strings.Designer.cs
+++ b/src/EntityFramework.Core/Properties/Strings.Designer.cs
@@ -29,6 +29,14 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
+        /// The value for the configuration entry '{configurationKey}' is '{invalidValue}', but an integer is expected.
+        /// </summary>
+        public static string IntegerConfigurationValueFormatError([CanBeNull] object configurationKey, [CanBeNull] object invalidValue)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("IntegerConfigurationValueFormatError", "configurationKey", "invalidValue"), configurationKey, invalidValue);
+        }
+
+        /// <summary>
         /// The value provided for argument '{argumentName}' must be a valid value of enum type '{enumType}'.
         /// </summary>
         public static string InvalidEnumValue([CanBeNull] object argumentName, [CanBeNull] object enumType)

--- a/src/EntityFramework.Core/Properties/Strings.resx
+++ b/src/EntityFramework.Core/Properties/Strings.resx
@@ -417,4 +417,7 @@
   <data name="InvalidEntityType" xml:space="preserve">
     <value>The entity type '{type}' provided for the argument '{argumentName}' must be a reference type.</value>
   </data>
+  <data name="IntegerConfigurationValueFormatError" xml:space="preserve">
+    <value>The value for the configuration entry '{configurationKey}' is '{invalidValue}', but an integer is expected.</value>
+  </data>
 </root>

--- a/src/EntityFramework.Relational/Properties/Strings.Designer.cs
+++ b/src/EntityFramework.Relational/Properties/Strings.Designer.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Data.Entity.Relational
     {
         private static readonly ResourceManager _resourceManager
             = new ResourceManager("EntityFramework.Relational.Strings", typeof(Strings).GetTypeInfo().Assembly);
-        
+
         /// <summary>
         /// The value provided for argument '{argumentName}' must be a valid value of enum type '{enumType}'.
         /// </summary>
@@ -74,6 +74,22 @@ namespace Microsoft.Data.Entity.Relational
         public static string NoConnectionOrConnectionString
         {
             get { return GetString("NoConnectionOrConnectionString"); }
+        }
+
+        /// <summary>
+        /// The specified CommandTimeout value is not valid. It must be a positive number.
+        /// </summary>
+        public static string InvalidCommandTimeout
+        {
+            get { return GetString("InvalidCommandTimeout"); }
+        }
+
+        /// <summary>
+        /// The specified MaxBatchSize value is not valid. It must be a positive number.
+        /// </summary>
+        public static string InvalidMaxBatchSize
+        {
+            get { return GetString("InvalidMaxBatchSize"); }
         }
 
         /// <summary>
@@ -284,13 +300,6 @@ namespace Microsoft.Data.Entity.Relational
             get { return GetString("MigrationsNotInUse"); }
         }
 
-        /// <summary>
-        /// The specified CommandTimeout value is not valid. It must be a positive number.
-        /// </summary>
-        public static string InvalidCommandTimeout
-        {
-            get { return GetString("InvalidCommandTimeout");}
-        }
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EntityFramework.Relational/Properties/Strings.resx
+++ b/src/EntityFramework.Relational/Properties/Strings.resx
@@ -222,4 +222,7 @@
   <data name="InvalidCommandTimeout" xml:space="preserve">
     <value>The specified CommandTimeout value is not valid. It must be a positive number.</value>
   </data>
+  <data name="InvalidMaxBatchSize" xml:space="preserve">
+    <value>The specified MaxBatchSize value is not valid. It must be a positive number.</value>
+  </data>
 </root>

--- a/src/EntityFramework.SqlServer/Properties/Strings.Designer.cs
+++ b/src/EntityFramework.SqlServer/Properties/Strings.Designer.cs
@@ -11,14 +11,6 @@ namespace Microsoft.Data.Entity.SqlServer
     {
         private static readonly ResourceManager _resourceManager
             = new ResourceManager("EntityFramework.SqlServer.Strings", typeof(Strings).GetTypeInfo().Assembly);
-        
-        /// <summary>
-        /// The value for the configuration entry '{configurationKey}' is '{invalidValue}', but an integer is expected.
-        /// </summary>
-        public static string IntegerConfigurationValueFormatError([CanBeNull] object configurationKey, [CanBeNull] object invalidValue)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("IntegerConfigurationValueFormatError", "configurationKey", "invalidValue"), configurationKey, invalidValue);
-        }
 
         /// <summary>
         /// The value provided for argument '{argumentName}' must be a valid value of enum type '{enumType}'.
@@ -26,14 +18,6 @@ namespace Microsoft.Data.Entity.SqlServer
         public static string InvalidEnumValue([CanBeNull] object argumentName, [CanBeNull] object enumType)
         {
             return string.Format(CultureInfo.CurrentCulture, GetString("InvalidEnumValue", "argumentName", "enumType"), argumentName, enumType);
-        }
-
-        /// <summary>
-        /// The value provided for max batch size must be positive.
-        /// </summary>
-        public static string MaxBatchSizeMustBePositive
-        {
-            get { return GetString("MaxBatchSizeMustBePositive"); }
         }
 
         /// <summary>

--- a/src/EntityFramework.SqlServer/Properties/Strings.resx
+++ b/src/EntityFramework.SqlServer/Properties/Strings.resx
@@ -117,14 +117,8 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="IntegerConfigurationValueFormatError" xml:space="preserve">
-    <value>The value for the configuration entry '{configurationKey}' is '{invalidValue}', but an integer is expected.</value>
-  </data>
   <data name="InvalidEnumValue" xml:space="preserve">
     <value>The value provided for argument '{argumentName}' must be a valid value of enum type '{enumType}'.</value>
-  </data>
-  <data name="MaxBatchSizeMustBePositive" xml:space="preserve">
-    <value>The value provided for max batch size must be positive.</value>
   </data>
   <data name="SequenceBadBlockSize" xml:space="preserve">
     <value>The increment value of '{increment}' for sequence '{sequenceName}' cannot be used for value generation. Sequences used for value generation must have positive increments.</value>

--- a/src/EntityFramework.SqlServer/SqlServerOptionsExtension.cs
+++ b/src/EntityFramework.SqlServer/SqlServerOptionsExtension.cs
@@ -1,11 +1,6 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using JetBrains.Annotations;
-using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Relational;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.DependencyInjection;
@@ -14,42 +9,6 @@ namespace Microsoft.Data.Entity.SqlServer
 {
     public class SqlServerOptionsExtension : RelationalOptionsExtension
     {
-        private const string ProviderPrefix = "SqlServer";
-        private const string MaxBatchSizeKey = "MaxBatchSize";
-
-        private int? _maxBatchSize;
-
-        public virtual int? MaxBatchSize
-        {
-            get { return _maxBatchSize; }
-
-            [param:CanBeNull]
-            set
-            {
-                _maxBatchSize = value;
-            }
-
-        }
-
-        protected override void Configure(IReadOnlyDictionary<string, string> rawOptions)
-        {
-            base.Configure(rawOptions);
-            if (!_maxBatchSize.HasValue)
-            {
-                var MaxBatchSizeConfigurationKey = ProviderPrefix + ":" + MaxBatchSizeKey;
-                string maxBatchSizeString;
-                if (rawOptions.TryGetValue(MaxBatchSizeConfigurationKey, out maxBatchSizeString))
-                {
-                    int maxBatchSizeInt;
-                    if (!Int32.TryParse(maxBatchSizeString, out maxBatchSizeInt))
-                    {
-                        throw new InvalidOperationException(Strings.IntegerConfigurationValueFormatError(MaxBatchSizeConfigurationKey, maxBatchSizeString));
-                    }
-                    _maxBatchSize = maxBatchSizeInt;
-                }
-            }
-        }
-
         protected override void ApplyServices(EntityServicesBuilder builder)
         {
             Check.NotNull(builder, "builder");

--- a/src/EntityFramework.SqlServer/Update/SqlServerModificationCommandBatch.cs
+++ b/src/EntityFramework.SqlServer/Update/SqlServerModificationCommandBatch.cs
@@ -9,6 +9,7 @@ using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Relational.Metadata;
 using Microsoft.Data.Entity.Relational.Update;
 using Microsoft.Data.Entity.Utilities;
+using RelationalStrings = Microsoft.Data.Entity.Relational.Strings;
 
 namespace Microsoft.Data.Entity.SqlServer.Update
 {
@@ -38,7 +39,7 @@ namespace Microsoft.Data.Entity.SqlServer.Update
             if (maxBatchSize.HasValue
                 && maxBatchSize.Value <= 0)
             {
-                throw new ArgumentOutOfRangeException("maxBatchSize", Strings.MaxBatchSizeMustBePositive);
+                throw new ArgumentOutOfRangeException("maxBatchSize", RelationalStrings.InvalidCommandTimeout);
             }
 
             _maxBatchSize = Math.Min(maxBatchSize ?? Int32.MaxValue, MaxRowCount);

--- a/test/EntityFramework.Microbenchmarks/LocalConfig.json
+++ b/test/EntityFramework.Microbenchmarks/LocalConfig.json
@@ -13,9 +13,7 @@
     },
     "EntityFramework": {
         "CudContext": {
-            "SqlServer": {
-                "MaxBatchSize": "1"
-            }
+            "MaxBatchSize": "1"
         }
     }
 }

--- a/test/EntityFramework.Relational.Tests/EntityFramework.Relational.Tests.csproj
+++ b/test/EntityFramework.Relational.Tests/EntityFramework.Relational.Tests.csproj
@@ -134,6 +134,7 @@
     <Compile Include="RelationalEntityServicesBuilderExtensionsTest.cs" />
     <Compile Include="RelationalObjectArrayValueReaderFactoryTest.cs" />
     <Compile Include="RelationalObjectArrayValueReaderTest.cs" />
+    <Compile Include="RelationalOptionsExtensionTest.cs" />
     <Compile Include="RelationalTypedValueReaderFactoryTest.cs" />
     <Compile Include="RelationalTypedValueReaderTest.cs" />
     <Compile Include="SchemaQualifiedNameTest.cs" />

--- a/test/EntityFramework.Relational.Tests/RelationalOptionsExtensionTest.cs
+++ b/test/EntityFramework.Relational.Tests/RelationalOptionsExtensionTest.cs
@@ -1,0 +1,235 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using Moq;
+using Xunit;
+using CoreStrings = Microsoft.Data.Entity.Internal.Strings;
+
+namespace Microsoft.Data.Entity.Relational.Tests
+{
+    public class RelationalOptionsExtensionTest
+    {
+        private const string ConnectionStringKey = "ConnectionString";
+        private const string CommandTimeoutKey = "CommandTimeout";
+        private const string MaxBatchSizeKey = "MaxBatchSize";
+
+        private const string ConnectionString = "Fraggle=Rock";
+
+        [Fact]
+        public void Can_set_Connection()
+        {
+            var optionsExtension = new TestRelationalOptionsExtension();
+
+            Assert.Null(optionsExtension.Connection);
+
+            var connection = Mock.Of<DbConnection>();
+            optionsExtension.Connection = connection;
+
+            Assert.Same(connection, optionsExtension.Connection);
+        }
+
+        [Fact]
+        public void Throws_when_setting_Connection_to_null()
+        {
+            Assert.Throws<ArgumentNullException>(() => { new TestRelationalOptionsExtension().Connection = null; });
+        }
+
+        [Fact]
+        public void Can_set_ConnectionString()
+        {
+            var optionsExtension = new TestRelationalOptionsExtension();
+
+            Assert.Null(optionsExtension.ConnectionString);
+
+            optionsExtension.ConnectionString = ConnectionString;
+
+            Assert.Equal(ConnectionString, optionsExtension.ConnectionString);
+        }
+
+        [Fact]
+        public void Throws_when_setting_ConnectionString_to_null()
+        {
+            Assert.Throws<ArgumentNullException>(() => { new TestRelationalOptionsExtension().ConnectionString = null; });
+        }
+
+        [Fact]
+        public void Configure_sets_ConnectionString_to_value_specified_in_raw_options()
+        {
+            var rawOptions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { { ConnectionStringKey, ConnectionString } };
+            var optionsExtension = new TestRelationalOptionsExtension();
+
+            optionsExtension.Configure(rawOptions);
+
+            Assert.Equal(ConnectionString, optionsExtension.ConnectionString);
+        }
+
+        [Fact]
+        public void Configure_does_not_set_ConnectionString_if_value_already_set()
+        {
+            const string originalConnectionString = "The=Doozers";
+            var rawOptions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { { ConnectionStringKey, ConnectionString } };
+
+            var optionsExtension = new TestRelationalOptionsExtension { ConnectionString = originalConnectionString };
+
+            optionsExtension.Configure(rawOptions);
+
+            Assert.Equal(originalConnectionString, optionsExtension.ConnectionString);
+        }
+
+        [Fact]
+        public void Configure_does_not_set_ConnectionString_if_not_specified_in_raw_options()
+        {
+            var rawOptions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var optionsExtension = new TestRelationalOptionsExtension();
+
+            optionsExtension.Configure(rawOptions);
+
+            Assert.Null(optionsExtension.ConnectionString);
+        }
+
+        [Fact]
+        public void Can_set_CommandTimeout()
+        {
+            var optionsExtension = new TestRelationalOptionsExtension();
+
+            Assert.Null(optionsExtension.CommandTimeout);
+
+            optionsExtension.CommandTimeout = 1;
+
+            Assert.Equal(1, optionsExtension.CommandTimeout);
+        }
+
+        [Fact]
+        public void Throws_if_CommandTimeout_out_of_range()
+        {
+            Assert.Equal(
+                Strings.InvalidCommandTimeout,
+                Assert.Throws<InvalidOperationException>(() => { new TestRelationalOptionsExtension().CommandTimeout = -1; }).Message);
+        }
+
+        [Fact]
+        public void Configure_sets_CommandTimeout_to_value_specified_in_raw_options()
+        {
+            var rawOptions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { { CommandTimeoutKey, "1" } };
+            var optionsExtension = new TestRelationalOptionsExtension();
+
+            optionsExtension.Configure(rawOptions);
+
+            Assert.Equal(1, optionsExtension.CommandTimeout);
+        }
+
+        [Fact]
+        public void Configure_does_not_set_CommandTimeout_if_value_already_set()
+        {
+            var optionsExtension = new TestRelationalOptionsExtension { CommandTimeout = 42 };
+
+            var rawOptions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { { CommandTimeoutKey, "1" } };
+
+            optionsExtension.Configure(rawOptions);
+
+            Assert.Equal(42, optionsExtension.CommandTimeout);
+        }
+
+        [Fact]
+        public void Configure_does_not_set_CommandTimeout_if_not_specified_in_raw_options()
+        {
+            var rawOptions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var optionsExtension = new TestRelationalOptionsExtension();
+
+            optionsExtension.Configure(rawOptions);
+
+            Assert.Null(optionsExtension.CommandTimeout);
+        }
+
+        [Fact]
+        public void Configure_throws_if_CommandTimeout_specified_in_raw_options_is_invalid()
+        {
+            var rawOptions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { { CommandTimeoutKey, "one" } };
+
+            Assert.Equal(
+                CoreStrings.IntegerConfigurationValueFormatError(CommandTimeoutKey, "one"),
+                Assert.Throws<InvalidOperationException>(
+                    () => new TestRelationalOptionsExtension().Configure(rawOptions)).Message);
+        }
+
+        [Fact]
+        public void Can_set_MaxBatchSize()
+        {
+            var optionsExtension = new TestRelationalOptionsExtension();
+
+            Assert.Null(optionsExtension.MaxBatchSize);
+
+            optionsExtension.MaxBatchSize = 1;
+
+            Assert.Equal(1, optionsExtension.MaxBatchSize);
+        }
+
+        [Fact]
+        public void Throws_if_MaxBatchSize_out_of_range()
+        {
+            Assert.Equal(
+                Strings.InvalidMaxBatchSize,
+                Assert.Throws<InvalidOperationException>(() => { new TestRelationalOptionsExtension().MaxBatchSize = -1; }).Message);
+        }
+
+        [Fact]
+        public void Configure_sets_MaxBatchSize_to_value_specified_in_raw_options()
+        {
+            var rawOptions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { { MaxBatchSizeKey, "1" } };
+            var optionsExtension = new TestRelationalOptionsExtension();
+
+            optionsExtension.Configure(rawOptions);
+
+            Assert.Equal(1, optionsExtension.MaxBatchSize);
+        }
+
+        [Fact]
+        public void Configure_does_not_set_MaxBatchSize_if_value_already_set()
+        {
+            var optionsExtension = new TestRelationalOptionsExtension { MaxBatchSize = 42 };
+
+            var rawOptions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { { MaxBatchSizeKey, "1" } };
+
+            optionsExtension.Configure(rawOptions);
+
+            Assert.Equal(42, optionsExtension.MaxBatchSize);
+        }
+
+        [Fact]
+        public void Configure_does_not_set_MaxBatchSize_if_not_specified_in_raw_options()
+        {
+            var rawOptions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var optionsExtension = new TestRelationalOptionsExtension();
+
+            optionsExtension.Configure(rawOptions);
+
+            Assert.Null(optionsExtension.MaxBatchSize);
+        }
+
+        [Fact]
+        public void Configure_throws_if_MaxBatchSize_specified_in_raw_options_is_invalid()
+        {
+            var rawOptions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { { MaxBatchSizeKey, "one" } };
+
+            Assert.Equal(
+                CoreStrings.IntegerConfigurationValueFormatError(MaxBatchSizeKey, "one"),
+                Assert.Throws<InvalidOperationException>(() => new TestRelationalOptionsExtension().Configure(rawOptions)).Message);
+        }
+
+        private class TestRelationalOptionsExtension : RelationalOptionsExtension
+        {
+            protected override void ApplyServices(EntityServicesBuilder builder)
+            {
+                throw new NotImplementedException();
+            }
+
+            new public void Configure(IReadOnlyDictionary<string, string> rawOptions)
+            {
+                base.Configure(rawOptions);
+            }
+        }
+    }
+}

--- a/test/EntityFramework.SqlServer.Tests/CommandConfigurationTests.cs
+++ b/test/EntityFramework.SqlServer.Tests/CommandConfigurationTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             public void Setting_CommandTimeout_to_negative_value_throws()
             {
                 var options = new SqlServerDbContextOptions(new DbContextOptions());
-                Assert.Throws<ArgumentException>(() => options.CommandTimeout(-55));
+                Assert.Throws<InvalidOperationException>(() => options.CommandTimeout(-55));
 
                 using (var context = new TimeoutContext())
                 {

--- a/test/EntityFramework.SqlServer.Tests/SqlServerOptionsExtensionTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerOptionsExtensionTest.cs
@@ -1,85 +1,24 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Data.Common;
 using System.Linq;
 using System.Reflection;
-using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Framework.DependencyInjection;
-using Moq;
 using Xunit;
 
 namespace Microsoft.Data.Entity.SqlServer.Tests
 {
     public class SqlServerOptionsExtensionTest
     {
-        private static readonly MethodInfo _applyServices
-            = typeof(SqlServerOptionsExtension).GetTypeInfo().DeclaredMethods.Single(m => m.Name == "ApplyServices");
-
         [Fact]
-        public void Adds_SQL_server_services()
+        public void ApplyServices_adds_SQL_server_services()
         {
             var services = new ServiceCollection();
             var builder = new EntityServicesBuilder(services);
 
-            _applyServices.Invoke(new SqlServerOptionsExtension(), new object[] { builder });
+            new SqlServerOptionsExtension().ApplyServices(builder);
 
             Assert.True(services.Any(sd => sd.ServiceType == typeof(SqlServerDataStore)));
-        }
-
-        [Fact]
-        public void Can_access_properties()
-        {
-            var configuration = new SqlServerOptionsExtension();
-
-            Assert.Null(configuration.Connection);
-            Assert.Null(configuration.ConnectionString);
-            Assert.Null(configuration.MaxBatchSize);
-
-            var connection = Mock.Of<DbConnection>();
-            configuration.Connection = connection;
-            configuration.ConnectionString = "Fraggle=Rock";
-            configuration.MaxBatchSize = 1;
-
-            Assert.Same(connection, configuration.Connection);
-            Assert.Equal("Fraggle=Rock", configuration.ConnectionString);
-            Assert.Equal(1, configuration.MaxBatchSize);
-        }
-
-        [Fact]
-        public void Configures_max_batch_size_specified_in_dbContext_options()
-        {
-            IDbContextOptions options = new DbContextOptions();
-            options.RawOptions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { { "SqlServer:MaxBatchSize", "1" } };
-            options.AddExtension(new SqlServerOptionsExtension());
-
-            var optionsExtension = options.Extensions.OfType<SqlServerOptionsExtension>().First();
-
-            Assert.Equal(1, optionsExtension.MaxBatchSize);
-        }
-
-        [Fact]
-        public void MaxBatchSize_in_sqlServerOptionsExtension_is_optional()
-        {
-            IDbContextOptions options = new DbContextOptions();
-            options.RawOptions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            options.AddExtension(new SqlServerOptionsExtension());
-
-            var optionsExtension = options.Extensions.OfType<SqlServerOptionsExtension>().First();
-
-            Assert.Null(optionsExtension.MaxBatchSize);
-        }
-
-        [Fact]
-        public void Throws_on_invalid_MaxBatchSize_specified_in_dbContextOptions()
-        {
-            IDbContextOptions options = new DbContextOptions();
-            options.RawOptions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { { "SqlServer:MaxBatchSize", "one" } };
-
-            Assert.Equal(Strings.IntegerConfigurationValueFormatError("SqlServer:MaxBatchSize", "one"),
-                Assert.Throws<InvalidOperationException>(() => options.AddExtension(new SqlServerOptionsExtension())).Message);
         }
     }
 }

--- a/test/EntityFramework.SqlServer.Tests/Update/SqlServerModificationCommandBatchFactoryTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/Update/SqlServerModificationCommandBatchFactoryTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Update
         {
             var factory = new SqlServerModificationCommandBatchFactory(new SqlServerSqlGenerator());
             IDbContextOptions options = new DbContextOptions();
-            options.RawOptions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { { "SqlServer:MaxBatchSize", "1" } };
+            options.RawOptions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { { "MaxBatchSize", "1" } };
             options.AddExtension(new SqlServerOptionsExtension());
 
             var batch = factory.Create(options);
@@ -59,7 +59,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Update
         {
             var factory = new SqlServerModificationCommandBatchFactory(new SqlServerSqlGenerator());
             IDbContextOptions options = new DbContextOptions();
-            options.RawOptions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { { "SqlServer:MaxBatchSize", "1" } };
+            options.RawOptions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { { "MaxBatchSize", "1" } };
 
             var batch = factory.Create(options);
 


### PR DESCRIPTION
While working on #1168, I discovered that CommandTimeout settings were not being loaded from Configuration. This PR adds the missing functionality, and unit tests. I also reworked the unit tests for the ```SqlServerOptionsExtensions``` for consistency and more complete coverage of the configuration behaviors.
@lukewaters @ajcvickers 