### PR TITLE
fix to include bugs - 1452 and 1460

### DIFF
--- a/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/IncludeExpressionTreeVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/IncludeExpressionTreeVisitor.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
 
                         targetSelectExpression
                             .AddToOrderBy(
-                                columnExpression.Name,
+                                columnExpression.Alias ?? columnExpression.Name,
                                 columnExpression.Property,
                                 innerJoinExpression,
                                 ordering.OrderingDirection);
@@ -318,7 +318,7 @@ namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
             }
 
             var matchingColumnExpression
-                = projections.Single(p => p.Property == property);
+                = projections.Last(p => p.Property == property);
 
             return new ColumnExpression(
                 matchingColumnExpression.Alias ?? matchingColumnExpression.Name,

--- a/src/EntityFramework.Relational/Query/Sql/DefaultSqlQueryGenerator.cs
+++ b/src/EntityFramework.Relational/Query/Sql/DefaultSqlQueryGenerator.cs
@@ -96,7 +96,16 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
 
                 VisitJoin(selectExpression.OrderBy, t =>
                     {
-                        VisitExpression(t.Expression);
+                        var columnExpression = t.Expression as ColumnExpression;
+                        if (columnExpression != null)
+                        {
+                            // strip column expression from alias - it should not be generated for ORDER BY clause
+                            VisitExpression(new ColumnExpression(columnExpression.Name, columnExpression.Property, columnExpression.Table));
+                        }
+                        else
+                        {
+                            VisitExpression(t.Expression);
+                        }
 
                         if (t.OrderingDirection == OrderingDirection.Desc)
                         {

--- a/test/EntityFramework.Core.FunctionalTests/ComplexNavigationsQueryFixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/ComplexNavigationsQueryFixtureBase.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.FunctionalTests.TestModels.ComplexNavigationsModel;
+using Microsoft.Data.Entity.Metadata;
+
+namespace Microsoft.Data.Entity.FunctionalTests
+{
+    public abstract class ComplexNavigationsQueryFixtureBase<TTestStore>
+            where TTestStore : TestStore
+    {
+        public abstract TTestStore CreateTestStore();
+
+        public abstract ComplexNavigationsContext CreateContext(TTestStore testStore);
+
+        protected virtual void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Level1>().Key(e => e.Id);
+            modelBuilder.Entity<Level2>().Key(e => e.Id);
+            modelBuilder.Entity<Level3>().Key(e => e.Id);
+            modelBuilder.Entity<Level4>().Key(e => e.Id);
+
+            modelBuilder.Entity<Level1>().Property(e => e.Id).GenerateValueOnAdd(false);
+            modelBuilder.Entity<Level2>().Property(e => e.Id).GenerateValueOnAdd(false);
+            modelBuilder.Entity<Level1>().HasOne(e => e.OneToOne_Required_PK).WithOne(e => e.OneToOne_Required_PK_Inverse).ReferencedKey<Level1>(e => e.Id).Required(true);
+            modelBuilder.Entity<Level1>().HasOne(e => e.OneToOne_Optional_PK).WithOne(e => e.OneToOne_Optional_PK_Inverse).ReferencedKey<Level1>(e => e.Id).Required(false);
+            modelBuilder.Entity<Level1>().HasOne(e => e.OneToOne_Required_FK).WithOne(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level2>(e => e.Level1_Required_Id).Required(true);
+            modelBuilder.Entity<Level1>().HasOne(e => e.OneToOne_Optional_FK).WithOne(e => e.OneToOne_Optional_FK_Inverse).ForeignKey<Level2>(e => e.Level1_Optional_Id).Required(false);
+            modelBuilder.Entity<Level1>().HasMany(e => e.OneToMany_Required).WithOne(e => e.OneToMany_Required_Inverse).Required(true);
+            modelBuilder.Entity<Level1>().HasMany(e => e.OneToMany_Optional).WithOne(e => e.OneToMany_Optional_Inverse).Required(false);
+            modelBuilder.Entity<Level1>().HasMany(e => e.OneToMany_Required_Self).WithOne(e => e.OneToMany_Required_Self_Inverse).Required(true);
+            modelBuilder.Entity<Level1>().HasMany(e => e.OneToMany_Optional_Self).WithOne(e => e.OneToMany_Optional_Self_Inverse).Required(false);
+
+            // issue #1417
+            //modelBuilder.Entity<Level1>().HasOne(e => e.OneToOne_Optional_Self).WithOne(); 
+
+            modelBuilder.Entity<Level2>().Property(e => e.Id).GenerateValueOnAdd(false);
+            modelBuilder.Entity<Level2>().Property(e => e.Id).GenerateValueOnAdd(false);
+            modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Required_PK).WithOne(e => e.OneToOne_Required_PK_Inverse).ReferencedKey<Level2>(e => e.Id).Required(true);
+            modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Optional_PK).WithOne(e => e.OneToOne_Optional_PK_Inverse).ReferencedKey<Level2>(e => e.Id).Required(false);
+            modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Required_FK).WithOne(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level3>(e => e.Level2_Required_Id).Required(true);
+            modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Optional_FK).WithOne(e => e.OneToOne_Optional_FK_Inverse).ForeignKey<Level3>(e => e.Level2_Optional_Id).Required(false);
+            modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Required_FK).WithOne(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level3>(e => e.Level2_Required_Id).Required(true);
+            modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Optional_FK).WithOne(e => e.OneToOne_Optional_FK_Inverse).ForeignKey<Level3>(e => e.Level2_Optional_Id).Required(false);
+            modelBuilder.Entity<Level2>().HasMany(e => e.OneToMany_Required).WithOne(e => e.OneToMany_Required_Inverse).Required(true);
+            modelBuilder.Entity<Level2>().HasMany(e => e.OneToMany_Optional).WithOne(e => e.OneToMany_Optional_Inverse).Required(false);
+            modelBuilder.Entity<Level2>().HasMany(e => e.OneToMany_Required_Self).WithOne(e => e.OneToMany_Required_Self_Inverse).Required(true);
+            modelBuilder.Entity<Level2>().HasMany(e => e.OneToMany_Optional_Self).WithOne(e => e.OneToMany_Optional_Self_Inverse).Required(false);
+
+            // issue #1417
+            //modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Optional_Self).WithOne(); 
+
+            modelBuilder.Entity<Level3>().Property(e => e.Id).GenerateValueOnAdd(false);
+            modelBuilder.Entity<Level3>().Property(e => e.Id).GenerateValueOnAdd(false);
+            modelBuilder.Entity<Level3>().HasOne(e => e.OneToOne_Required_PK).WithOne(e => e.OneToOne_Required_PK_Inverse).ReferencedKey<Level3>(e => e.Id).Required(true);
+            modelBuilder.Entity<Level3>().HasOne(e => e.OneToOne_Optional_PK).WithOne(e => e.OneToOne_Optional_PK_Inverse).ReferencedKey<Level3>(e => e.Id).Required(false);
+            modelBuilder.Entity<Level3>().HasOne(e => e.OneToOne_Required_FK).WithOne(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level4>(e => e.Level3_Required_Id).Required(true);
+            modelBuilder.Entity<Level3>().HasOne(e => e.OneToOne_Optional_FK).WithOne(e => e.OneToOne_Optional_FK_Inverse).ForeignKey<Level4>(e => e.Level3_Optional_Id).Required(false);
+            modelBuilder.Entity<Level3>().HasMany(e => e.OneToMany_Required).WithOne(e => e.OneToMany_Required_Inverse).Required(true);
+            modelBuilder.Entity<Level3>().HasMany(e => e.OneToMany_Optional).WithOne(e => e.OneToMany_Optional_Inverse).Required(false);
+            modelBuilder.Entity<Level3>().HasMany(e => e.OneToMany_Required_Self).WithOne(e => e.OneToMany_Required_Self_Inverse).Required(true);
+            modelBuilder.Entity<Level3>().HasMany(e => e.OneToMany_Optional_Self).WithOne(e => e.OneToMany_Optional_Self_Inverse).Required(false);
+
+            // issue #1417
+            //modelBuilder.Entity<Level3>().HasOne(e => e.OneToOne_Optional_Self).WithOne();
+
+            modelBuilder.Entity<Level4>().Property(e => e.Id).GenerateValueOnAdd(false);
+            modelBuilder.Entity<Level4>().Property(e => e.Id).GenerateValueOnAdd(false);
+            modelBuilder.Entity<Level4>().HasMany(e => e.OneToMany_Required_Self).WithOne(e => e.OneToMany_Required_Self_Inverse).Required(true);
+            modelBuilder.Entity<Level4>().HasMany(e => e.OneToMany_Optional_Self).WithOne(e => e.OneToMany_Optional_Self_Inverse).Required(false);
+        }
+    }
+}

--- a/test/EntityFramework.Core.FunctionalTests/ComplexNavigationsQueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/ComplexNavigationsQueryTestBase.cs
@@ -1,0 +1,115 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.Data.Entity.FunctionalTests.TestModels.ComplexNavigationsModel;
+using Xunit;
+
+namespace Microsoft.Data.Entity.FunctionalTests
+{
+    public abstract class ComplexNavigationsQueryTestBase<TTestStore, TFixture> : IClassFixture<TFixture>, IDisposable
+             where TTestStore : TestStore
+             where TFixture : ComplexNavigationsQueryFixtureBase<TTestStore>, new()
+    {
+        protected ComplexNavigationsContext CreateContext()
+        {
+            return Fixture.CreateContext(TestStore);
+        }
+
+        protected ComplexNavigationsQueryTestBase(TFixture fixture)
+        {
+            Fixture = fixture;
+
+            TestStore = Fixture.CreateTestStore();
+        }
+
+        protected TFixture Fixture { get; private set; }
+
+        protected TTestStore TestStore { get; private set; }
+
+        public void Dispose()
+        {
+            TestStore.Dispose();
+        }
+
+        // blockec by 1528
+        //[Fact]
+        public virtual void Data_reader_is_closed_correct_number_of_times_for_include_queries_on_optional_navigations()
+        {
+            using (var context = CreateContext())
+            {
+                // reader for the last include is not opened because there is no data one level below - we should only try to close connection as many times as we tried to open it
+                // if we close it too many times, consecutive query will not work
+                // see issue #1457 for more details
+                context.LevelOne.Include(e => e.OneToMany_Optional).ThenInclude(e => e.OneToMany_Optional).ThenInclude(e => e.OneToMany_Optional_Inverse.OneToMany_Optional).ToList();
+
+                context.LevelOne.ToList();
+            }
+        }
+    
+        [Fact]
+        public virtual void Multi_level_include_one_to_many_optional_and_one_to_many_optional_produces_valid_sql()
+        {
+            using (var context = CreateContext())
+            {
+                var result = context.LevelOne.Include(e => e.OneToMany_Optional).ThenInclude(e => e.OneToMany_Optional).ToList();
+
+                Assert.Equal(10, result.Count);
+
+                var level1 = result.Where(e => e.Name == "L1 01").Single();
+
+                Assert.Equal(5, level1.OneToMany_Optional.Count);
+                Assert.True(level1.OneToMany_Optional.Select(e => e.Name).Contains("L2 02"));
+                Assert.True(level1.OneToMany_Optional.Select(e => e.Name).Contains("L2 04"));
+                Assert.True(level1.OneToMany_Optional.Select(e => e.Name).Contains("L2 06"));
+                Assert.True(level1.OneToMany_Optional.Select(e => e.Name).Contains("L2 08"));
+                Assert.True(level1.OneToMany_Optional.Select(e => e.Name).Contains("L2 10"));
+
+                var level2 = level1.OneToMany_Optional.Where(e => e.Name == "L2 02").Single();
+
+                Assert.Equal(2, level2.OneToMany_Optional.Count);
+                Assert.True(level2.OneToMany_Optional.Select(e => e.Name).Contains("L3 04"));
+                Assert.True(level2.OneToMany_Optional.Select(e => e.Name).Contains("L3 08"));
+            }
+        }
+
+
+        // blockec by 1528
+        //[Fact]
+        public virtual void Multi_level_include_correct_PK_is_chosen_as_the_join_predicate_for_queries_that_join_same_table_multiple_times()
+        {
+            using (var context = CreateContext())
+            {
+                var result = context.LevelOne.Include(e => e.OneToMany_Optional).ThenInclude(e => e.OneToMany_Optional).ThenInclude(e => e.OneToMany_Required_Inverse.OneToMany_Optional).ToList();
+
+                Assert.Equal(10, result.Count);
+
+                var level1 = result.Where(e => e.Name == "L1 01").Single();
+
+                Assert.Equal(5, level1.OneToMany_Optional.Count);
+                Assert.True(level1.OneToMany_Optional.Select(e => e.Name).Contains("L2 02"));
+                Assert.True(level1.OneToMany_Optional.Select(e => e.Name).Contains("L2 04"));
+                Assert.True(level1.OneToMany_Optional.Select(e => e.Name).Contains("L2 06"));
+                Assert.True(level1.OneToMany_Optional.Select(e => e.Name).Contains("L2 08"));
+                Assert.True(level1.OneToMany_Optional.Select(e => e.Name).Contains("L2 10"));
+
+                var level2 = level1.OneToMany_Optional.Where(e => e.Name == "L2 02").Single();
+
+                Assert.Equal(2, level2.OneToMany_Optional.Count);
+                Assert.True(level2.OneToMany_Optional.Select(e => e.Name).Contains("L3 04"));
+                Assert.True(level2.OneToMany_Optional.Select(e => e.Name).Contains("L3 08"));
+
+                Assert.True(level2.OneToMany_Optional.Select(e => e.OneToMany_Required_Inverse).All(e => e.Name == "L2 01"));
+
+                var level2Reverse = level2.OneToMany_Optional.Select(e => e.OneToMany_Required_Inverse).First();
+
+                Assert.Equal(3, level2Reverse.OneToMany_Optional.Count);
+                Assert.True(level2Reverse.OneToMany_Optional.Select(e => e.Name).Contains("L3 02"));
+                Assert.True(level2Reverse.OneToMany_Optional.Select(e => e.Name).Contains("L3 06"));
+                Assert.True(level2Reverse.OneToMany_Optional.Select(e => e.Name).Contains("L3 10"));
+            }
+        }
+    }
+}
+

--- a/test/EntityFramework.Core.FunctionalTests/EntityFramework.Core.FunctionalTests.csproj
+++ b/test/EntityFramework.Core.FunctionalTests/EntityFramework.Core.FunctionalTests.csproj
@@ -73,6 +73,8 @@
   <ItemGroup>
     <Compile Include="AsNoTrackingTestBase.cs" />
     <Compile Include="ChangeTrackingTestBase.cs" />
+    <Compile Include="ComplexNavigationsQueryFixtureBase.cs" />
+    <Compile Include="ComplexNavigationsQueryTestBase.cs" />
     <Compile Include="DeadlockTestBase.cs" />
     <Compile Include="DataStoreErrorLogStateTest.cs" />
     <Compile Include="BuiltInDataTypesFixtureBase.cs" />
@@ -107,6 +109,12 @@
     <Compile Include="F1FixtureBase.cs" />
     <Compile Include="QueryTestBase.cs" />
     <Compile Include="OptimisticConcurrencyTestBase.cs" />
+    <Compile Include="TestModels\ComplexNavigationsModel\ComplexNavigationsContext.cs" />
+    <Compile Include="TestModels\ComplexNavigationsModel\ComplexNavigationsModelInitializer.cs" />
+    <Compile Include="TestModels\ComplexNavigationsModel\Level1.cs" />
+    <Compile Include="TestModels\ComplexNavigationsModel\Level2.cs" />
+    <Compile Include="TestModels\ComplexNavigationsModel\Level3.cs" />
+    <Compile Include="TestModels\ComplexNavigationsModel\Level4.cs" />
     <Compile Include="TestModels\Northwind\Customer.cs" />
     <Compile Include="TestModels\Northwind\Employee.cs" />
     <Compile Include="TestModels\Northwind\NorthwindContext.cs" />

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/ComplexNavigationsModel/ComplexNavigationsContext.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/ComplexNavigationsModel/ComplexNavigationsContext.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Data.Entity.FunctionalTests.TestModels.ComplexNavigationsModel
+{
+    public class ComplexNavigationsContext : DbContext
+    {
+        public static readonly string StoreName = "ComplexNavigations";
+
+        public ComplexNavigationsContext(IServiceProvider serviceProvider, DbContextOptions options)
+            : base(serviceProvider, options)
+        {
+        }
+
+        public DbSet<Level1> LevelOne { get; set; }
+        public DbSet<Level2> LevelTwo { get; set; }
+        public DbSet<Level3> LevelThree { get; set; }
+        public DbSet<Level4> LevelFour { get; set; }
+    }
+}

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/ComplexNavigationsModel/ComplexNavigationsModelInitializer.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/ComplexNavigationsModel/ComplexNavigationsModelInitializer.cs
@@ -1,0 +1,281 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Data.Entity.FunctionalTests.TestModels.ComplexNavigationsModel
+{
+    public class ComplexNavigationsModelInitializer
+    {
+        public static void Seed(ComplexNavigationsContext context)
+        {
+            // TODO: only delete if model has changed
+            context.Database.EnsureDeleted();
+            if (context.Database.EnsureCreated())
+            {
+                var l1_01 = new Level1 { Id = 1, Name = "L1 01", };
+                var l1_02 = new Level1 { Id = 2, Name = "L1 02", };
+                var l1_03 = new Level1 { Id = 3, Name = "L1 03", };
+                var l1_04 = new Level1 { Id = 4, Name = "L1 04", };
+                var l1_05 = new Level1 { Id = 5, Name = "L1 05", };
+                var l1_06 = new Level1 { Id = 6, Name = "L1 06", };
+                var l1_07 = new Level1 { Id = 7, Name = "L1 07", };
+                var l1_08 = new Level1 { Id = 8, Name = "L1 08", };
+                var l1_09 = new Level1 { Id = 9, Name = "L1 09", };
+                var l1_10 = new Level1 { Id = 10, Name = "L1 10" };
+
+                var l2_01 = new Level2 { Id = 1, Name = "L2 01", };
+                var l2_02 = new Level2 { Id = 2, Name = "L2 02", };
+                var l2_03 = new Level2 { Id = 3, Name = "L2 03", };
+                var l2_04 = new Level2 { Id = 4, Name = "L2 04", };
+                var l2_05 = new Level2 { Id = 5, Name = "L2 05", };
+                var l2_06 = new Level2 { Id = 6, Name = "L2 06", };
+                var l2_07 = new Level2 { Id = 7, Name = "L2 07", };
+                var l2_08 = new Level2 { Id = 8, Name = "L2 08", };
+                var l2_09 = new Level2 { Id = 9, Name = "L2 09", };
+                var l2_10 = new Level2 { Id = 10, Name = "L2 10" };
+
+                var l3_01 = new Level3 { Id = 1, Name = "L3 01", };
+                var l3_02 = new Level3 { Id = 2, Name = "L3 02", };
+                var l3_03 = new Level3 { Id = 3, Name = "L3 03", };
+                var l3_04 = new Level3 { Id = 4, Name = "L3 04", };
+                var l3_05 = new Level3 { Id = 5, Name = "L3 05", };
+                var l3_06 = new Level3 { Id = 6, Name = "L3 06", };
+                var l3_07 = new Level3 { Id = 7, Name = "L3 07", };
+                var l3_08 = new Level3 { Id = 8, Name = "L3 08", };
+                var l3_09 = new Level3 { Id = 9, Name = "L3 09", };
+                var l3_10 = new Level3 { Id = 10, Name = "L3 10" };
+
+                var l4_01 = new Level4 { Id = 1, Name = "L4 01", };
+                var l4_02 = new Level4 { Id = 2, Name = "L4 02", };
+                var l4_03 = new Level4 { Id = 3, Name = "L4 03", };
+                var l4_04 = new Level4 { Id = 4, Name = "L4 04", };
+                var l4_05 = new Level4 { Id = 5, Name = "L4 05", };
+                var l4_06 = new Level4 { Id = 6, Name = "L4 06", };
+                var l4_07 = new Level4 { Id = 7, Name = "L4 07", };
+                var l4_08 = new Level4 { Id = 8, Name = "L4 08", };
+                var l4_09 = new Level4 { Id = 9, Name = "L4 09", };
+                var l4_10 = new Level4 { Id = 10, Name = "L4 10" };
+
+
+                var l1s = new[] { l1_01, l1_02, l1_03, l1_04, l1_05, l1_06, l1_07, l1_08, l1_09, l1_10 };
+                var l2s = new[] { l2_01, l2_02, l2_03, l2_04, l2_05, l2_06, l2_07, l2_08, l2_09, l2_10 };
+                var l3s = new[] { l3_01, l3_02, l3_03, l3_04, l3_05, l3_06, l3_07, l3_08, l3_09, l3_10 };
+                var l4s = new[] { l4_01, l4_02, l4_03, l4_04, l4_05, l4_06, l4_07, l4_08, l4_09, l4_10 };
+
+                context.LevelOne.Add(l1s);
+                context.LevelTwo.Add(l2s);
+                context.LevelThree.Add(l3s);
+                context.LevelFour.Add(l4s);
+
+                l1s[0].OneToOne_Required_PK = l2s[0];
+                l1s[1].OneToOne_Required_PK = l2s[1];
+                l1s[2].OneToOne_Required_PK = l2s[2];
+                l1s[3].OneToOne_Required_PK = l2s[3];
+                l1s[4].OneToOne_Required_PK = l2s[4];
+                l1s[5].OneToOne_Required_PK = l2s[5];
+                l1s[6].OneToOne_Required_PK = l2s[6];
+                l1s[7].OneToOne_Required_PK = l2s[7];
+                l1s[8].OneToOne_Required_PK = l2s[8];
+                l1s[9].OneToOne_Required_PK = l2s[9];
+
+                l1s[0].OneToOne_Required_FK = l2s[9];
+                l1s[1].OneToOne_Required_FK = l2s[8];
+                l1s[2].OneToOne_Required_FK = l2s[7];
+                l1s[3].OneToOne_Required_FK = l2s[6];
+                l1s[4].OneToOne_Required_FK = l2s[5];
+                l1s[5].OneToOne_Required_FK = l2s[4];
+                l1s[6].OneToOne_Required_FK = l2s[3];
+                l1s[7].OneToOne_Required_FK = l2s[2];
+                l1s[8].OneToOne_Required_FK = l2s[1];
+                l1s[9].OneToOne_Required_FK = l2s[0];
+
+                l1s[0].OneToMany_Required = new List<Level2> { l2s[0], l2s[1], l2s[2], l2s[3], l2s[4], l2s[5], l2s[6], l2s[7], l2s[8], l2s[9] };
+
+                l1s[0].OneToMany_Required_Self = new List<Level1> { l1s[0], l1s[1] };
+                l1s[1].OneToMany_Required_Self = new List<Level1> { l1s[2] };
+                l1s[2].OneToMany_Required_Self = new List<Level1> { l1s[3] };
+                l1s[3].OneToMany_Required_Self = new List<Level1> { l1s[4] };
+                l1s[4].OneToMany_Required_Self = new List<Level1> { l1s[5] };
+                l1s[5].OneToMany_Required_Self = new List<Level1> { l1s[6] };
+                l1s[6].OneToMany_Required_Self = new List<Level1> { l1s[7] };
+                l1s[7].OneToMany_Required_Self = new List<Level1> { l1s[8] };
+                l1s[8].OneToMany_Required_Self = new List<Level1> { l1s[9] };
+                l1s[9].OneToMany_Required_Self = new List<Level1>();
+
+                l2s[0].OneToOne_Required_PK = l3s[0];
+                l2s[1].OneToOne_Required_PK = l3s[1];
+                l2s[2].OneToOne_Required_PK = l3s[2];
+                l2s[3].OneToOne_Required_PK = l3s[3];
+                l2s[4].OneToOne_Required_PK = l3s[4];
+                l2s[5].OneToOne_Required_PK = l3s[5];
+                l2s[6].OneToOne_Required_PK = l3s[6];
+                l2s[7].OneToOne_Required_PK = l3s[7];
+                l2s[8].OneToOne_Required_PK = l3s[8];
+                l2s[9].OneToOne_Required_PK = l3s[9];
+
+                l2s[0].OneToOne_Required_FK = l3s[9];
+                l2s[1].OneToOne_Required_FK = l3s[8];
+                l2s[2].OneToOne_Required_FK = l3s[7];
+                l2s[3].OneToOne_Required_FK = l3s[6];
+                l2s[4].OneToOne_Required_FK = l3s[5];
+                l2s[5].OneToOne_Required_FK = l3s[4];
+                l2s[6].OneToOne_Required_FK = l3s[3];
+                l2s[7].OneToOne_Required_FK = l3s[2];
+                l2s[8].OneToOne_Required_FK = l3s[1];
+                l2s[9].OneToOne_Required_FK = l3s[0];
+
+                l2s[0].OneToMany_Required = new List<Level3> { l3s[0], l3s[1], l3s[2], l3s[3], l3s[4], l3s[5], l3s[6], l3s[7], l3s[8], l3s[9] };
+
+                l2s[0].OneToMany_Required_Self = new List<Level2> { l2s[0], l2s[1] };
+                l2s[1].OneToMany_Required_Self = new List<Level2> { l2s[2] };
+                l2s[2].OneToMany_Required_Self = new List<Level2> { l2s[3] };
+                l2s[3].OneToMany_Required_Self = new List<Level2> { l2s[4] };
+                l2s[4].OneToMany_Required_Self = new List<Level2> { l2s[5] };
+                l2s[5].OneToMany_Required_Self = new List<Level2> { l2s[6] };
+                l2s[6].OneToMany_Required_Self = new List<Level2> { l2s[7] };
+                l2s[7].OneToMany_Required_Self = new List<Level2> { l2s[8] };
+                l2s[8].OneToMany_Required_Self = new List<Level2> { l2s[9] };
+                l2s[9].OneToMany_Required_Self = new List<Level2>();
+
+                l3s[0].OneToOne_Required_PK = l4s[0];
+                l3s[1].OneToOne_Required_PK = l4s[1];
+                l3s[2].OneToOne_Required_PK = l4s[2];
+                l3s[3].OneToOne_Required_PK = l4s[3];
+                l3s[4].OneToOne_Required_PK = l4s[4];
+                l3s[5].OneToOne_Required_PK = l4s[5];
+                l3s[6].OneToOne_Required_PK = l4s[6];
+                l3s[7].OneToOne_Required_PK = l4s[7];
+                l3s[8].OneToOne_Required_PK = l4s[8];
+                l3s[9].OneToOne_Required_PK = l4s[9];
+
+                l3s[0].OneToOne_Required_FK = l4s[9];
+                l3s[1].OneToOne_Required_FK = l4s[8];
+                l3s[2].OneToOne_Required_FK = l4s[7];
+                l3s[3].OneToOne_Required_FK = l4s[6];
+                l3s[4].OneToOne_Required_FK = l4s[5];
+                l3s[5].OneToOne_Required_FK = l4s[4];
+                l3s[6].OneToOne_Required_FK = l4s[3];
+                l3s[7].OneToOne_Required_FK = l4s[2];
+                l3s[8].OneToOne_Required_FK = l4s[1];
+                l3s[9].OneToOne_Required_FK = l4s[0];
+
+                l3s[0].OneToMany_Required = new List<Level4> { l4s[0], l4s[1], l4s[2], l4s[3], l4s[4], l4s[5], l4s[6], l4s[7], l4s[8], l4s[9] };
+
+                l3s[0].OneToMany_Required_Self = new List<Level3> { l3s[0], l3s[1] };
+                l3s[1].OneToMany_Required_Self = new List<Level3> { l3s[2] };
+                l3s[2].OneToMany_Required_Self = new List<Level3> { l3s[3] };
+                l3s[3].OneToMany_Required_Self = new List<Level3> { l3s[4] };
+                l3s[4].OneToMany_Required_Self = new List<Level3> { l3s[5] };
+                l3s[5].OneToMany_Required_Self = new List<Level3> { l3s[6] };
+                l3s[6].OneToMany_Required_Self = new List<Level3> { l3s[7] };
+                l3s[7].OneToMany_Required_Self = new List<Level3> { l3s[8] };
+                l3s[8].OneToMany_Required_Self = new List<Level3> { l3s[9] };
+                l3s[9].OneToMany_Required_Self = new List<Level3>();
+
+                l4s[0].OneToMany_Required_Self = new List<Level4> { l4s[0], l4s[1] };
+                l4s[1].OneToMany_Required_Self = new List<Level4> { l4s[2] };
+                l4s[2].OneToMany_Required_Self = new List<Level4> { l4s[3] };
+                l4s[3].OneToMany_Required_Self = new List<Level4> { l4s[4] };
+                l4s[4].OneToMany_Required_Self = new List<Level4> { l4s[5] };
+                l4s[5].OneToMany_Required_Self = new List<Level4> { l4s[6] };
+                l4s[6].OneToMany_Required_Self = new List<Level4> { l4s[7] };
+                l4s[7].OneToMany_Required_Self = new List<Level4> { l4s[8] };
+                l4s[8].OneToMany_Required_Self = new List<Level4> { l4s[9] };
+                l4s[9].OneToMany_Required_Self = new List<Level4>();
+
+                context.SaveChanges();
+
+                l1s[0].OneToOne_Optional_PK = l2s[0];
+                l1s[2].OneToOne_Optional_PK = l2s[2];
+                l1s[4].OneToOne_Optional_PK = l2s[4];
+                l1s[6].OneToOne_Optional_PK = l2s[6];
+                l1s[8].OneToOne_Optional_PK = l2s[8];
+
+                l1s[1].OneToOne_Optional_FK = l2s[8];
+                l1s[3].OneToOne_Optional_FK = l2s[6];
+                l1s[5].OneToOne_Optional_FK = l2s[4];
+                l1s[7].OneToOne_Optional_FK = l2s[2];
+                l1s[9].OneToOne_Optional_FK = l2s[0];
+
+                l1s[0].OneToMany_Optional = new List<Level2> { l2s[1], l2s[3], l2s[5], l2s[7], l2s[9] };
+
+                l1s[1].OneToMany_Optional_Self = new List<Level1> { l1s[0] };
+                l1s[3].OneToMany_Optional_Self = new List<Level1> { l1s[2] };
+                l1s[5].OneToMany_Optional_Self = new List<Level1> { l1s[4] };
+                l1s[7].OneToMany_Optional_Self = new List<Level1> { l1s[6] };
+                l1s[9].OneToMany_Optional_Self = new List<Level1> { l1s[8] };
+
+                // issue #1417
+                //l1s[0].OneToOne_Optional_Self = l1s[9];
+                //l1s[1].OneToOne_Optional_Self = l1s[8];
+                //l1s[2].OneToOne_Optional_Self = l1s[7];
+                //l1s[3].OneToOne_Optional_Self = l1s[6];
+                //l1s[4].OneToOne_Optional_Self = l1s[5];
+
+                l2s[0].OneToOne_Optional_PK = l3s[0];
+                l2s[2].OneToOne_Optional_PK = l3s[2];
+                l2s[4].OneToOne_Optional_PK = l3s[4];
+                l2s[6].OneToOne_Optional_PK = l3s[6];
+                l2s[8].OneToOne_Optional_PK = l3s[8];
+
+                l2s[1].OneToOne_Optional_FK = l3s[8];
+                l2s[3].OneToOne_Optional_FK = l3s[6];
+                l2s[5].OneToOne_Optional_FK = l3s[4];
+                l2s[7].OneToOne_Optional_FK = l3s[2];
+                l2s[9].OneToOne_Optional_FK = l3s[0];
+
+                l2s[0].OneToMany_Optional = new List<Level3> { l3s[1], l3s[5], l3s[9] };
+                l2s[1].OneToMany_Optional = new List<Level3> { l3s[3], l3s[7], };
+
+                l2s[1].OneToMany_Optional_Self = new List<Level2> { l2s[0] };
+                l2s[3].OneToMany_Optional_Self = new List<Level2> { l2s[2] };
+                l2s[5].OneToMany_Optional_Self = new List<Level2> { l2s[4] };
+                l2s[7].OneToMany_Optional_Self = new List<Level2> { l2s[6] };
+                l2s[9].OneToMany_Optional_Self = new List<Level2> { l2s[8] };
+
+                // issue #1417
+                //l2s[0].OneToOne_Optional_Self = l2s[9];
+                //l2s[1].OneToOne_Optional_Self = l2s[8];
+                //l2s[2].OneToOne_Optional_Self = l2s[7];
+                //l2s[3].OneToOne_Optional_Self = l2s[6];
+                //l2s[4].OneToOne_Optional_Self = l2s[5];
+
+                l3s[0].OneToOne_Optional_PK = l4s[0];
+                l3s[2].OneToOne_Optional_PK = l4s[2];
+                l3s[4].OneToOne_Optional_PK = l4s[4];
+                l3s[6].OneToOne_Optional_PK = l4s[6];
+                l3s[8].OneToOne_Optional_PK = l4s[8];
+
+                l3s[1].OneToOne_Optional_FK = l4s[8];
+                l3s[3].OneToOne_Optional_FK = l4s[6];
+                l3s[5].OneToOne_Optional_FK = l4s[4];
+                l3s[7].OneToOne_Optional_FK = l4s[2];
+                l3s[9].OneToOne_Optional_FK = l4s[0];
+
+                l3s[0].OneToMany_Optional = new List<Level4> { l4s[1], l4s[3], l4s[5], l4s[7], l4s[9] };
+
+                l3s[1].OneToMany_Optional_Self = new List<Level3> { l3s[0] };
+                l3s[3].OneToMany_Optional_Self = new List<Level3> { l3s[2] };
+                l3s[5].OneToMany_Optional_Self = new List<Level3> { l3s[4] };
+                l3s[7].OneToMany_Optional_Self = new List<Level3> { l3s[6] };
+                l3s[9].OneToMany_Optional_Self = new List<Level3> { l3s[8] };
+
+                // issue #1417
+                //l3s[0].OneToOne_Optional_Self = l3s[9];
+                //l3s[1].OneToOne_Optional_Self = l3s[8];
+                //l3s[2].OneToOne_Optional_Self = l3s[7];
+                //l3s[3].OneToOne_Optional_Self = l3s[6];
+                //l3s[4].OneToOne_Optional_Self = l3s[5];
+
+                l4s[1].OneToMany_Optional_Self = new List<Level4> { l4s[0] };
+                l4s[3].OneToMany_Optional_Self = new List<Level4> { l4s[2] };
+                l4s[5].OneToMany_Optional_Self = new List<Level4> { l4s[4] };
+                l4s[7].OneToMany_Optional_Self = new List<Level4> { l4s[6] };
+                l4s[9].OneToMany_Optional_Self = new List<Level4> { l4s[8] };
+
+                context.SaveChanges();
+            }
+        }
+    }
+}

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/ComplexNavigationsModel/Level1.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/ComplexNavigationsModel/Level1.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Data.Entity.FunctionalTests.TestModels.ComplexNavigationsModel
+{
+    public class Level1
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+
+        public Level2 OneToOne_Required_PK { get; set; }
+        public Level2 OneToOne_Optional_PK { get; set; }
+
+        public Level2 OneToOne_Required_FK { get; set; }
+        public Level2 OneToOne_Optional_FK { get; set; }
+
+        public ICollection<Level2> OneToMany_Required { get; set; }
+        public ICollection<Level2> OneToMany_Optional { get; set; }
+
+        // issue #1417
+        //public Level1 OneToOne_Optional_Self { get; set; }
+
+        public ICollection<Level1> OneToMany_Required_Self { get; set; }
+        public ICollection<Level1> OneToMany_Optional_Self { get; set; }
+        public Level1 OneToMany_Required_Self_Inverse { get; set; }
+        public Level1 OneToMany_Optional_Self_Inverse { get; set; }
+    }
+}

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/ComplexNavigationsModel/Level2.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/ComplexNavigationsModel/Level2.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Data.Entity.FunctionalTests.TestModels.ComplexNavigationsModel
+{
+    public class Level2
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+
+        public int Level1_Required_Id { get; set; }
+        public int? Level1_Optional_Id { get; set; }
+
+        public Level3 OneToOne_Required_PK { get; set; }
+        public Level3 OneToOne_Optional_PK { get; set; }
+
+        public Level3 OneToOne_Required_FK { get; set; }
+        public Level3 OneToOne_Optional_FK { get; set; }
+
+        public ICollection<Level3> OneToMany_Required { get; set; }
+        public ICollection<Level3> OneToMany_Optional { get; set; }
+
+        public Level1 OneToOne_Required_PK_Inverse { get; set; }
+        public Level1 OneToOne_Optional_PK_Inverse { get; set; }
+        public Level1 OneToOne_Required_FK_Inverse { get; set; }
+        public Level1 OneToOne_Optional_FK_Inverse { get; set; }
+
+        public Level1 OneToMany_Required_Inverse { get; set; }
+        public Level1 OneToMany_Optional_Inverse { get; set; }
+
+        // issue #1417
+        //public Level2 OneToOne_Optional_Self { get; set; }
+
+        public ICollection<Level2> OneToMany_Required_Self { get; set; }
+        public ICollection<Level2> OneToMany_Optional_Self { get; set; }
+        public Level2 OneToMany_Required_Self_Inverse { get; set; }
+        public Level2 OneToMany_Optional_Self_Inverse { get; set; }
+    }
+}

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/ComplexNavigationsModel/Level3.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/ComplexNavigationsModel/Level3.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Data.Entity.FunctionalTests.TestModels.ComplexNavigationsModel
+{
+    public class Level3
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+
+        public int Level2_Required_Id { get; set; }
+        public int? Level2_Optional_Id { get; set; }
+
+        public Level4 OneToOne_Required_PK { get; set; }
+        public Level4 OneToOne_Optional_PK { get; set; }
+
+        public Level4 OneToOne_Required_FK { get; set; }
+        public Level4 OneToOne_Optional_FK { get; set; }
+
+        public ICollection<Level4> OneToMany_Required { get; set; }
+        public ICollection<Level4> OneToMany_Optional { get; set; }
+
+        public Level2 OneToOne_Required_PK_Inverse { get; set; }
+        public Level2 OneToOne_Optional_PK_Inverse { get; set; }
+        public Level2 OneToOne_Required_FK_Inverse { get; set; }
+        public Level2 OneToOne_Optional_FK_Inverse { get; set; }
+
+        public Level2 OneToMany_Required_Inverse { get; set; }
+        public Level2 OneToMany_Optional_Inverse { get; set; }
+
+        // issue #1417
+        //public Level3 OneToOne_Optional_Self { get; set; }
+
+        public ICollection<Level3> OneToMany_Required_Self { get; set; }
+        public ICollection<Level3> OneToMany_Optional_Self { get; set; }
+        public Level3 OneToMany_Required_Self_Inverse { get; set; }
+        public Level3 OneToMany_Optional_Self_Inverse { get; set; }
+    }
+}

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/ComplexNavigationsModel/Level4.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/ComplexNavigationsModel/Level4.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Data.Entity.FunctionalTests.TestModels.ComplexNavigationsModel
+{
+    public class Level4
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+
+        public int Level3_Required_Id { get; set; }
+        public int? Level3_Optional_Id { get; set; }
+
+        public Level3 OneToOne_Required_PK_Inverse { get; set; }
+        public Level3 OneToOne_Optional_PK_Inverse { get; set; }
+        public Level3 OneToOne_Required_FK_Inverse { get; set; }
+        public Level3 OneToOne_Optional_FK_Inverse { get; set; }
+
+        public Level3 OneToMany_Required_Inverse { get; set; }
+        public Level3 OneToMany_Optional_Inverse { get; set; }
+
+        // issue #1417
+        //public Level4 OneToOne_Optional_Self { get; set; }
+
+        public ICollection<Level4> OneToMany_Required_Self { get; set; }
+        public ICollection<Level4> OneToMany_Optional_Self { get; set; }
+        public Level4 OneToMany_Required_Self_Inverse { get; set; }
+        public Level4 OneToMany_Optional_Self_Inverse { get; set; }
+    }
+}

--- a/test/EntityFramework.Relational.FunctionalTests/EntityFramework.Relational.FunctionalTests.csproj
+++ b/test/EntityFramework.Relational.FunctionalTests/EntityFramework.Relational.FunctionalTests.csproj
@@ -70,6 +70,7 @@
   <ItemGroup>
     <Compile Include="MappingQueryTestBase.cs" />
     <Compile Include="MappingQueryFixtureBase.cs" />
+    <Compile Include="RelationalComplexNavigationsQueryFixture.cs" />
     <Compile Include="RelationalF1Fixture.cs" />
     <Compile Include="RelationalGearsOfWarQueryFixture.cs" />
     <Compile Include="RelationalNorthwindQueryFixture.cs" />

--- a/test/EntityFramework.Relational.FunctionalTests/RelationalComplexNavigationsQueryFixture.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/RelationalComplexNavigationsQueryFixture.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Data.Entity.Metadata;
+
+namespace Microsoft.Data.Entity.Relational.FunctionalTests
+{
+    public abstract class RelationalComplexNavigationsQueryFixture<TTestStore> : ComplexNavigationsQueryFixtureBase<TTestStore>
+        where TTestStore : TestStore
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+        }
+    }
+}

--- a/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
+++ b/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
@@ -89,6 +89,8 @@
     <Compile Include="MappingQueryFixture.cs" />
     <Compile Include="MappingQueryTest.cs" />
     <Compile Include="SqlServerChangeTrackingTest.cs" />
+    <Compile Include="SqlServerComplexNavigationsQueryFixture.cs" />
+    <Compile Include="SqlServerComplexNavigationsQueryTest.cs" />
     <Compile Include="SqlServerF1Fixture.cs" />
     <Compile Include="SqlServerFixture.cs" />
     <Compile Include="SqlServerGearsOfWarQueryFixture.cs" />

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerComplexNavigationsQueryFixture.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerComplexNavigationsQueryFixture.cs
@@ -1,25 +1,25 @@
-// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Relational.FunctionalTests;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.DependencyInjection.Fallback;
 using Microsoft.Framework.Logging;
+using Microsoft.Data.Entity.FunctionalTests.TestModels.ComplexNavigationsModel;
 
 namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 {
-    public class SqlServerGearsOfWarQueryFixture : RelationalGearsOfWarQueryFixture<SqlServerTestStore>
+    public class SqlServerComplexNavigationsQueryFixture : RelationalComplexNavigationsQueryFixture<SqlServerTestStore>
     {
-        public static readonly string DatabaseName = "GearsOfWarQueryTest";
+        public static readonly string DatabaseName = "ComplexNavigations";
 
         private readonly IServiceProvider _serviceProvider;
 
         private readonly string _connectionString = SqlServerTestStore.CreateConnectionString(DatabaseName);
 
-        public SqlServerGearsOfWarQueryFixture()
+        public SqlServerComplexNavigationsQueryFixture()
         {
             _serviceProvider = new ServiceCollection()
                 .AddEntityFramework()
@@ -33,30 +33,30 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         public override SqlServerTestStore CreateTestStore()
         {
             return SqlServerTestStore.GetOrCreateShared(DatabaseName, () =>
+            {
+                var options = new DbContextOptions();
+                options.UseSqlServer(_connectionString);
+
+                using (var context = new ComplexNavigationsContext(_serviceProvider, options))
                 {
-                    var options = new DbContextOptions();
-                    options.UseSqlServer(_connectionString);
+                    // TODO: Delete DB if model changed
 
-                    using (var context = new GearsOfWarContext(_serviceProvider, options))
+                    if (context.Database.EnsureCreated())
                     {
-                        // TODO: Delete DB if model changed
-
-                        if (context.Database.EnsureCreated())
-                        {
-                            GearsOfWarModelInitializer.Seed(context);
-                        }
-
-                        TestSqlLoggerFactory.SqlStatements.Clear();
+                        ComplexNavigationsModelInitializer.Seed(context);
                     }
-                });
+
+                    TestSqlLoggerFactory.SqlStatements.Clear();
+                }
+            });
         }
 
-        public override GearsOfWarContext CreateContext(SqlServerTestStore testStore)
+        public override ComplexNavigationsContext CreateContext(SqlServerTestStore testStore)
         {
             var options = new DbContextOptions();
             options.UseSqlServer(testStore.Connection);
 
-            var context = new GearsOfWarContext(_serviceProvider, options);
+            var context = new ComplexNavigationsContext(_serviceProvider, options);
             context.Database.AsRelational().Connection.UseTransaction(testStore.Transaction);
             return context;
         }

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerComplexNavigationsQueryTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerComplexNavigationsQueryTest.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Data.Entity.Relational.FunctionalTests;
+using Xunit;
+
+namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
+{
+    public class SqlServerComplexNavigationsQueryTest : ComplexNavigationsQueryTestBase<SqlServerTestStore, SqlServerComplexNavigationsQueryFixture>
+    {
+        public SqlServerComplexNavigationsQueryTest(SqlServerComplexNavigationsQueryFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        public override void Multi_level_include_one_to_many_optional_and_one_to_many_optional_produces_valid_sql()
+        {
+            base.Multi_level_include_one_to_many_optional_and_one_to_many_optional_produces_valid_sql();
+
+            Assert.Equal(
+@"SELECT [e].[Id], [e].[Level1Id], [e].[Level1Id1], [e].[Name]
+FROM [Level1] AS [e]
+ORDER BY [e].[Id]
+
+SELECT [l].[Id], [l].[Level1Id], [l].[Level1Id1], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Level2Id], [l].[Level2Id1], [l].[Name], [l].[OneToOne_Optional_PK_InverseId]
+FROM [Level2] AS [l]
+INNER JOIN (
+    SELECT DISTINCT [e].[Id]
+    FROM [Level1] AS [e]
+) AS [e] ON [l].[Level1Id1] = [e].[Id]
+ORDER BY [e].[Id], [l].[Id]
+
+SELECT [l].[Id], [l].[Level2Id], [l].[Level2Id1], [l].[Level2_Optional_Id], [l].[Level2_Required_Id], [l].[Level3Id], [l].[Level3Id1], [l].[Name], [l].[OneToOne_Optional_PK_InverseId]
+FROM [Level3] AS [l]
+INNER JOIN (
+    SELECT DISTINCT [e].[Id], [l].[Id] AS [Id0]
+    FROM [Level2] AS [l]
+    INNER JOIN (
+        SELECT DISTINCT [e].[Id]
+        FROM [Level1] AS [e]
+    ) AS [e] ON [l].[Level1Id1] = [e].[Id]
+) AS [l0] ON [l].[Level2Id1] = [l0].[Id0]
+ORDER BY [l0].[Id], [l0].[Id0]", Sql);
+        }
+
+        public override void Multi_level_include_correct_PK_is_chosen_as_the_join_predicate_for_queries_that_join_same_table_multiple_times()
+        {
+            base.Multi_level_include_correct_PK_is_chosen_as_the_join_predicate_for_queries_that_join_same_table_multiple_times();
+
+            Assert.Equal(
+@"SELECT [e].[Id], [e].[Level1Id], [e].[Level1Id1], [e].[Name]
+FROM [Level1] AS [e]
+ORDER BY [e].[Id]
+
+SELECT [l].[Id], [l].[Level1Id], [l].[Level1Id1], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Level2Id], [l].[Level2Id1], [l].[Name], [l].[OneToOne_Optional_PK_InverseId]
+FROM [Level2] AS [l]
+INNER JOIN (
+    SELECT DISTINCT [e].[Id]
+    FROM [Level1] AS [e]
+) AS [e] ON [l].[Level1Id1] = [e].[Id]
+ORDER BY [e].[Id], [l].[Id]
+
+SELECT [l].[Id], [l].[Level2Id], [l].[Level2Id1], [l].[Level2_Optional_Id], [l].[Level2_Required_Id], [l].[Level3Id], [l].[Level3Id1], [l].[Name], [l].[OneToOne_Optional_PK_InverseId], [l1].[Id], [l1].[Level1Id], [l1].[Level1Id1], [l1].[Level1_Optional_Id], [l1].[Level1_Required_Id], [l1].[Level2Id], [l1].[Level2Id1], [l1].[Name], [l1].[OneToOne_Optional_PK_InverseId]
+FROM [Level3] AS [l]
+INNER JOIN (
+    SELECT DISTINCT [e].[Id], [l].[Id] AS [Id0]
+    FROM [Level2] AS [l]
+    INNER JOIN (
+        SELECT DISTINCT [e].[Id]
+        FROM [Level1] AS [e]
+    ) AS [e] ON [l].[Level1Id1] = [e].[Id]
+) AS [l0] ON [l].[Level2Id1] = [l0].[Id0]
+INNER JOIN [Level2] AS [l1] ON [l].[Level2Id] = [l1].[Id]
+ORDER BY [l0].[Id], [l0].[Id0], [l1].[Id]
+
+SELECT [l].[Id], [l].[Level2Id], [l].[Level2Id1], [l].[Level2_Optional_Id], [l].[Level2_Required_Id], [l].[Level3Id], [l].[Level3Id1], [l].[Name], [l].[OneToOne_Optional_PK_InverseId]
+FROM [Level3] AS [l]
+INNER JOIN (
+    SELECT DISTINCT [l0].[Id], [l0].[Id0], [l1].[Id] AS [Id1]
+    FROM [Level3] AS [l]
+    INNER JOIN (
+        SELECT DISTINCT [e].[Id], [l].[Id] AS [Id0]
+        FROM [Level2] AS [l]
+        INNER JOIN (
+            SELECT DISTINCT [e].[Id]
+            FROM [Level1] AS [e]
+        ) AS [e] ON [l].[Level1Id1] = [e].[Id]
+    ) AS [l0] ON [l].[Level2Id1] = [l0].[Id0]
+    INNER JOIN [Level2] AS [l1] ON [l].[Level2Id] = [l1].[Id]
+) AS [l1] ON [l].[Level2Id1] = [l1].[Id1]
+ORDER BY [l1].[Id], [l1].[Id0]", Sql);
+        }
+
+        private static string Sql
+        {
+            get { return TestSqlLoggerFactory.Sql; }
+        }
+    }
+}


### PR DESCRIPTION
#1452 - Multiple multi-level collection/reference Include can fail
#1460 - "Sequence contains more than one matching element" thrown in some cases of multi level include

#1452 - problem appears in include queries in which Id columns of Included entities have same name. When this happens, we uniquefy them (see #1362). However, for more complex multi-level include, we use those keys in sort clause in one stage of the include but then we need to uniquefy it in the stage that comes after. This would result in SQL that tried to apply alias in the sort clause which is invalid. Fix is to not generate the alias for the order by during sql generation. Also another issue around this area was that we were passing original column name rather than aliased one to the order clause in the SelectExpression.

#1460 - problem appears in multi-level include queries that include same entity type multiple times in the chain. We uniquefy the names, however when constructing join conditions we only have column original name and table it comes from. This would lead to errors, since we assumed there would always be only one column in the projection list, that would match the criteria for the join condition. Fix is to use the last column from the list of candidates - as we always stick the column from the most recently joined table at the end of the projection list.

Some tests are currently blocked by another issue - #1528