### PR TITLE
Functional tests for graph manipulation and fixes to fixup bugs

### DIFF
--- a/test/EntityFramework.Core.FunctionalTests/EntityFramework.Core.FunctionalTests.csproj
+++ b/test/EntityFramework.Core.FunctionalTests/EntityFramework.Core.FunctionalTests.csproj
@@ -80,6 +80,7 @@
     <Compile Include="FixupTest.cs" />
     <Compile Include="GearsOfWarQueryFixtureBase.cs" />
     <Compile Include="GearsOfWarQueryTestBase.cs" />
+    <Compile Include="GraphUpdatesTestBase.cs" />
     <Compile Include="IncludeAsyncTestBase.cs" />
     <Compile Include="IncludeOneToOneTestBase.cs" />
     <Compile Include="IncludeTestBase.cs" />

--- a/test/EntityFramework.Core.FunctionalTests/GraphUpdatesTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/GraphUpdatesTestBase.cs
@@ -1,0 +1,2464 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Microsoft.Data.Entity.Internal;
+using Microsoft.Data.Entity.Metadata;
+using Xunit;
+
+namespace Microsoft.Data.Entity.FunctionalTests
+{
+    public abstract class GraphUpdatesTestBase<TTestStore, TFixture> : IClassFixture<TFixture>, IDisposable
+        where TTestStore : TestStore
+        where TFixture : GraphUpdatesTestBase<TTestStore, TFixture>.GraphUpdatesFixtureBase, new()
+    {
+        protected GraphUpdatesTestBase(TFixture fixture)
+        {
+            Fixture = fixture;
+            TestStore = Fixture.CreateTestStore();
+        }
+
+        [Theory]
+        [InlineData((int)ChangeMechanism.Principal, false)]
+        [InlineData((int)ChangeMechanism.Principal, true)]
+        [InlineData((int)ChangeMechanism.Dependent, false)]
+        [InlineData((int)ChangeMechanism.Dependent, true)]
+        [InlineData((int)ChangeMechanism.FK, false)]
+        [InlineData((int)ChangeMechanism.FK, true)]
+        public virtual void Save_optional_many_to_one_dependents(ChangeMechanism changeMechanism, bool useExistingEntities)
+        {
+            var new2a = new Optional2();
+            var new2b = new Optional2();
+            var new1 = new Optional1();
+
+            if (useExistingEntities)
+            {
+                using (var context = CreateContext())
+                {
+                    context.Add(new1, new2a, new2b);
+                    context.SaveChanges();
+                }
+            }
+
+            Root root;
+            int entityCount;
+            using (var context = CreateContext())
+            {
+                root = LoadFullGraph(context);
+                var existing = root.OptionalChildren.OrderBy(e => e.Id).First();
+
+                if (useExistingEntities)
+                {
+                    new1 = context.Optional1s.Single(e => e.Id == new1.Id);
+                    new2a = context.Optional2s.Single(e => e.Id == new2a.Id);
+                    new2b = context.Optional2s.Single(e => e.Id == new2b.Id);
+                }
+                else
+                {
+                    context.Add(new1, new2a, new2b);
+                }
+
+                switch (changeMechanism)
+                {
+                    case ChangeMechanism.Principal:
+                        existing.Children.Add(new2a);
+                        existing.Children.Add(new2b);
+                        root.OptionalChildren.Add(new1);
+                        break;
+                    case ChangeMechanism.Dependent:
+                        new2a.Parent = existing;
+                        new2b.Parent = existing;
+                        new1.Parent = root;
+                        break;
+                    case ChangeMechanism.FK:
+                        new2a.ParentId = existing.Id;
+                        new2b.ParentId = existing.Id;
+                        new1.ParentId = root.Id;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("changeMechanism");
+                }
+
+                context.SaveChanges();
+
+                Assert.Contains(new2a, existing.Children);
+                Assert.Contains(new2b, existing.Children);
+                Assert.Contains(new1, root.OptionalChildren);
+
+                Assert.Same(existing, new2a.Parent);
+                Assert.Same(existing, new2b.Parent);
+                Assert.Same(root, existing.Parent);
+
+                Assert.Equal(existing.Id, new2a.ParentId);
+                Assert.Equal(existing.Id, new2b.ParentId);
+                Assert.Equal(root.Id, existing.ParentId);
+
+                entityCount = context.ChangeTracker.Entries().Count();
+            }
+
+            using (var context = CreateContext())
+            {
+                var loadedRoot = LoadFullGraph(context);
+
+                Assert.Equal(entityCount, context.ChangeTracker.Entries().Count());
+                AssertKeys(root, loadedRoot);
+                AssertNavigations(loadedRoot);
+            }
+        }
+
+        [Theory]
+        [InlineData((int)ChangeMechanism.Principal, false)]
+        [InlineData((int)ChangeMechanism.Principal, true)]
+        [InlineData((int)ChangeMechanism.Dependent, false)]
+        [InlineData((int)ChangeMechanism.Dependent, true)]
+        [InlineData((int)ChangeMechanism.FK, false)]
+        [InlineData((int)ChangeMechanism.FK, true)]
+        public virtual void Save_required_many_to_one_dependents(ChangeMechanism changeMechanism, bool useExistingEntities)
+        {
+            var newRoot = new Root();
+            var new1 = new Required1 { Parent = newRoot };
+            var new2a = new Required2 { Parent = new1 };
+            var new2b = new Required2 { Parent = new1 };
+
+            if (useExistingEntities)
+            {
+                using (var context = CreateContext())
+                {
+                    context.Add(newRoot, new1, new2a, new2b);
+                    context.SaveChanges();
+                }
+            }
+
+            Root root;
+            int entityCount;
+            using (var context = CreateContext())
+            {
+                root = LoadFullGraph(context, e => e.Id != newRoot.Id);
+                var existing = root.RequiredChildren.OrderBy(e => e.Id).First();
+
+                if (useExistingEntities)
+                {
+                    new1 = context.Required1s.Single(e => e.Id == new1.Id);
+                    new2a = context.Required2s.Single(e => e.Id == new2a.Id);
+                    new2b = context.Required2s.Single(e => e.Id == new2b.Id);
+                }
+                else
+                {
+                    context.Add(new1, new2a, new2b);
+                }
+
+                switch (changeMechanism)
+                {
+                    case ChangeMechanism.Principal:
+                        existing.Children.Add(new2a);
+                        existing.Children.Add(new2b);
+                        root.RequiredChildren.Add(new1);
+                        break;
+                    case ChangeMechanism.Dependent:
+                        new2a.Parent = existing;
+                        new2b.Parent = existing;
+                        new1.Parent = root;
+                        break;
+                    case ChangeMechanism.FK:
+                        new2a.ParentId = existing.Id;
+                        new2b.ParentId = existing.Id;
+                        new1.ParentId = root.Id;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("changeMechanism");
+                }
+
+                context.SaveChanges();
+
+                Assert.Contains(new2a, existing.Children);
+                Assert.Contains(new2b, existing.Children);
+                Assert.Contains(new1, root.RequiredChildren);
+
+                Assert.Same(existing, new2a.Parent);
+                Assert.Same(existing, new2b.Parent);
+                Assert.Same(root, existing.Parent);
+
+                Assert.Equal(existing.Id, new2a.ParentId);
+                Assert.Equal(existing.Id, new2b.ParentId);
+                Assert.Equal(root.Id, existing.ParentId);
+
+                entityCount = context.ChangeTracker.Entries().Count();
+            }
+
+            using (var context = CreateContext())
+            {
+                var loadedRoot = LoadFullGraph(context, e => e.Id != newRoot.Id);
+
+                Assert.Equal(entityCount, context.ChangeTracker.Entries().Count());
+                AssertKeys(root, loadedRoot);
+                AssertNavigations(loadedRoot);
+            }
+        }
+
+        [Theory]
+        [InlineData((int)ChangeMechanism.Principal)]
+        [InlineData((int)ChangeMechanism.Dependent)]
+        [InlineData((int)ChangeMechanism.FK)]
+        public virtual void Save_removed_optional_many_to_one_dependents(ChangeMechanism changeMechanism)
+        {
+            Root root;
+            using (var context = CreateContext())
+            {
+                root = LoadFullGraph(context);
+
+                var childCollection = root.OptionalChildren.First().Children;
+                var removed2 = childCollection.First();
+                var removed1 = root.OptionalChildren.Skip(1).First();
+
+                switch (changeMechanism)
+                {
+                    case ChangeMechanism.Dependent:
+                        removed2.Parent = null;
+                        removed1.Parent = null;
+                        break;
+                    case ChangeMechanism.Principal:
+                        childCollection.Remove(removed2);
+                        root.OptionalChildren.Remove(removed1);
+                        break;
+                    case ChangeMechanism.FK:
+                        removed2.ParentId = null;
+                        removed1.ParentId = null;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("changeMechanism");
+                }
+
+                context.SaveChanges();
+
+                Assert.DoesNotContain(removed1, root.OptionalChildren);
+                Assert.DoesNotContain(removed2, childCollection);
+
+                Assert.Null(removed1.Parent);
+                Assert.Null(removed2.Parent);
+                Assert.Null(removed1.ParentId);
+                Assert.Null(removed2.ParentId);
+            }
+
+            using (var context = CreateContext())
+            {
+                var loadedRoot = LoadFullGraph(context);
+
+                AssertKeys(root, loadedRoot);
+                AssertNavigations(loadedRoot);
+
+                Assert.Equal(2, loadedRoot.RequiredChildren.Count);
+                Assert.Equal(2, loadedRoot.RequiredChildren.First().Children.Count);
+
+                Assert.Equal(1, loadedRoot.OptionalChildren.Count);
+                Assert.Equal(1, loadedRoot.OptionalChildren.First().Children.Count);
+            }
+        }
+
+        [Theory]
+        [InlineData((int)ChangeMechanism.Principal)]
+        [InlineData((int)ChangeMechanism.Dependent)]
+        public virtual void Save_removed_required_many_to_one_dependents(ChangeMechanism changeMechanism)
+        {
+            using (var context = CreateContext())
+            {
+                var root = LoadFullGraph(context);
+
+                var childCollection = root.RequiredChildren.First().Children;
+                var removed2 = childCollection.First();
+                var removed1 = root.RequiredChildren.Skip(1).First();
+
+                switch (changeMechanism)
+                {
+                    case ChangeMechanism.Dependent:
+                        removed2.Parent = null;
+                        removed1.Parent = null;
+                        break;
+                    case ChangeMechanism.Principal:
+                        childCollection.Remove(removed2);
+                        root.RequiredChildren.Remove(removed1);
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("changeMechanism");
+                }
+
+                // TODO: Conceptual nulls (Issue #323)
+                //context.SaveChanges();
+            }
+        }
+
+        [Theory]
+        [InlineData((int)ChangeMechanism.Dependent, false)]
+        [InlineData((int)ChangeMechanism.Dependent, true)]
+        [InlineData((int)ChangeMechanism.Principal, false)]
+        [InlineData((int)ChangeMechanism.Principal, true)]
+        [InlineData((int)ChangeMechanism.FK, false)]
+        [InlineData((int)ChangeMechanism.FK, true)]
+        public virtual void Save_changed_optional_one_to_one(ChangeMechanism changeMechanism, bool useExistingEntities)
+        {
+            var new2 = new OptionalSingle2();
+            var new1 = new OptionalSingle1 { Single = new2 };
+
+            if (useExistingEntities)
+            {
+                using (var context = CreateContext())
+                {
+                    context.Add(new1, new2);
+                    context.SaveChanges();
+                }
+            }
+
+            Root root;
+            OptionalSingle1 old1;
+            OptionalSingle2 old2;
+            using (var context = CreateContext())
+            {
+                root = LoadFullGraph(context);
+
+                old1 = root.OptionalSingle;
+                old2 = root.OptionalSingle.Single;
+
+                if (useExistingEntities)
+                {
+                    new1 = context.OptionalSingle1s.Single(e => e.Id == new1.Id);
+                    new2 = context.OptionalSingle2s.Single(e => e.Id == new2.Id);
+                }
+                else
+                {
+                    context.Add(new1, new2);
+                }
+
+                switch (changeMechanism)
+                {
+                    case ChangeMechanism.Dependent:
+                        new1.Root = root;
+                        break;
+                    case ChangeMechanism.Principal:
+                        root.OptionalSingle = new1;
+                        break;
+                    case ChangeMechanism.FK:
+                        new1.RootId = root.Id;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("changeMechanism");
+                }
+
+                context.SaveChanges();
+
+                Assert.Equal(root.Id, new1.RootId);
+                Assert.Equal(new1.Id, new2.BackId);
+                Assert.Same(root, new1.Root);
+                Assert.Same(new1, new2.Back);
+
+                Assert.Null(old1.Root);
+                Assert.Same(old1, old2.Back);
+                Assert.Null(old1.RootId);
+                Assert.Equal(old1.Id, old2.BackId);
+            }
+
+            using (var context = CreateContext())
+            {
+                var loadedRoot = LoadFullGraph(context);
+
+                AssertKeys(root, loadedRoot);
+                AssertNavigations(loadedRoot);
+
+                var loaded1 = context.OptionalSingle1s.Single(e => e.Id == old1.Id);
+                var loaded2 = context.OptionalSingle2s.Single(e => e.Id == old2.Id);
+
+                Assert.Null(loaded1.Root);
+                Assert.Same(loaded1, loaded2.Back);
+                Assert.Null(loaded1.RootId);
+                Assert.Equal(loaded1.Id, loaded2.BackId);
+            }
+        }
+
+        [Theory]
+        [InlineData((int)ChangeMechanism.Dependent, false)]
+        [InlineData((int)ChangeMechanism.Dependent, true)]
+        [InlineData((int)ChangeMechanism.Principal, false)]
+        [InlineData((int)ChangeMechanism.Principal, true)]
+        [InlineData((int)ChangeMechanism.FK, false)]
+        [InlineData((int)ChangeMechanism.FK, true)]
+        public virtual void Save_required_one_to_one_changed_by_reference(ChangeMechanism changeMechanism, bool useExistingEntities)
+        {
+            var new2 = new RequiredSingle2();
+            var new1 = new RequiredSingle1 { Single = new2 };
+            var newRoot = new Root { RequiredSingle = new1 };
+
+            if (useExistingEntities)
+            {
+                using (var context = CreateContext())
+                {
+                    context.Add(newRoot, new1, new2);
+                    context.SaveChanges();
+                }
+            }
+
+            Root root;
+            RequiredSingle1 old1;
+            RequiredSingle2 old2;
+            using (var context = CreateContext())
+            {
+                root = LoadFullGraph(context, e => e.Id != newRoot.Id);
+
+                old1 = root.RequiredSingle;
+                old2 = root.RequiredSingle.Single;
+
+                if (useExistingEntities)
+                {
+                    new1 = context.RequiredSingle1s.Single(e => e.Id == new1.Id);
+                    new2 = context.RequiredSingle2s.Single(e => e.Id == new2.Id);
+                }
+                else
+                {
+                    context.Add(new1, new2);
+                }
+
+                switch (changeMechanism)
+                {
+                    case ChangeMechanism.Dependent:
+                        new1.Root = root;
+                        break;
+                    case ChangeMechanism.Principal:
+                        root.RequiredSingle = new1;
+                        break;
+                    case ChangeMechanism.FK:
+                        new1.Id = root.Id;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("changeMechanism");
+                }
+
+                // TODO: Conceptual nulls (Issue #323)
+                //context.SaveChanges();
+
+                //Assert.Equal(root.Id, new1.Id);
+                //Assert.Equal(new1.Id, new2.Id);
+                //Assert.Same(root, new1.Root);
+                //Assert.Same(new1, new2.Back);
+
+                //Assert.Null(old1.Root);
+                //Assert.Same(old1, old2.Back);
+                //Assert.Null(old1.Id);
+                //Assert.Equal(old1.Id, old2.Id);
+            }
+
+            //using (var context = CreateContext())
+            //{
+            //    var loadedRoot = LoadFullGraph(context);
+
+            //    AssertKeys(root, loadedRoot);
+            //    AssertNavigations(loadedRoot);
+
+            //    var loaded1 = context.RequiredSingle1s.Single(e => e.Id == old1.Id);
+            //    var loaded2 = context.RequiredSingle2s.Single(e => e.Id == old2.Id);
+
+            //    Assert.Null(loaded1.Root);
+            //    Assert.Same(loaded1, loaded2.Back);
+            //    Assert.Null(loaded1.Id);
+            //    Assert.Equal(loaded1.Id, loaded2.Id);
+            //}
+        }
+
+        [Theory]
+        [InlineData((int)ChangeMechanism.Dependent, false)]
+        [InlineData((int)ChangeMechanism.Dependent, true)]
+        [InlineData((int)ChangeMechanism.Principal, false)]
+        [InlineData((int)ChangeMechanism.Principal, true)]
+        [InlineData((int)ChangeMechanism.FK, false)]
+        [InlineData((int)ChangeMechanism.FK, true)]
+        public virtual void Save_required_non_PK_one_to_one_changed_by_reference(ChangeMechanism changeMechanism, bool useExistingEntities)
+        {
+            var new2 = new RequiredNonPkSingle2();
+            var new1 = new RequiredNonPkSingle1 { Single = new2 };
+            var newRoot = new Root { RequiredNonPkSingle = new1 };
+
+            if (useExistingEntities)
+            {
+                using (var context = CreateContext())
+                {
+                    context.Add(newRoot, new1, new2);
+                    context.SaveChanges();
+                }
+            }
+
+            Root root;
+            RequiredNonPkSingle1 old1;
+            RequiredNonPkSingle2 old2;
+            using (var context = CreateContext())
+            {
+                root = LoadFullGraph(context, e => e.Id != newRoot.Id);
+
+                old1 = root.RequiredNonPkSingle;
+                old2 = root.RequiredNonPkSingle.Single;
+
+                if (useExistingEntities)
+                {
+                    new1 = context.RequiredNonPkSingle1s.Single(e => e.Id == new1.Id);
+                    new2 = context.RequiredNonPkSingle2s.Single(e => e.Id == new2.Id);
+                }
+                else
+                {
+                    context.Add(new1, new2);
+                }
+
+                switch (changeMechanism)
+                {
+                    case ChangeMechanism.Dependent:
+                        new1.Root = root;
+                        break;
+                    case ChangeMechanism.Principal:
+                        root.RequiredNonPkSingle = new1;
+                        break;
+                    case ChangeMechanism.FK:
+                        new1.Id = root.Id;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("changeMechanism");
+                }
+
+                // TODO: Conceptual nulls (Issue #323)
+                //context.SaveChanges();
+
+                //Assert.Equal(root.Id, new1.RootId);
+                //Assert.Equal(new1.Id, new2.BackId);
+                //Assert.Same(root, new1.Root);
+                //Assert.Same(new1, new2.Back);
+
+                //Assert.Null(old1.Root);
+                //Assert.Same(old1, old2.Back);
+                //Assert.Null(old1.RootId);
+                //Assert.Equal(old1.Id, old2.BackId);
+            }
+
+            //using (var context = CreateContext())
+            //{
+            //    var loadedRoot = LoadFullGraph(context);
+
+            //    AssertKeys(root, loadedRoot);
+            //    AssertNavigations(loadedRoot);
+
+            //    var loaded1 = context.RequiredNonPkSingle1s.Single(e => e.Id == old1.Id);
+            //    var loaded2 = context.RequiredNonPkSingle2s.Single(e => e.Id == old2.Id);
+
+            //    Assert.Null(loaded1.Root);
+            //    Assert.Same(loaded1, loaded2.Back);
+            //    Assert.Null(loaded1.RootId);
+            //    Assert.Equal(loaded1.Id, loaded2.BackId);
+            //}
+        }
+
+        [Theory]
+        [InlineData((int)ChangeMechanism.Dependent)]
+        [InlineData((int)ChangeMechanism.Principal)]
+        [InlineData((int)ChangeMechanism.FK)]
+        public virtual void Sever_optional_one_to_one(ChangeMechanism changeMechanism)
+        {
+            Root root;
+            OptionalSingle1 old1;
+            OptionalSingle2 old2;
+            using (var context = CreateContext())
+            {
+                root = LoadFullGraph(context);
+
+                old1 = root.OptionalSingle;
+                old2 = root.OptionalSingle.Single;
+
+                switch (changeMechanism)
+                {
+                    case ChangeMechanism.Dependent:
+                        old1.Root = null;
+                        break;
+                    case ChangeMechanism.Principal:
+                        root.OptionalSingle = null;
+                        break;
+                    case ChangeMechanism.FK:
+                        old1.RootId = null;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("changeMechanism");
+                }
+
+                context.SaveChanges();
+
+                Assert.Null(old1.Root);
+                Assert.Same(old1, old2.Back);
+                Assert.Null(old1.RootId);
+                Assert.Equal(old1.Id, old2.BackId);
+            }
+
+            using (var context = CreateContext())
+            {
+                var loadedRoot = LoadFullGraph(context);
+
+                AssertKeys(root, loadedRoot);
+                AssertPossiblyNullNavigations(loadedRoot);
+
+                var loaded1 = context.OptionalSingle1s.Single(e => e.Id == old1.Id);
+                var loaded2 = context.OptionalSingle2s.Single(e => e.Id == old2.Id);
+
+                Assert.Null(loaded1.Root);
+                Assert.Same(loaded1, loaded2.Back);
+                Assert.Null(loaded1.RootId);
+                Assert.Equal(loaded1.Id, loaded2.BackId);
+            }
+        }
+
+        [Theory]
+        [InlineData((int)ChangeMechanism.Dependent)]
+        [InlineData((int)ChangeMechanism.Principal)]
+        public virtual void Sever_required_one_to_one(ChangeMechanism changeMechanism)
+        {
+            using (var context = CreateContext())
+            {
+                var root = LoadFullGraph(context);
+
+                switch (changeMechanism)
+                {
+                    case ChangeMechanism.Dependent:
+                        root.RequiredSingle.Root = null;
+                        break;
+                    case ChangeMechanism.Principal:
+                        root.RequiredSingle = null;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("changeMechanism");
+                }
+
+                // TODO: Conceptual nulls (Issue #323)
+                //context.SaveChanges();
+            }
+        }
+
+        [Theory]
+        [InlineData((int)ChangeMechanism.Dependent)]
+        [InlineData((int)ChangeMechanism.Principal)]
+        public virtual void Sever_required_non_PK_one_to_one(ChangeMechanism changeMechanism)
+        {
+            using (var context = CreateContext())
+            {
+                var root = LoadFullGraph(context);
+
+                switch (changeMechanism)
+                {
+                    case ChangeMechanism.Dependent:
+                        root.RequiredNonPkSingle.Root = null;
+                        break;
+                    case ChangeMechanism.Principal:
+                        root.RequiredNonPkSingle = null;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("changeMechanism");
+                }
+
+                // TODO: Conceptual nulls (Issue #323)
+                //context.SaveChanges();
+            }
+        }
+
+        [Theory]
+        [InlineData((int)ChangeMechanism.Dependent, false)]
+        [InlineData((int)ChangeMechanism.Dependent, true)]
+        [InlineData((int)ChangeMechanism.Principal, false)]
+        [InlineData((int)ChangeMechanism.Principal, true)]
+        [InlineData((int)ChangeMechanism.FK, false)]
+        [InlineData((int)ChangeMechanism.FK, true)]
+        public virtual void Reparent_optional_one_to_one(ChangeMechanism changeMechanism, bool useExistingRoot)
+        {
+            var newRoot = new Root();
+
+            if (useExistingRoot)
+            {
+                using (var context = CreateContext())
+                {
+                    context.Add(newRoot);
+                    context.SaveChanges();
+                }
+            }
+
+            Root root;
+            OptionalSingle1 old1;
+            OptionalSingle2 old2;
+            using (var context = CreateContext())
+            {
+                root = LoadFullGraph(context, e => e.Id != newRoot.Id);
+
+                context.Entry(newRoot).SetState(useExistingRoot ? EntityState.Unchanged : EntityState.Added);
+
+                old1 = root.OptionalSingle;
+                old2 = root.OptionalSingle.Single;
+
+                switch (changeMechanism)
+                {
+                    case ChangeMechanism.Dependent:
+                        old1.Root = newRoot;
+                        break;
+                    case ChangeMechanism.Principal:
+                        newRoot.OptionalSingle = old1;
+                        break;
+                    case ChangeMechanism.FK:
+                        old1.RootId = newRoot.Id;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("changeMechanism");
+                }
+
+                context.SaveChanges();
+
+                Assert.Null(root.OptionalSingle);
+
+                Assert.Same(newRoot, old1.Root);
+                Assert.Same(old1, old2.Back);
+                Assert.Equal(newRoot.Id, old1.RootId);
+                Assert.Equal(old1.Id, old2.BackId);
+            }
+
+            using (var context = CreateContext())
+            {
+                var loadedRoot = LoadFullGraph(context, e => e.Id == root.Id);
+
+                AssertKeys(root, loadedRoot);
+                AssertPossiblyNullNavigations(loadedRoot);
+
+                newRoot = context.Roots.Single(e => e.Id == newRoot.Id);
+                var loaded1 = context.OptionalSingle1s.Single(e => e.Id == old1.Id);
+                var loaded2 = context.OptionalSingle2s.Single(e => e.Id == old2.Id);
+
+                Assert.Same(newRoot, loaded1.Root);
+                Assert.Same(loaded1, loaded2.Back);
+                Assert.Equal(newRoot.Id, loaded1.RootId);
+                Assert.Equal(loaded1.Id, loaded2.BackId);
+            }
+        }
+
+        [Theory]
+        [InlineData((int)ChangeMechanism.Dependent, false)]
+        [InlineData((int)ChangeMechanism.Dependent, true)]
+        [InlineData((int)ChangeMechanism.Principal, false)]
+        [InlineData((int)ChangeMechanism.Principal, true)]
+        [InlineData((int)ChangeMechanism.FK, false)]
+        [InlineData((int)ChangeMechanism.FK, true)]
+        public virtual void Reparent_required_one_to_one(ChangeMechanism changeMechanism, bool useExistingRoot)
+        {
+            var newRoot = new Root();
+
+            if (useExistingRoot)
+            {
+                using (var context = CreateContext())
+                {
+                    context.Add(newRoot);
+                    context.SaveChanges();
+                }
+            }
+
+            using (var context = CreateContext())
+            {
+                var root = LoadFullGraph(context, e => e.Id != newRoot.Id);
+
+                context.Entry(newRoot).SetState(useExistingRoot ? EntityState.Unchanged : EntityState.Added);
+
+                switch (changeMechanism)
+                {
+                    case ChangeMechanism.Dependent:
+                        root.RequiredSingle.Root = newRoot;
+                        break;
+                    case ChangeMechanism.Principal:
+                        newRoot.RequiredSingle = root.RequiredSingle;
+                        break;
+                    case ChangeMechanism.FK:
+                        root.RequiredSingle.Id = newRoot.Id;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("changeMechanism");
+                }
+
+                newRoot.RequiredSingle = root.RequiredSingle;
+
+                Assert.Equal(
+                    Strings.PropertyReadOnly("Id", typeof(RequiredSingle1).FullName),
+                    Assert.Throws<NotSupportedException>(() => context.SaveChanges()).Message);
+            }
+        }
+
+        [Theory]
+        [InlineData((int)ChangeMechanism.Dependent, false)]
+        [InlineData((int)ChangeMechanism.Dependent, true)]
+        [InlineData((int)ChangeMechanism.Principal, false)]
+        [InlineData((int)ChangeMechanism.Principal, true)]
+        [InlineData((int)ChangeMechanism.FK, false)]
+        [InlineData((int)ChangeMechanism.FK, true)]
+        public virtual void Reparent_required_non_PK_one_to_one(ChangeMechanism changeMechanism, bool useExistingRoot)
+        {
+            var newRoot = new Root();
+
+            if (useExistingRoot)
+            {
+                using (var context = CreateContext())
+                {
+                    context.Add(newRoot);
+                    context.SaveChanges();
+                }
+            }
+
+            Root root;
+            RequiredNonPkSingle1 old1;
+            RequiredNonPkSingle2 old2;
+            using (var context = CreateContext())
+            {
+                root = LoadFullGraph(context, e => e.Id != newRoot.Id);
+
+                context.Entry(newRoot).SetState(useExistingRoot ? EntityState.Unchanged : EntityState.Added);
+
+                old1 = root.RequiredNonPkSingle;
+                old2 = root.RequiredNonPkSingle.Single;
+
+                switch (changeMechanism)
+                {
+                    case ChangeMechanism.Dependent:
+                        old1.Root = newRoot;
+                        break;
+                    case ChangeMechanism.Principal:
+                        newRoot.RequiredNonPkSingle = old1;
+                        break;
+                    case ChangeMechanism.FK:
+                        old1.RootId = newRoot.Id;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("changeMechanism");
+                }
+
+                context.SaveChanges();
+
+                Assert.Null(root.RequiredNonPkSingle);
+
+                Assert.Same(newRoot, old1.Root);
+                Assert.Same(old1, old2.Back);
+                Assert.Equal(newRoot.Id, old1.RootId);
+                Assert.Equal(old1.Id, old2.BackId);
+            }
+
+            using (var context = CreateContext())
+            {
+                var loadedRoot = LoadFullGraph(context, e => e.Id == root.Id);
+
+                AssertKeys(root, loadedRoot);
+                AssertPossiblyNullNavigations(loadedRoot);
+
+                newRoot = context.Roots.Single(e => e.Id == newRoot.Id);
+                var loaded1 = context.RequiredNonPkSingle1s.Single(e => e.Id == old1.Id);
+                var loaded2 = context.RequiredNonPkSingle2s.Single(e => e.Id == old2.Id);
+
+                Assert.Same(newRoot, loaded1.Root);
+                Assert.Same(loaded1, loaded2.Back);
+                Assert.Equal(newRoot.Id, loaded1.RootId);
+                Assert.Equal(loaded1.Id, loaded2.BackId);
+            }
+        }
+
+        [Theory]
+        [InlineData((int)ChangeMechanism.Principal, false)]
+        [InlineData((int)ChangeMechanism.Principal, true)]
+        [InlineData((int)ChangeMechanism.Dependent, false)]
+        [InlineData((int)ChangeMechanism.Dependent, true)]
+        [InlineData((int)ChangeMechanism.FK, false)]
+        [InlineData((int)ChangeMechanism.FK, true)]
+        public virtual void Save_optional_many_to_one_dependents_with_alternate_key(ChangeMechanism changeMechanism, bool useExistingEntities)
+        {
+            var new2a = new OptionalAk2 { AlternateId = Guid.NewGuid() };
+            var new2b = new OptionalAk2 { AlternateId = Guid.NewGuid() };
+            var new1 = new OptionalAk1 { AlternateId = Guid.NewGuid() };
+
+            if (useExistingEntities)
+            {
+                using (var context = CreateContext())
+                {
+                    context.Add(new1, new2a, new2b);
+                    context.SaveChanges();
+                }
+            }
+
+            Root root;
+            int entityCount;
+            using (var context = CreateContext())
+            {
+                root = LoadFullGraph(context);
+                var existing = root.OptionalChildrenAk.OrderBy(e => e.Id).First();
+
+                if (useExistingEntities)
+                {
+                    new1 = context.OptionalAk1s.Single(e => e.Id == new1.Id);
+                    new2a = context.OptionalAk2s.Single(e => e.Id == new2a.Id);
+                    new2b = context.OptionalAk2s.Single(e => e.Id == new2b.Id);
+                }
+                else
+                {
+                    context.Add(new1, new2a, new2b);
+                }
+
+                switch (changeMechanism)
+                {
+                    case ChangeMechanism.Principal:
+                        existing.Children.Add(new2a);
+                        existing.Children.Add(new2b);
+                        root.OptionalChildrenAk.Add(new1);
+                        break;
+                    case ChangeMechanism.Dependent:
+                        new2a.Parent = existing;
+                        new2b.Parent = existing;
+                        new1.Parent = root;
+                        break;
+                    case ChangeMechanism.FK:
+                        new2a.ParentId = existing.AlternateId;
+                        new2b.ParentId = existing.AlternateId;
+                        new1.ParentId = root.AlternateId;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("changeMechanism");
+                }
+
+                context.SaveChanges();
+
+                Assert.Contains(new2a, existing.Children);
+                Assert.Contains(new2b, existing.Children);
+                Assert.Contains(new1, root.OptionalChildrenAk);
+
+                Assert.Same(existing, new2a.Parent);
+                Assert.Same(existing, new2b.Parent);
+                Assert.Same(root, existing.Parent);
+
+                Assert.Equal(existing.AlternateId, new2a.ParentId);
+                Assert.Equal(existing.AlternateId, new2b.ParentId);
+                Assert.Equal(root.AlternateId, existing.ParentId);
+
+                entityCount = context.ChangeTracker.Entries().Count();
+            }
+
+            using (var context = CreateContext())
+            {
+                var loadedRoot = LoadFullGraph(context);
+
+                Assert.Equal(entityCount, context.ChangeTracker.Entries().Count());
+                AssertKeys(root, loadedRoot);
+                AssertNavigations(loadedRoot);
+            }
+        }
+
+        [Theory]
+        [InlineData((int)ChangeMechanism.Principal, false)]
+        [InlineData((int)ChangeMechanism.Principal, true)]
+        [InlineData((int)ChangeMechanism.Dependent, false)]
+        [InlineData((int)ChangeMechanism.Dependent, true)]
+        [InlineData((int)ChangeMechanism.FK, false)]
+        [InlineData((int)ChangeMechanism.FK, true)]
+        public virtual void Save_required_many_to_one_dependents_with_alternate_key(ChangeMechanism changeMechanism, bool useExistingEntities)
+        {
+            var newRoot = new Root();
+            var new1 = new RequiredAk1 { AlternateId = Guid.NewGuid(), Parent = newRoot };
+            var new2a = new RequiredAk2 { AlternateId = Guid.NewGuid(), Parent = new1 };
+            var new2b = new RequiredAk2 { AlternateId = Guid.NewGuid(), Parent = new1 };
+
+            if (useExistingEntities)
+            {
+                using (var context = CreateContext())
+                {
+                    context.Add(newRoot, new1, new2a, new2b);
+                    context.SaveChanges();
+                }
+            }
+
+            Root root;
+            int entityCount;
+            using (var context = CreateContext())
+            {
+                root = LoadFullGraph(context, e => e.Id != newRoot.Id);
+                var existing = root.RequiredChildrenAk.OrderBy(e => e.Id).First();
+
+                if (useExistingEntities)
+                {
+                    new1 = context.RequiredAk1s.Single(e => e.Id == new1.Id);
+                    new2a = context.RequiredAk2s.Single(e => e.Id == new2a.Id);
+                    new2b = context.RequiredAk2s.Single(e => e.Id == new2b.Id);
+                }
+                else
+                {
+                    context.Add(new1, new2a, new2b);
+                }
+
+                switch (changeMechanism)
+                {
+                    case ChangeMechanism.Principal:
+                        existing.Children.Add(new2a);
+                        existing.Children.Add(new2b);
+                        root.RequiredChildrenAk.Add(new1);
+                        break;
+                    case ChangeMechanism.Dependent:
+                        new2a.Parent = existing;
+                        new2b.Parent = existing;
+                        new1.Parent = root;
+                        break;
+                    case ChangeMechanism.FK:
+                        new2a.ParentId = existing.AlternateId;
+                        new2b.ParentId = existing.AlternateId;
+                        new1.ParentId = root.AlternateId;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("changeMechanism");
+                }
+
+                context.SaveChanges();
+
+                Assert.Contains(new2a, existing.Children);
+                Assert.Contains(new2b, existing.Children);
+                Assert.Contains(new1, root.RequiredChildrenAk);
+
+                Assert.Same(existing, new2a.Parent);
+                Assert.Same(existing, new2b.Parent);
+                Assert.Same(root, existing.Parent);
+
+                Assert.Equal(existing.AlternateId, new2a.ParentId);
+                Assert.Equal(existing.AlternateId, new2b.ParentId);
+                Assert.Equal(root.AlternateId, existing.ParentId);
+
+                entityCount = context.ChangeTracker.Entries().Count();
+            }
+
+            using (var context = CreateContext())
+            {
+                var loadedRoot = LoadFullGraph(context, e => e.Id != newRoot.Id);
+
+                Assert.Equal(entityCount, context.ChangeTracker.Entries().Count());
+                AssertKeys(root, loadedRoot);
+                AssertNavigations(loadedRoot);
+            }
+        }
+
+        [Theory]
+        [InlineData((int)ChangeMechanism.Principal)]
+        [InlineData((int)ChangeMechanism.Dependent)]
+        [InlineData((int)ChangeMechanism.FK)]
+        public virtual void Save_removed_optional_many_to_one_dependents_with_alternate_key(ChangeMechanism changeMechanism)
+        {
+            Root root;
+            using (var context = CreateContext())
+            {
+                root = LoadFullGraph(context);
+
+                var childCollection = root.OptionalChildrenAk.First().Children;
+                var removed2 = childCollection.First();
+                var removed1 = root.OptionalChildrenAk.Skip(1).First();
+
+                switch (changeMechanism)
+                {
+                    case ChangeMechanism.Dependent:
+                        removed2.Parent = null;
+                        removed1.Parent = null;
+                        break;
+                    case ChangeMechanism.Principal:
+                        childCollection.Remove(removed2);
+                        root.OptionalChildrenAk.Remove(removed1);
+                        break;
+                    case ChangeMechanism.FK:
+                        removed2.ParentId = null;
+                        removed1.ParentId = null;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("changeMechanism");
+                }
+
+                context.SaveChanges();
+
+                Assert.DoesNotContain(removed1, root.OptionalChildrenAk);
+                Assert.DoesNotContain(removed2, childCollection);
+
+                Assert.Null(removed1.Parent);
+                Assert.Null(removed2.Parent);
+                Assert.Null(removed1.ParentId);
+                Assert.Null(removed2.ParentId);
+            }
+
+            using (var context = CreateContext())
+            {
+                var loadedRoot = LoadFullGraph(context);
+
+                AssertKeys(root, loadedRoot);
+                AssertNavigations(loadedRoot);
+
+                Assert.Equal(2, loadedRoot.RequiredChildrenAk.Count);
+                Assert.Equal(2, loadedRoot.RequiredChildrenAk.First().Children.Count);
+
+                Assert.Equal(1, loadedRoot.OptionalChildrenAk.Count);
+                Assert.Equal(1, loadedRoot.OptionalChildrenAk.First().Children.Count);
+            }
+        }
+
+        [Theory]
+        [InlineData((int)ChangeMechanism.Principal)]
+        [InlineData((int)ChangeMechanism.Dependent)]
+        public virtual void Save_removed_required_many_to_one_dependents_with_alternate_key(ChangeMechanism changeMechanism)
+        {
+            using (var context = CreateContext())
+            {
+                var root = LoadFullGraph(context);
+
+                var childCollection = root.RequiredChildrenAk.First().Children;
+                var removed2 = childCollection.First();
+                var removed1 = root.RequiredChildrenAk.Skip(1).First();
+
+                switch (changeMechanism)
+                {
+                    case ChangeMechanism.Dependent:
+                        removed2.Parent = null;
+                        removed1.Parent = null;
+                        break;
+                    case ChangeMechanism.Principal:
+                        childCollection.Remove(removed2);
+                        root.RequiredChildrenAk.Remove(removed1);
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("changeMechanism");
+                }
+
+                // TODO: Conceptual nulls (Issue #323)
+                //context.SaveChanges();
+            }
+        }
+
+        [Theory]
+        [InlineData((int)ChangeMechanism.Dependent, false)]
+        [InlineData((int)ChangeMechanism.Dependent, true)]
+        [InlineData((int)ChangeMechanism.Principal, false)]
+        [InlineData((int)ChangeMechanism.Principal, true)]
+        [InlineData((int)ChangeMechanism.FK, false)]
+        [InlineData((int)ChangeMechanism.FK, true)]
+        public virtual void Save_changed_optional_one_to_one_with_alternate_key(ChangeMechanism changeMechanism, bool useExistingEntities)
+        {
+            var new2 = new OptionalSingleAk2 { AlternateId = Guid.NewGuid() };
+            var new1 = new OptionalSingleAk1 { AlternateId = Guid.NewGuid(), Single = new2 };
+
+            if (useExistingEntities)
+            {
+                using (var context = CreateContext())
+                {
+                    context.Add(new1, new2);
+                    context.SaveChanges();
+                }
+            }
+
+            Root root;
+            OptionalSingleAk1 old1;
+            OptionalSingleAk2 old2;
+            using (var context = CreateContext())
+            {
+                root = LoadFullGraph(context);
+
+                old1 = root.OptionalSingleAk;
+                old2 = root.OptionalSingleAk.Single;
+
+                if (useExistingEntities)
+                {
+                    new1 = context.OptionalSingleAk1s.Single(e => e.Id == new1.Id);
+                    new2 = context.OptionalSingleAk2s.Single(e => e.Id == new2.Id);
+                }
+                else
+                {
+                    context.Add(new1, new2);
+                }
+
+                switch (changeMechanism)
+                {
+                    case ChangeMechanism.Dependent:
+                        new1.Root = root;
+                        break;
+                    case ChangeMechanism.Principal:
+                        root.OptionalSingleAk = new1;
+                        break;
+                    case ChangeMechanism.FK:
+                        new1.RootId = root.AlternateId;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("changeMechanism");
+                }
+
+                context.SaveChanges();
+
+                Assert.Equal(root.AlternateId, new1.RootId);
+                Assert.Equal(new1.AlternateId, new2.BackId);
+                Assert.Same(root, new1.Root);
+                Assert.Same(new1, new2.Back);
+
+                Assert.Null(old1.Root);
+                Assert.Same(old1, old2.Back);
+                Assert.Null(old1.RootId);
+                Assert.Equal(old1.AlternateId, old2.BackId);
+            }
+
+            using (var context = CreateContext())
+            {
+                var loadedRoot = LoadFullGraph(context);
+
+                AssertKeys(root, loadedRoot);
+                AssertNavigations(loadedRoot);
+
+                var loaded1 = context.OptionalSingleAk1s.Single(e => e.Id == old1.Id);
+                var loaded2 = context.OptionalSingleAk2s.Single(e => e.Id == old2.Id);
+
+                Assert.Null(loaded1.Root);
+                Assert.Same(loaded1, loaded2.Back);
+                Assert.Null(loaded1.RootId);
+                Assert.Equal(loaded1.AlternateId, loaded2.BackId);
+            }
+        }
+
+        [Theory]
+        [InlineData((int)ChangeMechanism.Dependent, false)]
+        [InlineData((int)ChangeMechanism.Dependent, true)]
+        [InlineData((int)ChangeMechanism.Principal, false)]
+        [InlineData((int)ChangeMechanism.Principal, true)]
+        [InlineData((int)ChangeMechanism.FK, false)]
+        [InlineData((int)ChangeMechanism.FK, true)]
+        public virtual void Save_required_one_to_one_changed_by_reference_with_alternate_key(
+            ChangeMechanism changeMechanism, bool useExistingEntities)
+        {
+            var new2 = new RequiredSingleAk2 { AlternateId = Guid.NewGuid() };
+            var new1 = new RequiredSingleAk1 { AlternateId = Guid.NewGuid(), Single = new2 };
+            var newRoot = new Root { RequiredSingleAk = new1 };
+
+            if (useExistingEntities)
+            {
+                using (var context = CreateContext())
+                {
+                    context.Add(newRoot, new1, new2);
+                    context.SaveChanges();
+                }
+            }
+
+            Root root;
+            RequiredSingleAk1 old1;
+            RequiredSingleAk2 old2;
+            using (var context = CreateContext())
+            {
+                root = LoadFullGraph(context, e => e.Id != newRoot.Id);
+
+                old1 = root.RequiredSingleAk;
+                old2 = root.RequiredSingleAk.Single;
+
+                if (useExistingEntities)
+                {
+                    new1 = context.RequiredSingleAk1s.Single(e => e.Id == new1.Id);
+                    new2 = context.RequiredSingleAk2s.Single(e => e.Id == new2.Id);
+                }
+                else
+                {
+                    context.Add(new1, new2);
+                }
+
+                switch (changeMechanism)
+                {
+                    case ChangeMechanism.Dependent:
+                        new1.Root = root;
+                        break;
+                    case ChangeMechanism.Principal:
+                        root.RequiredSingleAk = new1;
+                        break;
+                    case ChangeMechanism.FK:
+                        new1.AlternateId = root.AlternateId;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("changeMechanism");
+                }
+
+                // TODO: Conceptual nulls (Issue #323)
+                //context.SaveChanges();
+
+                //Assert.Equal(root.AlternateId, new1.AlternateId);
+                //Assert.Equal(new1.AlternateId, new2.AlternateId);
+                //Assert.Same(root, new1.Root);
+                //Assert.Same(new1, new2.Back);
+
+                //Assert.Null(old1.Root);
+                //Assert.Same(old1, old2.Back);
+                //Assert.Null(old1.AlternateId);
+                //Assert.Equal(old1.AlternateId, old2.AlternateId);
+            }
+
+            //using (var context = CreateContext())
+            //{
+            //    var loadedRoot = LoadFullGraph(context);
+
+            //    AssertKeys(root, loadedRoot);
+            //    AssertNavigations(loadedRoot);
+
+            //    var loaded1 = context.RequiredSingleAk1s.Single(e => e.Id == old1.Id);
+            //    var loaded2 = context.RequiredSingleAk2s.Single(e => e.Id == old2.Id);
+
+            //    Assert.Null(loaded1.Root);
+            //    Assert.Same(loaded1, loaded2.Back);
+            //    Assert.Null(loaded1.AlternateId);
+            //    Assert.Equal(loaded1.AlternateId, loaded2.AlternateId);
+            //}
+        }
+
+        [Theory]
+        [InlineData((int)ChangeMechanism.Dependent, false)]
+        [InlineData((int)ChangeMechanism.Dependent, true)]
+        [InlineData((int)ChangeMechanism.Principal, false)]
+        [InlineData((int)ChangeMechanism.Principal, true)]
+        [InlineData((int)ChangeMechanism.FK, false)]
+        [InlineData((int)ChangeMechanism.FK, true)]
+        public virtual void Save_required_non_PK_one_to_one_changed_by_reference_with_alternate_key(
+            ChangeMechanism changeMechanism, bool useExistingEntities)
+        {
+            var new2 = new RequiredNonPkSingleAk2 { AlternateId = Guid.NewGuid() };
+            var new1 = new RequiredNonPkSingleAk1 { AlternateId = Guid.NewGuid(), Single = new2 };
+            var newRoot = new Root { RequiredNonPkSingleAk = new1 };
+
+            if (useExistingEntities)
+            {
+                using (var context = CreateContext())
+                {
+                    context.Add(newRoot, new1, new2);
+                    context.SaveChanges();
+                }
+            }
+
+            Root root;
+            RequiredNonPkSingleAk1 old1;
+            RequiredNonPkSingleAk2 old2;
+            using (var context = CreateContext())
+            {
+                root = LoadFullGraph(context, e => e.Id != newRoot.Id);
+
+                old1 = root.RequiredNonPkSingleAk;
+                old2 = root.RequiredNonPkSingleAk.Single;
+
+                if (useExistingEntities)
+                {
+                    new1 = context.RequiredNonPkSingleAk1s.Single(e => e.Id == new1.Id);
+                    new2 = context.RequiredNonPkSingleAk2s.Single(e => e.Id == new2.Id);
+                }
+                else
+                {
+                    context.Add(new1, new2);
+                }
+
+                switch (changeMechanism)
+                {
+                    case ChangeMechanism.Dependent:
+                        new1.Root = root;
+                        break;
+                    case ChangeMechanism.Principal:
+                        root.RequiredNonPkSingleAk = new1;
+                        break;
+                    case ChangeMechanism.FK:
+                        new1.AlternateId = root.AlternateId;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("changeMechanism");
+                }
+
+                // TODO: Conceptual nulls (Issue #323)
+                //context.SaveChanges();
+
+                //Assert.Equal(root.AlternateId, new1.RootId);
+                //Assert.Equal(new1.AlternateId, new2.BackId);
+                //Assert.Same(root, new1.Root);
+                //Assert.Same(new1, new2.Back);
+
+                //Assert.Null(old1.Root);
+                //Assert.Same(old1, old2.Back);
+                //Assert.Null(old1.RootId);
+                //Assert.Equal(old1.AlternateId, old2.BackId);
+            }
+
+            //using (var context = CreateContext())
+            //{
+            //    var loadedRoot = LoadFullGraph(context);
+
+            //    AssertKeys(root, loadedRoot);
+            //    AssertNavigations(loadedRoot);
+
+            //    var loaded1 = context.RequiredNonPkSingleAk1s.Single(e => e.Id == old1.Id);
+            //    var loaded2 = context.RequiredNonPkSingleAk2s.Single(e => e.Id == old2.Id);
+
+            //    Assert.Null(loaded1.Root);
+            //    Assert.Same(loaded1, loaded2.Back);
+            //    Assert.Null(loaded1.RootId);
+            //    Assert.Equal(loaded1.AlternateId, loaded2.BackId);
+            //}
+        }
+
+        [Theory]
+        [InlineData((int)ChangeMechanism.Dependent)]
+        [InlineData((int)ChangeMechanism.Principal)]
+        [InlineData((int)ChangeMechanism.FK)]
+        public virtual void Sever_optional_one_to_one_with_alternate_key(ChangeMechanism changeMechanism)
+        {
+            Root root;
+            OptionalSingleAk1 old1;
+            OptionalSingleAk2 old2;
+            using (var context = CreateContext())
+            {
+                root = LoadFullGraph(context);
+
+                old1 = root.OptionalSingleAk;
+                old2 = root.OptionalSingleAk.Single;
+
+                switch (changeMechanism)
+                {
+                    case ChangeMechanism.Dependent:
+                        old1.Root = null;
+                        break;
+                    case ChangeMechanism.Principal:
+                        root.OptionalSingleAk = null;
+                        break;
+                    case ChangeMechanism.FK:
+                        old1.RootId = null;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("changeMechanism");
+                }
+
+                context.SaveChanges();
+
+                Assert.Null(old1.Root);
+                Assert.Same(old1, old2.Back);
+                Assert.Null(old1.RootId);
+                Assert.Equal(old1.AlternateId, old2.BackId);
+            }
+
+            using (var context = CreateContext())
+            {
+                var loadedRoot = LoadFullGraph(context);
+
+                AssertKeys(root, loadedRoot);
+                AssertPossiblyNullNavigations(loadedRoot);
+
+                var loaded1 = context.OptionalSingleAk1s.Single(e => e.Id == old1.Id);
+                var loaded2 = context.OptionalSingleAk2s.Single(e => e.Id == old2.Id);
+
+                Assert.Null(loaded1.Root);
+                Assert.Same(loaded1, loaded2.Back);
+                Assert.Null(loaded1.RootId);
+                Assert.Equal(loaded1.AlternateId, loaded2.BackId);
+            }
+        }
+
+        [Theory]
+        [InlineData((int)ChangeMechanism.Dependent)]
+        [InlineData((int)ChangeMechanism.Principal)]
+        public virtual void Sever_required_one_to_one_with_alternate_key(ChangeMechanism changeMechanism)
+        {
+            using (var context = CreateContext())
+            {
+                var root = LoadFullGraph(context);
+
+                switch (changeMechanism)
+                {
+                    case ChangeMechanism.Dependent:
+                        root.RequiredSingleAk.Root = null;
+                        break;
+                    case ChangeMechanism.Principal:
+                        root.RequiredSingleAk = null;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("changeMechanism");
+                }
+
+                // TODO: Conceptual nulls (Issue #323)
+                //context.SaveChanges();
+            }
+        }
+
+        [Theory]
+        [InlineData((int)ChangeMechanism.Dependent)]
+        [InlineData((int)ChangeMechanism.Principal)]
+        public virtual void Sever_required_non_PK_one_to_one_with_alternate_key(ChangeMechanism changeMechanism)
+        {
+            using (var context = CreateContext())
+            {
+                var root = LoadFullGraph(context);
+
+                switch (changeMechanism)
+                {
+                    case ChangeMechanism.Dependent:
+                        root.RequiredNonPkSingleAk.Root = null;
+                        break;
+                    case ChangeMechanism.Principal:
+                        root.RequiredNonPkSingleAk = null;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("changeMechanism");
+                }
+
+                // TODO: Conceptual nulls (Issue #323)
+                //context.SaveChanges();
+            }
+        }
+
+        [Theory]
+        [InlineData((int)ChangeMechanism.Dependent, false)]
+        [InlineData((int)ChangeMechanism.Dependent, true)]
+        [InlineData((int)ChangeMechanism.Principal, false)]
+        [InlineData((int)ChangeMechanism.Principal, true)]
+        [InlineData((int)ChangeMechanism.FK, false)]
+        [InlineData((int)ChangeMechanism.FK, true)]
+        public virtual void Reparent_optional_one_to_one_with_alternate_key(ChangeMechanism changeMechanism, bool useExistingRoot)
+        {
+            var newRoot = new Root();
+
+            if (useExistingRoot)
+            {
+                using (var context = CreateContext())
+                {
+                    context.Add(newRoot);
+                    context.SaveChanges();
+                }
+            }
+
+            Root root;
+            OptionalSingleAk1 old1;
+            OptionalSingleAk2 old2;
+            using (var context = CreateContext())
+            {
+                root = LoadFullGraph(context, e => e.Id != newRoot.Id);
+
+                context.Entry(newRoot).SetState(useExistingRoot ? EntityState.Unchanged : EntityState.Added);
+
+                old1 = root.OptionalSingleAk;
+                old2 = root.OptionalSingleAk.Single;
+
+                switch (changeMechanism)
+                {
+                    case ChangeMechanism.Dependent:
+                        old1.Root = newRoot;
+                        break;
+                    case ChangeMechanism.Principal:
+                        newRoot.OptionalSingleAk = old1;
+                        break;
+                    case ChangeMechanism.FK:
+                        old1.RootId = newRoot.AlternateId;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("changeMechanism");
+                }
+
+                context.SaveChanges();
+
+                Assert.Null(root.OptionalSingleAk);
+
+                Assert.Same(newRoot, old1.Root);
+                Assert.Same(old1, old2.Back);
+                Assert.Equal(newRoot.AlternateId, old1.RootId);
+                Assert.Equal(old1.AlternateId, old2.BackId);
+            }
+
+            using (var context = CreateContext())
+            {
+                var loadedRoot = LoadFullGraph(context, e => e.Id == root.Id);
+
+                AssertKeys(root, loadedRoot);
+                AssertPossiblyNullNavigations(loadedRoot);
+
+                newRoot = context.Roots.Single(e => e.Id == newRoot.Id);
+                var loaded1 = context.OptionalSingleAk1s.Single(e => e.Id == old1.Id);
+                var loaded2 = context.OptionalSingleAk2s.Single(e => e.Id == old2.Id);
+
+                Assert.Same(newRoot, loaded1.Root);
+                Assert.Same(loaded1, loaded2.Back);
+                Assert.Equal(newRoot.AlternateId, loaded1.RootId);
+                Assert.Equal(loaded1.AlternateId, loaded2.BackId);
+            }
+        }
+
+        [Theory]
+        [InlineData((int)ChangeMechanism.Dependent, false)]
+        [InlineData((int)ChangeMechanism.Dependent, true)]
+        [InlineData((int)ChangeMechanism.Principal, false)]
+        [InlineData((int)ChangeMechanism.Principal, true)]
+        [InlineData((int)ChangeMechanism.FK, false)]
+        [InlineData((int)ChangeMechanism.FK, true)]
+        public virtual void Reparent_required_one_to_one_with_alternate_key(ChangeMechanism changeMechanism, bool useExistingRoot)
+        {
+            var newRoot = new Root();
+
+            if (useExistingRoot)
+            {
+                using (var context = CreateContext())
+                {
+                    context.Add(newRoot);
+                    context.SaveChanges();
+                }
+            }
+
+            using (var context = CreateContext())
+            {
+                var root = LoadFullGraph(context, e => e.Id != newRoot.Id);
+
+                context.Entry(newRoot).SetState(useExistingRoot ? EntityState.Unchanged : EntityState.Added);
+
+                switch (changeMechanism)
+                {
+                    case ChangeMechanism.Dependent:
+                        root.RequiredSingleAk.Root = newRoot;
+                        break;
+                    case ChangeMechanism.Principal:
+                        newRoot.RequiredSingleAk = root.RequiredSingleAk;
+                        break;
+                    case ChangeMechanism.FK:
+                        root.RequiredSingleAk.AlternateId = newRoot.AlternateId;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("changeMechanism");
+                }
+
+                newRoot.RequiredSingleAk = root.RequiredSingleAk;
+
+                Assert.Equal(
+                    Strings.PropertyReadOnly("AlternateId", typeof(RequiredSingleAk1).FullName),
+                    Assert.Throws<NotSupportedException>(() => context.SaveChanges()).Message);
+            }
+        }
+
+        [Theory]
+        [InlineData((int)ChangeMechanism.Dependent, false)]
+        [InlineData((int)ChangeMechanism.Dependent, true)]
+        [InlineData((int)ChangeMechanism.Principal, false)]
+        [InlineData((int)ChangeMechanism.Principal, true)]
+        [InlineData((int)ChangeMechanism.FK, false)]
+        [InlineData((int)ChangeMechanism.FK, true)]
+        public virtual void Reparent_required_non_PK_one_to_one_with_alternate_key(ChangeMechanism changeMechanism, bool useExistingRoot)
+        {
+            var newRoot = new Root();
+
+            if (useExistingRoot)
+            {
+                using (var context = CreateContext())
+                {
+                    context.Add(newRoot);
+                    context.SaveChanges();
+                }
+            }
+
+            Root root;
+            RequiredNonPkSingleAk1 old1;
+            RequiredNonPkSingleAk2 old2;
+            using (var context = CreateContext())
+            {
+                root = LoadFullGraph(context, e => e.Id != newRoot.Id);
+
+                context.Entry(newRoot).SetState(useExistingRoot ? EntityState.Unchanged : EntityState.Added);
+
+                old1 = root.RequiredNonPkSingleAk;
+                old2 = root.RequiredNonPkSingleAk.Single;
+
+                switch (changeMechanism)
+                {
+                    case ChangeMechanism.Dependent:
+                        old1.Root = newRoot;
+                        break;
+                    case ChangeMechanism.Principal:
+                        newRoot.RequiredNonPkSingleAk = old1;
+                        break;
+                    case ChangeMechanism.FK:
+                        old1.RootId = newRoot.AlternateId;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("changeMechanism");
+                }
+
+                context.SaveChanges();
+
+                Assert.Null(root.RequiredNonPkSingleAk);
+
+                Assert.Same(newRoot, old1.Root);
+                Assert.Same(old1, old2.Back);
+                Assert.Equal(newRoot.AlternateId, old1.RootId);
+                Assert.Equal(old1.AlternateId, old2.BackId);
+            }
+
+            using (var context = CreateContext())
+            {
+                var loadedRoot = LoadFullGraph(context, e => e.Id == root.Id);
+
+                AssertKeys(root, loadedRoot);
+                AssertPossiblyNullNavigations(loadedRoot);
+
+                newRoot = context.Roots.Single(e => e.Id == newRoot.Id);
+                var loaded1 = context.RequiredNonPkSingleAk1s.Single(e => e.Id == old1.Id);
+                var loaded2 = context.RequiredNonPkSingleAk2s.Single(e => e.Id == old2.Id);
+
+                Assert.Same(newRoot, loaded1.Root);
+                Assert.Same(loaded1, loaded2.Back);
+                Assert.Equal(newRoot.AlternateId, loaded1.RootId);
+                Assert.Equal(loaded1.AlternateId, loaded2.BackId);
+            }
+        }
+
+        public enum ChangeMechanism
+        {
+            Dependent,
+            Principal,
+            FK
+        }
+
+        protected static Root LoadFullGraph(GraphUpdatesContext context, Expression<Func<Root, bool>> predicate = null)
+        {
+            var query = context.Roots
+                .Include(e => e.RequiredChildren)
+                .Include(e => e.OptionalChildren)
+                .Include(e => e.RequiredSingle)
+                .Include(e => e.RequiredNonPkSingle)
+                .Include(e => e.OptionalSingle);
+
+            var loadedGraph = predicate == null
+                ? query.Single()
+                : query.Single(predicate);
+
+            // TODO: Use Include when supported
+            context.RequiredAk1s.Load();
+            context.OptionalAk1s.Load();
+            context.RequiredSingleAk1s.Load();
+            context.OptionalSingleAk1s.Load();
+            context.RequiredNonPkSingleAk1s.Load();
+
+            context.RequiredSingle2s.Load();
+            context.RequiredNonPkSingle2s.Load();
+            context.OptionalSingle2s.Load();
+            context.Required2s.Load();
+            context.Optional2s.Load();
+
+            context.RequiredSingleAk2s.Load();
+            context.RequiredNonPkSingleAk2s.Load();
+            context.OptionalSingleAk2s.Load();
+            context.RequiredAk2s.Load();
+            context.OptionalAk2s.Load();
+
+            return loadedGraph;
+        }
+
+        protected static Root CreateFullGraph()
+        {
+            return new Root
+                {
+                    AlternateId = Guid.NewGuid(),
+                    RequiredChildren = new List<Required1>
+                        {
+                            new Required1
+                                {
+                                    Children = new List<Required2>
+                                        {
+                                            new Required2(),
+                                            new Required2()
+                                        }
+                                },
+                            new Required1
+                                {
+                                    Children = new List<Required2>
+                                        {
+                                            new Required2(),
+                                            new Required2()
+                                        }
+                                }
+                        },
+                    OptionalChildren = new List<Optional1>
+                        {
+                            new Optional1
+                                {
+                                    Children = new List<Optional2>
+                                        {
+                                            new Optional2(),
+                                            new Optional2()
+                                        }
+                                },
+                            new Optional1
+                                {
+                                    Children = new List<Optional2>
+                                        {
+                                            new Optional2(),
+                                            new Optional2()
+                                        }
+                                }
+                        },
+                    RequiredSingle = new RequiredSingle1
+                        {
+                            Single = new RequiredSingle2()
+                        },
+                    OptionalSingle = new OptionalSingle1
+                        {
+                            Single = new OptionalSingle2()
+                        },
+                    RequiredNonPkSingle = new RequiredNonPkSingle1
+                        {
+                            Single = new RequiredNonPkSingle2()
+                        },
+                    RequiredChildrenAk = new List<RequiredAk1>
+                        {
+                            new RequiredAk1
+                                {
+                                    AlternateId = Guid.NewGuid(),
+                                    Children = new List<RequiredAk2>
+                                        {
+                                            new RequiredAk2 { AlternateId = Guid.NewGuid() },
+                                            new RequiredAk2 { AlternateId = Guid.NewGuid() }
+                                        }
+                                },
+                            new RequiredAk1
+                                {
+                                    AlternateId = Guid.NewGuid(),
+                                    Children = new List<RequiredAk2>
+                                        {
+                                            new RequiredAk2 { AlternateId = Guid.NewGuid() },
+                                            new RequiredAk2 { AlternateId = Guid.NewGuid() }
+                                        }
+                                }
+                        },
+                    OptionalChildrenAk = new List<OptionalAk1>
+                        {
+                            new OptionalAk1
+                                {
+                                    AlternateId = Guid.NewGuid(),
+                                    Children = new List<OptionalAk2>
+                                        {
+                                            new OptionalAk2 { AlternateId = Guid.NewGuid() },
+                                            new OptionalAk2 { AlternateId = Guid.NewGuid() }
+                                        }
+                                },
+                            new OptionalAk1
+                                {
+                                    AlternateId = Guid.NewGuid(),
+                                    Children = new List<OptionalAk2>
+                                        {
+                                            new OptionalAk2 { AlternateId = Guid.NewGuid() },
+                                            new OptionalAk2 { AlternateId = Guid.NewGuid() }
+                                        }
+                                }
+                        },
+                    RequiredSingleAk = new RequiredSingleAk1
+                        {
+                            Single = new RequiredSingleAk2()
+                        },
+                    OptionalSingleAk = new OptionalSingleAk1
+                        {
+                            Single = new OptionalSingleAk2()
+                        },
+                    RequiredNonPkSingleAk = new RequiredNonPkSingleAk1
+                        {
+                            AlternateId = Guid.NewGuid(),
+                            Single = new RequiredNonPkSingleAk2 { AlternateId = Guid.NewGuid() }
+                        }
+                };
+        }
+
+        private static void AssertKeys(Root expected, Root actual)
+        {
+            Assert.Equal(expected.Id, actual.Id);
+
+            Assert.Equal(
+                expected.RequiredChildren.OrderBy(e => e.Id).Select(e => e.Id),
+                actual.RequiredChildren.OrderBy(e => e.Id).Select(e => e.Id));
+
+            Assert.Equal(
+                expected.RequiredChildren.OrderBy(e => e.Id).Select(e => e.Children.Count),
+                actual.RequiredChildren.OrderBy(e => e.Id).Select(e => e.Children.Count));
+
+            Assert.Equal(
+                expected.RequiredChildren.OrderBy(e => e.Id).SelectMany(e => e.Children).OrderBy(e => e.Id).Select(e => e.Id),
+                actual.RequiredChildren.OrderBy(e => e.Id).SelectMany(e => e.Children).OrderBy(e => e.Id).Select(e => e.Id));
+
+            Assert.Equal(
+                expected.OptionalChildren.OrderBy(e => e.Id).Select(e => e.Id),
+                actual.OptionalChildren.OrderBy(e => e.Id).Select(e => e.Id));
+
+            Assert.Equal(
+                expected.OptionalChildren.OrderBy(e => e.Id).Select(e => e.Children.Count),
+                actual.OptionalChildren.OrderBy(e => e.Id).Select(e => e.Children.Count));
+
+            Assert.Equal(
+                expected.OptionalChildren.OrderBy(e => e.Id).SelectMany(e => e.Children).OrderBy(e => e.Id).Select(e => e.Id),
+                actual.OptionalChildren.OrderBy(e => e.Id).SelectMany(e => e.Children).OrderBy(e => e.Id).Select(e => e.Id));
+
+            Assert.Equal(expected.RequiredSingle?.Id, actual.RequiredSingle?.Id);
+            Assert.Equal(expected.OptionalSingle?.Id, actual.OptionalSingle?.Id);
+            Assert.Equal(expected.RequiredNonPkSingle?.Id, actual.RequiredNonPkSingle?.Id);
+
+            Assert.Equal(expected.RequiredSingle?.Single?.Id, actual.RequiredSingle?.Single?.Id);
+            Assert.Equal(expected.OptionalSingle?.Single?.Id, actual.OptionalSingle?.Single?.Id);
+            Assert.Equal(expected.RequiredNonPkSingle?.Single?.Id, actual.RequiredNonPkSingle?.Single?.Id);
+
+            Assert.Equal(expected.AlternateId, actual.AlternateId);
+
+            Assert.Equal(
+                expected.RequiredChildrenAk.OrderBy(e => e.Id).Select(e => e.AlternateId),
+                actual.RequiredChildrenAk.OrderBy(e => e.Id).Select(e => e.AlternateId));
+
+            Assert.Equal(
+                expected.RequiredChildrenAk.OrderBy(e => e.Id).Select(e => e.Children.Count),
+                actual.RequiredChildrenAk.OrderBy(e => e.Id).Select(e => e.Children.Count));
+
+            Assert.Equal(
+                expected.RequiredChildrenAk.OrderBy(e => e.Id).SelectMany(e => e.Children).OrderBy(e => e.Id).Select(e => e.AlternateId),
+                actual.RequiredChildrenAk.OrderBy(e => e.Id).SelectMany(e => e.Children).OrderBy(e => e.Id).Select(e => e.AlternateId));
+
+            Assert.Equal(
+                expected.OptionalChildrenAk.OrderBy(e => e.Id).Select(e => e.AlternateId),
+                actual.OptionalChildrenAk.OrderBy(e => e.Id).Select(e => e.AlternateId));
+
+            Assert.Equal(
+                expected.OptionalChildrenAk.OrderBy(e => e.Id).Select(e => e.Children.Count),
+                actual.OptionalChildrenAk.OrderBy(e => e.Id).Select(e => e.Children.Count));
+
+            Assert.Equal(
+                expected.OptionalChildrenAk.OrderBy(e => e.Id).SelectMany(e => e.Children).OrderBy(e => e.Id).Select(e => e.AlternateId),
+                actual.OptionalChildrenAk.OrderBy(e => e.Id).SelectMany(e => e.Children).OrderBy(e => e.Id).Select(e => e.AlternateId));
+
+            Assert.Equal(expected.RequiredSingleAk?.AlternateId, actual.RequiredSingleAk?.AlternateId);
+            Assert.Equal(expected.OptionalSingleAk?.AlternateId, actual.OptionalSingleAk?.AlternateId);
+            Assert.Equal(expected.RequiredNonPkSingleAk?.AlternateId, actual.RequiredNonPkSingleAk?.AlternateId);
+
+            Assert.Equal(expected.RequiredSingleAk?.Single?.AlternateId, actual.RequiredSingleAk?.Single?.AlternateId);
+            Assert.Equal(expected.OptionalSingleAk?.Single?.AlternateId, actual.OptionalSingleAk?.Single?.AlternateId);
+            Assert.Equal(expected.RequiredNonPkSingleAk?.Single?.AlternateId, actual.RequiredNonPkSingleAk?.Single?.AlternateId);
+        }
+
+        private static void AssertNavigations(Root root)
+        {
+            foreach (var child in root.RequiredChildren)
+            {
+                Assert.Same(root, child.Parent);
+                Assert.All(child.Children.Select(e => e.Parent), e => Assert.Same(child, e));
+            }
+
+            foreach (var child in root.OptionalChildren)
+            {
+                Assert.Same(root, child.Parent);
+                Assert.All(child.Children.Select(e => e.Parent), e => Assert.Same(child, e));
+            }
+
+            foreach (var child in root.OptionalChildren)
+            {
+                Assert.Same(root, child.Parent);
+                Assert.All(child.Children.Select(e => e.Parent), e => Assert.Same(child, e));
+            }
+
+            Assert.Same(root, root.RequiredSingle.Root);
+            Assert.Same(root, root.OptionalSingle.Root);
+            Assert.Same(root, root.RequiredNonPkSingle.Root);
+
+            Assert.Same(root.RequiredSingle, root.RequiredSingle.Single.Back);
+            Assert.Same(root.OptionalSingle, root.OptionalSingle.Single.Back);
+            Assert.Same(root.RequiredNonPkSingle, root.RequiredNonPkSingle.Single.Back);
+
+            foreach (var child in root.RequiredChildrenAk)
+            {
+                Assert.Same(root, child.Parent);
+                Assert.All(child.Children.Select(e => e.Parent), e => Assert.Same(child, e));
+            }
+
+            foreach (var child in root.OptionalChildrenAk)
+            {
+                Assert.Same(root, child.Parent);
+                Assert.All(child.Children.Select(e => e.Parent), e => Assert.Same(child, e));
+            }
+
+            foreach (var child in root.OptionalChildrenAk)
+            {
+                Assert.Same(root, child.Parent);
+                Assert.All(child.Children.Select(e => e.Parent), e => Assert.Same(child, e));
+            }
+
+            Assert.Same(root, root.RequiredSingleAk.Root);
+            Assert.Same(root, root.OptionalSingleAk.Root);
+            Assert.Same(root, root.RequiredNonPkSingleAk.Root);
+
+            Assert.Same(root.RequiredSingleAk, root.RequiredSingleAk.Single.Back);
+            Assert.Same(root.OptionalSingleAk, root.OptionalSingleAk.Single.Back);
+            Assert.Same(root.RequiredNonPkSingleAk, root.RequiredNonPkSingleAk.Single.Back);
+        }
+
+        private static void AssertPossiblyNullNavigations(Root root)
+        {
+            foreach (var child in root.RequiredChildren)
+            {
+                Assert.Same(root, child.Parent);
+                Assert.All(child.Children.Select(e => e.Parent), e => Assert.Same(child, e));
+            }
+
+            foreach (var child in root.OptionalChildren)
+            {
+                Assert.Same(root, child.Parent);
+                Assert.All(child.Children.Select(e => e.Parent), e => Assert.Same(child, e));
+            }
+
+            foreach (var child in root.OptionalChildren)
+            {
+                Assert.Same(root, child.Parent);
+                Assert.All(child.Children.Select(e => e.Parent), e => Assert.Same(child, e));
+            }
+
+            if (root.RequiredSingle != null)
+            {
+                Assert.Same(root, root.RequiredSingle.Root);
+                Assert.Same(root.RequiredSingle, root.RequiredSingle.Single.Back);
+            }
+
+            if (root.OptionalSingle != null)
+            {
+                Assert.Same(root, root.OptionalSingle.Root);
+                Assert.Same(root.OptionalSingle, root.OptionalSingle.Single.Back);
+            }
+
+            if (root.RequiredNonPkSingle != null)
+            {
+                Assert.Same(root, root.RequiredNonPkSingle.Root);
+                Assert.Same(root.RequiredNonPkSingle, root.RequiredNonPkSingle.Single.Back);
+            }
+
+            foreach (var child in root.RequiredChildrenAk)
+            {
+                Assert.Same(root, child.Parent);
+                Assert.All(child.Children.Select(e => e.Parent), e => Assert.Same(child, e));
+            }
+
+            foreach (var child in root.OptionalChildrenAk)
+            {
+                Assert.Same(root, child.Parent);
+                Assert.All(child.Children.Select(e => e.Parent), e => Assert.Same(child, e));
+            }
+
+            foreach (var child in root.OptionalChildrenAk)
+            {
+                Assert.Same(root, child.Parent);
+                Assert.All(child.Children.Select(e => e.Parent), e => Assert.Same(child, e));
+            }
+
+            if (root.RequiredSingleAk != null)
+            {
+                Assert.Same(root, root.RequiredSingleAk.Root);
+                Assert.Same(root.RequiredSingleAk, root.RequiredSingleAk.Single.Back);
+            }
+
+            if (root.OptionalSingleAk != null)
+            {
+                Assert.Same(root, root.OptionalSingleAk.Root);
+                Assert.Same(root.OptionalSingleAk, root.OptionalSingleAk.Single.Back);
+            }
+
+            if (root.RequiredNonPkSingleAk != null)
+            {
+                Assert.Same(root, root.RequiredNonPkSingleAk.Root);
+                Assert.Same(root.RequiredNonPkSingleAk, root.RequiredNonPkSingleAk.Single.Back);
+            }
+        }
+
+        protected class Root
+        {
+            public int Id { get; set; }
+            public Guid AlternateId { get; set; }
+
+            public ICollection<Required1> RequiredChildren { get; set; } = new List<Required1>();
+            public ICollection<Optional1> OptionalChildren { get; set; } = new List<Optional1>();
+            public RequiredSingle1 RequiredSingle { get; set; }
+            public RequiredNonPkSingle1 RequiredNonPkSingle { get; set; }
+            public OptionalSingle1 OptionalSingle { get; set; }
+
+            public ICollection<RequiredAk1> RequiredChildrenAk { get; set; } = new List<RequiredAk1>();
+            public ICollection<OptionalAk1> OptionalChildrenAk { get; set; } = new List<OptionalAk1>();
+            public RequiredSingleAk1 RequiredSingleAk { get; set; }
+            public RequiredNonPkSingleAk1 RequiredNonPkSingleAk { get; set; }
+            public OptionalSingleAk1 OptionalSingleAk { get; set; }
+        }
+
+        protected class Required1
+        {
+            public int Id { get; set; }
+
+            public int ParentId { get; set; }
+            public Root Parent { get; set; }
+
+            public ICollection<Required2> Children { get; set; } = new List<Required2>();
+        }
+
+        protected class Required2
+        {
+            public int Id { get; set; }
+
+            public int ParentId { get; set; }
+            public Required1 Parent { get; set; }
+        }
+
+        protected class Optional1
+        {
+            public int Id { get; set; }
+
+            public int? ParentId { get; set; }
+            public Root Parent { get; set; }
+
+            public ICollection<Optional2> Children { get; set; } = new List<Optional2>();
+        }
+
+        protected class Optional2
+        {
+            public int Id { get; set; }
+
+            public int? ParentId { get; set; }
+            public Optional1 Parent { get; set; }
+        }
+
+        protected class RequiredSingle1
+        {
+            public int Id { get; set; }
+
+            public Root Root { get; set; }
+            public RequiredSingle2 Single { get; set; }
+        }
+
+        protected class RequiredSingle2
+        {
+            public int Id { get; set; }
+
+            public RequiredSingle1 Back { get; set; }
+        }
+
+        protected class RequiredNonPkSingle1
+        {
+            public int Id { get; set; }
+
+            public int RootId { get; set; }
+            public Root Root { get; set; }
+
+            public RequiredNonPkSingle2 Single { get; set; }
+        }
+
+        protected class RequiredNonPkSingle2
+        {
+            public int Id { get; set; }
+
+            public int BackId { get; set; }
+            public RequiredNonPkSingle1 Back { get; set; }
+        }
+
+        protected class OptionalSingle1
+        {
+            public int Id { get; set; }
+
+            public int? RootId { get; set; }
+            public Root Root { get; set; }
+
+            public OptionalSingle2 Single { get; set; }
+        }
+
+        protected class OptionalSingle2
+        {
+            public int Id { get; set; }
+
+            public int? BackId { get; set; }
+            public OptionalSingle1 Back { get; set; }
+        }
+
+        protected class RequiredAk1
+        {
+            public int Id { get; set; }
+            public Guid AlternateId { get; set; }
+
+            public Guid ParentId { get; set; }
+            public Root Parent { get; set; }
+
+            public ICollection<RequiredAk2> Children { get; set; } = new List<RequiredAk2>();
+        }
+
+        protected class RequiredAk2
+        {
+            public int Id { get; set; }
+            public Guid AlternateId { get; set; }
+
+            public Guid ParentId { get; set; }
+            public RequiredAk1 Parent { get; set; }
+        }
+
+        protected class OptionalAk1
+        {
+            public int Id { get; set; }
+            public Guid AlternateId { get; set; }
+
+            public Guid? ParentId { get; set; }
+            public Root Parent { get; set; }
+
+            public ICollection<OptionalAk2> Children { get; set; } = new List<OptionalAk2>();
+        }
+
+        protected class OptionalAk2
+        {
+            public int Id { get; set; }
+            public Guid AlternateId { get; set; }
+
+            public Guid? ParentId { get; set; }
+            public OptionalAk1 Parent { get; set; }
+        }
+
+        protected class RequiredSingleAk1
+        {
+            public int Id { get; set; }
+            public Guid AlternateId { get; set; }
+
+            public Root Root { get; set; }
+            public RequiredSingleAk2 Single { get; set; }
+        }
+
+        protected class RequiredSingleAk2
+        {
+            public int Id { get; set; }
+            public Guid AlternateId { get; set; }
+
+            public RequiredSingleAk1 Back { get; set; }
+        }
+
+        protected class RequiredNonPkSingleAk1
+        {
+            public int Id { get; set; }
+            public Guid AlternateId { get; set; }
+
+            public Guid RootId { get; set; }
+            public Root Root { get; set; }
+
+            public RequiredNonPkSingleAk2 Single { get; set; }
+        }
+
+        protected class RequiredNonPkSingleAk2
+        {
+            public int Id { get; set; }
+            public Guid AlternateId { get; set; }
+
+            public Guid BackId { get; set; }
+            public RequiredNonPkSingleAk1 Back { get; set; }
+        }
+
+        protected class OptionalSingleAk1
+        {
+            public int Id { get; set; }
+            public Guid AlternateId { get; set; }
+
+            public Guid? RootId { get; set; }
+            public Root Root { get; set; }
+
+            public OptionalSingleAk2 Single { get; set; }
+        }
+
+        protected class OptionalSingleAk2
+        {
+            public int Id { get; set; }
+            public Guid AlternateId { get; set; }
+
+            public Guid? BackId { get; set; }
+            public OptionalSingleAk1 Back { get; set; }
+        }
+
+        protected class GraphUpdatesContext : DbContext
+        {
+            public GraphUpdatesContext(IServiceProvider serviceProvider, DbContextOptions options)
+                : base(serviceProvider, options)
+            {
+            }
+
+            public DbSet<Root> Roots { get; set; }
+            public DbSet<RequiredSingle1> RequiredSingle1s { get; set; }
+            public DbSet<RequiredSingle2> RequiredSingle2s { get; set; }
+            public DbSet<RequiredNonPkSingle1> RequiredNonPkSingle1s { get; set; }
+            public DbSet<RequiredNonPkSingle2> RequiredNonPkSingle2s { get; set; }
+            public DbSet<OptionalSingle1> OptionalSingle1s { get; set; }
+            public DbSet<OptionalSingle2> OptionalSingle2s { get; set; }
+            public DbSet<Required1> Required1s { get; set; }
+            public DbSet<Optional1> Optional1s { get; set; }
+            public DbSet<Required2> Required2s { get; set; }
+            public DbSet<Optional2> Optional2s { get; set; }
+
+            public DbSet<RequiredSingleAk1> RequiredSingleAk1s { get; set; }
+            public DbSet<RequiredSingleAk2> RequiredSingleAk2s { get; set; }
+            public DbSet<RequiredNonPkSingleAk1> RequiredNonPkSingleAk1s { get; set; }
+            public DbSet<RequiredNonPkSingleAk2> RequiredNonPkSingleAk2s { get; set; }
+            public DbSet<OptionalSingleAk1> OptionalSingleAk1s { get; set; }
+            public DbSet<OptionalSingleAk2> OptionalSingleAk2s { get; set; }
+            public DbSet<RequiredAk1> RequiredAk1s { get; set; }
+            public DbSet<OptionalAk1> OptionalAk1s { get; set; }
+            public DbSet<RequiredAk2> RequiredAk2s { get; set; }
+            public DbSet<OptionalAk2> OptionalAk2s { get; set; }
+        }
+
+        protected GraphUpdatesContext CreateContext()
+        {
+            return (GraphUpdatesContext)Fixture.CreateContext(TestStore);
+        }
+
+        public void Dispose()
+        {
+            TestStore.Dispose();
+        }
+
+        protected TFixture Fixture { get; }
+
+        protected TTestStore TestStore { get; }
+
+        public abstract class GraphUpdatesFixtureBase
+        {
+            public abstract TTestStore CreateTestStore();
+
+            public abstract DbContext CreateContext(TTestStore testStore);
+
+            protected virtual void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<Root>(b =>
+                    {
+                        b.HasMany(e => e.RequiredChildren)
+                            .WithOne(e => e.Parent)
+                            .ForeignKey(e => e.ParentId);
+
+                        b.HasMany(e => e.OptionalChildren)
+                            .WithOne(e => e.Parent)
+                            .ForeignKey(e => e.ParentId);
+
+                        b.HasOne(e => e.RequiredSingle)
+                            .WithOne(e => e.Root)
+                            .ForeignKey<RequiredSingle1>(e => e.Id);
+
+                        b.HasOne(e => e.OptionalSingle)
+                            .WithOne(e => e.Root)
+                            .ForeignKey<OptionalSingle1>(e => e.RootId);
+
+                        b.HasOne(e => e.RequiredNonPkSingle)
+                            .WithOne(e => e.Root)
+                            .ForeignKey<RequiredNonPkSingle1>(e => e.RootId);
+
+                        b.HasMany(e => e.RequiredChildrenAk)
+                            .WithOne(e => e.Parent)
+                            .ReferencedKey(e => e.AlternateId)
+                            .ForeignKey(e => e.ParentId);
+
+                        b.HasMany(e => e.OptionalChildrenAk)
+                            .WithOne(e => e.Parent)
+                            .ReferencedKey(e => e.AlternateId)
+                            .ForeignKey(e => e.ParentId);
+
+                        b.HasOne(e => e.RequiredSingleAk)
+                            .WithOne(e => e.Root)
+                            .ReferencedKey<Root>(e => e.AlternateId)
+                            .ForeignKey<RequiredSingleAk1>(e => e.AlternateId);
+
+                        b.HasOne(e => e.OptionalSingleAk)
+                            .WithOne(e => e.Root)
+                            .ReferencedKey<Root>(e => e.AlternateId)
+                            .ForeignKey<OptionalSingleAk1>(e => e.RootId);
+
+                        b.HasOne(e => e.RequiredNonPkSingleAk)
+                            .WithOne(e => e.Root)
+                            .ReferencedKey<Root>(e => e.AlternateId)
+                            .ForeignKey<RequiredNonPkSingleAk1>(e => e.RootId);
+                    });
+
+                modelBuilder.Entity<Required1>()
+                    .HasMany(e => e.Children)
+                    .WithOne(e => e.Parent)
+                    .ForeignKey(e => e.ParentId);
+
+                modelBuilder.Entity<Optional1>()
+                    .HasMany(e => e.Children)
+                    .WithOne(e => e.Parent)
+                    .ForeignKey(e => e.ParentId);
+
+                modelBuilder.Entity<RequiredSingle1>()
+                    .HasOne(e => e.Single)
+                    .WithOne(e => e.Back)
+                    .ForeignKey<RequiredSingle2>(e => e.Id);
+
+                modelBuilder.Entity<OptionalSingle1>()
+                    .HasOne(e => e.Single)
+                    .WithOne(e => e.Back)
+                    .ForeignKey<OptionalSingle2>(e => e.BackId);
+
+                modelBuilder.Entity<RequiredNonPkSingle1>()
+                    .HasOne(e => e.Single)
+                    .WithOne(e => e.Back)
+                    .ForeignKey<RequiredNonPkSingle2>(e => e.BackId);
+
+                modelBuilder.Entity<RequiredAk1>()
+                    .HasMany(e => e.Children)
+                    .WithOne(e => e.Parent)
+                    .ReferencedKey(e => e.AlternateId)
+                    .ForeignKey(e => e.ParentId);
+
+                modelBuilder.Entity<OptionalAk1>()
+                    .HasMany(e => e.Children)
+                    .WithOne(e => e.Parent)
+                    .ReferencedKey(e => e.AlternateId)
+                    .ForeignKey(e => e.ParentId);
+
+                // This code fails--see Issue #1495
+                //modelBuilder.Entity<RequiredSingleAk1>()
+                //    .HasOne(e => e.Single)
+                //    .WithOne(e => e.Back)
+                //    .ReferencedKey<RequiredSingleAk1>(e => e.AlternateId)
+                //    .ForeignKey<RequiredSingleAk2>(e => e.AlternateId);
+
+                //modelBuilder.Entity<OptionalSingleAk1>()
+                //    .HasOne(e => e.Single)
+                //    .WithOne(e => e.Back)
+                //    .ForeignKey<OptionalSingleAk2>(e => e.BackId)
+                //    .ReferencedKey<OptionalSingleAk1>(e => e.AlternateId);
+
+                //modelBuilder.Entity<RequiredNonPkSingleAk1>()
+                //    .HasOne(e => e.Single)
+                //    .WithOne(e => e.Back)
+                //    .ForeignKey<RequiredNonPkSingleAk2>(e => e.BackId)
+                //    .ReferencedKey<RequiredNonPkSingleAk1>(e => e.AlternateId);
+
+                // This code removes the relationships discovered by convention and adds them back manually
+                // to work around issue #1495.
+                var requiredSingle1 = modelBuilder.Entity<RequiredSingleAk1>().Metadata;
+                var requiredSingle2 = modelBuilder.Entity<RequiredSingleAk2>().Metadata;
+                requiredSingle1.RemoveNavigation(requiredSingle1.GetNavigation("Single"));
+                requiredSingle2.RemoveNavigation(requiredSingle2.GetNavigation("Back"));
+                requiredSingle1.RemoveForeignKey(requiredSingle1.ForeignKeys.Single(fk => fk.Properties.Single().Name == "Id"));
+
+                var optionalSingle1 = modelBuilder.Entity<OptionalSingleAk1>().Metadata;
+                var optionalSingle2 = modelBuilder.Entity<OptionalSingleAk2>().Metadata;
+                optionalSingle1.RemoveNavigation(optionalSingle1.GetNavigation("Single"));
+                optionalSingle2.RemoveNavigation(optionalSingle2.GetNavigation("Back"));
+                optionalSingle1.RemoveForeignKey(optionalSingle1.ForeignKeys.Single(fk => fk.Properties.Single().Name == "Id"));
+
+                var nonPkSingle1 = modelBuilder.Entity<RequiredNonPkSingleAk1>().Metadata;
+                var nonPkSingle2 = modelBuilder.Entity<RequiredNonPkSingleAk2>().Metadata;
+                nonPkSingle1.RemoveNavigation(nonPkSingle1.GetNavigation("Single"));
+                nonPkSingle2.RemoveNavigation(nonPkSingle2.GetNavigation("Back"));
+                nonPkSingle1.RemoveForeignKey(nonPkSingle1.ForeignKeys.Single(fk => fk.Properties.Single().Name == "Id"));
+
+                var requiredFk = requiredSingle2.GetOrAddForeignKey(
+                    requiredSingle2.GetProperty("AlternateId"),
+                    requiredSingle1.GetOrAddKey(requiredSingle1.GetProperty("AlternateId")));
+                requiredFk.IsUnique = true;
+                requiredSingle1.AddNavigation("Single", requiredFk, pointsToPrincipal: false);
+                requiredSingle2.AddNavigation("Back", requiredFk, pointsToPrincipal: true);
+
+                var optionalFk = optionalSingle2.GetOrAddForeignKey(
+                    optionalSingle2.GetProperty("BackId"),
+                    optionalSingle1.GetOrAddKey(optionalSingle1.GetProperty("AlternateId")));
+                optionalFk.IsUnique = true;
+                optionalSingle1.AddNavigation("Single", optionalFk, pointsToPrincipal: false);
+                optionalSingle2.AddNavigation("Back", optionalFk, pointsToPrincipal: true);
+
+                var nonPkFk = nonPkSingle2.GetOrAddForeignKey(
+                    nonPkSingle2.GetProperty("BackId"),
+                    nonPkSingle1.GetOrAddKey(nonPkSingle1.GetProperty("AlternateId")));
+                nonPkFk.IsUnique = true;
+                nonPkSingle1.AddNavigation("Single", nonPkFk, pointsToPrincipal: false);
+                nonPkSingle2.AddNavigation("Back", nonPkFk, pointsToPrincipal: true);
+            }
+
+            protected virtual void Seed(DbContext context)
+            {
+                context.ChangeTracker.AttachGraph(CreateFullGraph());
+                context.SaveChanges();
+            }
+        }
+    }
+}

--- a/test/EntityFramework.Core.Tests/ChangeTracking/NavigationFixerTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/NavigationFixerTest.cs
@@ -45,8 +45,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var dependentEntry = manager.StartTracking(manager.GetOrCreateEntry(dependent));
 
-            var fixer = CreateNavigationFixer(contextServices);
-            fixer.StateChanged(dependentEntry, EntityState.Unknown);
+            dependentEntry.SetEntityState(EntityState.Added);
 
             Assert.Same(dependent.Category, principal2);
             Assert.Contains(dependent, principal2.Products);
@@ -105,12 +104,10 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var dependentEntry2 = manager.StartTracking(manager.GetOrCreateEntry(dependent2));
             var dependentEntry4 = manager.StartTracking(manager.GetOrCreateEntry(dependent4));
 
-            var fixer = CreateNavigationFixer(contextServices);
-
             Assert.Null(principal1.Detail);
             Assert.Null(dependent1.Product);
 
-            fixer.StateChanged(principalEntry1, EntityState.Unknown);
+            principalEntry1.SetEntityState(EntityState.Added);
 
             Assert.Same(principal1, dependent1.Product);
             Assert.Same(dependent1, principal1.Detail);
@@ -118,7 +115,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             Assert.Null(principal2.Detail);
             Assert.Null(dependent2.Product);
 
-            fixer.StateChanged(dependentEntry2, EntityState.Unknown);
+            dependentEntry2.SetEntityState(EntityState.Added);
 
             Assert.Same(principal2, dependent2.Product);
             Assert.Same(dependent2, principal2.Detail);
@@ -126,8 +123,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             Assert.Null(principal3.Detail);
             Assert.Null(dependent4.Product);
 
-            fixer.StateChanged(principalEntry3, EntityState.Unknown);
-            fixer.StateChanged(dependentEntry4, EntityState.Unknown);
+            principalEntry3.SetEntityState(EntityState.Added);
+            dependentEntry4.SetEntityState(EntityState.Added);
 
             Assert.Null(principal3.Detail);
             Assert.Null(dependent4.Product);
@@ -147,8 +144,6 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var entry2 = manager.StartTracking(manager.GetOrCreateEntry(entity2));
             var entry3 = manager.StartTracking(manager.GetOrCreateEntry(entity3));
 
-            var fixer = CreateNavigationFixer(contextServices);
-
             Assert.Null(entity1.AlternateProduct);
             Assert.Null(entity1.OriginalProduct);
 
@@ -158,7 +153,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             Assert.Null(entity3.AlternateProduct);
             Assert.Null(entity3.OriginalProduct);
 
-            fixer.StateChanged(entry1, EntityState.Unknown);
+            entry1.SetEntityState(EntityState.Added);
 
             Assert.Same(entity2, entity1.AlternateProduct);
             Assert.Null(entity1.OriginalProduct);
@@ -169,7 +164,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             Assert.Null(entity3.AlternateProduct);
             Assert.Null(entity3.OriginalProduct);
 
-            fixer.StateChanged(entry3, EntityState.Unknown);
+            entry3.SetEntityState(EntityState.Added);
 
             Assert.Same(entity2, entity1.AlternateProduct);
             Assert.Null(entity1.OriginalProduct);
@@ -196,8 +191,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var dependentEntry = manager.StartTracking(manager.GetOrCreateEntry(dependent));
 
-            var fixer = CreateNavigationFixer(contextServices);
-            fixer.StateChanged(dependentEntry, EntityState.Unknown);
+            dependentEntry.SetEntityState(EntityState.Added);
 
             Assert.Equal(12, dependent.CategoryId);
             Assert.Same(dependent.Category, principal2);
@@ -222,8 +216,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var dependentEntry = manager.StartTracking(manager.GetOrCreateEntry(dependent));
 
-            var fixer = CreateNavigationFixer(contextServices);
-            fixer.StateChanged(dependentEntry, EntityState.Unknown);
+            dependentEntry.SetEntityState(EntityState.Added);
 
             Assert.Equal(12, dependent.CategoryId);
             Assert.Same(dependent.Category, principal2);
@@ -249,8 +242,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var principalEntry = manager.StartTracking(manager.GetOrCreateEntry(principal));
 
-            var fixer = CreateNavigationFixer(contextServices);
-            fixer.StateChanged(principalEntry, EntityState.Unknown);
+            principalEntry.SetEntityState(EntityState.Added);
 
             Assert.Equal(11, dependent1.CategoryId);
             Assert.Equal(0, dependent2.CategoryId);
@@ -286,8 +278,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var principalEntry = manager.StartTracking(manager.GetOrCreateEntry(principal));
 
-            var fixer = CreateNavigationFixer(contextServices);
-            fixer.StateChanged(principalEntry, EntityState.Unknown);
+            principalEntry.SetEntityState(EntityState.Added);
 
             Assert.Equal(11, dependent1.CategoryId);
             Assert.Equal(0, dependent2.CategoryId);
@@ -319,8 +310,6 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var entry2 = manager.StartTracking(manager.GetOrCreateEntry(entity2));
             var entry3 = manager.StartTracking(manager.GetOrCreateEntry(entity3));
 
-            var fixer = CreateNavigationFixer(contextServices);
-
             Assert.Null(entity1.AlternateProductId);
             Assert.Null(entity2.AlternateProductId);
             Assert.Null(entity3.AlternateProductId);
@@ -334,7 +323,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             Assert.Null(entity3.AlternateProduct);
             Assert.Null(entity3.OriginalProduct);
 
-            fixer.StateChanged(entry1, EntityState.Unknown);
+            entry1.SetEntityState(EntityState.Added);
 
             Assert.Equal(22, entity1.AlternateProductId);
             Assert.Null(entity2.AlternateProductId);
@@ -349,7 +338,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             Assert.Null(entity3.AlternateProduct);
             Assert.Null(entity3.OriginalProduct);
 
-            fixer.StateChanged(entry3, EntityState.Unknown);
+            entry3.SetEntityState(EntityState.Added);
 
             Assert.Equal(22, entity1.AlternateProductId);
             Assert.Equal(23, entity2.AlternateProductId);
@@ -382,8 +371,6 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var entry2 = manager.StartTracking(manager.GetOrCreateEntry(entity2));
             var entry3 = manager.StartTracking(manager.GetOrCreateEntry(entity3));
 
-            var fixer = CreateNavigationFixer(contextServices);
-
             Assert.Null(entity1.AlternateProductId);
             Assert.Null(entity2.AlternateProductId);
             Assert.Null(entity3.AlternateProductId);
@@ -397,7 +384,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             Assert.Null(entity3.AlternateProduct);
             Assert.Same(entity2, entity3.OriginalProduct);
 
-            fixer.StateChanged(entry1, EntityState.Unknown);
+            entry1.SetEntityState(EntityState.Added);
 
             Assert.Equal(22, entity1.AlternateProductId);
             Assert.Null(entity2.AlternateProductId);
@@ -412,7 +399,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             Assert.Null(entity3.AlternateProduct);
             Assert.Same(entity2, entity3.OriginalProduct);
 
-            fixer.StateChanged(entry3, EntityState.Unknown);
+            entry3.SetEntityState(EntityState.Added);
 
             Assert.Equal(22, entity1.AlternateProductId);
             Assert.Equal(23, entity2.AlternateProductId);
@@ -445,7 +432,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var dependentEntry = manager.StartTracking(manager.GetOrCreateEntry(dependent));
 
             var fixer = CreateNavigationFixer(contextServices);
-            fixer.StateChanged(dependentEntry, EntityState.Unknown);
+            dependentEntry.SetEntityState(EntityState.Added);
 
             Assert.Null(dependent.Category);
             Assert.DoesNotContain(dependent, principal2.Products);
@@ -477,7 +464,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var dependentEntry = manager.StartTracking(manager.GetOrCreateEntry(dependent));
 
             var fixer = CreateNavigationFixer(contextServices);
-            fixer.StateChanged(dependentEntry, EntityState.Unknown);
+            dependentEntry.SetEntityState(EntityState.Added);
 
             Assert.Same(dependent.Category, principal2);
             Assert.Contains(dependent, principal2.Products);
@@ -509,7 +496,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var dependentEntry = manager.StartTracking(manager.GetOrCreateEntry(dependent));
 
             var fixer = CreateNavigationFixer(contextServices);
-            fixer.StateChanged(dependentEntry, EntityState.Unknown);
+            dependentEntry.SetEntityState(EntityState.Added);
 
             Assert.Same(dependent.Category, principal2);
             Assert.Contains(dependent, principal2.Products);
@@ -541,7 +528,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var fixer = CreateNavigationFixer(contextServices);
 
-            fixer.StateChanged(principalEntry1, EntityState.Unknown);
+            principalEntry1.SetEntityState(EntityState.Added);
 
             Assert.Same(principal1, dependent.Product);
             Assert.Same(dependent, principal1.Detail);
@@ -571,7 +558,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var fixer = CreateNavigationFixer(contextServices);
 
-            fixer.StateChanged(principalEntry, EntityState.Unknown);
+            principalEntry.SetEntityState(EntityState.Added);
 
             Assert.Same(principal, dependent.Product);
             Assert.Same(dependent, principal.Detail);
@@ -599,7 +586,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var fixer = CreateNavigationFixer(contextServices);
 
-            fixer.StateChanged(principalEntry, EntityState.Unknown);
+            principalEntry.SetEntityState(EntityState.Added);
 
             Assert.Null(dependent.Product);
             Assert.Null(principal.Detail);
@@ -631,8 +618,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var fixer = CreateNavigationFixer(contextServices);
 
-            fixer.StateChanged(principalEntry1, EntityState.Unknown);
-            fixer.StateChanged(principalEntry2, EntityState.Unknown);
+            principalEntry1.SetEntityState(EntityState.Added);
+            principalEntry2.SetEntityState(EntityState.Added);
 
             Assert.Same(principal1, dependent1.Product);
             Assert.Same(dependent1, principal1.Detail);
@@ -666,9 +653,9 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var fixer = CreateNavigationFixer(contextServices);
 
-            fixer.StateChanged(entry1, EntityState.Unknown);
-            fixer.StateChanged(entry1, EntityState.Unknown);
-            fixer.StateChanged(entry3, EntityState.Unknown);
+            entry1.SetEntityState(EntityState.Added);
+            entry1.SetEntityState(EntityState.Added);
+            entry3.SetEntityState(EntityState.Added);
 
             Assert.Same(entity2, entity1.AlternateProduct);
             Assert.Null(entity1.OriginalProduct);
@@ -710,9 +697,9 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var fixer = CreateNavigationFixer(contextServices);
 
-            fixer.StateChanged(entry1, EntityState.Unknown);
-            fixer.StateChanged(entry1, EntityState.Unknown);
-            fixer.StateChanged(entry3, EntityState.Unknown);
+            entry1.SetEntityState(EntityState.Added);
+            entry1.SetEntityState(EntityState.Added);
+            entry3.SetEntityState(EntityState.Added);
 
             Assert.Same(entity2, entity1.AlternateProduct);
             Assert.Null(entity1.OriginalProduct);
@@ -788,22 +775,22 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var fixer = CreateNavigationFixer(contextServices);
 
-            fixer.StateChanged(photoEntry1, EntityState.Unknown);
-            fixer.StateChanged(photoEntry2, EntityState.Unknown);
-            fixer.StateChanged(photoEntry3, EntityState.Unknown);
-            fixer.StateChanged(photoEntry4, EntityState.Unknown);
-            fixer.StateChanged(reviewEntry1, EntityState.Unknown);
-            fixer.StateChanged(reviewEntry2, EntityState.Unknown);
-            fixer.StateChanged(reviewEntry3, EntityState.Unknown);
-            fixer.StateChanged(reviewEntry4, EntityState.Unknown);
-            fixer.StateChanged(tagEntry1, EntityState.Unknown);
-            fixer.StateChanged(tagEntry2, EntityState.Unknown);
-            fixer.StateChanged(tagEntry3, EntityState.Unknown);
-            fixer.StateChanged(tagEntry4, EntityState.Unknown);
-            fixer.StateChanged(tagEntry5, EntityState.Unknown);
-            fixer.StateChanged(tagEntry6, EntityState.Unknown);
-            fixer.StateChanged(tagEntry7, EntityState.Unknown);
-            fixer.StateChanged(tagEntry8, EntityState.Unknown);
+            photoEntry1.SetEntityState(EntityState.Added);
+            photoEntry2.SetEntityState(EntityState.Added);
+            photoEntry3.SetEntityState(EntityState.Added);
+            photoEntry4.SetEntityState(EntityState.Added);
+            reviewEntry1.SetEntityState(EntityState.Added);
+            reviewEntry2.SetEntityState(EntityState.Added);
+            reviewEntry3.SetEntityState(EntityState.Added);
+            reviewEntry4.SetEntityState(EntityState.Added);
+            tagEntry1.SetEntityState(EntityState.Added);
+            tagEntry2.SetEntityState(EntityState.Added);
+            tagEntry3.SetEntityState(EntityState.Added);
+            tagEntry4.SetEntityState(EntityState.Added);
+            tagEntry5.SetEntityState(EntityState.Added);
+            tagEntry6.SetEntityState(EntityState.Added);
+            tagEntry7.SetEntityState(EntityState.Added);
+            tagEntry8.SetEntityState(EntityState.Added);
 
             Assert.Equal(new[] { tag1, tag2 }, photo1.ProductTags.OrderBy(t => t.Id).ToArray());
             Assert.Equal(new[] { tag3, tag4 }, photo2.ProductTags.OrderBy(t => t.Id).ToArray());

--- a/test/EntityFramework.InMemory.FunctionalTests/EntityFramework.InMemory.FunctionalTests.csproj
+++ b/test/EntityFramework.InMemory.FunctionalTests/EntityFramework.InMemory.FunctionalTests.csproj
@@ -69,6 +69,7 @@
     <Compile Include="InMemoryAsNoTrackingTest.cs" />
     <Compile Include="InMemoryChangeTrackingTest.cs" />
     <Compile Include="InMemoryFixture.cs" />
+    <Compile Include="InMemoryGraphUpdatesTest.cs" />
     <Compile Include="InMemoryNullKeysTest.cs" />
     <Compile Include="InMemoryTestStore.cs" />
     <Compile Include="InMemoryBuiltInDataTypesFixture.cs" />

--- a/test/EntityFramework.InMemory.FunctionalTests/InMemoryGraphUpdatesTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/InMemoryGraphUpdatesTest.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.DependencyInjection.Fallback;
+
+namespace Microsoft.Data.Entity.InMemory.FunctionalTests
+{
+    public class InMemoryGraphUpdatesTest : GraphUpdatesTestBase<InMemoryTestStore, InMemoryGraphUpdatesTest.InMemoryGraphUpdatesFixture>
+    {
+        public InMemoryGraphUpdatesTest(InMemoryGraphUpdatesFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        public class InMemoryGraphUpdatesFixture : GraphUpdatesFixtureBase
+        {
+            public static readonly string DatabaseName = "GraphUpdatesTest";
+
+            private readonly IServiceProvider _serviceProvider;
+
+            public InMemoryGraphUpdatesFixture()
+            {
+                _serviceProvider = new ServiceCollection()
+                    .AddEntityFramework()
+                    .AddInMemoryStore()
+                    .ServiceCollection
+                    .AddSingleton<InMemoryModelSource>(p => new TestInMemoryModelSource(OnModelCreating))
+                    .BuildServiceProvider();
+            }
+
+            public override InMemoryTestStore CreateTestStore()
+            {
+                var store = new InMemoryGraphUpdatesTestStore(_serviceProvider);
+                Seed(store.Context);
+                return store;
+            }
+
+            public override DbContext CreateContext(InMemoryTestStore testStore)
+            {
+                return ((InMemoryGraphUpdatesTestStore)testStore).Context;
+            }
+        }
+
+        public class InMemoryGraphUpdatesTestStore : InMemoryTestStore
+        {
+            public InMemoryGraphUpdatesTestStore(IServiceProvider serviceProvider)
+            {
+                var options = new DbContextOptions();
+                options.UseInMemoryStore(persist: true);
+
+                Context = new GraphUpdatesContext(serviceProvider, options);
+
+                Context.Database.EnsureCreated();
+            }
+
+            public DbContext Context { get; }
+
+            public override void Dispose()
+            {
+                Context.Database.EnsureDeleted();
+
+                base.Dispose();
+            }
+        }
+    }
+}

--- a/test/EntityFramework.InMemory.FunctionalTests/InMemoryTestStore.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/InMemoryTestStore.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Threading.Tasks;
 using Microsoft.Data.Entity.FunctionalTests;
 
 namespace Microsoft.Data.Entity.InMemory.FunctionalTests

--- a/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
+++ b/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
@@ -93,6 +93,7 @@
     <Compile Include="SqlServerFixture.cs" />
     <Compile Include="SqlServerGearsOfWarQueryFixture.cs" />
     <Compile Include="SqlServerGearsOfWarQueryTest.cs" />
+    <Compile Include="SqlServerGraphUpdatesTest.cs" />
     <Compile Include="SqlServerIncludeAsyncTest.cs" />
     <Compile Include="SqlServerIncludeOneToOneTest.cs" />
     <Compile Include="SqlServerIncludeTest.cs" />

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerGraphUpdatesTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerGraphUpdatesTest.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.DependencyInjection.Fallback;
+
+namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
+{
+    public class SqlServerGraphUpdatesTest : GraphUpdatesTestBase<SqlServerTestStore, SqlServerGraphUpdatesTest.SqlServerGraphUpdatesFixture>
+    {
+        public SqlServerGraphUpdatesTest(SqlServerGraphUpdatesFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        public class SqlServerGraphUpdatesFixture : GraphUpdatesFixtureBase
+        {
+            public static readonly string DatabaseName = "GraphUpdatesTest";
+
+            private readonly IServiceProvider _serviceProvider;
+
+            private readonly string _connectionString = SqlServerTestStore.CreateConnectionString(DatabaseName);
+
+            public SqlServerGraphUpdatesFixture()
+            {
+                _serviceProvider = new ServiceCollection()
+                    .AddEntityFramework()
+                    .AddSqlServer()
+                    .ServiceCollection
+                    .AddSingleton<SqlServerModelSource>(p => new TestSqlServerModelSource(OnModelCreating))
+                    .BuildServiceProvider();
+            }
+
+            public override SqlServerTestStore CreateTestStore()
+            {
+                return SqlServerTestStore.GetOrCreateShared(DatabaseName, () =>
+                    {
+                        var options = new DbContextOptions();
+                        options.UseSqlServer(_connectionString);
+
+                        using (var context = new GraphUpdatesContext(_serviceProvider, options))
+                        {
+                            context.Database.EnsureDeleted();
+                            if (context.Database.EnsureCreated())
+                            {
+                                Seed(context);
+                            }
+                        }
+                    });
+            }
+
+            public override DbContext CreateContext(SqlServerTestStore testStore)
+            {
+                var options = new DbContextOptions();
+                options.UseSqlServer(testStore.Connection);
+
+                var context = new GraphUpdatesContext(_serviceProvider, options);
+                context.Database.AsRelational().Connection.UseTransaction(testStore.Transaction);
+                return context;
+            }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                base.OnModelCreating(modelBuilder);
+
+                modelBuilder.ForSqlServer().UseSequence();
+            }
+        }
+    }
+}


### PR DESCRIPTION
These tests cover adding, removing, and changing relationships between entities. Dimensions are:
* Multiplicity (1:1, 1:*)
* Required/optional relationships
* PK <-> PK and PK <-> FK
* New (Added) entities or existing (Unchanged) entities
* Changing relationship at principal end, dependent end, or using FK
* PK principal keys or alternate principal keys

Note that these tests do no cover deleting entities, composite keys, or unidirectional navigations. Also, we don't yet handle conceptually null FKs.