### PR TITLE
Remove uses of CreateScratchAsync from test fixtures

### DIFF
--- a/test/EntityFramework.SqlServer.FunctionalTests/BatchingTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/BatchingTest.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
         public BatchingTest()
         {
-            _testStore = SqlServerTestStore.CreateScratchAsync().Result;
+            _testStore = SqlServerTestStore.CreateScratch();
             _serviceProvider = new ServiceCollection()
                 .AddEntityFramework()
                 .AddSqlServer()

--- a/test/EntityFramework.SqlServer.FunctionalTests/DeadlockTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/DeadlockTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
         protected override SqlServerTestDatabase CreateTestDatabase()
         {
-            return SqlServerTestDatabase.Scratch(createDatabase: false).Result;
+            return SqlServerTestDatabase.Scratch(createDatabase: false);
         }
 
         protected override DbContext CreateContext(SqlServerTestDatabase testDatabase)

--- a/test/EntityFramework.SqlServer.FunctionalTests/MappingQueryFixture.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/MappingQueryFixture.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 .AddInstance<ILoggerFactory>(new TestSqlLoggerFactory())
                 .BuildServiceProvider();
 
-            _testDatabase = SqlServerNorthwindContext.GetSharedStoreAsync().Result;
+            _testDatabase = SqlServerNorthwindContext.GetSharedStore();
 
             _options = new DbContextOptions()
                 .UseModel(CreateModel());

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerBuiltInDataTypesFixture.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerBuiltInDataTypesFixture.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
         public override SqlServerTestStore CreateTestStore()
         {
-            return SqlServerTestStore.CreateScratchAsync().Result;
+            return SqlServerTestStore.CreateScratch();
         }
 
         public override DbContext CreateContext(SqlServerTestStore testStore)

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerOneToOneQueryFixture.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerOneToOneQueryFixture.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                     .BuildServiceProvider();
 
             var model = CreateModel();
-            var database = SqlServerTestStore.CreateScratchAsync().Result;
+            var database = SqlServerTestStore.CreateScratch();
 
             _options
                 = new DbContextOptions()

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerTransactionFixture.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerTransactionFixture.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
         public override SqlServerTestStore CreateTestStore()
         {
-            var db = SqlServerTestStore.CreateScratchAsync().Result;
+            var db = SqlServerTestStore.CreateScratch();
 
             using (var command = db.Connection.CreateCommand())
             {


### PR DESCRIPTION
I missed these cases in the previous change.