### PR TITLE
Set GenerateValueOnAdd flag for all Key properties by convention

### DIFF
--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -125,6 +125,9 @@
     <Compile Include="Infrastructure\EntityFrameworkServicesBuilder.cs" />
     <Compile Include="Infrastructure\ModelValidatorBase.cs" />
     <Compile Include="Infrastructure\IAccessor.cs" />
+    <Compile Include="Metadata\ModelConventions\IForeignKeyRemovedConvention.cs" />
+    <Compile Include="Metadata\ModelConventions\IKeyConvention.cs" />
+    <Compile Include="Metadata\ModelConventions\KeyConvention.cs" />
     <Compile Include="ModelBuilder.cs" />
     <Compile Include="Query\IIncludableQueryable.cs" />
     <Compile Include="Infrastructure\DbContextService.cs" />
@@ -263,7 +266,7 @@
     <Compile Include="Metadata\ObjectArrayValueReader.cs" />
     <Compile Include="Metadata\Property.cs" />
     <Compile Include="Metadata\ModelConventions\IEntityTypeConvention.cs" />
-    <Compile Include="Metadata\ModelConventions\KeyConvention.cs" />
+    <Compile Include="Metadata\ModelConventions\KeyDiscoveryConvention.cs" />
     <Compile Include="Metadata\ModelConventions\PropertiesConvention.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\InternalsVisibleTo.cs" />

--- a/src/EntityFramework.Core/Metadata/Internal/InternalEntityBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/InternalEntityBuilder.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 () => existingKey,
                 () => Metadata.SetPrimaryKey(properties),
                 key => new InternalKeyBuilder(key, ModelBuilder),
-                onNewKeyAdded: null,
+                onNewKeyAdded: ModelBuilder.ConventionDispatcher.OnKeyAdded,
                 configurationSource: configurationSource);
         }
 
@@ -106,7 +106,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 () => Metadata.TryGetKey(properties),
                 () => Metadata.AddKey(properties),
                 key => new InternalKeyBuilder(key, ModelBuilder),
-                onNewKeyAdded: null,
+                onNewKeyAdded: ModelBuilder.ConventionDispatcher.OnKeyAdded,
                 configurationSource: configurationSource);
         }
 
@@ -486,6 +486,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             navigationToPrincipal?.EntityType.RemoveNavigation(navigationToPrincipal);
 
             Metadata.RemoveForeignKey(foreignKey);
+            ModelBuilder.ConventionDispatcher.OnForeignKeyRemoved(this, foreignKey);
             RemoveShadowPropertiesIfUnused(foreignKey.Properties);
             principalEntityBuilder.RemoveKeyIfUnused(foreignKey.ReferencedKey);
 
@@ -1013,6 +1014,12 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
             var newForeignKey = dependentType.AddForeignKey(foreignKeyProperties, principalKey);
             newForeignKey.IsUnique = isUnique;
+
+            foreach (var foreignKeyProperty in foreignKeyProperties)
+            {
+                Property(foreignKeyProperty.PropertyType, foreignKeyProperty.Name, ConfigurationSource.Convention)
+                    .GenerateValueOnAdd(false, ConfigurationSource.Convention);
+            }
 
             return newForeignKey;
         }

--- a/src/EntityFramework.Core/Metadata/ModelBuilderFactory.cs
+++ b/src/EntityFramework.Core/Metadata/ModelBuilderFactory.cs
@@ -21,10 +21,14 @@ namespace Microsoft.Data.Entity.Metadata
             var conventions = new ConventionSet();
 
             conventions.EntityTypeAddedConventions.Add(new PropertiesConvention());
-            conventions.EntityTypeAddedConventions.Add(new KeyConvention());
+            conventions.EntityTypeAddedConventions.Add(new KeyDiscoveryConvention());
             conventions.EntityTypeAddedConventions.Add(new RelationshipDiscoveryConvention());
 
+            conventions.KeyAddedConventions.Add(new KeyConvention());
+
             conventions.ForeignKeyAddedConventions.Add(new ForeignKeyPropertyDiscoveryConvention());
+
+            conventions.ForeignKeyRemovedConventions.Add(new KeyConvention());
 
             return conventions;
         }

--- a/src/EntityFramework.Core/Metadata/ModelConventions/ConventionDispatcher.cs
+++ b/src/EntityFramework.Core/Metadata/ModelConventions/ConventionDispatcher.cs
@@ -34,6 +34,33 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
             return entityBuilder;
         }
 
+        public virtual InternalKeyBuilder OnKeyAdded([NotNull] InternalKeyBuilder keyBuilder)
+        {
+            Check.NotNull(keyBuilder, "keyBuilder");
+
+            foreach (var keyConvention in _conventionSet.KeyAddedConventions)
+            {
+                keyBuilder = keyConvention.Apply(keyBuilder);
+                if (keyBuilder == null)
+                {
+                    break;
+                }
+            }
+
+            return keyBuilder;
+        }
+
+        public virtual void OnForeignKeyRemoved([NotNull] InternalEntityBuilder entityBuilder, [NotNull] ForeignKey foreignKey)
+        {
+            Check.NotNull(entityBuilder, "entityBuilder");
+            Check.NotNull(foreignKey, "foreignKey");
+
+            foreach (var keyConvention in _conventionSet.ForeignKeyRemovedConventions)
+            {
+                keyConvention.Apply(entityBuilder, foreignKey);
+            }
+        }
+
         public virtual InternalRelationshipBuilder OnRelationshipAdded([NotNull] InternalRelationshipBuilder relationshipBuilder)
         {
             Check.NotNull(relationshipBuilder, nameof(relationshipBuilder));

--- a/src/EntityFramework.Core/Metadata/ModelConventions/ConventionSet.cs
+++ b/src/EntityFramework.Core/Metadata/ModelConventions/ConventionSet.cs
@@ -9,6 +9,10 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
     {
         public virtual IList<IEntityTypeConvention> EntityTypeAddedConventions { get; } = new List<IEntityTypeConvention>();
 
+        public virtual IList<IKeyConvention> KeyAddedConventions { get; } = new List<IKeyConvention>();
+
         public virtual IList<IRelationshipConvention> ForeignKeyAddedConventions { get; } = new List<IRelationshipConvention>();
+
+        public virtual IList<IForeignKeyRemovedConvention> ForeignKeyRemovedConventions { get; } = new List<IForeignKeyRemovedConvention>();
     }
 }

--- a/src/EntityFramework.Core/Metadata/ModelConventions/IForeignKeyRemovedConvention.cs
+++ b/src/EntityFramework.Core/Metadata/ModelConventions/IForeignKeyRemovedConvention.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata.Internal;
+
+namespace Microsoft.Data.Entity.Metadata.ModelConventions
+{
+    public interface IForeignKeyRemovedConvention
+    {
+        void Apply([NotNull] InternalEntityBuilder entityBuilder, [NotNull] ForeignKey foreignKey);
+    }
+}

--- a/src/EntityFramework.Core/Metadata/ModelConventions/IKeyConvention.cs
+++ b/src/EntityFramework.Core/Metadata/ModelConventions/IKeyConvention.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata.Internal;
+
+namespace Microsoft.Data.Entity.Metadata.ModelConventions
+{
+    public interface IKeyConvention
+    {
+        InternalKeyBuilder Apply([NotNull] InternalKeyBuilder keyBuilder);
+    }
+}

--- a/src/EntityFramework.Core/Metadata/ModelConventions/KeyDiscoveryConvention.cs
+++ b/src/EntityFramework.Core/Metadata/ModelConventions/KeyDiscoveryConvention.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Internal;
+using Microsoft.Data.Entity.Metadata.Internal;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Metadata.ModelConventions
+{
+    public class KeyDiscoveryConvention : IEntityTypeConvention
+    {
+        private const string KeySuffix = "Id";
+
+        public virtual InternalEntityBuilder Apply(InternalEntityBuilder entityBuilder)
+        {
+            Check.NotNull(entityBuilder, "entityBuilder");
+            var entityType = entityBuilder.Metadata;
+
+            var keyProperties = DiscoverKeyProperties(entityType);
+            if (keyProperties.Count != 0)
+            {
+                entityBuilder.PrimaryKey(keyProperties.Select(p => p.Name).ToList(), ConfigurationSource.Convention);
+            }
+
+            return entityBuilder;
+        }
+
+        protected virtual IReadOnlyList<Property> DiscoverKeyProperties([NotNull] EntityType entityType)
+        {
+            Check.NotNull(entityType, "entityType");
+
+            // TODO: Honor [Key]
+            // Issue #213
+            var keyProperties = entityType.Properties
+                .Where(p => string.Equals(p.Name, KeySuffix, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            if (keyProperties.Count == 0)
+            {
+                keyProperties = entityType.Properties.Where(
+                    p => string.Equals(p.Name, entityType.SimpleName + KeySuffix, StringComparison.OrdinalIgnoreCase))
+                    .ToList();
+            }
+
+            if (keyProperties.Count > 1)
+            {
+                throw new InvalidOperationException(
+                    Strings.MultiplePropertiesMatchedAsKeys(keyProperties.First().Name, entityType.Name));
+            }
+
+            return keyProperties;
+        }
+    }
+}

--- a/src/EntityFramework.SqlServer/EntityFramework.SqlServer.csproj
+++ b/src/EntityFramework.SqlServer/EntityFramework.SqlServer.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Metadata\ISqlServerKeyExtensions.cs" />
     <Compile Include="Metadata\ISqlServerModelExtensions.cs" />
     <Compile Include="Metadata\ISqlServerPropertyExtensions.cs" />
+    <Compile Include="Metadata\ModelConventions\SqlServerKeyConvention.cs" />
     <Compile Include="Metadata\ReadOnlySqlServerEntityTypeExtensions.cs" />
     <Compile Include="Metadata\ReadOnlySqlServerForeignKeyExtensions.cs" />
     <Compile Include="Metadata\ReadOnlySqlServerIndexExtensions.cs" />

--- a/src/EntityFramework.SqlServer/Metadata/ModelConventions/SqlServerKeyConvention.cs
+++ b/src/EntityFramework.SqlServer/Metadata/ModelConventions/SqlServerKeyConvention.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Metadata.Internal;
+using Microsoft.Data.Entity.Metadata.ModelConventions;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.SqlServer.Metadata.ModelConventions
+{
+    public class SqlServerKeyConvention : IKeyConvention
+    {
+        private const string IdentityKeySuffix = "Id";
+        public virtual InternalKeyBuilder Apply(InternalKeyBuilder keyBuilder)
+        {
+            Check.NotNull(keyBuilder, "keyBuilder");
+
+            var key = keyBuilder.Metadata;
+            var properties = key.Properties;
+
+            if (key == key.EntityType.TryGetPrimaryKey())
+            {
+                var identityProperty = DiscoverIdentityProperty(properties);
+                if (identityProperty != null)
+                {
+                    var entityBuilder = keyBuilder.ModelBuilder.Entity(identityProperty.EntityType.Name, ConfigurationSource.Convention);
+                    ConfigureIdentityProperty(entityBuilder.Property(identityProperty.PropertyType, identityProperty.Name, ConfigurationSource.Convention));
+                }
+            }
+            return keyBuilder;
+        }
+
+        protected virtual IProperty DiscoverIdentityProperty(IReadOnlyList<Property> properties)
+        {
+            var identityProperty = properties
+                .Where(p => p.PropertyType.IsInteger())
+                .FirstOrDefault(p => string.Equals(p.Name, IdentityKeySuffix, StringComparison.OrdinalIgnoreCase));
+
+            if (identityProperty == null)
+            {
+                var entityType = properties.First().EntityType;
+
+                identityProperty = properties
+                    .Where(p => p.PropertyType.IsInteger())
+                    .FirstOrDefault(p => string.Equals(p.Name, entityType.SimpleName + IdentityKeySuffix, StringComparison.OrdinalIgnoreCase));
+            }
+
+            return identityProperty ?? properties.FirstOrDefault(p => p.PropertyType.IsInteger());
+        }
+
+        protected virtual void ConfigureIdentityProperty([NotNull] InternalPropertyBuilder propertyBuilder)
+        {
+            Check.NotNull(propertyBuilder, "propertyBuilder");
+
+            propertyBuilder.Annotation(SqlServerAnnotationNames.Prefix + SqlServerAnnotationNames.ValueGeneration, SqlServerValueGenerationStrategy.Identity.ToString(), ConfigurationSource.Convention);
+        }
+    }
+}

--- a/src/EntityFramework.SqlServer/Migrations/SqlServerModelDiffer.cs
+++ b/src/EntityFramework.SqlServer/Migrations/SqlServerModelDiffer.cs
@@ -123,11 +123,10 @@ namespace Microsoft.Data.Entity.SqlServer.Migrations
         // TODO: Move to metadata API?
         // See Issue #1271: Principal keys need to generate values on add, but the database should only have one Identity column.
         private SqlServerValueGenerationStrategy? GetValueGenerationStrategy(IProperty property) =>
-            property.SqlServer().ValueGenerationStrategy
-            ?? property.EntityType.Model.SqlServer().ValueGenerationStrategy
-            ?? (property.GenerateValueOnAdd && property.PropertyType.IsInteger() && property.IsPrimaryKey()
-                ? SqlServerValueGenerationStrategy.Identity
-                : default(SqlServerValueGenerationStrategy?));
+            property.GenerateValueOnAdd
+            ? (property.SqlServer().ValueGenerationStrategy
+                ?? property.EntityType.Model.SqlServer().ValueGenerationStrategy)
+            : default(SqlServerValueGenerationStrategy?);
 
         #endregion
 

--- a/src/EntityFramework.SqlServer/SqlServerModelBuilderFactory.cs
+++ b/src/EntityFramework.SqlServer/SqlServerModelBuilderFactory.cs
@@ -2,10 +2,20 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Metadata.ModelConventions;
+using Microsoft.Data.Entity.SqlServer.Metadata.ModelConventions;
 
 namespace Microsoft.Data.Entity.SqlServer
 {
     public class SqlServerModelBuilderFactory : ModelBuilderFactory
     {
+        protected override ConventionSet CreateConventionSet()
+        {
+            var conventions = base.CreateConventionSet();
+
+            conventions.KeyAddedConventions.Add(new SqlServerKeyConvention());
+
+            return conventions;
+        }
     }
 }

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
@@ -1802,20 +1802,25 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         {
             var builder = TestHelpers.Instance.CreateConventionBuilder();
 
-            builder.Entity<Product>()
-                .HasOne(e => e.Tag).WithOne(e => e.Product)
-                .ReferencedKey<Product>(e => e.TagId)
-                .ForeignKey<ProductTag>(e => e.ProductId);
+            builder.Entity<Product>(b =>
+                {
+                    b.HasOne(e => e.Tag).WithOne(e => e.Product)
+                        .ReferencedKey<Product>(e => e.TagId)
+                        .ForeignKey<ProductTag>(e => e.ProductId);
+                    b.Property(e => e.TagId).GenerateValueOnAdd(false);
+                });
 
             builder.Entity<Category>(b =>
                 {
                     b.HasMany(e => e.Products).WithOne(e => e.Category)
                         .ForeignKey(e => e.DependentId)
                         .ReferencedKey(e => e.PrincipalId);
+                    b.Property(e => e.PrincipalId).GenerateValueOnAdd(false);
 
                     b.HasOne(e => e.Tag).WithOne(e => e.Category)
                         .ForeignKey<CategoryTag>(e => e.CategoryId)
                         .ReferencedKey<Category>(e => e.TagId);
+                    b.Property(e => e.TagId).GenerateValueOnAdd(false);
                 });
 
             builder.Entity<Person>()
@@ -2022,20 +2027,26 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         {
             var builder = TestHelpers.Instance.CreateConventionBuilder();
 
-            builder.Entity<NotifyingProduct>()
-                .HasOne(e => e.Tag).WithOne(e => e.Product)
-                .ReferencedKey<NotifyingProduct>(e => e.TagId)
-                .ForeignKey<NotifyingProductTag>(e => e.ProductId);
+            builder.Entity<NotifyingProduct>(b =>
+                {
+                    b.HasOne(e => e.Tag).WithOne(e => e.Product)
+                        .ReferencedKey<NotifyingProduct>(e => e.TagId)
+                        .ForeignKey<NotifyingProductTag>(e => e.ProductId);
+                    b.Property(e => e.TagId).GenerateValueOnAdd(false);
+                });
+
 
             builder.Entity<NotifyingCategory>(b =>
                 {
                     b.HasMany(e => e.Products).WithOne(e => e.Category)
                         .ForeignKey(e => e.DependentId)
                         .ReferencedKey(e => e.PrincipalId);
+                    b.Property(e => e.PrincipalId).GenerateValueOnAdd(false);
 
                     b.HasOne(e => e.Tag).WithOne(e => e.Category)
                         .ForeignKey<NotifyingCategoryTag>(e => e.CategoryId)
                         .ReferencedKey<NotifyingCategory>(e => e.TagId);
+                    b.Property(e => e.TagId).GenerateValueOnAdd(false);
                 });
 
             builder.Entity<NotifyingPerson>()

--- a/test/EntityFramework.Core.Tests/EntityFramework.Core.Tests.csproj
+++ b/test/EntityFramework.Core.Tests/EntityFramework.Core.Tests.csproj
@@ -132,6 +132,7 @@
     <Compile Include="Metadata\MetadataBuilderTest.cs" />
     <Compile Include="Metadata\ModelConventions\ConventionsDispatcherTest.cs" />
     <Compile Include="Metadata\ModelConventions\ForeignKeyPropertyDiscoveryConventionTest.cs" />
+    <Compile Include="Metadata\ModelConventions\KeyConventionTest.cs" />
     <Compile Include="Metadata\ModelConventions\RelationshipDiscoveryConventionTest.cs" />
     <Compile Include="Metadata\NavigationExtensionsTest.cs" />
     <Compile Include="Extensions\QueryableExtensionsTest.cs" />
@@ -159,7 +160,7 @@
     <Compile Include="Metadata\NavigationTest.cs" />
     <Compile Include="Metadata\ObjectArrayValueReaderTest.cs" />
     <Compile Include="Metadata\PropertyTest.cs" />
-    <Compile Include="Metadata\ModelConventions\KeyConventionTest.cs" />
+    <Compile Include="Metadata\ModelConventions\KeyDiscoveryConventionTest.cs" />
     <Compile Include="Metadata\ModelConventions\PropertiesConventionTest.cs" />
     <Compile Include="Query\TaskResultAsyncEnumerableTest.cs" />
     <Compile Include="Storage\DataStoreSelectorTest.cs" />

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/KeyConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/KeyConventionTest.cs
@@ -1,193 +1,43 @@
-// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Metadata.ModelConventions;
-using Moq;
-using Moq.Protected;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
 {
     public class KeyConventionTest
     {
-        private class EntityWithNoId
-        {
-            public string Name { get; set; }
-            public DateTime ModifiedDate { get; set; }
-        }
-
-        [Fact]
-        public void ConfigureKey_is_noop_when_zero_key_properties()
-        {
-            var entityBuilder = CreateInternalEntityBuilder<EntityWithNoId>();
-
-            Assert.Same(entityBuilder, new KeyConvention().Apply(entityBuilder));
-
-            var key = entityBuilder.Metadata.TryGetPrimaryKey();
-            Assert.Null(key);
-        }
-
-        [Fact]
-        public void ConfigureKey_handles_multiple_key_properties()
-        {
-            var entityBuilder = CreateInternalEntityBuilder<EntityWithNoId>();
-            var convention = new Mock<KeyConvention> { CallBase = true };
-            convention.Protected().Setup<IEnumerable<Property>>("DiscoverKeyProperties", ItExpr.IsAny<EntityType>())
-                .Returns<EntityType>(t => t.Properties.ToList());
-
-            Assert.Same(entityBuilder, convention.Object.Apply(entityBuilder));
-
-            var key = entityBuilder.Metadata.TryGetPrimaryKey();
-            Assert.NotNull(key);
-            Assert.Equal(new[] { "ModifiedDate", "Name" }, key.Properties.Select(p => p.Name));
-        }
-
-        private class EntityWithId
+        private class SampleEntity
         {
             public int Id { get; set; }
+            public string Title { get; set; }
         }
 
         [Fact]
-        public void DiscoverKeyProperties_discovers_id()
+        public void ConfigureKeyProperties_set_GenerateValueOnAdd_flag_for_key_properties()
         {
-            var entityBuilder = CreateInternalEntityBuilder<EntityWithId>();
+            var conventions = new ConventionSet();
+            conventions.EntityTypeAddedConventions.Add(new PropertiesConvention());
 
-            Assert.Same(entityBuilder, new KeyConvention().Apply(entityBuilder));
+            var modelBuilder = new InternalModelBuilder(new Model(), conventions);
+            var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
 
-            var key = entityBuilder.Metadata.TryGetPrimaryKey();
-            Assert.NotNull(key);
-            Assert.Equal(new[] { "Id" }, key.Properties.Select(p => p.Name));
-            Assert.Equal(true, key.Properties.Single().GenerateValueOnAdd);
-        }
+            var properties = new List<string>() { "Id", "Title" };
+            var keyBuilder = entityBuilder.Key(properties, ConfigurationSource.Convention);
 
-        private class EntityWithTypeId
-        {
-            public int EntityWithTypeIdId { get; set; }
-        }
+            Assert.Same(keyBuilder, new KeyConvention().Apply(keyBuilder));
 
-        [Fact]
-        public void DiscoverKeyProperties_discovers_type_id()
-        {
-            var entityBuilder = CreateInternalEntityBuilder<EntityWithTypeId>();
+            var keyProperties = keyBuilder.Metadata.Properties;
 
-            Assert.Same(entityBuilder, new KeyConvention().Apply(entityBuilder));
+            Assert.NotNull(keyProperties[0].GenerateValueOnAdd);
+            Assert.NotNull(keyProperties[1].GenerateValueOnAdd);
 
-            var key = entityBuilder.Metadata.TryGetPrimaryKey();
-            Assert.NotNull(key);
-            Assert.Equal(new[] { "EntityWithTypeIdId" }, key.Properties.Select(p => p.Name));
-            Assert.Equal(true, key.Properties.Single().GenerateValueOnAdd);
-        }
-
-        private class EntityWithIdAndTypeId
-        {
-            public int Id { get; set; }
-            public int EntityWithIdAndTypeIdId { get; set; }
-        }
-
-        [Fact]
-        public void DiscoverKeyProperties_prefers_id_over_type_id()
-        {
-            var entityBuilder = CreateInternalEntityBuilder<EntityWithIdAndTypeId>();
-
-            Assert.Same(entityBuilder, new KeyConvention().Apply(entityBuilder));
-
-            var key = entityBuilder.Metadata.TryGetPrimaryKey();
-            Assert.NotNull(key);
-            Assert.Equal(new[] { "Id" }, key.Properties.Select(p => p.Name));
-            Assert.Equal(true, key.Properties.Single().GenerateValueOnAdd);
-        }
-
-        private class EntityWithMultipleIds
-        {
-            public int ID { get; set; }
-            public int Id { get; set; }
-        }
-
-        [Fact]
-        public void DiscoverKeyProperties_throws_when_multiple_ids()
-        {
-            var entityType = CreateInternalEntityBuilder<EntityWithMultipleIds>();
-            var convention = new KeyConvention();
-
-            var ex = Assert.Throws<InvalidOperationException>(() => convention.Apply(entityType));
-
-            Assert.Equal(
-                Strings.MultiplePropertiesMatchedAsKeys("ID", typeof(EntityWithMultipleIds).FullName),
-                ex.Message);
-        }
-
-        private class EntityWithGenericKey<T>
-        {
-            public T Id { get; set; }
-        }
-
-        [Fact]
-        public void ConfigureKeyProperty_sets_generation_strategy_only_when_guid_or_common_integer()
-        {
-            ConfigureKeyProperty_generation_strategy<Guid>();
-            ConfigureKeyProperty_generation_strategy<long>();
-            ConfigureKeyProperty_generation_strategy<int>();
-            ConfigureKeyProperty_generation_strategy<short>();
-            ConfigureKeyProperty_generation_strategy<byte>();
-            ConfigureKeyProperty_generation_strategy<long?>();
-            ConfigureKeyProperty_generation_strategy<int?>();
-            ConfigureKeyProperty_generation_strategy<short?>();
-            ConfigureKeyProperty_generation_strategy<byte?>();
-            ConfigureKeyProperty_generation_strategy<string>();
-            ConfigureKeyProperty_generation_strategy<Enum1>();
-            ConfigureKeyProperty_generation_strategy<Enum1?>();
-            ConfigureKeyProperty_generation_strategy<bool>();
-            ConfigureKeyProperty_generation_strategy<bool?>();
-            ConfigureKeyProperty_generation_strategy<sbyte>();
-            ConfigureKeyProperty_generation_strategy<uint>();
-            ConfigureKeyProperty_generation_strategy<ulong>();
-            ConfigureKeyProperty_generation_strategy<ushort>();
-            ConfigureKeyProperty_generation_strategy<decimal>();
-            ConfigureKeyProperty_generation_strategy<float>();
-            ConfigureKeyProperty_generation_strategy<DateTime>();
-        }
-
-        private void ConfigureKeyProperty_generation_strategy<T>()
-        {
-            var entityBuilder = CreateInternalEntityBuilder<EntityWithGenericKey<T>>();
-
-            Assert.Same(entityBuilder, new KeyConvention().Apply(entityBuilder));
-
-            var property = entityBuilder.Metadata.TryGetProperty("Id");
-            Assert.NotNull(property);
-            Assert.True(property.GenerateValueOnAdd.Value);
-        }
-
-        private enum Enum1
-        {
-        }
-
-        [Fact]
-        public void ConfigureKeyProperty_does_not_override_generation_strategy_when_configured_explicitly()
-        {
-            var entityBuilder = CreateInternalEntityBuilder<EntityWithGenericKey<Guid>>();
-            var property = entityBuilder.Metadata.TryGetProperty("Id");
-            property.GenerateValueOnAdd = false;
-
-            Assert.Same(entityBuilder, new KeyConvention().Apply(entityBuilder));
-
-            Assert.Equal(false, property.GenerateValueOnAdd);
-        }
-
-        private static InternalEntityBuilder CreateInternalEntityBuilder<T>()
-        {
-            var modelBuilder = new InternalModelBuilder(new Model());
-            var entityBuilder = modelBuilder.Entity(typeof(T), ConfigurationSource.Convention);
-
-            new PropertiesConvention().Apply(entityBuilder);
-
-            return entityBuilder;
+            Assert.True(keyProperties[0].GenerateValueOnAdd.Value);
+            Assert.True(keyProperties[1].GenerateValueOnAdd.Value);
         }
     }
 }

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/KeyDiscoveryConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/KeyDiscoveryConventionTest.cs
@@ -1,0 +1,131 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Data.Entity.Internal;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Metadata.Internal;
+using Microsoft.Data.Entity.Metadata.ModelConventions;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
+{
+    public class KeyDiscoveryConventionTest
+    {
+        private class EntityWithNoId
+        {
+            public string Name { get; set; }
+            public DateTime ModifiedDate { get; set; }
+        }
+
+        [Fact]
+        public void Primary_key_is_not_set_when_zero_key_properties()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<EntityWithNoId>();
+
+            Assert.Same(entityBuilder, new KeyDiscoveryConvention().Apply(entityBuilder));
+
+            var key = entityBuilder.Metadata.TryGetPrimaryKey();
+            Assert.Null(key);
+        }
+
+        [Fact]
+        public void Composite_primary_key_is_set_when_multiple_key_properties()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<EntityWithNoId>();
+            var convention = new Mock<KeyDiscoveryConvention> { CallBase = true };
+            convention.Protected().Setup<IEnumerable<Property>>("DiscoverKeyProperties", ItExpr.IsAny<EntityType>()).Returns<EntityType>(t => t.Properties.ToList());
+            
+            Assert.Same(entityBuilder, convention.Object.Apply(entityBuilder));
+
+            var key = entityBuilder.Metadata.TryGetPrimaryKey();
+            Assert.NotNull(key);
+            Assert.Equal(new[] { "ModifiedDate", "Name" }, key.Properties.Select(p => p.Name));
+        }
+
+        private class EntityWithId
+        {
+            public int Id { get; set; }
+        }
+
+        [Fact]
+        public void DiscoverKeyProperties_discovers_id()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<EntityWithId>();
+
+            Assert.Same(entityBuilder, new KeyDiscoveryConvention().Apply(entityBuilder));
+
+            var key = entityBuilder.Metadata.TryGetPrimaryKey();
+            Assert.NotNull(key);
+            Assert.Equal(new[] { "Id" }, key.Properties.Select(p => p.Name));
+        }
+
+        private class EntityWithTypeId
+        {
+            public int EntityWithTypeIdId { get; set; }
+        }
+
+        [Fact]
+        public void DiscoverKeyProperties_discovers_type_id()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<EntityWithTypeId>();
+
+            Assert.Same(entityBuilder, new KeyDiscoveryConvention().Apply(entityBuilder));
+
+            var key = entityBuilder.Metadata.TryGetPrimaryKey();
+            Assert.NotNull(key);
+            Assert.Equal(new[] { "EntityWithTypeIdId" }, key.Properties.Select(p => p.Name));
+        }
+
+        private class EntityWithIdAndTypeId
+        {
+            public int Id { get; set; }
+            public int EntityWithIdAndTypeIdId { get; set; }
+        }
+
+        [Fact]
+        public void DiscoverKeyProperties_prefers_id_over_type_id()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<EntityWithIdAndTypeId>();
+
+            Assert.Same(entityBuilder, new KeyDiscoveryConvention().Apply(entityBuilder));
+
+            var key = entityBuilder.Metadata.TryGetPrimaryKey();
+            Assert.NotNull(key);
+            Assert.Equal(new[] { "Id" }, key.Properties.Select(p => p.Name));
+        }
+
+        private class EntityWithMultipleIds
+        {
+            public int ID { get; set; }
+            public int Id { get; set; }
+        }
+
+        [Fact]
+        public void DiscoverKeyProperties_throws_when_multiple_ids()
+        {
+            var entityType = CreateInternalEntityBuilder<EntityWithMultipleIds>();
+            var convention = new KeyDiscoveryConvention();
+
+            var ex = Assert.Throws<InvalidOperationException>(() => convention.Apply(entityType));
+
+            Assert.Equal(
+                Strings.MultiplePropertiesMatchedAsKeys("ID", typeof(EntityWithMultipleIds).FullName),
+                ex.Message);
+        }
+
+        private static InternalEntityBuilder CreateInternalEntityBuilder<T>()
+        {
+            var modelBuilder = new InternalModelBuilder(new Model());
+            var entityBuilder = modelBuilder.Entity(typeof(T), ConfigurationSource.Convention);
+
+            new PropertiesConvention().Apply(entityBuilder);
+
+            return entityBuilder;
+        }
+    }
+}

--- a/test/EntityFramework.SqlServer.Tests/EntityFramework.SqlServer.Tests.csproj
+++ b/test/EntityFramework.SqlServer.Tests/EntityFramework.SqlServer.Tests.csproj
@@ -78,6 +78,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ApiConsistencyTest.cs" />
+    <Compile Include="Metadata\ModelConventions\SqlServerKeyConventionTest.cs" />
     <Compile Include="Metadata\SqlServerBuilderExtensionsTest.cs" />
     <Compile Include="Metadata\SqlServerMetadataExtensionsTest.cs" />
     <Compile Include="CommandConfigurationTests.cs" />

--- a/test/EntityFramework.SqlServer.Tests/Metadata/ModelConventions/SqlServerKeyConventionTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/Metadata/ModelConventions/SqlServerKeyConventionTest.cs
@@ -1,0 +1,136 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Metadata.Internal;
+using Microsoft.Data.Entity.Metadata.ModelConventions;
+using Microsoft.Data.Entity.SqlServer.Metadata;
+using Microsoft.Data.Entity.SqlServer.Metadata.ModelConventions;
+using Xunit;
+
+namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata.ModelConventions
+{
+    class SqlServerKeyConventionTest
+    {
+        public class SampleEntity
+        {
+            public int Id { get; set; }
+            public int SampleEntityId { get; set; }
+            public int Number { get; set; }
+            public string Name { get; set; }
+        }
+
+        [Fact]
+        public void Identity_annotation_is_set_for_primary_key()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<SampleEntity>();
+
+            var keyBuilder = entityBuilder.PrimaryKey(new List<string>() { "Id" }, ConfigurationSource.Convention);
+
+            Assert.Same(keyBuilder, new SqlServerKeyConvention().Apply(keyBuilder));
+
+            var property = entityBuilder.Property(typeof(int), "Id", ConfigurationSource.Convention).Metadata;
+
+            Assert.Equal(1, property.Annotations.Count());
+            Assert.Equal(SqlServerValueGenerationStrategy.Identity.ToString(), property[SqlServerAnnotationNames.Prefix + SqlServerAnnotationNames.ValueGeneration]);
+        }
+
+        [Fact]
+        public void Identity_annotation_is_not_set_for_non_primary_key()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<SampleEntity>();
+
+            var keyBuilder = entityBuilder.Key(new List<string>() { "Id" }, ConfigurationSource.Convention);
+
+            Assert.Same(keyBuilder, new SqlServerKeyConvention().Apply(keyBuilder));
+
+            Assert.Equal(0, entityBuilder.Property(typeof(int), "Id", ConfigurationSource.Convention).Metadata.Annotations.Count());
+        }
+
+        [Fact]
+        public void DiscoverIdentityProperty_discovers_id()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<SampleEntity>();
+
+            var keyBuilder = entityBuilder.PrimaryKey(new List<string>() { "Id", "Name" }, ConfigurationSource.Convention);
+
+            Assert.Same(keyBuilder, new SqlServerKeyConvention().Apply(keyBuilder));
+
+            var property = entityBuilder.Property(typeof(int), "Id", ConfigurationSource.Convention).Metadata;
+
+            Assert.Equal(1, property.Annotations.Count());
+            Assert.Equal(SqlServerValueGenerationStrategy.Identity.ToString(), property[SqlServerAnnotationNames.Prefix + SqlServerAnnotationNames.ValueGeneration]);
+        }
+
+        [Fact]
+        public void DiscoverIdentityProperty_discovers_type_id()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<SampleEntity>();
+
+            var keyBuilder = entityBuilder.PrimaryKey(new List<string>() { "SampleEntityId", "Name" }, ConfigurationSource.Convention);
+
+            Assert.Same(keyBuilder, new SqlServerKeyConvention().Apply(keyBuilder));
+
+            var property = entityBuilder.Property(typeof(int), "SampleEntityId", ConfigurationSource.Convention).Metadata;
+
+            Assert.Equal(1, property.Annotations.Count());
+            Assert.Equal(SqlServerValueGenerationStrategy.Identity.ToString(), property[SqlServerAnnotationNames.Prefix + SqlServerAnnotationNames.ValueGeneration]);
+        }
+
+        [Fact]
+        public void DiscoverIdentityProperty_prefers_id_over_type_id()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<SampleEntity>();
+
+            var keyBuilder = entityBuilder.PrimaryKey(new List<string>() { "Id", "SampleEntityId", "Name" }, ConfigurationSource.Convention);
+
+            Assert.Same(keyBuilder, new SqlServerKeyConvention().Apply(keyBuilder));
+
+            var property = entityBuilder.Property(typeof(int), "Id", ConfigurationSource.Convention).Metadata;
+
+            Assert.Equal(1, property.Annotations.Count());
+            Assert.Equal(SqlServerValueGenerationStrategy.Identity.ToString(), property[SqlServerAnnotationNames.Prefix + SqlServerAnnotationNames.ValueGeneration]);
+        }
+
+        [Fact]
+        public void DiscoverIdentityProperty_chooses_first_integer_property_when_no_id_found()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<SampleEntity>();
+
+            var keyBuilder = entityBuilder.PrimaryKey(new List<string>() { "Number", "Name" }, ConfigurationSource.Convention);
+
+            Assert.Same(keyBuilder, new SqlServerKeyConvention().Apply(keyBuilder));
+
+            var property = entityBuilder.Property(typeof(int), "Number", ConfigurationSource.Convention).Metadata;
+
+            Assert.Equal(1, property.Annotations.Count());
+            Assert.Equal(SqlServerValueGenerationStrategy.Identity.ToString(), property[SqlServerAnnotationNames.Prefix + SqlServerAnnotationNames.ValueGeneration]);
+        }
+
+        [Fact]
+        public void No_annotation_set_when_no_integer_property_found_in_key()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<SampleEntity>();
+
+            var keyBuilder = entityBuilder.PrimaryKey(new List<string>() { "Name" }, ConfigurationSource.Convention);
+
+            Assert.Same(keyBuilder, new SqlServerKeyConvention().Apply(keyBuilder));
+
+            var property = entityBuilder.Property(typeof(string), "Name", ConfigurationSource.Convention).Metadata;
+
+            Assert.Equal(0, property.Annotations.Count());
+        }
+
+        private static InternalEntityBuilder CreateInternalEntityBuilder<T>()
+        {
+            var modelBuilder = new InternalModelBuilder(new Model());
+            var entityBuilder = modelBuilder.Entity(typeof(T), ConfigurationSource.Convention);
+
+            new PropertiesConvention().Apply(entityBuilder);
+
+            return entityBuilder;
+        }
+    }
+}


### PR DESCRIPTION
Implements #1271 
Added convention to set GenerateValueOnAdd flag as true whenever new key is added.
Flag is not set for Dependent end of Foreign Key
Resolves #1126 
Since above enhancement sets GenerateValueOnAdd flag as true for multiple properties in composite PK,
added sql server specific convention to add annotation to the property which should be used as Identity column.
