### PR TITLE
Make FK convention not match the PK properties if the FK is optional.

### DIFF
--- a/src/EntityFramework.Core/Metadata/ModelConventions/ForeignKeyPropertyDiscoveryConvention.cs
+++ b/src/EntityFramework.Core/Metadata/ModelConventions/ForeignKeyPropertyDiscoveryConvention.cs
@@ -51,7 +51,8 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
                 }
             }
 
-            if (((IForeignKey)foreignKey).IsUnique)
+            if (((IForeignKey)foreignKey).IsUnique
+                && foreignKey.IsRequired != false)
             {
                 var dependentPkProperties = foreignKey.EntityType.TryGetPrimaryKey()?.Properties;
                 if (dependentPkProperties != null

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/ForeignKeyPropertyDiscoveryConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/ForeignKeyPropertyDiscoveryConventionTest.cs
@@ -298,7 +298,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
                 null,
                 null,
                 ConfigurationSource.Convention,
-                true);
+                isUnique: true);
 
             var newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder);
             Assert.NotSame(relationshipBuilder, newRelationshipBuilder);
@@ -324,7 +324,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
                 null,
                 null,
                 ConfigurationSource.Convention,
-                false);
+                isUnique: false);
 
             Assert.Same(relationshipBuilder, new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder));
 
@@ -332,6 +332,32 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             Assert.Same(fk, DependentType.Metadata.ForeignKeys.Single());
             Assert.Equal(PrincipalType.Metadata.SimpleName + PrimaryKey.Name, fk.Properties.Single().Name);
             Assert.False(fk.IsUnique);
+            Assert.False(fk.IsRequired);
+        }
+
+        [Fact]
+        public void Does_not_match_non_nullable_dependent_PK_for_optional_unique_FK()
+        {
+            var fkProperty = DependentType.Metadata.GetPrimaryKey().Properties.Single();
+
+            var relationshipBuilder = DependentType.Relationship(
+                PrincipalType,
+                DependentType,
+                "SomeNav",
+                null,
+                null,
+                null,
+                ConfigurationSource.Convention,
+                isUnique: true,
+                isRequired: false);
+
+            Assert.Same(relationshipBuilder, new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder));
+
+            var fk = (IForeignKey)relationshipBuilder.Metadata;
+            Assert.NotSame(fkProperty, fk.Properties.Single());
+            Assert.Equal("SomeNav" + PrimaryKey.Name, fk.Properties.Single().Name);
+            Assert.Same(PrimaryKey, fk.ReferencedProperties.Single());
+            Assert.True(fk.IsUnique);
             Assert.False(fk.IsRequired);
         }
 
@@ -349,7 +375,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
                 null,
                 null,
                 ConfigurationSource.Convention,
-                true);
+                isUnique: true);
 
             var newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder);
             Assert.NotSame(relationshipBuilder, newRelationshipBuilder);
@@ -379,7 +405,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
                 null,
                 null,
                 ConfigurationSource.Convention,
-                false);
+                isUnique: false);
 
             Assert.Same(relationshipBuilder, new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder));
 
@@ -390,6 +416,34 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             Assert.Same(CompositePrimaryKey[0], fk.ReferencedProperties[0]);
             Assert.Same(CompositePrimaryKey[1], fk.ReferencedProperties[1]);
             Assert.False(fk.IsUnique);
+            Assert.False(fk.IsRequired);
+        }
+
+        [Fact]
+        public void Does_not_match_nullable_composite_dependent_PK_for_optional_unique_FK()
+        {
+            DependentTypeWithCompositeKey.Metadata.GetPrimaryKey().Properties[1].IsNullable = true;
+
+            var relationshipBuilder = DependentTypeWithCompositeKey.Relationship(
+                PrincipalTypeWithCompositeKey,
+                DependentTypeWithCompositeKey,
+                "NavProp",
+                null,
+                null,
+                null,
+                ConfigurationSource.Convention,
+                isUnique: true,
+                isRequired: false);
+
+            Assert.Same(relationshipBuilder, new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder));
+
+            var fk = (IForeignKey)relationshipBuilder.Metadata;
+            Assert.Same(fk, DependentTypeWithCompositeKey.Metadata.ForeignKeys.Single());
+            Assert.Equal("NavProp" + CompositePrimaryKey[0].Name, fk.Properties[0].Name);
+            Assert.Equal("NavProp" + CompositePrimaryKey[1].Name, fk.Properties[1].Name);
+            Assert.Same(CompositePrimaryKey[0], fk.ReferencedProperties[0]);
+            Assert.Same(CompositePrimaryKey[1], fk.ReferencedProperties[1]);
+            Assert.True(fk.IsUnique);
             Assert.False(fk.IsRequired);
         }
 
@@ -407,7 +461,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
                 null,
                 null,
                 ConfigurationSource.Convention,
-                true);
+                isUnique: true);
 
             Assert.Same(relationshipBuilder, new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder));
 

--- a/test/EntityFramework.SqlServer.FunctionalTests/DefaultValuesTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/DefaultValuesTest.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
 using System.Linq;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Framework.DependencyInjection;
@@ -18,9 +20,76 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             .ServiceCollection
             .BuildServiceProvider();
 
+        public class Level1
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+
+            //public Level2 OneToOne_Required_PK { get; set; } // remove to repro
+            public Level2 OneToOne_Optional_PK { get; set; }
+
+            public Level2 OneToOne_Optional_FK { get; set; }
+
+            public ICollection<Level2> OneToMany_Optional { get; set; }
+            public ICollection<Level1> OneToMany_Optional_Self { get; set; }
+            public Level1 OneToMany_Optional_Self_Inverse { get; set; }
+        }
+
+        public class Level2
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+
+            public int Level1_Required_Id { get; set; }
+            public int? Level1_Optional_Id { get; set; }
+
+            public Level1 OneToOne_Required_PK_Inverse { get; set; }
+            public Level1 OneToOne_Optional_PK_Inverse { get; set; }
+            public Level1 OneToOne_Required_FK_Inverse { get; set; }
+            public Level1 OneToOne_Optional_FK_Inverse { get; set; }
+
+            public Level1 OneToMany_Optional_Inverse { get; set; } //
+        }
+
+        public class MyContext : DbContext
+        {
+            public DbSet<Level1> LevelOne { get; set; }
+            public DbSet<Level2> LevelTwo { get; set; }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                base.OnModelCreating(modelBuilder);
+
+                modelBuilder.Entity<Level1>().Property(e => e.Id).GenerateValueOnAdd(false);
+                modelBuilder.Entity<Level2>().Property(e => e.Id).GenerateValueOnAdd(false);
+
+                //modelBuilder.Entity<Level1>().HasOne(e => e.OneToOne_Required_PK).WithOne(e => e.OneToOne_Required_PK_Inverse).ReferencedKey<Level1>(e => e.Id).Required(true);  // remove to repro
+                modelBuilder.Entity<Level1>().HasOne(e => e.OneToOne_Optional_PK).WithOne(e => e.OneToOne_Optional_PK_Inverse).ReferencedKey<Level1>(e => e.Id).Required(false);
+                modelBuilder.Entity<Level1>().HasOne(e => e.OneToOne_Optional_FK).WithOne(e => e.OneToOne_Optional_FK_Inverse).ForeignKey<Level2>(e => e.Level1_Optional_Id).Required(false);
+                modelBuilder.Entity<Level1>().HasMany(e => e.OneToMany_Optional).WithOne(e => e.OneToMany_Optional_Inverse).Required(false);
+                modelBuilder.Entity<Level1>().HasMany(e => e.OneToMany_Optional_Self).WithOne(e => e.OneToMany_Optional_Self_Inverse).Required(false);
+
+                modelBuilder.Entity<Level2>().Property(e => e.Id).GenerateValueOnAdd(false);
+                modelBuilder.Entity<Level2>().Property(e => e.Id).GenerateValueOnAdd(false);
+            }
+
+            protected override void OnConfiguring(DbContextOptions options)
+            {
+                options.UseSqlServer(new SqlConnectionStringBuilder { DataSource = ".", InitialCatalog = "Repro1479", MultipleActiveResultSets = true, IntegratedSecurity = true }.ToString());
+            }
+        }
+
         [Fact]
         public void Can_use_SQL_Server_default_values()
         {
+            
+
+            using (var context = new MyContext())
+            {
+                context.Database.EnsureDeleted();
+                context.Database.EnsureCreated();
+            }
+
             using (var context = new ChipsContext(_serviceProvider, "DefaultKettleChips"))
             {
                 context.Database.EnsureDeleted();


### PR DESCRIPTION
Resolves #1479