### PR TITLE
API docs for Microsoft.Data.Entity.Extensions.*

### DIFF
--- a/src/EntityFramework.Core/Extensions/EntityServiceCollectionExtensions.cs
+++ b/src/EntityFramework.Core/Extensions/EntityServiceCollectionExtensions.cs
@@ -6,12 +6,12 @@ using JetBrains.Annotations;
 using Microsoft.Data.Entity;
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
-using Microsoft.Data.Entity.ValueGeneration;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Query;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Utilities;
+using Microsoft.Data.Entity.ValueGeneration;
 using Microsoft.Framework.Cache.Memory;
 using Microsoft.Framework.ConfigurationModel;
 using Microsoft.Framework.Logging;
@@ -21,10 +21,51 @@ using Microsoft.Framework.OptionsModel;
 
 namespace Microsoft.Framework.DependencyInjection
 {
+    /// <summary>
+    ///     Extension methods for setting up Entity Framework related services in an <see cref="IServiceCollection" />.
+    /// </summary>
     public static class EntityServiceCollectionExtensions
     {
         private const int ConfigurationOrder = -1000; // OptionsConstants is internal.
 
+        /// <summary>
+        ///     Adds the services required by the core of Entity Framework to an <see cref="IServiceCollection" />.
+        ///     You use this method when using dependency injection in your application, such as with ASP.NET.
+        ///     For more information on setting up dependency injection, see http://go.microsoft.com/fwlink/?LinkId=526890.
+        /// </summary>
+        /// <remarks>
+        ///     <para>
+        ///         You only need to use this functionality when you want Entity Framework to resolve the services it uses
+        ///         from an external <see cref="IServiceProvider" />. If you are not using an external
+        ///         <see cref="IServiceProvider" /> Entity Framework will take care of creating the services it requires.
+        ///     </para>
+        ///     <para>
+        ///         The data store you are using will also define extension methods that can be called on the returned
+        ///         <see cref="EntityFrameworkServicesBuilder" /> to register the services for the data store. For example,
+        ///         when using EntityFramework.SqlServer you would call 
+        ///         <c>collection.AddEntityFramework(config).UseSqlServer()</c>.
+        ///     </para>
+        ///     <para>
+        ///         For derived contexts to resolve their services from the <see cref="IServiceProvider" /> you must chain a call
+        ///         to the <see cref="AddDbContext{TContext}" /> extension method on the returned
+        ///         <see cref="EntityFrameworkServicesBuilder" />.
+        ///         This will ensure services are resolved from the <see cref="IServiceProvider" /> and any Entity Framework
+        ///         configuration from the supplied <paramref name="configuration" /> will be honored.
+        ///     </para>
+        /// </remarks>
+        /// <param name="serviceCollection"> The <see cref="IServiceCollection" /> to add services to. </param>
+        /// <param name="configuration">
+        ///     <para>
+        ///         The configuration being used for the current application. Providing this allows configuration under the
+        ///         'entityFramework' node to be applied to contexts that are resolved from the <see cref="IServiceProvider" />.
+        ///         For this configuration to be applied you must register any derived contexts using the
+        ///         <see cref="AddDbContext{TContext}" /> extension method on the returned  
+        ///         <see cref="EntityFrameworkServicesBuilder" />.
+        ///     </para>
+        /// </param>
+        /// <returns>
+        ///     A builder that allows further Entity Framework specific setup of the <see cref="IServiceCollection" />.
+        /// </returns>
         public static EntityFrameworkServicesBuilder AddEntityFramework(
             [NotNull] this IServiceCollection serviceCollection,
             [CanBeNull] IConfiguration configuration = null)
@@ -93,6 +134,40 @@ namespace Microsoft.Framework.DependencyInjection
             return new EntityFrameworkServicesBuilder(serviceCollection, configuration);
         }
 
+        /// <summary>
+        ///     Registers the given context as a service in the <see cref="IServiceCollection" />. 
+        ///     You use this method when using dependency injection in your application, such as with ASP.NET.
+        ///     For more information on setting up dependency injection, see http://go.microsoft.com/fwlink/?LinkId=526890.
+        /// </summary>
+        /// <remarks>
+        ///     This method will ensure services that the context uses are resolved from the 
+        ///     <see cref="IServiceProvider" /> and any Entity Framework configuration 
+        ///     found in the configuration passed to <see cref="AddEntityFramework" /> will be honored.
+        /// </remarks>
+        /// <typeparam name="TContext"> The type of context to be registered. </typeparam>
+        /// <param name="builder"> The builder returned from <see cref="AddEntityFramework" />. </param>
+        /// <param name="optionsAction">
+        ///     <para>
+        ///         An optional action to configure the <see cref="DbContextOptions" /> for the context. This provides an
+        ///         alternative to performing configuration of the context by overriding the 
+        ///         <see cref="DbContext.OnConfiguring" /> method in your derived context.
+        ///     </para>
+        ///     <para>
+        ///         If an action is supplied here, the <see cref="DbContext.OnConfiguring" /> method will still be run if it has
+        ///         been overridden on the derived context. <see cref="DbContext.OnConfiguring" /> configuration will be applied 
+        ///         in addition to configuration performed here.
+        ///     </para>
+        ///     <para>
+        ///         You do not need to expose a constructor parameter for the <see cref="DbContextOptions" /> to be passed to the
+        ///         context. If you choose to expose a constructor parameter, you must type it as the generic
+        ///         <see cref="DbContextOptions{T}" /> as that is the type that will be registered in the 
+        ///         <see cref="IServiceCollection" /> (in order to support multiple context types being registered in the 
+        ///         same <see cref="IServiceCollection" />).
+        ///     </para>
+        /// </param>
+        /// <returns>
+        ///     A builder that allows further Entity Framework specific setup of the <see cref="IServiceCollection" />.
+        /// </returns>
         public static EntityFrameworkServicesBuilder AddDbContext<TContext>(
             [NotNull] this EntityFrameworkServicesBuilder builder,
             [CanBeNull] Action<DbContextOptions> optionsAction = null)

--- a/src/EntityFramework.Core/Extensions/QueryableExtensions.cs
+++ b/src/EntityFramework.Core/Extensions/QueryableExtensions.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity;
 using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Query;
 using Microsoft.Data.Entity.Utilities;
@@ -22,6 +23,26 @@ namespace System.Linq
 
         private static readonly MethodInfo _any = GetMethod("Any");
 
+        /// <summary>
+        ///     Asynchronously determines whether a sequence contains any elements.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" />.
+        /// </typeparam>
+        /// <param name="source">
+        ///     An <see cref="IQueryable{T}" /> to check for being empty.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains <c>true</c> if the source sequence contains any elements; otherwise, <c>false</c>.
+        /// </returns>
         public static Task<bool> AnyAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -33,6 +54,28 @@ namespace System.Linq
 
         private static readonly MethodInfo _anyPredicate = GetMethod("Any", 1);
 
+        /// <summary>
+        ///     Asynchronously determines whether any element of a sequence satisfies a condition.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" />.
+        /// </typeparam>
+        /// <param name="source">
+        ///     An <see cref="IQueryable{T}" /> whose elements to test for a condition.
+        /// </param>
+        /// <param name="predicate"> A function to test each element for a condition. </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains <c>true</c> if any elements in the source sequence pass the test in the specified
+        ///     predicate; otherwise, <c>false</c>.
+        /// </returns>
         public static Task<bool> AnyAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             [NotNull] Expression<Func<TSource, bool>> predicate,
@@ -46,6 +89,28 @@ namespace System.Linq
 
         private static readonly MethodInfo _allPredicate = GetMethod("All", 1);
 
+        /// <summary>
+        ///     Asynchronously determines whether all the elements of a sequence satisfy a condition.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" />.
+        /// </typeparam>
+        /// <param name="source">
+        ///     An <see cref="IQueryable{T}" /> whose elements to test for a condition.
+        /// </param>
+        /// <param name="predicate"> A function to test each element for a condition. </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains <c>true</c> if every element of the source sequence passes the test in the specified
+        ///     predicate; otherwise, <c>false</c>.
+        /// </returns>
         public static Task<bool> AllAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             [NotNull] Expression<Func<TSource, bool>> predicate,
@@ -63,6 +128,26 @@ namespace System.Linq
 
         private static readonly MethodInfo _count = GetMethod("Count");
 
+        /// <summary>
+        ///     Asynchronously returns the number of elements in a sequence.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" />.
+        /// </typeparam>
+        /// <param name="source">
+        ///     An <see cref="IQueryable{T}" /> that contains the elements to be counted.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the number of elements in the input sequence.
+        /// </returns>
         public static Task<int> CountAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -74,6 +159,28 @@ namespace System.Linq
 
         private static readonly MethodInfo _countPredicate = GetMethod("Count", 1);
 
+        /// <summary>
+        ///     Asynchronously returns the number of elements in a sequence that satisfy a condition.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" />.
+        /// </typeparam>
+        /// <param name="source">
+        ///     An <see cref="IQueryable{T}" /> that contains the elements to be counted.
+        /// </param>
+        /// <param name="predicate"> A function to test each element for a condition. </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the number of elements in the sequence that satisfy the condition in the predicate
+        ///     function.
+        /// </returns>
         public static Task<int> CountAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             [NotNull] Expression<Func<TSource, bool>> predicate,
@@ -87,6 +194,26 @@ namespace System.Linq
 
         private static readonly MethodInfo _longCount = GetMethod("LongCount");
 
+        /// <summary>
+        ///     Asynchronously returns an <see cref="Int64" /> that represents the total number of elements in a sequence.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" />.
+        /// </typeparam>
+        /// <param name="source">
+        ///     An <see cref="IQueryable{T}" /> that contains the elements to be counted.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the number of elements in the input sequence.
+        /// </returns>
         public static Task<long> LongCountAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -98,6 +225,29 @@ namespace System.Linq
 
         private static readonly MethodInfo _longCountPredicate = GetMethod("LongCount", 1);
 
+        /// <summary>
+        ///     Asynchronously returns an <see cref="Int64" /> that represents the number of elements in a sequence
+        ///     that satisfy a condition.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" />.
+        /// </typeparam>
+        /// <param name="source">
+        ///     An <see cref="IQueryable{T}" /> that contains the elements to be counted.
+        /// </param>
+        /// <param name="predicate"> A function to test each element for a condition. </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the number of elements in the sequence that satisfy the condition in the predicate
+        ///     function.
+        /// </returns>
         public static Task<long> LongCountAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             [NotNull] Expression<Func<TSource, bool>> predicate,
@@ -115,6 +265,26 @@ namespace System.Linq
 
         private static readonly MethodInfo _first = GetMethod("First");
 
+        /// <summary>
+        ///     Asynchronously returns the first element of a sequence.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" />.
+        /// </typeparam>
+        /// <param name="source">
+        ///     An <see cref="IQueryable{T}" /> to return the first element of.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the first element in <paramref name="source" />.
+        /// </returns>
         public static Task<TSource> FirstAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -126,6 +296,28 @@ namespace System.Linq
 
         private static readonly MethodInfo _firstPredicate = GetMethod("First", 1);
 
+        /// <summary>
+        ///     Asynchronously returns the first element of a sequence that satisfies a specified condition.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" />.
+        /// </typeparam>
+        /// <param name="source">
+        ///     An <see cref="IQueryable{T}" /> to return the first element of.
+        /// </param>
+        /// <param name="predicate"> A function to test each element for a condition. </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the first element in <paramref name="source" /> that passes the test in
+        ///     <paramref name="predicate" />.
+        /// </returns>
         public static Task<TSource> FirstAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             [NotNull] Expression<Func<TSource, bool>> predicate,
@@ -139,6 +331,27 @@ namespace System.Linq
 
         private static readonly MethodInfo _firstOrDefault = GetMethod("FirstOrDefault");
 
+        /// <summary>
+        ///     Asynchronously returns the first element of a sequence, or a default value if the sequence contains no elements.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" />.
+        /// </typeparam>
+        /// <param name="source">
+        ///     An <see cref="IQueryable{T}" /> to return the first element of.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains <c>default</c> ( <typeparamref name="TSource" /> ) if
+        ///     <paramref name="source" /> is empty; otherwise, the first element in <paramref name="source" />.
+        /// </returns>
         public static Task<TSource> FirstOrDefaultAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -150,6 +363,30 @@ namespace System.Linq
 
         private static readonly MethodInfo _firstOrDefaultPredicate = GetMethod("FirstOrDefault", 1);
 
+        /// <summary>
+        ///     Asynchronously returns the first element of a sequence that satisfies a specified condition
+        ///     or a default value if no such element is found.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" />.
+        /// </typeparam>
+        /// <param name="source">
+        ///     An <see cref="IQueryable{T}" /> to return the first element of.
+        /// </param>
+        /// <param name="predicate"> A function to test each element for a condition. </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains <c>default</c> ( <typeparamref name="TSource" /> ) if <paramref name="source" />
+        ///     is empty or if no element passes the test specified by <paramref name="predicate" /> ; otherwise, the first
+        ///     element in <paramref name="source" /> that passes the test specified by <paramref name="predicate" />.
+        /// </returns>
         public static Task<TSource> FirstOrDefaultAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             [NotNull] Expression<Func<TSource, bool>> predicate,
@@ -167,6 +404,26 @@ namespace System.Linq
 
         private static readonly MethodInfo _last = GetMethod("Last");
 
+        /// <summary>
+        ///     Asynchronously returns the last element of a sequence.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" />.
+        /// </typeparam>
+        /// <param name="source">
+        ///     An <see cref="IQueryable{T}" /> to return the last element of.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the last element in <paramref name="source" />.
+        /// </returns>
         public static Task<TSource> LastAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -178,6 +435,28 @@ namespace System.Linq
 
         private static readonly MethodInfo _lastPredicate = GetMethod("Last", 1);
 
+        /// <summary>
+        ///     Asynchronously returns the last element of a sequence that satisfies a specified condition.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" />.
+        /// </typeparam>
+        /// <param name="source">
+        ///     An <see cref="IQueryable{T}" /> to return the last element of.
+        /// </param>
+        /// <param name="predicate"> A function to test each element for a condition. </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the last element in <paramref name="source" /> that passes the test in
+        ///     <paramref name="predicate" />.
+        /// </returns>
         public static Task<TSource> LastAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             [NotNull] Expression<Func<TSource, bool>> predicate,
@@ -191,6 +470,27 @@ namespace System.Linq
 
         private static readonly MethodInfo _lastOrDefault = GetMethod("LastOrDefault");
 
+        /// <summary>
+        ///     Asynchronously returns the last element of a sequence, or a default value if the sequence contains no elements.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" />.
+        /// </typeparam>
+        /// <param name="source">
+        ///     An <see cref="IQueryable{T}" /> to return the last element of.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains <c>default</c> ( <typeparamref name="TSource" /> ) if
+        ///     <paramref name="source" /> is empty; otherwise, the last element in <paramref name="source" />.
+        /// </returns>
         public static Task<TSource> LastOrDefaultAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -202,6 +502,30 @@ namespace System.Linq
 
         private static readonly MethodInfo _lastOrDefaultPredicate = GetMethod("LastOrDefault", 1);
 
+        /// <summary>
+        ///     Asynchronously returns the last element of a sequence that satisfies a specified condition
+        ///     or a default value if no such element is found.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" />.
+        /// </typeparam>
+        /// <param name="source">
+        ///     An <see cref="IQueryable{T}" /> to return the last element of.
+        /// </param>
+        /// <param name="predicate"> A function to test each element for a condition. </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains <c>default</c> ( <typeparamref name="TSource" /> ) if <paramref name="source" />
+        ///     is empty or if no element passes the test specified by <paramref name="predicate" /> ; otherwise, the last
+        ///     element in <paramref name="source" /> that passes the test specified by <paramref name="predicate" />.
+        /// </returns>
         public static Task<TSource> LastOrDefaultAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             [NotNull] Expression<Func<TSource, bool>> predicate,
@@ -219,6 +543,27 @@ namespace System.Linq
 
         private static readonly MethodInfo _single = GetMethod("Single");
 
+        /// <summary>
+        ///     Asynchronously returns the only element of a sequence, and throws an exception
+        ///     if there is not exactly one element in the sequence.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" />.
+        /// </typeparam>
+        /// <param name="source">
+        ///     An <see cref="IQueryable{T}" /> to return the single element of.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the single element of the input sequence.
+        /// </returns>
         public static Task<TSource> SingleAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -230,6 +575,29 @@ namespace System.Linq
 
         private static readonly MethodInfo _singlePredicate = GetMethod("Single", 1);
 
+        /// <summary>
+        ///     Asynchronously returns the only element of a sequence that satisfies a specified condition,
+        ///     and throws an exception if more than one such element exists.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" />.
+        /// </typeparam>
+        /// <param name="source">
+        ///     An <see cref="IQueryable{T}" /> to return the single element of.
+        /// </param>
+        /// <param name="predicate"> A function to test an element for a condition. </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the single element of the input sequence that satisfies the condition in
+        ///     <paramref name="predicate" />.
+        /// </returns>
         public static Task<TSource> SingleAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             [NotNull] Expression<Func<TSource, bool>> predicate,
@@ -243,6 +611,29 @@ namespace System.Linq
 
         private static readonly MethodInfo _singleOrDefault = GetMethod("SingleOrDefault");
 
+        /// <summary>
+        ///     Asynchronously returns the only element of a sequence, or a default value if the sequence is empty;
+        ///     this method throws an exception if there is more than one element in the sequence.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" />.
+        /// </typeparam>
+        /// <param name="source">
+        ///     An <see cref="IQueryable{T}" /> to return the single element of.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the single element of the input sequence, or <c>default</c> (
+        ///     <typeparamref name="TSource" />)
+        ///     if the sequence contains no elements.
+        /// </returns>
         public static Task<TSource> SingleOrDefaultAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -254,6 +645,30 @@ namespace System.Linq
 
         private static readonly MethodInfo _singleOrDefaultPredicate = GetMethod("SingleOrDefault", 1);
 
+        /// <summary>
+        ///     Asynchronously returns the only element of a sequence that satisfies a specified condition or
+        ///     a default value if no such element exists; this method throws an exception if more than one element
+        ///     satisfies the condition.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" />.
+        /// </typeparam>
+        /// <param name="source">
+        ///     An <see cref="IQueryable{T}" /> to return the single element of.
+        /// </param>
+        /// <param name="predicate"> A function to test an element for a condition. </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the single element of the input sequence that satisfies the condition in
+        ///     <paramref name="predicate" />, or <c>default</c> ( <typeparamref name="TSource" /> ) if no such element is found.
+        /// </returns>
         public static Task<TSource> SingleOrDefaultAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             [NotNull] Expression<Func<TSource, bool>> predicate,
@@ -271,6 +686,26 @@ namespace System.Linq
 
         private static readonly MethodInfo _min = GetMethod("Min", predicate: mi => mi.IsGenericMethod);
 
+        /// <summary>
+        ///     Asynchronously returns the minimum value of a sequence.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" />.
+        /// </typeparam>
+        /// <param name="source">
+        ///     An <see cref="IQueryable{T}" /> that contains the elements to determine the minimum of.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the minimum value in the sequence.
+        /// </returns>
         public static Task<TSource> MinAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -282,6 +717,30 @@ namespace System.Linq
 
         private static readonly MethodInfo _minSelector = GetMethod("Min", 1, mi => mi.IsGenericMethod);
 
+        /// <summary>
+        ///     Asynchronously invokes a projection function on each element of a sequence and returns the minimum resulting value.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" />.
+        /// </typeparam>
+        /// <typeparam name="TResult">
+        ///     The type of the value returned by the function represented by <paramref name="selector" /> .
+        /// </typeparam>
+        /// <param name="source">
+        ///     An <see cref="IQueryable{T}" /> that contains the elements to determine the minimum of.
+        /// </param>
+        /// <param name="selector"> A projection function to apply to each element. </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the minimum value in the sequence.
+        /// </returns>
         public static Task<TResult> MinAsync<TSource, TResult>(
             [NotNull] this IQueryable<TSource> source,
             [NotNull] Expression<Func<TSource, TResult>> selector,
@@ -299,6 +758,26 @@ namespace System.Linq
 
         private static readonly MethodInfo _max = GetMethod("Max", predicate: mi => mi.IsGenericMethod);
 
+        /// <summary>
+        ///     Asynchronously returns the maximum value of a sequence.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" />.
+        /// </typeparam>
+        /// <param name="source">
+        ///     An <see cref="IQueryable{T}" /> that contains the elements to determine the maximum of.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the maximum value in the sequence.
+        /// </returns>
         public static Task<TSource> MaxAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -310,6 +789,30 @@ namespace System.Linq
 
         private static readonly MethodInfo _maxSelector = GetMethod("Max", 1, mi => mi.IsGenericMethod);
 
+        /// <summary>
+        ///     Asynchronously invokes a projection function on each element of a sequence and returns the maximum resulting value.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" />.
+        /// </typeparam>
+        /// <typeparam name="TResult">
+        ///     The type of the value returned by the function represented by <paramref name="selector" /> .
+        /// </typeparam>
+        /// <param name="source">
+        ///     An <see cref="IQueryable{T}" /> that contains the elements to determine the maximum of.
+        /// </param>
+        /// <param name="selector"> A projection function to apply to each element. </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the maximum value in the sequence.
+        /// </returns>
         public static Task<TResult> MaxAsync<TSource, TResult>(
             [NotNull] this IQueryable<TSource> source,
             [NotNull] Expression<Func<TSource, TResult>> selector,
@@ -327,6 +830,23 @@ namespace System.Linq
 
         private static readonly MethodInfo _sumDecimal = GetMethod<decimal>("Sum");
 
+        /// <summary>
+        ///     Asynchronously computes the sum of a sequence of values.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <param name="source">
+        ///     A sequence of values to calculate the sum of.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the sum of the values in the sequence.
+        /// </returns>
         public static Task<decimal> SumAsync(
             [NotNull] this IQueryable<decimal> source,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -338,6 +858,23 @@ namespace System.Linq
 
         private static readonly MethodInfo _sumNullableDecimal = GetMethod<decimal?>("Sum");
 
+        /// <summary>
+        ///     Asynchronously computes the sum of a sequence of values.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <param name="source">
+        ///     A sequence of values to calculate the sum of.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the sum of the values in the sequence.
+        /// </returns>
         public static Task<decimal?> SumAsync(
             [NotNull] this IQueryable<decimal?> source,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -349,6 +886,25 @@ namespace System.Linq
 
         private static readonly MethodInfo _sumDecimalSelector = GetMethod<decimal>("Sum", 1);
 
+        /// <summary>
+        ///     Asynchronously computes the sum of the sequence of values that is obtained by invoking a projection function on
+        ///     each element of the input sequence.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <param name="source">
+        ///     A sequence of values of type <typeparamref name="TSource" />.
+        /// </param>
+        /// <param name="selector"> A projection function to apply to each element. </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the sum of the projected values..
+        /// </returns>
         public static Task<decimal> SumAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             [NotNull] Expression<Func<TSource, decimal>> selector,
@@ -362,6 +918,25 @@ namespace System.Linq
 
         private static readonly MethodInfo _sumNullableDecimalSelector = GetMethod<decimal?>("Sum", 1);
 
+        /// <summary>
+        ///     Asynchronously computes the sum of the sequence of values that is obtained by invoking a projection function on
+        ///     each element of the input sequence.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <param name="source">
+        ///     A sequence of values of type <typeparamref name="TSource" />.
+        /// </param>
+        /// <param name="selector"> A projection function to apply to each element. </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the sum of the projected values..
+        /// </returns>
         public static Task<decimal?> SumAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             [NotNull] Expression<Func<TSource, decimal?>> selector,
@@ -375,6 +950,23 @@ namespace System.Linq
 
         private static readonly MethodInfo _sumInt = GetMethod<int>("Sum");
 
+        /// <summary>
+        ///     Asynchronously computes the sum of a sequence of values.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <param name="source">
+        ///     A sequence of values to calculate the sum of.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the sum of the values in the sequence.
+        /// </returns>
         public static Task<int> SumAsync(
             [NotNull] this IQueryable<int> source,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -386,6 +978,23 @@ namespace System.Linq
 
         private static readonly MethodInfo _sumNullableInt = GetMethod<int?>("Sum");
 
+        /// <summary>
+        ///     Asynchronously computes the sum of a sequence of values.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <param name="source">
+        ///     A sequence of values to calculate the sum of.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the sum of the values in the sequence.
+        /// </returns>
         public static Task<int?> SumAsync(
             [NotNull] this IQueryable<int?> source,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -397,6 +1006,25 @@ namespace System.Linq
 
         private static readonly MethodInfo _sumIntSelector = GetMethod<int>("Sum", 1);
 
+        /// <summary>
+        ///     Asynchronously computes the sum of the sequence of values that is obtained by invoking a projection function on
+        ///     each element of the input sequence.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <param name="source">
+        ///     A sequence of values of type <typeparamref name="TSource" />.
+        /// </param>
+        /// <param name="selector"> A projection function to apply to each element. </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the sum of the projected values..
+        /// </returns>
         public static Task<int> SumAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             [NotNull] Expression<Func<TSource, int>> selector,
@@ -410,6 +1038,25 @@ namespace System.Linq
 
         private static readonly MethodInfo _sumNullableIntSelector = GetMethod<int?>("Sum", 1);
 
+        /// <summary>
+        ///     Asynchronously computes the sum of the sequence of values that is obtained by invoking a projection function on
+        ///     each element of the input sequence.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <param name="source">
+        ///     A sequence of values of type <typeparamref name="TSource" />.
+        /// </param>
+        /// <param name="selector"> A projection function to apply to each element. </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the sum of the projected values..
+        /// </returns>
         public static Task<int?> SumAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             [NotNull] Expression<Func<TSource, int?>> selector,
@@ -423,6 +1070,23 @@ namespace System.Linq
 
         private static readonly MethodInfo _sumLong = GetMethod<long>("Sum");
 
+        /// <summary>
+        ///     Asynchronously computes the sum of a sequence of values.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <param name="source">
+        ///     A sequence of values to calculate the sum of.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the sum of the values in the sequence.
+        /// </returns>
         public static Task<long> SumAsync(
             [NotNull] this IQueryable<long> source,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -434,6 +1098,23 @@ namespace System.Linq
 
         private static readonly MethodInfo _sumNullableLong = GetMethod<long?>("Sum");
 
+        /// <summary>
+        ///     Asynchronously computes the sum of a sequence of values.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <param name="source">
+        ///     A sequence of values to calculate the sum of.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the sum of the values in the sequence.
+        /// </returns>
         public static Task<long?> SumAsync(
             [NotNull] this IQueryable<long?> source,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -445,6 +1126,25 @@ namespace System.Linq
 
         private static readonly MethodInfo _sumLongSelector = GetMethod<long>("Sum", 1);
 
+        /// <summary>
+        ///     Asynchronously computes the sum of the sequence of values that is obtained by invoking a projection function on
+        ///     each element of the input sequence.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <param name="source">
+        ///     A sequence of values of type <typeparamref name="TSource" />.
+        /// </param>
+        /// <param name="selector"> A projection function to apply to each element. </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the sum of the projected values..
+        /// </returns>
         public static Task<long> SumAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             [NotNull] Expression<Func<TSource, long>> selector,
@@ -458,6 +1158,25 @@ namespace System.Linq
 
         private static readonly MethodInfo _sumNullableLongSelector = GetMethod<long?>("Sum", 1);
 
+        /// <summary>
+        ///     Asynchronously computes the sum of the sequence of values that is obtained by invoking a projection function on
+        ///     each element of the input sequence.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <param name="source">
+        ///     A sequence of values of type <typeparamref name="TSource" />.
+        /// </param>
+        /// <param name="selector"> A projection function to apply to each element. </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the sum of the projected values..
+        /// </returns>
         public static Task<long?> SumAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             [NotNull] Expression<Func<TSource, long?>> selector,
@@ -471,6 +1190,23 @@ namespace System.Linq
 
         private static readonly MethodInfo _sumDouble = GetMethod<double>("Sum");
 
+        /// <summary>
+        ///     Asynchronously computes the sum of a sequence of values.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <param name="source">
+        ///     A sequence of values to calculate the sum of.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the sum of the values in the sequence.
+        /// </returns>
         public static Task<double> SumAsync(
             [NotNull] this IQueryable<double> source,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -482,6 +1218,23 @@ namespace System.Linq
 
         private static readonly MethodInfo _sumNullableDouble = GetMethod<double?>("Sum");
 
+        /// <summary>
+        ///     Asynchronously computes the sum of a sequence of values.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <param name="source">
+        ///     A sequence of values to calculate the sum of.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the sum of the values in the sequence.
+        /// </returns>
         public static Task<double?> SumAsync(
             [NotNull] this IQueryable<double?> source,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -493,6 +1246,25 @@ namespace System.Linq
 
         private static readonly MethodInfo _sumDoubleSelector = GetMethod<double>("Sum", 1);
 
+        /// <summary>
+        ///     Asynchronously computes the sum of the sequence of values that is obtained by invoking a projection function on
+        ///     each element of the input sequence.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <param name="source">
+        ///     A sequence of values of type <typeparamref name="TSource" />.
+        /// </param>
+        /// <param name="selector"> A projection function to apply to each element. </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the sum of the projected values..
+        /// </returns>
         public static Task<double> SumAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             [NotNull] Expression<Func<TSource, double>> selector,
@@ -506,6 +1278,25 @@ namespace System.Linq
 
         private static readonly MethodInfo _sumNullableDoubleSelector = GetMethod<double?>("Sum", 1);
 
+        /// <summary>
+        ///     Asynchronously computes the sum of the sequence of values that is obtained by invoking a projection function on
+        ///     each element of the input sequence.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <param name="source">
+        ///     A sequence of values of type <typeparamref name="TSource" />.
+        /// </param>
+        /// <param name="selector"> A projection function to apply to each element. </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the sum of the projected values..
+        /// </returns>
         public static Task<double?> SumAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             [NotNull] Expression<Func<TSource, double?>> selector,
@@ -519,6 +1310,23 @@ namespace System.Linq
 
         private static readonly MethodInfo _sumFloat = GetMethod<float>("Sum");
 
+        /// <summary>
+        ///     Asynchronously computes the sum of a sequence of values.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <param name="source">
+        ///     A sequence of values to calculate the sum of.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the sum of the values in the sequence.
+        /// </returns>
         public static Task<float> SumAsync(
             [NotNull] this IQueryable<float> source,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -530,6 +1338,23 @@ namespace System.Linq
 
         private static readonly MethodInfo _sumNullableFloat = GetMethod<float?>("Sum");
 
+        /// <summary>
+        ///     Asynchronously computes the sum of a sequence of values.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <param name="source">
+        ///     A sequence of values to calculate the sum of.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the sum of the values in the sequence.
+        /// </returns>
         public static Task<float?> SumAsync(
             [NotNull] this IQueryable<float?> source,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -541,6 +1366,25 @@ namespace System.Linq
 
         private static readonly MethodInfo _sumFloatSelector = GetMethod<float>("Sum", 1);
 
+        /// <summary>
+        ///     Asynchronously computes the sum of the sequence of values that is obtained by invoking a projection function on
+        ///     each element of the input sequence.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <param name="source">
+        ///     A sequence of values of type <typeparamref name="TSource" />.
+        /// </param>
+        /// <param name="selector"> A projection function to apply to each element. </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the sum of the projected values..
+        /// </returns>
         public static Task<float> SumAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             [NotNull] Expression<Func<TSource, float>> selector,
@@ -554,6 +1398,25 @@ namespace System.Linq
 
         private static readonly MethodInfo _sumNullableFloatSelector = GetMethod<float?>("Sum", 1);
 
+        /// <summary>
+        ///     Asynchronously computes the sum of the sequence of values that is obtained by invoking a projection function on
+        ///     each element of the input sequence.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <param name="source">
+        ///     A sequence of values of type <typeparamref name="TSource" />.
+        /// </param>
+        /// <param name="selector"> A projection function to apply to each element. </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the sum of the projected values..
+        /// </returns>
         public static Task<float?> SumAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             [NotNull] Expression<Func<TSource, float?>> selector,
@@ -584,6 +1447,23 @@ namespace System.Linq
 
         private static readonly MethodInfo _averageDecimal = GetAverageMethod<decimal, decimal>();
 
+        /// <summary>
+        ///     Asynchronously computes the average of a sequence of values.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <param name="source">
+        ///     A sequence of values to calculate the average of.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the average of the sequence of values.
+        /// </returns>
         public static Task<decimal> AverageAsync(
             [NotNull] this IQueryable<decimal> source,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -595,6 +1475,23 @@ namespace System.Linq
 
         private static readonly MethodInfo _averageNullableDecimal = GetAverageMethod<decimal?, decimal?>();
 
+        /// <summary>
+        ///     Asynchronously computes the average of a sequence of values.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <param name="source">
+        ///     A sequence of values to calculate the average of.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the average of the sequence of values.
+        /// </returns>
         public static Task<decimal?> AverageAsync(
             [NotNull] this IQueryable<decimal?> source,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -606,6 +1503,26 @@ namespace System.Linq
 
         private static readonly MethodInfo _averageDecimalSelector = GetAverageMethod<decimal, decimal>(1);
 
+        /// <summary>
+        ///     Asynchronously computes the average of a sequence of values that is obtained
+        ///     by invoking a projection function on each element of the input sequence.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" /> .
+        /// </typeparam>
+        /// <param name="source"> A sequence of values of type <typeparamref name="TSource" />. </param>
+        /// <param name="selector"> A projection function to apply to each element. </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the average of the projected values.
+        /// </returns>
         public static Task<decimal> AverageAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             [NotNull] Expression<Func<TSource, decimal>> selector,
@@ -619,6 +1536,26 @@ namespace System.Linq
 
         private static readonly MethodInfo _averageNullableDecimalSelector = GetAverageMethod<decimal?, decimal?>(1);
 
+        /// <summary>
+        ///     Asynchronously computes the average of a sequence of values that is obtained
+        ///     by invoking a projection function on each element of the input sequence.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" /> .
+        /// </typeparam>
+        /// <param name="source"> A sequence of values of type <typeparamref name="TSource" />. </param>
+        /// <param name="selector"> A projection function to apply to each element. </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the average of the projected values.
+        /// </returns>
         public static Task<decimal?> AverageAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             [NotNull] Expression<Func<TSource, decimal?>> selector,
@@ -632,6 +1569,23 @@ namespace System.Linq
 
         private static readonly MethodInfo _averageInt = GetAverageMethod<int, double>();
 
+        /// <summary>
+        ///     Asynchronously computes the average of a sequence of values.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <param name="source">
+        ///     A sequence of values to calculate the average of.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the average of the sequence of values.
+        /// </returns>
         public static Task<double> AverageAsync(
             [NotNull] this IQueryable<int> source,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -643,6 +1597,23 @@ namespace System.Linq
 
         private static readonly MethodInfo _averageNullableInt = GetAverageMethod<int?, double?>();
 
+        /// <summary>
+        ///     Asynchronously computes the average of a sequence of values.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <param name="source">
+        ///     A sequence of values to calculate the average of.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the average of the sequence of values.
+        /// </returns>
         public static Task<double?> AverageAsync(
             [NotNull] this IQueryable<int?> source,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -654,6 +1625,26 @@ namespace System.Linq
 
         private static readonly MethodInfo _averageIntSelector = GetAverageMethod<int, double>(1);
 
+        /// <summary>
+        ///     Asynchronously computes the average of a sequence of values that is obtained
+        ///     by invoking a projection function on each element of the input sequence.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" /> .
+        /// </typeparam>
+        /// <param name="source"> A sequence of values of type <typeparamref name="TSource" />. </param>
+        /// <param name="selector"> A projection function to apply to each element. </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the average of the projected values.
+        /// </returns>
         public static Task<double> AverageAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             [NotNull] Expression<Func<TSource, int>> selector,
@@ -667,6 +1658,26 @@ namespace System.Linq
 
         private static readonly MethodInfo _averageNullableIntSelector = GetAverageMethod<int?, double?>(1);
 
+        /// <summary>
+        ///     Asynchronously computes the average of a sequence of values that is obtained
+        ///     by invoking a projection function on each element of the input sequence.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" /> .
+        /// </typeparam>
+        /// <param name="source"> A sequence of values of type <typeparamref name="TSource" />. </param>
+        /// <param name="selector"> A projection function to apply to each element. </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the average of the projected values.
+        /// </returns>
         public static Task<double?> AverageAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             [NotNull] Expression<Func<TSource, int?>> selector,
@@ -680,6 +1691,23 @@ namespace System.Linq
 
         private static readonly MethodInfo _averageLong = GetAverageMethod<long, double>();
 
+        /// <summary>
+        ///     Asynchronously computes the average of a sequence of values.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <param name="source">
+        ///     A sequence of values to calculate the average of.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the average of the sequence of values.
+        /// </returns>
         public static Task<double> AverageAsync(
             [NotNull] this IQueryable<long> source,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -691,6 +1719,23 @@ namespace System.Linq
 
         private static readonly MethodInfo _averageNullableLong = GetAverageMethod<long?, double?>();
 
+        /// <summary>
+        ///     Asynchronously computes the average of a sequence of values.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <param name="source">
+        ///     A sequence of values to calculate the average of.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the average of the sequence of values.
+        /// </returns>
         public static Task<double?> AverageAsync(
             [NotNull] this IQueryable<long?> source,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -702,6 +1747,26 @@ namespace System.Linq
 
         private static readonly MethodInfo _averageLongSelector = GetAverageMethod<long, double>(1);
 
+        /// <summary>
+        ///     Asynchronously computes the average of a sequence of values that is obtained
+        ///     by invoking a projection function on each element of the input sequence.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" /> .
+        /// </typeparam>
+        /// <param name="source"> A sequence of values of type <typeparamref name="TSource" />. </param>
+        /// <param name="selector"> A projection function to apply to each element. </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the average of the projected values.
+        /// </returns>
         public static Task<double> AverageAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             [NotNull] Expression<Func<TSource, long>> selector,
@@ -715,6 +1780,26 @@ namespace System.Linq
 
         private static readonly MethodInfo _averageNullableLongSelector = GetAverageMethod<long?, double?>(1);
 
+        /// <summary>
+        ///     Asynchronously computes the average of a sequence of values that is obtained
+        ///     by invoking a projection function on each element of the input sequence.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" /> .
+        /// </typeparam>
+        /// <param name="source"> A sequence of values of type <typeparamref name="TSource" />. </param>
+        /// <param name="selector"> A projection function to apply to each element. </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the average of the projected values.
+        /// </returns>
         public static Task<double?> AverageAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             [NotNull] Expression<Func<TSource, long?>> selector,
@@ -728,6 +1813,23 @@ namespace System.Linq
 
         private static readonly MethodInfo _averageDouble = GetAverageMethod<double, double>();
 
+        /// <summary>
+        ///     Asynchronously computes the average of a sequence of values.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <param name="source">
+        ///     A sequence of values to calculate the average of.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the average of the sequence of values.
+        /// </returns>
         public static Task<double> AverageAsync(
             [NotNull] this IQueryable<double> source,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -739,6 +1841,23 @@ namespace System.Linq
 
         private static readonly MethodInfo _averageNullableDouble = GetAverageMethod<double?, double?>();
 
+        /// <summary>
+        ///     Asynchronously computes the average of a sequence of values.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <param name="source">
+        ///     A sequence of values to calculate the average of.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the average of the sequence of values.
+        /// </returns>
         public static Task<double?> AverageAsync(
             [NotNull] this IQueryable<double?> source,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -750,6 +1869,26 @@ namespace System.Linq
 
         private static readonly MethodInfo _averageDoubleSelector = GetAverageMethod<double, double>(1);
 
+        /// <summary>
+        ///     Asynchronously computes the average of a sequence of values that is obtained
+        ///     by invoking a projection function on each element of the input sequence.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" /> .
+        /// </typeparam>
+        /// <param name="source"> A sequence of values of type <typeparamref name="TSource" />. </param>
+        /// <param name="selector"> A projection function to apply to each element. </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the average of the projected values.
+        /// </returns>
         public static Task<double> AverageAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             [NotNull] Expression<Func<TSource, double>> selector,
@@ -763,6 +1902,26 @@ namespace System.Linq
 
         private static readonly MethodInfo _averageNullableDoubleSelector = GetAverageMethod<double?, double?>(1);
 
+        /// <summary>
+        ///     Asynchronously computes the average of a sequence of values that is obtained
+        ///     by invoking a projection function on each element of the input sequence.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" /> .
+        /// </typeparam>
+        /// <param name="source"> A sequence of values of type <typeparamref name="TSource" />. </param>
+        /// <param name="selector"> A projection function to apply to each element. </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the average of the projected values.
+        /// </returns>
         public static Task<double?> AverageAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             [NotNull] Expression<Func<TSource, double?>> selector,
@@ -776,6 +1935,23 @@ namespace System.Linq
 
         private static readonly MethodInfo _averageFloat = GetAverageMethod<float, float>();
 
+        /// <summary>
+        ///     Asynchronously computes the average of a sequence of values.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <param name="source">
+        ///     A sequence of values to calculate the average of.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the average of the sequence of values.
+        /// </returns>
         public static Task<float> AverageAsync(
             [NotNull] this IQueryable<float> source,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -787,6 +1963,23 @@ namespace System.Linq
 
         private static readonly MethodInfo _averageNullableFloat = GetAverageMethod<float?, float?>();
 
+        /// <summary>
+        ///     Asynchronously computes the average of a sequence of values.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <param name="source">
+        ///     A sequence of values to calculate the average of.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the average of the sequence of values.
+        /// </returns>
         public static Task<float?> AverageAsync(
             [NotNull] this IQueryable<float?> source,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -798,6 +1991,26 @@ namespace System.Linq
 
         private static readonly MethodInfo _averageFloatSelector = GetAverageMethod<float, float>(1);
 
+        /// <summary>
+        ///     Asynchronously computes the average of a sequence of values that is obtained
+        ///     by invoking a projection function on each element of the input sequence.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" /> .
+        /// </typeparam>
+        /// <param name="source"> A sequence of values of type <typeparamref name="TSource" />. </param>
+        /// <param name="selector"> A projection function to apply to each element. </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the average of the projected values.
+        /// </returns>
         public static Task<float> AverageAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             [NotNull] Expression<Func<TSource, float>> selector,
@@ -811,6 +2024,26 @@ namespace System.Linq
 
         private static readonly MethodInfo _averageNullableFloatSelector = GetAverageMethod<float?, float?>(1);
 
+        /// <summary>
+        ///     Asynchronously computes the average of a sequence of values that is obtained
+        ///     by invoking a projection function on each element of the input sequence.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" /> .
+        /// </typeparam>
+        /// <param name="source"> A sequence of values of type <typeparamref name="TSource" />. </param>
+        /// <param name="selector"> A projection function to apply to each element. </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains the average of the projected values.
+        /// </returns>
         public static Task<float?> AverageAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             [NotNull] Expression<Func<TSource, float?>> selector,
@@ -828,6 +2061,27 @@ namespace System.Linq
 
         private static readonly MethodInfo _contains = GetMethod("Contains", 1);
 
+        /// <summary>
+        ///     Asynchronously determines whether a sequence contains a specified element by using the default equality comparer.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" />.
+        /// </typeparam>
+        /// <param name="source">
+        ///     An <see cref="IQueryable{T}" /> to return the single element of.
+        /// </param>
+        /// <param name="item"> The object to locate in the sequence. </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains <c>true</c> if the input sequence contains the specified value; otherwise, <c>false</c>.
+        /// </returns>
         public static Task<bool> ContainsAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             [NotNull] TSource item,
@@ -846,6 +2100,27 @@ namespace System.Linq
 
         #region ToList/Array
 
+        /// <summary>
+        ///     Asynchronously creates a <see cref="List{T}" /> from an <see cref="IQueryable{T}" /> by enumerating it
+        ///     asynchronously.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" />.
+        /// </typeparam>
+        /// <param name="source">
+        ///     An <see cref="IQueryable{T}" /> to create a list from.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains a <see cref="List{T}" /> that contains elements from the input sequence.
+        /// </returns>
         public static Task<List<TSource>> ToListAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -855,6 +2130,26 @@ namespace System.Linq
             return source.AsAsyncEnumerable().ToList(cancellationToken);
         }
 
+        /// <summary>
+        ///     Asynchronously creates an array from an <see cref="IQueryable{T}" /> by enumerating it asynchronously.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" />.
+        /// </typeparam>
+        /// <param name="source">
+        ///     An <see cref="IQueryable{T}" /> to create an array from.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains an array that contains elements from the input sequence.
+        /// </returns>
         public static Task<TSource[]> ToArrayAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -873,6 +2168,7 @@ namespace System.Linq
                 .GetTypeInfo().GetDeclaredMethods("Include")
                 .Single(mi => mi.GetParameters().Any(pi => pi.Name == "navigationPropertyPath"));
 
+        // TODO API docs once we resolve #1709
         public static IIncludableQueryable<TEntity, TProperty> Include<TEntity, TProperty>(
             [NotNull] this IQueryable<TEntity> source,
             [NotNull] Expression<Func<TEntity, TProperty>> navigationPropertyPath)
@@ -894,6 +2190,7 @@ namespace System.Linq
                 .GetTypeInfo().GetDeclaredMethods("ThenInclude")
                 .Single();
 
+        // TODO API docs once we resolve #1709
         public static IIncludableQueryable<TEntity, TProperty> ThenInclude<TEntity, TPreviousProperty, TProperty>(
             [NotNull] this IIncludableQueryable<TEntity, ICollection<TPreviousProperty>> source,
             [NotNull] Expression<Func<TPreviousProperty, TProperty>> navigationPropertyPath)
@@ -940,6 +2237,20 @@ namespace System.Linq
 
         #region AsAsyncEnumerable
 
+        /// <summary>
+        ///     Provides an <see cref="IAsyncEnumerable{T}" /> that allows asynchronous enumeration
+        ///     of the query. This method is typically not used in application code. <see cref="ForEachAsync{T}" />
+        ///     provides a simple way to asynchronously enumerate the results of a query.
+        /// </summary>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" />.
+        /// </typeparam>
+        /// <param name="source">
+        ///     An <see cref="IQueryable{T}" /> to create the <see cref="IAsyncEnumerable{T}" /> from.
+        /// </param>
+        /// <returns>
+        ///     An object to asynchronously enumerate the results.
+        /// </returns>
         public static IAsyncEnumerable<TSource> AsAsyncEnumerable<TSource>([NotNull] this IQueryable<TSource> source)
         {
             Check.NotNull(source, nameof(source));
@@ -969,6 +2280,28 @@ namespace System.Linq
             = typeof(QueryableExtensions)
                 .GetTypeInfo().GetDeclaredMethod("AsNoTracking");
 
+        /// <summary>
+        ///     <para>
+        ///         Returns a new query where the entities returned in the result set will not be tracked
+        ///         by the context.
+        ///     </para>
+        ///     <para>
+        ///         No tracking is designed to be used as a performance optimization when working with
+        ///         result sets where changes to the entity instances will not be persisted by
+        ///         the context they were queries with. This includes disconnected scenarios (such as
+        ///         web services) and read-only data.
+        ///     </para>
+        ///     <para>
+        ///         Identity resolution will still be performed to ensure
+        ///         that all occurrences of an entity with a given key in the result set are represented by
+        ///         the same entity instance.
+        ///     </para>
+        /// </summary>
+        /// <typeparam name="TEntity"> The type of entity being queried. </typeparam>
+        /// <param name="source"> The source query. </param>
+        /// <returns> 
+        ///     A new query where the result set will not be tracked by the context. 
+        /// </returns>
         public static IQueryable<TEntity> AsNoTracking<TEntity>([NotNull] this IQueryable<TEntity> source) where TEntity : class
         {
             Check.NotNull(source, nameof(source));
@@ -983,6 +2316,12 @@ namespace System.Linq
 
         #region Load
 
+        /// <summary>
+        ///     Enumerates the query. When using Entity Framework, this causes the results of the query to
+        ///     be loaded into the associated context. This is equivalent to calling ToList
+        ///     and then throwing away the list (without the overhead of actually creating the list).
+        /// </summary>
+        /// <param name="source"> The source query. </param>
         public static void Load<TSource>([NotNull] this IQueryable<TSource> source)
         {
             Check.NotNull(source, nameof(source));
@@ -995,6 +2334,16 @@ namespace System.Linq
             }
         }
 
+        /// <summary>
+        ///     Asynchronously enumerates the query. When using Entity Framework, this causes the results of the query to
+        ///     be loaded into the associated context. This is equivalent to calling ToList
+        ///     and then throwing away the list (without the overhead of actually creating the list).
+        /// </summary>
+        /// <param name="source"> The source query. </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns> A task that represents the asynchronous operation. </returns>
         public static async Task LoadAsync<TSource>(
             [NotNull] this IQueryable<TSource> source, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -1014,6 +2363,32 @@ namespace System.Linq
 
         #region ToDictionary
 
+        /// <summary>
+        ///     Creates a <see cref="Dictionary{TKey, TValue}" /> from an <see cref="IQueryable{T}" /> by enumerating it
+        ///     asynchronously
+        ///     according to a specified key selector function.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" />.
+        /// </typeparam>
+        /// <typeparam name="TKey">
+        ///     The type of the key returned by <paramref name="keySelector" /> .
+        /// </typeparam>
+        /// <param name="source">
+        ///     An <see cref="IQueryable{T}" /> to create a <see cref="Dictionary{TKey, TValue}" /> from.
+        /// </param>
+        /// <param name="keySelector"> A function to extract a key from each element. </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains a <see cref="Dictionary{TKey, TSource}" /> that contains selected keys and values.
+        /// </returns>
         public static Task<Dictionary<TKey, TSource>> ToDictionaryAsync<TSource, TKey>(
             [NotNull] this IQueryable<TSource> source,
             [NotNull] Func<TSource, TKey> keySelector,
@@ -1025,6 +2400,35 @@ namespace System.Linq
             return source.AsAsyncEnumerable().ToDictionary(keySelector, cancellationToken);
         }
 
+        /// <summary>
+        ///     Creates a <see cref="Dictionary{TKey, TValue}" /> from an <see cref="IQueryable{T}" /> by enumerating it
+        ///     asynchronously
+        ///     according to a specified key selector function and a comparer.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" />.
+        /// </typeparam>
+        /// <typeparam name="TKey">
+        ///     The type of the key returned by <paramref name="keySelector" /> .
+        /// </typeparam>
+        /// <param name="source">
+        ///     An <see cref="IQueryable{T}" /> to create a <see cref="Dictionary{TKey, TValue}" /> from.
+        /// </param>
+        /// <param name="keySelector"> A function to extract a key from each element. </param>
+        /// <param name="comparer">
+        ///     An <see cref="IEqualityComparer{TKey}" /> to compare keys.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains a <see cref="Dictionary{TKey, TSource}" /> that contains selected keys and values.
+        /// </returns>
         public static Task<Dictionary<TKey, TSource>> ToDictionaryAsync<TSource, TKey>(
             [NotNull] this IQueryable<TSource> source,
             [NotNull] Func<TSource, TKey> keySelector,
@@ -1038,6 +2442,37 @@ namespace System.Linq
             return source.AsAsyncEnumerable().ToDictionary(keySelector, comparer, cancellationToken);
         }
 
+        /// <summary>
+        ///     Creates a <see cref="Dictionary{TKey, TValue}" /> from an <see cref="IQueryable{T}" /> by enumerating it
+        ///     asynchronously
+        ///     according to a specified key selector and an element selector function.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" />.
+        /// </typeparam>
+        /// <typeparam name="TKey">
+        ///     The type of the key returned by <paramref name="keySelector" /> .
+        /// </typeparam>
+        /// <typeparam name="TElement">
+        ///     The type of the value returned by <paramref name="elementSelector" />.
+        /// </typeparam>
+        /// <param name="source">
+        ///     An <see cref="IQueryable{T}" /> to create a <see cref="Dictionary{TKey, TValue}" /> from.
+        /// </param>
+        /// <param name="keySelector"> A function to extract a key from each element. </param>
+        /// <param name="elementSelector"> A transform function to produce a result element value from each element. </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains a <see cref="Dictionary{TKey, TElement}" /> that contains values of type
+        ///     <typeparamref name="TElement" /> selected from the input sequence.
+        /// </returns>
         public static Task<Dictionary<TKey, TElement>> ToDictionaryAsync<TSource, TKey, TElement>(
             [NotNull] this IQueryable<TSource> source,
             [NotNull] Func<TSource, TKey> keySelector,
@@ -1051,6 +2486,40 @@ namespace System.Linq
             return source.AsAsyncEnumerable().ToDictionary(keySelector, elementSelector, cancellationToken);
         }
 
+        /// <summary>
+        ///     Creates a <see cref="Dictionary{TKey, TValue}" /> from an <see cref="IQueryable{T}" /> by enumerating it
+        ///     asynchronously
+        ///     according to a specified key selector function, a comparer, and an element selector function.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="TSource">
+        ///     The type of the elements of <paramref name="source" />.
+        /// </typeparam>
+        /// <typeparam name="TKey">
+        ///     The type of the key returned by <paramref name="keySelector" /> .
+        /// </typeparam>
+        /// <typeparam name="TElement">
+        ///     The type of the value returned by <paramref name="elementSelector" />.
+        /// </typeparam>
+        /// <param name="source">
+        ///     An <see cref="IQueryable{T}" /> to create a <see cref="Dictionary{TKey, TValue}" /> from.
+        /// </param>
+        /// <param name="keySelector"> A function to extract a key from each element. </param>
+        /// <param name="elementSelector"> A transform function to produce a result element value from each element. </param>
+        /// <param name="comparer">
+        ///     An <see cref="IEqualityComparer{TKey}" /> to compare keys.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns>
+        ///     A task that represents the asynchronous operation.
+        ///     The task result contains a <see cref="Dictionary{TKey, TElement}" /> that contains values of type
+        ///     <typeparamref name="TElement" /> selected from the input sequence.
+        /// </returns>
         public static Task<Dictionary<TKey, TElement>> ToDictionaryAsync<TSource, TKey, TElement>(
             [NotNull] this IQueryable<TSource> source,
             [NotNull] Func<TSource, TKey> keySelector,
@@ -1070,6 +2539,24 @@ namespace System.Linq
 
         #region ForEach
 
+        /// <summary>
+        ///     Asynchronously enumerates the query results and performs the specified action on each element.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
+        ///     that any asynchronous operations have completed before calling another method on this context.
+        /// </remarks>
+        /// <typeparam name="T">
+        ///     The type of the elements of <paramref name="source" />.
+        /// </typeparam>
+        /// <param name="source">
+        ///     An <see cref="IQueryable{T}" /> to enumerate.
+        /// </param>
+        /// <param name="action"> The action to perform on each element. </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken" /> to observe while waiting for the task to complete.
+        /// </param>
+        /// <returns> A task that represents the asynchronous operation. </returns>
         public static Task ForEachAsync<T>(
             [NotNull] this IQueryable<T> source,
             [NotNull] Action<T> action,


### PR DESCRIPTION
Docs in QueryableExtensions are copied from EF6.x except for the following (which need a detailed review):
- Include
- AsAsyncEnumerable
- AsNoTracking
- Load