### PR TITLE
renaming GetNewHighValue

### DIFF
--- a/src/EntityFramework.Core/ValueGeneration/HiLoValueGenerator.cs
+++ b/src/EntityFramework.Core/ValueGeneration/HiLoValueGenerator.cs
@@ -22,8 +22,8 @@ namespace Microsoft.Data.Entity.ValueGeneration
             _generatorState = generatorState;
         }
 
-        public override TValue Next() => _generatorState.Next<TValue>(GetNewHighValue);
+        public override TValue Next() => _generatorState.Next<TValue>(GetNewLowValue);
 
-        protected abstract long GetNewHighValue();
+        protected abstract long GetNewLowValue();
     }
 }

--- a/src/EntityFramework.Core/ValueGeneration/HiLoValueGeneratorState.cs
+++ b/src/EntityFramework.Core/ValueGeneration/HiLoValueGeneratorState.cs
@@ -28,9 +28,9 @@ namespace Microsoft.Data.Entity.ValueGeneration
             }
         }
 
-        public virtual TValue Next<TValue>([NotNull] Func<long> getNewHighValue)
+        public virtual TValue Next<TValue>([NotNull] Func<long> getNewLowValue)
         {
-            Check.NotNull(getNewHighValue, nameof(getNewHighValue));
+            Check.NotNull(getNewLowValue, nameof(getNewLowValue));
 
             var poolIndexToUse = _poolIndex;
             _poolIndex = (_poolIndex + 1) % _pool.Length;
@@ -48,7 +48,7 @@ namespace Microsoft.Data.Entity.ValueGeneration
                     // case just get a value out of the new block instead of requesting one.
                     if (newValue.High == _pool[poolIndexToUse].High)
                     {
-                        var newCurrent = getNewHighValue();
+                        var newCurrent = getNewLowValue();
                         newValue = new HiLoValue(newCurrent, newCurrent + _blockSize);
                         _pool[poolIndexToUse] = newValue;
                     }

--- a/src/EntityFramework.SqlServer/SqlServerSequenceValueGenerator.cs
+++ b/src/EntityFramework.SqlServer/SqlServerSequenceValueGenerator.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Data.Entity.SqlServer
             _connection = connection;
         }
 
-        protected override long GetNewHighValue()
+        protected override long GetNewLowValue()
         {
             // TODO: Parameterize query and/or delimit identifier without using SqlServerMigrationOperationSqlGenerator
             var sql = string.Format(CultureInfo.InvariantCulture, "SELECT NEXT VALUE FOR {0}", _sequenceName);


### PR DESCRIPTION
Prompted by issue #1540

the GetNewHighValue function doesn't get the new high bound of a block, but instead, it gets the next available low value in the sequence.  