### PR TITLE
Fix #1463 - Include :: Multi-level include doesn't work with collections...

### DIFF
--- a/src/EntityFramework.Core/IIncludableQueryable.cs
+++ b/src/EntityFramework.Core/IIncludableQueryable.cs
@@ -6,7 +6,7 @@ using System.Linq;
 namespace Microsoft.Data.Entity
 {
     // ReSharper disable once UnusedTypeParameter
-    public interface IIncludableQueryable<out TEntity, in TProperty> : IQueryable<TEntity>
+    public interface IIncludableQueryable<out TEntity, out TProperty> : IQueryable<TEntity>
     {
     }
 }

--- a/src/EntityFramework.Core/Query/EntityQueryable`.cs
+++ b/src/EntityFramework.Core/Query/EntityQueryable`.cs
@@ -9,8 +9,8 @@ using Remotion.Linq;
 
 namespace Microsoft.Data.Entity.Query
 {
-    public class EntityQueryable<TResult> 
-        : QueryableBase<TResult>, IAsyncEnumerable<TResult>, IIncludableQueryable<TResult, object>
+    public class EntityQueryable<TResult>
+        : QueryableBase<TResult>, IAsyncEnumerable<TResult>
     {
         public EntityQueryable([NotNull] EntityQueryProvider provider)
             : base(Check.NotNull(provider, "provider"))

--- a/src/EntityFramework.Core/Query/ResultOperators/IncludeExpressionNode.cs
+++ b/src/EntityFramework.Core/Query/ResultOperators/IncludeExpressionNode.cs
@@ -15,8 +15,7 @@ namespace Microsoft.Data.Entity.Query.ResultOperators
     {
         public static readonly MethodInfo[] SupportedMethods =
             {
-                QueryableExtensions.IncludeMethodInfo,
-                QueryableExtensions.IncludeCollectionMethodInfo
+                QueryableExtensions.IncludeMethodInfo
             };
 
         private readonly LambdaExpression _navigationPropertyPathLambda;

--- a/src/EntityFramework.Core/Query/ResultOperators/ThenIncludeExpressionNode.cs
+++ b/src/EntityFramework.Core/Query/ResultOperators/ThenIncludeExpressionNode.cs
@@ -16,8 +16,7 @@ namespace Microsoft.Data.Entity.Query.ResultOperators
     {
         public static readonly MethodInfo[] SupportedMethods =
             {
-                QueryableExtensions.ThenIncludeMethodInfo,
-                QueryableExtensions.ThenIncludeCollectionMethodInfo
+                QueryableExtensions.ThenIncludeMethodInfo
             };
 
         private readonly LambdaExpression _navigationPropertyPathLambda;

--- a/test/EntityFramework.Core.FunctionalTests/IncludeAsyncTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/IncludeAsyncTestBase.cs
@@ -7,6 +7,8 @@ using Microsoft.Data.Entity.FunctionalTests.TestModels.Northwind;
 using Microsoft.Data.Entity.Utilities;
 using Xunit;
 
+// ReSharper disable AccessToDisposedClosure
+
 namespace Microsoft.Data.Entity.FunctionalTests
 {
     public abstract class IncludeAsyncTestBase<TFixture> : IClassFixture<TFixture>
@@ -575,21 +577,6 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
-        public virtual async Task Include_multi_level_reference_then_include_collection_predicate()
-        {
-            using (var context = CreateContext())
-            {
-                var order
-                    = await context.Set<Order>()
-                        .Include(o => o.Customer).ThenInclude(c => c.Orders)
-                        .SingleAsync(o => o.OrderID == 10248);
-
-                Assert.NotNull(order.Customer);
-                Assert.True(order.Customer.Orders.All(o => o != null));
-            }
-        }
-
-        [Fact]
         public virtual async Task Include_multi_level_collection_and_then_include_reference_predicate()
         {
             using (var context = CreateContext())
@@ -642,23 +629,6 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
-        public virtual async Task Include_multiple_references_then_include_collection_multi_level()
-        {
-            using (var context = CreateContext())
-            {
-                var orderDetails
-                    = await context.Set<OrderDetail>()
-                        .Include(od => od.Order).ThenInclude(o => o.Customer).ThenInclude(c => c.Orders)
-                        .Include(od => od.Product)
-                        .ToListAsync();
-
-                Assert.True(orderDetails.Count > 0);
-                Assert.True(orderDetails.All(od => od.Order.Customer != null));
-                Assert.True(orderDetails.All(od => od.Order.Customer.Orders != null));
-            }
-        }
-
-        [Fact]
         public virtual async Task Include_multiple_references_and_collection_multi_level_reverse()
         {
             using (var context = CreateContext())
@@ -667,23 +637,6 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     = await context.Set<OrderDetail>()
                         .Include(od => od.Product)
                         .Include(od => od.Order.Customer.Orders)
-                        .ToListAsync();
-
-                Assert.True(orderDetails.Count > 0);
-                Assert.True(orderDetails.All(od => od.Order.Customer != null));
-                Assert.True(orderDetails.All(od => od.Order.Customer.Orders != null));
-            }
-        }
-
-        [Fact]
-        public virtual async Task Include_multiple_references_then_include_collection_multi_level_reverse()
-        {
-            using (var context = CreateContext())
-            {
-                var orderDetails
-                    = await context.Set<OrderDetail>()
-                        .Include(od => od.Product)
-                        .Include(od => od.Order).ThenInclude(o => o.Customer).ThenInclude(c => c.Orders)
                         .ToListAsync();
 
                 Assert.True(orderDetails.Count > 0);
@@ -709,22 +662,6 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
-        public virtual async Task Include_multiple_references_then_include_multi_level()
-        {
-            using (var context = CreateContext())
-            {
-                var orderDetails
-                    = await context.Set<OrderDetail>()
-                        .Include(od => od.Order).ThenInclude(o => o.Customer)
-                        .Include(od => od.Product)
-                        .ToListAsync();
-
-                Assert.True(orderDetails.Count > 0);
-                Assert.True(orderDetails.All(od => od.Order.Customer != null));
-            }
-        }
-
-        [Fact]
         public virtual async Task Include_multiple_references_multi_level_reverse()
         {
             using (var context = CreateContext())
@@ -733,22 +670,6 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     = await context.Set<OrderDetail>()
                         .Include(od => od.Product)
                         .Include(od => od.Order.Customer)
-                        .ToListAsync();
-
-                Assert.True(orderDetails.Count > 0);
-                Assert.True(orderDetails.All(od => od.Order.Customer != null));
-            }
-        }
-
-        [Fact]
-        public virtual async Task Include_multiple_references_then_include_multi_level_reverse()
-        {
-            using (var context = CreateContext())
-            {
-                var orderDetails
-                    = await context.Set<OrderDetail>()
-                        .Include(od => od.Product)
-                        .Include(od => od.Order).ThenInclude(o => o.Customer)
                         .ToListAsync();
 
                 Assert.True(orderDetails.Count > 0);
@@ -925,22 +846,6 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
-        public virtual async Task Include_references_then_include_collection_multi_level()
-        {
-            using (var context = CreateContext())
-            {
-                var orderDetails
-                    = await context.Set<OrderDetail>()
-                        .Include(od => od.Order).ThenInclude(o => o.Customer).ThenInclude(c => c.Orders)
-                        .ToListAsync();
-
-                Assert.True(orderDetails.Count > 0);
-                Assert.True(orderDetails.All(od => od.Order.Customer != null));
-                Assert.True(orderDetails.All(od => od.Order.Customer.Orders != null));
-            }
-        }
-
-        [Fact]
         public virtual async Task Include_collection_then_include_collection()
         {
             using (var context = CreateContext())
@@ -1006,23 +911,6 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
-        public virtual async Task Include_references_then_include_collection_multi_level_predicate()
-        {
-            using (var context = CreateContext())
-            {
-                var orderDetails
-                    = await context.Set<OrderDetail>()
-                        .Include(od => od.Order).ThenInclude(o => o.Customer).ThenInclude(c => c.Orders)
-                        .Where(od => od.OrderID == 10248)
-                        .ToListAsync();
-
-                Assert.True(orderDetails.Count > 0);
-                Assert.True(orderDetails.All(od => od.Order.Customer != null));
-                Assert.True(orderDetails.All(od => od.Order.Customer.Orders != null));
-            }
-        }
-
-        [Fact]
         public virtual async Task Include_references_multi_level()
         {
             using (var context = CreateContext())
@@ -1034,22 +922,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
                 Assert.True(orderDetails.Count > 0);
                 Assert.True(orderDetails.All(od => od.Order.Customer != null));
-            }
-        }
-
-        [Fact]
-        public virtual async Task Include_references_then_include_multi_level()
-        {
-            using (var context = CreateContext())
-            {
-                var orderDetails
-                    = await context.Set<OrderDetail>()
-                        .Include(od => od.Order).ThenInclude(o => o.Customer)
-                        .ToListAsync();
-
-                Assert.True(orderDetails.Count > 0);
-                Assert.True(orderDetails.All(od => od.Order.Customer != null));
-            }
+            } 
         }
     }
 }

--- a/test/EntityFramework.Core.FunctionalTests/IncludeTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/IncludeTestBase.cs
@@ -41,6 +41,20 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
+        public virtual void Include_list()
+        {
+            using (var context = CreateContext())
+            {
+                var products
+                    = context.Set<Product>()
+                        .Include(c => c.OrderDetails).ThenInclude(od => od.Order)
+                        .ToList();
+
+                Assert.Equal(77, products.Count);
+            }
+        }
+
+        [Fact]
         public virtual void Include_collection_alias_generation()
         {
             using (var context = CreateContext())
@@ -575,21 +589,6 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
-        public virtual void Include_multi_level_reference_then_include_collection_predicate()
-        {
-            using (var context = CreateContext())
-            {
-                var order
-                    = context.Set<Order>()
-                        .Include(o => o.Customer).ThenInclude(c => c.Orders)
-                        .Single(o => o.OrderID == 10248);
-
-                Assert.NotNull(order.Customer);
-                Assert.True(order.Customer.Orders.All(o => o != null));
-            }
-        }
-
-        [Fact]
         public virtual void Include_multi_level_collection_and_then_include_reference_predicate()
         {
             using (var context = CreateContext())
@@ -642,23 +641,6 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
-        public virtual void Include_multiple_references_then_include_collection_multi_level()
-        {
-            using (var context = CreateContext())
-            {
-                var orderDetails
-                    = context.Set<OrderDetail>()
-                        .Include(od => od.Order).ThenInclude(o => o.Customer).ThenInclude(c => c.Orders)
-                        .Include(od => od.Product)
-                        .ToList();
-
-                Assert.True(orderDetails.Count > 0);
-                Assert.True(orderDetails.All(od => od.Order.Customer != null));
-                Assert.True(orderDetails.All(od => od.Order.Customer.Orders != null));
-            }
-        }
-
-        [Fact]
         public virtual void Include_multiple_references_and_collection_multi_level_reverse()
         {
             using (var context = CreateContext())
@@ -667,23 +649,6 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     = context.Set<OrderDetail>()
                         .Include(od => od.Product)
                         .Include(od => od.Order.Customer.Orders)
-                        .ToList();
-
-                Assert.True(orderDetails.Count > 0);
-                Assert.True(orderDetails.All(od => od.Order.Customer != null));
-                Assert.True(orderDetails.All(od => od.Order.Customer.Orders != null));
-            }
-        }
-
-        [Fact]
-        public virtual void Include_multiple_references_then_include_collection_multi_level_reverse()
-        {
-            using (var context = CreateContext())
-            {
-                var orderDetails
-                    = context.Set<OrderDetail>()
-                        .Include(od => od.Product)
-                        .Include(od => od.Order).ThenInclude(o => o.Customer).ThenInclude(c => c.Orders)
                         .ToList();
 
                 Assert.True(orderDetails.Count > 0);
@@ -709,22 +674,6 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
-        public virtual void Include_multiple_references_then_include_multi_level()
-        {
-            using (var context = CreateContext())
-            {
-                var orderDetails
-                    = context.Set<OrderDetail>()
-                        .Include(od => od.Order).ThenInclude(o => o.Customer)
-                        .Include(od => od.Product)
-                        .ToList();
-
-                Assert.True(orderDetails.Count > 0);
-                Assert.True(orderDetails.All(od => od.Order.Customer != null));
-            }
-        }
-
-        [Fact]
         public virtual void Include_multiple_references_multi_level_reverse()
         {
             using (var context = CreateContext())
@@ -733,22 +682,6 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     = context.Set<OrderDetail>()
                         .Include(od => od.Product)
                         .Include(od => od.Order.Customer)
-                        .ToList();
-
-                Assert.True(orderDetails.Count > 0);
-                Assert.True(orderDetails.All(od => od.Order.Customer != null));
-            }
-        }
-
-        [Fact]
-        public virtual void Include_multiple_references_then_include_multi_level_reverse()
-        {
-            using (var context = CreateContext())
-            {
-                var orderDetails
-                    = context.Set<OrderDetail>()
-                        .Include(od => od.Product)
-                        .Include(od => od.Order).ThenInclude(o => o.Customer)
                         .ToList();
 
                 Assert.True(orderDetails.Count > 0);
@@ -808,8 +741,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
             {
                 var result
                     = (from o in context.Set<Order>().Include(o => o.OrderDetails)
-                       where o.CustomerID == "ALFKI"
-                       select o)
+                        where o.CustomerID == "ALFKI"
+                        select o)
                         .ToList();
 
                 Assert.Equal(6, result.Count());
@@ -940,22 +873,6 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
-        public virtual void Include_references_then_include_collection_multi_level()
-        {
-            using (var context = CreateContext())
-            {
-                var orderDetails
-                    = context.Set<OrderDetail>()
-                        .Include(od => od.Order).ThenInclude(o => o.Customer).ThenInclude(c => c.Orders)
-                        .ToList();
-
-                Assert.True(orderDetails.Count > 0);
-                Assert.True(orderDetails.All(od => od.Order.Customer != null));
-                Assert.True(orderDetails.All(od => od.Order.Customer.Orders != null));
-            }
-        }
-
-        [Fact]
         public virtual void Include_collection_then_include_collection()
         {
             using (var context = CreateContext())
@@ -1021,23 +938,6 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
-        public virtual void Include_references_then_include_collection_multi_level_predicate()
-        {
-            using (var context = CreateContext())
-            {
-                var orderDetails
-                    = context.Set<OrderDetail>()
-                        .Include(od => od.Order).ThenInclude(o => o.Customer).ThenInclude(c => c.Orders)
-                        .Where(od => od.OrderID == 10248)
-                        .ToList();
-
-                Assert.True(orderDetails.Count > 0);
-                Assert.True(orderDetails.All(od => od.Order.Customer != null));
-                Assert.True(orderDetails.All(od => od.Order.Customer.Orders != null));
-            }
-        }
-
-        [Fact]
         public virtual void Include_references_multi_level()
         {
             using (var context = CreateContext())
@@ -1045,21 +945,6 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 var orderDetails
                     = context.Set<OrderDetail>()
                         .Include(od => od.Order.Customer)
-                        .ToList();
-
-                Assert.True(orderDetails.Count > 0);
-                Assert.True(orderDetails.All(od => od.Order.Customer != null));
-            }
-        }
-
-        [Fact]
-        public virtual void Include_references_then_include_multi_level()
-        {
-            using (var context = CreateContext())
-            {
-                var orderDetails
-                    = context.Set<OrderDetail>()
-                        .Include(od => od.Order).ThenInclude(o => o.Customer)
                         .ToList();
 
                 Assert.True(orderDetails.Count > 0);

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/Northwind/Product.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/Northwind/Product.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.Northwind
         public short? ReorderLevel { get; set; }
         public bool Discontinued { get; set; }
 
-        public virtual ICollection<OrderDetail> OrderDetails { get; set; }
+        public virtual List<OrderDetail> OrderDetails { get; set; }
 
         protected bool Equals(Product other)
         {


### PR DESCRIPTION
... of type List<T> etc (incorrect overload of Include chosen by compiler)

Implemented solution proposed by @divega in bug discussion.