### PR TITLE
Fix to multiple include bugs - #1433, #1478, #1487 #1488

### DIFF
--- a/test/EntityFramework.Core.FunctionalTests/ComplexNavigationsQueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/ComplexNavigationsQueryTestBase.cs
@@ -108,6 +108,44 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 Assert.True(level2Reverse.OneToMany_Optional.Select(e => e.Name).Contains("L3 10"));
             }
         }
+
+        [Fact]
+        public virtual void Multi_level_include_reads_key_values_from_data_reader_rather_than_incorrect_reader_deep_into_the_stack()
+        {
+            using (var context = CreateContext())
+            {
+                // #1433
+                context.LevelOne.Include(e => e.OneToMany_Optional).ToList();
+                context.LevelOne.Include(e => e.OneToMany_Optional_Self).ToList();
+
+                //# 1478
+                context.LevelOne
+                    .Include(e => e.OneToMany_Optional)
+                    .ThenInclude(e => e.OneToMany_Optional_Inverse.OneToMany_Optional_Self_Inverse.OneToOne_Optional_FK).ToList();
+
+                context.LevelOne
+                    .Include(e => e.OneToMany_Optional)
+                    .ThenInclude(e => e.OneToMany_Optional_Inverse.OneToMany_Optional_Self_Inverse.OneToOne_Optional_PK).ToList();
+
+                // #1487
+                context.LevelOne
+                    .Include(e => e.OneToMany_Optional)
+                    .ThenInclude(e => e.OneToMany_Optional_Inverse.OneToOne_Optional_PK.OneToOne_Optional_FK).ToList();
+
+                context.LevelOne
+                    .Include(e => e.OneToMany_Optional)
+                    .ThenInclude(e => e.OneToMany_Optional_Inverse.OneToOne_Optional_PK.OneToOne_Optional_FK_Inverse).ToList();
+
+                // #1488
+                context.LevelOne
+                    .Include(e => e.OneToMany_Optional)
+                    .ThenInclude(e => e.OneToMany_Optional_Inverse.OneToOne_Optional_PK.OneToOne_Required_FK).ToList();
+
+                context.LevelOne
+                    .Include(e => e.OneToMany_Optional)
+                    .ThenInclude(e => e.OneToMany_Optional_Inverse.OneToOne_Optional_PK.OneToOne_Required_FK_Inverse).ToList();
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Problem was that if a query was executed multiple times, or after another query, some of the entities were stored in state manager and not in the reader buffer. However when accessing PK/FK we were always using the buffered readers. This could cause multitude of errors, e.g buffer being empty, trying to access element of the reader that doesn't exist, is of a wrong type, or worst case - cause data corruption.

Fix is to mark first element of the buffer for a given entity with a null value, if that entity is already in state manager - later, when we try to retrieve the keys we check for that null, and if we find it we use state manager instead.