### PR TITLE
Query: Perf: Stop doing DBNull->null compenstation in RelationalObjectAr...

### DIFF
--- a/src/EntityFramework.Core/Query/QueryBuffer.cs
+++ b/src/EntityFramework.Core/Query/QueryBuffer.cs
@@ -118,10 +118,16 @@ namespace Microsoft.Data.Entity.Query
 
             var stateEntry = _stateManager.TryGetEntry(entity);
 
-            return stateEntry != null
-                ? stateEntry[property]
-                : _byEntityInstance[entity][0].ValueReader
-                    .ReadValue<object>(property.Index);
+            if (stateEntry != null)
+            {
+                return stateEntry[property];
+            }
+
+            var valueReader = _byEntityInstance[entity][0].ValueReader;
+
+            return valueReader.IsNull(property.Index)
+                ? null
+                : valueReader.ReadValue<object>(property.Index);
         }
 
         public virtual void StartTracking(object entity)

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerQueryTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerQueryTest.cs
@@ -17,6 +17,18 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 {
     public class SqlServerQueryTest : QueryTestBase<SqlServerNorthwindQueryFixture>
     {
+//        [Fact]
+//        public void Materialization_Perf()
+//        {
+//            using (var context = CreateContext())
+//            {
+//                for (var i = 0; i < 1; i++)
+//                {
+//                    context.Orders.AsNoTracking().ToList();
+//                }
+//            }
+//        }
+
         public override void Count_with_predicate()
         {
             base.Count_with_predicate();


### PR DESCRIPTION
...rayValueReader buffer creation