### PR TITLE
[TINY] Disable failing .NET Core perf tests

### DIFF
--- a/test/EntityFramework.Microbenchmarks/project.json
+++ b/test/EntityFramework.Microbenchmarks/project.json
@@ -10,12 +10,6 @@
         "test": "xunit.runner.kre"
     },
     "frameworks": {
-        "aspnetcore50": {
-            "dependencies": {
-                "System.ComponentModel.Annotations": "4.0.10-beta-*",
-                "System.Net.NetworkInformation":  "4.0.10-beta-*"
-            }
-        },
         "aspnet50": {
             "frameworkAssemblies": {
                 "System.ComponentModel.DataAnnotations": ""


### PR DESCRIPTION
These tests are hitting the same dynamic code generation issues that have resulted in us disabling a number of other test projects on CoreCLR. They don't show up on standard CI because perf tests are run on a separate CI server.