### PR TITLE
Fix to #1251 - join + orderby + count produces invalid sql

### DIFF
--- a/src/EntityFramework.Relational/Query/RelationalResultOperatorHandler.cs
+++ b/src/EntityFramework.Relational/Query/RelationalResultOperatorHandler.cs
@@ -158,6 +158,8 @@ namespace Microsoft.Data.Entity.Relational.Query
             handlerContext.SelectExpression
                 .SetProjectionExpression(new CountExpression());
 
+            handlerContext.SelectExpression.ClearOrderBy();
+
             return TransformClientExpression<int>(handlerContext);
         }
 

--- a/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
@@ -1866,6 +1866,12 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
+        public virtual void Count_with_order_by()
+        {
+            AssertQuery<Order>(os => os.OrderBy(o => o.CustomerID).Count());
+        }
+
+        [Fact]
         public virtual void Distinct()
         {
             AssertQuery<Customer>(

--- a/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -242,6 +242,16 @@ WHERE [o].[CustomerID] = 'ALFKI'",
                 Sql);
         }
 
+        public override void Count_with_order_by()
+        {
+            base.Count_with_order_by();
+
+            Assert.Equal(
+                @"SELECT COUNT(*)
+FROM [Orders] AS [o]",
+                Sql);
+        }
+
         public override void Sum_with_no_arg()
         {
             base.Sum_with_no_arg();


### PR DESCRIPTION
Problem was that we would procude queries like:
SELECT COUNT(*)
FROM [Customer] AS [c]
ORDER BY [c].[Id]

which were invalid, because column on which you order should be projected, and we project COUNT(*) instead. However, ordering is redundant when querying for count and could be removed.

Fix is to remove any orderings when querying for count, just like we already do for some other result operators (e.g. Any)