### PR TITLE
Fix to #740 Test coverage for different nullability in foreign and principal keys

### DIFF
--- a/src/EntityFramework.Core/ChangeTracking/NavigationFixer.cs
+++ b/src/EntityFramework.Core/ChangeTracking/NavigationFixer.cs
@@ -461,8 +461,6 @@ namespace Microsoft.Data.Entity.ChangeTracking
                 if (!foreignKey.GetRootPrincipals(i).Any(p => p.GenerateValueOnAdd)
                     || !foreignKey.ReferencedProperties[i].PropertyType.IsDefaultValue(principalValues[i]))
                 {
-                    // TODO: Consider nullable/non-nullable assignment issues
-                    // Issue #740
                     var dependentProperty = foreignKey.Properties[i];
                     dependentEntry[dependentProperty] = principalValues[i];
                     dependentEntry.RelationshipsSnapshot.TakeSnapshot(dependentProperty);

--- a/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/IncludeExpressionTreeVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/IncludeExpressionTreeVisitor.cs
@@ -290,6 +290,12 @@ namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
                         primaryKeyExpression
                             = Expression.Convert(primaryKeyExpression, foreignKeyColumnExpression.Type);
                     }
+                    else if (primaryKeyExpression.Type.IsNullableType()
+                        && !foreignKeyColumnExpression.Type.IsNullableType())
+                    {
+                        foreignKeyColumnExpression
+                            = Expression.Convert(foreignKeyColumnExpression, primaryKeyColumnExpression.Type);
+                    }
                 }
 
                 var equalExpression


### PR DESCRIPTION
:white_check_mark: Add test for non-nullable FK with nullable PK
:bug: Fix InvalidOperationException in Query exposed by new test
@ajcvickers @AndriySvyryd 