### PR TITLE
Stop resolving Database facade API directly from DI

### DIFF
--- a/src/EntityFramework.Core/DbContext.cs
+++ b/src/EntityFramework.Core/DbContext.cs
@@ -49,6 +49,7 @@ namespace Microsoft.Data.Entity
         private LazyRef<DbContextServices> _contextServices;
         private LazyRef<ILogger> _logger;
         private LazyRef<DbSetInitializer> _setInitializer;
+        private LazyRef<Database> _database;
 
         private bool _initializing;
 
@@ -144,6 +145,7 @@ namespace Microsoft.Data.Entity
             _contextServices = new LazyRef<DbContextServices>(() => InitializeServices(serviceProvider, options));
             _logger = new LazyRef<ILogger>(CreateLogger);
             _setInitializer = new LazyRef<DbSetInitializer>(GetSetInitializer);
+            _database = new LazyRef<Database>(GetDatabase);
         }
 
         private DbContextOptions GetOptions(IServiceProvider serviceProvider)
@@ -190,6 +192,8 @@ namespace Microsoft.Data.Entity
         private ChangeDetector GetChangeDetector() => _contextServices.Value.ServiceProvider.GetRequiredServiceChecked<ChangeDetector>();
 
         private StateManager GetStateManager() => _contextServices.Value.ServiceProvider.GetRequiredServiceChecked<StateManager>();
+
+        private Database GetDatabase() => _contextServices.Value.ServiceProvider.GetRequiredServiceChecked<IDatabaseFactory>().CreateDatabase();
 
         private DbContextServices InitializeServices(IServiceProvider serviceProvider, DbContextOptions options)
         {
@@ -778,7 +782,7 @@ namespace Microsoft.Data.Entity
         /// <summary>
         ///     Provides access to database related information and operations for this context.
         /// </summary>
-        public virtual Database Database => _contextServices.Value.ServiceProvider.GetRequiredServiceChecked<Database>();
+        public virtual Database Database => _database.Value;
 
         /// <summary>
         ///     Provides access to information and operations for entity instances this context is tracking.

--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -120,6 +120,7 @@
     <Compile Include="ChangeTracking\Internal\ValueGenerationManager.cs" />
     <Compile Include="ChangeTracking\KeyValueEntityTracker.cs" />
     <Compile Include="DbContext.cs" />
+    <Compile Include="Infrastructure\IDatabaseFactory.cs" />
     <Compile Include="Infrastructure\LoggingModelValidator.cs" />
     <Compile Include="Infrastructure\ModelValidator.cs" />
     <Compile Include="Infrastructure\EntityFrameworkServicesBuilder.cs" />

--- a/src/EntityFramework.Core/Extensions/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/EntityFramework.Core/Extensions/EntityFrameworkServiceCollectionExtensions.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Framework.DependencyInjection
                 .AddScoped(DataStoreServiceFactories.DataStoreFactory)
                 .AddScoped(DataStoreServiceFactories.QueryContextFactoryFactory)
                 .AddScoped(DataStoreServiceFactories.ConnectionFactory)
-                .AddScoped(DataStoreServiceFactories.DatabaseFactory)
+                .AddScoped(DataStoreServiceFactories.DatabaseFactoryFactory)
                 .AddScoped(DataStoreServiceFactories.ValueGeneratorSelectorFactory)
                 .AddScoped(DataStoreServiceFactories.DataStoreCreatorFactory)
                 .AddScoped(DataStoreServiceFactories.ModelBuilderFactoryFactory)

--- a/src/EntityFramework.Core/Infrastructure/IDatabaseFactory.cs
+++ b/src/EntityFramework.Core/Infrastructure/IDatabaseFactory.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Data.Entity.Infrastructure
+{
+    public interface IDatabaseFactory
+    {
+        Database CreateDatabase();
+    }
+}

--- a/src/EntityFramework.Core/Storage/DataStoreServices.cs
+++ b/src/EntityFramework.Core/Storage/DataStoreServices.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Data.Entity.Storage
         IDataStoreCreator Creator { get; }
         IDataStoreConnection Connection { get; }
         IValueGeneratorSelector ValueGeneratorSelector { get; }
-        Database Database { get; }
+        IDatabaseFactory DatabaseFactory { get; }
         IModelBuilderFactory ModelBuilderFactory { get; }
         IModelSource ModelSource { get; }
         IQueryContextFactory QueryContextFactory { get; }

--- a/src/EntityFramework.Core/Storage/Internal/DataStoreServiceFactories.cs
+++ b/src/EntityFramework.Core/Storage/Internal/DataStoreServiceFactories.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Data.Entity.Storage.Internal
 
         public static Func<IServiceProvider, IQueryContextFactory> QueryContextFactoryFactory => p => GetStoreServices(p).QueryContextFactory;
 
-        public static Func<IServiceProvider, Database> DatabaseFactory => p => GetStoreServices(p).Database;
+        public static Func<IServiceProvider, IDatabaseFactory> DatabaseFactoryFactory => p => GetStoreServices(p).DatabaseFactory;
 
         public static Func<IServiceProvider, IDataStoreCreator> DataStoreCreatorFactory => p => GetStoreServices(p).Creator;
 

--- a/src/EntityFramework.InMemory/EntityFramework.InMemory.csproj
+++ b/src/EntityFramework.InMemory/EntityFramework.InMemory.csproj
@@ -63,6 +63,7 @@
       <Link>LoggingExtensions.cs</Link>
     </Compile>
     <Compile Include="IInMemoryConnection.cs" />
+    <Compile Include="IInMemoryDatabaseFactory.cs" />
     <Compile Include="IInMemoryDataStore.cs" />
     <Compile Include="IInMemoryDataStoreCreator.cs" />
     <Compile Include="IInMemoryDataStoreServices.cs" />
@@ -72,6 +73,7 @@
     <Compile Include="IInMemoryValueGeneratorSelector.cs" />
     <Compile Include="InMemoryDatabaseExtensions.cs" />
     <Compile Include="InMemoryDatabaseFacade.cs" />
+    <Compile Include="InMemoryDatabaseFactory.cs" />
     <Compile Include="InMemoryDataStoreServices.cs" />
     <Compile Include="InMemoryIntegerValueGeneratorFactory.cs" />
     <Compile Include="InMemoryModelBuilderFactory.cs" />

--- a/src/EntityFramework.InMemory/Extensions/InMemoryEntityServicesBuilderExtensions.cs
+++ b/src/EntityFramework.InMemory/Extensions/InMemoryEntityServicesBuilderExtensions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Framework.DependencyInjection
                     .AddScoped<IInMemoryQueryContextFactory, InMemoryQueryContextFactory>()
                     .AddScoped<IInMemoryValueGeneratorSelector, InMemoryValueGeneratorSelector>()
                     .AddScoped<IInMemoryDataStoreServices, InMemoryDataStoreServices>()
-                    .AddScoped<InMemoryDatabaseFacade>()
+                    .AddScoped<IInMemoryDatabaseFactory, InMemoryDatabaseFactory>()
                     .AddScoped<IInMemoryDataStore, InMemoryDataStore>()
                     .AddScoped<IInMemoryConnection, InMemoryConnection>()
                     .AddScoped<IInMemoryDataStoreCreator, InMemoryDataStoreCreator>());

--- a/src/EntityFramework.InMemory/IInMemoryDatabaseFactory.cs
+++ b/src/EntityFramework.InMemory/IInMemoryDatabaseFactory.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Infrastructure;
+
+namespace Microsoft.Data.Entity.InMemory
+{
+    public interface IInMemoryDatabaseFactory : IDatabaseFactory
+    {
+    }
+}

--- a/src/EntityFramework.InMemory/InMemoryDataStoreServices.cs
+++ b/src/EntityFramework.InMemory/InMemoryDataStoreServices.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Data.Entity.InMemory
 
         public virtual IValueGeneratorSelector ValueGeneratorSelector => _serviceProvider.GetRequiredService<IInMemoryValueGeneratorSelector>();
 
-        public virtual Database Database => _serviceProvider.GetRequiredService<InMemoryDatabaseFacade>();
+        public virtual IDatabaseFactory DatabaseFactory => _serviceProvider.GetRequiredService<IInMemoryDatabaseFactory>();
 
         public virtual IModelBuilderFactory ModelBuilderFactory => _serviceProvider.GetRequiredService<IInMemoryModelBuilderFactory>();
 

--- a/src/EntityFramework.InMemory/InMemoryDatabaseFactory.cs
+++ b/src/EntityFramework.InMemory/InMemoryDatabaseFactory.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Utilities;
+using Microsoft.Framework.Logging;
+
+namespace Microsoft.Data.Entity.InMemory
+{
+    public class InMemoryDatabaseFactory : IInMemoryDatabaseFactory
+    {
+        private readonly DbContext _context;
+        private readonly IInMemoryDataStoreCreator _dataStoreCreator;
+        private readonly IInMemoryConnection _connection;
+        private readonly ILoggerFactory _loggerFactory;
+
+        public InMemoryDatabaseFactory(
+            [NotNull] DbContext context,
+            [NotNull] IInMemoryDataStoreCreator dataStoreCreator,
+            [NotNull] IInMemoryConnection connection,
+            [NotNull] ILoggerFactory loggerFactory)
+        {
+            Check.NotNull(context, nameof(context));
+            Check.NotNull(dataStoreCreator, nameof(dataStoreCreator));
+            Check.NotNull(connection, nameof(connection));
+            Check.NotNull(loggerFactory, nameof(loggerFactory));
+
+            _context = context;
+            _dataStoreCreator = dataStoreCreator;
+            _connection = connection;
+            _loggerFactory = loggerFactory;
+        }
+
+        public virtual Database CreateDatabase() => new InMemoryDatabaseFacade(_context, _dataStoreCreator, _connection, _loggerFactory);
+    }
+}

--- a/src/EntityFramework.SqlServer/EntityFramework.SqlServer.csproj
+++ b/src/EntityFramework.SqlServer/EntityFramework.SqlServer.csproj
@@ -67,6 +67,7 @@
     </Compile>
     <Compile Include="Extensions\SqlServerDbContextOptions.cs" />
     <Compile Include="ISqlServerConnection.cs" />
+    <Compile Include="ISqlServerDatabaseFactory.cs" />
     <Compile Include="ISqlServerDataStore.cs" />
     <Compile Include="ISqlServerDataStoreCreator.cs" />
     <Compile Include="ISqlServerDataStoreServices.cs" />
@@ -114,6 +115,7 @@
     <Compile Include="SqlServerBuilderExtensions.cs" />
     <Compile Include="SqlServerDatabase.cs" />
     <Compile Include="SqlServerDatabaseExtensions.cs" />
+    <Compile Include="SqlServerDatabaseFactory.cs" />
     <Compile Include="SqlServerMetadataExtensions.cs" />
     <Compile Include="SqlServerModelBuilderFactory.cs" />
     <Compile Include="Migrations\SqlServerModelDiffer.cs" />

--- a/src/EntityFramework.SqlServer/Extensions/SqlServerEntityServicesBuilderExtensions.cs
+++ b/src/EntityFramework.SqlServer/Extensions/SqlServerEntityServicesBuilderExtensions.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Framework.DependencyInjection
                     .AddScoped<ISqlServerDataStore, SqlServerDataStore>()
                     .AddScoped<ISqlServerConnection, SqlServerConnection>()
                     .AddScoped<ISqlServerModelDiffer, SqlServerModelDiffer>()
-                    .AddScoped<SqlServerDatabase>()
+                    .AddScoped<ISqlServerDatabaseFactory, SqlServerDatabaseFactory>()
                     .AddScoped<ISqlServerMigrationSqlGenerator, SqlServerMigrationSqlGenerator>()
                     .AddScoped<ISqlServerDataStoreCreator, SqlServerDataStoreCreator>()
                     .AddScoped<ISqlServerHistoryRepository, SqlServerHistoryRepository>());

--- a/src/EntityFramework.SqlServer/ISqlServerDatabaseFactory.cs
+++ b/src/EntityFramework.SqlServer/ISqlServerDatabaseFactory.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Infrastructure;
+
+namespace Microsoft.Data.Entity.SqlServer
+{
+    public interface ISqlServerDatabaseFactory : IDatabaseFactory
+    {
+    }
+}

--- a/src/EntityFramework.SqlServer/SqlServerDataStoreServices.cs
+++ b/src/EntityFramework.SqlServer/SqlServerDataStoreServices.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Data.Entity.SqlServer
 
         public virtual IValueGeneratorSelector ValueGeneratorSelector => _serviceProvider.GetRequiredService<ISqlServerValueGeneratorSelector>();
 
-        public virtual Database Database => _serviceProvider.GetRequiredService<SqlServerDatabase>();
+        public virtual IDatabaseFactory DatabaseFactory => _serviceProvider.GetRequiredService<ISqlServerDatabaseFactory>();
 
         public virtual IModelBuilderFactory ModelBuilderFactory => _serviceProvider.GetRequiredService<ISqlServerModelBuilderFactory>();
 

--- a/src/EntityFramework.SqlServer/SqlServerDatabaseFactory.cs
+++ b/src/EntityFramework.SqlServer/SqlServerDatabaseFactory.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Relational.Migrations;
+using Microsoft.Data.Entity.Utilities;
+using Microsoft.Framework.Logging;
+
+namespace Microsoft.Data.Entity.SqlServer
+{
+    public class SqlServerDatabaseFactory : ISqlServerDatabaseFactory
+    {
+        private readonly DbContext _context;
+        private readonly ISqlServerDataStoreCreator _dataStoreCreator;
+        private readonly ISqlServerConnection _connection;
+        private readonly Migrator _migrator;
+        private readonly ILoggerFactory _loggerFactory;
+
+        public SqlServerDatabaseFactory(
+            [NotNull] DbContext context,
+            [NotNull] ISqlServerDataStoreCreator dataStoreCreator,
+            [NotNull] ISqlServerConnection connection,
+            [NotNull] Migrator migrator,
+            [NotNull] ILoggerFactory loggerFactory)
+        {
+            Check.NotNull(context, nameof(context));
+            Check.NotNull(dataStoreCreator, nameof(dataStoreCreator));
+            Check.NotNull(connection, nameof(connection));
+            Check.NotNull(migrator, nameof(migrator));
+            Check.NotNull(loggerFactory, nameof(loggerFactory));
+
+            _context = context;
+            _dataStoreCreator = dataStoreCreator;
+            _connection = connection;
+            _migrator = migrator;
+            _loggerFactory = loggerFactory;
+        }
+
+        public virtual Database CreateDatabase() 
+            => new SqlServerDatabase(_context, _dataStoreCreator, _connection, _migrator, _loggerFactory);
+    }
+}

--- a/test/EntityFramework.Core.Tests/Extensions/EntityServiceCollectionExtensionsTest.cs
+++ b/test/EntityFramework.Core.Tests/Extensions/EntityServiceCollectionExtensionsTest.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Data.Entity.Tests
             VerifyScoped<IDataStoreSelector>();
             VerifyScoped<IDataStore>();
             VerifyScoped<IDataStoreConnection>();
-            VerifyScoped<Database>();
+            VerifyScoped<IDatabaseFactory>();
             VerifyScoped<IValueGeneratorSelector>();
             VerifyScoped<IDataStoreCreator>();
 
@@ -88,7 +88,7 @@ namespace Microsoft.Data.Entity.Tests
             Assert.NotNull(VerifyScoped<IDbContextOptions>());
             Assert.NotNull(VerifyScoped<IDataStore>());
             Assert.NotNull(VerifyScoped<IDataStoreConnection>());
-            Assert.NotNull(VerifyScoped<Database>());
+            Assert.NotNull(VerifyScoped<IDatabaseFactory>());
             Assert.NotNull(VerifyScoped<IValueGeneratorSelector>());
             Assert.NotNull(VerifyScoped<IDataStoreCreator>());
             Assert.NotNull(VerifySingleton<IModelBuilderFactory>());

--- a/test/EntityFramework.InMemory.Tests/InMemoryEntityServicesBuilderExtensionsTest.cs
+++ b/test/EntityFramework.InMemory.Tests/InMemoryEntityServicesBuilderExtensionsTest.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
             VerifyScoped<IInMemoryQueryContextFactory>();
             VerifyScoped<IInMemoryValueGeneratorSelector>();
             VerifyScoped<IInMemoryDataStoreServices>();
-            VerifyScoped<InMemoryDatabaseFacade>();
+            VerifyScoped<IInMemoryDatabaseFactory>();
             VerifyScoped<IInMemoryDataStore>();
             VerifyScoped<IInMemoryConnection>();
             VerifyScoped<IInMemoryDataStoreCreator>();

--- a/test/EntityFramework.SqlServer.Tests/SqlServerEntityServicesBuilderExtensionsTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerEntityServicesBuilderExtensionsTest.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             VerifyScoped<ISqlServerDataStore>();
             VerifyScoped<ISqlServerConnection>();
             VerifyScoped<ISqlServerModelDiffer>();
-            VerifyScoped<SqlServerDatabase>();
+            VerifyScoped<ISqlServerDatabaseFactory>();
             VerifyScoped<ISqlServerMigrationSqlGenerator>();
             VerifyScoped<ISqlServerDataStoreCreator>();
             VerifyScoped<ISqlServerHistoryRepository>();


### PR DESCRIPTION
We want to resolve DI services by contract, and specifically by interfaces for dynamic data store services. However, we want facade classes to have explicitly implemented interfaces for people writing extension methods on them. These two things were in conflict. This change adds a simple factory abstraction to allow a contract to be resolved from DI that will generate the facade API. We might also consider not extending RelationalDatabase, etc from Database since this is not really required anymore, but that is not done here.