### PR TITLE
Moving relational options class out of SQL specific namespace

### DIFF
--- a/src/EntityFramework.Relational/RelationalDbContextOptions.cs
+++ b/src/EntityFramework.Relational/RelationalDbContextOptions.cs
@@ -4,7 +4,7 @@
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Utilities;
 
-namespace Microsoft.Data.Entity.SqlServer.Extensions
+namespace Microsoft.Data.Entity.Relational
 {
     public class RelationalDbContextOptions
     {


### PR DESCRIPTION
Correction for issue #1493 
Talked with @rowanmiller about the change, there are a few other "Extensions" classes in the relational assembly but no extensions namespace yet. We will likely revisit this in API review, but for now this change is consistent with the existing code.