### PR TITLE
fix to #1485 - enable GearsOfWar sql tests disabled by recent test change

### DIFF
--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerGearsOfWarQueryFixture.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerGearsOfWarQueryFixture.cs
@@ -47,6 +47,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                         {
                             GearsOfWarModelInitializer.Seed(context);
                         }
+
+                        TestSqlLoggerFactory.SqlStatements.Clear();
                     }
                 });
         }

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerGearsOfWarQueryTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerGearsOfWarQueryTest.cs
@@ -14,108 +14,108 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         {
         }
 
-        // SQL logging disabled: See Issue #1485.
-        //        public override void Include_multiple_one_to_one_and_one_to_many()
-        //        {
-        //            base.Include_multiple_one_to_one_and_one_to_many();
+        //SQL logging disabled: See Issue #1485.
+        public override void Include_multiple_one_to_one_and_one_to_many()
+        {
+            base.Include_multiple_one_to_one_and_one_to_many();
 
-        //            Assert.Equal(
-        //                @"SELECT [t].[GearNickName], [t].[GearSquadId], [t].[Id], [t].[Note], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Nickname], [g].[Rank], [g].[SquadId]
-        //FROM [CogTag] AS [t]
-        //LEFT JOIN [Gear] AS [g] ON ([t].[GearNickName] = [g].[Nickname] AND [t].[GearSquadId] = [g].[SquadId])
-        //ORDER BY [g].[Nickname], [g].[SquadId]
+            Assert.Equal(
+@"SELECT [t].[GearNickName], [t].[GearSquadId], [t].[Id], [t].[Note], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Nickname], [g].[Rank], [g].[SquadId]
+FROM [CogTag] AS [t]
+LEFT JOIN [Gear] AS [g] ON ([t].[GearNickName] = [g].[Nickname] AND [t].[GearSquadId] = [g].[SquadId])
+ORDER BY [g].[Nickname], [g].[SquadId]
 
-        //SELECT [w].[Id], [w].[Name], [w].[OwnerNickname], [w].[OwnerSquadId], [w].[SynergyWithId]
-        //FROM [Weapon] AS [w]
-        //INNER JOIN (
-        //    SELECT DISTINCT [g].[Nickname], [g].[SquadId]
-        //    FROM [CogTag] AS [t]
-        //    LEFT JOIN [Gear] AS [g] ON ([t].[GearNickName] = [g].[Nickname] AND [t].[GearSquadId] = [g].[SquadId])
-        //) AS [g] ON ([w].[OwnerNickname] = [g].[Nickname] AND [w].[OwnerSquadId] = [g].[SquadId])
-        //ORDER BY [g].[Nickname], [g].[SquadId]",
-        //                Sql);
-        //        }
+SELECT [w].[Id], [w].[Name], [w].[OwnerNickname], [w].[OwnerSquadId], [w].[SynergyWithId]
+FROM [Weapon] AS [w]
+INNER JOIN (
+    SELECT DISTINCT [g].[Nickname], [g].[SquadId]
+    FROM [CogTag] AS [t]
+    LEFT JOIN [Gear] AS [g] ON ([t].[GearNickName] = [g].[Nickname] AND [t].[GearSquadId] = [g].[SquadId])
+) AS [g] ON ([w].[OwnerNickname] = [g].[Nickname] AND [w].[OwnerSquadId] = [g].[SquadId])
+ORDER BY [g].[Nickname], [g].[SquadId]",
+                Sql);
+        }
 
-        //        public override void Include_multiple_one_to_one_and_one_to_many_self_reference()
-        //        {
-        //            base.Include_multiple_one_to_one_and_one_to_many_self_reference();
+        public override void Include_multiple_one_to_one_and_one_to_many_self_reference()
+        {
+            base.Include_multiple_one_to_one_and_one_to_many_self_reference();
 
-        //            Assert.Equal(
-        //                @"SELECT [t].[GearNickName], [t].[GearSquadId], [t].[Id], [t].[Note], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Nickname], [g].[Rank], [g].[SquadId]
-        //FROM [CogTag] AS [t]
-        //LEFT JOIN [Gear] AS [g] ON ([t].[GearNickName] = [g].[Nickname] AND [t].[GearSquadId] = [g].[SquadId])
-        //ORDER BY [g].[Nickname], [g].[SquadId]
+            Assert.Equal(
+@"SELECT [t].[GearNickName], [t].[GearSquadId], [t].[Id], [t].[Note], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Nickname], [g].[Rank], [g].[SquadId]
+FROM [CogTag] AS [t]
+LEFT JOIN [Gear] AS [g] ON ([t].[GearNickName] = [g].[Nickname] AND [t].[GearSquadId] = [g].[SquadId])
+ORDER BY [g].[Nickname], [g].[SquadId]
 
-        //SELECT [g].[AssignedCityName], [g].[CityOrBirthName], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Nickname], [g].[Rank], [g].[SquadId]
-        //FROM [Gear] AS [g]
-        //INNER JOIN (
-        //    SELECT DISTINCT [g].[Nickname], [g].[SquadId]
-        //    FROM [CogTag] AS [t]
-        //    LEFT JOIN [Gear] AS [g] ON ([t].[GearNickName] = [g].[Nickname] AND [t].[GearSquadId] = [g].[SquadId])
-        //) AS [g0] ON ([g].[LeaderNickname] = [g0].[Nickname] AND [g].[LeaderSquadId] = [g0].[SquadId])
-        //ORDER BY [g0].[Nickname], [g0].[SquadId]",
-        //                Sql);
-        //        }
+SELECT [g].[AssignedCityName], [g].[CityOrBirthName], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Nickname], [g].[Rank], [g].[SquadId]
+FROM [Gear] AS [g]
+INNER JOIN (
+    SELECT DISTINCT [g].[Nickname], [g].[SquadId]
+    FROM [CogTag] AS [t]
+    LEFT JOIN [Gear] AS [g] ON ([t].[GearNickName] = [g].[Nickname] AND [t].[GearSquadId] = [g].[SquadId])
+) AS [g0] ON ([g].[LeaderNickname] = [g0].[Nickname] AND [g].[LeaderSquadId] = [g0].[SquadId])
+ORDER BY [g0].[Nickname], [g0].[SquadId]",
+                Sql);
+        }
 
-        //        public override void Include_multiple_one_to_one_and_one_to_one_and_one_to_many()
-        //        {
-        //            base.Include_multiple_one_to_one_and_one_to_one_and_one_to_many();
+        public override void Include_multiple_one_to_one_and_one_to_one_and_one_to_many()
+        {
+            base.Include_multiple_one_to_one_and_one_to_one_and_one_to_many();
 
-        //            Assert.Equal(
-        //                @"TBD", Sql);
-        //        }
+            Assert.Equal(
+                @"TBD", Sql);
+        }
 
-        //        public override void Include_multiple_one_to_one_optional_and_one_to_one_required()
-        //        {
-        //            base.Include_multiple_one_to_one_optional_and_one_to_one_required();
+        public override void Include_multiple_one_to_one_optional_and_one_to_one_required()
+        {
+            base.Include_multiple_one_to_one_optional_and_one_to_one_required();
 
-        //            Assert.Equal(
-        //                @"TBD", Sql);
-        //        }
+            Assert.Equal(
+                @"TBD", Sql);
+        }
 
-        //        public override void Include_multiple_circular()
-        //        {
-        //            base.Include_multiple_circular();
+        public override void Include_multiple_circular()
+        {
+            base.Include_multiple_circular();
 
-        //            Assert.Equal(
-        //                @"SELECT [g].[AssignedCityName], [g].[CityOrBirthName], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Nickname], [g].[Rank], [g].[SquadId], [c].[Location], [c].[Name]
-        //FROM [Gear] AS [g]
-        //INNER JOIN [City] AS [c] ON [g].[CityOrBirthName] = [c].[Name]
-        //ORDER BY [c].[Name]
+            Assert.Equal(
+@"SELECT [g].[AssignedCityName], [g].[CityOrBirthName], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Nickname], [g].[Rank], [g].[SquadId], [c].[Location], [c].[Name]
+FROM [Gear] AS [g]
+INNER JOIN [City] AS [c] ON [g].[CityOrBirthName] = [c].[Name]
+ORDER BY [c].[Name]
 
-        //SELECT [g].[AssignedCityName], [g].[CityOrBirthName], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Nickname], [g].[Rank], [g].[SquadId]
-        //FROM [Gear] AS [g]
-        //INNER JOIN (
-        //    SELECT DISTINCT [c].[Name]
-        //    FROM [Gear] AS [g]
-        //    INNER JOIN [City] AS [c] ON [g].[CityOrBirthName] = [c].[Name]
-        //) AS [c] ON [g].[AssignedCityName] = [c].[Name]
-        //ORDER BY [c].[Name]",
-        //                Sql);
-        //        }
+SELECT [g].[AssignedCityName], [g].[CityOrBirthName], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Nickname], [g].[Rank], [g].[SquadId]
+FROM [Gear] AS [g]
+INNER JOIN (
+    SELECT DISTINCT [c].[Name]
+    FROM [Gear] AS [g]
+    INNER JOIN [City] AS [c] ON [g].[CityOrBirthName] = [c].[Name]
+) AS [c] ON [g].[AssignedCityName] = [c].[Name]
+ORDER BY [c].[Name]",
+                Sql);
+        }
 
-        //        public override void Include_multiple_circular_with_filter()
-        //        {
-        //            base.Include_multiple_circular_with_filter();
+        public override void Include_multiple_circular_with_filter()
+        {
+            base.Include_multiple_circular_with_filter();
 
-        //            Assert.Equal(
-        //                @"SELECT [g].[AssignedCityName], [g].[CityOrBirthName], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Nickname], [g].[Rank], [g].[SquadId], [c].[Location], [c].[Name]
-        //FROM [Gear] AS [g]
-        //INNER JOIN [City] AS [c] ON [g].[CityOrBirthName] = [c].[Name]
-        //WHERE [g].[Nickname] = @p0
-        //ORDER BY [c].[Name]
+            Assert.Equal(
+@"SELECT [g].[AssignedCityName], [g].[CityOrBirthName], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Nickname], [g].[Rank], [g].[SquadId], [c].[Location], [c].[Name]
+FROM [Gear] AS [g]
+INNER JOIN [City] AS [c] ON [g].[CityOrBirthName] = [c].[Name]
+WHERE [g].[Nickname] = @p0
+ORDER BY [c].[Name]
 
-        //SELECT [g].[AssignedCityName], [g].[CityOrBirthName], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Nickname], [g].[Rank], [g].[SquadId]
-        //FROM [Gear] AS [g]
-        //INNER JOIN (
-        //    SELECT DISTINCT [c].[Name]
-        //    FROM [Gear] AS [g]
-        //    INNER JOIN [City] AS [c] ON [g].[CityOrBirthName] = [c].[Name]
-        //    WHERE [g].[Nickname] = @p0
-        //) AS [c] ON [g].[AssignedCityName] = [c].[Name]
-        //ORDER BY [c].[Name]",
-        //                Sql);
-        //        }
+SELECT [g].[AssignedCityName], [g].[CityOrBirthName], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Nickname], [g].[Rank], [g].[SquadId]
+FROM [Gear] AS [g]
+INNER JOIN (
+    SELECT DISTINCT [c].[Name]
+    FROM [Gear] AS [g]
+    INNER JOIN [City] AS [c] ON [g].[CityOrBirthName] = [c].[Name]
+    WHERE [g].[Nickname] = @p0
+) AS [c] ON [g].[AssignedCityName] = [c].[Name]
+ORDER BY [c].[Name]",
+                Sql);
+        }
 
         private static string Sql
         {


### PR DESCRIPTION
Issue was that GearsOfWar uses SqlLogger to validate the expected query, and with recent change, the logger could contain database creation SQL on top of the actual query that was tested. Fix is to clear log after the database has been created