### PR TITLE
Clean up relationships after Ignore

### DIFF
--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -297,7 +297,8 @@
     <Compile Include="Update\DbUpdateConcurrencyException.cs" />
     <Compile Include="Update\DbUpdateException.cs" />
     <Compile Include="Utilities\AsyncLock.cs" />
-    <Compile Include="Utilities\ModelUndirectedGraphAdapter.cs" />
+    <Compile Include="Utilities\ModelNavigationsGraphAdapter.cs" />
+    <Compile Include="Utilities\ModelForeignKeyUndirectedGraphAdapter.cs" />
     <Compile Include="Utilities\EnumerableExtensions.cs" />
     <Compile Include="Utilities\ExpressionExtensions.cs" />
     <Compile Include="Utilities\Graph.cs" />

--- a/src/EntityFramework.Core/Metadata/Internal/InternalEntityBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/InternalEntityBuilder.cs
@@ -353,6 +353,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 }
 
                 RemoveForeignKeyIfUnused(navigation.ForeignKey, configurationSource);
+                ModelBuilder.RemoveEntityTypesUnreachableByNavigations(configurationSource);
             }
 
             _ignoredProperties.Value[propertyName] = configurationSource;
@@ -403,8 +404,9 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
             foreach (var foreignKey in Metadata.ForeignKeys.Where(i => i.Properties.Contains(property)).ToList())
             {
-                var removed = RemoveRelationship(foreignKey, configurationSource);
-                Debug.Assert(removed.HasValue);
+                var relationship = Relationship(foreignKey, true, ConfigurationSource.Convention)
+                    .ForeignKey(new Property[0], configurationSource);
+                Debug.Assert(relationship != null);
             }
 
             foreach (var key in Metadata.Keys.Where(i => i.Properties.Contains(property)).ToList())

--- a/src/EntityFramework.Core/Utilities/ModelForeignKeyUndirectedGraphAdapter.cs
+++ b/src/EntityFramework.Core/Utilities/ModelForeignKeyUndirectedGraphAdapter.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+
+namespace Microsoft.Data.Entity.Utilities
+{
+    public class ModelForeignKeyUndirectedGraphAdapter : Graph<EntityType>
+    {
+        private readonly Model _model;
+
+        public ModelForeignKeyUndirectedGraphAdapter([NotNull] Model model)
+        {
+            Check.NotNull(model, "model");
+
+            _model = model;
+        }
+
+        public override IEnumerable<EntityType> Vertices
+        {
+            get { return _model.EntityTypes; }
+        }
+
+        public override IEnumerable<EntityType> GetOutgoingNeighbours(EntityType from)
+        {
+            return from.ForeignKeys.Select(fk => fk.ReferencedEntityType)
+                .Union(_model.GetReferencingForeignKeys(from).Select(fk => fk.EntityType));
+        }
+
+        public override IEnumerable<EntityType> GetIncomingNeighbours(EntityType to)
+        {
+            return GetOutgoingNeighbours(to);
+        }
+    }
+}

--- a/src/EntityFramework.Core/Utilities/ModelNavigationsGraphAdapter.cs
+++ b/src/EntityFramework.Core/Utilities/ModelNavigationsGraphAdapter.cs
@@ -8,11 +8,11 @@ using Microsoft.Data.Entity.Metadata;
 
 namespace Microsoft.Data.Entity.Utilities
 {
-    public class ModelUndirectedGraphAdapter : Graph<EntityType>
+    public class ModelNavigationsGraphAdapter : Graph<EntityType>
     {
         private readonly Model _model;
 
-        public ModelUndirectedGraphAdapter([NotNull] Model model)
+        public ModelNavigationsGraphAdapter([NotNull] Model model)
         {
             Check.NotNull(model, "model");
 
@@ -26,13 +26,14 @@ namespace Microsoft.Data.Entity.Utilities
 
         public override IEnumerable<EntityType> GetOutgoingNeighbours(EntityType from)
         {
-            return from.ForeignKeys.Select(fk => fk.ReferencedEntityType)
-                .Union(_model.GetReferencingForeignKeys(from).Select(fk => fk.EntityType));
+            return from.ForeignKeys.Where(fk => fk.GetNavigationToPrincipal() != null).Select(fk => fk.ReferencedEntityType)
+                .Union(_model.GetReferencingForeignKeys(from).Where(fk => fk.GetNavigationToDependent() != null).Select(fk => fk.EntityType));
         }
 
         public override IEnumerable<EntityType> GetIncomingNeighbours(EntityType to)
         {
-            return GetOutgoingNeighbours(to);
+            return to.ForeignKeys.Where(fk => fk.GetNavigationToDependent() != null).Select(fk => fk.ReferencedEntityType)
+                .Union(_model.GetReferencingForeignKeys(to).Where(fk => fk.GetNavigationToPrincipal() != null).Select(fk => fk.EntityType));
         }
     }
 }

--- a/test/EntityFramework.Core.Tests/Metadata/ModelBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelBuilderTest.cs
@@ -517,6 +517,40 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                             b.Property<string>("Shadow");
                         })).Message);
         }
+        
+        [Fact]
+        public void Ignoring_a_navigation_property_removes_discovered_entity_types()
+        {
+            var model = new Model();
+            var modelBuilder = CreateModelBuilder(model);
+            modelBuilder.Entity<Customer>(b =>
+                {
+                    b.Ignore(c => c.Details);
+                    b.Ignore(c => c.Orders);
+                });
+
+            Assert.Equal(1, model.EntityTypes.Count);
+        }
+
+        [Fact]
+        public void Ignoring_a_navigation_property_removes_discovered_relationship()
+        {
+            var model = new Model();
+            var modelBuilder = CreateModelBuilder(model);
+            modelBuilder.Entity<Customer>(b =>
+            {
+                b.Ignore(c => c.Details);
+                b.Ignore(c => c.Orders);
+            });
+            modelBuilder.Entity<CustomerDetails>(b =>
+            {
+                b.Ignore(c => c.Customer);
+            });
+
+            Assert.Equal(2, model.EntityTypes.Count);
+            Assert.Equal(0, model.EntityTypes[0].ForeignKeys.Count);
+            Assert.Equal(0, model.EntityTypes[1].ForeignKeys.Count);
+        }
 
         [Fact]
         public void Properties_can_be_made_required()


### PR DESCRIPTION
Remove unreachable entity type discovered by convention after ignoring a navigation
Remove relationship discovered by convention after ignoring the associated navigations
Replace a foreign key discovered by convention when a contained property is ignored

Resolves #1215