### PR TITLE
Query: Adds a SQL predicate optimizer that optimizes two cases:

### DIFF
--- a/src/EntityFramework.Relational/EntityFramework.Relational.csproj
+++ b/src/EntityFramework.Relational/EntityFramework.Relational.csproj
@@ -140,8 +140,12 @@
     <Compile Include="Query\AsyncQueryMethodProvider.cs" />
     <Compile Include="Query\CommandBuilder.cs" />
     <Compile Include="Query\CommandParameter.cs" />
+    <Compile Include="Query\EqualityPredicateOptimizer.cs" />
     <Compile Include="Query\Expressions\ColumnAggregateExpression.cs" />
     <Compile Include="Query\Expressions\DiscriminatorPredicateExpression.cs" />
+    <Compile Include="Query\Expressions\InExpressionBase.cs" />
+    <Compile Include="Query\Expressions\NotInExpression.cs" />
+    <Compile Include="Query\Expressions\InExpression.cs" />
     <Compile Include="Query\Expressions\JoinExpressionBase.cs" />
     <Compile Include="Query\Expressions\LeftOuterJoinExpression.cs" />
     <Compile Include="Query\Expressions\MaxExpression.cs" />

--- a/src/EntityFramework.Relational/Query/EqualityPredicateOptimizer.cs
+++ b/src/EntityFramework.Relational/Query/EqualityPredicateOptimizer.cs
@@ -1,0 +1,143 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Relational.Query.Expressions;
+using Microsoft.Data.Entity.Utilities;
+using Remotion.Linq.Parsing;
+
+namespace Microsoft.Data.Entity.Relational.Query
+{
+    public class EqualityPredicateOptimizer : ExpressionTreeVisitor
+    {
+        protected override Expression VisitBinaryExpression(
+            [NotNull] BinaryExpression binaryExpression)
+        {
+            Check.NotNull(binaryExpression, nameof(binaryExpression));
+
+            switch (binaryExpression.NodeType)
+            {
+                case ExpressionType.OrElse:
+                {
+                    var optimized
+                        = TryOptimize(
+                            binaryExpression,
+                            expressionType: ExpressionType.OrElse,
+                            equalityType: ExpressionType.Equal,
+                            inFactory: (c, vs) => new InExpression(c, vs));
+
+                    if (optimized != null)
+                    {
+                        return optimized;
+                    }
+
+                    break;
+                }
+
+                case ExpressionType.AndAlso:
+                {
+                    var optimized
+                        = TryOptimize(
+                            binaryExpression,
+                            expressionType: ExpressionType.AndAlso,
+                            equalityType: ExpressionType.NotEqual,
+                            inFactory: (c, vs) => new NotInExpression(c, vs));
+
+                    if (optimized != null)
+                    {
+                        return optimized;
+                    }
+
+                    break;
+                }
+            }
+
+            return base.VisitBinaryExpression(binaryExpression);
+        }
+
+        private Expression TryOptimize(
+            BinaryExpression binaryExpression,
+            ExpressionType expressionType,
+            ExpressionType equalityType,
+            Func<ColumnExpression, Expression[], InExpressionBase> inFactory)
+        {
+            Expression value;
+
+            var column = MatchEqualityExpression(binaryExpression.Left, equalityType, out value);
+
+            var newLeft
+                = column != null
+                    ? inFactory(column, new[] { value })
+                    : VisitExpression(binaryExpression.Left) as InExpressionBase;
+
+            column = MatchEqualityExpression(binaryExpression.Right, equalityType, out value);
+
+            var newRight
+                = column != null
+                    ? inFactory(column, new[] { value })
+                    : VisitExpression(binaryExpression.Right) as InExpressionBase;
+
+            if (newLeft != null
+                && newRight != null)
+            {
+                if (newLeft.Column.Equals(newRight.Column))
+                {
+                    return inFactory(
+                        newLeft.Column,
+                        newLeft.Values.Concat(newRight.Values).ToArray());
+                }
+
+                return Expression.MakeBinary(
+                    expressionType,
+                    newLeft.Values.Count > 1 ? newLeft : binaryExpression.Left,
+                    newRight.Values.Count > 1 ? newRight : binaryExpression.Right);
+            }
+
+            if (newLeft != null)
+            {
+                return Expression.MakeBinary(
+                    expressionType,
+                    newLeft.Values.Count > 1 ? newLeft : binaryExpression.Left,
+                    binaryExpression.Right);
+            }
+
+            if (newRight != null)
+            {
+                return Expression.MakeBinary(
+                    expressionType,
+                    binaryExpression.Left,
+                    newRight.Values.Count > 1 ? newRight : binaryExpression.Right);
+            }
+
+            return null;
+        }
+
+        private static ColumnExpression MatchEqualityExpression(
+            Expression expression,
+            ExpressionType equalityType,
+            out Expression value)
+        {
+            value = null;
+
+            var binaryExpression = expression as BinaryExpression;
+
+            if (binaryExpression?.NodeType == equalityType)
+            {
+                value
+                    = binaryExpression.Right as ConstantExpression
+                      ?? binaryExpression.Left as ConstantExpression;
+
+                if (value != null)
+                {
+                    return binaryExpression.Right as ColumnExpression
+                           ?? binaryExpression.Left as ColumnExpression;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/EntityFramework.Relational/Query/Expressions/ColumnExpression.cs
+++ b/src/EntityFramework.Relational/Query/Expressions/ColumnExpression.cs
@@ -30,22 +30,13 @@ namespace Microsoft.Data.Entity.Relational.Query.Expressions
             _tableExpression = tableExpression;
         }
 
-        public virtual TableExpressionBase Table
-        {
-            get { return _tableExpression; }
-        }
+        public virtual TableExpressionBase Table => _tableExpression;
 
-        public virtual string TableAlias
-        {
-            get { return _tableExpression.Alias; }
-        }
+        public virtual string TableAlias => _tableExpression.Alias;
 
 #pragma warning disable 108
-        public virtual IProperty Property
+        public virtual IProperty Property => _property;
 #pragma warning restore 108
-        {
-            get { return _property; }
-        }
 
         public virtual string Name { get; }
 

--- a/src/EntityFramework.Relational/Query/Expressions/DiscriminatorPredicateExpression.cs
+++ b/src/EntityFramework.Relational/Query/Expressions/DiscriminatorPredicateExpression.cs
@@ -41,7 +41,11 @@ namespace Microsoft.Data.Entity.Relational.Query.Expressions
 
         protected override Expression VisitChildren(ExpressionTreeVisitor visitor)
         {
-            return this;
+            var newPredicate = visitor.VisitExpression(_predicate);
+
+            return _predicate != newPredicate
+                ? new DiscriminatorPredicateExpression(newPredicate, QuerySource)
+                : this;
         }
     }
 }

--- a/src/EntityFramework.Relational/Query/Expressions/InExpression.cs
+++ b/src/EntityFramework.Relational/Query/Expressions/InExpression.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Relational.Query.Sql;
+using Microsoft.Data.Entity.Utilities;
+using Remotion.Linq.Parsing;
+
+namespace Microsoft.Data.Entity.Relational.Query.Expressions
+{
+    public class InExpression : InExpressionBase
+    {
+        public InExpression(
+            [NotNull] ColumnExpression column,
+            [NotNull] IReadOnlyList<Expression> values)
+            : base(
+                Check.NotNull(column, nameof(column)),
+                Check.NotNull(values, nameof(values)))
+        {
+        }
+
+        public override Expression Accept([NotNull] ExpressionTreeVisitor visitor)
+        {
+            Check.NotNull(visitor, nameof(visitor));
+
+            var specificVisitor = visitor as ISqlExpressionVisitor;
+
+            return specificVisitor != null
+                ? specificVisitor.VisitInExpression(this)
+                : base.Accept(visitor);
+        }
+    }
+}

--- a/src/EntityFramework.Relational/Query/Expressions/InExpressionBase.cs
+++ b/src/EntityFramework.Relational/Query/Expressions/InExpressionBase.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Utilities;
+using Remotion.Linq.Clauses.Expressions;
+using Remotion.Linq.Parsing;
+
+namespace Microsoft.Data.Entity.Relational.Query.Expressions
+{
+    public abstract class InExpressionBase : ExtensionExpression
+    {
+        protected InExpressionBase(
+            [NotNull] ColumnExpression column,
+            [NotNull] IReadOnlyList<Expression> values)
+            : base(typeof(bool))
+        {
+            Check.NotNull(column, nameof(column));
+            Check.NotNull(values, nameof(values));
+
+            Column = column;
+            Values = values;
+        }
+
+        public virtual ColumnExpression Column { get; }
+        public virtual IReadOnlyList<Expression> Values { get; }
+
+        protected override Expression VisitChildren(ExpressionTreeVisitor visitor)
+        {
+            return this;
+        }
+    }
+}

--- a/src/EntityFramework.Relational/Query/Expressions/NotInExpression.cs
+++ b/src/EntityFramework.Relational/Query/Expressions/NotInExpression.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Relational.Query.Sql;
+using Microsoft.Data.Entity.Utilities;
+using Remotion.Linq.Parsing;
+
+namespace Microsoft.Data.Entity.Relational.Query.Expressions
+{
+    public class NotInExpression : InExpressionBase
+    {
+        public NotInExpression(
+            [NotNull] ColumnExpression column,
+            [NotNull] IReadOnlyList<Expression> values)
+            : base(
+                Check.NotNull(column, nameof(column)),
+                Check.NotNull(values, nameof(values)))
+        {
+        }
+
+        public override Expression Accept([NotNull] ExpressionTreeVisitor visitor)
+        {
+            Check.NotNull(visitor, nameof(visitor));
+
+            var specificVisitor = visitor as ISqlExpressionVisitor;
+
+            return specificVisitor != null
+                ? specificVisitor.VisitNotInExpression(this)
+                : base.Accept(visitor);
+        }
+    }
+}

--- a/src/EntityFramework.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EntityFramework.Relational/Query/RelationalQueryModelVisitor.cs
@@ -86,6 +86,19 @@ namespace Microsoft.Data.Entity.Relational.Query
             return new RelationalOrderingExpressionTreeVisitor(this, ordering);
         }
 
+        public override void VisitQueryModel(QueryModel queryModel)
+        {
+            base.VisitQueryModel(queryModel);
+
+            var predicateOptimizer = new EqualityPredicateOptimizer();
+
+            foreach (var selectExpression in _queriesBySource.Values.Where(se => se.Predicate != null))
+            {
+                selectExpression.Predicate
+                    = predicateOptimizer.VisitExpression(selectExpression.Predicate);
+            }
+        }
+
         protected override void IncludeNavigations(
             IQuerySource querySource,
             Type resultType,

--- a/src/EntityFramework.Relational/Query/Sql/DefaultSqlQueryGenerator.cs
+++ b/src/EntityFramework.Relational/Query/Sql/DefaultSqlQueryGenerator.cs
@@ -239,6 +239,32 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
             return maxExpression;
         }
 
+        public virtual Expression VisitInExpression(InExpression inExpression)
+        {
+            VisitExpression(inExpression.Column);
+
+            _sql.Append(" IN (");
+
+            VisitJoin(inExpression.Values);
+            
+            _sql.Append(")");
+
+            return inExpression;
+        }
+
+        public virtual Expression VisitNotInExpression(NotInExpression inExpression)
+        {
+            VisitExpression(inExpression.Column);
+
+            _sql.Append(" NOT IN (");
+
+            VisitJoin(inExpression.Values);
+
+            _sql.Append(")");
+
+            return inExpression;
+        }
+
         public virtual Expression VisitInnerJoinExpression(InnerJoinExpression innerJoinExpression)
         {
             Check.NotNull(innerJoinExpression, nameof(innerJoinExpression));

--- a/src/EntityFramework.Relational/Query/Sql/ISqlExpressionVisitor.cs
+++ b/src/EntityFramework.Relational/Query/Sql/ISqlExpressionVisitor.cs
@@ -25,5 +25,7 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
         Expression VisitSumExpression([NotNull] SumExpression sumExpression);
         Expression VisitMinExpression([NotNull] MinExpression minExpression);
         Expression VisitMaxExpression([NotNull] MaxExpression maxExpression);
+        Expression VisitInExpression([NotNull] InExpression inExpression);
+        Expression VisitNotInExpression([NotNull] NotInExpression inExpression);
     }
 }

--- a/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
@@ -697,6 +697,78 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
+        public virtual void Where_select_many_or3()
+        {
+            AssertQuery<Customer, Employee>((cs, es) =>
+                from c in cs
+                from e in es
+                where c.City == "London"
+                      || c.City == "Berlin"
+                      || c.City == "Seattle"
+                select new { c, e });
+        }
+        
+        [Fact]
+        public virtual void Where_select_many_or4()
+        {
+            AssertQuery<Customer, Employee>((cs, es) =>
+                from c in cs
+                from e in es
+                where c.City == "London"
+                      || c.City == "Berlin"
+                      || c.City == "Seattle"
+                      || c.City == "Lisboa"
+                select new { c, e });
+        }
+
+        [Fact]
+        public virtual void Where_not_in_optimization1()
+        {
+            AssertQuery<Customer, Employee>((cs, es) =>
+                from c in cs
+                from e in es
+                where c.City != "London"
+                      && e.City != "London"
+                select new { c, e });
+        }
+
+        [Fact]
+        public virtual void Where_not_in_optimization2()
+        {
+            AssertQuery<Customer, Employee>((cs, es) =>
+                from c in cs
+                from e in es
+                where c.City != "London"
+                      && c.City != "Berlin"
+                select new { c, e });
+        }
+
+        [Fact]
+        public virtual void Where_not_in_optimization3()
+        {
+            AssertQuery<Customer, Employee>((cs, es) =>
+                from c in cs
+                from e in es
+                where c.City != "London"
+                      && c.City != "Berlin"
+                      && c.City != "Seattle"
+                select new { c, e });
+        }
+
+        [Fact]
+        public virtual void Where_not_in_optimization4()
+        {
+            AssertQuery<Customer, Employee>((cs, es) =>
+                from c in cs
+                from e in es
+                where c.City != "London"
+                      && c.City != "Berlin"
+                      && c.City != "Seattle"
+                      && c.City != "Lisboa"
+                select new { c, e });
+        }
+
+        [Fact]
         public virtual void Where_select_many_and()
         {
             AssertQuery<Customer, Employee>((cs, es) =>

--- a/test/EntityFramework.SqlServer.FunctionalTests/InheritanceSqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/InheritanceSqlServerTest.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             Assert.Equal(
                 @"SELECT [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[Species], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
 FROM [Animal] AS [a]
-WHERE ([a].[Discriminator] = 'Kiwi' OR [a].[Discriminator] = 'Eagle')
+WHERE [a].[Discriminator] IN ('Kiwi', 'Eagle')
 ORDER BY [a].[Species]",
                 Sql);
         }
@@ -28,7 +28,7 @@ ORDER BY [a].[Species]",
             Assert.Equal(
                 @"SELECT [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[Species], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
 FROM [Animal] AS [a]
-WHERE ([a].[Discriminator] = 'Kiwi' OR [a].[Discriminator] = 'Eagle')
+WHERE [a].[Discriminator] IN ('Kiwi', 'Eagle')
 ORDER BY [a].[Species]",
                 Sql);
         }
@@ -51,7 +51,7 @@ WHERE [a].[Discriminator] = 'Kiwi'",
             Assert.Equal(
                 @"SELECT [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[Species], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
 FROM [Animal] AS [a]
-WHERE ([a].[Discriminator] = 'Kiwi' OR [a].[Discriminator] = 'Eagle')
+WHERE [a].[Discriminator] IN ('Kiwi', 'Eagle')
 ORDER BY [a].[Species]",
                 Sql);
         }
@@ -63,7 +63,7 @@ ORDER BY [a].[Species]",
             Assert.Equal(
                 @"SELECT [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[Species], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
 FROM [Animal] AS [a]
-WHERE (([a].[Discriminator] = 'Kiwi' OR [a].[Discriminator] = 'Eagle') AND [a].[Name] = 'Great spotted kiwi')
+WHERE ([a].[Discriminator] IN ('Kiwi', 'Eagle') AND [a].[Name] = 'Great spotted kiwi')
 ORDER BY [a].[Species]",
                 Sql);
         }
@@ -75,7 +75,7 @@ ORDER BY [a].[Species]",
             Assert.Equal(
                 @"SELECT [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[Species], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
 FROM [Animal] AS [a]
-WHERE ([a].[Discriminator] = 'Kiwi' OR [a].[Discriminator] = 'Eagle')
+WHERE [a].[Discriminator] IN ('Kiwi', 'Eagle')
 ORDER BY [a].[Species]",
                 Sql);
         }

--- a/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -993,7 +993,79 @@ WHERE ([c].[City] = 'London' OR [e].[City] = 'London')",
                 @"SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [e].[City], [e].[Country], [e].[EmployeeID], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Customers] AS [c]
 CROSS JOIN [Employees] AS [e]
-WHERE ([c].[City] = 'London' OR [c].[City] = 'Berlin')",
+WHERE [c].[City] IN ('London', 'Berlin')",
+                Sql);
+        }
+
+        public override void Where_select_many_or3()
+        {
+            base.Where_select_many_or3();
+
+            Assert.StartsWith(
+                @"SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [e].[City], [e].[Country], [e].[EmployeeID], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Customers] AS [c]
+CROSS JOIN [Employees] AS [e]
+WHERE [c].[City] IN ('London', 'Berlin', 'Seattle')",
+                Sql);
+        }
+
+        public override void Where_select_many_or4()
+        {
+            base.Where_select_many_or4();
+
+            Assert.StartsWith(
+                @"SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [e].[City], [e].[Country], [e].[EmployeeID], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Customers] AS [c]
+CROSS JOIN [Employees] AS [e]
+WHERE [c].[City] IN ('London', 'Berlin', 'Seattle', 'Lisboa')",
+                Sql);
+        }
+
+        public override void Where_not_in_optimization1()
+        {
+            base.Where_not_in_optimization1();
+
+            Assert.Equal(
+                @"SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [e].[City], [e].[Country], [e].[EmployeeID], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Customers] AS [c]
+CROSS JOIN [Employees] AS [e]
+WHERE ([c].[City] <> 'London' AND [e].[City] <> 'London')",
+                Sql);
+        }
+
+        public override void Where_not_in_optimization2()
+        {
+            base.Where_not_in_optimization2();
+
+            Assert.StartsWith(
+                @"SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [e].[City], [e].[Country], [e].[EmployeeID], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Customers] AS [c]
+CROSS JOIN [Employees] AS [e]
+WHERE [c].[City] NOT IN ('London', 'Berlin')",
+                Sql);
+        }
+
+        public override void Where_not_in_optimization3()
+        {
+            base.Where_not_in_optimization3();
+
+            Assert.StartsWith(
+                @"SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [e].[City], [e].[Country], [e].[EmployeeID], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Customers] AS [c]
+CROSS JOIN [Employees] AS [e]
+WHERE [c].[City] NOT IN ('London', 'Berlin', 'Seattle')",
+                Sql);
+        }
+
+        public override void Where_not_in_optimization4()
+        {
+            base.Where_not_in_optimization4();
+
+            Assert.StartsWith(
+                @"SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [e].[City], [e].[Country], [e].[EmployeeID], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Customers] AS [c]
+CROSS JOIN [Employees] AS [e]
+WHERE [c].[City] NOT IN ('London', 'Berlin', 'Seattle', 'Lisboa')",
                 Sql);
         }
 


### PR DESCRIPTION
1) x.Foo = 1 OR x.Foo = 2 becomes x.Foo IN (1, 2)
2) x.Foo != 1 AND x.Foo != 2 becomes x.Foo NOT IN (1, 2)