### PR TITLE
Metadata: Inheritance: Adds more fundamental inheritance support.

### DIFF
--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -126,6 +126,7 @@
     <Compile Include="Infrastructure\ModelValidatorBase.cs" />
     <Compile Include="Infrastructure\IAccessor.cs" />
     <Compile Include="ModelBuilder.cs" />
+    <Compile Include="Query\EntityLoadInfo.cs" />
     <Compile Include="Query\IIncludableQueryable.cs" />
     <Compile Include="Infrastructure\DbContextService.cs" />
     <Compile Include="Infrastructure\DbContextActivator.cs" />

--- a/src/EntityFramework.Core/Metadata/EntityMaterializerSource.cs
+++ b/src/EntityFramework.Core/Metadata/EntityMaterializerSource.cs
@@ -51,12 +51,17 @@ namespace Microsoft.Data.Entity.Metadata
             var materializer = entityType as IEntityMaterializer;
             if (materializer != null)
             {
-                return materializer.CreatEntity;
+                return materializer.CreateEntity;
             }
 
             if (!entityType.HasClrType)
             {
                 throw new InvalidOperationException(Strings.NoClrType(entityType.Name));
+            }
+
+            if (entityType.IsAbstract)
+            {
+                throw new InvalidOperationException(Strings.CannotMaterializeAbstractType(entityType));
             }
 
             return _cache.GetOrAdd(entityType.Type, k => BuildDelegate(entityType));

--- a/src/EntityFramework.Core/Metadata/EntityTypeExtensions.cs
+++ b/src/EntityFramework.Core/Metadata/EntityTypeExtensions.cs
@@ -12,7 +12,8 @@ namespace Microsoft.Data.Entity.Metadata
 {
     public static class EntityTypeExtensions
     {
-        public static IEnumerable<IPropertyBase> GetPropertiesAndNavigations([NotNull] this IEntityType entityType)
+        public static IEnumerable<IPropertyBase> GetPropertiesAndNavigations(
+            [NotNull] this IEntityType entityType)
         {
             Check.NotNull(entityType, nameof(entityType));
 
@@ -22,17 +23,23 @@ namespace Microsoft.Data.Entity.Metadata
         [NotNull]
         public static IEnumerable<IForeignKey> GetReferencingForeignKeys([NotNull] this IEntityType entityType)
         {
+            Check.NotNull(entityType, nameof(entityType));
+
             return entityType.Model.GetReferencingForeignKeys(entityType);
         }
 
         public static bool HasPropertyChangingNotifications([NotNull] this IEntityType entityType)
         {
+            Check.NotNull(entityType, nameof(entityType));
+
             return entityType.Type == null
                    || typeof(INotifyPropertyChanging).GetTypeInfo().IsAssignableFrom(entityType.Type.GetTypeInfo());
         }
 
         public static bool HasPropertyChangedNotifications([NotNull] this IEntityType entityType)
         {
+            Check.NotNull(entityType, nameof(entityType));
+
             return entityType.Type == null
                    || typeof(INotifyPropertyChanged).GetTypeInfo().IsAssignableFrom(entityType.Type.GetTypeInfo());
         }

--- a/src/EntityFramework.Core/Metadata/IEntityMaterializer.cs
+++ b/src/EntityFramework.Core/Metadata/IEntityMaterializer.cs
@@ -7,6 +7,6 @@ namespace Microsoft.Data.Entity.Metadata
 {
     public interface IEntityMaterializer
     {
-        object CreatEntity([NotNull] IValueReader valueReader);
+        object CreateEntity([NotNull] IValueReader valueReader);
     }
 }

--- a/src/EntityFramework.Core/Metadata/IEntityType.cs
+++ b/src/EntityFramework.Core/Metadata/IEntityType.cs
@@ -12,8 +12,14 @@ namespace Microsoft.Data.Entity.Metadata
         IModel Model { get; }
 
         string Name { get; }
-
         string SimpleName { get; }
+        int PropertyCount { get; }
+        int ShadowPropertyCount { get; }
+        int OriginalValueCount { get; }
+        bool IsAbstract { get; }
+        bool HasClrType { get; }
+        bool UseEagerSnapshots { get; }
+        bool HasDerivedTypes { get; }
 
         [CanBeNull]
         IEntityType BaseType { get; }
@@ -48,11 +54,7 @@ namespace Microsoft.Data.Entity.Metadata
         IReadOnlyList<IIndex> Indexes { get; }
         IReadOnlyList<IKey> Keys { get; }
 
-        int PropertyCount { get; }
-        int ShadowPropertyCount { get; }
-        int OriginalValueCount { get; }
-
-        bool HasClrType { get; }
-        bool UseEagerSnapshots { get; }
+        IEnumerable<IEntityType> GetDerivedTypes();
+        IEnumerable<IEntityType> GetConcreteTypesInHierarchy();
     }
 }

--- a/src/EntityFramework.Core/Metadata/Navigation.cs
+++ b/src/EntityFramework.Core/Metadata/Navigation.cs
@@ -11,7 +11,8 @@ namespace Microsoft.Data.Entity.Metadata
         private ForeignKey _foreignKey;
         private bool _pointsToPrincipal;
 
-        public Navigation([NotNull] string name, [NotNull] ForeignKey foreignKey, bool pointsToPrincipal)
+        public Navigation(
+            [NotNull] string name, [NotNull] ForeignKey foreignKey, bool pointsToPrincipal)
             : base(Check.NotEmpty(name, nameof(name)))
         {
             Check.NotNull(foreignKey, nameof(foreignKey));
@@ -45,19 +46,11 @@ namespace Microsoft.Data.Entity.Metadata
         }
 
         public override EntityType EntityType
-        {
-            get
-            {
-                return PointsToPrincipal
-                    ? ForeignKey.EntityType
-                    : ForeignKey.ReferencedEntityType;
-            }
-        }
+            => PointsToPrincipal
+                ? ForeignKey.EntityType
+                : ForeignKey.ReferencedEntityType;
 
-        IForeignKey INavigation.ForeignKey
-        {
-            get { return ForeignKey; }
-        }
+        IForeignKey INavigation.ForeignKey => ForeignKey;
 
         public override string ToString()
         {

--- a/src/EntityFramework.Core/Metadata/Property.cs
+++ b/src/EntityFramework.Core/Metadata/Property.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Data.Entity.Metadata
                 {
                     _shadowIndex = value ? 0 : -1;
 
-                    EntityType.PropertyMetadataChanged(this);
+                    EntityType.OnPropertyMetadataChanged(this, this);
                 }
             }
         }
@@ -149,7 +149,7 @@ namespace Microsoft.Data.Entity.Metadata
                 {
                     SetFlag(value, PropertyFlags.IsConcurrencyToken);
 
-                    EntityType.PropertyMetadataChanged(this);
+                    EntityType.OnPropertyMetadataChanged(this, this);
                 }
             }
         }

--- a/src/EntityFramework.Core/Properties/Strings.Designer.cs
+++ b/src/EntityFramework.Core/Properties/Strings.Designer.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Data.Entity.Internal
     using System.Globalization;
     using System.Reflection;
     using System.Resources;
-    using JetBrains.Annotations;
+	using JetBrains.Annotations;
 
     public static class Strings
     {
@@ -138,14 +138,6 @@ namespace Microsoft.Data.Entity.Internal
         public static string CollectionArgumentIsEmpty([CanBeNull] object argumentName)
         {
             return string.Format(CultureInfo.CurrentCulture, GetString("CollectionArgumentIsEmpty", "argumentName"), argumentName);
-        }
-
-        /// <summary>
-        /// The edge cannot be added because the graph does not contain vertex '{vertex}'.
-        /// </summary>
-        public static string GraphDoesNotContainVertex([CanBeNull] object vertex)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("GraphDoesNotContainVertex", "vertex"), vertex);
         }
 
         /// <summary>
@@ -906,6 +898,30 @@ namespace Microsoft.Data.Entity.Internal
         public static string DerivedEntityCannotHaveKeys([CanBeNull] object entityType)
         {
             return string.Format(CultureInfo.CurrentCulture, GetString("DerivedEntityCannotHaveKeys", "entityType"), entityType);
+        }
+
+        /// <summary>
+        /// The edge cannot be added because the graph does not contain vertex '{vertex}'.
+        /// </summary>
+        public static string GraphDoesNotContainVertex([CanBeNull] object vertex)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("GraphDoesNotContainVertex", "vertex"), vertex);
+        }
+
+        /// <summary>
+        /// Unable to create an instance of type entity type '{entityType}' because it is abstract. Either make it non-abstract or consider mapping at least one derived type.
+        /// </summary>
+        public static string CannotMaterializeAbstractType([CanBeNull] object entityType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("CannotMaterializeAbstractType", "entityType"), entityType);
+        }
+
+        /// <summary>
+        /// The provided referenced entity key '{referencedKey}' is not a key on the entity type '{referencedEntityType}'.
+        /// </summary>
+        public static string ForeignKeyReferencedEntityKeyMismatch([CanBeNull] object referencedKey, [CanBeNull] object referencedEntityType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("ForeignKeyReferencedEntityKeyMismatch", "referencedKey", "referencedEntityType"), referencedKey, referencedEntityType);
         }
 
         private static string GetString(string name, params string[] formatterNames)

--- a/src/EntityFramework.Core/Properties/Strings.resx
+++ b/src/EntityFramework.Core/Properties/Strings.resx
@@ -439,7 +439,7 @@
     <value>An exception was thrown while attempting to evaluate the LINQ query parameter expression '{expression}'.</value>
   </data>
   <data name="InvalidValueGeneratorFactoryProperty" xml:space="preserve">
-      <value>The '{factory}' cannot create a value generator for property '{property}' on entity type '{entityType}'. Only integer properties are supported.</value>
+    <value>The '{factory}' cannot create a value generator for property '{property}' on entity type '{entityType}'. Only integer properties are supported.</value>
   </data>
   <data name="InvalidForDerivedEntity" xml:space="preserve">
     <value>The entity type method '{method}' is not valid for derived type '{derivedType}'.</value>
@@ -452,5 +452,11 @@
   </data>
   <data name="GraphDoesNotContainVertex" xml:space="preserve">
     <value>The edge cannot be added because the graph does not contain vertex '{vertex}'.</value>
+  </data>
+  <data name="CannotMaterializeAbstractType" xml:space="preserve">
+    <value>Unable to create an instance of type entity type '{entityType}' because it is abstract. Either make it non-abstract or consider mapping at least one derived type.</value>
+  </data>
+  <data name="ForeignKeyReferencedEntityKeyMismatch" xml:space="preserve">
+    <value>The provided referenced entity key '{referencedKey}' is not a key on the entity type '{referencedEntityType}'.</value>
   </data>
 </root>

--- a/src/EntityFramework.Core/Query/CompiledQueryCache.cs
+++ b/src/EntityFramework.Core/Query/CompiledQueryCache.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -338,7 +339,9 @@ namespace Microsoft.Data.Entity.Query
             }
             catch (TargetInvocationException e)
             {
-                throw e.InnerException;
+                ExceptionDispatchInfo.Capture(e.InnerException).Throw();
+
+                throw;
             }
         }
 

--- a/src/EntityFramework.Core/Query/EntityLoadInfo.cs
+++ b/src/EntityFramework.Core/Query/EntityLoadInfo.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+
+namespace Microsoft.Data.Entity.Query
+{
+    public struct EntityLoadInfo
+    {
+        private readonly Func<IValueReader, object> _materializer;
+
+        public EntityLoadInfo(
+            [NotNull] IValueReader valueReader, [NotNull] Func<IValueReader, object> materializer)
+        {
+            // hot path
+            Debug.Assert(valueReader != null);
+            Debug.Assert(materializer != null);
+
+            ValueReader = valueReader;
+            _materializer = materializer;
+        }
+
+        public IValueReader ValueReader { get; }
+
+        public object Materialize() => _materializer(ValueReader);
+    }
+}

--- a/src/EntityFramework.Core/Query/IQueryBuffer.cs
+++ b/src/EntityFramework.Core/Query/IQueryBuffer.cs
@@ -11,13 +11,18 @@ using Microsoft.Data.Entity.Metadata;
 
 namespace Microsoft.Data.Entity.Query
 {
+    public delegate IEnumerable<EntityLoadInfo> RelatedEntitiesLoader(
+        EntityKey primaryKey, Func<IValueReader, EntityKey> foreignKeyFactory);
+
+    public delegate IAsyncEnumerable<EntityLoadInfo> AsyncRelatedEntitiesLoader(
+        EntityKey primaryKey, Func<IValueReader, EntityKey> foreignKeyFactory);
+
     public interface IQueryBuffer
     {
         object GetEntity(
             [NotNull] IEntityType entityType,
             [NotNull] EntityKey entityKey,
-            [NotNull] IValueReader valueReader,
-            [NotNull] Func<IValueReader, object> materializer,
+            EntityLoadInfo entityLoadInfo,
             bool queryStateManager);
 
         object GetPropertyValue([NotNull] object entity, [NotNull] IProperty property);
@@ -27,13 +32,13 @@ namespace Microsoft.Data.Entity.Query
         void Include(
             [CanBeNull] object entity,
             [NotNull] IReadOnlyList<INavigation> navigationPath,
-            [NotNull] IReadOnlyList<Func<EntityKey, Func<IValueReader, EntityKey>, IEnumerable<IValueReader>>> relatedValueReaders,
+            [NotNull] IReadOnlyList<RelatedEntitiesLoader> relatedEntitiesLoaders,
             bool querySourceRequiresTracking);
 
         Task IncludeAsync(
             [CanBeNull] object entity,
             [NotNull] IReadOnlyList<INavigation> navigationPath,
-            [NotNull] IReadOnlyList<Func<EntityKey, Func<IValueReader, EntityKey>, IAsyncEnumerable<IValueReader>>> relatedValueReaders,
+            [NotNull] IReadOnlyList<AsyncRelatedEntitiesLoader> relatedEntitiesLoaders,
             CancellationToken cancellationToken,
             bool querySourceRequiresTracking);
     }

--- a/src/EntityFramework.Core/Storage/DataStore.cs
+++ b/src/EntityFramework.Core/Storage/DataStore.cs
@@ -76,7 +76,6 @@ namespace Microsoft.Data.Entity.Storage
             return new QueryBuffer(
                 _stateManager,
                 EntityKeyFactorySource,
-                EntityMaterializerSource,
                 _collectionAccessorSource,
                 _propertySetterSource);
         }

--- a/src/EntityFramework.Relational/Query/IAsyncIncludeRelatedValuesStrategy.cs
+++ b/src/EntityFramework.Relational/Query/IAsyncIncludeRelatedValuesStrategy.cs
@@ -6,12 +6,13 @@ using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Query;
 
 namespace Microsoft.Data.Entity.Relational.Query
 {
     public interface IAsyncIncludeRelatedValuesStrategy : IDisposable
     {
-        IAsyncEnumerable<IValueReader> GetRelatedValues(
+        IAsyncEnumerable<EntityLoadInfo> GetRelatedValues(
             [NotNull] EntityKey key, [NotNull] Func<IValueReader, EntityKey> keyFactory);
     }
 }

--- a/src/EntityFramework.Relational/Query/IIncludeRelatedValuesStrategy.cs
+++ b/src/EntityFramework.Relational/Query/IIncludeRelatedValuesStrategy.cs
@@ -6,12 +6,13 @@ using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Query;
 
 namespace Microsoft.Data.Entity.Relational.Query
 {
     public interface IIncludeRelatedValuesStrategy : IDisposable
     {
-        IEnumerable<IValueReader> GetRelatedValues(
+        IEnumerable<EntityLoadInfo> GetRelatedValues(
             [NotNull] EntityKey key, [NotNull] Func<IValueReader, EntityKey> keyFactory);
     }
 }

--- a/src/EntityFramework.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EntityFramework.Relational/Query/RelationalQueryModelVisitor.cs
@@ -495,8 +495,9 @@ namespace Microsoft.Data.Entity.Relational.Query
                     .GetEntity(
                         entityType,
                         entityKey,
-                        valueReader,
-                        materializer,
+                        new EntityLoadInfo(
+                            valueReader,
+                            materializer),
                         queryStateManager),
                 parentQuerySourceScope);
         }

--- a/test/EntityFramework.Core.FunctionalTests/EntityFramework.Core.FunctionalTests.csproj
+++ b/test/EntityFramework.Core.FunctionalTests/EntityFramework.Core.FunctionalTests.csproj
@@ -126,6 +126,7 @@
     <Compile Include="TestModels\ComplexNavigationsModel\Level4.cs" />
     <Compile Include="TestModels\Inheritance\Animal.cs" />
     <Compile Include="TestModels\Inheritance\Bird.cs" />
+    <Compile Include="TestModels\Inheritance\Country.cs" />
     <Compile Include="TestModels\Inheritance\Eagle.cs" />
     <Compile Include="TestModels\Inheritance\Kiwi.cs" />
     <Compile Include="TestModels\Inheritance\AnimalContext.cs" />

--- a/test/EntityFramework.Core.FunctionalTests/InheritanceTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/InheritanceTestBase.cs
@@ -10,12 +10,88 @@ namespace Microsoft.Data.Entity.FunctionalTests
     public abstract class InheritanceTestBase<TFixture> : IClassFixture<TFixture>
         where TFixture : InheritanceFixtureBase, new()
     {
-        //[Fact]
+        [Fact]
         public virtual void Can_query_all_animals()
         {
             using (var context = CreateContext())
             {
-                Assert.Equal(2, context.Animals.ToList().Count);
+                var animals = context.Set<Animal>().OrderBy(a => a.Species).ToList();
+
+                Assert.Equal(2, animals.Count);
+                Assert.IsType<Kiwi>(animals[0]);
+                Assert.IsType<Eagle>(animals[1]);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_filter_all_animals()
+        {
+            using (var context = CreateContext())
+            {
+                var animals
+                    = context.Set<Animal>()
+                        .OrderBy(a => a.Species)
+                        .Where(a => a.Name == "Great spotted kiwi")
+                        .ToList();
+
+                Assert.Equal(1, animals.Count);
+                Assert.IsType<Kiwi>(animals[0]);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_query_all_birds()
+        {
+            using (var context = CreateContext())
+            {
+                var birds = context.Set<Bird>().OrderBy(a => a.Species).ToList();
+
+                Assert.Equal(2, birds.Count);
+                Assert.IsType<Kiwi>(birds[0]);
+                Assert.IsType<Eagle>(birds[1]);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_query_just_kiwis()
+        {
+            using (var context = CreateContext())
+            {
+                var kiwi = context.Set<Kiwi>().Single();
+
+                Assert.NotNull(kiwi);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_include_animals()
+        {
+            using (var context = CreateContext())
+            {
+                var countries
+                    = context.Set<Country>()
+                        .OrderBy(c => c.Name)
+                        .Include(c => c.Animals)
+                        .ToList();
+
+                Assert.Equal(2, countries.Count);
+                Assert.IsType<Kiwi>(countries[0].Animals[0]);
+                Assert.IsType<Eagle>(countries[1].Animals[0]);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_include_prey()
+        {
+            using (var context = CreateContext())
+            {
+                var eagle
+                    = context.Set<Eagle>()
+                        .Include(e => e.Prey)
+                        .Single();
+
+                Assert.NotNull(eagle);
+                Assert.Equal(1, eagle.Prey.Count);
             }
         }
 

--- a/test/EntityFramework.Core.FunctionalTests/Metadata/Compiled/CompiledEntityType.cs
+++ b/test/EntityFramework.Core.FunctionalTests/Metadata/Compiled/CompiledEntityType.cs
@@ -48,10 +48,14 @@ namespace Microsoft.Data.Entity.Metadata.Compiled
 
         public Type Type => typeof(TEntity);
 
+        public bool IsAbstract => false;
+
+        public bool HasDerivedTypes => false;
+
         public IEntityType BaseType => null;
 
         public IEntityType RootType => null;
-
+        
         public string SimpleName => typeof(TEntity).Name;
 
         protected abstract IKey LoadKey();
@@ -86,8 +90,18 @@ namespace Microsoft.Data.Entity.Metadata.Compiled
 
         public IEnumerable<IProperty> Properties => EnsurePropertiesInitialized();
 
-        private IProperty[] EnsurePropertiesInitialized() => LazyInitializer.EnsureInitialized(ref _properties, LoadProperties);
+        public IEnumerable<IEntityType> GetDerivedTypes()
+        {
+            return Enumerable.Empty<IEntityType>();
+        }
 
+        public IEnumerable<IEntityType> GetConcreteTypesInHierarchy()
+        {
+            return Enumerable.Empty<IEntityType>();
+        }
+
+        private IProperty[] EnsurePropertiesInitialized() => LazyInitializer.EnsureInitialized(ref _properties, LoadProperties);
+        
         public int PropertyCount  => 0;
 
         public int ShadowPropertyCount => 0;

--- a/test/EntityFramework.Core.FunctionalTests/Metadata/KoolModel.cs
+++ b/test/EntityFramework.Core.FunctionalTests/Metadata/KoolModel.cs
@@ -734,7 +734,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.Metadata
 
         public bool CreateEntityWasUsed { get; set; }
 
-        public object CreatEntity(IValueReader valueReader)
+        public object CreateEntity(IValueReader valueReader)
         {
             CreateEntityWasUsed = true;
             return KoolEntity15._EntityFramework_Create(valueReader);

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/Inheritance/Animal.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/Inheritance/Animal.cs
@@ -7,5 +7,6 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.Inheritance
     {
         public string Species { get; set; }
         public string Name { get; set; }
+        public int CountryId { get; set; }
     }
 }

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/Inheritance/Bird.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/Inheritance/Bird.cs
@@ -6,5 +6,6 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.Inheritance
     public abstract class Bird : Animal
     {
         public bool IsFlightless { get; set; }
+        public string EagleId { get; set; }
     }
 }

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/Inheritance/Country.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/Inheritance/Country.cs
@@ -1,17 +1,20 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
+using System.Collections.Generic;
 
 namespace Microsoft.Data.Entity.FunctionalTests.TestModels.Inheritance
 {
-    public class AnimalContext : DbContext
+    public class Country
     {
-        public static readonly string StoreName = "Animals";
-
-        public AnimalContext(IServiceProvider serviceProvider, DbContextOptions options)
-            : base(serviceProvider, options)
+        public Country()
         {
+            Animals = new List<Animal>();
         }
+
+        public int Id { get; set; }
+        public string Name { get; set; }
+
+        public IList<Animal> Animals { get; set; }
     }
 }

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/Inheritance/Eagle.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/Inheritance/Eagle.cs
@@ -1,11 +1,20 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+
 namespace Microsoft.Data.Entity.FunctionalTests.TestModels.Inheritance
 {
     public class Eagle : Bird
     {
+        public Eagle()
+        {
+            Prey = new List<Bird>();
+        }
+
         public EagleGroup Group { get; set; }
+
+        public ICollection<Bird> Prey { get; set; }
     }
 
     public enum EagleGroup

--- a/test/EntityFramework.Core.Tests/ApiConsistencyTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ApiConsistencyTestBase.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -32,6 +33,7 @@ namespace Microsoft.Data.Entity
                     from method in type.GetMethods(PublicInstance)
                     where method.DeclaringType == type
                           && !(method.IsVirtual && !method.IsFinal)
+                          && !method.GetCustomAttributes(typeof(CompilerGeneratedAttribute)).Any()
                     select type.FullName + "." + method.Name)
                     .ToList();
 

--- a/test/EntityFramework.Core.Tests/Metadata/EntityMaterializerSourceTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/EntityMaterializerSourceTest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var reader = Mock.Of<IValueReader>();
             new EntityMaterializerSource(new MemberMapper(new FieldMatcher())).GetMaterializer(typeMock.Object)(reader);
 
-            materializerMock.Verify(m => m.CreatEntity(reader));
+            materializerMock.Verify(m => m.CreateEntity(reader));
         }
 
         [Fact]

--- a/test/EntityFramework.Core.Tests/Metadata/ForeignKeyTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ForeignKeyTest.cs
@@ -12,6 +12,23 @@ namespace Microsoft.Data.Entity.Tests.Metadata
     public class ForeignKeyTest
     {
         [Fact]
+        public void Throws_when_referenced_key_not_on_referenced_entity()
+        {
+            var model = new Model();
+
+            var referencedEntityType = model.AddEntityType("R");
+            var pk = referencedEntityType.AddProperty("Pk", typeof(int), shadowProperty: true);
+            
+            var dependentEntityType = model.AddEntityType("D");
+            var fk = dependentEntityType.AddProperty("Fk", typeof(int), shadowProperty: true);
+
+            var referencedKey = dependentEntityType.SetPrimaryKey(fk);
+
+            Assert.Throws<ArgumentException>(() =>
+                new ForeignKey(new[] { fk }, referencedKey, referencedEntityType));
+        }
+
+        [Fact]
         public void Can_create_foreign_key()
         {
             var entityType = new Model().AddEntityType("E");


### PR DESCRIPTION
- EntityTypes can now be abstract.
- Fixed bug in entity type index maintenance.
- ForeignKey now maintains referenced entity type independently of referenced key so we can handle FKs to derived types.
- Added EntityLoadInfo to query pipeline as a way to track which materializer is associated with a given value reader.
- Modified InMemoryDatabase to maintain a table for each concrete entity type.
- Lots of C# 6 goodness.