### PR TITLE
fix to issue #1457

### DIFF
--- a/src/EntityFramework.Relational/Query/AsyncQueryingEnumerable.cs
+++ b/src/EntityFramework.Relational/Query/AsyncQueryingEnumerable.cs
@@ -95,11 +95,15 @@ namespace Microsoft.Data.Entity.Relational.Query
             {
                 if (!_disposed)
                 {
-                    _disposed = true;
+                    if (_reader != null)
+                    {
+                        _enumerable._relationalQueryContext.Connection?.Close();
+                        _reader.Dispose();
+                    }
 
-                    _reader?.Dispose();
                     _command?.Dispose();
-                    _enumerable._relationalQueryContext.Connection?.Close();
+
+                    _disposed = true;
                 }
             }
         }

--- a/src/EntityFramework.Relational/Query/QueryingEnumerable.cs
+++ b/src/EntityFramework.Relational/Query/QueryingEnumerable.cs
@@ -51,6 +51,7 @@ namespace Microsoft.Data.Entity.Relational.Query
 
             private DbCommand _command;
             private DbDataReader _reader;
+            private bool _disposed;
 
             public Enumerator(QueryingEnumerable<T> enumerable)
             {
@@ -87,9 +88,18 @@ namespace Microsoft.Data.Entity.Relational.Query
 
             public void Dispose()
             {
-                _reader?.Dispose();
-                _command?.Dispose();
-                _enumerable._relationalQueryContext.Connection?.Close();
+                if (!_disposed)
+                {
+                    if (_reader != null)
+                    {
+                        _enumerable._relationalQueryContext.Connection?.Close();
+                        _reader.Dispose();
+                    }
+
+                    _command?.Dispose();
+
+                    _disposed = true;
+                }
             }
 
             public void Reset()


### PR DESCRIPTION
Problem was that in some cases we would try to close connection more times than we tried to open it. This would result in a corrupted state that would prevent opening the connection by subsequent queries.
This could happen in case of multi-level include. During that scenario we create multiple queries (data readers) and combine their results together in the end. Once data is retrieved there is a cleanup code that disposes of the participating enumerators.
However, if one of the queries throw or at some point during Include chain there is no more data (i.e. collection is empty) - it is possible that not all readers will be used, and therefore connection will be opened fewer times than assumed.
Cleanup code was trying to close connection once per expected reader, regardless of whether it was being used or not - which lead to this bug.

Fix is to only attempt to close connection if the associated reader has been used. Additionally I made QueryingEnumerable.Dispose() method idempotent.