### PR TITLE
Fix to #1528 - Exception thrown for multi-level include dotting over one-one navigation into one to many deeper inside the include chain

### DIFF
--- a/src/EntityFramework.Core/Query/ResultOperators/ThenIncludeExpressionNode.cs
+++ b/src/EntityFramework.Core/Query/ResultOperators/ThenIncludeExpressionNode.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Data.Entity.Query.ResultOperators
             var includeResultOperator
                 = (IncludeResultOperator)clauseGenerationContext.GetContextInfo(Source);
 
-            includeResultOperator.AppendToNavigationPath(_navigationPropertyPathLambda.GetPropertyAccessList());
+            includeResultOperator.AppendToNavigationPath(_navigationPropertyPathLambda.GetComplexPropertyAccess());
 
             clauseGenerationContext.AddContextInfo(this, includeResultOperator);
 

--- a/src/EntityFramework.Core/Utilities/ExpressionExtensions.cs
+++ b/src/EntityFramework.Core/Utilities/ExpressionExtensions.cs
@@ -89,6 +89,34 @@ namespace System.Linq.Expressions
             return propertyInfos != null && propertyInfos.Length == 1 ? propertyInfos[0] : null;
         }
 
+        public static PropertyInfo[] GetComplexPropertyAccess(this LambdaExpression propertyAccessExpression)
+        {
+            Debug.Assert(propertyAccessExpression.Parameters.Count == 1);
+
+            var propertyPath
+                = propertyAccessExpression
+                    .Parameters
+                    .Single()
+                    .MatchComplexPropertyAccess(propertyAccessExpression.Body);
+
+            if (propertyPath == null)
+            {
+                throw new ArgumentException(
+                    Strings.InvalidPropertiesExpression(propertyAccessExpression),
+                    "propertyAccessExpression");
+            }
+
+            return propertyPath;
+        }
+
+        private static PropertyInfo[] MatchComplexPropertyAccess(
+            this Expression parameterExpression, Expression propertyAccessExpression)
+        {
+            var propertyPath = MatchPropertyAccess(parameterExpression, propertyAccessExpression);
+
+            return propertyPath;
+        }
+
         private static PropertyInfo[] MatchPropertyAccess(
             this Expression parameterExpression, Expression propertyAccessExpression)
         {

--- a/test/EntityFramework.Core.FunctionalTests/ComplexNavigationsQueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/ComplexNavigationsQueryTestBase.cs
@@ -33,8 +33,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             TestStore.Dispose();
         }
 
-        // blockec by 1528
-        //[Fact]
+        [Fact]
         public virtual void Data_reader_is_closed_correct_number_of_times_for_include_queries_on_optional_navigations()
         {
             using (var context = CreateContext())
@@ -75,8 +74,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
 
-        // blockec by 1528
-        //[Fact]
+        [Fact]
         public virtual void Multi_level_include_correct_PK_is_chosen_as_the_join_predicate_for_queries_that_join_same_table_multiple_times()
         {
             using (var context = CreateContext())


### PR DESCRIPTION
Problem was that when we tried to extract list of PropertyInfos that include chain consists of, we were doing it incorrectly - always assuming it would be a simple property (or list of those inside anonymous type).
Fix is to use a proper method that expects complex properties instead.