### PR TITLE
#1638 Make _sql protected in DefaultSqlQueryGenerator

### DIFF
--- a/src/EntityFramework.Relational/Query/Sql/DefaultSqlQueryGenerator.cs
+++ b/src/EntityFramework.Relational/Query/Sql/DefaultSqlQueryGenerator.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
 {
     public class DefaultSqlQueryGenerator : ThrowingExpressionTreeVisitor, ISqlExpressionVisitor, ISqlQueryGenerator
     {
-        private IndentedStringBuilder _sql;
+        protected IndentedStringBuilder _sql;
         private Expression _binaryExpression;
         private List<string> _parameters;
         private IDictionary<string, object> _parameterValues;


### PR DESCRIPTION
Please import this change to make sure inherited classes can provide their own implementation for queries.