### PR TITLE
Remove async overloads of Add and related code

### DIFF
--- a/src/EntityFramework.Core/ChangeTracking/ChangeTracker.cs
+++ b/src/EntityFramework.Core/ChangeTracking/ChangeTracker.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Utilities;
@@ -84,11 +82,6 @@ namespace Microsoft.Data.Entity.ChangeTracking
             _changeDetector.DetectChanges(StateManager);
         }
 
-        public virtual Task DetectChangesAsync(CancellationToken cancellationToken = default(CancellationToken))
-        {
-            return _changeDetector.DetectChangesAsync(StateManager, cancellationToken);
-        }
-
         public virtual void AttachGraph([NotNull] object rootEntity, [NotNull] Action<EntityEntry> callback)
         {
             Check.NotNull(rootEntity, "rootEntity");
@@ -100,20 +93,6 @@ namespace Microsoft.Data.Entity.ChangeTracking
             }
         }
 
-        public virtual async Task AttachGraphAsync(
-            [NotNull] object rootEntity,
-            [NotNull] Func<EntityEntry, CancellationToken, Task> callback,
-            CancellationToken cancellationToken = default(CancellationToken))
-        {
-            Check.NotNull(rootEntity, "rootEntity");
-            Check.NotNull(callback, "callback");
-
-            foreach (var entry in _graphIterator.TraverseGraph(rootEntity))
-            {
-                await callback(entry, cancellationToken).WithCurrentCulture();
-            }
-        }
-
         public virtual void AttachGraph([NotNull] object rootEntity)
         {
             Check.NotNull(rootEntity, "rootEntity");
@@ -122,32 +101,12 @@ namespace Microsoft.Data.Entity.ChangeTracking
             AttachGraph(rootEntity, attacher.HandleEntity);
         }
 
-        public virtual Task AttachGraphAsync(
-            [NotNull] object rootEntity,
-            CancellationToken cancellationToken = default(CancellationToken))
-        {
-            Check.NotNull(rootEntity, "rootEntity");
-
-            var attacher = _attacherFactory.CreateForAttach();
-            return AttachGraphAsync(rootEntity, attacher.HandleEntityAsync, cancellationToken);
-        }
-
         public virtual void UpdateGraph([NotNull] object rootEntity)
         {
             Check.NotNull(rootEntity, "rootEntity");
 
             var attacher = _attacherFactory.CreateForUpdate();
             AttachGraph(rootEntity, attacher.HandleEntity);
-        }
-
-        public virtual Task UpdateGraphAsync(
-            [NotNull] object rootEntity,
-            CancellationToken cancellationToken = default(CancellationToken))
-        {
-            Check.NotNull(rootEntity, "rootEntity");
-
-            var attacher = _attacherFactory.CreateForUpdate();
-            return AttachGraphAsync(rootEntity, attacher.HandleEntityAsync, cancellationToken);
         }
     }
 }

--- a/src/EntityFramework.Core/ChangeTracking/EntityEntry.cs
+++ b/src/EntityFramework.Core/ChangeTracking/EntityEntry.cs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Diagnostics;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Utilities;
 
@@ -24,21 +21,15 @@ namespace Microsoft.Data.Entity.ChangeTracking
 
         public virtual object Entity => StateEntry.Entity;
 
-        public virtual EntityState State => StateEntry.EntityState;
-
-        public virtual void SetState(EntityState entityState)
+        public virtual EntityState State
         {
-            Check.IsDefined(entityState, "entityState");
+            get { return StateEntry.EntityState; }
+            set
+            {
+                Check.IsDefined(value, "value");
 
-            StateEntry.SetEntityState(entityState);
-        }
-
-        public virtual Task SetStateAsync(
-            EntityState entityState, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            Check.IsDefined(entityState, "entityState");
-
-            return StateEntry.SetEntityStateAsync(entityState, false, cancellationToken);
+                StateEntry.SetEntityState(value);
+            }
         }
 
         public virtual StateEntry StateEntry { get; }

--- a/src/EntityFramework.Core/ChangeTracking/IEntityAttacher.cs
+++ b/src/EntityFramework.Core/ChangeTracking/IEntityAttacher.cs
@@ -10,6 +10,5 @@ namespace Microsoft.Data.Entity.ChangeTracking
     public interface IEntityAttacher
     {
         void HandleEntity([NotNull] EntityEntry entry);
-        Task HandleEntityAsync([NotNull] EntityEntry entry, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/EntityFramework.Core/ChangeTracking/KeyValueEntityAttacher.cs
+++ b/src/EntityFramework.Core/ChangeTracking/KeyValueEntityAttacher.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Threading;
-using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Utilities;
 
@@ -21,14 +19,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
         {
             Check.NotNull(entry, "entry");
 
-            entry.SetState(DetermineState(entry));
-        }
-
-        public virtual Task HandleEntityAsync(EntityEntry entry, CancellationToken cancellationToken = new CancellationToken())
-        {
-            Check.NotNull(entry, "entry");
-
-            return entry.SetStateAsync(DetermineState(entry), cancellationToken);
+            entry.State = DetermineState(entry);
         }
 
         public virtual EntityState DetermineState([NotNull] EntityEntry entry)

--- a/src/EntityFramework.Core/ChangeTracking/StateEntry.cs
+++ b/src/EntityFramework.Core/ChangeTracking/StateEntry.cs
@@ -5,8 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
@@ -118,20 +116,6 @@ namespace Microsoft.Data.Entity.ChangeTracking
             if (PrepareForAdd(entityState))
             {
                 StateManager.ValueGeneration.Generate(this);
-            }
-
-            SetEntityState(oldState, entityState, acceptChanges);
-        }
-
-        public virtual async Task SetEntityStateAsync(EntityState entityState, bool acceptChanges = false, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            Check.IsDefined(entityState, "entityState");
-
-            var oldState = _stateData.EntityState;
-
-            if (PrepareForAdd(entityState))
-            {
-                await StateManager.ValueGeneration.GenerateAsync(this, cancellationToken).WithCurrentCulture();
             }
 
             SetEntityState(oldState, entityState, acceptChanges);

--- a/src/EntityFramework.Core/ChangeTracking/ValueGenerationManager.cs
+++ b/src/EntityFramework.Core/ChangeTracking/ValueGenerationManager.cs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Diagnostics;
-using System.Threading;
-using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Identity;
 using Microsoft.Data.Entity.Infrastructure;
@@ -54,33 +52,6 @@ namespace Microsoft.Data.Entity.ChangeTracking
                         Debug.Assert(valueGenerator != null);
 
                         var generatedValue = valueGenerator.Next(property, _dataStoreServices);
-                        SetGeneratedValue(entry, property, generatedValue, valueGenerator.GeneratesTemporaryValues);
-                    }
-                }
-            }
-        }
-
-        public virtual async Task GenerateAsync([NotNull] StateEntry entry, CancellationToken cancellationToken)
-        {
-            Check.NotNull(entry, "entry");
-
-            foreach (var property in entry.EntityType.Properties)
-            {
-                var isForeignKey = property.IsForeignKey();
-
-                if ((property.GenerateValueOnAdd || isForeignKey)
-                    && entry.HasDefaultValue(property))
-                {
-                    if (isForeignKey)
-                    {
-                        await _foreignKeyValuePropagator.PropagateValueAsync(entry, property, cancellationToken).WithCurrentCulture();
-                    }
-                    else
-                    {
-                        var valueGenerator = _valueGeneratorCache.Service.GetGenerator(property);
-                        Debug.Assert(valueGenerator != null);
-
-                        var generatedValue = await valueGenerator.NextAsync(property, _dataStoreServices, cancellationToken).WithCurrentCulture();
                         SetGeneratedValue(entry, property, generatedValue, valueGenerator.GeneratesTemporaryValues);
                     }
                 }

--- a/src/EntityFramework.Core/DbContext.cs
+++ b/src/EntityFramework.Core/DbContext.cs
@@ -216,7 +216,7 @@ namespace Microsoft.Data.Entity
 
             if (ChangeTracker.AutoDetectChangesEnabled)
             {
-                await GetChangeDetector().DetectChangesAsync(stateManager, cancellationToken).WithCurrentCulture();
+                GetChangeDetector().DetectChanges(stateManager);
             }
 
             try
@@ -282,21 +282,6 @@ namespace Microsoft.Data.Entity
             return SetEntityState(entity, EntityState.Added);
         }
 
-        public virtual async Task<EntityEntry<TEntity>> AddAsync<TEntity>(
-            [NotNull] TEntity entity, CancellationToken cancellationToken = default(CancellationToken))
-            where TEntity : class
-        {
-            Check.NotNull(entity, "entity");
-
-            var entry = EntryWithoutDetectChanges(entity);
-
-            await entry.StateEntry
-                .SetEntityStateAsync(EntityState.Added, true, cancellationToken)
-                .WithCurrentCulture();
-
-            return entry;
-        }
-
         public virtual EntityEntry<TEntity> Attach<TEntity>([NotNull] TEntity entity) where TEntity : class
         {
             Check.NotNull(entity, "entity");
@@ -327,7 +312,7 @@ namespace Microsoft.Data.Entity
         {
             var entry = EntryWithoutDetectChanges(entity);
 
-            entry.SetState(entityState);
+            entry.State = entityState;
 
             return entry;
         }
@@ -337,20 +322,6 @@ namespace Microsoft.Data.Entity
             Check.NotNull(entity, "entity");
 
             return SetEntityState(entity, EntityState.Added);
-        }
-
-        public virtual async Task<EntityEntry> AddAsync(
-            [NotNull] object entity, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            Check.NotNull(entity, "entity");
-
-            var entry = EntryWithoutDetectChanges(entity);
-
-            await entry.StateEntry
-                .SetEntityStateAsync(EntityState.Added, true, cancellationToken)
-                .WithCurrentCulture();
-
-            return entry;
         }
 
         public virtual EntityEntry Attach([NotNull] object entity)
@@ -383,7 +354,7 @@ namespace Microsoft.Data.Entity
         {
             var entry = EntryWithoutDetectChanges(entity);
 
-            entry.SetState(entityState);
+            entry.State = entityState;
 
             return entry;
         }
@@ -393,32 +364,6 @@ namespace Microsoft.Data.Entity
             Check.NotNull(entities, "entities");
 
             return SetEntityStates(entities, EntityState.Added);
-        }
-
-        public virtual Task<IReadOnlyList<EntityEntry<TEntity>>> AddAsync<TEntity>([NotNull] params TEntity[] entities) where TEntity : class
-        {
-            Check.NotNull(entities, "entities");
-
-            return AddAsync(entities, default(CancellationToken));
-        }
-
-        public virtual async Task<IReadOnlyList<EntityEntry<TEntity>>> AddAsync<TEntity>(
-            [NotNull] TEntity[] entities,
-            CancellationToken cancellationToken)
-            where TEntity : class
-        {
-            Check.NotNull(entities, "entities");
-
-            var entries = GetOrCreateEntries(entities);
-
-            foreach (var entry in entries)
-            {
-                await entry.StateEntry
-                    .SetEntityStateAsync(EntityState.Added, true, cancellationToken)
-                    .WithCurrentCulture();
-            }
-
-            return entries;
         }
 
         public virtual IReadOnlyList<EntityEntry<TEntity>> Attach<TEntity>([NotNull] params TEntity[] entities) where TEntity : class
@@ -445,10 +390,10 @@ namespace Microsoft.Data.Entity
             // nothing to delete because it was not yet inserted, so just make sure it doesn't get inserted.
             foreach (var entry in entries)
             {
-                entry.SetState(
+                entry.State = 
                     entry.State == EntityState.Added
                         ? EntityState.Unknown
-                        : EntityState.Deleted);
+                        : EntityState.Deleted;
             }
 
             return entries;
@@ -460,7 +405,7 @@ namespace Microsoft.Data.Entity
 
             foreach (var entry in entries)
             {
-                entry.SetState(entityState);
+                entry.State = entityState;
             }
 
             return entries;
@@ -478,31 +423,6 @@ namespace Microsoft.Data.Entity
             Check.NotNull(entities, "entities");
 
             return SetEntityStates(entities, EntityState.Added);
-        }
-
-        public virtual Task<IReadOnlyList<EntityEntry>> AddAsync([NotNull] params object[] entities)
-        {
-            Check.NotNull(entities, "entities");
-
-            return AddAsync(entities, default(CancellationToken));
-        }
-
-        public virtual async Task<IReadOnlyList<EntityEntry>> AddAsync(
-            [NotNull] object[] entities,
-            CancellationToken cancellationToken)
-        {
-            Check.NotNull(entities, "entities");
-
-            var entries = GetOrCreateEntries(entities);
-
-            foreach (var entry in entries)
-            {
-                await entry.StateEntry
-                    .SetEntityStateAsync(EntityState.Added, true, cancellationToken)
-                    .WithCurrentCulture();
-            }
-
-            return entries;
         }
 
         public virtual IReadOnlyList<EntityEntry> Attach([NotNull] params object[] entities)
@@ -529,10 +449,10 @@ namespace Microsoft.Data.Entity
             // nothing to delete because it was not yet inserted, so just make sure it doesn't get inserted.
             foreach (var entry in entries)
             {
-                entry.SetState(
+                entry.State = 
                     entry.State == EntityState.Added
                         ? EntityState.Unknown
-                        : EntityState.Deleted);
+                        : EntityState.Deleted;
             }
 
             return entries;
@@ -544,7 +464,7 @@ namespace Microsoft.Data.Entity
 
             foreach (var entry in entries)
             {
-                entry.SetState(entityState);
+                entry.State = entityState;
             }
 
             return entries;

--- a/src/EntityFramework.Core/DbSet`.cs
+++ b/src/EntityFramework.Core/DbSet`.cs
@@ -55,14 +55,6 @@ namespace Microsoft.Data.Entity
             return _context.Add(entity);
         }
 
-        public virtual Task<EntityEntry<TEntity>> AddAsync(
-            [NotNull] TEntity entity, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            Check.NotNull(entity, "entity");
-
-            return _context.AddAsync(entity, cancellationToken);
-        }
-
         public virtual EntityEntry<TEntity> Attach([NotNull] TEntity entity)
         {
             Check.NotNull(entity, "entity");
@@ -89,21 +81,6 @@ namespace Microsoft.Data.Entity
             Check.NotNull(entities, "entities");
 
             return _context.Add(entities);
-        }
-
-        public virtual Task<IReadOnlyList<EntityEntry<TEntity>>> AddAsync([NotNull] params TEntity[] entities)
-        {
-            Check.NotNull(entities, "entities");
-
-            return _context.AddAsync(entities);
-        }
-
-        public virtual Task<IReadOnlyList<EntityEntry<TEntity>>> AddAsync(
-            CancellationToken cancellationToken, [NotNull] params TEntity[] entities)
-        {
-            Check.NotNull(entities, "entities");
-
-            return _context.AddAsync(entities, cancellationToken);
         }
 
         public virtual IReadOnlyList<EntityEntry<TEntity>> Attach([NotNull] params TEntity[] entities)

--- a/src/EntityFramework.Core/Identity/ForeignKeyValuePropagator.cs
+++ b/src/EntityFramework.Core/Identity/ForeignKeyValuePropagator.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Infrastructure;
@@ -63,29 +61,6 @@ namespace Microsoft.Data.Entity.Identity
                 if (valueGenerator != null)
                 {
                     stateEntry[property] = valueGenerator.Next(property, _storeServices);
-                }
-            }
-        }
-
-        public virtual async Task PropagateValueAsync(
-            [NotNull] StateEntry stateEntry,
-            [NotNull] IProperty property,
-            CancellationToken cancellationToken = default(CancellationToken))
-        {
-            Check.NotNull(stateEntry, "stateEntry");
-            Check.NotNull(property, "property");
-
-            Debug.Assert(property.IsForeignKey());
-
-            if (!TryPropagateValue(stateEntry, property)
-                && property.IsKey())
-            {
-                var valueGenerator = TryGetValueGenerator(property);
-
-                if (valueGenerator != null)
-                {
-                    stateEntry[property] = 
-                        (await valueGenerator.NextAsync(property, _storeServices, cancellationToken).WithCurrentCulture());
                 }
             }
         }

--- a/test/EntityFramework.Core.FunctionalTests/ChangeTrackingTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/ChangeTrackingTestBase.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 Assert.Equal(EntityState.Modified, firstTrackedEntity.State);
                 Assert.Equal("425-882-8080", firstTrackedEntity.Property(c => c.Phone).CurrentValue);
 
-                firstTrackedEntity.SetState(EntityState.Unchanged);
+                firstTrackedEntity.State = EntityState.Unchanged;
                 
                 Assert.Equal(customer.CustomerID, firstTrackedEntity.Property(c => c.CustomerID).CurrentValue);                
                 Assert.Equal(originalPhoneNumber, firstTrackedEntity.Property(c => c.Phone).CurrentValue);
@@ -55,7 +55,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
                 foreach (var entityEntry in context.ChangeTracker.Entries())
                 {
-                    entityEntry.SetState(EntityState.Unchanged);
+                    entityEntry.State = EntityState.Unchanged;
                 }
 
                 var newCustomerPostalCodes = context.Customers.Select(c => c.PostalCode);

--- a/test/EntityFramework.Core.FunctionalTests/DataStoreErrorLogStateTest.cs
+++ b/test/EntityFramework.Core.FunctionalTests/DataStoreErrorLogStateTest.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             {
                 context.Blogs.Add(new BloggingContext.Blog(jimSaysThrow: false) { Url = "http://sample.com" });
                 context.SaveChanges();
-                context.ChangeTracker.Entries().Single().SetState(EntityState.Added);
+                context.ChangeTracker.Entries().Single().State = EntityState.Added;
 
                 Exception ex;
                 if (async)

--- a/test/EntityFramework.Core.FunctionalTests/GraphUpdatesTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/GraphUpdatesTestBase.cs
@@ -686,7 +686,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             {
                 root = LoadFullGraph(context, e => e.Id != newRoot.Id);
 
-                context.Entry(newRoot).SetState(useExistingRoot ? EntityState.Unchanged : EntityState.Added);
+                context.Entry(newRoot).State = useExistingRoot ? EntityState.Unchanged : EntityState.Added;
 
                 old1 = root.OptionalSingle;
                 old2 = root.OptionalSingle.Single;
@@ -758,7 +758,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             {
                 var root = LoadFullGraph(context, e => e.Id != newRoot.Id);
 
-                context.Entry(newRoot).SetState(useExistingRoot ? EntityState.Unchanged : EntityState.Added);
+                context.Entry(newRoot).State = useExistingRoot ? EntityState.Unchanged : EntityState.Added;
 
                 switch (changeMechanism)
                 {
@@ -810,7 +810,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             {
                 root = LoadFullGraph(context, e => e.Id != newRoot.Id);
 
-                context.Entry(newRoot).SetState(useExistingRoot ? EntityState.Unchanged : EntityState.Added);
+                context.Entry(newRoot).State = useExistingRoot ? EntityState.Unchanged : EntityState.Added;
 
                 old1 = root.RequiredNonPkSingle;
                 old2 = root.RequiredNonPkSingle.Single;
@@ -1525,7 +1525,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             {
                 root = LoadFullGraph(context, e => e.Id != newRoot.Id);
 
-                context.Entry(newRoot).SetState(useExistingRoot ? EntityState.Unchanged : EntityState.Added);
+                context.Entry(newRoot).State = useExistingRoot ? EntityState.Unchanged : EntityState.Added;
 
                 old1 = root.OptionalSingleAk;
                 old2 = root.OptionalSingleAk.Single;
@@ -1597,7 +1597,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             {
                 var root = LoadFullGraph(context, e => e.Id != newRoot.Id);
 
-                context.Entry(newRoot).SetState(useExistingRoot ? EntityState.Unchanged : EntityState.Added);
+                context.Entry(newRoot).State = useExistingRoot ? EntityState.Unchanged : EntityState.Added;
 
                 switch (changeMechanism)
                 {
@@ -1649,7 +1649,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             {
                 root = LoadFullGraph(context, e => e.Id != newRoot.Id);
 
-                context.Entry(newRoot).SetState(useExistingRoot ? EntityState.Unchanged : EntityState.Added);
+                context.Entry(newRoot).State = useExistingRoot ? EntityState.Unchanged : EntityState.Added;
 
                 old1 = root.RequiredNonPkSingleAk;
                 old2 = root.RequiredNonPkSingleAk.Single;

--- a/test/EntityFramework.Core.FunctionalTests/OptimisticConcurrencyTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/OptimisticConcurrencyTestBase.cs
@@ -542,7 +542,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                             Name = "Larry David",
                             TeamId = Team.Ferrari
                         });
-                entry.SetState(EntityState.Unknown);
+                entry.State = EntityState.Unknown;
 
                 Assert.Equal("Can't reload an unknown entity",
                     Assert.Throws<InvalidOperationException>(() => entry.Reload(context)).Message);
@@ -573,7 +573,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             {
                 var larry = context.Drivers.Single(d => d.Name == "Jenson Button");
                 var entry = context.Entry(larry);
-                entry.SetState(state);
+                entry.State = state;
 
                 entry.Reload(context);
 
@@ -615,7 +615,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                             Name = "Larry David",
                             TeamId = Team.Ferrari
                         });
-                entry.SetState(EntityState.Unknown);
+                entry.State = EntityState.Unknown;
 
                 Assert.Equal("Can't reload an unknown entity",
                     (await Assert.ThrowsAsync<InvalidOperationException>(() => entry.ReloadAsync(context))).Message);
@@ -646,7 +646,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             {
                 var larry = context.Drivers.Single(d => d.Name == "Jenson Button");
                 var entry = context.Entry(larry);
-                entry.SetState(state);
+                entry.State = state;
 
                 await entry.ReloadAsync(context);
 

--- a/test/EntityFramework.Core.Tests/ChangeTracking/ChangeDetectorTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/ChangeDetectorTest.cs
@@ -7,7 +7,6 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
@@ -137,10 +136,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             Assert.Null(entry.TryGetSidecar(Sidecar.WellKnownNames.RelationshipsSnapshot));
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task Detects_scalar_property_change(bool async)
+        [Fact]
+        public void Detects_scalar_property_change()
         {
             var contextServices = TestHelpers.CreateContextServices(BuildModel());
 
@@ -152,23 +149,14 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             product.Name = "Gear VR";
 
-            if (async)
-            {
-                await changeDetector.DetectChangesAsync(entry);
-            }
-            else
-            {
-                changeDetector.DetectChanges(entry);
-            }
+            changeDetector.DetectChanges(entry);
 
             Assert.Equal(EntityState.Modified, entry.EntityState);
             Assert.True(entry.IsPropertyModified(entry.EntityType.GetProperty("Name")));
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task Skips_detection_of_scalar_property_change_for_notification_entities(bool async)
+        [Fact]
+        public void Skips_detection_of_scalar_property_change_for_notification_entities()
         {
             var contextServices = TestHelpers.CreateContextServices(BuildModelWithChanged());
 
@@ -180,23 +168,14 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             product.Name = "Gear VR";
 
-            if (async)
-            {
-                await changeDetector.DetectChangesAsync(entry);
-            }
-            else
-            {
-                changeDetector.DetectChanges(entry);
-            }
+            changeDetector.DetectChanges(entry);
 
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
             Assert.False(entry.IsPropertyModified(entry.EntityType.GetProperty("Name")));
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task Detects_principal_key_change(bool async)
+        [Fact]
+        public void Detects_principal_key_change()
         {
             var contextServices = TestHelpers.CreateContextServices(
                 new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
@@ -213,14 +192,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             category.PrincipalId = 78;
 
-            if (async)
-            {
-                await changeDetector.DetectChangesAsync(entry);
-            }
-            else
-            {
-                changeDetector.DetectChanges(entry);
-            }
+            changeDetector.DetectChanges(entry);
 
             Assert.Equal(78, entry.RelationshipsSnapshot[entry.EntityType.GetProperty("PrincipalId")]);
             Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType, -1)));
@@ -242,10 +214,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             AssertDetectChangesNoOp(changeDetector, stateManager, testListener);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task Detects_principal_key_changing_back_to_original_value(bool async)
+        [Fact]
+        public void Detects_principal_key_changing_back_to_original_value()
         {
             var contextServices = TestHelpers.CreateContextServices(
                 new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
@@ -260,25 +230,11 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             category.PrincipalId = 78;
 
-            if (async)
-            {
-                await changeDetector.DetectChangesAsync(entry);
-            }
-            else
-            {
-                changeDetector.DetectChanges(entry);
-            }
+            changeDetector.DetectChanges(entry);
 
             category.PrincipalId = 77;
 
-            if (async)
-            {
-                await changeDetector.DetectChangesAsync(entry);
-            }
-            else
-            {
-                changeDetector.DetectChanges(entry);
-            }
+            changeDetector.DetectChanges(entry);
 
             Assert.Equal(77, entry.RelationshipsSnapshot[entry.EntityType.GetProperty("PrincipalId")]);
 
@@ -299,10 +255,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             AssertDetectChangesNoOp(changeDetector, stateManager, testListener);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task Reacts_to_principal_key_change_in_sidecar(bool async)
+        [Fact]
+        public void Reacts_to_principal_key_change_in_sidecar()
         {
             var contextServices = TestHelpers.CreateContextServices(
                 new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
@@ -322,14 +276,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             sidecar[property] = 78;
 
-            if (async)
-            {
-                await changeDetector.DetectChangesAsync(entry);
-            }
-            else
-            {
-                changeDetector.DetectChanges(entry);
-            }
+            changeDetector.DetectChanges(entry);
 
             Assert.Equal(78, entry.RelationshipsSnapshot[property]);
 
@@ -350,10 +297,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             AssertDetectChangesNoOp(changeDetector, stateManager, testListener);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task Detects_primary_key_change(bool async)
+        [Fact]
+        public void Detects_primary_key_change()
         {
             var contextServices = TestHelpers.CreateContextServices(
                 new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
@@ -370,14 +315,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             category.Id = 78;
 
-            if (async)
-            {
-                await changeDetector.DetectChangesAsync(entry);
-            }
-            else
-            {
-                changeDetector.DetectChanges(entry);
-            }
+            changeDetector.DetectChanges(entry);
 
             Assert.Equal(78, entry.RelationshipsSnapshot[entry.EntityType.GetProperty("Id")]);
             Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType, 78)));
@@ -395,10 +333,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             AssertDetectChangesNoOp(changeDetector, stateManager, testListener);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task Reacts_to_primary_key_change_in_sidecar(bool async)
+        [Fact]
+        public void Reacts_to_primary_key_change_in_sidecar()
         {
             var contextServices = TestHelpers.CreateContextServices(
                 new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
@@ -420,14 +356,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             sidecar[property] = 78;
 
-            if (async)
-            {
-                await changeDetector.DetectChangesAsync(entry);
-            }
-            else
-            {
-                changeDetector.DetectChanges(entry);
-            }
+            changeDetector.DetectChanges(entry);
 
             Assert.Equal(78, entry.RelationshipsSnapshot[property]);
 
@@ -446,10 +375,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             AssertDetectChangesNoOp(changeDetector, stateManager, testListener);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task Ignores_no_change_to_principal_key(bool async)
+        [Fact]
+        public void Ignores_no_change_to_principal_key()
         {
             var contextServices = TestHelpers.CreateContextServices(
                 new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
@@ -466,14 +393,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             category.PrincipalId = 77;
 
-            if (async)
-            {
-                await changeDetector.DetectChangesAsync(entry);
-            }
-            else
-            {
-                changeDetector.DetectChanges(entry);
-            }
+            changeDetector.DetectChanges(entry);
 
             Assert.Equal(77, entry.RelationshipsSnapshot[entry.EntityType.GetProperty("PrincipalId")]);
             Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType, -1)));
@@ -491,10 +411,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             AssertDetectChangesNoOp(changeDetector, stateManager, testListener);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task Ignores_no_change_to_principal_key_in_sidecar(bool async)
+        [Fact]
+        public void Ignores_no_change_to_principal_key_in_sidecar()
         {
             var contextServices = TestHelpers.CreateContextServices(
                 new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
@@ -514,14 +432,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             sidecar[property] = 77;
 
-            if (async)
-            {
-                await changeDetector.DetectChangesAsync(entry);
-            }
-            else
-            {
-                changeDetector.DetectChanges(entry);
-            }
+            changeDetector.DetectChanges(entry);
 
             Assert.Equal(77, entry.RelationshipsSnapshot[property]);
 
@@ -538,10 +449,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             AssertDetectChangesNoOp(changeDetector, stateManager, testListener);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task Detects_foreign_key_change(bool async)
+        [Fact]
+        public void Detects_foreign_key_change()
         {
             var contextServices = TestHelpers.CreateContextServices(
                 new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
@@ -556,14 +465,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             product.DependentId = 78;
 
-            if (async)
-            {
-                await changeDetector.DetectChangesAsync(entry);
-            }
-            else
-            {
-                changeDetector.DetectChanges(entry);
-            }
+            changeDetector.DetectChanges(entry);
 
             Assert.Equal(EntityState.Modified, entry.EntityState);
             Assert.Equal(78, entry.RelationshipsSnapshot[entry.EntityType.GetProperty("DependentId")]);
@@ -585,10 +487,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             AssertDetectChangesNoOp(changeDetector, stateManager, testListener);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task Detects_foreign_key_changing_back_to_original_value(bool async)
+        [Fact]
+        public void Detects_foreign_key_changing_back_to_original_value()
         {
             var contextServices = TestHelpers.CreateContextServices(
                 new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
@@ -603,25 +503,11 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             product.DependentId = 78;
 
-            if (async)
-            {
-                await changeDetector.DetectChangesAsync(entry);
-            }
-            else
-            {
-                changeDetector.DetectChanges(entry);
-            }
+            changeDetector.DetectChanges(entry);
 
             product.DependentId = 77;
 
-            if (async)
-            {
-                await changeDetector.DetectChangesAsync(entry);
-            }
-            else
-            {
-                changeDetector.DetectChanges(entry);
-            }
+            changeDetector.DetectChanges(entry);
 
             Assert.Equal(EntityState.Modified, entry.EntityState);
             Assert.Equal(77, entry.RelationshipsSnapshot[entry.EntityType.GetProperty("DependentId")]);
@@ -643,10 +529,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             AssertDetectChangesNoOp(changeDetector, stateManager, testListener);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task Reacts_to_foreign_key_change_in_sidecar(bool async)
+        [Fact]
+        public void Reacts_to_foreign_key_change_in_sidecar()
         {
             var contextServices = TestHelpers.CreateContextServices(
                 new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
@@ -666,14 +550,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             sidecar[property] = 78;
 
-            if (async)
-            {
-                await changeDetector.DetectChangesAsync(entry);
-            }
-            else
-            {
-                changeDetector.DetectChanges(entry);
-            }
+            changeDetector.DetectChanges(entry);
 
             Assert.Equal(EntityState.Modified, entry.EntityState);
             Assert.Equal(78, entry.RelationshipsSnapshot[property]);
@@ -695,10 +572,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             AssertDetectChangesNoOp(changeDetector, stateManager, testListener);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task Ignores_no_change_to_foreign_key(bool async)
+        [Fact]
+        public void Ignores_no_change_to_foreign_key()
         {
             var contextServices = TestHelpers.CreateContextServices(
                 new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
@@ -713,14 +588,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             product.DependentId = 77;
 
-            if (async)
-            {
-                await changeDetector.DetectChangesAsync(entry);
-            }
-            else
-            {
-                changeDetector.DetectChanges(entry);
-            }
+            changeDetector.DetectChanges(entry);
 
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
             Assert.Equal(77, entry.RelationshipsSnapshot[entry.EntityType.GetProperty("DependentId")]);
@@ -738,10 +606,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             AssertDetectChangesNoOp(changeDetector, stateManager, testListener);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task Ignores_no_change_to_foreign_key_in_sidecar(bool async)
+        [Fact]
+        public void Ignores_no_change_to_foreign_key_in_sidecar()
         {
             var contextServices = TestHelpers.CreateContextServices(
                 new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
@@ -761,14 +627,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             sidecar[property] = 77;
 
-            if (async)
-            {
-                await changeDetector.DetectChangesAsync(entry);
-            }
-            else
-            {
-                changeDetector.DetectChanges(entry);
-            }
+            changeDetector.DetectChanges(entry);
 
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
             Assert.Equal(77, entry.RelationshipsSnapshot[property]);
@@ -786,10 +645,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             AssertDetectChangesNoOp(changeDetector, stateManager, testListener);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task Detects_reference_navigation_change(bool async)
+        [Fact]
+        public void Detects_reference_navigation_change()
         {
             var contextServices = TestHelpers.CreateContextServices(
                 new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
@@ -806,14 +663,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var newCategory = new Category { PrincipalId = 2 };
             product.Category = newCategory;
 
-            if (async)
-            {
-                await changeDetector.DetectChangesAsync(entry);
-            }
-            else
-            {
-                changeDetector.DetectChanges(entry);
-            }
+            changeDetector.DetectChanges(entry);
 
             Assert.Equal(EntityState.Modified, entry.EntityState);
             Assert.Equal(newCategory, entry.RelationshipsSnapshot[entry.EntityType.GetNavigation("Category")]);
@@ -839,10 +689,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             AssertDetectChangesNoOp(changeDetector, stateManager, testListener);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task Detects_reference_navigation_changing_back_to_original_value(bool async)
+        [Fact]
+        public void Detects_reference_navigation_changing_back_to_original_value()
         {
             var contextServices = TestHelpers.CreateContextServices(
                 new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
@@ -859,25 +707,11 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var newCategory = new Category { PrincipalId = 2 };
             product.Category = newCategory;
 
-            if (async)
-            {
-                await changeDetector.DetectChangesAsync(entry);
-            }
-            else
-            {
-                changeDetector.DetectChanges(entry);
-            }
+            changeDetector.DetectChanges(entry);
 
             product.Category = originalCategory;
 
-            if (async)
-            {
-                await changeDetector.DetectChangesAsync(entry);
-            }
-            else
-            {
-                changeDetector.DetectChanges(entry);
-            }
+            changeDetector.DetectChanges(entry);
 
             Assert.Equal(EntityState.Modified, entry.EntityState);
             Assert.Equal(originalCategory, entry.RelationshipsSnapshot[entry.EntityType.GetNavigation("Category")]);
@@ -903,10 +737,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             AssertDetectChangesNoOp(changeDetector, stateManager, testListener);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task Ignores_no_change_to_reference_navigation(bool async)
+        [Fact]
+        public void Ignores_no_change_to_reference_navigation()
         {
             var contextServices = TestHelpers.CreateContextServices(
                 new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
@@ -922,14 +754,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             product.Category = category;
 
-            if (async)
-            {
-                await changeDetector.DetectChangesAsync(entry);
-            }
-            else
-            {
-                changeDetector.DetectChanges(entry);
-            }
+            changeDetector.DetectChanges(entry);
 
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
             Assert.Equal(category, entry.RelationshipsSnapshot[entry.EntityType.GetNavigation("Category")]);
@@ -947,10 +772,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             AssertDetectChangesNoOp(changeDetector, stateManager, testListener);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task Detects_adding_to_collection_navigation(bool async)
+        [Fact]
+        public void Detects_adding_to_collection_navigation()
         {
             var contextServices = TestHelpers.CreateContextServices(
                 new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
@@ -968,14 +791,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var product3 = new Product { DependentId = 77 };
             category.Products.Add(product3);
 
-            if (async)
-            {
-                await changeDetector.DetectChangesAsync(entry);
-            }
-            else
-            {
-                changeDetector.DetectChanges(entry);
-            }
+            changeDetector.DetectChanges(entry);
 
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
             Assert.Equal(
@@ -1001,10 +817,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             AssertDetectChangesNoOp(changeDetector, stateManager, testListener);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task Detects_removing_from_collection_navigation(bool async)
+        [Fact]
+        public void Detects_removing_from_collection_navigation()
         {
             var contextServices = TestHelpers.CreateContextServices(
                 new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
@@ -1021,14 +835,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             category.Products.Remove(product1);
 
-            if (async)
-            {
-                await changeDetector.DetectChangesAsync(entry);
-            }
-            else
-            {
-                changeDetector.DetectChanges(entry);
-            }
+            changeDetector.DetectChanges(entry);
 
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
             Assert.Equal(
@@ -1058,10 +865,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             AssertDetectChangesNoOp(changeDetector, stateManager, testListener);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task Ignores_no_change_to_collection_navigation(bool async)
+        [Fact]
+        public void Ignores_no_change_to_collection_navigation()
         {
             var contextServices = TestHelpers.CreateContextServices(
                 new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
@@ -1079,14 +884,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             category.Products.Remove(product1);
             category.Products.Add(product1);
 
-            if (async)
-            {
-                await changeDetector.DetectChangesAsync(entry);
-            }
-            else
-            {
-                changeDetector.DetectChanges(entry);
-            }
+            changeDetector.DetectChanges(entry);
 
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
             Assert.Equal(
@@ -1108,10 +906,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             AssertDetectChangesNoOp(changeDetector, stateManager, testListener);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task Skips_detecting_changes_to_primary_principal_key_for_notification_entities(bool async)
+        [Fact]
+        public void Skips_detecting_changes_to_primary_principal_key_for_notification_entities()
         {
             var contextServices = TestHelpers.CreateContextServices(
                 new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
@@ -1128,14 +924,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             product.Id = 78;
 
-            if (async)
-            {
-                await changeDetector.DetectChangesAsync(entry);
-            }
-            else
-            {
-                changeDetector.DetectChanges(entry);
-            }
+            changeDetector.DetectChanges(entry);
 
             Assert.Equal(77, entry.RelationshipsSnapshot[entry.EntityType.GetProperty("Id")]);
             Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType, 77)));
@@ -1153,10 +942,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             AssertDetectChangesNoOp(changeDetector, stateManager, testListener);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task Skips_detecting_changes_to_foreign_key_for_notification_entities(bool async)
+        [Fact]
+        public void Skips_detecting_changes_to_foreign_key_for_notification_entities()
         {
             var contextServices = TestHelpers.CreateContextServices(
                 new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
@@ -1171,14 +958,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             product.DependentId = 78;
 
-            if (async)
-            {
-                await changeDetector.DetectChangesAsync(entry);
-            }
-            else
-            {
-                changeDetector.DetectChanges(entry);
-            }
+            changeDetector.DetectChanges(entry);
 
             Assert.Equal(77, entry.RelationshipsSnapshot[entry.EntityType.GetProperty("DependentId")]);
 
@@ -1195,10 +975,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             AssertDetectChangesNoOp(changeDetector, stateManager, testListener);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task Skips_detecting_changes_to_reference_navigation_for_notification_entities(bool async)
+        [Fact]
+        public void Skips_detecting_changes_to_reference_navigation_for_notification_entities()
         {
             var contextServices = TestHelpers.CreateContextServices(
                 new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
@@ -1214,14 +992,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             product.Category = new CategoryWithChanged { Id = 2 };
 
-            if (async)
-            {
-                await changeDetector.DetectChangesAsync(entry);
-            }
-            else
-            {
-                changeDetector.DetectChanges(entry);
-            }
+            changeDetector.DetectChanges(entry);
 
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
             Assert.Equal(category, entry.RelationshipsSnapshot[entry.EntityType.GetNavigation("Category")]);
@@ -1239,10 +1010,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             AssertDetectChangesNoOp(changeDetector, stateManager, testListener);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task Skips_detecting_changes_to_notifying_collections(bool async)
+        [Fact]
+        public void Skips_detecting_changes_to_notifying_collections()
         {
             var contextServices = TestHelpers.CreateContextServices(
                 new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
@@ -1264,14 +1033,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var product3 = new ProductWithChanged { DependentId = 77 };
             category.Products.Add(product3);
 
-            if (async)
-            {
-                await changeDetector.DetectChangesAsync(entry);
-            }
-            else
-            {
-                changeDetector.DetectChanges(entry);
-            }
+            changeDetector.DetectChanges(entry);
 
             // TODO: DetectChanges is actually used here until INotifyCollectionChanged is supported (Issue #445)
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
@@ -1298,10 +1060,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             AssertDetectChangesNoOp(changeDetector, stateManager, testListener);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task Change_detection_still_happens_for_non_notifying_collections_on_notifying_entities(bool async)
+        [Fact]
+        public void Change_detection_still_happens_for_non_notifying_collections_on_notifying_entities()
         {
             var contextServices = TestHelpers.CreateContextServices(
                 new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
@@ -1323,14 +1083,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var product3 = new ProductWithChanged { DependentId = 77 };
             category.Products.Add(product3);
 
-            if (async)
-            {
-                await changeDetector.DetectChangesAsync(entry);
-            }
-            else
-            {
-                changeDetector.DetectChanges(entry);
-            }
+            changeDetector.DetectChanges(entry);
 
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
             Assert.Equal(
@@ -1356,10 +1109,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             AssertDetectChangesNoOp(changeDetector, stateManager, testListener);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task Brings_in_single_new_entity_set_on_reference_navigation(bool async)
+        [Fact]
+        public void Brings_in_single_new_entity_set_on_reference_navigation()
         {
             var contextServices = TestHelpers.CreateContextServices(BuildModel());
 
@@ -1374,14 +1125,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var newCategory = new Category { PrincipalId = 2, Tag = new CategoryTag() };
             product.Category = newCategory;
 
-            if (async)
-            {
-                await changeDetector.DetectChangesAsync(entry);
-            }
-            else
-            {
-                changeDetector.DetectChanges(stateManager);
-            }
+            changeDetector.DetectChanges(stateManager);
 
             Assert.Equal(EntityState.Modified, entry.EntityState);
             Assert.Equal(newCategory, entry.RelationshipsSnapshot[entry.EntityType.GetNavigation("Category")]);
@@ -1395,22 +1139,13 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             Assert.Equal(EntityState.Unknown, stateManager.GetOrCreateEntry(newCategory.Tag).EntityState);
 
-            if (async)
-            {
-                await changeDetector.DetectChangesAsync(entry);
-            }
-            else
-            {
-                changeDetector.DetectChanges(stateManager);
-            }
+            changeDetector.DetectChanges(stateManager);
 
             Assert.Equal(EntityState.Unknown, stateManager.GetOrCreateEntry(newCategory.Tag).EntityState);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task Brings_in_new_entity_set_on_principal_of_one_to_one_navigation(bool async)
+        [Fact]
+        public void Brings_in_new_entity_set_on_principal_of_one_to_one_navigation()
         {
             var contextServices = TestHelpers.CreateContextServices(BuildModel());
 
@@ -1424,14 +1159,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var tag = new CategoryTag();
             category.Tag = tag;
 
-            if (async)
-            {
-                await changeDetector.DetectChangesAsync(entry);
-            }
-            else
-            {
-                changeDetector.DetectChanges(stateManager);
-            }
+            changeDetector.DetectChanges(stateManager);
 
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
             Assert.Equal(tag, entry.RelationshipsSnapshot[entry.EntityType.GetNavigation("Tag")]);
@@ -1444,10 +1172,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             Assert.Equal(EntityState.Added, stateManager.GetOrCreateEntry(tag).EntityState);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task Brings_in_new_entity_set_on_dependent_of_one_to_one_navigation(bool async)
+        [Fact]
+        public void Brings_in_new_entity_set_on_dependent_of_one_to_one_navigation()
         {
             var contextServices = TestHelpers.CreateContextServices(BuildModel());
 
@@ -1461,14 +1187,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var category = new Category { TagId = 77 };
             tag.Category = category;
 
-            if (async)
-            {
-                await changeDetector.DetectChangesAsync(entry);
-            }
-            else
-            {
-                changeDetector.DetectChanges(stateManager);
-            }
+            changeDetector.DetectChanges(stateManager);
 
             Assert.Equal(EntityState.Modified, entry.EntityState);
             Assert.Equal(category, entry.RelationshipsSnapshot[entry.EntityType.GetNavigation("Category")]);
@@ -1481,10 +1200,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             Assert.Equal(EntityState.Added, stateManager.GetOrCreateEntry(category).EntityState);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task Brings_in_single_new_entity_set_on_collection_navigation(bool async)
+        [Fact]
+        public void Brings_in_single_new_entity_set_on_collection_navigation()
         {
             var contextServices = TestHelpers.CreateContextServices(BuildModel());
 
@@ -1500,14 +1217,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var product3 = new Product { Tag = new ProductTag() };
             category.Products.Add(product3);
 
-            if (async)
-            {
-                await changeDetector.DetectChangesAsync(entry);
-            }
-            else
-            {
-                changeDetector.DetectChanges(stateManager);
-            }
+            changeDetector.DetectChanges(stateManager);
 
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
 
@@ -1519,22 +1229,13 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             Assert.Equal(EntityState.Unknown, stateManager.GetOrCreateEntry(product3.Tag).EntityState);
 
-            if (async)
-            {
-                await changeDetector.DetectChangesAsync(entry);
-            }
-            else
-            {
-                changeDetector.DetectChanges(stateManager);
-            }
+            changeDetector.DetectChanges(stateManager);
 
             Assert.Equal(EntityState.Unknown, stateManager.GetOrCreateEntry(product3.Tag).EntityState);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task Brings_in_new_entity_set_on_principal_of_one_to_one_self_ref(bool async)
+        [Fact]
+        public void Brings_in_new_entity_set_on_principal_of_one_to_one_self_ref()
         {
             var contextServices = TestHelpers.CreateContextServices(BuildModel());
 
@@ -1548,14 +1249,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var husband = new Person();
             wife.Husband = husband;
 
-            if (async)
-            {
-                await changeDetector.DetectChangesAsync(entry);
-            }
-            else
-            {
-                changeDetector.DetectChanges(stateManager);
-            }
+            changeDetector.DetectChanges(stateManager);
 
             Assert.Equal(EntityState.Added, entry.EntityState);
             Assert.Equal(husband, entry.RelationshipsSnapshot[entry.EntityType.GetNavigation("Husband")]);
@@ -1570,10 +1264,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             Assert.Equal(EntityState.Added, stateManager.GetOrCreateEntry(husband).EntityState);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task Brings_in_new_entity_set_on_dependent_of_one_to_one_self_ref(bool async)
+        [Fact]
+        public void Brings_in_new_entity_set_on_dependent_of_one_to_one_self_ref()
         {
             var contextServices = TestHelpers.CreateContextServices(BuildModel());
 
@@ -1587,14 +1279,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var wife = new Person();
             husband.Wife = wife;
 
-            if (async)
-            {
-                await changeDetector.DetectChangesAsync(entry);
-            }
-            else
-            {
-                changeDetector.DetectChanges(stateManager);
-            }
+            changeDetector.DetectChanges(stateManager);
 
             Assert.Equal(EntityState.Added, entry.EntityState);
             Assert.Equal(wife, entry.RelationshipsSnapshot[entry.EntityType.GetNavigation("Wife")]);

--- a/test/EntityFramework.Core.Tests/ChangeTracking/EntityEntryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/EntityEntryTest.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Tests.ChangeTracking
@@ -54,29 +53,11 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
                 var entity = new Chunky();
                 var stateEntry = context.Add(entity).StateEntry;
 
-                context.Entry(entity).SetState(EntityState.Modified);
+                context.Entry(entity).State = EntityState.Modified;
                 Assert.Equal(EntityState.Modified, stateEntry.EntityState);
                 Assert.Equal(EntityState.Modified, context.Entry(entity).State);
 
-                context.Entry((object)entity).SetState(EntityState.Unchanged);
-                Assert.Equal(EntityState.Unchanged, stateEntry.EntityState);
-                Assert.Equal(EntityState.Unchanged, context.Entry((object)entity).State);
-            }
-        }
-
-        [Fact]
-        public async Task Can_get_and_change_state_async()
-        {
-            using (var context = new FreezerContext())
-            {
-                var entity = new Chunky();
-                var stateEntry = context.Add(entity).StateEntry;
-
-                await context.Entry(entity).SetStateAsync(EntityState.Modified);
-                Assert.Equal(EntityState.Modified, stateEntry.EntityState);
-                Assert.Equal(EntityState.Modified, context.Entry(entity).State);
-
-                await context.Entry((object)entity).SetStateAsync(EntityState.Unchanged);
+                context.Entry((object)entity).State = EntityState.Unchanged;
                 Assert.Equal(EntityState.Unchanged, stateEntry.EntityState);
                 Assert.Equal(EntityState.Unchanged, context.Entry((object)entity).State);
             }
@@ -138,8 +119,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             {
                 var entry = context.Add(new Chunky());
 
-                entry.SetState(initialState);
-                entry.SetState(expectedState);
+                entry.State = initialState;
+                entry.State = expectedState;
 
                 Assert.Equal(expectedState, entry.State);
             }

--- a/test/EntityFramework.Core.Tests/ChangeTracking/KeyValueEntityAttacherTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/KeyValueEntityAttacherTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Threading.Tasks;
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Metadata;
 using Xunit;
@@ -12,35 +11,24 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
     public class KeyValueEntityAttacherTest
     {
         [Fact]
-        public async Task Entities_with_default_value_object_key_values_are_made_Added_sync()
-        {
-            await Entities_with_default_value_object_key_values_are_made_Added(async: false);
-        }
-
-        [Fact]
-        public async Task Entities_with_default_value_object_key_values_are_made_Added_async()
-        {
-            await Entities_with_default_value_object_key_values_are_made_Added(async: true);
-        }
-
-        private static async Task Entities_with_default_value_object_key_values_are_made_Added(bool async)
+        public void Entities_with_default_value_object_key_values_are_made_Added()
         {
             using (var context = new StoteInTheSnow())
             {
                 var entry = context.Entry(new Stoat());
-                await HandleEntity(async, entry, updateExistingEntities: false);
+                HandleEntity(entry, updateExistingEntities: false);
 
                 Assert.Equal(EntityState.Added, entry.State);
                 Assert.Equal(1, entry.Entity.Id);
 
                 entry = context.Entry(new Stoat { Id = 77 });
-                await HandleEntity(async, entry, updateExistingEntities: false);
+                HandleEntity(entry, updateExistingEntities: false);
 
                 Assert.Equal(EntityState.Unchanged, entry.State);
                 Assert.Equal(77, entry.Entity.Id);
 
                 entry = context.Entry(new Stoat { Id = 78 });
-                await HandleEntity(async, entry, updateExistingEntities: true);
+                HandleEntity(entry, updateExistingEntities: true);
 
                 Assert.Equal(EntityState.Modified, entry.State);
                 Assert.Equal(78, entry.Entity.Id);
@@ -48,35 +36,24 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         }
 
         [Fact]
-        public async Task Entities_with_default_reference_key_values_are_made_Added_sync()
-        {
-            await Entities_with_default_reference_key_values_are_made_Added(async: false);
-        }
-
-        [Fact]
-        public async Task Entities_with_default_reference_key_values_are_made_Added_async()
-        {
-            await Entities_with_default_reference_key_values_are_made_Added(async: true);
-        }
-
-        private static async Task Entities_with_default_reference_key_values_are_made_Added(bool async)
+        public void Entities_with_default_reference_key_values_are_made_Added()
         {
             using (var context = new StoteInTheSnow())
             {
                 var entry = context.Entry(new StoatInACoat());
-                await HandleEntity(async, entry, updateExistingEntities: false);
+                HandleEntity(entry, updateExistingEntities: false);
 
                 Assert.Equal(EntityState.Added, entry.State);
                 Assert.NotEqual(Guid.NewGuid(), Guid.Parse(entry.Entity.Id));
 
                 entry = context.Entry(new StoatInACoat { Id = "Brrrr! It's chilly." });
-                await HandleEntity(async, entry, updateExistingEntities: false);
+                HandleEntity(entry, updateExistingEntities: false);
 
                 Assert.Equal(EntityState.Unchanged, entry.State);
                 Assert.Equal("Brrrr! It's chilly.", entry.Entity.Id);
 
                 entry = context.Entry(new StoatInACoat { Id = "Hot chocolate please!" });
-                await HandleEntity(async, entry, updateExistingEntities: true);
+                HandleEntity(entry, updateExistingEntities: true);
 
                 Assert.Equal(EntityState.Modified, entry.State);
                 Assert.Equal("Hot chocolate please!", entry.Entity.Id);
@@ -84,23 +61,12 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         }
 
         [Fact]
-        public async Task Entities_with_composite_key_with_any_default_values_are_made_Added_sync()
-        {
-            await Entities_with_composite_key_with_any_default_values_are_made_Added(async: false);
-        }
-
-        [Fact]
-        public async Task Entities_with_composite_key_with_any_default_values_are_made_Added_async()
-        {
-            await Entities_with_composite_key_with_any_default_values_are_made_Added(async: true);
-        }
-
-        private static async Task Entities_with_composite_key_with_any_default_values_are_made_Added(bool async)
+        public void Entities_with_composite_key_with_any_default_values_are_made_Added()
         {
             using (var context = new StoteInTheSnow())
             {
                 var entry = context.Entry(new CompositeStoat());
-                await HandleEntity(async, entry, updateExistingEntities: false);
+                HandleEntity(entry, updateExistingEntities: false);
 
                 Assert.Equal(EntityState.Added, entry.State);
                 Assert.NotEqual(Guid.NewGuid(), entry.Entity.Id1);
@@ -108,28 +74,28 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
                 var guid = Guid.NewGuid();
                 entry = context.Entry(new CompositeStoat { Id1 = guid });
-                await HandleEntity(async, entry, updateExistingEntities: false);
+                HandleEntity(entry, updateExistingEntities: false);
 
                 Assert.Equal(EntityState.Added, entry.State);
                 Assert.Equal(guid, entry.Entity.Id1);
                 Assert.NotEqual(Guid.NewGuid(), Guid.Parse(entry.Entity.Id2));
 
                 entry = context.Entry(new CompositeStoat { Id2 = "Ready for winter!" });
-                await HandleEntity(async, entry, updateExistingEntities: false);
+                HandleEntity(entry, updateExistingEntities: false);
 
                 Assert.Equal(EntityState.Added, entry.State);
                 Assert.NotEqual(Guid.NewGuid(), entry.Entity.Id1);
                 Assert.Equal("Ready for winter!", entry.Entity.Id2);
 
                 entry = context.Entry(new CompositeStoat { Id1 = guid, Id2 = "Ready for winter!" });
-                await HandleEntity(async, entry, updateExistingEntities: false);
+                HandleEntity(entry, updateExistingEntities: false);
 
                 Assert.Equal(EntityState.Unchanged, entry.State);
                 Assert.Equal(guid, entry.Entity.Id1);
                 Assert.Equal("Ready for winter!", entry.Entity.Id2);
 
                 entry = context.Entry(new CompositeStoat { Id1 = guid, Id2 = "Little black eyes" });
-                await HandleEntity(async, entry, updateExistingEntities: true);
+                HandleEntity(entry, updateExistingEntities: true);
 
                 Assert.Equal(EntityState.Modified, entry.State);
                 Assert.Equal(guid, entry.Entity.Id1);
@@ -137,18 +103,9 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             }
         }
 
-        private static async Task HandleEntity(bool async, EntityEntry entry, bool updateExistingEntities)
+        private void HandleEntity(EntityEntry entry, bool updateExistingEntities)
         {
-            var attacher = new KeyValueEntityAttacher(updateExistingEntities: updateExistingEntities);
-
-            if (async)
-            {
-                await attacher.HandleEntityAsync(entry);
-            }
-            else
-            {
-                attacher.HandleEntity(entry);
-            }
+            new KeyValueEntityAttacher(updateExistingEntities: updateExistingEntities).HandleEntity(entry);
         }
 
         private class Stoat

--- a/test/EntityFramework.Core.Tests/DbContextTest.cs
+++ b/test/EntityFramework.Core.Tests/DbContextTest.cs
@@ -257,12 +257,6 @@ namespace Microsoft.Data.Entity.Tests
         }
 
         [Fact]
-        public void Can_add_new_entities_to_context_async()
-        {
-            TrackEntitiesTest((c, e) => c.AddAsync(e).Result, (c, e) => c.AddAsync(e).Result, EntityState.Added);
-        }
-
-        [Fact]
         public void Can_add_existing_entities_to_context_to_be_attached()
         {
             TrackEntitiesTest((c, e) => c.Attach(e), (c, e) => c.Attach(e), EntityState.Unchanged);
@@ -322,16 +316,6 @@ namespace Microsoft.Data.Entity.Tests
         public void Can_add_multiple_new_entities_to_context()
         {
             TrackMultipleEntitiesTest((c, e) => c.Add(e[0], e[1]), (c, e) => c.Add(e[0], e[1]), EntityState.Added);
-        }
-
-        [Fact]
-        public void Can_add_multiple_new_entities_to_context_async()
-        {
-            TrackMultipleEntitiesTest((c, e) => c.AddAsync(e[0], e[1]).Result, (c, e) => c.AddAsync(e[0], e[1]).Result, EntityState.Added);
-
-            TrackMultipleEntitiesTest(
-                (c, e) => c.AddAsync(new[] { e[0], e[1] }, new CancellationToken()).Result,
-                (c, e) => c.AddAsync(new[] { e[0], e[1] }, new CancellationToken()).Result, EntityState.Added);
         }
 
         [Fact]
@@ -398,16 +382,6 @@ namespace Microsoft.Data.Entity.Tests
         }
 
         [Fact]
-        public void Can_add_no_new_entities_to_context_async()
-        {
-            TrackNoEntitiesTest(c => c.AddAsync(new Category[0]).Result, c => c.AddAsync(new Product[0]).Result, EntityState.Added);
-
-            TrackNoEntitiesTest(
-                c => c.AddAsync(new Category[0], new CancellationToken()).Result,
-                c => c.AddAsync(new Product[0], new CancellationToken()).Result, EntityState.Added);
-        }
-
-        [Fact]
         public void Can_add_no_existing_entities_to_context_to_be_attached()
         {
             TrackNoEntitiesTest(c => c.Attach(new Category[0]), c => c.Attach(new Product[0]), EntityState.Unchanged);
@@ -440,12 +414,6 @@ namespace Microsoft.Data.Entity.Tests
         public void Can_add_new_entities_to_context_non_generic()
         {
             TrackEntitiesTestNonGeneric((c, e) => c.Add(e), (c, e) => c.Add(e), EntityState.Added);
-        }
-
-        [Fact]
-        public void Can_add_new_entities_to_context_async_non_generic()
-        {
-            TrackEntitiesTestNonGeneric((c, e) => c.AddAsync(e).Result, (c, e) => c.AddAsync(e).Result, EntityState.Added);
         }
 
         [Fact]
@@ -508,16 +476,6 @@ namespace Microsoft.Data.Entity.Tests
         public void Can_add_multiple_new_entities_to_context_non_generic()
         {
             TrackMultipleEntitiesTestNonGeneric((c, e) => c.Add(e[0], e[1]), (c, e) => c.Add(e[0], e[1]), EntityState.Added);
-        }
-
-        [Fact]
-        public void Can_add_multiple_new_entities_to_context_async_non_generic()
-        {
-            TrackMultipleEntitiesTestNonGeneric((c, e) => c.AddAsync(e[0], e[1]).Result, (c, e) => c.AddAsync(e[0], e[1]).Result, EntityState.Added);
-
-            TrackMultipleEntitiesTestNonGeneric(
-                (c, e) => c.AddAsync(new[] { e[0], e[1] }, new CancellationToken()).Result,
-                (c, e) => c.AddAsync(new[] { e[0], e[1] }, new CancellationToken()).Result, EntityState.Added);
         }
 
         [Fact]
@@ -584,16 +542,6 @@ namespace Microsoft.Data.Entity.Tests
         }
 
         [Fact]
-        public void Can_add_no_new_entities_to_context_async_non_generic()
-        {
-            TrackNoEntitiesTestNonGeneric(c => c.AddAsync().Result, c => c.AddAsync().Result, EntityState.Added);
-
-            TrackNoEntitiesTestNonGeneric(
-                c => c.AddAsync(new object[0], new CancellationToken()).Result,
-                c => c.AddAsync(new object[0], new CancellationToken()).Result, EntityState.Added);
-        }
-
-        [Fact]
         public void Can_add_no_existing_entities_to_context_to_be_attached_non_generic()
         {
             TrackNoEntitiesTestNonGeneric(c => c.Attach(), c => c.Attach(), EntityState.Unchanged);
@@ -626,12 +574,6 @@ namespace Microsoft.Data.Entity.Tests
         public void Can_add_new_entities_to_context_with_key_generation()
         {
             TrackEntitiesWithKeyGenerationTest((c, e) => c.Add(e).Entity);
-        }
-
-        [Fact]
-        public void Can_add_new_entities_to_context_with_key_generation_async()
-        {
-            TrackEntitiesWithKeyGenerationTest((c, e) => c.AddAsync(e).Result.Entity);
         }
 
         private static void TrackEntitiesWithKeyGenerationTest(Func<DbContext, TheGu, TheGu> adder)
@@ -704,7 +646,7 @@ namespace Microsoft.Data.Entity.Tests
                 var entity = new Category { Name = "Beverages" };
                 var entry = context.Entry(entity);
 
-                entry.SetState(initialState);
+                entry.State = initialState;
 
                 action(context, entity);
 
@@ -887,7 +829,7 @@ namespace Microsoft.Data.Entity.Tests
                 var product = new Product { Id = 1, CategoryId = 7, Name = "Marmite", Category = category };
                 category.Products = new List<Product> { product };
 
-                context.Entry(category).SetState(EntityState.Unchanged);
+                context.Entry(category).State = EntityState.Unchanged;
 
                 Assert.Equal(1, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
@@ -895,7 +837,7 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
                 Assert.Equal(EntityState.Unknown, context.Entry(product).State);
 
-                context.Entry(product).SetState(EntityState.Unchanged);
+                context.Entry(product).State = EntityState.Unchanged;
 
                 Assert.Equal(1, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
@@ -916,7 +858,7 @@ namespace Microsoft.Data.Entity.Tests
                 var product = new Product { Id = 1, CategoryId = 7, Name = "Marmite", Category = category };
                 category.Products = new List<Product> { product };
 
-                context.Entry(product).SetState(EntityState.Unchanged);
+                context.Entry(product).State = EntityState.Unchanged;
 
                 Assert.Equal(1, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
@@ -924,7 +866,7 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Equal(EntityState.Unknown, context.Entry(category).State);
                 Assert.Equal(EntityState.Modified, context.Entry(product).State);
 
-                context.Entry(category).SetState(EntityState.Unchanged);
+                context.Entry(category).State = EntityState.Unchanged;
 
                 Assert.Equal(1, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
@@ -943,7 +885,7 @@ namespace Microsoft.Data.Entity.Tests
                 var product = new Product { Id = 1, CategoryId = 7, Name = "Marmite", Category = category };
                 category.Products = new List<Product>();
 
-                context.Entry(category).SetState(EntityState.Unchanged);
+                context.Entry(category).State = EntityState.Unchanged;
 
                 Assert.Equal(7, product.CategoryId);
                 Assert.Empty(category.Products);
@@ -951,7 +893,7 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
                 Assert.Equal(EntityState.Unknown, context.Entry(product).State);
 
-                context.Entry(product).SetState(EntityState.Unchanged);
+                context.Entry(product).State = EntityState.Unchanged;
 
                 Assert.Equal(1, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
@@ -970,7 +912,7 @@ namespace Microsoft.Data.Entity.Tests
                 var product = new Product { Id = 1, CategoryId = 7, Name = "Marmite", Category = category };
                 category.Products = new List<Product>();
 
-                context.Entry(product).SetState(EntityState.Unchanged);
+                context.Entry(product).State = EntityState.Unchanged;
 
                 Assert.Equal(1, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
@@ -978,7 +920,7 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Equal(EntityState.Unknown, context.Entry(category).State);
                 Assert.Equal(EntityState.Modified, context.Entry(product).State);
 
-                context.Entry(category).SetState(EntityState.Unchanged);
+                context.Entry(category).State = EntityState.Unchanged;
 
                 Assert.Equal(1, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
@@ -997,7 +939,7 @@ namespace Microsoft.Data.Entity.Tests
                 var product = new Product { Id = 1, CategoryId = 7, Name = "Marmite" };
                 category.Products = new List<Product> { product };
 
-                context.Entry(category).SetState(EntityState.Unchanged);
+                context.Entry(category).State = EntityState.Unchanged;
 
                 Assert.Equal(1, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
@@ -1005,7 +947,7 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
                 Assert.Equal(EntityState.Unknown, context.Entry(product).State);
 
-                context.Entry(product).SetState(EntityState.Unchanged);
+                context.Entry(product).State = EntityState.Unchanged;
 
                 Assert.Equal(1, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
@@ -1026,7 +968,7 @@ namespace Microsoft.Data.Entity.Tests
                 var product = new Product { Id = 1, CategoryId = 7, Name = "Marmite" };
                 category.Products = new List<Product> { product };
 
-                context.Entry(product).SetState(EntityState.Unchanged);
+                context.Entry(product).State = EntityState.Unchanged;
 
                 Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
@@ -1034,7 +976,7 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Equal(EntityState.Unknown, context.Entry(category).State);
                 Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
 
-                context.Entry(category).SetState(EntityState.Unchanged);
+                context.Entry(category).State = EntityState.Unchanged;
 
                 Assert.Equal(1, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
@@ -1245,7 +1187,7 @@ namespace Microsoft.Data.Entity.Tests
                 var product = new Product { Id = 1, CategoryId = 7, Name = "Marmite", Category = category };
                 category.Products = new List<Product> { product };
 
-                context.Entry(category).SetState(EntityState.Unchanged);
+                context.Entry(category).State = EntityState.Unchanged;
 
                 Assert.Equal(1, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
@@ -1254,7 +1196,7 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
                 Assert.Equal(EntityState.Unknown, context.Entry(product).State);
 
-                context.Entry(product).SetState(EntityState.Unchanged);
+                context.Entry(product).State = EntityState.Unchanged;
 
                 Assert.Equal(1, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
@@ -1278,7 +1220,7 @@ namespace Microsoft.Data.Entity.Tests
                 var product = new Product { Id = 1, CategoryId = 7, Name = "Marmite", Category = category };
                 category.Products = new List<Product> { product };
 
-                context.Entry(product).SetState(EntityState.Unchanged);
+                context.Entry(product).State = EntityState.Unchanged;
 
                 Assert.Equal(1, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
@@ -1287,7 +1229,7 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Equal(EntityState.Unknown, context.Entry(category).State);
                 Assert.Equal(EntityState.Modified, context.Entry(product).State);
 
-                context.Entry(category).SetState(EntityState.Unchanged);
+                context.Entry(category).State = EntityState.Unchanged;
 
                 Assert.Equal(1, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
@@ -1309,7 +1251,7 @@ namespace Microsoft.Data.Entity.Tests
                 var product = new Product { Id = 1, CategoryId = 7, Name = "Marmite", Category = category };
                 category.Products = new List<Product>();
 
-                context.Entry(category).SetState(EntityState.Unchanged);
+                context.Entry(category).State = EntityState.Unchanged;
 
                 Assert.Equal(7, product.CategoryId);
                 Assert.Empty(category.Products);
@@ -1318,7 +1260,7 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
                 Assert.Equal(EntityState.Unknown, context.Entry(product).State);
 
-                context.Entry(product).SetState(EntityState.Unchanged);
+                context.Entry(product).State = EntityState.Unchanged;
 
                 Assert.Equal(1, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
@@ -1340,7 +1282,7 @@ namespace Microsoft.Data.Entity.Tests
                 var product = new Product { Id = 1, CategoryId = 7, Name = "Marmite", Category = category };
                 category.Products = new List<Product>();
 
-                context.Entry(product).SetState(EntityState.Unchanged);
+                context.Entry(product).State = EntityState.Unchanged;
 
                 Assert.Equal(1, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
@@ -1349,7 +1291,7 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Equal(EntityState.Unknown, context.Entry(category).State);
                 Assert.Equal(EntityState.Modified, context.Entry(product).State);
 
-                context.Entry(category).SetState(EntityState.Unchanged);
+                context.Entry(category).State = EntityState.Unchanged;
 
                 Assert.Equal(1, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
@@ -1371,7 +1313,7 @@ namespace Microsoft.Data.Entity.Tests
                 var product = new Product { Id = 1, CategoryId = 7, Name = "Marmite" };
                 category.Products = new List<Product> { product };
 
-                context.Entry(category).SetState(EntityState.Unchanged);
+                context.Entry(category).State = EntityState.Unchanged;
 
                 Assert.Equal(1, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
@@ -1380,7 +1322,7 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
                 Assert.Equal(EntityState.Unknown, context.Entry(product).State);
 
-                context.Entry(product).SetState(EntityState.Unchanged);
+                context.Entry(product).State = EntityState.Unchanged;
 
                 Assert.Equal(1, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
@@ -1404,7 +1346,7 @@ namespace Microsoft.Data.Entity.Tests
                 var product = new Product { Id = 1, CategoryId = 7, Name = "Marmite" };
                 category.Products = new List<Product> { product };
 
-                context.Entry(product).SetState(EntityState.Unchanged);
+                context.Entry(product).State = EntityState.Unchanged;
 
                 Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
@@ -1413,7 +1355,7 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Equal(EntityState.Unknown, context.Entry(category).State);
                 Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
 
-                context.Entry(category).SetState(EntityState.Unchanged);
+                context.Entry(category).State = EntityState.Unchanged;
 
                 Assert.Equal(1, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
@@ -1520,8 +1462,8 @@ namespace Microsoft.Data.Entity.Tests
 
             using (var context = new EarlyLearningCenter(serviceProvider, options))
             {
-                context.Entry(new Category { Id = 1 }).SetState(EntityState.Unchanged);
-                context.Entry(new Category { Id = 2 }).SetState(EntityState.Unchanged);
+                context.Entry(new Category { Id = 1 }).State = EntityState.Unchanged;
+                context.Entry(new Category { Id = 2 }).State = EntityState.Unchanged;
                 Assert.Equal(2, context.ChangeTracker.Entries().Count());
 
                 context.SaveChanges();
@@ -1565,10 +1507,10 @@ namespace Microsoft.Data.Entity.Tests
 
             using (var context = new EarlyLearningCenter(serviceProvider, options))
             {
-                context.Entry(new Category { Id = 1 }).SetState(EntityState.Unchanged);
-                context.Entry(new Category { Id = 2 }).SetState(EntityState.Modified);
-                context.Entry(new Category { Id = 3 }).SetState(EntityState.Added);
-                context.Entry(new Category { Id = 4 }).SetState(EntityState.Deleted);
+                context.Entry(new Category { Id = 1 }).State = EntityState.Unchanged;
+                context.Entry(new Category { Id = 2 }).State = EntityState.Modified;
+                context.Entry(new Category { Id = 3 }).State = EntityState.Added;
+                context.Entry(new Category { Id = 4 }).State = EntityState.Deleted;
                 Assert.Equal(4, context.ChangeTracker.Entries().Count());
 
                 context.SaveChanges();
@@ -1614,10 +1556,10 @@ namespace Microsoft.Data.Entity.Tests
 
             using (var context = new EarlyLearningCenter(serviceProvider, options))
             {
-                context.Entry(new Category { Id = 1 }).SetState(EntityState.Unchanged);
-                context.Entry(new Category { Id = 2 }).SetState(EntityState.Modified);
-                context.Entry(new Category { Id = 3 }).SetState(EntityState.Added);
-                context.Entry(new Category { Id = 4 }).SetState(EntityState.Deleted);
+                context.Entry(new Category { Id = 1 }).State = EntityState.Unchanged;
+                context.Entry(new Category { Id = 2 }).State = EntityState.Modified;
+                context.Entry(new Category { Id = 3 }).State = EntityState.Added;
+                context.Entry(new Category { Id = 4 }).State = EntityState.Deleted;
                 Assert.Equal(4, context.ChangeTracker.Entries().Count());
 
                 await context.SaveChangesAsync();
@@ -2423,7 +2365,7 @@ namespace Microsoft.Data.Entity.Tests
         }
 
         [Fact]
-        public async Task Add_Attach_Remove_Update_do_not_call_DetectChanges()
+        public void Add_Attach_Remove_Update_do_not_call_DetectChanges()
         {
             var provider = TestHelpers.CreateServiceProvider(new ServiceCollection().AddScoped<ChangeDetector, ChangeDetectorProxy>());
             using (var context = new ButTheHedgehogContext(provider))
@@ -2435,10 +2377,10 @@ namespace Microsoft.Data.Entity.Tests
 
                 changeDetector.DetectChangesCalled = false;
 
-                await context.AddAsync(entity);
-                await context.AddAsync((object)entity);
-                await context.AddAsync(new[] { entity });
-                await context.AddAsync(new object[] { entity });
+                context.Add(entity);
+                context.Add((object)entity);
+                context.Add(new[] { entity });
+                context.Add(new object[] { entity });
                 context.Add(entity);
                 context.Add((object)entity);
                 context.Add(new[] { entity });
@@ -2485,20 +2427,6 @@ namespace Microsoft.Data.Entity.Tests
                 DetectChangesCalled = true;
 
                 base.DetectChanges(stateManager);
-            }
-
-            public override Task DetectChangesAsync(StateEntry entry, CancellationToken cancellationToken = new CancellationToken())
-            {
-                DetectChangesCalled = true;
-
-                return base.DetectChangesAsync(entry, cancellationToken);
-            }
-
-            public override Task DetectChangesAsync(StateManager stateManager, CancellationToken cancellationToken = new CancellationToken())
-            {
-                DetectChangesCalled = true;
-
-                return base.DetectChangesAsync(stateManager, cancellationToken);
             }
         }
     }

--- a/test/EntityFramework.Core.Tests/DbSetTest.cs
+++ b/test/EntityFramework.Core.Tests/DbSetTest.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Threading;
 using Microsoft.Data.Entity.ChangeTracking;
 using Xunit;
 
@@ -15,12 +14,6 @@ namespace Microsoft.Data.Entity.Tests
         public void Can_add_new_entities_to_context()
         {
             TrackEntitiesTest((c, e) => c.Add(e), (c, e) => c.Add(e), EntityState.Added);
-        }
-
-        [Fact]
-        public void Can_add_new_entities_to_context_async()
-        {
-            TrackEntitiesTest((c, e) => c.AddAsync(e).Result, (c, e) => c.AddAsync(e).Result, EntityState.Added);
         }
 
         [Fact]
@@ -86,16 +79,6 @@ namespace Microsoft.Data.Entity.Tests
         }
 
         [Fact]
-        public void Can_add_multiple_new_entities_to_context_async()
-        {
-            TrackMultipleEntitiesTest((c, e) => c.AddAsync(e[0], e[1]).Result, (c, e) => c.AddAsync(e[0], e[1]).Result, EntityState.Added);
-
-            TrackMultipleEntitiesTest(
-                (c, e) => c.AddAsync(new CancellationToken(), e[0], e[1]).Result,
-                (c, e) => c.AddAsync(new CancellationToken(), e[0], e[1]).Result, EntityState.Added);
-        }
-
-        [Fact]
         public void Can_add_multiple_existing_entities_to_context_to_be_attached()
         {
             TrackMultipleEntitiesTest((c, e) => c.Attach(e[0], e[1]), (c, e) => c.Attach(e[0], e[1]), EntityState.Unchanged);
@@ -153,16 +136,6 @@ namespace Microsoft.Data.Entity.Tests
         public void Can_add_no_new_entities_to_context()
         {
             TrackNoEntitiesTest(c => c.Add(new Category[0]), c => c.Add(new Product[0]), EntityState.Added);
-        }
-
-        [Fact]
-        public void Can_add_no_new_entities_to_context_async()
-        {
-            TrackNoEntitiesTest(c => c.AddAsync(new Category[0]).Result, c => c.AddAsync(new Product[0]).Result, EntityState.Added);
-
-            TrackNoEntitiesTest(
-                c => c.AddAsync(new CancellationToken(), new Category[0]).Result,
-                c => c.AddAsync(new CancellationToken(), new Product[0]).Result, EntityState.Added);
         }
 
         [Fact]
@@ -241,7 +214,7 @@ namespace Microsoft.Data.Entity.Tests
                 var entity = new Category { Name = "Beverages" };
                 var entry = context.Entry(entity);
 
-                entry.SetState(initialState);
+                entry.State = initialState;
 
                 action(context, entity);
 
@@ -253,12 +226,6 @@ namespace Microsoft.Data.Entity.Tests
         public void Can_add_new_entities_to_context_with_key_generation()
         {
             TrackEntitiesWithKeyGenerationTest((c, e) => c.Add(e).Entity);
-        }
-
-        [Fact]
-        public void Can_add_new_entities_to_context_with_key_generation_async()
-        {
-            TrackEntitiesWithKeyGenerationTest((c, e) => c.AddAsync(e).Result.Entity);
         }
 
         private static void TrackEntitiesWithKeyGenerationTest(Func<DbSet<TheGu>, TheGu, TheGu> adder)

--- a/test/EntityFramework.Core.Tests/Identity/ForeignKeyValuePropagatorTest.cs
+++ b/test/EntityFramework.Core.Tests/Identity/ForeignKeyValuePropagatorTest.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Identity;
 using Microsoft.Data.Entity.Metadata;
@@ -14,10 +13,8 @@ namespace Microsoft.Data.Entity.Tests.Identity
 {
     public class ForeignKeyValuePropagatorTest
     {
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task Foreign_key_value_is_obtained_from_reference_to_principal(bool async)
+        [Fact]
+        public void Foreign_key_value_is_obtained_from_reference_to_principal()
         {
             var model = BuildModel();
 
@@ -28,15 +25,13 @@ namespace Microsoft.Data.Entity.Tests.Identity
             var dependentEntry = contextServices.GetRequiredService<StateManager>().GetOrCreateEntry(dependent);
             var property = model.GetEntityType(typeof(Product)).GetProperty("CategoryId");
 
-            await PropagateValue(contextServices.GetRequiredService<ForeignKeyValuePropagator>(), dependentEntry, property, async);
+            PropagateValue(contextServices.GetRequiredService<ForeignKeyValuePropagator>(), dependentEntry, property);
 
             Assert.Equal(11, dependentEntry[property]);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task Foreign_key_value_is_obtained_from_tracked_principal_with_populated_collection(bool async)
+        [Fact]
+        public void Foreign_key_value_is_obtained_from_tracked_principal_with_populated_collection()
         {
             var model = BuildModel();
             var contextServices = CreateContextServices(model);
@@ -50,15 +45,13 @@ namespace Microsoft.Data.Entity.Tests.Identity
             var dependentEntry = manager.GetOrCreateEntry(dependent);
             var property = model.GetEntityType(typeof(Product)).GetProperty("CategoryId");
 
-            await PropagateValue(contextServices.GetRequiredService<ForeignKeyValuePropagator>(), dependentEntry, property, async);
+            PropagateValue(contextServices.GetRequiredService<ForeignKeyValuePropagator>(), dependentEntry, property);
 
             Assert.Equal(11, dependentEntry[property]);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task Non_identifying_foreign_key_value_is_not_generated_if_principal_key_not_set(bool async)
+        [Fact]
+        public void Non_identifying_foreign_key_value_is_not_generated_if_principal_key_not_set()
         {
             var model = BuildModel();
 
@@ -69,15 +62,13 @@ namespace Microsoft.Data.Entity.Tests.Identity
             var dependentEntry = contextServices.GetRequiredService<StateManager>().GetOrCreateEntry(dependent);
             var property = model.GetEntityType(typeof(Product)).GetProperty("CategoryId");
 
-            await PropagateValue(contextServices.GetRequiredService<ForeignKeyValuePropagator>(), dependentEntry, property, async);
+            PropagateValue(contextServices.GetRequiredService<ForeignKeyValuePropagator>(), dependentEntry, property);
 
             Assert.Equal(0, dependentEntry[property]);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task One_to_one_foreign_key_value_is_obtained_from_reference_to_principal(bool async)
+        [Fact]
+        public void One_to_one_foreign_key_value_is_obtained_from_reference_to_principal()
         {
             var model = BuildModel();
 
@@ -88,15 +79,13 @@ namespace Microsoft.Data.Entity.Tests.Identity
             var dependentEntry = contextServices.GetRequiredService<StateManager>().GetOrCreateEntry(dependent);
             var property = model.GetEntityType(typeof(ProductDetail)).GetProperty("Id");
 
-            await PropagateValue(contextServices.GetRequiredService<ForeignKeyValuePropagator>(), dependentEntry, property, async);
+            PropagateValue(contextServices.GetRequiredService<ForeignKeyValuePropagator>(), dependentEntry, property);
 
             Assert.Equal(21, dependentEntry[property]);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task One_to_one_foreign_key_value_is_obtained_from_tracked_principal(bool async)
+        [Fact]
+        public void One_to_one_foreign_key_value_is_obtained_from_tracked_principal()
         {
             var model = BuildModel();
             var contextServices = CreateContextServices(model);
@@ -109,15 +98,13 @@ namespace Microsoft.Data.Entity.Tests.Identity
             var dependentEntry = manager.GetOrCreateEntry(dependent);
             var property = model.GetEntityType(typeof(ProductDetail)).GetProperty("Id");
 
-            await PropagateValue(contextServices.GetRequiredService<ForeignKeyValuePropagator>(), dependentEntry, property, async);
+            PropagateValue(contextServices.GetRequiredService<ForeignKeyValuePropagator>(), dependentEntry, property);
 
             Assert.Equal(21, dependentEntry[property]);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task Identifying_foreign_key_value_is_generated_if_principal_key_not_set(bool async)
+        [Fact]
+        public void Identifying_foreign_key_value_is_generated_if_principal_key_not_set()
         {
             var model = BuildModel();
 
@@ -128,15 +115,13 @@ namespace Microsoft.Data.Entity.Tests.Identity
             var dependentEntry = contextServices.GetRequiredService<StateManager>().GetOrCreateEntry(dependent);
             var property = model.GetEntityType(typeof(ProductDetail)).GetProperty("Id");
 
-            await PropagateValue(contextServices.GetRequiredService<ForeignKeyValuePropagator>(), dependentEntry, property, async);
+            PropagateValue(contextServices.GetRequiredService<ForeignKeyValuePropagator>(), dependentEntry, property);
 
             Assert.Equal(1, dependentEntry[property]);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task Composite_foreign_key_value_is_obtained_from_reference_to_principal(bool async)
+        [Fact]
+        public void Composite_foreign_key_value_is_obtained_from_reference_to_principal()
         {
             var model = BuildModel();
 
@@ -149,17 +134,15 @@ namespace Microsoft.Data.Entity.Tests.Identity
             var property2 = model.GetEntityType(typeof(OrderLineDetail)).GetProperty("ProductId");
 
             var valuePropagator = contextServices.GetRequiredService<ForeignKeyValuePropagator>();
-            await PropagateValue(valuePropagator, dependentEntry, property1, async);
-            await PropagateValue(valuePropagator, dependentEntry, property2, async);
+            PropagateValue(valuePropagator, dependentEntry, property1);
+            PropagateValue(valuePropagator, dependentEntry, property2);
 
             Assert.Equal(11, dependentEntry[property1]);
             Assert.Equal(21, dependentEntry[property2]);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task Composite_foreign_key_value_is_obtained_from_tracked_principal(bool async)
+        [Fact]
+        public void Composite_foreign_key_value_is_obtained_from_tracked_principal()
         {
             var model = BuildModel();
             var contextServices = CreateContextServices(model);
@@ -174,8 +157,8 @@ namespace Microsoft.Data.Entity.Tests.Identity
             var property2 = model.GetEntityType(typeof(OrderLineDetail)).GetProperty("ProductId");
 
             var valuePropagator = contextServices.GetRequiredService<ForeignKeyValuePropagator>();
-            await PropagateValue(valuePropagator, dependentEntry, property1, async);
-            await PropagateValue(valuePropagator, dependentEntry, property2, async);
+            PropagateValue(valuePropagator, dependentEntry, property1);
+            PropagateValue(valuePropagator, dependentEntry, property2);
 
             Assert.Equal(11, dependentEntry[property1]);
             Assert.Equal(21, dependentEntry[property2]);
@@ -186,20 +169,9 @@ namespace Microsoft.Data.Entity.Tests.Identity
             return TestHelpers.CreateContextServices(model ?? BuildModel());
         }
 
-        private static async Task PropagateValue(
-            ForeignKeyValuePropagator valuePropagator,
-            StateEntry dependentEntry,
-            IProperty property,
-            bool async)
+        private static void PropagateValue(ForeignKeyValuePropagator valuePropagator, StateEntry dependentEntry, IProperty property)
         {
-            if (async)
-            {
-                await valuePropagator.PropagateValueAsync(dependentEntry, property);
-            }
-            else
-            {
-                valuePropagator.PropagateValue(dependentEntry, property);
-            }
+            valuePropagator.PropagateValue(dependentEntry, property);
         }
 
         private class Category

--- a/test/EntityFramework.InMemory.FunctionalTests/CompositeKeyEndToEndTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/CompositeKeyEndToEndTest.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
 
             using (var context = new BronieContext(serviceProvider))
             {
-                await context.AddAsync(new Pegasus { Id1 = ticks, Id2 = ticks + 1, Name = "Rainbow Dash" });
+                context.Add(new Pegasus { Id1 = ticks, Id2 = ticks + 1, Name = "Rainbow Dash" });
                 await context.SaveChangesAsync();
             }
 
@@ -72,7 +72,7 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
 
             using (var context = new BronieContext(serviceProvider))
             {
-                var added = (await context.AddAsync(new Unicorn { Id2 = id2, Name = "Rarity" })).Entity;
+                var added = context.Add(new Unicorn { Id2 = id2, Name = "Rarity" }).Entity;
 
                 Assert.True(added.Id1 > 0);
                 Assert.NotEqual(Guid.Empty, added.Id3);
@@ -127,9 +127,9 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
 
             using (var context = new BronieContext(serviceProvider))
             {
-                var pony1 = (await context.AddAsync(new EarthPony { Id2 = 7, Name = "Apple Jack 1" })).Entity;
-                var pony2 = (await context.AddAsync(new EarthPony { Id2 = 7, Name = "Apple Jack 2" })).Entity;
-                var pony3 = (await context.AddAsync(new EarthPony { Id2 = 7, Name = "Apple Jack 3" })).Entity;
+                var pony1 = context.Add(new EarthPony { Id2 = 7, Name = "Apple Jack 1" }).Entity;
+                var pony2 = context.Add(new EarthPony { Id2 = 7, Name = "Apple Jack 2" }).Entity;
+                var pony3 = context.Add(new EarthPony { Id2 = 7, Name = "Apple Jack 3" }).Entity;
 
                 await context.SaveChangesAsync();
 

--- a/test/EntityFramework.InMemory.FunctionalTests/GuidValueGeneratorEndToEndTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/GuidValueGeneratorEndToEndTest.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
             {
                 for (var i = 0; i < 10; i++)
                 {
-                    guids.Add((await context.AddAsync(new Pegasus { Name = "Rainbow Dash " + i })).Entity.Id);
+                    guids.Add(context.Add(new Pegasus { Name = "Rainbow Dash " + i }).Entity.Id);
                     guidsHash.Add(guids.Last());
                 }
 

--- a/test/EntityFramework.InMemory.FunctionalTests/InMemoryIntegerGeneratorEndToEndTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/InMemoryIntegerGeneratorEndToEndTest.cs
@@ -82,8 +82,8 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
             {
                 for (var i = 0; i < 50; i++)
                 {
-                    await context.AddAsync(new Pegasus { Name = "Rainbow Dash " + i });
-                    await context.AddAsync(new Pegasus { Name = "Fluttershy " + i });
+                    context.Add(new Pegasus { Name = "Rainbow Dash " + i });
+                    context.Add(new Pegasus { Name = "Fluttershy " + i });
                 }
 
                 await context.SaveChangesAsync();

--- a/test/EntityFramework.InMemory.FunctionalTests/ShadowStateUpdateTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/ShadowStateUpdateTest.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
                 customerEntry[customerType.GetProperty("Id")] = 42;
                 customerEntry[customerType.GetProperty("Name")] = "Daenerys";
 
-                await customerEntry.SetEntityStateAsync(EntityState.Added);
+                customerEntry.SetEntityState(EntityState.Added);
 
                 await context.SaveChangesAsync();
 
@@ -51,7 +51,7 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
                 customerEntry[customerType.GetProperty("Id")] = 42;
                 customerEntry[customerType.GetProperty("Name")] = "Daenerys Targaryen";
 
-                await customerEntry.SetEntityStateAsync(EntityState.Modified);
+                customerEntry.SetEntityState(EntityState.Modified);
 
                 await context.SaveChangesAsync();
             }
@@ -66,7 +66,7 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
                 var customerEntry = context.ChangeTracker.StateManager.CreateNewEntry(customerType);
                 customerEntry[customerType.GetProperty("Id")] = 42;
 
-                await customerEntry.SetEntityStateAsync(EntityState.Deleted);
+                customerEntry.SetEntityState(EntityState.Deleted);
 
                 await context.SaveChangesAsync();
             }

--- a/test/EntityFramework.InMemory.Tests/InMemoryDataStoreTest.cs
+++ b/test/EntityFramework.InMemory.Tests/InMemoryDataStoreTest.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
             var serviceProvider = TestHelpers.CreateContextServices(CreateModel());
             var customer = new Customer { Id = 42, Name = "Unikorn" };
             var entityEntry = serviceProvider.GetRequiredService<StateManager>().GetOrCreateEntry(customer);
-            await entityEntry.SetEntityStateAsync(EntityState.Added);
+            entityEntry.SetEntityState(EntityState.Added);
 
             var inMemoryDataStore = serviceProvider.GetRequiredService<InMemoryDataStore>();
 
@@ -112,14 +112,14 @@ namespace Microsoft.Data.Entity.InMemory.Tests
 
             var customer = new Customer { Id = 42, Name = "Unikorn" };
             var entityEntry = serviceProvider.GetRequiredService<StateManager>().GetOrCreateEntry(customer);
-            await entityEntry.SetEntityStateAsync(EntityState.Added);
+            entityEntry.SetEntityState(EntityState.Added);
 
             var inMemoryDataStore = serviceProvider.GetRequiredService<InMemoryDataStore>();
 
             await inMemoryDataStore.SaveChangesAsync(new[] { entityEntry });
 
             customer.Name = "Unikorn, The Return";
-            await entityEntry.SetEntityStateAsync(EntityState.Modified);
+            entityEntry.SetEntityState(EntityState.Modified);
 
             await inMemoryDataStore.SaveChangesAsync(new[] { entityEntry });
 
@@ -134,17 +134,17 @@ namespace Microsoft.Data.Entity.InMemory.Tests
 
             var customer = new Customer { Id = 42, Name = "Unikorn" };
             var entityEntry = serviceProvider.GetRequiredService<StateManager>().GetOrCreateEntry(customer);
-            await entityEntry.SetEntityStateAsync(EntityState.Added);
+            entityEntry.SetEntityState(EntityState.Added);
 
             var inMemoryDataStore = serviceProvider.GetRequiredService<InMemoryDataStore>();
 
             await inMemoryDataStore.SaveChangesAsync(new[] { entityEntry });
 
             // Because the data store is being used directly the entity state must be manually changed after saving.
-            await entityEntry.SetEntityStateAsync(EntityState.Unchanged);
+            entityEntry.SetEntityState(EntityState.Unchanged);
 
             customer.Name = "Unikorn, The Return";
-            await entityEntry.SetEntityStateAsync(EntityState.Deleted);
+            entityEntry.SetEntityState(EntityState.Deleted);
 
             await inMemoryDataStore.SaveChangesAsync(new[] { entityEntry });
 
@@ -168,7 +168,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
 
             var customer = new Customer { Id = 42, Name = "Unikorn" };
             var entityEntry = scopedServices.GetRequiredService<StateManager>().GetOrCreateEntry(customer);
-            await entityEntry.SetEntityStateAsync(EntityState.Added);
+            entityEntry.SetEntityState(EntityState.Added);
 
             var inMemoryDataStore = scopedServices.GetRequiredService<InMemoryDataStore>();
 

--- a/test/EntityFramework.Relational.FunctionalTests/TransactionTestBase.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/TransactionTestBase.cs
@@ -20,8 +20,8 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
         {
             using (var context = CreateContext())
             {
-                context.Entry(context.Set<TransactionCustomer>().First()).SetState(EntityState.Deleted);
-                context.Entry(context.Set<TransactionCustomer>().Last()).SetState(EntityState.Added);
+                context.Entry(context.Set<TransactionCustomer>().First()).State = EntityState.Deleted;
+                context.Entry(context.Set<TransactionCustomer>().Last()).State = EntityState.Added;
 
                 Assert.Throws<DbUpdateException>(() => context.SaveChanges());
             }
@@ -34,8 +34,8 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
         {
             using (var context = CreateContext())
             {
-                context.Entry(context.Set<TransactionCustomer>().First()).SetState(EntityState.Deleted);
-                context.Entry(context.Set<TransactionCustomer>().Last()).SetState(EntityState.Added);
+                context.Entry(context.Set<TransactionCustomer>().First()).State = EntityState.Deleted;
+                context.Entry(context.Set<TransactionCustomer>().Last()).State = EntityState.Added;
 
                 try
                 {
@@ -56,7 +56,7 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
             {
                 using (context.Database.AsRelational().Connection.BeginTransaction())
                 {
-                    context.Entry(context.Set<TransactionCustomer>().First()).SetState(EntityState.Deleted);
+                    context.Entry(context.Set<TransactionCustomer>().First()).State = EntityState.Deleted;
                     context.SaveChanges();
                 }
             }
@@ -71,7 +71,7 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
             {
                 using (await context.Database.AsRelational().Connection.BeginTransactionAsync())
                 {
-                    context.Entry(context.Set<TransactionCustomer>().First()).SetState(EntityState.Deleted);
+                    context.Entry(context.Set<TransactionCustomer>().First()).State = EntityState.Deleted;
                     await context.SaveChangesAsync();
                 }
             }
@@ -86,8 +86,8 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
             {
                 using (var transaction = context.Database.AsRelational().Connection.BeginTransaction())
                 {
-                    context.Entry(context.Set<TransactionCustomer>().First()).SetState(EntityState.Deleted);
-                    context.Entry(context.Set<TransactionCustomer>().Last()).SetState(EntityState.Added);
+                    context.Entry(context.Set<TransactionCustomer>().First()).State = EntityState.Deleted;
+                    context.Entry(context.Set<TransactionCustomer>().Last()).State = EntityState.Added;
 
                     try
                     {
@@ -109,8 +109,8 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
             {
                 using (var transaction = await context.Database.AsRelational().Connection.BeginTransactionAsync())
                 {
-                    context.Entry(context.Set<TransactionCustomer>().First()).SetState(EntityState.Deleted);
-                    context.Entry(context.Set<TransactionCustomer>().Last()).SetState(EntityState.Added);
+                    context.Entry(context.Set<TransactionCustomer>().First()).State = EntityState.Deleted;
+                    context.Entry(context.Set<TransactionCustomer>().Last()).State = EntityState.Added;
 
                     try
                     {
@@ -132,7 +132,7 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
             {
                 using (var transaction = await context.Database.AsRelational().Connection.BeginTransactionAsync())
                 {
-                    context.Entry(context.Set<TransactionCustomer>().First()).SetState(EntityState.Deleted);
+                    context.Entry(context.Set<TransactionCustomer>().First()).State = EntityState.Deleted;
                     await context.SaveChangesAsync();
                     transaction.Commit();
                 }
@@ -151,7 +151,7 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
             {
                 using (var transaction = await context.Database.AsRelational().Connection.BeginTransactionAsync())
                 {
-                    context.Entry(context.Set<TransactionCustomer>().First()).SetState(EntityState.Deleted);
+                    context.Entry(context.Set<TransactionCustomer>().First()).State = EntityState.Deleted;
                     await context.SaveChangesAsync();
                     transaction.Rollback();
 
@@ -167,7 +167,7 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
             {
                 using (var transaction = context.Database.AsRelational().Connection.BeginTransaction())
                 {
-                    context.Entry(context.Set<TransactionCustomer>().First()).SetState(EntityState.Deleted);
+                    context.Entry(context.Set<TransactionCustomer>().First()).State = EntityState.Deleted;
                     context.SaveChanges();
 
                     using (var innerContext = CreateContext())
@@ -202,7 +202,7 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
             {
                 using (var transaction = await context.Database.AsRelational().Connection.BeginTransactionAsync())
                 {
-                    context.Entry(context.Set<TransactionCustomer>().First()).SetState(EntityState.Deleted);
+                    context.Entry(context.Set<TransactionCustomer>().First()).State = EntityState.Deleted;
                     await context.SaveChangesAsync();
 
                     using (var innerContext = CreateContext())
@@ -239,7 +239,7 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
                 {
                     context.Database.AsRelational().Connection.UseTransaction(transaction);
 
-                    context.Entry(context.Set<TransactionCustomer>().First()).SetState(EntityState.Deleted);
+                    context.Entry(context.Set<TransactionCustomer>().First()).State = EntityState.Deleted;
                     await context.SaveChangesAsync();
                 }
             }

--- a/test/EntityFramework.Relational.Tests/Update/CommandBatchPreparerTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/CommandBatchPreparerTest.cs
@@ -9,7 +9,6 @@ using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Relational.Metadata;
 using Microsoft.Data.Entity.Relational.Update;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.DependencyInjection;
 using Moq;
 using Xunit;
@@ -19,13 +18,13 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
     public class CommandBatchPreparerTest
     {
         [Fact]
-        public async Task BatchCommands_creates_valid_batch_for_added_entities()
+        public void BatchCommands_creates_valid_batch_for_added_entities()
         {
             var stateManager = CreateContextServices(CreateSimpleFKModel()).GetRequiredService<StateManager>();
 
             var stateEntry = stateManager.GetOrCreateEntry(new FakeEntity { Id = 42, Value = "Test" });
 
-            await stateEntry.SetEntityStateAsync(EntityState.Added);
+            stateEntry.SetEntityState(EntityState.Added);
 
             var commandBatches = CreateCommandBatchPreparer().BatchCommands(new[] { stateEntry }, new DbContextOptions()).ToArray();
             Assert.Equal(1, commandBatches.Count());
@@ -57,13 +56,13 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         }
 
         [Fact]
-        public async Task BatchCommands_creates_valid_batch_for_modified_entities()
+        public void BatchCommands_creates_valid_batch_for_modified_entities()
         {
             var stateManager = CreateContextServices(CreateSimpleFKModel()).GetRequiredService<StateManager>();
 
             var stateEntry = stateManager.GetOrCreateEntry(new FakeEntity { Id = 42, Value = "Test" });
 
-            await stateEntry.SetEntityStateAsync(EntityState.Modified);
+            stateEntry.SetEntityState(EntityState.Modified);
             stateEntry.SetPropertyModified(stateEntry.EntityType.GetPrimaryKey().Properties.Single(), isModified: false);
 
             var commandBatches = CreateCommandBatchPreparer().BatchCommands(new[] { stateEntry }, new DbContextOptions()).ToArray();
@@ -96,13 +95,13 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         }
 
         [Fact]
-        public async Task BatchCommands_creates_valid_batch_for_deleted_entities()
+        public void BatchCommands_creates_valid_batch_for_deleted_entities()
         {
             var stateManager = CreateContextServices(CreateSimpleFKModel()).GetRequiredService<StateManager>();
 
             var stateEntry = stateManager.GetOrCreateEntry(new FakeEntity { Id = 42, Value = "Test" });
 
-            await stateEntry.SetEntityStateAsync(EntityState.Deleted);
+            stateEntry.SetEntityState(EntityState.Deleted);
 
             var commandBatches = CreateCommandBatchPreparer().BatchCommands(new[] { stateEntry }, new DbContextOptions()).ToArray();
             Assert.Equal(1, commandBatches.Count());
@@ -124,16 +123,16 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         }
 
         [Fact]
-        public async Task BatchCommands_sorts_related_added_entities()
+        public void BatchCommands_sorts_related_added_entities()
         {
             var configuration = CreateContextServices(CreateSimpleFKModel());
             var stateManager = configuration.GetRequiredService<StateManager>();
 
             var stateEntry = stateManager.GetOrCreateEntry(new FakeEntity { Id = 42, Value = "Test" });
-            await stateEntry.SetEntityStateAsync(EntityState.Added);
+            stateEntry.SetEntityState(EntityState.Added);
 
             var relatedStateEntry = stateManager.GetOrCreateEntry(new RelatedFakeEntity { Id = 42 });
-            await relatedStateEntry.SetEntityStateAsync(EntityState.Added);
+            relatedStateEntry.SetEntityState(EntityState.Added);
 
             var commandBatches = CreateCommandBatchPreparer().BatchCommands(new[] { relatedStateEntry, stateEntry }, new DbContextOptions()).ToArray();
 
@@ -143,16 +142,16 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         }
 
         [Fact]
-        public async Task BatchCommands_sorts_added_and_related_modified_entities()
+        public void BatchCommands_sorts_added_and_related_modified_entities()
         {
             var configuration = CreateContextServices(CreateSimpleFKModel());
             var stateManager = configuration.GetRequiredService<StateManager>();
 
             var stateEntry = stateManager.GetOrCreateEntry(new FakeEntity { Id = 42, Value = "Test" });
-            await stateEntry.SetEntityStateAsync(EntityState.Added);
+            stateEntry.SetEntityState(EntityState.Added);
 
             var relatedStateEntry = stateManager.GetOrCreateEntry(new RelatedFakeEntity { Id = 42 });
-            await relatedStateEntry.SetEntityStateAsync(EntityState.Modified);
+            relatedStateEntry.SetEntityState(EntityState.Modified);
 
             var commandBatches = CreateCommandBatchPreparer().BatchCommands(new[] { relatedStateEntry, stateEntry }, new DbContextOptions()).ToArray();
 
@@ -162,16 +161,16 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         }
 
         [Fact]
-        public async Task BatchCommands_sorts_unrelated_entities()
+        public void BatchCommands_sorts_unrelated_entities()
         {
             var configuration = CreateContextServices(CreateSimpleFKModel());
             var stateManager = configuration.GetRequiredService<StateManager>();
 
             var firstStateEntry = stateManager.GetOrCreateEntry(new FakeEntity { Id = 42, Value = "Test" });
-            await firstStateEntry.SetEntityStateAsync(EntityState.Added);
+            firstStateEntry.SetEntityState(EntityState.Added);
 
             var secondStateEntry = stateManager.GetOrCreateEntry(new RelatedFakeEntity { Id = 1 });
-            await secondStateEntry.SetEntityStateAsync(EntityState.Added);
+            secondStateEntry.SetEntityState(EntityState.Added);
 
             var commandBatches = CreateCommandBatchPreparer().BatchCommands(new[] { secondStateEntry, firstStateEntry }, new DbContextOptions()).ToArray();
 
@@ -181,19 +180,19 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         }
 
         [Fact]
-        public async Task BatchCommands_sorts_entities_when_reparenting()
+        public void BatchCommands_sorts_entities_when_reparenting()
         {
             var configuration = CreateContextServices(CreateCyclicFKModel());
             var stateManager = configuration.GetRequiredService<StateManager>();
 
             var previousParent = stateManager.GetOrCreateEntry(new FakeEntity { Id = 42, Value = "Test" });
-            await previousParent.SetEntityStateAsync(EntityState.Deleted);
+            previousParent.SetEntityState(EntityState.Deleted);
 
             var newParent = stateManager.GetOrCreateEntry(new FakeEntity { Id = 3, Value = "Test" });
-            await newParent.SetEntityStateAsync(EntityState.Added);
+            newParent.SetEntityState(EntityState.Added);
 
             var relatedStateEntry = stateManager.GetOrCreateEntry(new RelatedFakeEntity { Id = 1, RelatedId = 3 });
-            await relatedStateEntry.SetEntityStateAsync(EntityState.Modified);
+            relatedStateEntry.SetEntityState(EntityState.Modified);
             relatedStateEntry.OriginalValues[relatedStateEntry.EntityType.GetProperty("RelatedId")] = 42;
             relatedStateEntry.SetPropertyModified(relatedStateEntry.EntityType.GetPrimaryKey().Properties.Single(), isModified: false);
 
@@ -205,17 +204,17 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         }
 
         [Fact]
-        public async Task BatchCommands_creates_batches_lazily()
+        public void BatchCommands_creates_batches_lazily()
         {
             var configuration = CreateContextServices(CreateSimpleFKModel());
             var stateManager = configuration.GetRequiredService<StateManager>();
 
             var fakeEntity = new FakeEntity { Id = 42, Value = "Test" };
             var stateEntry = stateManager.GetOrCreateEntry(fakeEntity);
-            await stateEntry.SetEntityStateAsync(EntityState.Added);
+            stateEntry.SetEntityState(EntityState.Added);
 
             var relatedStateEntry = stateManager.GetOrCreateEntry(new RelatedFakeEntity { Id = 42 });
-            await relatedStateEntry.SetEntityStateAsync(EntityState.Added);
+            relatedStateEntry.SetEntityState(EntityState.Added);
 
             var modificationCommandBatchFactoryMock = new Mock<ModificationCommandBatchFactory>();
             var options = new Mock<IDbContextOptions>().Object;

--- a/test/EntityFramework.SqlServer.FunctionalTests/CommandConfigurationTests.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/CommandConfigurationTests.cs
@@ -222,13 +222,13 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             {
                 context.Database.EnsureCreated();
 
-                await context.Chips.AddAsync(new KettleChips { BestBuyDate = DateTime.Now, Name = "Doritos Locos Tacos" });
+                context.Chips.Add(new KettleChips { BestBuyDate = DateTime.Now, Name = "Doritos Locos Tacos" });
                 await context.SaveChangesAsync();
                 Assert.Null(globalCommandTimeout);
 
                 context.Database.AsRelational().Connection.CommandTimeout = 88;
 
-                await context.Chips.AddAsync(new KettleChips { BestBuyDate = DateTime.Now, Name = "Doritos Locos Tacos" });
+                context.Chips.Add(new KettleChips { BestBuyDate = DateTime.Now, Name = "Doritos Locos Tacos" });
                 await context.SaveChangesAsync();
                 Assert.Equal(88, globalCommandTimeout);
             }
@@ -248,13 +248,13 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             {
                 context.Database.EnsureCreated(); 
 
-                await context.Chips.AddAsync(new KettleChips { BestBuyDate = DateTime.Now, Name = "Doritos Locos Tacos" });
+                context.Chips.Add(new KettleChips { BestBuyDate = DateTime.Now, Name = "Doritos Locos Tacos" });
                 await context.SaveChangesAsync();
                 Assert.Equal(77, globalCommandTimeout);
 
                 context.Database.AsRelational().Connection.CommandTimeout = 88;
 
-                await context.Chips.AddAsync(new KettleChips { BestBuyDate = DateTime.Now, Name = "Doritos Locos Tacos" });
+                context.Chips.Add(new KettleChips { BestBuyDate = DateTime.Now, Name = "Doritos Locos Tacos" });
                 await context.SaveChangesAsync();
                 Assert.Equal(88, globalCommandTimeout);
             }
@@ -276,7 +276,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
                 context.Database.AsRelational().Connection.CommandTimeout = 88;
 
-                await context.Chips.AddAsync(new KettleChips { BestBuyDate = DateTime.Now, Name = "Doritos Locos Tacos" });
+                context.Chips.Add(new KettleChips { BestBuyDate = DateTime.Now, Name = "Doritos Locos Tacos" });
                 await context.SaveChangesAsync();
                 Assert.Equal(88, globalCommandTimeout);
             }

--- a/test/EntityFramework.SqlServer.FunctionalTests/CompositeKeyEndToEndTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/CompositeKeyEndToEndTest.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             {
                 context.Database.EnsureCreated();
 
-                await context.AddAsync(new Pegasus { Id1 = ticks, Id2 = ticks + 1, Name = "Rainbow Dash" });
+                context.Add(new Pegasus { Id1 = ticks, Id2 = ticks + 1, Name = "Rainbow Dash" });
                 await context.SaveChangesAsync();
             }
 
@@ -76,7 +76,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             {
                 context.Database.EnsureCreated();
 
-                var added = (await context.AddAsync(new Unicorn { Id2 = id2, Name = "Rarity" })).Entity;
+                var added = context.Add(new Unicorn { Id2 = id2, Name = "Rarity" }).Entity;
 
                 Assert.True(added.Id1 < 0);
                 Assert.NotEqual(Guid.Empty, added.Id3);
@@ -135,9 +135,9 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             {
                 context.Database.EnsureCreated();
 
-                var pony1 = (await context.AddAsync(new EarthPony { Id2 = 7, Name = "Apple Jack 1" })).Entity;
-                var pony2 = (await context.AddAsync(new EarthPony { Id2 = 7, Name = "Apple Jack 2" })).Entity;
-                var pony3 = (await context.AddAsync(new EarthPony { Id2 = 7, Name = "Apple Jack 3" })).Entity;
+                var pony1 = context.Add(new EarthPony { Id2 = 7, Name = "Apple Jack 1" }).Entity;
+                var pony2 = context.Add(new EarthPony { Id2 = 7, Name = "Apple Jack 2" }).Entity;
+                var pony3 = context.Add(new EarthPony { Id2 = 7, Name = "Apple Jack 3" }).Entity;
 
                 await context.SaveChangesAsync();
 

--- a/test/EntityFramework.SqlServer.FunctionalTests/SequenceEndToEndTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SequenceEndToEndTest.cs
@@ -113,8 +113,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             {
                 for (var i = 0; i < 10; i++)
                 {
-                    await context.AddAsync(new Pegasus { Name = "Rainbow Dash " + i });
-                    await context.AddAsync(new Pegasus { Name = "Fluttershy " + i });
+                    context.Add(new Pegasus { Name = "Rainbow Dash " + i });
+                    context.Add(new Pegasus { Name = "Fluttershy " + i });
                 }
 
                 await context.SaveChangesAsync();

--- a/test/EntityFramework.SqlServer.FunctionalTests/SequentialGuidEndToEndTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SequentialGuidEndToEndTest.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
                 for (var i = 0; i < 50; i++)
                 {
-                    await context.AddAsync(new Pegasus { Name = "Rainbow Dash " + i });
+                    context.Add(new Pegasus { Name = "Rainbow Dash " + i });
                 }
 
                 await context.SaveChangesAsync();
@@ -64,7 +64,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
                 for (var i = 0; i < 50; i++)
                 {
-                    guids.Add((await context.AddAsync(new Pegasus { Name = "Rainbow Dash " + i, Index = i, Id = Guid.NewGuid() })).Entity.Id);
+                    guids.Add(context.Add(new Pegasus { Name = "Rainbow Dash " + i, Index = i, Id = Guid.NewGuid() }).Entity.Id);
                 }
 
                 await context.SaveChangesAsync();

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
@@ -167,8 +167,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                     toDelete.Name = "Blog to delete";
                     var deletedId = toDelete.Id;
 
-                    db.Entry(toUpdate).SetState(EntityState.Modified);
-                    db.Entry(toDelete).SetState(EntityState.Deleted);
+                    db.Entry(toUpdate).State = EntityState.Modified;
+                    db.Entry(toDelete).State = EntityState.Deleted;
 
                     var toAdd = db.Add(new Blog
                     {
@@ -246,7 +246,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                         Away = 0.12345f,
                         AndChew = new byte[16]
                     }).Entity;
-                    db.Entry(toAdd).SetState(EntityState.Unknown);
+                    db.Entry(toAdd).State = EntityState.Unknown;
 
                     var blogs = await CreateBlogDatabaseAsync<Blog>(db);
 
@@ -258,7 +258,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                     deletedId = toDelete.Id;
 
                     db.Remove(toDelete);
-                    db.Entry(toAdd).SetState(EntityState.Added);
+                    db.Entry(toAdd).State = EntityState.Added;
 
                     await db.SaveChangesAsync();
 
@@ -482,7 +482,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         private static async Task<TBlog[]> CreateBlogDatabaseAsync<TBlog>(DbContext context) where TBlog : class, IBlog, new()
         {
             await context.Database.EnsureCreatedAsync();
-            var blog1 = (await context.AddAsync(new TBlog
+            var blog1 = context.Add(new TBlog
             {
                 Name = "Blog1",
                 George = true,
@@ -499,8 +499,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 //OrUSkint = 8888888, // TODO: The parameter data type of UInt32 is invalid.
                 //OrUShort = 888888888888888, // TODO: The parameter data type of UInt64 is invalid.
                 AndChew = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }
-            })).Entity;
-            var blog2 = (await context.AddAsync(new TBlog
+            }).Entity;
+            var blog2 = context.Add(new TBlog
             {
                 Name = "Blog2",
                 George = false,
@@ -517,7 +517,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 //OrUSkint = 8888888, // TODO: The parameter data type of UInt32 is invalid.
                 //OrUShort = 888888888888888, // TODO: The parameter data type of UInt64 is invalid.
                 AndChew = new byte[16]
-            })).Entity;
+            }).Entity;
             await context.SaveChangesAsync();
 
             return new[] { blog1, blog2 };


### PR DESCRIPTION
Based on API review decision. Async versions of Add were included because when value generation is being used it may occasionally be necessary to make a database call to get a new sequence. However, there are two problems with this:
* It is not possible to have async code paths for all places where Add may be called. For example, if a new entity is detected from a call to INotifyPropertyChanged.
* All higher-level code paths that may call Add need to have async versions as well. This spreads quicky--for example DetectChanged, AttachGraph.

There are two options for an application that wants to ensure that every possible database call is async:
* Use a value generation strategy that never queries the database on Add
* Make the database call to get sequence values explicitly and set key values directly before Adding new entities.