### PR TITLE
Inheritance - Initial impl. of relational query support:

### DIFF
--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -128,6 +128,8 @@
     <Compile Include="Internal\DbContextServices.cs" />
     <Compile Include="ModelBuilder.cs" />
     <Compile Include="Query\EntityLoadInfo.cs" />
+    <Compile Include="Query\ExpressionTreeVisitors\ExpressionStringBuilder.cs" />
+    <Compile Include="Query\ExpressionTreeVisitors\ExpressionTreeVisitorBase.cs" />
     <Compile Include="Query\IIncludableQueryable.cs" />
     <Compile Include="Infrastructure\DbContextActivator.cs" />
     <Compile Include="DbContextOptions.cs" />

--- a/src/EntityFramework.Core/Metadata/IMetadata.cs
+++ b/src/EntityFramework.Core/Metadata/IMetadata.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Data.Entity.Metadata
     public interface IMetadata
     {
         string this[[NotNull] string annotationName] { get; }
+        Annotation GetAnnotation([NotNull] string annotationName);
         IEnumerable<IAnnotation> Annotations { get; }
     }
 }

--- a/src/EntityFramework.Core/Metadata/MetadataBase.cs
+++ b/src/EntityFramework.Core/Metadata/MetadataBase.cs
@@ -53,8 +53,10 @@ namespace Microsoft.Data.Entity.Metadata
                 : null;
         }
 
-        public virtual Annotation GetAnnotation([NotNull] string annotationName)
+        public virtual Annotation GetAnnotation(string annotationName)
         {
+            Check.NotEmpty(annotationName, nameof(annotationName));
+
             var annotation = TryGetAnnotation(annotationName);
             if (annotation == null)
             {
@@ -83,11 +85,7 @@ namespace Microsoft.Data.Entity.Metadata
         // ReSharper disable once AnnotationRedundanceInHierarchy
         public virtual string this[[NotNull] string annotationName]
         {
-            get
-            {
-                var annotation = TryGetAnnotation(annotationName);
-                return annotation == null ? null : annotation.Value;
-            }
+            get { return TryGetAnnotation(annotationName)?.Value; }
             [param: CanBeNull]
             set
             {
@@ -103,14 +101,9 @@ namespace Microsoft.Data.Entity.Metadata
         }
 
         public virtual IEnumerable<Annotation> Annotations
-        {
-            get
-            {
-                return _annotations.HasValue
-                    ? (IEnumerable<Annotation>)_annotations.Value
-                    : ImmutableList<Annotation>.Empty;
-            }
-        }
+            => _annotations.HasValue
+                ? (IEnumerable<Annotation>)_annotations.Value
+                : ImmutableList<Annotation>.Empty;
 
         private class AnnotationComparer : IComparer<IAnnotation>
         {
@@ -120,9 +113,6 @@ namespace Microsoft.Data.Entity.Metadata
             }
         }
 
-        IEnumerable<IAnnotation> IMetadata.Annotations
-        {
-            get { return Annotations; }
-        }
+        IEnumerable<IAnnotation> IMetadata.Annotations => Annotations;
     }
 }

--- a/src/EntityFramework.Core/Query/AsyncLinqOperatorProvider.cs
+++ b/src/EntityFramework.Core/Query/AsyncLinqOperatorProvider.cs
@@ -337,6 +337,7 @@ namespace Microsoft.Data.Entity.Query
         private static readonly MethodInfo _last = GetMethod("Last");
         private static readonly MethodInfo _lastOrDefault = GetMethod("LastOrDefault");
         private static readonly MethodInfo _longCount = GetMethod("LongCount");
+        private static readonly MethodInfo _ofType = GetMethod("OfType");
         private static readonly MethodInfo _single = GetMethod("Single");
         private static readonly MethodInfo _singleOrDefault = GetMethod("SingleOrDefault");
         private static readonly MethodInfo _skip = GetMethod("Skip", 1);
@@ -345,6 +346,7 @@ namespace Microsoft.Data.Entity.Query
         public virtual MethodInfo Last => _last;
         public virtual MethodInfo LastOrDefault => _lastOrDefault;
         public virtual MethodInfo LongCount => _longCount;
+        public virtual MethodInfo OfType => _ofType;
         public virtual MethodInfo Single => _single;
         public virtual MethodInfo SingleOrDefault => _singleOrDefault;
         public virtual MethodInfo Skip => _skip;

--- a/src/EntityFramework.Core/Query/CompiledQueryCache.cs
+++ b/src/EntityFramework.Core/Query/CompiledQueryCache.cs
@@ -11,13 +11,13 @@ using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Internal;
+using Microsoft.Data.Entity.Query.ExpressionTreeVisitors;
 using Microsoft.Data.Entity.Query.ResultOperators;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Cache.Memory;
 using Remotion.Linq;
 using Remotion.Linq.Clauses.StreamedData;
-using Remotion.Linq.Parsing;
 using Remotion.Linq.Parsing.ExpressionTreeVisitors.Transformation;
 using Remotion.Linq.Parsing.ExpressionTreeVisitors.TreeEvaluation;
 using Remotion.Linq.Parsing.Structure;
@@ -144,7 +144,8 @@ namespace Microsoft.Data.Entity.Query
             var cacheKey
                 = dataStore.Model.GetHashCode().ToString()
                   + isAsync
-                  + query;
+                  + new ExpressionStringBuilder()
+                      .Build(query);
 
             var compiledQuery
                 = _memoryCache.GetOrSet(
@@ -160,7 +161,7 @@ namespace Microsoft.Data.Entity.Query
             return compiledQuery;
         }
 
-        private class ParameterExtractingExpressionTreeVisitor : ExpressionTreeVisitor
+        private class ParameterExtractingExpressionTreeVisitor : ExpressionTreeVisitorBase
         {
             public static Expression ExtractParameters(Expression expressionTree, QueryContext queryContext)
             {

--- a/src/EntityFramework.Core/Query/EntityQueryModelVisitor.cs
+++ b/src/EntityFramework.Core/Query/EntityQueryModelVisitor.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Data.Entity.Query
             protected set
             {
                 Check.NotNull(value, nameof(value));
-
+                
                 _expression = value;
             }
         }

--- a/src/EntityFramework.Core/Query/ExpressionTreeVisitors/DefaultQueryExpressionTreeVisitor.cs
+++ b/src/EntityFramework.Core/Query/ExpressionTreeVisitors/DefaultQueryExpressionTreeVisitor.cs
@@ -6,11 +6,10 @@ using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Utilities;
 using Remotion.Linq.Clauses.Expressions;
-using Remotion.Linq.Parsing;
 
 namespace Microsoft.Data.Entity.Query.ExpressionTreeVisitors
 {
-    public class DefaultQueryExpressionTreeVisitor : ExpressionTreeVisitor
+    public class DefaultQueryExpressionTreeVisitor : ExpressionTreeVisitorBase
     {
         private readonly EntityQueryModelVisitor _entityQueryModelVisitor;
 

--- a/src/EntityFramework.Core/Query/ExpressionTreeVisitors/EntityResultFindingExpressionTreeVisitor.cs
+++ b/src/EntityFramework.Core/Query/ExpressionTreeVisitors/EntityResultFindingExpressionTreeVisitor.cs
@@ -7,11 +7,10 @@ using JetBrains.Annotations;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Utilities;
 using Remotion.Linq.Clauses.Expressions;
-using Remotion.Linq.Parsing;
 
 namespace Microsoft.Data.Entity.Query.ExpressionTreeVisitors
 {
-    public class EntityResultFindingExpressionTreeVisitor : ExpressionTreeVisitor
+    public class EntityResultFindingExpressionTreeVisitor : ExpressionTreeVisitorBase
     {
         private readonly IModel _model;
 

--- a/src/EntityFramework.Core/Query/ExpressionTreeVisitors/ExpressionStringBuilder.cs
+++ b/src/EntityFramework.Core/Query/ExpressionTreeVisitors/ExpressionStringBuilder.cs
@@ -1,0 +1,859 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Query.ExpressionTreeVisitors
+{
+    public class ExpressionStringBuilder : ExpressionVisitor
+    {
+        private readonly StringBuilder _out;
+
+        // Associate every unique label or anonymous parameter in the tree with an integer.
+        // The label is displayed as Label_#.
+        private Dictionary<object, int> _ids;
+
+        public ExpressionStringBuilder()
+        {
+            _out = new StringBuilder();
+        }
+
+        public virtual string Build([NotNull] Expression node)
+        {
+            Check.NotNull(node, nameof(node));
+
+            var expressionStringBuilder = new ExpressionStringBuilder();
+
+            expressionStringBuilder.Visit(node);
+
+            return expressionStringBuilder.ToString();
+        }
+
+        public override string ToString()
+        {
+            return _out.ToString();
+        }
+
+        private void AddLabel(LabelTarget label)
+        {
+            if (_ids == null)
+            {
+                _ids = new Dictionary<object, int> { { label, 0 } };
+            }
+            else
+            {
+                if (!_ids.ContainsKey(label))
+                {
+                    _ids.Add(label, _ids.Count);
+                }
+            }
+        }
+
+        private int GetLabelId(LabelTarget label)
+        {
+            if (_ids == null)
+            {
+                _ids = new Dictionary<object, int>();
+                AddLabel(label);
+                return 0;
+            }
+            int id;
+            if (!_ids.TryGetValue(label, out id))
+            {
+                //label is met the first time
+                id = _ids.Count;
+                AddLabel(label);
+            }
+            return id;
+        }
+
+        private void AddParam(ParameterExpression p)
+        {
+            if (_ids == null)
+            {
+                _ids = new Dictionary<object, int>();
+                _ids.Add(_ids, 0);
+            }
+            else
+            {
+                if (!_ids.ContainsKey(p))
+                {
+                    _ids.Add(p, _ids.Count);
+                }
+            }
+        }
+
+        private int GetParamId(ParameterExpression p)
+        {
+            if (_ids == null)
+            {
+                _ids = new Dictionary<object, int>();
+                AddParam(p);
+                return 0;
+            }
+            int id;
+            if (!_ids.TryGetValue(p, out id))
+            {
+                // p is met the first time
+                id = _ids.Count;
+                AddParam(p);
+            }
+            return id;
+        }
+
+        private void Out(string s)
+        {
+            _out.Append(s);
+        }
+
+        private void Out(char c)
+        {
+            _out.Append(c);
+        }
+
+        private void VisitExpressions<T>(char open, IList<T> expressions, char close, string seperator = ", ")
+            where T : Expression
+        {
+            Out(open);
+            if (expressions != null)
+            {
+                var isFirst = true;
+                foreach (var e in expressions)
+                {
+                    if (isFirst)
+                    {
+                        isFirst = false;
+                    }
+                    else
+                    {
+                        Out(seperator);
+                    }
+                    Visit(e);
+                }
+            }
+            Out(close);
+        }
+
+        protected override Expression VisitBinary(BinaryExpression node)
+        {
+            if (node.NodeType == ExpressionType.ArrayIndex)
+            {
+                Visit(node.Left);
+                Out("[");
+                Visit(node.Right);
+                Out("]");
+            }
+            else
+            {
+                string op;
+                switch (node.NodeType)
+                {
+                    case ExpressionType.AndAlso:
+                        op = "AndAlso";
+                        break;
+                    case ExpressionType.OrElse:
+                        op = "OrElse";
+                        break;
+                    case ExpressionType.Assign:
+                        op = "=";
+                        break;
+                    case ExpressionType.Equal:
+                        op = "==";
+                        break;
+                    case ExpressionType.NotEqual:
+                        op = "!=";
+                        break;
+                    case ExpressionType.GreaterThan:
+                        op = ">";
+                        break;
+                    case ExpressionType.LessThan:
+                        op = "<";
+                        break;
+                    case ExpressionType.GreaterThanOrEqual:
+                        op = ">=";
+                        break;
+                    case ExpressionType.LessThanOrEqual:
+                        op = "<=";
+                        break;
+                    case ExpressionType.Add:
+                        op = "+";
+                        break;
+                    case ExpressionType.AddAssign:
+                        op = "+=";
+                        break;
+                    case ExpressionType.AddAssignChecked:
+                        op = "+=";
+                        break;
+                    case ExpressionType.AddChecked:
+                        op = "+";
+                        break;
+                    case ExpressionType.Subtract:
+                        op = "-";
+                        break;
+                    case ExpressionType.SubtractAssign:
+                        op = "-=";
+                        break;
+                    case ExpressionType.SubtractAssignChecked:
+                        op = "-=";
+                        break;
+                    case ExpressionType.SubtractChecked:
+                        op = "-";
+                        break;
+                    case ExpressionType.Divide:
+                        op = "/";
+                        break;
+                    case ExpressionType.DivideAssign:
+                        op = "/=";
+                        break;
+                    case ExpressionType.Modulo:
+                        op = "%";
+                        break;
+                    case ExpressionType.ModuloAssign:
+                        op = "%=";
+                        break;
+                    case ExpressionType.Multiply:
+                        op = "*";
+                        break;
+                    case ExpressionType.MultiplyAssign:
+                        op = "*=";
+                        break;
+                    case ExpressionType.MultiplyAssignChecked:
+                        op = "*=";
+                        break;
+                    case ExpressionType.MultiplyChecked:
+                        op = "*";
+                        break;
+                    case ExpressionType.LeftShift:
+                        op = "<<";
+                        break;
+                    case ExpressionType.LeftShiftAssign:
+                        op = "<<=";
+                        break;
+                    case ExpressionType.RightShift:
+                        op = ">>";
+                        break;
+                    case ExpressionType.RightShiftAssign:
+                        op = ">>=";
+                        break;
+                    case ExpressionType.And:
+                        if (node.Type == typeof(bool)
+                            || node.Type == typeof(bool?))
+                        {
+                            op = "And";
+                        }
+                        else
+                        {
+                            op = "&";
+                        }
+                        break;
+                    case ExpressionType.AndAssign:
+                        if (node.Type == typeof(bool)
+                            || node.Type == typeof(bool?))
+                        {
+                            op = "&&=";
+                        }
+                        else
+                        {
+                            op = "&=";
+                        }
+                        break;
+                    case ExpressionType.Or:
+                        if (node.Type == typeof(bool)
+                            || node.Type == typeof(bool?))
+                        {
+                            op = "Or";
+                        }
+                        else
+                        {
+                            op = "|";
+                        }
+                        break;
+                    case ExpressionType.OrAssign:
+                        if (node.Type == typeof(bool)
+                            || node.Type == typeof(bool?))
+                        {
+                            op = "||=";
+                        }
+                        else
+                        {
+                            op = "|=";
+                        }
+                        break;
+                    case ExpressionType.ExclusiveOr:
+                        op = "^";
+                        break;
+                    case ExpressionType.ExclusiveOrAssign:
+                        op = "^=";
+                        break;
+                    case ExpressionType.Power:
+                        op = "^";
+                        break;
+                    case ExpressionType.PowerAssign:
+                        op = "**=";
+                        break;
+                    case ExpressionType.Coalesce:
+                        op = "??";
+                        break;
+
+                    default:
+                        throw new InvalidOperationException();
+                }
+                Out("(");
+                Visit(node.Left);
+                Out(' ');
+                Out(op);
+                Out(' ');
+                Visit(node.Right);
+                Out(")");
+            }
+            return node;
+        }
+
+        protected override Expression VisitParameter(ParameterExpression node)
+        {
+            if (node.IsByRef)
+            {
+                Out("ref ");
+            }
+            var name = node.Name;
+            if (string.IsNullOrEmpty(name))
+            {
+                Out("Param_" + GetParamId(node));
+            }
+            else
+            {
+                Out(name);
+            }
+            return node;
+        }
+
+        protected override Expression VisitLambda<T>(Expression<T> node)
+        {
+            if (node.Parameters.Count == 1)
+            {
+                // p => body
+                Visit(node.Parameters[0]);
+            }
+            else
+            {
+                // (p1, p2, ..., pn) => body
+                VisitExpressions('(', node.Parameters, ')');
+            }
+            Out(" => ");
+            Visit(node.Body);
+            return node;
+        }
+
+        protected override Expression VisitListInit(ListInitExpression node)
+        {
+            Visit(node.NewExpression);
+            Out(" {");
+            for (int i = 0, n = node.Initializers.Count; i < n; i++)
+            {
+                if (i > 0)
+                {
+                    Out(", ");
+                }
+                Out(node.Initializers[i].ToString());
+            }
+            Out("}");
+            return node;
+        }
+
+        protected override Expression VisitConditional(ConditionalExpression node)
+        {
+            Out("IIF(");
+            Visit(node.Test);
+            Out(", ");
+            Visit(node.IfTrue);
+            Out(", ");
+            Visit(node.IfFalse);
+            Out(")");
+            return node;
+        }
+
+        protected override Expression VisitConstant(ConstantExpression node)
+        {
+            if (node.Value != null)
+            {
+                var sValue = node.Value.ToString();
+                if (node.Value is string)
+                {
+                    Out("\"");
+                    Out(sValue);
+                    Out("\"");
+                }
+                else if (sValue == node.Value.GetType().ToString())
+                {
+                    Out("value(");
+                    Out(sValue);
+                    Out(")");
+                }
+                else
+                {
+                    Out(sValue);
+                }
+            }
+            else
+            {
+                Out("null");
+            }
+            return node;
+        }
+
+        protected override Expression VisitDebugInfo(DebugInfoExpression node)
+        {
+            var s = string.Format(
+                CultureInfo.CurrentCulture,
+                "<DebugInfo({0}: {1}, {2}, {3}, {4})>",
+                node.Document.FileName,
+                node.StartLine,
+                node.StartColumn,
+                node.EndLine,
+                node.EndColumn
+                );
+            Out(s);
+            return node;
+        }
+
+        protected override Expression VisitRuntimeVariables(RuntimeVariablesExpression node)
+        {
+            VisitExpressions('(', node.Variables, ')');
+            return node;
+        }
+
+        // Prints ".instanceField" or "declaringType.staticField"
+        private void OutMember(Expression instance, MemberInfo member)
+        {
+            if (instance != null)
+            {
+                Visit(instance);
+                Out("." + member.Name);
+            }
+            else
+            {
+                // For static members, include the type name
+                Out(member.DeclaringType.Name + "." + member.Name);
+            }
+        }
+
+        protected override Expression VisitMember(MemberExpression node)
+        {
+            OutMember(node.Expression, node.Member);
+            return node;
+        }
+
+        protected override Expression VisitMemberInit(MemberInitExpression node)
+        {
+            if (node.NewExpression.Arguments.Count == 0
+                &&
+                node.NewExpression.Type.Name.Contains("<"))
+            {
+                // anonymous type constructor
+                Out("new");
+            }
+            else
+            {
+                Visit(node.NewExpression);
+            }
+            Out(" {");
+            for (int i = 0, n = node.Bindings.Count; i < n; i++)
+            {
+                var b = node.Bindings[i];
+                if (i > 0)
+                {
+                    Out(", ");
+                }
+                VisitMemberBinding(b);
+            }
+            Out("}");
+            return node;
+        }
+
+        protected override MemberAssignment VisitMemberAssignment(MemberAssignment assignment)
+        {
+            Out(assignment.Member.Name);
+            Out(" = ");
+            Visit(assignment.Expression);
+            return assignment;
+        }
+
+        protected override MemberListBinding VisitMemberListBinding(MemberListBinding binding)
+        {
+            Out(binding.Member.Name);
+            Out(" = {");
+            for (int i = 0, n = binding.Initializers.Count; i < n; i++)
+            {
+                if (i > 0)
+                {
+                    Out(", ");
+                }
+                VisitElementInit(binding.Initializers[i]);
+            }
+            Out("}");
+            return binding;
+        }
+
+        protected override MemberMemberBinding VisitMemberMemberBinding(MemberMemberBinding binding)
+        {
+            Out(binding.Member.Name);
+            Out(" = {");
+            for (int i = 0, n = binding.Bindings.Count; i < n; i++)
+            {
+                if (i > 0)
+                {
+                    Out(", ");
+                }
+                VisitMemberBinding(binding.Bindings[i]);
+            }
+            Out("}");
+            return binding;
+        }
+
+        protected override ElementInit VisitElementInit(ElementInit initializer)
+        {
+            Out(initializer.AddMethod.ToString());
+
+            VisitExpressions('(', initializer.Arguments, ')');
+            return initializer;
+        }
+
+        protected override Expression VisitInvocation(InvocationExpression node)
+        {
+            Out("Invoke(");
+            Visit(node.Expression);
+            const string sep = ", ";
+            for (int i = 0, n = node.Arguments.Count; i < n; i++)
+            {
+                Out(sep);
+                Visit(node.Arguments[i]);
+            }
+            Out(")");
+            return node;
+        }
+
+        protected override Expression VisitMethodCall(MethodCallExpression node)
+        {
+            var start = 0;
+            var ob = node.Object;
+
+            if (node.Method.GetCustomAttribute<ExtensionAttribute>() != null)
+            {
+                start = 1;
+                ob = node.Arguments[0];
+            }
+
+            if (ob != null)
+            {
+                Visit(ob);
+                Out(".");
+            }
+            Out(node.Method.Name);
+
+            if (node.Method.IsGenericMethod)
+            {
+                Out("[");
+                var genericArguments = node.Method.GetGenericArguments();
+                for (int i = 0, n = genericArguments.Length; i < n; i++)
+                {
+                    if (i > start)
+                    {
+                        Out(", ");
+                    }
+                    Out(genericArguments[i].Name);
+                }
+                Out("]");
+            }
+
+            Out("(");
+            for (int i = start, n = node.Arguments.Count; i < n; i++)
+            {
+                if (i > start)
+                {
+                    Out(", ");
+                }
+                Visit(node.Arguments[i]);
+            }
+            Out(")");
+            return node;
+        }
+
+        protected override Expression VisitNewArray(NewArrayExpression node)
+        {
+            switch (node.NodeType)
+            {
+                case ExpressionType.NewArrayBounds:
+                    // new MyType[](expr1, expr2)
+                    Out("new " + node.Type);
+                    VisitExpressions('(', node.Expressions, ')');
+                    break;
+                case ExpressionType.NewArrayInit:
+                    // new [] {expr1, expr2}
+                    Out("new [] ");
+                    VisitExpressions('{', node.Expressions, '}');
+                    break;
+            }
+            return node;
+        }
+
+        protected override Expression VisitNew(NewExpression node)
+        {
+            Out("new " + node.Type.Name);
+            Out("(");
+            var members = node.Members;
+            for (var i = 0; i < node.Arguments.Count; i++)
+            {
+                if (i > 0)
+                {
+                    Out(", ");
+                }
+                if (members != null)
+                {
+                    var name = members[i].Name;
+                    Out(name);
+                    Out(" = ");
+                }
+                Visit(node.Arguments[i]);
+            }
+            Out(")");
+            return node;
+        }
+
+        protected override Expression VisitTypeBinary(TypeBinaryExpression node)
+        {
+            Out("(");
+            Visit(node.Expression);
+            switch (node.NodeType)
+            {
+                case ExpressionType.TypeIs:
+                    Out(" Is ");
+                    break;
+                case ExpressionType.TypeEqual:
+                    Out(" TypeEqual ");
+                    break;
+            }
+            Out(node.TypeOperand.Name);
+            Out(")");
+            return node;
+        }
+
+        protected override Expression VisitUnary(UnaryExpression node)
+        {
+            switch (node.NodeType)
+            {
+                case ExpressionType.TypeAs:
+                    Out("(");
+                    break;
+                case ExpressionType.Not:
+                    Out("Not(");
+                    break;
+                case ExpressionType.Negate:
+                case ExpressionType.NegateChecked:
+                    Out("-");
+                    break;
+                case ExpressionType.UnaryPlus:
+                    Out("+");
+                    break;
+                case ExpressionType.Quote:
+                    break;
+                case ExpressionType.Throw:
+                    Out("throw(");
+                    break;
+                case ExpressionType.Increment:
+                    Out("Increment(");
+                    break;
+                case ExpressionType.Decrement:
+                    Out("Decrement(");
+                    break;
+                case ExpressionType.PreIncrementAssign:
+                    Out("++");
+                    break;
+                case ExpressionType.PreDecrementAssign:
+                    Out("--");
+                    break;
+                case ExpressionType.OnesComplement:
+                    Out("~(");
+                    break;
+                default:
+                    Out(node.NodeType.ToString());
+                    Out("(");
+                    break;
+            }
+
+            Visit(node.Operand);
+
+            switch (node.NodeType)
+            {
+                case ExpressionType.Negate:
+                case ExpressionType.NegateChecked:
+                case ExpressionType.UnaryPlus:
+                case ExpressionType.PreDecrementAssign:
+                case ExpressionType.PreIncrementAssign:
+                case ExpressionType.Quote:
+                    break;
+                case ExpressionType.TypeAs:
+                    Out(" As ");
+                    Out(node.Type.Name);
+                    Out(")");
+                    break;
+                case ExpressionType.PostIncrementAssign:
+                    Out("++");
+                    break;
+                case ExpressionType.PostDecrementAssign:
+                    Out("--");
+                    break;
+                default:
+                    Out(")");
+                    break;
+            }
+            return node;
+        }
+
+        protected override Expression VisitBlock(BlockExpression node)
+        {
+            Out("{");
+            foreach (var v in node.Variables)
+            {
+                Out("var ");
+                Visit(v);
+                Out(";");
+            }
+            Out(" ... }");
+            return node;
+        }
+
+        protected override Expression VisitDefault(DefaultExpression node)
+        {
+            Out("default(");
+            Out(node.Type.Name);
+            Out(")");
+            return node;
+        }
+
+        protected override Expression VisitLabel(LabelExpression node)
+        {
+            Out("{ ... } ");
+            DumpLabel(node.Target);
+            Out(":");
+            return node;
+        }
+
+        protected override Expression VisitGoto(GotoExpression node)
+        {
+            Out(node.Kind.ToString().ToLowerInvariant());
+            DumpLabel(node.Target);
+            if (node.Value != null)
+            {
+                Out(" (");
+                Visit(node.Value);
+                Out(") ");
+            }
+            return node;
+        }
+
+        protected override Expression VisitLoop(LoopExpression node)
+        {
+            Out("loop { ... }");
+            return node;
+        }
+
+        protected override SwitchCase VisitSwitchCase(SwitchCase node)
+        {
+            Out("case ");
+            VisitExpressions('(', node.TestValues, ')');
+            Out(": ...");
+            return node;
+        }
+
+        protected override Expression VisitSwitch(SwitchExpression node)
+        {
+            Out("switch ");
+            Out("(");
+            Visit(node.SwitchValue);
+            Out(") { ... }");
+            return node;
+        }
+
+        protected override CatchBlock VisitCatchBlock(CatchBlock node)
+        {
+            Out("catch (" + node.Test.Name);
+            if (node.Variable != null)
+            {
+                Out(node.Variable.Name ?? "");
+            }
+            Out(") { ... }");
+            return node;
+        }
+
+        protected override Expression VisitTry(TryExpression node)
+        {
+            Out("try { ... }");
+            return node;
+        }
+
+        protected override Expression VisitIndex(IndexExpression node)
+        {
+            if (node.Object != null)
+            {
+                Visit(node.Object);
+            }
+            else
+            {
+                Debug.Assert(node.Indexer != null);
+                Out(node.Indexer.DeclaringType.Name);
+            }
+            if (node.Indexer != null)
+            {
+                Out(".");
+                Out(node.Indexer.Name);
+            }
+
+            VisitExpressions('[', node.Arguments, ']');
+            return node;
+        }
+
+        protected override Expression VisitExtension(Expression node)
+        {
+            // Prefer an overriden ToString, if available.
+            var toString = node.GetType().GetRuntimeMethod("ToString", new Type[0]);
+
+            if (toString.DeclaringType != typeof(Expression))
+            {
+                Out(node.ToString());
+                return node;
+            }
+
+            Out("[");
+
+            Out(node.NodeType == ExpressionType.Extension
+                ? node.GetType().FullName
+                : node.NodeType.ToString());
+
+            Out("]");
+
+            return node;
+        }
+
+        private void DumpLabel(LabelTarget target)
+        {
+            if (!string.IsNullOrEmpty(target.Name))
+            {
+                Out(target.Name);
+            }
+            else
+            {
+                var labelId = GetLabelId(target);
+                Out("UnamedLabel_" + labelId);
+            }
+        }
+    }
+}

--- a/src/EntityFramework.Core/Query/ExpressionTreeVisitors/ExpressionTreeVisitorBase.cs
+++ b/src/EntityFramework.Core/Query/ExpressionTreeVisitors/ExpressionTreeVisitorBase.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Remotion.Linq.Parsing;
+
+namespace Microsoft.Data.Entity.Query.ExpressionTreeVisitors
+{
+    public abstract class ExpressionTreeVisitorBase : ExpressionTreeVisitor
+    {
+        public override Expression VisitExpression([CanBeNull] Expression expression)
+        {
+            return
+                expression == null
+                || expression.NodeType == ExpressionType.Block
+                    ? expression
+                    : base.VisitExpression(expression);
+        }
+    }
+}

--- a/src/EntityFramework.Core/Query/ExpressionTreeVisitors/QuerySourceTracingExpressionTreeVisitor.cs
+++ b/src/EntityFramework.Core/Query/ExpressionTreeVisitors/QuerySourceTracingExpressionTreeVisitor.cs
@@ -6,11 +6,10 @@ using JetBrains.Annotations;
 using Microsoft.Data.Entity.Utilities;
 using Remotion.Linq.Clauses;
 using Remotion.Linq.Clauses.Expressions;
-using Remotion.Linq.Parsing;
 
 namespace Microsoft.Data.Entity.Query.ExpressionTreeVisitors
 {
-    public class QuerySourceTracingExpressionTreeVisitor : ExpressionTreeVisitor
+    public class QuerySourceTracingExpressionTreeVisitor : ExpressionTreeVisitorBase
     {
         private IQuerySource _targetQuerySource;
         private QuerySourceReferenceExpression _originQuerySourceReferenceExpression;

--- a/src/EntityFramework.Core/Query/ExpressionTreeVisitors/RequiresMaterializationExpressionTreeVisitor.cs
+++ b/src/EntityFramework.Core/Query/ExpressionTreeVisitors/RequiresMaterializationExpressionTreeVisitor.cs
@@ -8,11 +8,10 @@ using JetBrains.Annotations;
 using Microsoft.Data.Entity.Utilities;
 using Remotion.Linq.Clauses;
 using Remotion.Linq.Clauses.Expressions;
-using Remotion.Linq.Parsing;
 
 namespace Microsoft.Data.Entity.Query.ExpressionTreeVisitors
 {
-    public class RequiresMaterializationExpressionTreeVisitor : ExpressionTreeVisitor
+    public class RequiresMaterializationExpressionTreeVisitor : ExpressionTreeVisitorBase
     {
         private readonly EntityQueryModelVisitor _queryModelVisitor;
         private readonly Dictionary<IQuerySource, int> _querySources = new Dictionary<IQuerySource, int>();

--- a/src/EntityFramework.Core/Query/ExpressionTreeVisitors/TaskBlockingExpressionTreeVisitor.cs
+++ b/src/EntityFramework.Core/Query/ExpressionTreeVisitors/TaskBlockingExpressionTreeVisitor.cs
@@ -5,11 +5,10 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
-using Remotion.Linq.Parsing;
 
 namespace Microsoft.Data.Entity.Query.ExpressionTreeVisitors
 {
-    public class TaskBlockingExpressionTreeVisitor : ExpressionTreeVisitor
+    public class TaskBlockingExpressionTreeVisitor : ExpressionTreeVisitorBase
     {
         public override Expression VisitExpression([CanBeNull] Expression expression)
         {

--- a/src/EntityFramework.Core/Query/ILinqOperatorProvider.cs
+++ b/src/EntityFramework.Core/Query/ILinqOperatorProvider.cs
@@ -39,10 +39,9 @@ namespace Microsoft.Data.Entity.Query
         MethodInfo AsQueryable { get; }
         MethodInfo TrackEntities { get; }
         MethodInfo InterceptExceptions { get; }
+        MethodInfo OfType { get; }
 
-        MethodInfo GetAggregateMethod(
-            [NotNull] string methodName, [NotNull] Type elementType);
-
+        MethodInfo GetAggregateMethod([NotNull] string methodName, [NotNull] Type elementType);
         Expression AdjustSequenceType([NotNull] Expression expression);
     }
 }

--- a/src/EntityFramework.Core/Query/LinqOperatorProvider.cs
+++ b/src/EntityFramework.Core/Query/LinqOperatorProvider.cs
@@ -300,6 +300,7 @@ namespace Microsoft.Data.Entity.Query
         private static readonly MethodInfo _last = GetMethod("Last");
         private static readonly MethodInfo _lastOrDefault = GetMethod("LastOrDefault");
         private static readonly MethodInfo _longCount = GetMethod("LongCount");
+        private static readonly MethodInfo _ofType = GetMethod("OfType");
         private static readonly MethodInfo _single = GetMethod("Single");
         private static readonly MethodInfo _singleOrDefault = GetMethod("SingleOrDefault");
         private static readonly MethodInfo _skip = GetMethod("Skip", 1);
@@ -308,6 +309,7 @@ namespace Microsoft.Data.Entity.Query
         public virtual MethodInfo Last => _last;
         public virtual MethodInfo LastOrDefault => _lastOrDefault;
         public virtual MethodInfo LongCount => _longCount;
+        public virtual MethodInfo OfType => _ofType;
         public virtual MethodInfo Single => _single;
         public virtual MethodInfo SingleOrDefault => _singleOrDefault;
         public virtual MethodInfo Skip => _skip;

--- a/src/EntityFramework.Core/Query/QueryOptimizer.cs
+++ b/src/EntityFramework.Core/Query/QueryOptimizer.cs
@@ -68,7 +68,8 @@ namespace Microsoft.Data.Entity.Query
 
             VisitQueryModel(subQueryModel);
 
-            if (subQueryModel.ResultOperators.Any()
+            if (subQueryModel.ResultOperators
+                .Any(ro => !(ro is OfTypeResultOperator))
                 || subQueryModel.BodyClauses.Any(bc => bc is OrderByClause))
             {
                 return;
@@ -96,6 +97,11 @@ namespace Microsoft.Data.Entity.Query
 
             queryModel.TransformExpressions(ex =>
                 ReferenceReplacingExpressionTreeVisitor.ReplaceClauseReferences(ex, innerBodyClauseMapping, false));
+
+            foreach (var resultOperator in subQueryModel.ResultOperators.Reverse())
+            {
+                queryModel.ResultOperators.Insert(0, resultOperator);
+            }
 
             foreach (var queryAnnotation 
                 in _queryAnnotations

--- a/src/EntityFramework.Core/Query/ResultOperatorHandler.cs
+++ b/src/EntityFramework.Core/Query/ResultOperatorHandler.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Data.Entity.Query
                     { typeof(LongCountResultOperator), (v, _, __) => HandleLongCount(v) },
                     { typeof(MinResultOperator), (v, _, __) => HandleMin(v) },
                     { typeof(MaxResultOperator), (v, _, __) => HandleMax(v) },
+                    { typeof(OfTypeResultOperator), (v, r, q) => HandleOfType(v, (OfTypeResultOperator)r) },
                     { typeof(SingleResultOperator), (v, r, __) => HandleSingle(v, (ChoiceResultOperatorBase)r) },
                     { typeof(SkipResultOperator), (v, r, __) => HandleSkip(v, (SkipResultOperator)r) },
                     { typeof(SumResultOperator), (v, _, __) => HandleSum(v) },
@@ -236,6 +237,16 @@ namespace Microsoft.Data.Entity.Query
         private static Expression HandleMax(EntityQueryModelVisitor entityQueryModelVisitor)
         {
             return HandleAggregate(entityQueryModelVisitor, "Max");
+        }
+
+        private static Expression HandleOfType(
+           EntityQueryModelVisitor entityQueryModelVisitor,
+           OfTypeResultOperator ofTypeResultOperator)
+        {
+            return Expression.Call(
+                entityQueryModelVisitor.LinqOperatorProvider.OfType
+                    .MakeGenericMethod(ofTypeResultOperator.SearchedItemType),
+                entityQueryModelVisitor.Expression);
         }
 
         private static Expression HandleSingle(

--- a/src/EntityFramework.Relational/EntityFramework.Relational.csproj
+++ b/src/EntityFramework.Relational/EntityFramework.Relational.csproj
@@ -141,6 +141,7 @@
     <Compile Include="Query\CommandBuilder.cs" />
     <Compile Include="Query\CommandParameter.cs" />
     <Compile Include="Query\Expressions\ColumnAggregateExpression.cs" />
+    <Compile Include="Query\Expressions\DiscriminatorPredicateExpression.cs" />
     <Compile Include="Query\Expressions\JoinExpressionBase.cs" />
     <Compile Include="Query\Expressions\LeftOuterJoinExpression.cs" />
     <Compile Include="Query\Expressions\MaxExpression.cs" />
@@ -150,6 +151,7 @@
     <Compile Include="Query\ExpressionTreeVisitors\FilteringExpressionTreeVisitor.cs" />
     <Compile Include="Query\AsyncIncludeCollectionIterator.cs" />
     <Compile Include="Query\ExpressionTreeVisitors\IncludeExpressionTreeVisitor.cs" />
+    <Compile Include="Query\ExpressionTreeVisitors\MaterializerFactory.cs" />
     <Compile Include="Query\IAsyncIncludeRelatedValuesStrategy.cs" />
     <Compile Include="Query\IIncludeRelatedValuesStrategy.cs" />
     <Compile Include="Query\IncludeCollectionIterator.cs" />

--- a/src/EntityFramework.Relational/Metadata/IRelationalEntityTypeExtensions.cs
+++ b/src/EntityFramework.Relational/Metadata/IRelationalEntityTypeExtensions.cs
@@ -1,15 +1,15 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
 
 namespace Microsoft.Data.Entity.Relational.Metadata
 {
     public interface IRelationalEntityTypeExtensions
     {
         string Table { get; }
-
-        [CanBeNull]
         string Schema { get; }
+        IProperty DiscriminatorProperty { get; }
+        string DiscriminatorValue { get; } // TODO: should be object
     }
 }

--- a/src/EntityFramework.Relational/Metadata/ReadOnlyRelationalEntityTypeExtensions.cs
+++ b/src/EntityFramework.Relational/Metadata/ReadOnlyRelationalEntityTypeExtensions.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Data.Entity.Relational.Metadata
     {
         protected const string RelationalTableAnnotation = RelationalAnnotationNames.Prefix + RelationalAnnotationNames.TableName;
         protected const string RelationalSchemaAnnotation = RelationalAnnotationNames.Prefix + RelationalAnnotationNames.Schema;
+        protected const string DiscriminatorPropertyAnnotation = RelationalAnnotationNames.Prefix + RelationalAnnotationNames.DiscriminatorProperty;
+        protected const string DiscriminatorValueAnnotation = RelationalAnnotationNames.Prefix + RelationalAnnotationNames.DiscriminatorValue;
 
         private readonly IEntityType _entityType;
 
@@ -21,19 +23,19 @@ namespace Microsoft.Data.Entity.Relational.Metadata
             _entityType = entityType;
         }
 
-        public virtual string Table
-        {
-            get { return _entityType[RelationalTableAnnotation] ?? _entityType.SimpleName; }
-        }
+        public virtual string Table => _entityType.RootType[RelationalTableAnnotation] ?? _entityType.RootType.SimpleName;
 
-        public virtual string Schema
-        {
-            get { return _entityType[RelationalSchemaAnnotation]; }
-        }
+        public virtual string Schema => _entityType.RootType[RelationalSchemaAnnotation];
 
-        protected virtual IEntityType EntityType
-        {
-            get { return _entityType; }
-        }
+        public virtual IProperty DiscriminatorProperty
+            => _entityType.RootType
+                .GetProperty(
+                    _entityType.RootType
+                        .GetAnnotation(DiscriminatorPropertyAnnotation).Value);
+
+        public virtual string DiscriminatorValue 
+            => _entityType[DiscriminatorValueAnnotation] ?? _entityType.SimpleName;
+
+        protected virtual IEntityType EntityType => _entityType;
     }
 }

--- a/src/EntityFramework.Relational/Metadata/RelationalAnnotationNames.cs
+++ b/src/EntityFramework.Relational/Metadata/RelationalAnnotationNames.cs
@@ -15,5 +15,7 @@ namespace Microsoft.Data.Entity.Relational.Metadata
         public const string Schema = "Schema";
         public const string Name = "Name";
         public const string Sequence = "Sequence:";
+        public const string DiscriminatorProperty = "DiscriminatorProperty";
+        public const string DiscriminatorValue = "DiscriminatorValue";
     }
 }

--- a/src/EntityFramework.Relational/Metadata/RelationalEntityTypeExtensions.cs
+++ b/src/EntityFramework.Relational/Metadata/RelationalEntityTypeExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Utilities;
@@ -20,23 +21,59 @@ namespace Microsoft.Data.Entity.Relational.Metadata
             [param: CanBeNull]
             set
             {
-                Check.NullButNotEmpty(value, "value");
+                Check.NullButNotEmpty(value, nameof(value));
 
-                ((EntityType)EntityType)[RelationalTableAnnotation] = value;
+                EntityType[RelationalTableAnnotation] = value;
             }
         }
 
-        [CanBeNull]
         public new virtual string Schema
         {
             get { return base.Schema; }
             [param: CanBeNull]
             set
             {
-                Check.NullButNotEmpty(value, "value");
+                Check.NullButNotEmpty(value, nameof(value));
 
-                ((EntityType)EntityType)[RelationalSchemaAnnotation] = value;
+                EntityType[RelationalSchemaAnnotation] = value;
             }
         }
+
+        public new virtual IProperty DiscriminatorProperty
+        {
+            get { return base.DiscriminatorProperty; }
+            [param: CanBeNull]
+            set
+            {
+                if (value != null)
+                {
+                    if (EntityType != EntityType.RootType)
+                    {
+                        throw new InvalidOperationException(
+                            Strings.DiscriminatorPropertyMustBeOnRoot(EntityType));
+                    }
+
+                    if (value.EntityType != EntityType)
+                    {
+                        throw new InvalidOperationException(
+                            Strings.DiscriminatorPropertyNotFound(value, EntityType));
+                    }
+
+                    EntityType[DiscriminatorPropertyAnnotation] = value.Name;
+                }
+                else
+                {
+                    EntityType[DiscriminatorPropertyAnnotation] = null;
+                }
+            }
+        }
+
+        public new virtual string DiscriminatorValue
+        {
+            get { return base.DiscriminatorValue; }
+            [param: CanBeNull] set { EntityType[DiscriminatorValueAnnotation] = value; }
+        }
+
+        protected new virtual EntityType EntityType => (EntityType)base.EntityType;
     }
 }

--- a/src/EntityFramework.Relational/Properties/Strings.Designer.cs
+++ b/src/EntityFramework.Relational/Properties/Strings.Designer.cs
@@ -292,6 +292,30 @@ namespace Microsoft.Data.Entity.Relational
             get { return GetString("InvalidMaxBatchSize"); }
         }
 
+        /// <summary>
+        /// Unable to materialize entity of type '{entityType}'. No discriminators were matched.
+        /// </summary>
+        public static string UnableToDiscriminate([CanBeNull] object entityType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("UnableToDiscriminate", "entityType"), entityType);
+        }
+
+        /// <summary>
+        /// A discriminator property cannot be set for the entity type '{entityType}' because it is not the root of an inheritance hierarchy.
+        /// </summary>
+        public static string DiscriminatorPropertyMustBeOnRoot([CanBeNull] object entityType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("DiscriminatorPropertyMustBeOnRoot", "entityType"), entityType);
+        }
+
+        /// <summary>
+        /// Unable to set property '{property}' as a discriminator for entity type '{entityType}' because it is not a property of '{entityType}'.
+        /// </summary>
+        public static string DiscriminatorPropertyNotFound([CanBeNull] object property, [CanBeNull] object entityType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("DiscriminatorPropertyNotFound", "property", "entityType"), property, entityType);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EntityFramework.Relational/Properties/Strings.resx
+++ b/src/EntityFramework.Relational/Properties/Strings.resx
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <root>
-    <!-- 
+  <!-- 
     Microsoft ResX Schema 
     
     Version 2.0
@@ -60,173 +59,176 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-    <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-        <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
-        <xsd:element name="root" msdata:IsDataSet="true">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
             <xsd:complexType>
-                <xsd:choice maxOccurs="unbounded">
-                    <xsd:element name="metadata">
-                        <xsd:complexType>
-                            <xsd:sequence>
-                                <xsd:element name="value" type="xsd:string" minOccurs="0" />
-                            </xsd:sequence>
-                            <xsd:attribute name="name" use="required" type="xsd:string" />
-                            <xsd:attribute name="type" type="xsd:string" />
-                            <xsd:attribute name="mimetype" type="xsd:string" />
-                            <xsd:attribute ref="xml:space" />
-                        </xsd:complexType>
-                    </xsd:element>
-                    <xsd:element name="assembly">
-                        <xsd:complexType>
-                            <xsd:attribute name="alias" type="xsd:string" />
-                            <xsd:attribute name="name" type="xsd:string" />
-                        </xsd:complexType>
-                    </xsd:element>
-                    <xsd:element name="data">
-                        <xsd:complexType>
-                            <xsd:sequence>
-                                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-                                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-                            </xsd:sequence>
-                            <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
-                            <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-                            <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-                            <xsd:attribute ref="xml:space" />
-                        </xsd:complexType>
-                    </xsd:element>
-                    <xsd:element name="resheader">
-                        <xsd:complexType>
-                            <xsd:sequence>
-                                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-                            </xsd:sequence>
-                            <xsd:attribute name="name" type="xsd:string" use="required" />
-                        </xsd:complexType>
-                    </xsd:element>
-                </xsd:choice>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
-        </xsd:element>
-    </xsd:schema>
-    <resheader name="resmimetype">
-        <value>text/microsoft-resx</value>
-    </resheader>
-    <resheader name="version">
-        <value>2.0</value>
-    </resheader>
-    <resheader name="reader">
-        <value>
-            System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral,
-            PublicKeyToken=b77a5c561934e089
-        </value>
-    </resheader>
-    <resheader name="writer">
-        <value>
-            System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral,
-            PublicKeyToken=b77a5c561934e089
-        </value>
-    </resheader>
-    <data name="InvalidEnumValue" xml:space="preserve">
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="InvalidEnumValue" xml:space="preserve">
     <value>The value provided for argument '{argumentName}' must be a valid value of enum type '{enumType}'.</value>
   </data>
   <data name="ModificationFunctionInvalidEntityState" xml:space="preserve">
     <value>Can not create a ModificationFunction for an entity in state '{entityState}'.</value>
   </data>
-    <data name="UpdateConcurrencyException" xml:space="preserve">
+  <data name="UpdateConcurrencyException" xml:space="preserve">
     <value>Update failed. Expected {expectedRows} row(s) but {actualRows} row(s) returned.</value>
   </data>
-    <data name="MultipleDataStoresConfigured" xml:space="preserve">
+  <data name="MultipleDataStoresConfigured" xml:space="preserve">
     <value>Multiple relational data store configurations found. A context can only be configured to use a single data store.</value>
   </data>
-    <data name="NoDataStoreConfigured" xml:space="preserve">
+  <data name="NoDataStoreConfigured" xml:space="preserve">
     <value>No relational data stores are configured. Configure a data store using OnConfiguring or by creating an ImmutableDbContextOptions with a data store configured and passing it to the context.</value>
   </data>
-    <data name="ConnectionAndConnectionString" xml:space="preserve">
+  <data name="ConnectionAndConnectionString" xml:space="preserve">
     <value>Both an existing DbConnection and a connection string have been configured. When an existing DbConnection is used the connection string must be set on that connection.</value>
   </data>
-    <data name="NoConnectionOrConnectionString" xml:space="preserve">
+  <data name="NoConnectionOrConnectionString" xml:space="preserve">
     <value>A relational store has been configured without specifying either the DbConnection or connection string to use.</value>
   </data>
-    <data name="UnsupportedType" xml:space="preserve">
+  <data name="UnsupportedType" xml:space="preserve">
     <value>The property '{propertyName}' cannot be mapped because it is of type '{propertyType}' which is currently not supported.</value>
   </data>
-    <data name="RelationalNotInUse" xml:space="preserve">
+  <data name="RelationalNotInUse" xml:space="preserve">
     <value>Relational-specific methods can only be used when the context is using a relational data store.</value>
   </data>
-    <data name="UpdateStoreException" xml:space="preserve">
+  <data name="UpdateStoreException" xml:space="preserve">
     <value>An error occurred while updating the entries. See the inner exception for details.</value>
   </data>
-    <data name="TransactionAlreadyStarted" xml:space="preserve">
+  <data name="TransactionAlreadyStarted" xml:space="preserve">
     <value>The connection is already in a transaction and cannot participate in another transaction.</value>
   </data>
-    <data name="TransactionAssociatedWithDifferentConnection" xml:space="preserve">
+  <data name="TransactionAssociatedWithDifferentConnection" xml:space="preserve">
     <value>The specified transaction is not associated with the current connection. Only transactions associated with the current connection may be used.</value>
   </data>
-    <data name="SkipNeedsOrderBy" xml:space="preserve">
+  <data name="SkipNeedsOrderBy" xml:space="preserve">
     <value>A query containing the Skip operator must include at least one OrderBy operation.</value>
   </data>
-    <data name="SequenceDefinitionMismatch" xml:space="preserve">
+  <data name="SequenceDefinitionMismatch" xml:space="preserve">
     <value>The SQL Server sequence '{sequenceName}' was already specified with a different definition.</value>
   </data>
-    <data name="RelationalLoggerCreatingDatabase" xml:space="preserve">
+  <data name="RelationalLoggerCreatingDatabase" xml:space="preserve">
     <value>Creating database '{databaseName}'.</value>
   </data>
-    <data name="RelationalLoggerOpeningConnection" xml:space="preserve">
+  <data name="RelationalLoggerOpeningConnection" xml:space="preserve">
     <value>Opening connection '{connectionString}'.</value>
   </data>
-    <data name="RelationalLoggerClosingConnection" xml:space="preserve">
+  <data name="RelationalLoggerClosingConnection" xml:space="preserve">
     <value>Closing connection '{connectionString}'.</value>
   </data>
-    <data name="RelationalLoggerBeginningTransaction" xml:space="preserve">
+  <data name="RelationalLoggerBeginningTransaction" xml:space="preserve">
     <value>Beginning transaction with isolation level '{isolationLevel}'.</value>
   </data>
-    <data name="RelationalLoggerCommittingTransaction" xml:space="preserve">
+  <data name="RelationalLoggerCommittingTransaction" xml:space="preserve">
     <value>Committing transaction.</value>
   </data>
-    <data name="RelationalLoggerRollingbackTransaction" xml:space="preserve">
+  <data name="RelationalLoggerRollingbackTransaction" xml:space="preserve">
     <value>Rolling back transaction.</value>
   </data>
-    <data name="BadSequenceType" xml:space="preserve">
+  <data name="BadSequenceType" xml:space="preserve">
     <value>Invalid type for sequence. Valid types are 'Int64' (the default), 'Int32', 'Int16', and 'Byte'.</value>
   </data>
-    <data name="BadSequenceString" xml:space="preserve">
+  <data name="BadSequenceString" xml:space="preserve">
     <value>Unable to deserialize sequence from model metadata. See inner exception for details.</value>
   </data>
-    <data name="InvalidMigrationId" xml:space="preserve">
+  <data name="InvalidMigrationId" xml:space="preserve">
     <value>'{migrationId}' is not a valid migration identifier.</value>
   </data>
-    <data name="LocalMigrationNotFound" xml:space="preserve">
+  <data name="LocalMigrationNotFound" xml:space="preserve">
     <value>The history repository includes a migration with the identifier '{migrationId}' but the migration assembly does not contain the corresponding migration class.</value>
   </data>
-    <data name="MigrationsNotInUse" xml:space="preserve">
+  <data name="MigrationsNotInUse" xml:space="preserve">
     <value>Migrations-specific methods can only be used when the context is using a migrations-enabled data store.</value>
   </data>
-    <data name="MigratorLoggerApplyingMigration" xml:space="preserve">
+  <data name="MigratorLoggerApplyingMigration" xml:space="preserve">
     <value>Applying migration '{migrationId}'.</value>
   </data>
-    <data name="MigratorLoggerCreatingHistoryTable" xml:space="preserve">
+  <data name="MigratorLoggerCreatingHistoryTable" xml:space="preserve">
     <value>Creating migration history table.</value>
   </data>
-    <data name="MigratorLoggerDroppingHistoryTable" xml:space="preserve">
+  <data name="MigratorLoggerDroppingHistoryTable" xml:space="preserve">
     <value>Dropping migration history table.</value>
   </data>
-    <data name="MigratorLoggerRevertingMigration" xml:space="preserve">
+  <data name="MigratorLoggerRevertingMigration" xml:space="preserve">
     <value>Reverting migration '{migrationId}'.</value>
   </data>
-    <data name="MigratorLoggerUpToDate" xml:space="preserve">
+  <data name="MigratorLoggerUpToDate" xml:space="preserve">
     <value>The database is up to date.</value>
   </data>
-    <data name="MissingMigrationMetadata" xml:space="preserve">
+  <data name="MissingMigrationMetadata" xml:space="preserve">
     <value>'{migrationType}' does not implement IMigrationMetadata.</value>
   </data>
-    <data name="TargetMigrationNotFound" xml:space="preserve">
+  <data name="TargetMigrationNotFound" xml:space="preserve">
     <value>The target migration '{targetMigrationName}' was not found.</value>
   </data>
-    <data name="UnknownOperation" xml:space="preserve">
+  <data name="UnknownOperation" xml:space="preserve">
     <value>The current migration SQL generator '{sqlGeneratorType}' is unable to generate SQL for operations of type '{operationType}'.</value>
   </data>
-    <data name="InvalidCommandTimeout" xml:space="preserve">
+  <data name="InvalidCommandTimeout" xml:space="preserve">
     <value>The specified CommandTimeout value is not valid. It must be a positive number.</value>
   </data>
-    <data name="InvalidMaxBatchSize" xml:space="preserve">
+  <data name="InvalidMaxBatchSize" xml:space="preserve">
     <value>The specified MaxBatchSize value is not valid. It must be a positive number.</value>
+  </data>
+  <data name="UnableToDiscriminate" xml:space="preserve">
+    <value>Unable to materialize entity of type '{entityType}'. No discriminators were matched.</value>
+  </data>
+  <data name="DiscriminatorPropertyMustBeOnRoot" xml:space="preserve">
+    <value>A discriminator property cannot be set for the entity type '{entityType}' because it is not the root of an inheritance hierarchy.</value>
+  </data>
+  <data name="DiscriminatorPropertyNotFound" xml:space="preserve">
+    <value>Unable to set property '{property}' as a discriminator for entity type '{entityType}' because it is not a property of '{entityType}'.</value>
   </data>
 </root>

--- a/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/MaterializerFactory.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/MaterializerFactory.cs
@@ -1,0 +1,161 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Relational.Query.Expressions;
+using Microsoft.Data.Entity.Utilities;
+using Remotion.Linq.Clauses;
+
+namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
+{
+    public class MaterializerFactory
+    {
+        private readonly EntityMaterializerSource _entityMaterializerSource;
+
+        public MaterializerFactory([NotNull] EntityMaterializerSource entityMaterializerSource)
+        {
+            Check.NotNull(entityMaterializerSource, nameof(entityMaterializerSource));
+
+            _entityMaterializerSource = entityMaterializerSource;
+        }
+
+        public virtual Expression CreateMaterializer(
+            [NotNull] IEntityType entityType,
+            [NotNull] SelectExpression selectExpression,
+            [NotNull] Func<IProperty, SelectExpression, int> projectionAdder,
+            [CanBeNull] IQuerySource querySource)
+        {
+            Check.NotNull(entityType, nameof(entityType));
+            Check.NotNull(selectExpression, nameof(selectExpression));
+            Check.NotNull(projectionAdder, nameof(projectionAdder));
+
+            var valueReaderParameter
+                = Expression.Parameter(typeof(IValueReader));
+
+            var concreteEntityTypes
+                = entityType.GetConcreteTypesInHierarchy().ToArray();
+
+            var indexMap = new int[concreteEntityTypes[0].PropertyCount];
+            var propertyIndex = 0;
+
+            foreach (var property in concreteEntityTypes[0].Properties)
+            {
+                indexMap[propertyIndex++]
+                    = projectionAdder(property, selectExpression);
+            }
+
+            var materializer
+                = _entityMaterializerSource
+                    .CreateMaterializeExpression(
+                        concreteEntityTypes[0], valueReaderParameter, indexMap);
+
+            if (concreteEntityTypes.Length == 1
+                && concreteEntityTypes[0].RootType == concreteEntityTypes[0])
+            {
+                return Expression.Lambda<Func<IValueReader, object>>(materializer, valueReaderParameter);
+            }
+
+            var discriminatorProperty
+                = concreteEntityTypes[0].Relational().DiscriminatorProperty;
+
+            var discriminatorColumn
+                = selectExpression.Projection
+                    .Single(c => c.Property == discriminatorProperty);
+
+            var firstDiscriminatorValue
+                = Expression.Constant(
+                    concreteEntityTypes[0].Relational().DiscriminatorValue);
+
+            var discriminatorPredicate
+                = Expression.Equal(discriminatorColumn, firstDiscriminatorValue);
+
+            if (concreteEntityTypes.Length == 1)
+            {
+                selectExpression.Predicate
+                    = new DiscriminatorPredicateExpression(discriminatorPredicate, querySource);
+
+                return Expression.Lambda<Func<IValueReader, object>>(materializer, valueReaderParameter);
+            }
+
+            var discriminatorValueVariable
+                = Expression.Variable(discriminatorProperty.PropertyType);
+
+            var returnLabelTarget = Expression.Label(typeof(object));
+
+            var blockExpressions
+                = new Expression[]
+                    {
+                        Expression.Assign(
+                            discriminatorValueVariable,
+                            _entityMaterializerSource
+                                .CreateReadValueExpression(
+                                    valueReaderParameter,
+                                    discriminatorProperty.PropertyType,
+                                    discriminatorProperty.Index)),
+                        Expression.IfThenElse(
+                            Expression.Equal(discriminatorValueVariable, firstDiscriminatorValue),
+                            Expression.Return(returnLabelTarget, materializer),
+                            Expression.Throw(
+                                Expression.Call(
+                                    _createUnableToDiscriminateException,
+                                    Expression.Constant(concreteEntityTypes[0])))),
+                        Expression.Label(
+                            returnLabelTarget,
+                            Expression.Default(returnLabelTarget.Type))
+                    };
+
+            foreach (var concreteEntityType in concreteEntityTypes.Skip(1))
+            {
+                indexMap = new int[concreteEntityType.PropertyCount];
+                propertyIndex = 0;
+
+                foreach (var property in concreteEntityType.Properties)
+                {
+                    indexMap[propertyIndex++]
+                        = projectionAdder(property, selectExpression);
+                }
+
+                var discriminatorValue
+                    = Expression.Constant(
+                        concreteEntityType.Relational().DiscriminatorValue);
+
+                materializer
+                    = _entityMaterializerSource
+                        .CreateMaterializeExpression(concreteEntityType, valueReaderParameter, indexMap);
+
+                blockExpressions[1]
+                    = Expression.IfThenElse(
+                        Expression.Equal(discriminatorValueVariable, discriminatorValue),
+                        Expression.Return(returnLabelTarget, materializer),
+                        blockExpressions[1]);
+
+                discriminatorPredicate
+                    = Expression.OrElse(
+                        Expression.Equal(discriminatorColumn, discriminatorValue),
+                        discriminatorPredicate);
+            }
+
+            selectExpression.Predicate
+                = new DiscriminatorPredicateExpression(discriminatorPredicate, querySource);
+
+            return Expression.Lambda<Func<IValueReader, object>>(
+                Expression.Block(new[] { discriminatorValueVariable }, blockExpressions),
+                valueReaderParameter);
+        }
+
+        private static readonly MethodInfo _createUnableToDiscriminateException
+            = typeof(MaterializerFactory).GetTypeInfo()
+                .GetDeclaredMethod(nameof(CreateUnableToDiscriminateException));
+
+        [UsedImplicitly]
+        private static Exception CreateUnableToDiscriminateException(IEntityType entityType)
+        {
+            return new InvalidOperationException(Strings.UnableToDiscriminate(entityType.Name));
+        }
+    }
+}

--- a/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/QueryFlatteningExpressionTreeVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/QueryFlatteningExpressionTreeVisitor.cs
@@ -6,13 +6,13 @@ using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Query;
+using Microsoft.Data.Entity.Query.ExpressionTreeVisitors;
 using Microsoft.Data.Entity.Utilities;
 using Remotion.Linq.Clauses;
-using Remotion.Linq.Parsing;
 
 namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
 {
-    public class QueryFlatteningExpressionTreeVisitor : ExpressionTreeVisitor
+    public class QueryFlatteningExpressionTreeVisitor : ExpressionTreeVisitorBase
     {
         private readonly IQuerySource _outerQuerySource;
         private readonly IQuerySource _innerQuerySource;

--- a/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/ResultTransformingExpressionTreeVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/ResultTransformingExpressionTreeVisitor.cs
@@ -6,13 +6,13 @@ using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Query;
+using Microsoft.Data.Entity.Query.ExpressionTreeVisitors;
 using Microsoft.Data.Entity.Utilities;
 using Remotion.Linq.Clauses;
-using Remotion.Linq.Parsing;
 
 namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
 {
-    public class ResultTransformingExpressionTreeVisitor<TResult> : ExpressionTreeVisitor
+    public class ResultTransformingExpressionTreeVisitor<TResult> : ExpressionTreeVisitorBase
     {
         private readonly IQuerySource _outerQuerySource;
         private readonly RelationalQueryCompilationContext _relationalQueryCompilationContext;

--- a/src/EntityFramework.Relational/Query/Expressions/DiscriminatorPredicateExpression.cs
+++ b/src/EntityFramework.Relational/Query/Expressions/DiscriminatorPredicateExpression.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Utilities;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.Expressions;
+using Remotion.Linq.Parsing;
+
+namespace Microsoft.Data.Entity.Relational.Query.Expressions
+{
+    public class DiscriminatorPredicateExpression : ExtensionExpression
+    {
+        private readonly Expression _predicate;
+
+        public DiscriminatorPredicateExpression(
+            [NotNull] Expression predicate, [CanBeNull] IQuerySource querySource)
+            : base(predicate.Type)
+        {
+            Check.NotNull(predicate, nameof(predicate));
+
+            _predicate = predicate;
+
+            QuerySource = querySource;
+        }
+
+        public virtual IQuerySource QuerySource { get; }
+
+        public override bool CanReduce => true;
+
+        public override Expression Reduce()
+        {
+            return _predicate;
+        }
+
+        public override string ToString()
+        {
+            return _predicate.ToString();
+        }
+
+        protected override Expression VisitChildren(ExpressionTreeVisitor visitor)
+        {
+            return this;
+        }
+    }
+}

--- a/test/EntityFramework.Core.FunctionalTests/InheritanceFixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/InheritanceFixtureBase.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
             var kiwi = model.AddEntityType(typeof(Kiwi));
             kiwi.BaseType = bird;
+            kiwi.AddProperty("FoundOn", typeof(Island));
 
             var eagle = model.AddEntityType(typeof(Eagle));
             eagle.BaseType = bird;
@@ -47,7 +48,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 {
                     Species = "Apteryx owenii",
                     Name = "Great spotted kiwi",
-                    IsFlightless = true
+                    IsFlightless = true,
+                    FoundOn = Island.South
                 };
 
             var eagle = new Eagle

--- a/test/EntityFramework.Core.FunctionalTests/InheritanceTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/InheritanceTestBase.cs
@@ -11,6 +11,44 @@ namespace Microsoft.Data.Entity.FunctionalTests
         where TFixture : InheritanceFixtureBase, new()
     {
         [Fact]
+        public virtual void Can_use_of_type_animal()
+        {
+            using (var context = CreateContext())
+            {
+                var animals = context.Set<Animal>().OfType<Animal>().OrderBy(a => a.Species).ToList();
+
+                Assert.Equal(2, animals.Count);
+                Assert.IsType<Kiwi>(animals[0]);
+                Assert.IsType<Eagle>(animals[1]);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_use_of_type_bird()
+        {
+            using (var context = CreateContext())
+            {
+                var animals = context.Set<Animal>().OfType<Bird>().OrderBy(a => a.Species).ToList();
+
+                Assert.Equal(2, animals.Count);
+                Assert.IsType<Kiwi>(animals[0]);
+                Assert.IsType<Eagle>(animals[1]);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_use_of_type_kiwi()
+        {
+            using (var context = CreateContext())
+            {
+                var animals = context.Set<Animal>().OfType<Kiwi>().ToList();
+
+                Assert.Equal(1, animals.Count);
+                Assert.IsType<Kiwi>(animals[0]);
+            }
+        }
+
+        [Fact]
         public virtual void Can_query_all_animals()
         {
             using (var context = CreateContext())

--- a/test/EntityFramework.Core.FunctionalTests/Metadata/Compiled/CompiledMetadataBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/Metadata/Compiled/CompiledMetadataBase.cs
@@ -18,5 +18,7 @@ namespace Microsoft.Data.Entity.Metadata.Compiled
         protected abstract IAnnotation[] LoadAnnotations();
 
         protected static IEnumerable<IAnnotation> ZipAnnotations(string[] names, string[] values) => names.Zip(values, (n, v) => new Annotation(n, v)).ToArray();
+
+        public Annotation GetAnnotation(string annotationName) => null;
     }
 }

--- a/test/EntityFramework.Core.FunctionalTests/Metadata/Compiled/NoAnnotations.cs
+++ b/test/EntityFramework.Core.FunctionalTests/Metadata/Compiled/NoAnnotations.cs
@@ -13,5 +13,7 @@ namespace Microsoft.Data.Entity.Metadata.Compiled
         public string this[string annotationName] => null;
 
         public virtual string StorageName => null;
+
+        public Annotation GetAnnotation(string annotationName) => null;
     }
 }

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/Inheritance/Kiwi.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/Inheritance/Kiwi.cs
@@ -5,5 +5,12 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.Inheritance
 {
     public class Kiwi : Bird
     {
+        public Island FoundOn { get; set; }
+    }
+
+    public enum Island : byte
+    {
+        North,
+        South
     }
 }

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/Northwind/NorthwindData.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/Northwind/NorthwindData.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Query;
+using Microsoft.Data.Entity.Query.ExpressionTreeVisitors;
 using Remotion.Linq.Parsing;
 
 namespace Microsoft.Data.Entity.FunctionalTests.TestModels.Northwind
@@ -123,7 +124,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.Northwind
             }
         }
 
-        private class ShadowStateAccessRewriter : ExpressionTreeVisitor
+        private class ShadowStateAccessRewriter : ExpressionTreeVisitorBase
         {
             private static readonly MethodInfo _propertyMethodInfo
                 = typeof(QueryExtensions).GetTypeInfo().GetDeclaredMethod("Property");

--- a/test/EntityFramework.Core.Tests/ApiConsistencyTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ApiConsistencyTestBase.cs
@@ -33,8 +33,9 @@ namespace Microsoft.Data.Entity
                     from method in type.GetMethods(PublicInstance)
                     where method.DeclaringType == type
                           && !(method.IsVirtual && !method.IsFinal)
-                          && !method.GetCustomAttributes(typeof(CompilerGeneratedAttribute)).Any()
-                    select type.FullName + "." + method.Name)
+                          && !method.Name.StartsWith("add_")
+                          && !method.Name.StartsWith("remove_")
+                   select type.FullName + "." + method.Name)
                     .ToList();
 
             Assert.False(

--- a/test/EntityFramework.Core.Tests/Metadata/EntityMaterializerSourceTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/EntityMaterializerSourceTest.cs
@@ -30,6 +30,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             var materializerMock = new Mock<IEntityMaterializer>();
             var typeMock = materializerMock.As<IEntityType>();
+            typeMock.SetupGet(et => et.Type).Returns(typeof(string));
+            typeMock.SetupGet(et => et.HasClrType).Returns(true);
 
             var reader = Mock.Of<IValueReader>();
             new EntityMaterializerSource(new MemberMapper(new FieldMatcher())).GetMaterializer(typeMock.Object)(reader);

--- a/test/EntityFramework.InMemory.FunctionalTests/InheritanceInMemoryTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/InheritanceInMemoryTest.cs
@@ -5,9 +5,9 @@ using Microsoft.Data.Entity.FunctionalTests;
 
 namespace Microsoft.Data.Entity.InMemory.FunctionalTests
 {
-    public class InheritanceMemoryTest : InheritanceTestBase<InheritanceInMemoryFixture>
+    public class InheritanceInMemoryTest : InheritanceTestBase<InheritanceInMemoryFixture>
     {
-        public InheritanceMemoryTest(InheritanceInMemoryFixture fixture)
+        public InheritanceInMemoryTest(InheritanceInMemoryFixture fixture)
             : base(fixture)
         {
         }

--- a/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
+++ b/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
@@ -83,6 +83,8 @@
     <Compile Include="CommandConfigurationTests.cs" />
     <Compile Include="ComputedColumnTest.cs" />
     <Compile Include="NavigationTest.cs" />
+    <Compile Include="InheritanceSqlServerFixture.cs" />
+    <Compile Include="InheritanceSqlServerTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="BuiltInDataTypesSqlServerFixture.cs" />
     <Compile Include="BuiltInDataTypesSqlServerTest.cs" />

--- a/test/EntityFramework.SqlServer.FunctionalTests/InheritanceSqlServerFixture.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/InheritanceSqlServerFixture.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Data.Entity.FunctionalTests.TestModels.Inheritance;
+using Microsoft.Data.Entity.Relational.FunctionalTests;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.DependencyInjection.Fallback;
+using Microsoft.Framework.Logging;
+
+namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
+{
+    public class InheritanceSqlServerFixture : InheritanceFixtureBase
+    {
+        private readonly DbContextOptions _options = new DbContextOptions();
+        private readonly IServiceProvider _serviceProvider;
+
+        public InheritanceSqlServerFixture()
+        {
+            _serviceProvider
+                = new ServiceCollection()
+                    .AddEntityFramework()
+                    .AddSqlServer()
+                    .ServiceCollection()
+                    .AddSingleton(TestSqlServerModelSource.GetFactory(OnModelCreating))
+                    .AddInstance<ILoggerFactory>(new TestSqlLoggerFactory())
+                    .BuildServiceProvider();
+
+            var testStore = SqlServerTestStore.CreateScratch();
+
+            _options.UseSqlServer(testStore.Connection);
+
+            // TODO: Do this via migrations & update pipeline
+
+            testStore.ExecuteNonQueryAsync(@"
+                CREATE TABLE Country (
+                    Id int NOT NULL PRIMARY KEY,
+                    Name nvarchar(100) NOT NULL
+                );
+
+                CREATE TABLE Animal (
+                    Species nvarchar(100) NOT NULL PRIMARY KEY,
+                    Name nvarchar(100) NOT NULL,
+                    CountryId int NOT NULL FOREIGN KEY REFERENCES Country (Id),
+                    IsFlightless bit NOT NULL,
+                    EagleId nvarchar(100) FOREIGN KEY REFERENCES Animal (Species),
+                    [Group] int,
+                    FoundOn tinyint,
+                    Discriminator nvarchar(255)
+                );
+                
+                INSERT Country VALUES (1, 'New Zealand');
+                INSERT Country VALUES (2, 'USA');
+
+                INSERT Animal VALUES ('Aquila chrysaetos canadensis', 'American golden eagle', 2, 0, NULL, 1, NULL, 'Eagle');
+                INSERT Animal VALUES ('Apteryx owenii', 'Great spotted kiwi', 1, 1, 'Aquila chrysaetos canadensis', NULL, 1, 'Kiwi');
+            ").Wait();
+        }
+
+        public override AnimalContext CreateContext()
+        {
+            return new AnimalContext(_serviceProvider, _options);
+        }
+
+        public override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            // TODO: Code First this
+
+            var animal = modelBuilder.Entity<Animal>().Metadata;
+
+            var discriminatorProperty
+                = animal.AddProperty("Discriminator", typeof(string), shadowProperty: true);
+
+            animal.Relational().DiscriminatorProperty = discriminatorProperty;
+        }
+    }
+}

--- a/test/EntityFramework.SqlServer.FunctionalTests/InheritanceSqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/InheritanceSqlServerTest.cs
@@ -1,0 +1,143 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Data.Entity.Relational.FunctionalTests;
+using Xunit;
+
+namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
+{
+    public class InheritanceSqlServerTest : InheritanceTestBase<InheritanceSqlServerFixture>
+    {
+        public override void Can_use_of_type_animal()
+        {
+            base.Can_use_of_type_animal();
+
+            Assert.Equal(
+                @"SELECT [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[Species], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
+FROM [Animal] AS [a]
+WHERE ([a].[Discriminator] = 'Kiwi' OR [a].[Discriminator] = 'Eagle')
+ORDER BY [a].[Species]",
+                Sql);
+        }
+
+        public override void Can_use_of_type_bird()
+        {
+            base.Can_use_of_type_bird();
+
+            Assert.Equal(
+                @"SELECT [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[Species], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
+FROM [Animal] AS [a]
+WHERE ([a].[Discriminator] = 'Kiwi' OR [a].[Discriminator] = 'Eagle')
+ORDER BY [a].[Species]",
+                Sql);
+        }
+
+        public override void Can_use_of_type_kiwi()
+        {
+            base.Can_use_of_type_kiwi();
+
+            Assert.Equal(
+                @"SELECT [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[Species], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
+FROM [Animal] AS [a]
+WHERE [a].[Discriminator] = 'Kiwi'",
+                Sql);
+        }
+
+        public override void Can_query_all_animals()
+        {
+            base.Can_query_all_animals();
+
+            Assert.Equal(
+                @"SELECT [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[Species], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
+FROM [Animal] AS [a]
+WHERE ([a].[Discriminator] = 'Kiwi' OR [a].[Discriminator] = 'Eagle')
+ORDER BY [a].[Species]",
+                Sql);
+        }
+
+        public override void Can_filter_all_animals()
+        {
+            base.Can_filter_all_animals();
+
+            Assert.Equal(
+                @"SELECT [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[Species], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
+FROM [Animal] AS [a]
+WHERE (([a].[Discriminator] = 'Kiwi' OR [a].[Discriminator] = 'Eagle') AND [a].[Name] = 'Great spotted kiwi')
+ORDER BY [a].[Species]",
+                Sql);
+        }
+
+        public override void Can_query_all_birds()
+        {
+            base.Can_query_all_birds();
+
+            Assert.Equal(
+                @"SELECT [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[Species], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
+FROM [Animal] AS [a]
+WHERE ([a].[Discriminator] = 'Kiwi' OR [a].[Discriminator] = 'Eagle')
+ORDER BY [a].[Species]",
+                Sql);
+        }
+
+        public override void Can_query_just_kiwis()
+        {
+            base.Can_query_just_kiwis();
+
+            Assert.Equal(
+                @"SELECT TOP(2) [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[Species], [a].[EagleId], [a].[IsFlightless], [a].[FoundOn]
+FROM [Animal] AS [a]
+WHERE [a].[Discriminator] = 'Kiwi'",
+                Sql);
+        }
+
+        public override void Can_include_prey()
+        {
+            base.Can_include_prey();
+
+            Assert.Equal(
+                @"SELECT TOP(2) [e].[CountryId], [e].[Discriminator], [e].[Name], [e].[Species], [e].[EagleId], [e].[IsFlightless], [e].[Group]
+FROM [Animal] AS [e]
+WHERE [e].[Discriminator] = 'Eagle'
+ORDER BY [e].[Species]
+
+SELECT [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[Species], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
+FROM [Animal] AS [a]
+INNER JOIN (
+    SELECT DISTINCT TOP(2) [e].[Species]
+    FROM [Animal] AS [e]
+    WHERE [e].[Discriminator] = 'Eagle'
+) AS [e] ON [a].[EagleId] = [e].[Species]
+WHERE ([a].[Discriminator] = 'Kiwi' OR [a].[Discriminator] = 'Eagle')
+ORDER BY [e].[Species]",
+                Sql);
+        }
+
+        public override void Can_include_animals()
+        {
+            base.Can_include_animals();
+
+            Assert.Equal(
+                @"SELECT [c].[Id], [c].[Name]
+FROM [Country] AS [c]
+ORDER BY [c].[Name], [c].[Id]
+
+SELECT [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[Species], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
+FROM [Animal] AS [a]
+INNER JOIN (
+    SELECT DISTINCT [c].[Name], [c].[Id]
+    FROM [Country] AS [c]
+) AS [c] ON [a].[CountryId] = [c].[Id]
+WHERE ([a].[Discriminator] = 'Kiwi' OR [a].[Discriminator] = 'Eagle')
+ORDER BY [c].[Name], [c].[Id]",
+                Sql);
+        }
+
+        public InheritanceSqlServerTest(InheritanceSqlServerFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        private static string Sql => TestSqlLoggerFactory.Sql;
+    }
+}

--- a/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -1349,7 +1349,7 @@ FROM [Customers] AS [c]",
 
             Assert.Equal(
                 @"SELECT DISTINCT [c].[City]
-FROM [Customers] AS [c]",
+FROM [Customers] AS [c]", // Ordering not preserved by distinct
                 Sql);
         }
 


### PR DESCRIPTION
- EntityMaterializerSource can now return expressions to support tree composition.
- Added support for OfType result operator.
- Introduced ExpressionStringBuilder for complete control over query cache key generation.
- Added MaterializerFactory to relational, relational materializers need to take discriminators into account.
- Added Discriminator annotation metadata APIs to relational.