### PR TITLE
API review updates to ChangeTracker interfaces

### DIFF
--- a/src/EntityFramework.Core/ChangeTracking/Internal/ChangeDetector.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/ChangeDetector.cs
@@ -30,26 +30,6 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
             _model = model;
         }
 
-        public virtual void SidecarPropertyChanged(InternalEntityEntry entry, IPropertyBase propertyBase)
-        {
-            var property = propertyBase as IProperty;
-            if (property == null)
-            {
-                return;
-            }
-
-            var snapshot = entry.TryGetSidecar(Sidecar.WellKnownNames.RelationshipsSnapshot);
-            if (snapshot == null)
-            {
-                return;
-            }
-
-            DetectKeyChange(entry, property, snapshot);
-        }
-
-        public virtual void SidecarPropertyChanging(InternalEntityEntry entry, IPropertyBase propertyBase) 
-            => PropertyChanging(entry, propertyBase);
-
         public virtual void PropertyChanged(InternalEntityEntry entry, IPropertyBase propertyBase)
         {
             var snapshot = entry.TryGetSidecar(Sidecar.WellKnownNames.RelationshipsSnapshot);

--- a/src/EntityFramework.Core/ChangeTracking/Internal/CompositeEntityKeyFactory.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/CompositeEntityKeyFactory.cs
@@ -46,13 +46,13 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         }
 
         public override EntityKey Create(
-            IEntityType entityType, IReadOnlyList<IProperty> properties, IPropertyAccessor propertyBagEntry)
+            IEntityType entityType, IReadOnlyList<IProperty> properties, IPropertyAccessor propertyAccessor)
         {
             var components = new object[properties.Count];
 
             for (var i = 0; i < properties.Count; i++)
             {
-                var value = propertyBagEntry[properties[i]];
+                var value = propertyAccessor[properties[i]];
 
                 if (value == null
                     || Equals(value, _sentinels[i]))

--- a/src/EntityFramework.Core/ChangeTracking/Internal/EntityEntryMetadataServices.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/EntityEntryMetadataServices.cs
@@ -50,9 +50,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         public virtual EntityKey CreateKey(
             [NotNull] IEntityType entityType,
             [NotNull] IReadOnlyList<IProperty> properties,
-            [NotNull] IPropertyAccessor propertyBagEntry)
+            [NotNull] IPropertyAccessor propertyAccessor)
             => _entityKeyFactorySource
                 .GetKeyFactory(properties)
-                .Create(entityType, properties, propertyBagEntry);
+                .Create(entityType, properties, propertyAccessor);
     }
 }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/EntityKeyFactory.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/EntityKeyFactory.cs
@@ -15,6 +15,6 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
         [NotNull]
         public abstract EntityKey Create(
-            [NotNull] IEntityType entityType, [NotNull] IReadOnlyList<IProperty> properties, [NotNull] IPropertyAccessor propertyBagEntry);
+            [NotNull] IEntityType entityType, [NotNull] IReadOnlyList<IProperty> properties, [NotNull] IPropertyAccessor propertyAccessor);
     }
 }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/IForeignKeyListener.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/IForeignKeyListener.cs
@@ -6,9 +6,8 @@ using Microsoft.Data.Entity.Metadata;
 
 namespace Microsoft.Data.Entity.ChangeTracking.Internal
 {
-    public interface IPropertyListener
+    public interface IForeignKeyListener
     {
-        void PropertyChanged([NotNull] InternalEntityEntry entry, [NotNull] IPropertyBase property);
-        void PropertyChanging([NotNull] InternalEntityEntry entry, [NotNull] IPropertyBase property);
+        void ForeignKeyPropertyChanged([NotNull] InternalEntityEntry entry, [NotNull] IProperty property, [CanBeNull] object oldValue, [CanBeNull] object newValue);
     }
 }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/IKeyListener.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/IKeyListener.cs
@@ -6,9 +6,8 @@ using Microsoft.Data.Entity.Metadata;
 
 namespace Microsoft.Data.Entity.ChangeTracking.Internal
 {
-    public interface IPropertyListener
+    public interface IKeyListener
     {
-        void PropertyChanged([NotNull] InternalEntityEntry entry, [NotNull] IPropertyBase property);
-        void PropertyChanging([NotNull] InternalEntityEntry entry, [NotNull] IPropertyBase property);
+        void KeyPropertyChanged([NotNull] InternalEntityEntry entry, [NotNull] IProperty property, [CanBeNull] object oldValue, [CanBeNull] object newValue);
     }
 }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/INavigationListener.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/INavigationListener.cs
@@ -7,11 +7,9 @@ using Microsoft.Data.Entity.Metadata;
 
 namespace Microsoft.Data.Entity.ChangeTracking.Internal
 {
-    public interface IRelationshipListener
+    public interface INavigationListener
     {
-        void ForeignKeyPropertyChanged([NotNull] InternalEntityEntry entry, [NotNull] IProperty property, [CanBeNull] object oldValue, [CanBeNull] object newValue);
         void NavigationReferenceChanged([NotNull] InternalEntityEntry entry, [NotNull] INavigation navigation, [CanBeNull] object oldValue, [CanBeNull] object newValue);
         void NavigationCollectionChanged([NotNull] InternalEntityEntry entry, [NotNull] INavigation navigation, [NotNull] ISet<object> added, [NotNull] ISet<object> removed);
-        void PrincipalKeyPropertyChanged([NotNull] InternalEntityEntry entry, [NotNull] IProperty property, [CanBeNull] object oldValue, [CanBeNull] object newValue);
     }
 }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -308,12 +308,12 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
                         if (sidecar.TransparentWrite
                             && sidecar.CanStoreValue(property))
                         {
-                            StateManager.Notify.SidecarPropertyChanging(this, property);
+                            StateManager.Notify.PropertyChanging(this, property);
 
                             sidecar[property] = value;
                             wrote = true;
 
-                            StateManager.Notify.SidecarPropertyChanged(this, property);
+                            StateManager.Notify.PropertyChanged(this, property);
                         }
                     }
                     if (wrote)
@@ -339,7 +339,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         public virtual EntityKey CreateKey(
             [NotNull] IEntityType entityType,
             [NotNull] IReadOnlyList<IProperty> properties,
-            [NotNull] IPropertyAccessor propertyBagEntry) => _metadataServices.CreateKey(entityType, properties, propertyBagEntry);
+            [NotNull] IPropertyAccessor propertyAccessor) => _metadataServices.CreateKey(entityType, properties, propertyAccessor);
 
         public virtual EntityKey GetDependentKeySnapshot([NotNull] IForeignKey foreignKey)
             => CreateKey(foreignKey.ReferencedEntityType, foreignKey.Properties, RelationshipsSnapshot);

--- a/src/EntityFramework.Core/ChangeTracking/Internal/InternalEntityEntryNotifier.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/InternalEntityEntryNotifier.cs
@@ -13,7 +13,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
     {
         private readonly IEntityStateListener[] _entityStateListeners;
         private readonly IPropertyListener[] _propertyListeners;
-        private readonly IRelationshipListener[] _relationshipListeners;
+        private readonly IForeignKeyListener[] _fkListeners;
+        private readonly INavigationListener[] _navigationListeners;
+        private readonly IKeyListener[] _keyListeners;
 
         /// <summary>
         ///     This constructor is intended only for use when creating test doubles that will override members
@@ -27,7 +29,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         public InternalEntityEntryNotifier(
             [CanBeNull] IEnumerable<IEntityStateListener> entityStateListeners,
             [CanBeNull] IEnumerable<IPropertyListener> propertyListeners,
-            [CanBeNull] IEnumerable<IRelationshipListener> relationshipListeners)
+            [CanBeNull] IEnumerable<IForeignKeyListener> fkListeners,
+            [CanBeNull] IEnumerable<INavigationListener> navigationListeners,
+            [CanBeNull] IEnumerable<IKeyListener> keyListeners)
         {
             if (entityStateListeners != null)
             {
@@ -41,50 +45,46 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
                 _propertyListeners = listeners.Length == 0 ? null : listeners;
             }
 
-            if (relationshipListeners != null)
+            if (fkListeners != null)
             {
-                var listeners = relationshipListeners.ToArray();
-                _relationshipListeners = listeners.Length == 0 ? null : listeners;
+                var listeners = fkListeners.ToArray();
+                _fkListeners = listeners.Length == 0 ? null : listeners;
+            }
+
+            if (navigationListeners != null)
+            {
+                var listeners = navigationListeners.ToArray();
+                _navigationListeners = listeners.Length == 0 ? null : listeners;
+            }
+
+            if (keyListeners != null)
+            {
+                var listeners = keyListeners.ToArray();
+                _keyListeners = listeners.Length == 0 ? null : listeners;
             }
         }
 
-        public virtual void StateChanging([NotNull] InternalEntityEntry entry, EntityState newState)
-        {
-            Dispatch(l => l.StateChanging(entry, newState));
-        }
+        public virtual void StateChanging([NotNull] InternalEntityEntry entry, EntityState newState) 
+            => Dispatch(l => l.StateChanging(entry, newState));
 
-        public virtual void StateChanged([NotNull] InternalEntityEntry entry, EntityState oldState)
-        {
-            Dispatch(l => l.StateChanged(entry, oldState));
-        }
+        public virtual void StateChanged([NotNull] InternalEntityEntry entry, EntityState oldState) 
+            => Dispatch(l => l.StateChanged(entry, oldState));
 
         public virtual void ForeignKeyPropertyChanged(
-            [NotNull] InternalEntityEntry entry, [NotNull] IProperty property, [CanBeNull] object oldValue, [CanBeNull] object newValue)
-        {
-            Dispatch(l => l.ForeignKeyPropertyChanged(entry, property, oldValue, newValue));
-        }
+            [NotNull] InternalEntityEntry entry, [NotNull] IProperty property, [CanBeNull] object oldValue, [CanBeNull] object newValue) 
+            => Dispatch(l => l.ForeignKeyPropertyChanged(entry, property, oldValue, newValue));
 
         public virtual void NavigationReferenceChanged(
-            [NotNull] InternalEntityEntry entry, [NotNull] INavigation navigation, [CanBeNull] object oldValue, [CanBeNull] object newValue)
-        {
-            Dispatch(l => l.NavigationReferenceChanged(entry, navigation, oldValue, newValue));
-        }
+            [NotNull] InternalEntityEntry entry, [NotNull] INavigation navigation, [CanBeNull] object oldValue, [CanBeNull] object newValue) 
+            => Dispatch(l => l.NavigationReferenceChanged(entry, navigation, oldValue, newValue));
 
         public virtual void NavigationCollectionChanged(
-            [NotNull] InternalEntityEntry entry, [NotNull] INavigation navigation, [NotNull] ISet<object> added, [NotNull] ISet<object> removed)
-        {
-            Dispatch(l => l.NavigationCollectionChanged(entry, navigation, added, removed));
-        }
+            [NotNull] InternalEntityEntry entry, [NotNull] INavigation navigation, [NotNull] ISet<object> added, [NotNull] ISet<object> removed) 
+            => Dispatch(l => l.NavigationCollectionChanged(entry, navigation, added, removed));
 
         public virtual void PrincipalKeyPropertyChanged(
             [NotNull] InternalEntityEntry entry, [NotNull] IProperty property, [CanBeNull] object oldValue, [CanBeNull] object newValue)
-            => Dispatch(l => l.PrincipalKeyPropertyChanged(entry, property, oldValue, newValue));
-
-        public virtual void SidecarPropertyChanged([NotNull] InternalEntityEntry entry, [NotNull] IPropertyBase property)
-            => Dispatch(l => l.SidecarPropertyChanged(entry, property));
-
-        public virtual void SidecarPropertyChanging([NotNull] InternalEntityEntry entry, [NotNull] IPropertyBase property)
-            => Dispatch(l => l.SidecarPropertyChanging(entry, property));
+            => Dispatch(l => l.KeyPropertyChanged(entry, property, oldValue, newValue));
 
         public virtual void PropertyChanged([NotNull] InternalEntityEntry entry, [NotNull] IPropertyBase property)
             => Dispatch(l => l.PropertyChanged(entry, property));
@@ -107,7 +107,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
         private void Dispatch(Action<IPropertyListener> action)
         {
-            if (_entityStateListeners == null)
+            if (_propertyListeners == null)
             {
                 return;
             }
@@ -118,14 +118,40 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
             }
         }
 
-        private void Dispatch(Action<IRelationshipListener> action)
+        private void Dispatch(Action<IForeignKeyListener> action)
         {
-            if (_entityStateListeners == null)
+            if (_fkListeners == null)
             {
                 return;
             }
 
-            foreach (var listener in _relationshipListeners)
+            foreach (var listener in _fkListeners)
+            {
+                action(listener);
+            }
+        }
+
+        private void Dispatch(Action<INavigationListener> action)
+        {
+            if (_navigationListeners == null)
+            {
+                return;
+            }
+
+            foreach (var listener in _navigationListeners)
+            {
+                action(listener);
+            }
+        }
+
+        private void Dispatch(Action<IKeyListener> action)
+        {
+            if (_keyListeners == null)
+            {
+                return;
+            }
+
+            foreach (var listener in _keyListeners)
             {
                 action(listener);
             }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/NavigationFixer.cs
@@ -12,7 +12,7 @@ using Microsoft.Data.Entity.Metadata;
 
 namespace Microsoft.Data.Entity.ChangeTracking.Internal
 {
-    public class NavigationFixer : IEntityStateListener, IRelationshipListener
+    public class NavigationFixer : IEntityStateListener, IForeignKeyListener, INavigationListener, IKeyListener
     {
         private readonly ClrPropertySetterSource _setterSource;
         private readonly ClrPropertyGetterSource _getterSource;
@@ -156,7 +156,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
             }
         }
 
-        public virtual void PrincipalKeyPropertyChanged(InternalEntityEntry entry, IProperty property, object oldValue, object newValue)
+        public virtual void KeyPropertyChanged(InternalEntityEntry entry, IProperty property, object oldValue, object newValue)
         {
             // We don't prevent recursive entry here because changed of principal key can have cascading effects
             // when principal key is also foreign key.

--- a/src/EntityFramework.Core/ChangeTracking/Internal/PropertyAccessorExtensions.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/PropertyAccessorExtensions.cs
@@ -9,18 +9,18 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
     public static class PropertyAccessorExtensions
     {
         [NotNull]
-        public static EntityKey GetDependentKeyValue([NotNull] this IPropertyAccessor propertyBagEntry, [NotNull] IForeignKey foreignKey)
-            => propertyBagEntry.InternalEntityEntry.CreateKey(foreignKey.ReferencedEntityType, foreignKey.Properties, propertyBagEntry);
+        public static EntityKey GetDependentKeyValue([NotNull] this IPropertyAccessor propertyAccessor, [NotNull] IForeignKey foreignKey)
+            => propertyAccessor.InternalEntityEntry.CreateKey(foreignKey.ReferencedEntityType, foreignKey.Properties, propertyAccessor);
 
         [NotNull]
-        public static EntityKey GetPrincipalKeyValue([NotNull] this IPropertyAccessor propertyBagEntry, [NotNull] IForeignKey foreignKey)
-            => propertyBagEntry.InternalEntityEntry.CreateKey(foreignKey.ReferencedEntityType, foreignKey.ReferencedProperties, propertyBagEntry);
+        public static EntityKey GetPrincipalKeyValue([NotNull] this IPropertyAccessor propertyAccessor, [NotNull] IForeignKey foreignKey)
+            => propertyAccessor.InternalEntityEntry.CreateKey(foreignKey.ReferencedEntityType, foreignKey.ReferencedProperties, propertyAccessor);
 
         [NotNull]
-        public static EntityKey GetPrimaryKeyValue([NotNull] this IPropertyAccessor propertyBagEntry)
+        public static EntityKey GetPrimaryKeyValue([NotNull] this IPropertyAccessor propertyAccessor)
         {
-            var entityType = propertyBagEntry.InternalEntityEntry.EntityType;
-            return propertyBagEntry.InternalEntityEntry.CreateKey(entityType, entityType.GetPrimaryKey().Properties, propertyBagEntry);
+            var entityType = propertyAccessor.InternalEntityEntry.EntityType;
+            return propertyAccessor.InternalEntityEntry.CreateKey(entityType, entityType.GetPrimaryKey().Properties, propertyAccessor);
         }
     }
 }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/SimpleEntityKeyFactory.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/SimpleEntityKeyFactory.cs
@@ -33,9 +33,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         }
 
         public override EntityKey Create(
-            IEntityType entityType, IReadOnlyList<IProperty> properties, IPropertyAccessor propertyBagEntry)
+            IEntityType entityType, IReadOnlyList<IProperty> properties, IPropertyAccessor propertyAccessor)
         {
-            var value = propertyBagEntry[properties[0]];
+            var value = propertyAccessor[properties[0]];
 
             if (value != null)
             {

--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -83,6 +83,8 @@
     <Compile Include="ChangeTracking\Internal\ArraySidecar.cs" />
     <Compile Include="ChangeTracking\Internal\ChangeDetector.cs" />
     <Compile Include="ChangeTracking\Internal\KeyPropagator.cs" />
+    <Compile Include="ChangeTracking\Internal\IKeyListener.cs" />
+    <Compile Include="ChangeTracking\Internal\INavigationListener.cs" />
     <Compile Include="ChangeTracking\Internal\InternalClrEntityEntry.cs" />
     <Compile Include="ChangeTracking\Internal\CompositeEntityKey.cs" />
     <Compile Include="ChangeTracking\Internal\CompositeEntityKeyFactory.cs" />
@@ -94,7 +96,7 @@
     <Compile Include="ChangeTracking\Internal\IEntityStateListener.cs" />
     <Compile Include="ChangeTracking\Internal\IPropertyAccessor.cs" />
     <Compile Include="ChangeTracking\Internal\IPropertyListener.cs" />
-    <Compile Include="ChangeTracking\Internal\IRelationshipListener.cs" />
+    <Compile Include="ChangeTracking\Internal\IForeignKeyListener.cs" />
     <Compile Include="ChangeTracking\Internal\InternalMixedEntityEntry.cs" />
     <Compile Include="ChangeTracking\Internal\NavigationFixer.cs" />
     <Compile Include="ChangeTracking\Internal\OriginalValues.cs" />

--- a/src/EntityFramework.Core/Extensions/EntityServiceCollectionExtensions.cs
+++ b/src/EntityFramework.Core/Extensions/EntityServiceCollectionExtensions.cs
@@ -34,7 +34,9 @@ namespace Microsoft.Framework.DependencyInjection
             // TODO: Is this the appropriate way to register listeners?
             serviceCollection
                 .AddScoped<IEntityStateListener>(p => p.GetService<NavigationFixer>())
-                .AddScoped<IRelationshipListener>(p => p.GetService<NavigationFixer>())
+                .AddScoped<IForeignKeyListener>(p => p.GetService<NavigationFixer>())
+                .AddScoped<INavigationListener>(p => p.GetService<NavigationFixer>())
+                .AddScoped<IKeyListener>(p => p.GetService<NavigationFixer>())
                 .AddScoped<IPropertyListener>(p => p.GetService<ChangeDetector>());
 
             serviceCollection.TryAdd(new ServiceCollection()

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
@@ -177,9 +177,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Detects_principal_key_change()
         {
-            var contextServices = TestHelpers.Instance.CreateContextServices(
-                new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
-                BuildModel());
+            var contextServices = CreateContextServices();
 
             var stateManager = contextServices.GetRequiredService<StateManager>();
             var changeDetector = contextServices.GetRequiredService<ChangeDetector>();
@@ -197,10 +195,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             Assert.Equal(78, entry.RelationshipsSnapshot[entry.EntityType.GetProperty("PrincipalId")]);
             Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType, -1)));
 
-            var testListener = contextServices
-                .GetRequiredService<IEnumerable<IRelationshipListener>>()
-                .OfType<TestRelationshipListener>()
-                .Single();
+            var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
             Assert.Same(entry, testListener.PrincipalKeyChange.Item1);
             Assert.Same(entry.EntityType.GetProperty("PrincipalId"), testListener.PrincipalKeyChange.Item2);
@@ -217,9 +212,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Detects_principal_key_changing_back_to_original_value()
         {
-            var contextServices = TestHelpers.Instance.CreateContextServices(
-                new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
-                BuildModel());
+            var contextServices = CreateContextServices();
 
             var changeDetector = contextServices.GetRequiredService<ChangeDetector>();
             var stateManager = contextServices.GetRequiredService<StateManager>();
@@ -238,10 +231,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             Assert.Equal(77, entry.RelationshipsSnapshot[entry.EntityType.GetProperty("PrincipalId")]);
 
-            var testListener = contextServices
-                .GetRequiredService<IEnumerable<IRelationshipListener>>()
-                .OfType<TestRelationshipListener>()
-                .Single();
+            var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
             Assert.Same(entry, testListener.PrincipalKeyChange.Item1);
             Assert.Same(entry.EntityType.GetProperty("PrincipalId"), testListener.PrincipalKeyChange.Item2);
@@ -258,9 +248,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Reacts_to_principal_key_change_in_sidecar()
         {
-            var contextServices = TestHelpers.Instance.CreateContextServices(
-                new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
-                BuildModel());
+            var contextServices = CreateContextServices();
 
             var changeDetector = contextServices.GetRequiredService<ChangeDetector>();
             var stateManager = contextServices.GetRequiredService<StateManager>();
@@ -280,10 +268,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             Assert.Equal(78, entry.RelationshipsSnapshot[property]);
 
-            var testListener = contextServices
-                .GetRequiredService<IEnumerable<IRelationshipListener>>()
-                .OfType<TestRelationshipListener>()
-                .Single();
+            var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
             Assert.Same(entry, testListener.PrincipalKeyChange.Item1);
             Assert.Same(property, testListener.PrincipalKeyChange.Item2);
@@ -300,9 +285,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Detects_primary_key_change()
         {
-            var contextServices = TestHelpers.Instance.CreateContextServices(
-                new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
-                BuildModel());
+            var contextServices = CreateContextServices();
 
             var stateManager = contextServices.GetRequiredService<StateManager>();
             var changeDetector = contextServices.GetRequiredService<ChangeDetector>();
@@ -320,10 +303,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             Assert.Equal(78, entry.RelationshipsSnapshot[entry.EntityType.GetProperty("Id")]);
             Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType, 78)));
 
-            var testListener = contextServices
-                .GetRequiredService<IEnumerable<IRelationshipListener>>()
-                .OfType<TestRelationshipListener>()
-                .Single();
+            var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
             Assert.Null(testListener.PrincipalKeyChange);
             Assert.Null(testListener.ForeignKeyChange);
@@ -336,9 +316,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Reacts_to_primary_key_change_in_sidecar()
         {
-            var contextServices = TestHelpers.Instance.CreateContextServices(
-                new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
-                BuildModel());
+            var contextServices = CreateContextServices();
 
             var stateManager = contextServices.GetRequiredService<StateManager>();
             var changeDetector = contextServices.GetRequiredService<ChangeDetector>();
@@ -362,10 +340,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType, 78)));
 
-            var testListener = contextServices
-                .GetRequiredService<IEnumerable<IRelationshipListener>>()
-                .OfType<TestRelationshipListener>()
-                .Single();
+            var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
             Assert.Null(testListener.PrincipalKeyChange);
             Assert.Null(testListener.ForeignKeyChange);
@@ -378,9 +353,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Ignores_no_change_to_principal_key()
         {
-            var contextServices = TestHelpers.Instance.CreateContextServices(
-                new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
-                BuildModel());
+            var contextServices = CreateContextServices();
 
             var stateManager = contextServices.GetRequiredService<StateManager>();
             var changeDetector = contextServices.GetRequiredService<ChangeDetector>();
@@ -398,10 +371,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             Assert.Equal(77, entry.RelationshipsSnapshot[entry.EntityType.GetProperty("PrincipalId")]);
             Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType, -1)));
 
-            var testListener = contextServices
-                .GetRequiredService<IEnumerable<IRelationshipListener>>()
-                .OfType<TestRelationshipListener>()
-                .Single();
+            var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
             Assert.Null(testListener.PrincipalKeyChange);
             Assert.Null(testListener.ForeignKeyChange);
@@ -414,9 +384,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Ignores_no_change_to_principal_key_in_sidecar()
         {
-            var contextServices = TestHelpers.Instance.CreateContextServices(
-                new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
-                BuildModel());
+            var contextServices = CreateContextServices();
 
             var changeDetector = contextServices.GetRequiredService<ChangeDetector>();
             var stateManager = contextServices.GetRequiredService<StateManager>();
@@ -436,10 +404,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             Assert.Equal(77, entry.RelationshipsSnapshot[property]);
 
-            var testListener = contextServices
-                .GetRequiredService<IEnumerable<IRelationshipListener>>()
-                .OfType<TestRelationshipListener>()
-                .Single();
+            var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
             Assert.Null(testListener.PrincipalKeyChange);
             Assert.Null(testListener.ForeignKeyChange);
@@ -452,9 +417,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Detects_foreign_key_change()
         {
-            var contextServices = TestHelpers.Instance.CreateContextServices(
-                new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
-                BuildModel());
+            var contextServices = CreateContextServices();
 
             var changeDetector = contextServices.GetRequiredService<ChangeDetector>();
             var stateManager = contextServices.GetRequiredService<StateManager>();
@@ -470,10 +433,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             Assert.Equal(EntityState.Modified, entry.EntityState);
             Assert.Equal(78, entry.RelationshipsSnapshot[entry.EntityType.GetProperty("DependentId")]);
 
-            var testListener = contextServices
-                .GetRequiredService<IEnumerable<IRelationshipListener>>()
-                .OfType<TestRelationshipListener>()
-                .Single();
+            var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
             Assert.Same(entry, testListener.ForeignKeyChange.Item1);
             Assert.Same(entry.EntityType.GetProperty("DependentId"), testListener.ForeignKeyChange.Item2);
@@ -490,9 +450,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Detects_foreign_key_changing_back_to_original_value()
         {
-            var contextServices = TestHelpers.Instance.CreateContextServices(
-                new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
-                BuildModel());
+            var contextServices = CreateContextServices();
 
             var changeDetector = contextServices.GetRequiredService<ChangeDetector>();
             var stateManager = contextServices.GetRequiredService<StateManager>();
@@ -512,10 +470,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             Assert.Equal(EntityState.Modified, entry.EntityState);
             Assert.Equal(77, entry.RelationshipsSnapshot[entry.EntityType.GetProperty("DependentId")]);
 
-            var testListener = contextServices
-                .GetRequiredService<IEnumerable<IRelationshipListener>>()
-                .OfType<TestRelationshipListener>()
-                .Single();
+            var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
             Assert.Same(entry, testListener.ForeignKeyChange.Item1);
             Assert.Same(entry.EntityType.GetProperty("DependentId"), testListener.ForeignKeyChange.Item2);
@@ -532,9 +487,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Reacts_to_foreign_key_change_in_sidecar()
         {
-            var contextServices = TestHelpers.Instance.CreateContextServices(
-                new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
-                BuildModel());
+            var contextServices = CreateContextServices();
 
             var changeDetector = contextServices.GetRequiredService<ChangeDetector>();
             var stateManager = contextServices.GetRequiredService<StateManager>();
@@ -555,10 +508,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             Assert.Equal(EntityState.Modified, entry.EntityState);
             Assert.Equal(78, entry.RelationshipsSnapshot[property]);
 
-            var testListener = contextServices
-                .GetRequiredService<IEnumerable<IRelationshipListener>>()
-                .OfType<TestRelationshipListener>()
-                .Single();
+            var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
             Assert.Same(entry, testListener.ForeignKeyChange.Item1);
             Assert.Same(property, testListener.ForeignKeyChange.Item2);
@@ -575,9 +525,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Ignores_no_change_to_foreign_key()
         {
-            var contextServices = TestHelpers.Instance.CreateContextServices(
-                new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
-                BuildModel());
+            var contextServices = CreateContextServices();
 
             var changeDetector = contextServices.GetRequiredService<ChangeDetector>();
             var stateManager = contextServices.GetRequiredService<StateManager>();
@@ -593,10 +541,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
             Assert.Equal(77, entry.RelationshipsSnapshot[entry.EntityType.GetProperty("DependentId")]);
 
-            var testListener = contextServices
-                .GetRequiredService<IEnumerable<IRelationshipListener>>()
-                .OfType<TestRelationshipListener>()
-                .Single();
+            var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
             Assert.Null(testListener.PrincipalKeyChange);
             Assert.Null(testListener.ForeignKeyChange);
@@ -609,9 +554,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Ignores_no_change_to_foreign_key_in_sidecar()
         {
-            var contextServices = TestHelpers.Instance.CreateContextServices(
-                new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
-                BuildModel());
+            var contextServices = CreateContextServices();
 
             var changeDetector = contextServices.GetRequiredService<ChangeDetector>();
             var stateManager = contextServices.GetRequiredService<StateManager>();
@@ -632,10 +575,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
             Assert.Equal(77, entry.RelationshipsSnapshot[property]);
 
-            var testListener = contextServices
-                .GetRequiredService<IEnumerable<IRelationshipListener>>()
-                .OfType<TestRelationshipListener>()
-                .Single();
+            var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
             Assert.Null(testListener.PrincipalKeyChange);
             Assert.Null(testListener.ForeignKeyChange);
@@ -648,9 +588,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Detects_reference_navigation_change()
         {
-            var contextServices = TestHelpers.Instance.CreateContextServices(
-                new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
-                BuildModel());
+            var contextServices = CreateContextServices();
 
             var changeDetector = contextServices.GetRequiredService<ChangeDetector>();
             var stateManager = contextServices.GetRequiredService<StateManager>();
@@ -668,10 +606,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             Assert.Equal(EntityState.Modified, entry.EntityState);
             Assert.Equal(newCategory, entry.RelationshipsSnapshot[entry.EntityType.GetNavigation("Category")]);
 
-            var testListener = contextServices
-                .GetRequiredService<IEnumerable<IRelationshipListener>>()
-                .OfType<TestRelationshipListener>()
-                .Single();
+            var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
             Assert.Same(entry, testListener.ReferenceChange.Item1);
             Assert.Same(entry.EntityType.GetNavigation("Category"), testListener.ReferenceChange.Item2);
@@ -692,9 +627,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Detects_reference_navigation_changing_back_to_original_value()
         {
-            var contextServices = TestHelpers.Instance.CreateContextServices(
-                new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
-                BuildModel());
+            var contextServices = CreateContextServices();
 
             var changeDetector = contextServices.GetRequiredService<ChangeDetector>();
             var stateManager = contextServices.GetRequiredService<StateManager>();
@@ -716,10 +649,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             Assert.Equal(EntityState.Modified, entry.EntityState);
             Assert.Equal(originalCategory, entry.RelationshipsSnapshot[entry.EntityType.GetNavigation("Category")]);
 
-            var testListener = contextServices
-                .GetRequiredService<IEnumerable<IRelationshipListener>>()
-                .OfType<TestRelationshipListener>()
-                .Single();
+            var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
             Assert.Same(entry, testListener.ReferenceChange.Item1);
             Assert.Same(entry.EntityType.GetNavigation("Category"), testListener.ReferenceChange.Item2);
@@ -740,9 +670,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Ignores_no_change_to_reference_navigation()
         {
-            var contextServices = TestHelpers.Instance.CreateContextServices(
-                new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
-                BuildModel());
+            var contextServices = CreateContextServices();
 
             var changeDetector = contextServices.GetRequiredService<ChangeDetector>();
             var stateManager = contextServices.GetRequiredService<StateManager>();
@@ -759,10 +687,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
             Assert.Equal(category, entry.RelationshipsSnapshot[entry.EntityType.GetNavigation("Category")]);
 
-            var testListener = contextServices
-                .GetRequiredService<IEnumerable<IRelationshipListener>>()
-                .OfType<TestRelationshipListener>()
-                .Single();
+            var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
             Assert.Null(testListener.ReferenceChange);
             Assert.Null(testListener.ForeignKeyChange);
@@ -775,9 +700,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Detects_adding_to_collection_navigation()
         {
-            var contextServices = TestHelpers.Instance.CreateContextServices(
-                new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
-                BuildModel());
+            var contextServices = CreateContextServices();
 
             var changeDetector = contextServices.GetRequiredService<ChangeDetector>();
             var stateManager = contextServices.GetRequiredService<StateManager>();
@@ -800,10 +723,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
                     .Cast<Product>()
                     .OrderBy(e => e.DependentId));
 
-            var testListener = contextServices
-                .GetRequiredService<IEnumerable<IRelationshipListener>>()
-                .OfType<TestRelationshipListener>()
-                .Single();
+            var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
             Assert.Same(entry, testListener.CollectionChange.Item1);
             Assert.Same(entry.EntityType.GetNavigation("Products"), testListener.CollectionChange.Item2);
@@ -820,9 +740,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Detects_removing_from_collection_navigation()
         {
-            var contextServices = TestHelpers.Instance.CreateContextServices(
-                new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
-                BuildModel());
+            var contextServices = CreateContextServices();
 
             var changeDetector = contextServices.GetRequiredService<ChangeDetector>();
             var stateManager = contextServices.GetRequiredService<StateManager>();
@@ -844,10 +762,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
                     .Cast<Product>()
                     .OrderBy(e => e.DependentId));
 
-            var testListener = contextServices
-                .GetRequiredService<IEnumerable<IRelationshipListener>>()
-                .OfType<TestRelationshipListener>()
-                .Single();
+            var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
             Assert.Same(entry, testListener.CollectionChange.Item1);
             Assert.Same(entry.EntityType.GetNavigation("Products"), testListener.CollectionChange.Item2);
@@ -868,9 +783,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Ignores_no_change_to_collection_navigation()
         {
-            var contextServices = TestHelpers.Instance.CreateContextServices(
-                new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
-                BuildModel());
+            var contextServices = CreateContextServices();
 
             var changeDetector = contextServices.GetRequiredService<ChangeDetector>();
             var stateManager = contextServices.GetRequiredService<StateManager>();
@@ -893,10 +806,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
                     .Cast<Product>()
                     .OrderBy(e => e.DependentId));
 
-            var testListener = contextServices
-                .GetRequiredService<IEnumerable<IRelationshipListener>>()
-                .OfType<TestRelationshipListener>()
-                .Single();
+            var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
             Assert.Null(testListener.CollectionChange);
             Assert.Null(testListener.ForeignKeyChange);
@@ -909,9 +819,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Skips_detecting_changes_to_primary_principal_key_for_notification_entities()
         {
-            var contextServices = TestHelpers.Instance.CreateContextServices(
-                new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
-                BuildModelWithChanged());
+            var contextServices = CreateContextServices(BuildModelWithChanged());
 
             var stateManager = contextServices.GetRequiredService<StateManager>();
             var changeDetector = contextServices.GetRequiredService<ChangeDetector>();
@@ -929,10 +837,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             Assert.Equal(77, entry.RelationshipsSnapshot[entry.EntityType.GetProperty("Id")]);
             Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType, 77)));
 
-            var testListener = contextServices
-                .GetRequiredService<IEnumerable<IRelationshipListener>>()
-                .OfType<TestRelationshipListener>()
-                .Single();
+            var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
             Assert.Null(testListener.PrincipalKeyChange);
             Assert.Null(testListener.ForeignKeyChange);
@@ -945,9 +850,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Skips_detecting_changes_to_foreign_key_for_notification_entities()
         {
-            var contextServices = TestHelpers.Instance.CreateContextServices(
-                new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
-                BuildModelWithChanged());
+            var contextServices = CreateContextServices(BuildModelWithChanged());
 
             var changeDetector = contextServices.GetRequiredService<ChangeDetector>();
             var stateManager = contextServices.GetRequiredService<StateManager>();
@@ -962,10 +865,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             Assert.Equal(77, entry.RelationshipsSnapshot[entry.EntityType.GetProperty("DependentId")]);
 
-            var testListener = contextServices
-                .GetRequiredService<IEnumerable<IRelationshipListener>>()
-                .OfType<TestRelationshipListener>()
-                .Single();
+            var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
             Assert.Null(testListener.PrincipalKeyChange);
             Assert.Null(testListener.ForeignKeyChange);
@@ -978,9 +878,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Skips_detecting_changes_to_reference_navigation_for_notification_entities()
         {
-            var contextServices = TestHelpers.Instance.CreateContextServices(
-                new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
-                BuildModelWithChanged());
+            var contextServices = CreateContextServices(BuildModelWithChanged());
 
             var changeDetector = contextServices.GetRequiredService<ChangeDetector>();
             var stateManager = contextServices.GetRequiredService<StateManager>();
@@ -997,10 +895,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
             Assert.Equal(category, entry.RelationshipsSnapshot[entry.EntityType.GetNavigation("Category")]);
 
-            var testListener = contextServices
-                .GetRequiredService<IEnumerable<IRelationshipListener>>()
-                .OfType<TestRelationshipListener>()
-                .Single();
+            var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
             Assert.Null(testListener.ReferenceChange);
             Assert.Null(testListener.ForeignKeyChange);
@@ -1013,9 +908,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Skips_detecting_changes_to_notifying_collections()
         {
-            var contextServices = TestHelpers.Instance.CreateContextServices(
-                new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
-                BuildModelWithChanged());
+            var contextServices = CreateContextServices(BuildModelWithChanged());
 
             var changeDetector = contextServices.GetRequiredService<ChangeDetector>();
             var stateManager = contextServices.GetRequiredService<StateManager>();
@@ -1043,10 +936,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
                     .Cast<ProductWithChanged>()
                     .OrderBy(e => e.DependentId));
 
-            var testListener = contextServices
-                .GetRequiredService<IEnumerable<IRelationshipListener>>()
-                .OfType<TestRelationshipListener>()
-                .Single();
+            var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
             Assert.Same(entry, testListener.CollectionChange.Item1);
             Assert.Same(entry.EntityType.GetNavigation("Products"), testListener.CollectionChange.Item2);
@@ -1063,9 +953,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Change_detection_still_happens_for_non_notifying_collections_on_notifying_entities()
         {
-            var contextServices = TestHelpers.Instance.CreateContextServices(
-                new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
-                BuildModelWithChanged());
+            var contextServices = CreateContextServices(BuildModelWithChanged());
 
             var changeDetector = contextServices.GetRequiredService<ChangeDetector>();
             var stateManager = contextServices.GetRequiredService<StateManager>();
@@ -1092,10 +980,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
                     .Cast<ProductWithChanged>()
                     .OrderBy(e => e.DependentId));
 
-            var testListener = contextServices
-                .GetRequiredService<IEnumerable<IRelationshipListener>>()
-                .OfType<TestRelationshipListener>()
-                .Single();
+            var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
             Assert.Same(entry, testListener.CollectionChange.Item1);
             Assert.Same(entry.EntityType.GetNavigation("Products"), testListener.CollectionChange.Item2);
@@ -1297,9 +1182,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Handles_notification_of_principal_key_change()
         {
-            var contextServices = TestHelpers.Instance.CreateContextServices(
-                new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
-                BuildNotifyingModel());
+            var contextServices = CreateContextServices(BuildNotifyingModel());
 
             var changeDetector = contextServices.GetRequiredService<ChangeDetector>();
             var stateManager = contextServices.GetRequiredService<StateManager>();
@@ -1315,10 +1198,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             Assert.Equal(78, entry.RelationshipsSnapshot[entry.EntityType.GetProperty("PrincipalId")]);
             Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType, -1)));
 
-            var testListener = contextServices
-                .GetRequiredService<IEnumerable<IRelationshipListener>>()
-                .OfType<TestRelationshipListener>()
-                .Single();
+            var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
             Assert.Same(entry, testListener.PrincipalKeyChange.Item1);
             Assert.Same(entry.EntityType.GetProperty("PrincipalId"), testListener.PrincipalKeyChange.Item2);
@@ -1335,9 +1215,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Handles_notification_of_principal_key_changing_back_to_original_value()
         {
-            var contextServices = TestHelpers.Instance.CreateContextServices(
-                new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
-                BuildNotifyingModel());
+            var contextServices = CreateContextServices(BuildNotifyingModel());
 
             var changeDetector = contextServices.GetRequiredService<ChangeDetector>();
             var stateManager = contextServices.GetRequiredService<StateManager>();
@@ -1351,10 +1229,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             Assert.Equal(77, entry.RelationshipsSnapshot[entry.EntityType.GetProperty("PrincipalId")]);
 
-            var testListener = contextServices
-                .GetRequiredService<IEnumerable<IRelationshipListener>>()
-                .OfType<TestRelationshipListener>()
-                .Single();
+            var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
             Assert.Same(entry, testListener.PrincipalKeyChange.Item1);
             Assert.Same(entry.EntityType.GetProperty("PrincipalId"), testListener.PrincipalKeyChange.Item2);
@@ -1371,9 +1246,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Handles_notification_of_primary_key_change()
         {
-            var contextServices = TestHelpers.Instance.CreateContextServices(
-                new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
-                BuildNotifyingModel());
+            var contextServices = CreateContextServices(BuildNotifyingModel());
 
             var changeDetector = contextServices.GetRequiredService<ChangeDetector>();
             var stateManager = contextServices.GetRequiredService<StateManager>();
@@ -1389,10 +1262,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             Assert.Equal(78, entry.RelationshipsSnapshot[entry.EntityType.GetProperty("Id")]);
             Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType, 78)));
 
-            var testListener = contextServices
-                .GetRequiredService<IEnumerable<IRelationshipListener>>()
-                .OfType<TestRelationshipListener>()
-                .Single();
+            var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
             Assert.Null(testListener.PrincipalKeyChange);
             Assert.Null(testListener.ForeignKeyChange);
@@ -1405,9 +1275,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Handles_notification_of_no_change_to_principal_key()
         {
-            var contextServices = TestHelpers.Instance.CreateContextServices(
-                new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
-                BuildNotifyingModel());
+            var contextServices = CreateContextServices(BuildNotifyingModel());
 
             var changeDetector = contextServices.GetRequiredService<ChangeDetector>();
             var stateManager = contextServices.GetRequiredService<StateManager>();
@@ -1423,10 +1291,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             Assert.Equal(77, entry.RelationshipsSnapshot[entry.EntityType.GetProperty("PrincipalId")]);
             Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType, -1)));
 
-            var testListener = contextServices
-                .GetRequiredService<IEnumerable<IRelationshipListener>>()
-                .OfType<TestRelationshipListener>()
-                .Single();
+            var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
             Assert.Null(testListener.PrincipalKeyChange);
             Assert.Null(testListener.ForeignKeyChange);
@@ -1439,9 +1304,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Handles_notification_of_foreign_key_change()
         {
-            var contextServices = TestHelpers.Instance.CreateContextServices(
-                new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
-                BuildNotifyingModel());
+            var contextServices = CreateContextServices(BuildNotifyingModel());
 
             var changeDetector = contextServices.GetRequiredService<ChangeDetector>();
             var stateManager = contextServices.GetRequiredService<StateManager>();
@@ -1455,10 +1318,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             Assert.Equal(EntityState.Modified, entry.EntityState);
             Assert.Equal(78, entry.RelationshipsSnapshot[entry.EntityType.GetProperty("DependentId")]);
 
-            var testListener = contextServices
-                .GetRequiredService<IEnumerable<IRelationshipListener>>()
-                .OfType<TestRelationshipListener>()
-                .Single();
+            var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
             Assert.Same(entry, testListener.ForeignKeyChange.Item1);
             Assert.Same(entry.EntityType.GetProperty("DependentId"), testListener.ForeignKeyChange.Item2);
@@ -1475,9 +1335,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Handles_notification_of_foreign_key_changing_back_to_original_value()
         {
-            var contextServices = TestHelpers.Instance.CreateContextServices(
-                new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
-                BuildNotifyingModel());
+            var contextServices = CreateContextServices(BuildNotifyingModel());
 
             var changeDetector = contextServices.GetRequiredService<ChangeDetector>();
             var stateManager = contextServices.GetRequiredService<StateManager>();
@@ -1492,10 +1350,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             Assert.Equal(EntityState.Modified, entry.EntityState);
             Assert.Equal(77, entry.RelationshipsSnapshot[entry.EntityType.GetProperty("DependentId")]);
 
-            var testListener = contextServices
-                .GetRequiredService<IEnumerable<IRelationshipListener>>()
-                .OfType<TestRelationshipListener>()
-                .Single();
+            var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
             Assert.Same(entry, testListener.ForeignKeyChange.Item1);
             Assert.Same(entry.EntityType.GetProperty("DependentId"), testListener.ForeignKeyChange.Item2);
@@ -1512,9 +1367,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Handles_notification_of_no_change_to_foreign_key()
         {
-            var contextServices = TestHelpers.Instance.CreateContextServices(
-                new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
-                BuildNotifyingModel());
+            var contextServices = CreateContextServices(BuildNotifyingModel());
 
             var changeDetector = contextServices.GetRequiredService<ChangeDetector>();
             var stateManager = contextServices.GetRequiredService<StateManager>();
@@ -1528,10 +1381,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             Assert.Equal(EntityState.Modified, entry.EntityState);
             Assert.Equal(77, entry.RelationshipsSnapshot[entry.EntityType.GetProperty("DependentId")]);
 
-            var testListener = contextServices
-                .GetRequiredService<IEnumerable<IRelationshipListener>>()
-                .OfType<TestRelationshipListener>()
-                .Single();
+            var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
             Assert.Null(testListener.PrincipalKeyChange);
             Assert.Null(testListener.ForeignKeyChange);
@@ -1544,9 +1394,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Handles_notification_of_reference_navigation_change()
         {
-            var contextServices = TestHelpers.Instance.CreateContextServices(
-                new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
-                BuildNotifyingModel());
+            var contextServices = CreateContextServices(BuildNotifyingModel());
 
             var changeDetector = contextServices.GetRequiredService<ChangeDetector>();
             var stateManager = contextServices.GetRequiredService<StateManager>();
@@ -1562,10 +1410,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             Assert.Equal(EntityState.Modified, entry.EntityState);
             Assert.Equal(newCategory, entry.RelationshipsSnapshot[entry.EntityType.GetNavigation("Category")]);
 
-            var testListener = contextServices
-                .GetRequiredService<IEnumerable<IRelationshipListener>>()
-                .OfType<TestRelationshipListener>()
-                .Single();
+            var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
             Assert.Same(entry, testListener.ReferenceChange.Item1);
             Assert.Same(entry.EntityType.GetNavigation("Category"), testListener.ReferenceChange.Item2);
@@ -1586,9 +1431,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Handles_notification_of_reference_navigation_changing_back_to_original_value()
         {
-            var contextServices = TestHelpers.Instance.CreateContextServices(
-                new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
-                BuildNotifyingModel());
+            var contextServices = CreateContextServices(BuildNotifyingModel());
 
             var changeDetector = contextServices.GetRequiredService<ChangeDetector>();
             var stateManager = contextServices.GetRequiredService<StateManager>();
@@ -1606,10 +1449,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             Assert.Equal(EntityState.Modified, entry.EntityState);
             Assert.Equal(originalCategory, entry.RelationshipsSnapshot[entry.EntityType.GetNavigation("Category")]);
 
-            var testListener = contextServices
-                .GetRequiredService<IEnumerable<IRelationshipListener>>()
-                .OfType<TestRelationshipListener>()
-                .Single();
+            var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
             Assert.Same(entry, testListener.ReferenceChange.Item1);
             Assert.Same(entry.EntityType.GetNavigation("Category"), testListener.ReferenceChange.Item2);
@@ -1630,9 +1470,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Handles_notification_of_no_change_to_reference_navigation()
         {
-            var contextServices = TestHelpers.Instance.CreateContextServices(
-                new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
-                BuildNotifyingModel());
+            var contextServices = CreateContextServices(BuildNotifyingModel());
 
             var changeDetector = contextServices.GetRequiredService<ChangeDetector>();
             var stateManager = contextServices.GetRequiredService<StateManager>();
@@ -1647,10 +1485,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
             Assert.Equal(category, entry.RelationshipsSnapshot[entry.EntityType.GetNavigation("Category")]);
 
-            var testListener = contextServices
-                .GetRequiredService<IEnumerable<IRelationshipListener>>()
-                .OfType<TestRelationshipListener>()
-                .Single();
+            var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
             Assert.Null(testListener.ReferenceChange);
             Assert.Null(testListener.ForeignKeyChange);
@@ -1663,9 +1498,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Handles_notification_of_adding_to_collection_navigation()
         {
-            var contextServices = TestHelpers.Instance.CreateContextServices(
-                new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
-                BuildNotifyingModel());
+            var contextServices = CreateContextServices(BuildNotifyingModel());
 
             var changeDetector = contextServices.GetRequiredService<ChangeDetector>();
             var stateManager = contextServices.GetRequiredService<StateManager>();
@@ -1689,10 +1522,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
                     .Cast<NotifyingProduct>()
                     .OrderBy(e => e.DependentId));
 
-            var testListener = contextServices
-                .GetRequiredService<IEnumerable<IRelationshipListener>>()
-                .OfType<TestRelationshipListener>()
-                .Single();
+            var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
             Assert.Same(entry, testListener.CollectionChange.Item1);
             Assert.Same(entry.EntityType.GetNavigation("Products"), testListener.CollectionChange.Item2);
@@ -1713,9 +1543,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Handles_notification_of_removing_from_collection_navigation()
         {
-            var contextServices = TestHelpers.Instance.CreateContextServices(
-                new ServiceCollection().AddScoped<IRelationshipListener, TestRelationshipListener>(),
-                BuildNotifyingModel());
+            var contextServices = CreateContextServices(BuildNotifyingModel());
 
             var changeDetector = contextServices.GetRequiredService<ChangeDetector>();
             var stateManager = contextServices.GetRequiredService<StateManager>();
@@ -1738,10 +1566,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
                     .Cast<NotifyingProduct>()
                     .OrderBy(e => e.DependentId));
 
-            var testListener = contextServices
-                .GetRequiredService<IEnumerable<IRelationshipListener>>()
-                .OfType<TestRelationshipListener>()
-                .Single();
+            var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
             Assert.Same(entry, testListener.CollectionChange.Item1);
             Assert.Same(entry.EntityType.GetNavigation("Products"), testListener.CollectionChange.Item2);
@@ -2323,7 +2148,18 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             Assert.Null(testListener.CollectionChange);
         }
 
-        private class TestRelationshipListener : IRelationshipListener
+        private static IServiceProvider CreateContextServices(IModel model = null)
+        {
+            return TestHelpers.Instance.CreateContextServices(
+                new ServiceCollection()
+                    .AddScoped<TestRelationshipListener>()
+                    .AddScoped<IForeignKeyListener>(p => p.GetRequiredService<TestRelationshipListener>())
+                    .AddScoped<INavigationListener>(p => p.GetRequiredService<TestRelationshipListener>())
+                    .AddScoped<IKeyListener>(p => p.GetRequiredService<TestRelationshipListener>()),
+                model ?? BuildModel());
+        }
+
+        private class TestRelationshipListener : IForeignKeyListener, INavigationListener, IKeyListener
         {
             public Tuple<InternalEntityEntry, IProperty, object, object> ForeignKeyChange { get; set; }
             public Tuple<InternalEntityEntry, IProperty, object, object> PrincipalKeyChange { get; set; }
@@ -2345,7 +2181,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
                 CollectionChange = Tuple.Create(entry, navigation, added, removed);
             }
 
-            public void PrincipalKeyPropertyChanged(InternalEntityEntry entry, IProperty property, object oldValue, object newValue)
+            public void KeyPropertyChanged(InternalEntityEntry entry, IProperty property, object oldValue, object newValue)
             {
                 PrincipalKeyChange = Tuple.Create(entry, property, oldValue, newValue);
             }

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntryEntrySubscriberTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntryEntrySubscriberTest.cs
@@ -143,14 +143,6 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             public IPropertyBase Changing { get; set; }
             public IPropertyBase Changed { get; set; }
 
-            public void SidecarPropertyChanged(InternalEntityEntry entry, IPropertyBase property)
-            {
-            }
-
-            public void SidecarPropertyChanging(InternalEntityEntry entry, IPropertyBase property)
-            {
-            }
-
             public void PropertyChanged(InternalEntityEntry entry, IPropertyBase property)
             {
                 Changed = property;

--- a/test/EntityFramework.Core.Tests/Extensions/EntityServiceCollectionExtensionsTest.cs
+++ b/test/EntityFramework.Core.Tests/Extensions/EntityServiceCollectionExtensionsTest.cs
@@ -76,7 +76,9 @@ namespace Microsoft.Data.Entity.Tests
             var service = _serviceProvider.GetRequiredService<DbContextService<IDbContextOptions>>().Service;
 
             VerifyScoped<IEntityStateListener>(isExistingReplaced: true);
-            VerifyScoped<IRelationshipListener>(isExistingReplaced: true);
+            VerifyScoped<IForeignKeyListener>(isExistingReplaced: true);
+            VerifyScoped<INavigationListener>(isExistingReplaced: true);
+            VerifyScoped<IKeyListener>(isExistingReplaced: true);
             VerifyScoped<IPropertyListener>(isExistingReplaced: true);
         }
 


### PR DESCRIPTION
Removed Sidecar property notifications as they were no longer needed. Any property change is treated the same way regardless of whether it goes through a transparent sidecar or not.

Split IRelationshipListener into three interfaces.