### PR TITLE
Fix to #1393 - data corruption for multi level include with optional and required relationships

### DIFF
--- a/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/IncludeExpressionTreeVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/IncludeExpressionTreeVisitor.cs
@@ -88,6 +88,7 @@ namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
 
             var readerIndex = 0;
 
+            var canProduceInnerJoin = true;
             foreach (var navigation in navigationPath)
             {
                 if (!navigation.IsCollection())
@@ -112,9 +113,8 @@ namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
                                 p,
                                 joinedTableExpression));
 
-                    var joinExpression
-                        = navigation.ForeignKey.IsRequired
-                          && navigation.PointsToPrincipal
+                    canProduceInnerJoin = canProduceInnerJoin && (navigation.ForeignKey.IsRequired && navigation.PointsToPrincipal);
+                    var joinExpression = canProduceInnerJoin
                             ? selectExpression
                                 .AddInnerJoin(joinedTableExpression, columnExpressions)
                             : selectExpression

--- a/test/EntityFramework.Core.FunctionalTests/GearsOfWarQueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/GearsOfWarQueryTestBase.cs
@@ -67,8 +67,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        // blocked by issue #1393
-        ////[Fact]
+        [Fact]
         public virtual void Include_multiple_one_to_one_optional_and_one_to_one_required()
         {
             using (var context = CreateContext())
@@ -80,8 +79,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        // blocked by issue #1393
-        ////[Fact]
+        [Fact]
         public virtual void Include_multiple_one_to_one_and_one_to_one_and_one_to_many()
         {
             using (var context = CreateContext())
@@ -92,7 +90,6 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 Assert.Equal(6, result.Count);
             }
         }
-
 
         [Fact]
         public virtual void Include_multiple_circular()

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerGearsOfWarQueryTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerGearsOfWarQueryTest.cs
@@ -62,7 +62,21 @@ ORDER BY [g0].[Nickname], [g0].[SquadId]",
             base.Include_multiple_one_to_one_and_one_to_one_and_one_to_many();
 
             Assert.Equal(
-                @"TBD", Sql);
+@"SELECT [t].[GearNickName], [t].[GearSquadId], [t].[Id], [t].[Note], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Nickname], [g].[Rank], [g].[SquadId], [s].[Id], [s].[InternalNumber], [s].[Name]
+FROM [CogTag] AS [t]
+LEFT JOIN [Gear] AS [g] ON ([t].[GearNickName] = [g].[Nickname] AND [t].[GearSquadId] = [g].[SquadId])
+LEFT JOIN [Squad] AS [s] ON [g].[SquadId] = [s].[Id]
+ORDER BY [s].[Id]
+
+SELECT [g].[AssignedCityName], [g].[CityOrBirthName], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Nickname], [g].[Rank], [g].[SquadId]
+FROM [Gear] AS [g]
+INNER JOIN (
+    SELECT DISTINCT [s].[Id]
+    FROM [CogTag] AS [t]
+    LEFT JOIN [Gear] AS [g] ON ([t].[GearNickName] = [g].[Nickname] AND [t].[GearSquadId] = [g].[SquadId])
+    LEFT JOIN [Squad] AS [s] ON [g].[SquadId] = [s].[Id]
+) AS [s] ON [g].[SquadId] = [s].[Id]
+ORDER BY [s].[Id]", Sql);
         }
 
         public override void Include_multiple_one_to_one_optional_and_one_to_one_required()
@@ -70,7 +84,10 @@ ORDER BY [g0].[Nickname], [g0].[SquadId]",
             base.Include_multiple_one_to_one_optional_and_one_to_one_required();
 
             Assert.Equal(
-                @"TBD", Sql);
+@"SELECT [t].[GearNickName], [t].[GearSquadId], [t].[Id], [t].[Note], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Nickname], [g].[Rank], [g].[SquadId], [s].[Id], [s].[InternalNumber], [s].[Name]
+FROM [CogTag] AS [t]
+LEFT JOIN [Gear] AS [g] ON ([t].[GearNickName] = [g].[Nickname] AND [t].[GearSquadId] = [g].[SquadId])
+LEFT JOIN [Squad] AS [s] ON [g].[SquadId] = [s].[Id]", Sql);
         }
 
         public override void Include_multiple_circular()


### PR DESCRIPTION
Problem was that for include queries we would produce INNER JOIN for required relationships and OUTER JOIN for optional relationships. However for multi-level navigations this could cause data corruption. If one navigation was optional, all consequent joins should be OUTER JOINs as well, otherwise incorrect number of rows could be returned. 

Fix is to only produce INNER JOINs if there was no OUTER JOIN produced before.