### PR TITLE
Fix to #1251 - join + orderby + count produces invalid sql

### DIFF
--- a/src/EntityFramework.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EntityFramework.Relational/Query/RelationalQueryModelVisitor.cs
@@ -221,8 +221,7 @@ namespace Microsoft.Data.Entity.Relational.Query
                         })
                     .ToList();
 
-            _requiresClientFilter = !_queriesBySource.Any();
-
+            var requiresClientFilter = !_queriesBySource.Any();
             base.VisitWhereClause(whereClause, queryModel, index);
 
             foreach (var selectExpression in _queriesBySource.Values)
@@ -237,10 +236,10 @@ namespace Microsoft.Data.Entity.Relational.Query
                         : Expression.AndAlso(selectExpression.Predicate, predicate);
                 }
 
-                _requiresClientFilter |= filteringVisitor.RequiresClientEval;
+                requiresClientFilter |= filteringVisitor.RequiresClientEval;
             }
 
-            if (!_requiresClientFilter)
+            if (!requiresClientFilter)
             {
                 foreach (var projectionCount in projectionCounts)
                 {
@@ -250,6 +249,8 @@ namespace Microsoft.Data.Entity.Relational.Query
 
                 Expression = previousExpression;
             }
+
+            _requiresClientFilter |= requiresClientFilter;
         }
 
         public override void VisitOrderByClause(OrderByClause orderByClause, QueryModel queryModel, int index)

--- a/src/EntityFramework.Relational/Query/RelationalResultOperatorHandler.cs
+++ b/src/EntityFramework.Relational/Query/RelationalResultOperatorHandler.cs
@@ -158,6 +158,8 @@ namespace Microsoft.Data.Entity.Relational.Query
             handlerContext.SelectExpression
                 .SetProjectionExpression(new CountExpression());
 
+            handlerContext.SelectExpression.ClearOrderBy();
+
             return TransformClientExpression<int>(handlerContext);
         }
 

--- a/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
@@ -165,6 +165,20 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
+        public virtual void OrderBy_Take_Count()
+        {
+            AssertQuery<Order>(
+                   os => os.OrderBy(o => o.OrderID).Take(5).Count());
+        }
+
+        [Fact]
+        public virtual void Take_OrderBy_Count()
+        {
+            AssertQuery<Order>(
+                   os => os.Take(5).OrderBy(o => o.OrderID).Count());
+        }
+
+        [Fact]
         public virtual void Any_predicate()
         {
             AssertQuery<Customer>(
@@ -1872,6 +1886,106 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
+        public virtual void Count_with_order_by()
+        {
+            AssertQuery<Order>(os => os.OrderBy(o => o.CustomerID).Count());
+        }
+
+        [Fact]
+        public virtual void Where_OrderBy_Count()
+        {
+            AssertQuery<Order>(os => os.Where(o => o.CustomerID == "ALFKI").OrderBy(o => o.OrderID).Count());
+        }
+
+        [Fact]
+        public virtual void OrderBy_Where_Count()
+        {
+            AssertQuery<Order>(os => os.OrderBy(o => o.OrderID).Where(o => o.CustomerID == "ALFKI").Count());
+        }
+
+        [Fact]
+        public virtual void OrderBy_Count_with_predicate()
+        {
+            AssertQuery<Order>(os => os.OrderBy(o => o.OrderID).Count(o => o.CustomerID == "ALFKI"));
+        }
+
+        [Fact]
+        public virtual void OrderBy_Where_Count_with_predicate()
+        {
+            AssertQuery<Order>(os => os.OrderBy(o => o.OrderID).Where(o => o.OrderID > 10).Count(o => o.CustomerID != "ALFKI"));
+        }
+
+        [Fact]
+        public virtual void Where_OrderBy_Count_client_eval()
+        {
+            AssertQuery<Order>(os => os.Where(o => ClientEvalPredicate(o)).OrderBy(o => ClientEvalSelectorStateless()).Count());
+        }
+
+        [Fact]
+        public virtual void Where_OrderBy_Count_client_eval_mixed()
+        {
+            AssertQuery<Order>(os => os.Where(o => o.OrderID > 10).OrderBy(o => ClientEvalPredicate(o)).Count());
+        }
+
+        [Fact]
+        public virtual void OrderBy_Where_Count_client_eval()
+        {
+            AssertQuery<Order>(os => os.OrderBy(o => ClientEvalSelectorStateless()).Where(o => ClientEvalPredicate(o)).Count());
+        }
+
+        [Fact]
+        public virtual void OrderBy_Where_Count_client_eval_mixed()
+        {
+            AssertQuery<Order>(os => os.OrderBy(o => o.OrderID).Where(o => ClientEvalPredicate(o)).Count());
+        }
+
+        [Fact]
+        public virtual void OrderBy_Count_with_predicate_client_eval()
+        {
+            AssertQuery<Order>(os => os.OrderBy(o => ClientEvalSelectorStateless()).Count(o => ClientEvalPredicate(o)));
+        }
+
+        // error #1642
+        //[Fact]
+        public virtual void OrderBy_Count_with_predicate_client_eval_mixed()
+        {
+            AssertQuery<Order>(os => os.OrderBy(o => o.OrderID).Count(o => ClientEvalPredicateStateless()));
+        }
+
+        // error #1642
+        //[Fact]
+        public virtual void OrderBy_Where_Count_with_predicate_client_eval()
+        {
+            AssertQuery<Order>(os => os.OrderBy(o => ClientEvalSelectorStateless()).Where(o => ClientEvalPredicateStateless()).Count(o => ClientEvalPredicate(o)));
+        }
+
+        [Fact]
+        public virtual void OrderBy_Where_Count_with_predicate_client_eval_mixed()
+        {
+            AssertQuery<Order>(os => os.OrderBy(o => o.OrderID).Where(o => ClientEvalPredicate(o)).Count(o => o.CustomerID != "ALFKI"));
+        }
+
+        public static bool ClientEvalPredicateStateless()
+        {
+            return true;
+        }
+
+        protected static bool ClientEvalPredicate(Order order)
+        {
+            return order.OrderID > 10000;
+        }
+
+        private static int ClientEvalSelectorStateless()
+        {
+            return 42;
+        }
+
+        protected internal int ClientEvalSelector(Order order)
+        {
+            return order.EmployeeID.HasValue ? order.EmployeeID.Value % 10 : 0;
+        }
+
+        [Fact]
         public virtual void Distinct()
         {
             AssertQuery<Customer>(
@@ -2291,6 +2405,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             using (var context = CreateContext())
             {
+
+                var foo = context.Database.Connection;
                 AssertResults(
                     new[] { query(NorthwindData.Set<TItem>()) },
                     new[] { query(context.Set<TItem>()) },

--- a/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -242,6 +242,135 @@ WHERE [o].[CustomerID] = 'ALFKI'",
                 Sql);
         }
 
+        public override void Where_OrderBy_Count()
+        {
+            base.Where_OrderBy_Count();
+
+            Assert.Equal(
+                @"SELECT COUNT(*)
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] = 'ALFKI'",
+                Sql);
+        }
+
+        public override void OrderBy_Where_Count()
+        {
+            base.OrderBy_Where_Count();
+
+            Assert.Equal(
+                @"SELECT COUNT(*)
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] = 'ALFKI'",
+                Sql);
+        }
+
+        public override void OrderBy_Count_with_predicate()
+        {
+            base.OrderBy_Count_with_predicate();
+
+            Assert.Equal(
+                @"SELECT COUNT(*)
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] = 'ALFKI'",
+                Sql);
+        }
+
+        public override void OrderBy_Where_Count_with_predicate()
+        {
+            base.OrderBy_Where_Count_with_predicate();
+
+            Assert.Equal(
+                @"SELECT COUNT(*)
+FROM [Orders] AS [o]
+WHERE ([o].[OrderID] > 10 AND [o].[CustomerID] <> 'ALFKI')",
+                Sql);
+        }
+
+        public override void Where_OrderBy_Count_client_eval()
+        {
+            base.Where_OrderBy_Count_client_eval();
+
+            Assert.Equal(
+                @"SELECT [o].[CustomerID], [o].[OrderDate], [o].[OrderID]
+FROM [Orders] AS [o]",
+                Sql);
+        }
+
+        public override void Where_OrderBy_Count_client_eval_mixed()
+        {
+            base.Where_OrderBy_Count_client_eval_mixed();
+
+            Assert.Equal(
+                @"SELECT COUNT(*)
+FROM [Orders] AS [o]
+WHERE [o].[OrderID] > 10",
+                Sql);
+        }
+
+        public override void OrderBy_Where_Count_client_eval()
+        {
+            base.OrderBy_Where_Count_client_eval();
+
+            Assert.Equal(
+                @"SELECT [o].[CustomerID], [o].[OrderDate], [o].[OrderID]
+FROM [Orders] AS [o]",
+                Sql);
+        }
+
+        public override void OrderBy_Where_Count_client_eval_mixed()
+        {
+            base.OrderBy_Where_Count_client_eval_mixed();
+
+            Assert.Equal(
+                @"SELECT [o].[CustomerID], [o].[OrderDate], [o].[OrderID]
+FROM [Orders] AS [o]",
+                Sql);
+        }
+
+        public override void OrderBy_Count_with_predicate_client_eval()
+        {
+            base.OrderBy_Count_with_predicate_client_eval();
+
+            Assert.Equal(
+                @"SELECT [o].[CustomerID], [o].[OrderDate], [o].[OrderID]
+FROM [Orders] AS [o]",
+                Sql);
+        }
+
+        public override void OrderBy_Count_with_predicate_client_eval_mixed()
+        {
+            base.OrderBy_Count_with_predicate_client_eval_mixed();
+
+            Assert.Equal(
+                @"TBD",
+                Sql);
+        }
+
+        public override void OrderBy_Where_Count_with_predicate_client_eval()
+        {
+            base.OrderBy_Where_Count_with_predicate_client_eval();
+
+            Assert.Equal(
+                @"TBD",
+                Sql);
+        }
+
+        public override void OrderBy_Where_Count_with_predicate_client_eval_mixed()
+        {
+            base.OrderBy_Where_Count_with_predicate_client_eval_mixed();
+
+            Assert.Equal(
+                @"SELECT [o].[CustomerID], [o].[OrderDate], [o].[OrderID]
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] <> 'ALFKI'",
+                Sql);
+        }
+
+        public override void GroupBy_LongCount()
+        {
+            base.GroupBy_LongCount();
+        }
+
         public override void Sum_with_no_arg()
         {
             base.Sum_with_no_arg();
@@ -461,6 +590,30 @@ ORDER BY [c].[CustomerID]",
                 @"SELECT TOP(10) [c].[City]
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]",
+                Sql);
+        }
+
+        public override void OrderBy_Take_Count()
+        {
+            base.OrderBy_Take_Count();
+
+            Assert.Equal(
+                @"SELECT COUNT(*)
+FROM (
+    SELECT TOP(5) [o].[CustomerID], [o].[OrderDate], [o].[OrderID]
+    FROM [Orders] AS [o]
+    ORDER BY [o].[OrderID]
+) AS [t0]",
+                Sql);
+        }
+
+        public override void Take_OrderBy_Count()
+        {
+            base.Take_OrderBy_Count();
+
+            Assert.Equal(
+                @"SELECT TOP(5) [o].[CustomerID], [o].[OrderDate], [o].[OrderID]
+FROM [Orders] AS [o]",
                 Sql);
         }
 
@@ -1033,8 +1186,12 @@ WHERE [c].[CustomerID] = 'ALFKI'", Sql);
 
         public override void Join_OrderBy_Count()
         {
-            //// issue 1251
-            Assert.Throws<SqlException>(() => base.Join_OrderBy_Count());
+            base.Join_OrderBy_Count();
+
+            Assert.Equal(
+                @"SELECT COUNT(*)
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]", Sql);
         }
 
         public override void Multiple_joins_Where_Order_Any()


### PR DESCRIPTION
Problem was that we would procude queries like:
SELECT COUNT(*)
FROM [Customer] AS [c]
ORDER BY [c].[Id]

which were invalid, because column on which you order should be projected, and we project COUNT(*) instead. However, ordering is redundant when querying for count and could be removed.

Fix is to remove any orderings when querying for count.

There was another small issue that has been fixed - when calculating whether client eval for filter is required, we would use a common variable for the entire query. This could cause issues if multiple filters were present in the query, some being client eval, some being server eval. Fix is to use a variable local to the particular filter operation, and |= the results with the global variable. CR: Andrew