### PR TITLE
fix to #1642 -Query :: Bad sql generated for query with bool parameter in filter

### DIFF
--- a/src/EntityFramework.Relational/Query/Sql/DefaultSqlQueryGenerator.cs
+++ b/src/EntityFramework.Relational/Query/Sql/DefaultSqlQueryGenerator.cs
@@ -543,7 +543,16 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
 
         protected override Expression VisitParameterExpression(ParameterExpression parameterExpression)
         {
-            _sql.Append(ParameterPrefix + parameterExpression.Name);
+            if (parameterExpression.Type == typeof(bool)
+                && (_binaryExpression == null
+                    || _binaryExpression.IsLogicalOperation()))
+            {
+                _sql.Append(ParameterPrefix + parameterExpression.Name + " = 1");
+            }
+            else
+            {
+                _sql.Append(ParameterPrefix + parameterExpression.Name);
+            }
 
             _parameters.Add(parameterExpression.Name);
 

--- a/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
@@ -258,6 +258,17 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
+        public virtual void Where_simple_closure_constant()
+        {
+            // ReSharper disable once ConvertToConstant.Local
+            var predicate = true;
+
+            AssertQuery<Customer>(
+                cs => cs.Where(c => predicate),
+                entryCount: 91);
+        }
+
+        [Fact]
         public virtual void Where_simple_closure_via_query_cache()
         {
             var city = "London";
@@ -1946,14 +1957,14 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         // error #1642
-        //[Fact]
+        [Fact]
         public virtual void OrderBy_Count_with_predicate_client_eval_mixed()
         {
             AssertQuery<Order>(os => os.OrderBy(o => o.OrderID).Count(o => ClientEvalPredicateStateless()));
         }
 
         // error #1642
-        //[Fact]
+        [Fact]
         public virtual void OrderBy_Where_Count_with_predicate_client_eval()
         {
             AssertQuery<Order>(os => os.OrderBy(o => ClientEvalSelectorStateless()).Where(o => ClientEvalPredicateStateless()).Count(o => ClientEvalPredicate(o)));

--- a/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -28,6 +28,17 @@ WHERE [c].[City] = @__city_0",
                 Sql);
         }
 
+        public override void Where_simple_closure_constant()
+        {
+            base.Where_simple_closure_constant();
+
+            Assert.Equal(
+                @"SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE @__predicate_0 = 1",
+                Sql);
+        }
+
         public override void Where_simple_closure_via_query_cache_nullable_type_reverse()
         {
             base.Where_simple_closure_via_query_cache_nullable_type_reverse();
@@ -342,7 +353,9 @@ FROM [Orders] AS [o]",
             base.OrderBy_Count_with_predicate_client_eval_mixed();
 
             Assert.Equal(
-                @"TBD",
+                @"SELECT COUNT(*)
+FROM [Orders] AS [o]
+WHERE @__ClientEvalPredicateStateless_0 = 1",
                 Sql);
         }
 
@@ -351,7 +364,9 @@ FROM [Orders] AS [o]",
             base.OrderBy_Where_Count_with_predicate_client_eval();
 
             Assert.Equal(
-                @"TBD",
+                @"SELECT [o].[CustomerID], [o].[OrderDate], [o].[OrderID]
+FROM [Orders] AS [o]
+WHERE @__ClientEvalPredicateStateless_1 = 1",
                 Sql);
         }
 


### PR DESCRIPTION
Error is for queries that are using bool parameter (closure) in a filter query. We would produce query like: SELECT c.Id FROM Customers as c WHERE @prm, which is invalid.

Fix is to apply similar compensation as we do for constant bools in filter, to produce query like: SELECT c.Id FROM Customers as c WHERE @prm = 1