### PR TITLE
Honor configuration in write-package-references target

### DIFF
--- a/makefile.shade
+++ b/makefile.shade
@@ -12,7 +12,7 @@ k-standard-goals
   var programFilesX86='${Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86)}'
   var buildProgram='${Path.Combine(programFilesX86, "MSBuild", "14.0", "Bin", "MSBuild.exe")}'
   for each='var projectFile in Files.Include("src/**/*.csproj").Include("test/**/*.csproj")'
-    exec program='${buildProgram}' commandline='${projectFile} /t:WritePackageReferences /v:m /nologo'
+    exec program='${buildProgram}' commandline='${projectFile} /t:WritePackageReferences /v:m /nologo /p:Configuration=${E("Configuration")}'
 
 @{
     var packagesDir = Environment.GetEnvironmentVariable("DOTNET_PACKAGES")


### PR DESCRIPTION
To write package references for the Release configuration, use the following commands.
```cmd
SET Configuration=Release
build initialize
```

/cc @anpete