### PR TITLE
Make the first navigation specified when configuring self referencing relationship be the navigation to principal.

### DIFF
--- a/src/EntityFramework.Core/Metadata/Internal/InternalRelationshipBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/InternalRelationshipBuilder.cs
@@ -70,6 +70,13 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var hasChanged = navigationToPrincipalName != null &&
                              Metadata.GetNavigationToPrincipal()?.Name != navigationToPrincipalName;
 
+            if (Metadata.EntityType == Metadata.ReferencedEntityType
+                && navigationToPrincipalName != null
+                && navigationToPrincipalName == Metadata.GetNavigationToDependent()?.Name)
+            {
+                throw new InvalidOperationException(Strings.NavigationToSelfDuplicate(navigationToPrincipalName));
+            }
+
             return dependentEntityType
                 .Navigation(navigationToPrincipalName, Metadata, pointsToPrincipal: true, configurationSource: configurationSource)
                 ? hasChanged ? ReplaceForeignKey(configurationSource) : this
@@ -111,6 +118,13 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
             var hasChanged = navigationToDependentName != null &&
                              Metadata.GetNavigationToDependent()?.Name != navigationToDependentName;
+
+            if (Metadata.EntityType == Metadata.ReferencedEntityType
+                && navigationToDependentName != null
+                && navigationToDependentName == Metadata.GetNavigationToPrincipal()?.Name)
+            {
+                throw new InvalidOperationException(Strings.NavigationToSelfDuplicate(navigationToDependentName));
+            }
 
             return principalEntityType
                 .Navigation(navigationToDependentName, Metadata, pointsToPrincipal: false, configurationSource: configurationSource)

--- a/src/EntityFramework.Core/Metadata/ModelConventions/RelationshipDiscoveryConvention.cs
+++ b/src/EntityFramework.Core/Metadata/ModelConventions/RelationshipDiscoveryConvention.cs
@@ -44,7 +44,11 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
 
                     if (navigationPairCandidates.ContainsKey(targetEntityTypeBuilder))
                     {
-                        navigationPairCandidates[targetEntityTypeBuilder].Item1.Add(navigationPropertyInfo);
+                        if (entityType != targetEntityTypeBuilder.Metadata
+                            || !navigationPairCandidates[targetEntityTypeBuilder].Item2.Contains(navigationPropertyInfo))
+                        {
+                            navigationPairCandidates[targetEntityTypeBuilder].Item1.Add(navigationPropertyInfo);
+                        }
                         continue;
                     }
 
@@ -58,7 +62,8 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
                         Type reverseEntityClrType;
                         if (!reversePropertyInfo.IsCandidateNavigationProperty(out reverseEntityClrType)
                             || !targetEntityTypeBuilder.CanAddNavigation(reversePropertyInfo.Name, ConfigurationSource.Convention)
-                            || entityType.Type != reverseEntityClrType)
+                            || entityType.Type != reverseEntityClrType
+                            || navigationPropertyInfo == reversePropertyInfo)
                         {
                             continue;
                         }

--- a/src/EntityFramework.Core/ModelBuilder.cs
+++ b/src/EntityFramework.Core/ModelBuilder.cs
@@ -6,24 +6,26 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Metadata.ModelConventions;
 using Microsoft.Data.Entity.Utilities;
-using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.ValueGeneration;
 
 namespace Microsoft.Data.Entity
 {
     /// <summary>
     ///     <para>
-    ///         Provides a simple API surface for configuring a <see cref="Model"/> that defines the shape of your 
+    ///         Provides a simple API surface for configuring a <see cref="Model" /> that defines the shape of your
     ///         entities and how they map to the data store.
     ///     </para>
     ///     <para>
-    ///         You can use <see cref="ModelBuilder"/> to construct a model for a context by overriding
-    ///         <see cref="DbContext.OnModelCreating(ModelBuilder)"/> or creating a <see cref="Model"/> externally
-    ///         and setting is on a <see cref="DbContextOptions"/> instance that is passed to the context constructor.
+    ///         You can use <see cref="ModelBuilder" /> to construct a model for a context by overriding
+    ///         <see cref="DbContext.OnModelCreating(ModelBuilder)" /> or creating a <see cref="Model" />
+    ///         externally
+    ///         and setting is on a <see cref="DbContextOptions" /> instance that is passed to the context
+    ///         constructor.
     ///     </para>
     /// </summary>
     public class ModelBuilder : IModelBuilder<ModelBuilder>
@@ -35,8 +37,8 @@ namespace Microsoft.Data.Entity
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="ModelBuilder" /> class with an empty model.
-        ///     The builder will not use any conventions and the entire model must be explicitly configured. 
-        ///     To specify conventions to be used, use a constructor that accepts a <see cref="ConventionSet"/>.
+        ///     The builder will not use any conventions and the entire model must be explicitly configured.
+        ///     To specify conventions to be used, use a constructor that accepts a <see cref="ConventionSet" />.
         /// </summary>
         public ModelBuilder()
             : this(new Model())
@@ -44,10 +46,10 @@ namespace Microsoft.Data.Entity
         }
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="ModelBuilder" /> class that will 
-        ///     configure an existing model. The builder will not use any conventions and the 
-        ///     entire model must be explicitly configured. To specify conventions to be used, 
-        ///     use a constructor that accepts a <see cref="ConventionSet"/>.
+        ///     Initializes a new instance of the <see cref="ModelBuilder" /> class that will
+        ///     configure an existing model. The builder will not use any conventions and the
+        ///     entire model must be explicitly configured. To specify conventions to be used,
+        ///     use a constructor that accepts a <see cref="ConventionSet" />.
         /// </summary>
         /// <param name="model"> The model to be configured. </param>
         public ModelBuilder([NotNull] Model model)
@@ -57,7 +59,7 @@ namespace Microsoft.Data.Entity
         }
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="ModelBuilder" /> class that will 
+        ///     Initializes a new instance of the <see cref="ModelBuilder" /> class that will
         ///     configure an existing model and apply a set of conventions.
         /// </summary>
         /// <param name="model"> The model to be configured. </param>
@@ -71,10 +73,10 @@ namespace Microsoft.Data.Entity
         }
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="ModelBuilder" /> class that will 
-        ///     configure an existing model. The builder will not use any conventions and the 
-        ///     entire model must be explicitly configured. To specify conventions to be used, 
-        ///     use a constructor that accepts a <see cref="ConventionSet"/>.
+        ///     Initializes a new instance of the <see cref="ModelBuilder" /> class that will
+        ///     configure an existing model. The builder will not use any conventions and the
+        ///     entire model must be explicitly configured. To specify conventions to be used,
+        ///     use a constructor that accepts a <see cref="ConventionSet" />.
         /// </summary>
         /// <param name="internalBuilder"> The internal builder being used to configure the model. </param>
         protected internal ModelBuilder([NotNull] InternalModelBuilder internalBuilder)
@@ -95,8 +97,8 @@ namespace Microsoft.Data.Entity
         public virtual Model Model => Metadata;
 
         /// <summary>
-        ///     Adds or updates an annotation on the model. If an annotation with the key specified in <paramref name="annotation"/>
-        ///     already exists it's value will be updated.
+        ///     Adds or updates an annotation on the model. If an annotation with the key specified in
+        ///     <paramref name="annotation" /> already exists it's value will be updated.
         /// </summary>
         /// <param name="annotation"> The key of the annotation to be added or updated. </param>
         /// <param name="value"> The value to be stored in the annotation. </param>
@@ -150,19 +152,19 @@ namespace Microsoft.Data.Entity
 
         /// <summary>
         ///     <para>
-        ///         Performs configuration of a given entity type in the model. If the entity type is not already part of the model, it will 
-        ///         be added to the model.
+        ///         Performs configuration of a given entity type in the model. If the entity type is not already part
+        ///         of the model, it will be added to the model.
         ///     </para>
         ///     <para>
-        ///         This overload allows configuration of the entity type to be done in line in the method call rather than being chained 
-        ///         after a call to <see cref="Entity{TEntity}()"/>. This allows additional configuration at the model level to be 
-        ///         chained after configuration for the entity type.
+        ///         This overload allows configuration of the entity type to be done in line in the method call rather
+        ///         than being chained after a call to <see cref="Entity{TEntity}()" />. This allows additional
+        ///         configuration at the model level to be chained after configuration for the entity type.
         ///     </para>
         /// </summary>
         /// <typeparam name="TEntity"> The entity type to be configured. </typeparam>
         /// <param name="entityBuilder"> An action that performs configuration of the entity type. </param>
-        /// <returns> 
-        ///     The same builder instance so that additional configuration calls can be chained. 
+        /// <returns>
+        ///     The same builder instance so that additional configuration calls can be chained.
         /// </returns>
         public virtual ModelBuilder Entity<TEntity>([NotNull] Action<EntityBuilder<TEntity>> entityBuilder) where TEntity : class
         {
@@ -175,19 +177,19 @@ namespace Microsoft.Data.Entity
 
         /// <summary>
         ///     <para>
-        ///         Performs configuration of a given entity type in the model. If the entity type is not already part of the model, it will 
-        ///         be added to the model.
+        ///         Performs configuration of a given entity type in the model. If the entity type is not already part
+        ///         of the model, it will be added to the model.
         ///     </para>
         ///     <para>
-        ///         This overload allows configuration of the entity type to be done in line in the method call rather than being chained 
-        ///         after a call to <see cref="Entity{TEntity}()"/>. This allows additional configuration at the model level to be 
-        ///         chained after configuration for the entity type.
+        ///         This overload allows configuration of the entity type to be done in line in the method call rather
+        ///         than being chained after a call to <see cref="Entity{TEntity}()" />. This allows additional
+        ///         configuration at the model level to be chained after configuration for the entity type.
         ///     </para>
         /// </summary>
         /// <param name="entityType"> The entity type to be configured. </param>
         /// <param name="entityBuilder"> An action that performs configuration of the entity type. </param>
-        /// <returns> 
-        ///     The same builder instance so that additional configuration calls can be chained. 
+        /// <returns>
+        ///     The same builder instance so that additional configuration calls can be chained.
         /// </returns>
         public virtual ModelBuilder Entity([NotNull] Type entityType, [NotNull] Action<EntityBuilder> entityBuilder)
         {
@@ -211,7 +213,7 @@ namespace Microsoft.Data.Entity
         }
 
         /// <summary>
-        ///     Excludes the given entity type from the model. This method is typically used to remove types from 
+        ///     Excludes the given entity type from the model. This method is typically used to remove types from
         ///     the model that were added by convention.
         /// </summary>
         /// <typeparam name="TEntity"> The  entity type to be removed from the model. </typeparam>
@@ -221,7 +223,7 @@ namespace Microsoft.Data.Entity
         }
 
         /// <summary>
-        ///     Excludes the given entity type from the model. This method is typically used to remove types from 
+        ///     Excludes the given entity type from the model. This method is typically used to remove types from
         ///     the model that were added by convention.
         /// </summary>
         /// <param name="entityType"> The entity type to be removed from the model. </param>
@@ -242,10 +244,10 @@ namespace Microsoft.Data.Entity
 
         /// <summary>
         ///     <para>
-        ///         Provides a simple API for configuring an <see cref="EntityType"/>. 
+        ///         Provides a simple API for configuring an <see cref="EntityType" />.
         ///     </para>
         ///     <para>
-        ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder"/> API 
+        ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
         ///         and it is not designed to be directly constructed in your application code.
         ///     </para>
         /// </summary>
@@ -253,10 +255,11 @@ namespace Microsoft.Data.Entity
         {
             /// <summary>
             ///     <para>
-            ///         Initializes a new instance of the <see cref="EntityBuilder"/> class to configure a given entity type.
+            ///         Initializes a new instance of the <see cref="EntityBuilder" /> class to configure a given entity
+            ///         type.
             ///     </para>
             ///     <para>
-            ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder"/> API 
+            ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
             ///         and it is not designed to be directly constructed in your application code.
             ///     </para>
             /// </summary>
@@ -269,7 +272,7 @@ namespace Microsoft.Data.Entity
             }
 
             /// <summary>
-            ///     The internal builder being used to configure the entity type. 
+            ///     The internal builder being used to configure the entity type.
             /// </summary>
             protected virtual InternalEntityBuilder Builder { get; }
 
@@ -284,8 +287,8 @@ namespace Microsoft.Data.Entity
             Model IMetadataBuilder<EntityType, EntityBuilder>.Model => Builder.ModelBuilder.Metadata;
 
             /// <summary>
-            ///     Adds or updates an annotation on the entity type. If an annotation with the key specified in <paramref name="annotation"/>
-            ///     already exists it's value will be updated.
+            ///     Adds or updates an annotation on the entity type. If an annotation with the key specified in
+            ///     <paramref name="annotation" /> already exists it's value will be updated.
             /// </summary>
             /// <param name="annotation"> The key of the annotation to be added or updated. </param>
             /// <param name="value"> The value to be stored in the annotation. </param>
@@ -315,14 +318,14 @@ namespace Microsoft.Data.Entity
             /// <summary>
             ///     <para>
             ///         Returns an object that can be used to configure a property of the entity type.
-            ///         If no property with the given name exists, then a new property will be added. 
+            ///         If no property with the given name exists, then a new property will be added.
             ///     </para>
             ///     <para>
             ///         When adding a new property, if a property with the same name exists in the entity class
             ///         then it will be added to the model. If no property exists in the entity class, then
             ///         a new shadow state property will be added. A shadow state property is one that does not have a
             ///         corresponding property in the entity class. The current value for the property is stored in
-            ///         the <see cref="ChangeTracker"/> rather than being stored in instances of the entity class.
+            ///         the <see cref="ChangeTracker" /> rather than being stored in instances of the entity class.
             ///     </para>
             /// </summary>
             /// <typeparam name="TProperty"> The type of the property to be configured. </typeparam>
@@ -338,14 +341,14 @@ namespace Microsoft.Data.Entity
             /// <summary>
             ///     <para>
             ///         Returns an object that can be used to configure a property of the entity type.
-            ///         If no property with the given name exists, then a new property will be added. 
+            ///         If no property with the given name exists, then a new property will be added.
             ///     </para>
             ///     <para>
             ///         When adding a new property, if a property with the same name exists in the entity class
             ///         then it will be added to the model. If no property exists in the entity class, then
             ///         a new shadow state property will be added. A shadow state property is one that does not have a
             ///         corresponding property in the entity class. The current value for the property is stored in
-            ///         the <see cref="ChangeTracker"/> rather than being stored in instances of the entity class.
+            ///         the <see cref="ChangeTracker" /> rather than being stored in instances of the entity class.
             ///     </para>
             /// </summary>
             /// <param name="propertyType"> The type of the property to be configured. </param>
@@ -360,8 +363,8 @@ namespace Microsoft.Data.Entity
             }
 
             /// <summary>
-            ///     Excludes the given property from the entity type. This method is typically used to remove properties from 
-            ///     the entity type that were added by convention.
+            ///     Excludes the given property from the entity type. This method is typically used to remove properties
+            ///     from the entity type that were added by convention.
             /// </summary>
             /// <param name="propertyName"> The name of then property to be removed from the entity type. </param>
             public virtual void Ignore([NotNull] string propertyName)
@@ -387,24 +390,26 @@ namespace Microsoft.Data.Entity
             /// <summary>
             ///     <para>
             ///         Configures a relationship where this entity type has a reference that points
-            ///         to a single instance of the other type in the relationship. 
+            ///         to a single instance of the other type in the relationship.
             ///     </para>
             ///     <para>
-            ///         After calling this method, you should chain a call to <see cref="ReferenceNavigationBuilder.WithMany(string)"/> 
-            ///         or <see cref="ReferenceNavigationBuilder.WithOne(string)"/> to fully configure 
+            ///         After calling this method, you should chain a call to
+            ///         <see cref="ReferenceNavigationBuilder.WithMany(string)" />
+            ///         or <see cref="ReferenceNavigationBuilder.WithOne(string)" /> to fully configure
             ///         the relationship. Calling just this method without the chained call will not
             ///         produce a valid relationship.
             ///     </para>
             /// </summary>
             /// <param name="relatedType"> The entity type that this relationship targets. </param>
-            /// <param name="reference"> 
-            ///     The name of the reference navigation property on this entity type that represents the relationship. If no
-            ///     property is specified, the relationship will be configured without a navigation property on this end.
+            /// <param name="referenceName">
+            ///     The name of the reference navigation property on this entity type that represents the relationship. If
+            ///     no property is specified, the relationship will be configured without a navigation property on this
+            ///     end.
             /// </param>
             /// <returns> An object that can be used to configure the relationship. </returns>
             public virtual ReferenceNavigationBuilder HasOne(
                 [NotNull] Type relatedType,
-                [CanBeNull] string reference = null)
+                [CanBeNull] string referenceName = null)
             {
                 Check.NotNull(relatedType, nameof(relatedType));
 
@@ -412,71 +417,63 @@ namespace Microsoft.Data.Entity
 
                 return new ReferenceNavigationBuilder(
                     relatedEntityType,
-                    reference,
-                    Builder.Relationship(
-                        relatedEntityType,
-                        Metadata,
-                        reference ?? "",
-                        navigationToDependentName: null,
-                        configurationSource: ConfigurationSource.Explicit,
-                        strictPrincipal: false));
+                    referenceName,
+                    HasOneBuilder(relatedEntityType, referenceName));
             }
 
             /// <summary>
             ///     <para>
             ///         Configures a relationship where this entity type has a collection that contains
-            ///         instances of the other type in the relationship. 
+            ///         instances of the other type in the relationship.
             ///     </para>
             ///     <para>
-            ///         After calling this method, you should chain a call to <see cref="CollectionNavigationBuilder.WithOne(string)"/> 
+            ///         After calling this method, you should chain a call to
+            ///         <see cref="CollectionNavigationBuilder.WithOne(string)" />
             ///         to fully configure the relationship. Calling just this method without the chained call will not
             ///         produce a valid relationship.
             ///     </para>
             /// </summary>
-            /// <param name="relatedEntityType"> The entity type that this relationship targets. </param>
-            /// <param name="collection"> 
-            ///     The name of the collection navigation property on this entity type that represents the relationship. If no
-            ///     property is specified, the relationship will be configured without a navigation property on this end.
+            /// <param name="relatedType"> The entity type that this relationship targets. </param>
+            /// <param name="collectionName">
+            ///     The name of the collection navigation property on this entity type that represents the relationship. If
+            ///     no property is specified, the relationship will be configured without a navigation property on this
+            ///     end.
             /// </param>
             /// <returns> An object that can be used to configure the relationship. </returns>
             public virtual CollectionNavigationBuilder HasMany(
-                [NotNull] Type relatedEntityType,
-                [CanBeNull] string collection = null)
+                [NotNull] Type relatedType,
+                [CanBeNull] string collectionName = null)
             {
-                Check.NotNull(relatedEntityType, nameof(relatedEntityType));
+                Check.NotNull(relatedType, nameof(relatedType));
 
-                return new CollectionNavigationBuilder(
-                    collection ?? "",
-                    Builder.Relationship(
-                        Metadata,
-                        Builder.ModelBuilder.Entity(relatedEntityType, ConfigurationSource.Explicit).Metadata,
-                        null,
-                        collection ?? "",
-                        ConfigurationSource.Explicit,
-                        isUnique: false));
+                var relatedEntityType = Builder.ModelBuilder.Entity(relatedType, ConfigurationSource.Explicit).Metadata;
+
+                return new CollectionNavigationBuilder(HasManyBuilder(relatedEntityType, collectionName));
             }
 
             /// <summary>
             ///     <para>
             ///         Configures a relationship where this entity type has a reference that points
-            ///         to a single instance of the other type in the relationship. 
+            ///         to a single instance of the other type in the relationship.
             ///     </para>
             ///     <para>
-            ///         After calling this method, you should chain a call to <see cref="ReferenceNavigationBuilder.WithMany(string)"/> 
-            ///         or <see cref="ReferenceNavigationBuilder.WithOne(string)"/> to fully configure 
+            ///         After calling this method, you should chain a call to
+            ///         <see cref="ReferenceNavigationBuilder.WithMany(string)" />
+            ///         or <see cref="ReferenceNavigationBuilder.WithOne(string)" /> to fully configure
             ///         the relationship. Calling just this method without the chained call will not
             ///         produce a valid relationship.
             ///     </para>
             /// </summary>
             /// <param name="relatedEntityTypeName"> The name of the entity type that this relationship targets. </param>
-            /// <param name="reference"> 
-            ///     The name of the reference navigation property on this entity type that represents the relationship. If no
-            ///     property is specified, the relationship will be configured without a navigation property on this end.
+            /// <param name="referenceName">
+            ///     The name of the reference navigation property on this entity type that represents the relationship. If
+            ///     no  property is specified, the relationship will be configured without a navigation property on this
+            ///     end.
             /// </param>
             /// <returns> An object that can be used to configure the relationship. </returns>
             public virtual ReferenceNavigationBuilder HasOne(
                 [NotNull] string relatedEntityTypeName,
-                [CanBeNull] string reference = null)
+                [CanBeNull] string referenceName = null)
             {
                 Check.NotEmpty(relatedEntityTypeName, nameof(relatedEntityTypeName));
 
@@ -484,56 +481,68 @@ namespace Microsoft.Data.Entity
 
                 return new ReferenceNavigationBuilder(
                     relatedEntityType,
-                    reference,
-                    Builder.Relationship(
-                        relatedEntityType,
-                        Metadata,
-                        reference ?? "",
-                        navigationToDependentName: null,
-                        configurationSource: ConfigurationSource.Explicit,
-                        strictPrincipal: false));
+                    referenceName,
+                    HasOneBuilder(relatedEntityType, referenceName));
             }
 
             /// <summary>
             ///     <para>
             ///         Configures a relationship where this entity type has a collection that contains
-            ///         instances of the other type in the relationship. 
+            ///         instances of the other type in the relationship.
             ///     </para>
             ///     <para>
-            ///         After calling this method, you should chain a call to <see cref="CollectionNavigationBuilder.WithOne(string)"/> 
+            ///         After calling this method, you should chain a call to
+            ///         <see cref="CollectionNavigationBuilder.WithOne(string)" />
             ///         to fully configure the relationship. Calling just this method without the chained call will not
             ///         produce a valid relationship.
             ///     </para>
             /// </summary>
             /// <param name="relatedEntityTypeName"> The name of the entity type that this relationship targets. </param>
-            /// <param name="collection"> 
-            ///     The name of the collection navigation property on this entity type that represents the relationship. If no
-            ///     property is specified, the relationship will be configured without a navigation property on this end.
+            /// <param name="collectionName">
+            ///     The name of the collection navigation property on this entity type that represents the relationship. If
+            ///     no property is specified, the relationship will be configured without a navigation property on this
+            ///     end.
             /// </param>
             /// <returns> An object that can be used to configure the relationship. </returns>
             public virtual CollectionNavigationBuilder HasMany(
                 [NotNull] string relatedEntityTypeName,
-                [CanBeNull] string collection = null)
+                [CanBeNull] string collectionName = null)
             {
                 Check.NotEmpty(relatedEntityTypeName, nameof(relatedEntityTypeName));
 
-                return new CollectionNavigationBuilder(
-                    collection ?? "",
-                    Builder.Relationship(
-                        Metadata,
-                        Builder.ModelBuilder.Metadata.GetEntityType(relatedEntityTypeName),
-                        null,
-                        collection ?? "",
-                        ConfigurationSource.Explicit,
-                        isUnique: false));
+                var relatedEntityType = Builder.ModelBuilder.Metadata.GetEntityType(relatedEntityTypeName);
+
+                return new CollectionNavigationBuilder(HasManyBuilder(relatedEntityType, collectionName));
+            }
+
+            protected InternalRelationshipBuilder HasOneBuilder(EntityType relatedEntityType, string referenceName)
+            {
+                return Builder.Relationship(
+                    relatedEntityType,
+                    Metadata,
+                    navigationToPrincipalName: referenceName ?? "",
+                    navigationToDependentName: null,
+                    configurationSource: ConfigurationSource.Explicit,
+                    strictPrincipal: relatedEntityType == Metadata);
+            }
+
+            protected InternalRelationshipBuilder HasManyBuilder(EntityType relatedEntityType, string collectionName)
+            {
+                return Builder.Relationship(
+                    Metadata,
+                    relatedEntityType,
+                    navigationToPrincipalName: null,
+                    navigationToDependentName: collectionName ?? "",
+                    configurationSource: ConfigurationSource.Explicit,
+                    isUnique: false);
             }
 
             /// <summary>
             ///     <para>
-            ///         Provides a simple API for configuring a <see cref="Metadata.Key"/>.
+            ///         Provides a simple API for configuring a <see cref="Key" />.
             ///     </para>
             ///     <para>
-            ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder"/> API 
+            ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
             ///         and it is not designed to be directly constructed in your application code.
             ///     </para>
             /// </summary>
@@ -541,10 +550,10 @@ namespace Microsoft.Data.Entity
             {
                 /// <summary>
                 ///     <para>
-                ///         Initializes a new instance of the <see cref="KeyBuilder"/> class to configure a given key.
+                ///         Initializes a new instance of the <see cref="KeyBuilder" /> class to configure a given key.
                 ///     </para>
                 ///     <para>
-                ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder"/> API 
+                ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
                 ///         and it is not designed to be directly constructed in your application code.
                 ///     </para>
                 /// </summary>
@@ -557,7 +566,7 @@ namespace Microsoft.Data.Entity
                 }
 
                 /// <summary>
-                ///     The internal builder being used to configure the key. 
+                ///     The internal builder being used to configure the key.
                 /// </summary>
                 protected virtual InternalKeyBuilder Builder { get; }
 
@@ -572,7 +581,8 @@ namespace Microsoft.Data.Entity
                 Model IMetadataBuilder<Key, KeyBuilder>.Model => Builder.ModelBuilder.Metadata;
 
                 /// <summary>
-                ///     Adds or updates an annotation on the key. If an annotation with the key specified in <paramref name="annotation"/>
+                ///     Adds or updates an annotation on the key. If an annotation with the key specified in
+                ///     <paramref name="annotation" />
                 ///     already exists it's value will be updated.
                 /// </summary>
                 /// <param name="annotation"> The key of the annotation to be added or updated. </param>
@@ -591,10 +601,10 @@ namespace Microsoft.Data.Entity
 
             /// <summary>
             ///     <para>
-            ///         Provides a simple API for configuring a <see cref="Metadata.Property"/>.
+            ///         Provides a simple API for configuring a <see cref="Property" />.
             ///     </para>
             ///     <para>
-            ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder"/> API 
+            ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
             ///         and it is not designed to be directly constructed in your application code.
             ///     </para>
             /// </summary>
@@ -602,10 +612,11 @@ namespace Microsoft.Data.Entity
             {
                 /// <summary>
                 ///     <para>
-                ///         Initializes a new instance of the <see cref="PropertyBuilder"/> class to configure a given property.
+                ///         Initializes a new instance of the <see cref="PropertyBuilder" /> class to configure a given
+                ///         property.
                 ///     </para>
                 ///     <para>
-                ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder"/> API 
+                ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
                 ///         and it is not designed to be directly constructed in your application code.
                 ///     </para>
                 /// </summary>
@@ -618,7 +629,7 @@ namespace Microsoft.Data.Entity
                 }
 
                 /// <summary>
-                ///     The internal builder being used to configure the property. 
+                ///     The internal builder being used to configure the property.
                 /// </summary>
                 protected virtual InternalPropertyBuilder Builder { get; }
 
@@ -633,8 +644,8 @@ namespace Microsoft.Data.Entity
                 Model IMetadataBuilder<Property, PropertyBuilder>.Model => Builder.ModelBuilder.Metadata;
 
                 /// <summary>
-                ///     Adds or updates an annotation on the property. If an annotation with the key specified in <paramref name="annotation"/>
-                ///     already exists it's value will be updated.
+                ///     Adds or updates an annotation on the property. If an annotation with the key specified in
+                ///     <paramref name="annotation" /> already exists it's value will be updated.
                 /// </summary>
                 /// <param name="annotation"> The key of the annotation to be added or updated. </param>
                 /// <param name="value"> The value to be stored in the annotation. </param>
@@ -651,7 +662,7 @@ namespace Microsoft.Data.Entity
 
                 /// <summary>
                 ///     Configures whether this property must have a value assigned or whether null is a valid value.
-                ///     A property can only be configured as non-required if it is based on a CLR type that can be 
+                ///     A property can only be configured as non-required if it is based on a CLR type that can be
                 ///     assigned null.
                 /// </summary>
                 /// <param name="isRequired"> A value indicating whether the property is required. </param>
@@ -665,7 +676,7 @@ namespace Microsoft.Data.Entity
 
                 /// <summary>
                 ///     Configures the maximum length of data that can be stored in this property.
-                ///     Maximum length can only be set on array properties (including <see cref="string"/> properties).
+                ///     Maximum length can only be set on array properties (including <see cref="string" /> properties).
                 /// </summary>
                 /// <param name="maxLength"> The maximum length of data allowed in the property. </param>
                 /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
@@ -679,9 +690,9 @@ namespace Microsoft.Data.Entity
                 /// <summary>
                 ///     Configures whether this property should be used as a concurrency token. When a property is configured
                 ///     as a concurrency token the value in the data store will be checked when an instance of this entity type
-                ///     is updated or deleted during <see cref="DbContext.SaveChanges"/> to ensure it has not changed since the 
-                ///     instance was retrieved from the data store. If it has changed, an exception will be thrown and the changes 
-                ///     will not be applied to the data store.
+                ///     is updated or deleted during <see cref="DbContext.SaveChanges" /> to ensure it has not changed since
+                ///     the instance was retrieved from the data store. If it has changed, an exception will be thrown and the
+                ///     changes will not be applied to the data store.
                 /// </summary>
                 /// <param name="isConcurrencyToken"> A value indicating whether this property is a concurrency token. </param>
                 /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
@@ -695,7 +706,7 @@ namespace Microsoft.Data.Entity
                 /// <summary>
                 ///     Configures whether this is a shadow state property. A shadow state property is one that does not have a
                 ///     corresponding property in the entity class. The current value for the property is stored in
-                ///     the <see cref="ChangeTracker"/> rather than being stored in instances of the entity class.
+                ///     the <see cref="ChangeTracker" /> rather than being stored in instances of the entity class.
                 /// </summary>
                 /// <param name="isShadowProperty"> A value indicating whether this is a shadow state property. </param>
                 /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
@@ -709,7 +720,7 @@ namespace Microsoft.Data.Entity
                 /// <summary>
                 ///     Configures whether a value is generated for this property when a new instance of the entity type
                 ///     is added to a context. Data stores will typically register an appropriate
-                ///     <see cref="ValueGenerator"/> to handle generating values. This functionality is typically
+                ///     <see cref="ValueGenerator" /> to handle generating values. This functionality is typically
                 ///     used for key values and is switched on by convention.
                 /// </summary>
                 /// <param name="generateValue"> A value indicating whether a value should be generated. </param>
@@ -738,8 +749,8 @@ namespace Microsoft.Data.Entity
                 ///     Configures whether a default value is generated for this property by the store when an instance
                 ///     of this entity type is saved and no value has been set.
                 /// </summary>
-                /// <param name="useDefault"> 
-                ///     A value indicating whether a default value is generated by the data store when no value is set. 
+                /// <param name="useDefault">
+                ///     A value indicating whether a default value is generated by the data store when no value is set.
                 /// </param>
                 /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
                 public virtual PropertyBuilder UseStoreDefault(bool useDefault = true)
@@ -752,10 +763,10 @@ namespace Microsoft.Data.Entity
 
             /// <summary>
             ///     <para>
-            ///         Provides a simple API for configuring an <see cref="Metadata.Index"/>.
+            ///         Provides a simple API for configuring an <see cref="Index" />.
             ///     </para>
             ///     <para>
-            ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder"/> API 
+            ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
             ///         and it is not designed to be directly constructed in your application code.
             ///     </para>
             /// </summary>
@@ -763,10 +774,10 @@ namespace Microsoft.Data.Entity
             {
                 /// <summary>
                 ///     <para>
-                ///         Initializes a new instance of the <see cref="IndexBuilder"/> class to configure a given index.
+                ///         Initializes a new instance of the <see cref="IndexBuilder" /> class to configure a given index.
                 ///     </para>
                 ///     <para>
-                ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder"/> API 
+                ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
                 ///         and it is not designed to be directly constructed in your application code.
                 ///     </para>
                 /// </summary>
@@ -779,7 +790,7 @@ namespace Microsoft.Data.Entity
                 }
 
                 /// <summary>
-                ///     The internal builder being used to configure the index. 
+                ///     The internal builder being used to configure the index.
                 /// </summary>
                 protected virtual InternalIndexBuilder Builder { get; }
 
@@ -794,7 +805,8 @@ namespace Microsoft.Data.Entity
                 Model IMetadataBuilder<Index, IndexBuilder>.Model => Builder.ModelBuilder.Metadata;
 
                 /// <summary>
-                ///     Adds or updates an annotation on the index. If an annotation with the key specified in <paramref name="annotation"/>
+                ///     Adds or updates an annotation on the index. If an annotation with the key specified in
+                ///     <paramref name="annotation" />
                 ///     already exists it's value will be updated.
                 /// </summary>
                 /// <param name="annotation"> The key of the annotation to be added or updated. </param>
@@ -829,7 +841,7 @@ namespace Microsoft.Data.Entity
             ///         an end of the relationship with a reference that points to an instance of another entity type.
             ///     </para>
             ///     <para>
-            ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder"/> API 
+            ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
             ///         and it is not designed to be directly constructed in your application code.
             ///     </para>
             /// </summary>
@@ -837,37 +849,37 @@ namespace Microsoft.Data.Entity
             {
                 /// <summary>
                 ///     <para>
-                ///         Initializes a new instance of the <see cref="ReferenceNavigationBuilder"/> class.
+                ///         Initializes a new instance of the <see cref="ReferenceNavigationBuilder" /> class.
                 ///     </para>
                 ///     <para>
-                ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder"/> API 
+                ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
                 ///         and it is not designed to be directly constructed in your application code.
                 ///     </para>
                 /// </summary>
                 /// <param name="relatedEntityType"> The entity type that the reference points to. </param>
-                /// <param name="reference"> 
-                ///     The name of the reference navigation property on the end of the relationship that configuration began on. 
-                ///     If null, there is no navigation property on this end of the relationship.
-                ///  </param>
+                /// <param name="referenceName">
+                ///     The name of the reference navigation property on the end of the relationship that configuration began
+                ///     on. If null, there is no navigation property on this end of the relationship.
+                /// </param>
                 /// <param name="builder"> The internal builder being used to configure the relationship. </param>
                 public ReferenceNavigationBuilder(
                     [NotNull] EntityType relatedEntityType,
-                    [CanBeNull] string reference,
+                    [CanBeNull] string referenceName,
                     [NotNull] InternalRelationshipBuilder builder)
                 {
                     Check.NotNull(relatedEntityType, nameof(relatedEntityType));
                     Check.NotNull(builder, nameof(builder));
 
                     RelatedEntityType = relatedEntityType;
-                    Reference = reference;
+                    ReferenceName = referenceName;
                     Builder = builder;
                 }
 
                 /// <summary>
-                ///     Gets or sets the name of the reference navigation property on the end of the relationship that configuration 
-                ///     began on. If null, there is no navigation property on this end of the relationship.
+                ///     Gets or sets the name of the reference navigation property on the end of the relationship that
+                ///     configuration began on. If null, there is no navigation property on this end of the relationship.
                 /// </summary>
-                protected string Reference { get; set; }
+                protected string ReferenceName { get; set; }
 
                 /// <summary>
                 ///     Gets or sets the entity type that the reference points to.
@@ -887,18 +899,18 @@ namespace Microsoft.Data.Entity
                 /// <summary>
                 ///     Configures this as a one-to-many relationship.
                 /// </summary>
-                /// <param name="collection"> 
-                ///     The name of the collection navigation property on the other end of this relationship. 
+                /// <param name="collection">
+                ///     The name of the collection navigation property on the other end of this relationship.
                 ///     If null, there is no navigation property on the other end of the relationship.
                 /// </param>
                 /// <returns> An object to further configure the relationship. </returns>
                 public virtual ManyToOneBuilder WithMany([CanBeNull] string collection = null) => new ManyToOneBuilder(WithManyBuilder(collection));
 
                 /// <summary>
-                ///     Returns the internal builder to be used when <see cref="WithMany"/> is called.
+                ///     Returns the internal builder to be used when <see cref="WithMany" /> is called.
                 /// </summary>
-                /// <param name="collection"> 
-                ///     The name of the collection navigation property on the other end of this relationship. 
+                /// <param name="collection">
+                ///     The name of the collection navigation property on the other end of this relationship.
                 ///     If null, there is no navigation property on the other end of the relationship.
                 /// </param>
                 /// <returns> The internal builder to further configure the relationship. </returns>
@@ -927,29 +939,31 @@ namespace Microsoft.Data.Entity
                 /// <summary>
                 ///     Configures this as a one-to-one relationship.
                 /// </summary>
-                /// <param name="inverseReference"> 
-                ///     The name of the reference navigation property on the other end of this relationship. 
+                /// <param name="inverseReference">
+                ///     The name of the reference navigation property on the other end of this relationship.
                 ///     If null, there is no navigation property on the other end of the relationship.
                 /// </param>
                 /// <returns> An object to further configure the relationship. </returns>
                 public virtual OneToOneBuilder WithOne([CanBeNull] string inverseReference = null) => new OneToOneBuilder(WithOneBuilder(inverseReference));
 
                 /// <summary>
-                ///     Returns the internal builder to be used when <see cref="WithOne"/> is called.
+                ///     Returns the internal builder to be used when <see cref="WithOne" /> is called.
                 /// </summary>
-                /// <param name="inverseReferenceName"> 
-                ///     The name of the reference navigation property on the other end of this relationship. 
+                /// <param name="inverseReferenceName">
+                ///     The name of the reference navigation property on the other end of this relationship.
                 ///     If null, there is no navigation property on the other end of the relationship.
                 /// </param>
                 /// <returns> The internal builder to further configure the relationship. </returns>
                 protected InternalRelationshipBuilder WithOneBuilder(string inverseReferenceName)
                 {
-                    var inverseToPrincipal = Metadata.EntityType == RelatedEntityType
-                                             && (string.IsNullOrEmpty(Reference) || Metadata.GetNavigationToDependent()?.Name == Reference);
+                    var isSelfReferencing = Metadata.EntityType == Metadata.ReferencedEntityType;
+                    var inverseToPrincipal = !isSelfReferencing
+                                             && Metadata.EntityType == RelatedEntityType
+                                             && (string.IsNullOrEmpty(ReferenceName) || Metadata.GetNavigationToDependent()?.Name == ReferenceName);
 
                     Debug.Assert(inverseToPrincipal
                                  || (Metadata.ReferencedEntityType == RelatedEntityType
-                                     && (string.IsNullOrEmpty(Reference) || Metadata.GetNavigationToPrincipal()?.Name == Reference)));
+                                     && (string.IsNullOrEmpty(ReferenceName) || Metadata.GetNavigationToPrincipal()?.Name == ReferenceName)));
 
                     var builder = Builder;
                     if (!((IForeignKey)Metadata).IsUnique)
@@ -975,7 +989,7 @@ namespace Microsoft.Data.Entity
             ///         an end of the relationship with a collection that contains instances of another entity type.
             ///     </para>
             ///     <para>
-            ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder"/> API 
+            ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
             ///         and it is not designed to be directly constructed in your application code.
             ///     </para>
             /// </summary>
@@ -983,33 +997,20 @@ namespace Microsoft.Data.Entity
             {
                 /// <summary>
                 ///     <para>
-                ///         Initializes a new instance of the <see cref="CollectionNavigationBuilder"/> class.
+                ///         Initializes a new instance of the <see cref="CollectionNavigationBuilder" /> class.
                 ///     </para>
                 ///     <para>
-                ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder"/> API 
+                ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
                 ///         and it is not designed to be directly constructed in your application code.
                 ///     </para>
                 /// </summary>
-                /// <param name="collection"> 
-                ///     The name of the collection navigation property on the end of the relationship that configuration began on. 
-                ///     If null, there is no navigation property on this end of the relationship.
-                ///  </param>
                 /// <param name="builder"> The internal builder being used to configure the relationship. </param>
-                public CollectionNavigationBuilder(
-                    [CanBeNull] string collection,
-                    [NotNull] InternalRelationshipBuilder builder)
+                public CollectionNavigationBuilder([NotNull] InternalRelationshipBuilder builder)
                 {
                     Check.NotNull(builder, nameof(builder));
 
-                    Collection = collection;
                     Builder = builder;
                 }
-
-                /// <summary>
-                ///     Gets or sets the name of the collection navigation property. on the end of the relationship that 
-                ///     configuration began on. If null, there is no navigation property on this end of the relationship.
-                /// </summary>
-                protected string Collection { get; set; }
 
                 /// <summary>
                 ///     The foreign key that represents this relationship.
@@ -1024,18 +1025,18 @@ namespace Microsoft.Data.Entity
                 /// <summary>
                 ///     Configures this as a one-to-many relationship.
                 /// </summary>
-                /// <param name="reference"> 
-                ///     The name of the reference navigation property on the other end of this relationship. 
+                /// <param name="reference">
+                ///     The name of the reference navigation property on the other end of this relationship.
                 ///     If null, there is no navigation property on the other end of the relationship.
                 /// </param>
                 /// <returns> An object to further configure the relationship. </returns>
                 public virtual OneToManyBuilder WithOne([CanBeNull] string reference = null) => new OneToManyBuilder(WithOneBuilder(reference));
 
                 /// <summary>
-                ///     Returns the internal builder to be used when <see cref="WithOne"/> is called.
+                ///     Returns the internal builder to be used when <see cref="WithOne" /> is called.
                 /// </summary>
-                /// <param name="reference"> 
-                ///     The name of the reference navigation property on the other end of this relationship. 
+                /// <param name="reference">
+                ///     The name of the reference navigation property on the other end of this relationship.
                 ///     If null, there is no navigation property on the other end of the relationship.
                 /// </param>
                 /// <returns> The internal builder to further configure the relationship. </returns>
@@ -1050,7 +1051,7 @@ namespace Microsoft.Data.Entity
             ///         Provides a simple API for configuring a one-to-many relationship.
             ///     </para>
             ///     <para>
-            ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder"/> API 
+            ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
             ///         and it is not designed to be directly constructed in your application code.
             ///     </para>
             /// </summary>
@@ -1058,10 +1059,10 @@ namespace Microsoft.Data.Entity
             {
                 /// <summary>
                 ///     <para>
-                ///         Initializes a new instance of the <see cref="OneToManyBuilder"/> class.
+                ///         Initializes a new instance of the <see cref="OneToManyBuilder" /> class.
                 ///     </para>
                 ///     <para>
-                ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder"/> API 
+                ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
                 ///         and it is not designed to be directly constructed in your application code.
                 ///     </para>
                 /// </summary>
@@ -1089,7 +1090,8 @@ namespace Microsoft.Data.Entity
                 protected virtual InternalRelationshipBuilder Builder { get; }
 
                 /// <summary>
-                ///     Adds or updates an annotation on the relationship. If an annotation with the key specified in <paramref name="annotation"/>
+                ///     Adds or updates an annotation on the relationship. If an annotation with the key specified in
+                ///     <paramref name="annotation" />
                 ///     already exists it's value will be updated.
                 /// </summary>
                 /// <param name="annotation"> The key of the annotation to be added or updated. </param>
@@ -1110,21 +1112,21 @@ namespace Microsoft.Data.Entity
                 ///         Configures the property(s) to use as the foreign key for this relationship.
                 ///     </para>
                 ///     <para>
-                ///         If the specified property name(s) do not exist on the entity type then a new shadow state property(s)
-                ///         will be added to serve as the foreign key. A shadow state property is one 
-                ///         that does not have a corresponding property in the entity class. The current value for the 
-                ///         property is stored in the <see cref="ChangeTracker"/> rather than being stored in instances 
+                ///         If the specified property name(s) do not exist on the entity type then a new shadow state
+                ///         property(s) will be added to serve as the foreign key. A shadow state property is one that does not
+                ///         have a corresponding property in the entity class. The current value for the  property is stored in
+                ///         the <see cref="ChangeTracker" /> rather than being stored in instances
                 ///         of the entity class.
                 ///     </para>
                 ///     <para>
-                ///         If <see cref="ReferencedKey"/> is not specified, then an attempt will be made to match
-                ///         the data type and order of foreign key properties against the primary key of the principal 
-                ///         entity type. If they do not match, new shadow state properties that form a unique index will be 
-                ///         added to the principal entity type to serve as the reference key. 
+                ///         If <see cref="ReferencedKey" /> is not specified, then an attempt will be made to match
+                ///         the data type and order of foreign key properties against the primary key of the principal
+                ///         entity type. If they do not match, new shadow state properties that form a unique index will be
+                ///         added to the principal entity type to serve as the reference key.
                 ///     </para>
                 /// </summary>
-                /// <param name="foreignKeyPropertyNames"> 
-                ///     The name(s) of the foreign key property(s). 
+                /// <param name="foreignKeyPropertyNames">
+                ///     The name(s) of the foreign key property(s).
                 /// </param>
                 /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
                 public virtual OneToManyBuilder ForeignKey([NotNull] params string[] foreignKeyPropertyNames)
@@ -1166,7 +1168,7 @@ namespace Microsoft.Data.Entity
             ///         Provides a simple API for configuring a one-to-many relationship.
             ///     </para>
             ///     <para>
-            ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder"/> API 
+            ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
             ///         and it is not designed to be directly constructed in your application code.
             ///     </para>
             /// </summary>
@@ -1174,10 +1176,10 @@ namespace Microsoft.Data.Entity
             {
                 /// <summary>
                 ///     <para>
-                ///         Initializes a new instance of the <see cref="ManyToOneBuilder"/> class.
+                ///         Initializes a new instance of the <see cref="ManyToOneBuilder" /> class.
                 ///     </para>
                 ///     <para>
-                ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder"/> API 
+                ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
                 ///         and it is not designed to be directly constructed in your application code.
                 ///     </para>
                 /// </summary>
@@ -1205,8 +1207,8 @@ namespace Microsoft.Data.Entity
                 Model IMetadataBuilder<ForeignKey, ManyToOneBuilder>.Model => Builder.ModelBuilder.Metadata;
 
                 /// <summary>
-                ///     Adds or updates an annotation on the relationship. If an annotation with the key specified in <paramref name="annotation"/>
-                ///     already exists it's value will be updated.
+                ///     Adds or updates an annotation on the relationship. If an annotation with the key specified in
+                ///     <paramref name="annotation" /> already exists it's value will be updated.
                 /// </summary>
                 /// <param name="annotation"> The key of the annotation to be added or updated. </param>
                 /// <param name="value"> The value to be stored in the annotation. </param>
@@ -1226,21 +1228,21 @@ namespace Microsoft.Data.Entity
                 ///         Configures the property(s) to use as the foreign key for this relationship.
                 ///     </para>
                 ///     <para>
-                ///         If the specified property name(s) do not exist on the entity type then a new shadow state property(s)
-                ///         will be added to serve as the foreign key. A shadow state property is one 
-                ///         that does not have a corresponding property in the entity class. The current value for the 
-                ///         property is stored in the <see cref="ChangeTracker"/> rather than being stored in instances 
+                ///         If the specified property name(s) do not exist on the entity type then a new shadow state
+                ///         property(s) will be added to serve as the foreign key. A shadow state property is one
+                ///         that does not have a corresponding property in the entity class. The current value for the
+                ///         property is stored in the <see cref="ChangeTracker" /> rather than being stored in instances
                 ///         of the entity class.
                 ///     </para>
                 ///     <para>
-                ///         If <see cref="ReferencedKey"/> is not specified, then an attempt will be made to match
-                ///         the data type and order of foreign key properties against the primary key of the principal 
-                ///         entity type. If they do not match, new shadow state properties that form a unique index will be 
-                ///         added to the principal entity type to serve as the reference key. 
+                ///         If <see cref="ReferencedKey" /> is not specified, then an attempt will be made to match
+                ///         the data type and order of foreign key properties against the primary key of the principal
+                ///         entity type. If they do not match, new shadow state properties that form a unique index will be
+                ///         added to the principal entity type to serve as the reference key.
                 ///     </para>
                 /// </summary>
-                /// <param name="foreignKeyPropertyNames"> 
-                ///     The name(s) of the foreign key property(s). 
+                /// <param name="foreignKeyPropertyNames">
+                ///     The name(s) of the foreign key property(s).
                 /// </param>
                 /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
                 public virtual ManyToOneBuilder ForeignKey([NotNull] params string[] foreignKeyPropertyNames)
@@ -1280,18 +1282,19 @@ namespace Microsoft.Data.Entity
             ///         Provides a simple API for configuring a one-to-one relationship.
             ///     </para>
             ///     <para>
-            ///         If multiple reference key properties are specified, the order of reference key properties should match the 
-            ///         order that the primary key or unique index properties were configured on the principal entity type.
+            ///         If multiple reference key properties are specified, the order of reference key properties should
+            ///         match the order that the primary key or unique index properties were configured on the principal
+            ///         entity type.
             ///     </para>
             /// </summary>
             public class OneToOneBuilder : IOneToOneBuilder<OneToOneBuilder>
             {
                 /// <summary>
                 ///     <para>
-                ///         Initializes a new instance of the <see cref="OneToOneBuilder"/> class.
+                ///         Initializes a new instance of the <see cref="OneToOneBuilder" /> class.
                 ///     </para>
                 ///     <para>
-                ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder"/> API 
+                ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
                 ///         and it is not designed to be directly constructed in your application code.
                 ///     </para>
                 /// </summary>
@@ -1319,8 +1322,8 @@ namespace Microsoft.Data.Entity
                 Model IMetadataBuilder<ForeignKey, OneToOneBuilder>.Model => Builder.ModelBuilder.Metadata;
 
                 /// <summary>
-                ///     Adds or updates an annotation on the relationship. If an annotation with the key specified in <paramref name="annotation"/>
-                ///     already exists it's value will be updated.
+                ///     Adds or updates an annotation on the relationship. If an annotation with the key specified in
+                ///     <paramref name="annotation" /> already exists it's value will be updated.
                 /// </summary>
                 /// <param name="annotation"> The key of the annotation to be added or updated. </param>
                 /// <param name="value"> The value to be stored in the annotation. </param>
@@ -1340,24 +1343,25 @@ namespace Microsoft.Data.Entity
                 ///         Configures the property(s) to use as the foreign key for this relationship.
                 ///     </para>
                 ///     <para>
-                ///         If the specified property name(s) do not exist on the entity type then a new shadow state property(s)
-                ///         will be added to serve as the foreign key. A shadow state property is one 
-                ///         that does not have a corresponding property in the entity class. The current value for the 
-                ///         property is stored in the <see cref="ChangeTracker"/> rather than being stored in instances 
+                ///         If the specified property name(s) do not exist on the entity type then a new shadow state
+                ///         property(s) will be added to serve as the foreign key. A shadow state property is one
+                ///         that does not have a corresponding property in the entity class. The current value for the
+                ///         property is stored in the <see cref="ChangeTracker" /> rather than being stored in instances
                 ///         of the entity class.
                 ///     </para>
                 ///     <para>
-                ///         If <see cref="ReferencedKey(Type, string[])"/> is not specified, then an attempt will be made to match
-                ///         the data type and order of foreign key properties against the primary key of the principal 
-                ///         entity type. If they do not match, new shadow state properties that form a unique index will be 
-                ///         added to the principal entity type to serve as the reference key. 
+                ///         If <see cref="ReferencedKey(Type, string[])" /> is not specified, then an attempt will be made to
+                ///         match the data type and order of foreign key properties against the primary key of the principal
+                ///         entity type. If they do not match, new shadow state properties that form a unique index will be
+                ///         added to the principal entity type to serve as the reference key.
                 ///     </para>
                 /// </summary>
                 /// <param name="dependentEntityType">
-                ///     The entity type that is the dependent in this relationship (the type that has the foreign key properties).
+                ///     The entity type that is the dependent in this relationship (the type that has the foreign key
+                ///     properties).
                 /// </param>
-                /// <param name="foreignKeyPropertyNames"> 
-                ///     The name(s) of the foreign key property(s). 
+                /// <param name="foreignKeyPropertyNames">
+                ///     The name(s) of the foreign key property(s).
                 /// </param>
                 /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
                 public virtual OneToOneBuilder ForeignKey(
@@ -1397,24 +1401,25 @@ namespace Microsoft.Data.Entity
                 ///         Configures the property(s) to use as the foreign key for this relationship.
                 ///     </para>
                 ///     <para>
-                ///         If the specified property name(s) do not exist on the entity type then a new shadow state property(s)
-                ///         will be added to serve as the foreign key. A shadow state property is one 
-                ///         that does not have a corresponding property in the entity class. The current value for the 
-                ///         property is stored in the <see cref="ChangeTracker"/> rather than being stored in instances 
+                ///         If the specified property name(s) do not exist on the entity type then a new shadow state
+                ///         property(s) will be added to serve as the foreign key. A shadow state property is one
+                ///         that does not have a corresponding property in the entity class. The current value for the
+                ///         property is stored in the <see cref="ChangeTracker" /> rather than being stored in instances
                 ///         of the entity class.
                 ///     </para>
                 ///     <para>
-                ///         If <see cref="ReferencedKey(Type, string[])"/> is not specified, then an attempt will be made to match
-                ///         the data type and order of foreign key properties against the primary key of the principal 
-                ///         entity type. If they do not match, new shadow state properties that form a unique index will be 
-                ///         added to the principal entity type to serve as the reference key. 
+                ///         If <see cref="ReferencedKey(Type, string[])" /> is not specified, then an attempt will be made to
+                ///         match the data type and order of foreign key properties against the primary key of the principal
+                ///         entity type. If they do not match, new shadow state properties that form a unique index will be
+                ///         added to the principal entity type to serve as the reference key.
                 ///     </para>
                 /// </summary>
                 /// <param name="dependentEntityTypeName">
-                ///     The name of the entity type that is the dependent in this relationship (the type that has the foreign key properties).
+                ///     The name of the entity type that is the dependent in this relationship (the type that has the foreign
+                ///     key properties).
                 /// </param>
-                /// <param name="foreignKeyPropertyNames"> 
-                ///     The name(s) of the foreign key property(s). 
+                /// <param name="foreignKeyPropertyNames">
+                ///     The name(s) of the foreign key property(s).
                 /// </param>
                 /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
                 public virtual OneToOneBuilder ForeignKey(
@@ -1454,14 +1459,14 @@ namespace Microsoft.Data.Entity
                 ///         Configures the property(s) to use as the foreign key for this relationship.
                 ///     </para>
                 ///     <para>
-                ///         If <see cref="ReferencedKey{TPrincipalEntity}"/> 
-                ///         is not specified, then an attempt will be made to match
-                ///         the data type and order of foreign key properties against the primary key of the principal 
-                ///         entity type. If they do not match, new shadow state properties that form a unique index will be 
-                ///         added to the principal entity type to serve as the reference key. 
-                ///         A shadow state property is one that does not have a
-                ///         corresponding property in the entity class. The current value for the property is stored in
-                ///         the <see cref="ChangeTracker"/> rather than being stored in instances of the entity class.
+                ///         If <see cref="ReferencedKey{TPrincipalEntity}" />
+                ///         is not specified, then an attempt will be made to match the data type and order of foreign key
+                ///         properties against the primary key of the principal entity type. If they do not match, new shadow
+                ///         state properties that form a unique index will be
+                ///         added to the principal entity type to serve as the reference key.
+                ///         A shadow state property is one that does not have a corresponding property in the entity class. The
+                ///         current value for the property is stored in the <see cref="ChangeTracker" /> rather than being
+                ///         stored in instances of the entity class.
                 ///     </para>
                 /// </summary>
                 /// <typeparam name="TDependentEntity">
@@ -1473,8 +1478,9 @@ namespace Microsoft.Data.Entity
                 ///         A lambda expression representing the foreign key property(s) (<c>t => t.Id1</c>).
                 ///     </para>
                 ///     <para>
-                ///         If the foreign key is made up of multiple properties then specify an anonymous type including the properties (<c>t => new { t.Id1, t.Id2 }</c>).
-                ///         The order specified should match the order of corresponding keys in <see cref="ReferencedKey{TPrincipalEntity}"/>.
+                ///         If the foreign key is made up of multiple properties then specify an anonymous type including the
+                ///         properties (<c>t => new { t.Id1, t.Id2 }</c>). The order specified should match the order of
+                ///         corresponding keys in <see cref="ReferencedKey{TPrincipalEntity}" />.
                 ///     </para>
                 /// </param>
                 /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
@@ -1497,12 +1503,13 @@ namespace Microsoft.Data.Entity
                 ///     The entity type that is the principal in this relationship. That is, the type
                 ///     that has the reference key properties.
                 /// </typeparam>
-                /// <param name="keyExpression"> 
+                /// <param name="keyExpression">
                 ///     <para>
                 ///         A lambda expression representing the reference key property(s) (<c>t => t.Id</c>).
                 ///     </para>
                 ///     <para>
-                ///         If the referenced key is made up of multiple properties then specify an anonymous type including the properties (<c>t => new { t.Id1, t.Id2 }</c>).
+                ///         If the referenced key is made up of multiple properties then specify an anonymous type including
+                ///         the properties (<c>t => new { t.Id1, t.Id2 }</c>).
                 ///     </para>
                 /// </param>
                 /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
@@ -1529,10 +1536,10 @@ namespace Microsoft.Data.Entity
 
         /// <summary>
         ///     <para>
-        ///         Provides a simple API for configuring an <see cref="EntityType"/>. 
+        ///         Provides a simple API for configuring an <see cref="EntityType" />.
         ///     </para>
         ///     <para>
-        ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder"/> API 
+        ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
         ///         and it is not designed to be directly constructed in your application code.
         ///     </para>
         /// </summary>
@@ -1542,10 +1549,11 @@ namespace Microsoft.Data.Entity
         {
             /// <summary>
             ///     <para>
-            ///         Initializes a new instance of the <see cref="EntityBuilder{TEntity}"/> class to configure a given entity type.
+            ///         Initializes a new instance of the <see cref="EntityBuilder{TEntity}" /> class to configure a given
+            ///         entity type.
             ///     </para>
             ///     <para>
-            ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder"/> API 
+            ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
             ///         and it is not designed to be directly constructed in your application code.
             ///     </para>
             /// </summary>
@@ -1556,8 +1564,8 @@ namespace Microsoft.Data.Entity
             }
 
             /// <summary>
-            ///     Adds or updates an annotation on the entity type. If an annotation with the key specified in <paramref name="annotation"/>
-            ///     already exists it's value will be updated.
+            ///     Adds or updates an annotation on the entity type. If an annotation with the key specified in
+            ///     <paramref name="annotation" /> already exists it's value will be updated.
             /// </summary>
             /// <param name="annotation"> The key of the annotation to be added or updated. </param>
             /// <param name="value"> The value to be stored in the annotation. </param>
@@ -1582,7 +1590,8 @@ namespace Microsoft.Data.Entity
             ///         A lambda expression representing the primary key property(s) (<c>t => t.Id1</c>).
             ///     </para>
             ///     <para>
-            ///         If the primary key is made up of multiple properties then specify an anonymous type including the properties (<c>t => new { t.Id1, t.Id2 }</c>).
+            ///         If the primary key is made up of multiple properties then specify an anonymous type including the
+            ///         properties (<c>t => new { t.Id1, t.Id2 }</c>).
             ///     </para>
             /// </param>
             /// <returns> An object that can be used to configure the primary key. </returns>
@@ -1597,7 +1606,10 @@ namespace Microsoft.Data.Entity
             ///     Returns an object that can be used to configure a property of the entity type.
             ///     If the specified property is not already part of the model, it will be added.
             /// </summary>
-            /// <param name="propertyExpression"> A lambda expression representing the property to be configured (<c>t => t.Property1</c>). </param>
+            /// <param name="propertyExpression">
+            ///     A lambda expression representing the property to be configured (
+            ///     <c>t => t.Property1</c>).
+            /// </param>
             /// <returns> An object that can be used to configure the property. </returns>
             public virtual PropertyBuilder Property([NotNull] Expression<Func<TEntity, object>> propertyExpression)
             {
@@ -1608,10 +1620,13 @@ namespace Microsoft.Data.Entity
             }
 
             /// <summary>
-            ///     Excludes the given property from the entity type. This method is typically used to remove properties from 
-            ///     the entity type that were added by convention.
+            ///     Excludes the given property from the entity type. This method is typically used to remove properties
+            ///     from the entity type that were added by convention.
             /// </summary>
-            /// <param name="propertyExpression"> A lambda expression representing the property to be ignored (<c>t => t.Property1</c>). </param>
+            /// <param name="propertyExpression">
+            ///     A lambda expression representing the property to be ignored
+            ///     (<c>t => t.Property1</c>).
+            /// </param>
             public virtual void Ignore([NotNull] Expression<Func<TEntity, object>> propertyExpression)
             {
                 Check.NotNull(propertyExpression, nameof(propertyExpression));
@@ -1624,12 +1639,14 @@ namespace Microsoft.Data.Entity
             ///     Configures an index on the specified properties. If there is an existing index on the given
             ///     set of properties, then the existing index will be returned for configuration.
             /// </summary>
-            /// <param name="indexExpression"> 
+            /// <param name="indexExpression">
             ///     <para>
-            ///         A lambda expression representing the property(s) to be included in the index (<c>t => t.Property1</c>).
+            ///         A lambda expression representing the property(s) to be included in the index
+            ///         (<c>t => t.Property1</c>).
             ///     </para>
             ///     <para>
-            ///         If the index is made up of multiple properties then specify an anonymous type including the properties (<c>t => new { t.Property1, t.Property2 }</c>).
+            ///         If the index is made up of multiple properties then specify an anonymous type including the
+            ///         properties (<c>t => new { t.Property1, t.Property2 }</c>).
             ///     </para>
             /// </param>
             /// <returns> An object that can be used to configure the index. </returns>
@@ -1643,81 +1660,76 @@ namespace Microsoft.Data.Entity
             /// <summary>
             ///     <para>
             ///         Configures a relationship where this entity type has a reference that points
-            ///         to a single instance of the other type in the relationship. 
+            ///         to a single instance of the other type in the relationship.
             ///     </para>
             ///     <para>
-            ///         After calling this method, you should chain a call to <see cref="ReferenceNavigationBuilder{TRelatedEntity}.WithOne"/> 
-            ///         or <see cref="ReferenceNavigationBuilder{TRelatedEntity}.WithOne"/> to fully configure 
-            ///         the relationship. Calling just this method without the chained call will not
+            ///         After calling this method, you should chain a call to
+            ///         <see
+            ///             cref="ReferenceNavigationBuilder{TRelatedEntity}.WithMany(Expression{Func{TRelatedEntity, IEnumerable{TEntity}}})" />
+            ///         or
+            ///         <see
+            ///             cref="ReferenceNavigationBuilder{TRelatedEntity}.WithOne(Expression{Func{TRelatedEntity, TEntity}})" />
+            ///         to fully configure the relationship. Calling just this method without the chained call will not
             ///         produce a valid relationship.
             ///     </para>
             /// </summary>
             /// <typeparam name="TRelatedEntity"> The entity type that this relationship targets. </typeparam>
-            /// <param name="reference"> 
-            ///     A lambda expression representing the reference navigation property on this entity type that represents the 
-            ///     relationship (<c>t => t.Reference1</c>). If no property is specified, the relationship will be configured 
-            ///     without a navigation property on this end.
+            /// <param name="reference">
+            ///     A lambda expression representing the reference navigation property on this entity type that represents
+            ///     the relationship (<c>t => t.Reference1</c>). If no property is specified, the relationship will be
+            ///     configured without a navigation property on this end.
             /// </param>
             /// <returns> An object that can be used to configure the relationship. </returns>
             public virtual ReferenceNavigationBuilder<TRelatedEntity> HasOne<TRelatedEntity>(
                 [CanBeNull] Expression<Func<TEntity, TRelatedEntity>> reference = null)
             {
                 var relatedEntityType = Builder.ModelBuilder.Entity(typeof(TRelatedEntity), ConfigurationSource.Explicit).Metadata;
-                var referenceName = reference?.GetPropertyAccess().Name ?? "";
+                var referenceName = reference?.GetPropertyAccess().Name;
 
                 return new ReferenceNavigationBuilder<TRelatedEntity>(
                     relatedEntityType,
                     referenceName,
-                    Builder.Relationship(
-                        relatedEntityType,
-                        Metadata,
-                        referenceName,
-                        navigationToDependentName: null,
-                        configurationSource: ConfigurationSource.Explicit,
-                        strictPrincipal: false));
+                    HasOneBuilder(relatedEntityType, referenceName));
             }
 
             /// <summary>
             ///     <para>
             ///         Configures a relationship where this entity type has a collection that contains
-            ///         instances of the other type in the relationship. 
+            ///         instances of the other type in the relationship.
             ///     </para>
             ///     <para>
-            ///         After calling this method, you should chain a call to <see cref="CollectionNavigationBuilder{TRelatedEntity}.WithOne"/> 
+            ///         After calling this method, you should chain a call to
+            ///         <see
+            ///             cref="CollectionNavigationBuilder{TRelatedEntity}.WithOne(Expression{Func{TRelatedEntity, TEntity}})" />
             ///         to fully configure the relationship. Calling just this method without the chained call will not
             ///         produce a valid relationship.
             ///     </para>
             /// </summary>
             /// <typeparam name="TRelatedEntity"> The entity type that this relationship targets. </typeparam>
-            /// <param name="collection"> 
-            ///     A lambda expression representing the collection navigation property on this entity type that represents the 
-            ///     relationship (<c>t => t.Collection1</c>). If no property is specified, the relationship will be configured 
-            ///     without a navigation property on this end.
+            /// <param name="collection">
+            ///     A lambda expression representing the collection navigation property on this entity type that represents
+            ///     the relationship (<c>t => t.Collection1</c>). If no property is specified, the relationship will be
+            ///     configured without a navigation property on this end.
             /// </param>
             /// <returns> An object that can be used to configure the relationship. </returns>
             public virtual CollectionNavigationBuilder<TRelatedEntity> HasMany<TRelatedEntity>(
                 [CanBeNull] Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> collection = null)
             {
-                var collectionName = collection?.GetPropertyAccess().Name ?? "";
+                var relatedEntityType = Builder.ModelBuilder.Entity(typeof(TRelatedEntity), ConfigurationSource.Explicit).Metadata;
+                var collectionName = collection?.GetPropertyAccess().Name;
 
                 return new CollectionNavigationBuilder<TRelatedEntity>(
                     collectionName,
-                    Builder.Relationship(
-                        typeof(TEntity),
-                        typeof(TRelatedEntity),
-                        null,
-                        collectionName,
-                        configurationSource: ConfigurationSource.Explicit,
-                        isUnique: false));
+                    HasManyBuilder(relatedEntityType, collectionName));
             }
 
             /// <summary>
             ///     <para>
-            ///         Provides a simple API for configuring a relationship where configuration began on
-            ///         an end of the relationship with a reference that points to an instance of another entity type.
+            ///         Provides a simple API for configuring a relationship where configuration began on an end of the
+            ///         relationship with a reference that points to an instance of another entity type.
             ///     </para>
             ///     <para>
-            ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder"/> API 
+            ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
             ///         and it is not designed to be directly constructed in your application code.
             ///     </para>
             /// </summary>
@@ -1726,34 +1738,34 @@ namespace Microsoft.Data.Entity
             {
                 /// <summary>
                 ///     <para>
-                ///         Initializes a new instance of the <see cref="ReferenceNavigationBuilder{TRelatedEntity}"/> class.
+                ///         Initializes a new instance of the <see cref="ReferenceNavigationBuilder{TRelatedEntity}" /> class.
                 ///     </para>
                 ///     <para>
-                ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder"/> API 
+                ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
                 ///         and it is not designed to be directly constructed in your application code.
                 ///     </para>
                 /// </summary>
                 /// <param name="relatedEntityType"> The entity type that the reference points to. </param>
-                /// <param name="reference"> 
-                ///     The name of the reference navigation property on the end of the relationship that configuration began on. 
-                ///     If null, there is no navigation property on this end of the relationship.
-                ///  </param>
+                /// <param name="referenceName">
+                ///     The name of the reference navigation property on the end of the relationship that configuration began
+                ///     on. If null, there is no navigation property on this end of the relationship.
+                /// </param>
                 /// <param name="builder"> The internal builder being used to configure the relationship. </param>
                 public ReferenceNavigationBuilder(
                     [NotNull] EntityType relatedEntityType,
-                    [CanBeNull] string reference,
+                    [CanBeNull] string referenceName,
                     [NotNull] InternalRelationshipBuilder builder)
-                    : base(relatedEntityType, reference, builder)
+                    : base(relatedEntityType, referenceName, builder)
                 {
                 }
 
                 /// <summary>
                 ///     Configures this as a one-to-many relationship.
                 /// </summary>
-                /// <param name="collection"> 
+                /// <param name="collection">
                 ///     A lambda expression representing the collection navigation property on the other end of this
-                ///     relationship (<c>t => t.Collection1</c>). If no property is specified, the relationship will be configured 
-                ///     without a navigation property on the other end of the relationship.
+                ///     relationship (<c>t => t.Collection1</c>). If no property is specified, the relationship will be
+                ///     configured without a navigation property on the other end of the relationship.
                 /// </param>
                 /// <returns> An object to further configure the relationship. </returns>
                 public virtual ManyToOneBuilder<TRelatedEntity> WithMany(
@@ -1763,10 +1775,10 @@ namespace Microsoft.Data.Entity
                 /// <summary>
                 ///     Configures this as a one-to-one relationship.
                 /// </summary>
-                /// <param name="inverseReference"> 
+                /// <param name="inverseReference">
                 ///     A lambda expression representing the reference navigation property on the other end of this
-                ///     relationship (<c>t => t.Reference1</c>). If no property is specified, the relationship will be configured 
-                ///     without a navigation property on the other end of the relationship.
+                ///     relationship (<c>t => t.Reference1</c>). If no property is specified, the relationship will be
+                ///     configured without a navigation property on the other end of the relationship.
                 /// </param>
                 /// <returns> An object to further configure the relationship. </returns>
                 public virtual OneToOneBuilder WithOne([CanBeNull] Expression<Func<TRelatedEntity, TEntity>> inverseReference = null)
@@ -1779,7 +1791,7 @@ namespace Microsoft.Data.Entity
             ///         an end of the relationship with a collection that contains instances of another entity type.
             ///     </para>
             ///     <para>
-            ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder"/> API 
+            ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
             ///         and it is not designed to be directly constructed in your application code.
             ///     </para>
             /// </summary>
@@ -1788,32 +1800,32 @@ namespace Microsoft.Data.Entity
             {
                 /// <summary>
                 ///     <para>
-                ///         Initializes a new instance of the <see cref="CollectionNavigationBuilder{TRelatedEntity}"/> class.
+                ///         Initializes a new instance of the <see cref="CollectionNavigationBuilder{TRelatedEntity}" /> class.
                 ///     </para>
                 ///     <para>
-                ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder"/> API 
+                ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
                 ///         and it is not designed to be directly constructed in your application code.
                 ///     </para>
                 /// </summary>
-                /// <param name="collection"> 
-                ///     The name of the collection navigation property on the end of the relationship that configuration began on. 
-                ///     If null, there is no navigation property on this end of the relationship.
-                ///  </param>
+                /// <param name="collection">
+                ///     The name of the collection navigation property on the end of the relationship that configuration began
+                ///     on. If null, there is no navigation property on this end of the relationship.
+                /// </param>
                 /// <param name="builder"> The internal builder being used to configure the relationship. </param>
                 public CollectionNavigationBuilder(
                     [CanBeNull] string collection,
                     [NotNull] InternalRelationshipBuilder builder)
-                    : base(collection, builder)
+                    : base(builder)
                 {
                 }
 
                 /// <summary>
                 ///     Configures this as a one-to-many relationship.
                 /// </summary>
-                /// <param name="reference"> 
+                /// <param name="reference">
                 ///     A lambda expression representing the reference navigation property on the other end of this
-                ///     relationship (<c>t => t.Reference1</c>). If no property is specified, the relationship will be configured 
-                ///     without a navigation property on the other end of the relationship.
+                ///     relationship (<c>t => t.Reference1</c>). If no property is specified, the relationship will be
+                ///     configured without a navigation property on the other end of the relationship.
                 /// </param>
                 /// <returns> An object to further configure the relationship. </returns>
                 public virtual OneToManyBuilder<TRelatedEntity> WithOne([CanBeNull] Expression<Func<TRelatedEntity, TEntity>> reference = null)
@@ -1825,7 +1837,7 @@ namespace Microsoft.Data.Entity
             ///         Provides a simple API for configuring a one-to-many relationship.
             ///     </para>
             ///     <para>
-            ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder"/> API 
+            ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
             ///         and it is not designed to be directly constructed in your application code.
             ///     </para>
             /// </summary>
@@ -1834,10 +1846,10 @@ namespace Microsoft.Data.Entity
             {
                 /// <summary>
                 ///     <para>
-                ///         Initializes a new instance of the <see cref="OneToManyBuilder{TRelatedEntity}"/> class.
+                ///         Initializes a new instance of the <see cref="OneToManyBuilder{TRelatedEntity}" /> class.
                 ///     </para>
                 ///     <para>
-                ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder"/> API 
+                ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
                 ///         and it is not designed to be directly constructed in your application code.
                 ///     </para>
                 /// </summary>
@@ -1852,13 +1864,15 @@ namespace Microsoft.Data.Entity
                 ///         Configures the property(s) to use as the foreign key for this relationship.
                 ///     </para>
                 ///     <para>
-                ///         If <see cref="ReferencedKey(Expression{Func{TEntity, object}})"/> is not specified, then an attempt 
-                ///         will be made to match the data type and order of foreign key properties against the primary key of the 
-                ///         principal entity type. If they do not match, new shadow state properties that form a unique index will be 
-                ///         added to the principal entity type to serve as the reference key. 
-                ///         A shadow state property is one that does not have a
-                ///         corresponding property in the entity class. The current value for the property is stored in
-                ///         the <see cref="ChangeTracker"/> rather than being stored in instances of the entity class.
+                ///         If <see cref="ReferencedKey(Expression{Func{TEntity, object}})" /> is not specified, then an
+                ///         attempt will be made to match the data type and order of foreign key properties against the primary
+                ///         key of
+                ///         the principal entity type. If they do not match, new shadow state properties that form a unique
+                ///         index
+                ///         will be added to the principal entity type to serve as the reference key.
+                ///         A shadow state property is one that does not have a corresponding property in the entity class. The
+                ///         current value for the property is stored in the <see cref="ChangeTracker" /> rather than being
+                ///         stored in instances of the entity class.
                 ///     </para>
                 /// </summary>
                 /// <param name="foreignKeyExpression">
@@ -1866,8 +1880,9 @@ namespace Microsoft.Data.Entity
                 ///         A lambda expression representing the foreign key property(s) (<c>t => t.Id1</c>).
                 ///     </para>
                 ///     <para>
-                ///         If the foreign key is made up of multiple properties then specify an anonymous type including the properties (<c>t => new { t.Id1, t.Id2 }</c>).
-                ///         The order specified should match the order of corresponding keys in <see cref="ReferencedKey(Expression{Func{TEntity, object}})"/>.
+                ///         If the foreign key is made up of multiple properties then specify an anonymous type including the
+                ///         properties (<c>t => new { t.Id1, t.Id2 }</c>). The order specified should match the order of
+                ///         corresponding keys in <see cref="ReferencedKey(Expression{Func{TEntity, object}})" />.
                 ///     </para>
                 /// </param>
                 /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
@@ -1885,12 +1900,13 @@ namespace Microsoft.Data.Entity
                 ///     the specified property(s) is not already a unique index (or the primary key) then a new unique index
                 ///     will be introduced.
                 /// </summary>
-                /// <param name="keyExpression"> 
+                /// <param name="keyExpression">
                 ///     <para>
                 ///         A lambda expression representing the reference key property(s) (<c>t => t.Id</c>).
                 ///     </para>
                 ///     <para>
-                ///         If the referenced key is made up of multiple properties then specify an anonymous type including the properties (<c>t => new { t.Id1, t.Id2 }</c>).
+                ///         If the referenced key is made up of multiple properties then specify an anonymous type including
+                ///         the properties (<c>t => new { t.Id1, t.Id2 }</c>).
                 ///     </para>
                 /// </param>
                 /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
@@ -1903,8 +1919,8 @@ namespace Microsoft.Data.Entity
                 }
 
                 /// <summary>
-                ///     Adds or updates an annotation on the relationship. If an annotation with the key specified in <paramref name="annotation"/>
-                ///     already exists it's value will be updated.
+                ///     Adds or updates an annotation on the relationship. If an annotation with the key specified in
+                ///     <paramref name="annotation" /> already exists it's value will be updated.
                 /// </summary>
                 /// <param name="annotation"> The key of the annotation to be added or updated. </param>
                 /// <param name="value"> The value to be stored in the annotation. </param>
@@ -1922,21 +1938,21 @@ namespace Microsoft.Data.Entity
                 ///         Configures the property(s) to use as the foreign key for this relationship.
                 ///     </para>
                 ///     <para>
-                ///         If the specified property name(s) do not exist on the entity type then a new shadow state property(s)
-                ///         will be added to serve as the foreign key. A shadow state property is one 
-                ///         that does not have a corresponding property in the entity class. The current value for the 
-                ///         property is stored in the <see cref="ChangeTracker"/> rather than being stored in instances 
+                ///         If the specified property name(s) do not exist on the entity type then a new shadow state
+                ///         property(s) will be added to serve as the foreign key. A shadow state property is one
+                ///         that does not have a corresponding property in the entity class. The current value for the
+                ///         property is stored in the <see cref="ChangeTracker" /> rather than being stored in instances
                 ///         of the entity class.
                 ///     </para>
                 ///     <para>
-                ///         If <see cref="ReferencedKey(string[])"/> is not specified, then an attempt will be made to match
-                ///         the data type and order of foreign key properties against the primary key of the principal 
-                ///         entity type. If they do not match, new shadow state properties that form a unique index will be 
-                ///         added to the principal entity type to serve as the reference key. 
+                ///         If <see cref="ReferencedKey(string[])" /> is not specified, then an attempt will be made to match
+                ///         the data type and order of foreign key properties against the primary key of the principal
+                ///         entity type. If they do not match, new shadow state properties that form a unique index will be
+                ///         added to the principal entity type to serve as the reference key.
                 ///     </para>
                 /// </summary>
-                /// <param name="foreignKeyPropertyNames"> 
-                ///     The name(s) of the foreign key property(s). 
+                /// <param name="foreignKeyPropertyNames">
+                ///     The name(s) of the foreign key property(s).
                 /// </param>
                 /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
                 public new virtual OneToManyBuilder<TRelatedEntity> ForeignKey([NotNull] params string[] foreignKeyPropertyNames)
@@ -1976,7 +1992,7 @@ namespace Microsoft.Data.Entity
             ///         Provides a simple API for configuring a one-to-many relationship.
             ///     </para>
             ///     <para>
-            ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder"/> API 
+            ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
             ///         and it is not designed to be directly constructed in your application code.
             ///     </para>
             /// </summary>
@@ -1985,10 +2001,10 @@ namespace Microsoft.Data.Entity
             {
                 /// <summary>
                 ///     <para>
-                ///         Initializes a new instance of the <see cref="ManyToOneBuilder{TRelatedEntity}"/> class.
+                ///         Initializes a new instance of the <see cref="ManyToOneBuilder{TRelatedEntity}" /> class.
                 ///     </para>
                 ///     <para>
-                ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder"/> API 
+                ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
                 ///         and it is not designed to be directly constructed in your application code.
                 ///     </para>
                 /// </summary>
@@ -2003,13 +2019,14 @@ namespace Microsoft.Data.Entity
                 ///         Configures the property(s) to use as the foreign key for this relationship.
                 ///     </para>
                 ///     <para>
-                ///         If <see cref="ReferencedKey(Expression{Func{TRelatedEntity, object}})"/> is not specified, then an 
-                ///         attempt will be made to match the data type and order of foreign key properties against the primary key 
-                ///         of the principal entity type. If they do not match, new shadow state properties that form a unique index 
-                ///         will be added to the principal entity type to serve as the reference key. 
-                ///         A shadow state property is one that does not have a
-                ///         corresponding property in the entity class. The current value for the property is stored in
-                ///         the <see cref="ChangeTracker"/> rather than being stored in instances of the entity class.
+                ///         If <see cref="ReferencedKey(Expression{Func{TRelatedEntity, object}})" /> is not specified, then an
+                ///         attempt will be made to match the data type and order of foreign key properties against the primary
+                ///         key of the principal entity type. If they do not match, new shadow state properties that form a
+                ///         unique
+                ///         index will be added to the principal entity type to serve as the reference key.
+                ///         A shadow state property is one that does not have a corresponding property in the entity class. The
+                ///         current value for the property is stored in the <see cref="ChangeTracker" /> rather than being
+                ///         stored in instances of the entity class.
                 ///     </para>
                 /// </summary>
                 /// <param name="foreignKeyExpression">
@@ -2017,8 +2034,10 @@ namespace Microsoft.Data.Entity
                 ///         A lambda expression representing the foreign key property(s) (<c>t => t.Id1</c>).
                 ///     </para>
                 ///     <para>
-                ///         If the foreign key is made up of multiple properties then specify an anonymous type including the properties (<c>t => new { t.Id1, t.Id2 }</c>).
-                ///         The order specified should match the order of corresponding keys in <see cref="ReferencedKey(Expression{Func{TRelatedEntity, object}})"/>.
+                ///         If the foreign key is made up of multiple properties then specify an anonymous type including the
+                ///         properties (<c>t => new { t.Id1, t.Id2 }</c>).
+                ///         The order specified should match the order of corresponding keys in
+                ///         <see cref="ReferencedKey(Expression{Func{TRelatedEntity, object}})" />.
                 ///     </para>
                 /// </param>
                 /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
@@ -2036,12 +2055,13 @@ namespace Microsoft.Data.Entity
                 ///     the specified property(s) is not already a unique index (or the primary key) then a new unique index
                 ///     will be introduced.
                 /// </summary>
-                /// <param name="keyExpression"> 
+                /// <param name="keyExpression">
                 ///     <para>
                 ///         A lambda expression representing the reference key property(s) (<c>t => t.Id</c>).
                 ///     </para>
                 ///     <para>
-                ///         If the referenced key is made up of multiple properties then specify an anonymous type including the properties (<c>t => new { t.Id1, t.Id2 }</c>).
+                ///         If the referenced key is made up of multiple properties then specify an anonymous type including
+                ///         the properties (<c>t => new { t.Id1, t.Id2 }</c>).
                 ///     </para>
                 /// </param>
                 /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
@@ -2054,8 +2074,8 @@ namespace Microsoft.Data.Entity
                 }
 
                 /// <summary>
-                ///     Adds or updates an annotation on the relationship. If an annotation with the key specified in <paramref name="annotation"/>
-                ///     already exists it's value will be updated.
+                ///     Adds or updates an annotation on the relationship. If an annotation with the key specified in
+                ///     <paramref name="annotation" /> already exists it's value will be updated.
                 /// </summary>
                 /// <param name="annotation"> The key of the annotation to be added or updated. </param>
                 /// <param name="value"> The value to be stored in the annotation. </param>
@@ -2073,21 +2093,21 @@ namespace Microsoft.Data.Entity
                 ///         Configures the property(s) to use as the foreign key for this relationship.
                 ///     </para>
                 ///     <para>
-                ///         If the specified property name(s) do not exist on the entity type then a new shadow state property(s)
-                ///         will be added to serve as the foreign key. A shadow state property is one 
-                ///         that does not have a corresponding property in the entity class. The current value for the 
-                ///         property is stored in the <see cref="ChangeTracker"/> rather than being stored in instances 
+                ///         If the specified property name(s) do not exist on the entity type then a new shadow state
+                ///         property(s) will be added to serve as the foreign key. A shadow state property is one
+                ///         that does not have a corresponding property in the entity class. The current value for the
+                ///         property is stored in the <see cref="ChangeTracker" /> rather than being stored in instances
                 ///         of the entity class.
                 ///     </para>
                 ///     <para>
-                ///         If <see cref="ReferencedKey(string[])"/> is not specified, then an attempt will be made to match
-                ///         the data type and order of foreign key properties against the primary key of the principal 
-                ///         entity type. If they do not match, new shadow state properties that form a unique index will be 
-                ///         added to the principal entity type to serve as the reference key. 
+                ///         If <see cref="ReferencedKey(string[])" /> is not specified, then an attempt will be made to match
+                ///         the data type and order of foreign key properties against the primary key of the principal
+                ///         entity type. If they do not match, new shadow state properties that form a unique index will be
+                ///         added to the principal entity type to serve as the reference key.
                 ///     </para>
                 /// </summary>
-                /// <param name="foreignKeyPropertyNames"> 
-                ///     The name(s) of the foreign key property(s). 
+                /// <param name="foreignKeyPropertyNames">
+                ///     The name(s) of the foreign key property(s).
                 /// </param>
                 /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
                 public new virtual ManyToOneBuilder<TRelatedEntity> ForeignKey([NotNull] params string[] foreignKeyPropertyNames)

--- a/src/EntityFramework.Core/Properties/Strings.Designer.cs
+++ b/src/EntityFramework.Core/Properties/Strings.Designer.cs
@@ -924,6 +924,14 @@ namespace Microsoft.Data.Entity.Internal
             return string.Format(CultureInfo.CurrentCulture, GetString("ForeignKeyReferencedEntityKeyMismatch", "referencedKey", "referencedEntityType"), referencedKey, referencedEntityType);
         }
 
+        /// <summary>
+        /// The navigation property '{navigation}' cannot be used for both ends of the relationship. Either specify it on the principal side or the dependent side.
+        /// </summary>
+        public static string NavigationToSelfDuplicate([CanBeNull] object navigation)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("NavigationToSelfDuplicate", "navigation"), navigation);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EntityFramework.Core/Properties/Strings.resx
+++ b/src/EntityFramework.Core/Properties/Strings.resx
@@ -459,4 +459,7 @@
   <data name="ForeignKeyReferencedEntityKeyMismatch" xml:space="preserve">
     <value>The provided referenced entity key '{referencedKey}' is not a key on the entity type '{referencedEntityType}'.</value>
   </data>
+  <data name="NavigationToSelfDuplicate" xml:space="preserve">
+    <value>The navigation property '{navigation}' cannot be used for both ends of the relationship. Either specify it on the principal side or the dependent side.</value>
+  </data>
 </root>

--- a/test/EntityFramework.Core.FunctionalTests/NullKeysTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/NullKeysTestBase.cs
@@ -188,8 +188,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     .ForeignKey(e => e.Fk);
 
                 modelBuilder.Entity<WithStringFk>()
-                    .HasOne(e => e.Self)
-                    .WithOne()
+                    .HasOne<WithStringFk>()
+                    .WithOne(e => e.Self)
                     .ForeignKey<WithStringFk>(e => e.SelfFk);
 
                 modelBuilder.Entity<WithIntKey>()


### PR DESCRIPTION
Throw when configuring self referencing relationship with both navigations using the same property.
Reformat ModelBuilder.