### PR TITLE
Set GenerateValueOnAdd flag for all Key properties by convention

### DIFF
--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -145,6 +145,9 @@
     <Compile Include="Internal\BoxedValueReaderSource.cs" />
     <Compile Include="Internal\GenericBoxedValueReader.cs" />
     <Compile Include="Metadata\IModelBuilderFactory.cs" />
+    <Compile Include="Metadata\ModelConventions\IForeignKeyRemovedConvention.cs" />
+    <Compile Include="Metadata\ModelConventions\IKeyConvention.cs" />
+    <Compile Include="Metadata\ModelConventions\KeyConvention.cs" />
     <Compile Include="ModelBuilder.cs" />
     <Compile Include="Query\EntityLoadInfo.cs" />
     <Compile Include="Query\ExpressionTreeVisitors\ExpressionStringBuilder.cs" />
@@ -279,7 +282,7 @@
     <Compile Include="Metadata\ObjectArrayValueReader.cs" />
     <Compile Include="Metadata\Property.cs" />
     <Compile Include="Metadata\ModelConventions\IEntityTypeConvention.cs" />
-    <Compile Include="Metadata\ModelConventions\KeyConvention.cs" />
+    <Compile Include="Metadata\ModelConventions\KeyDiscoveryConvention.cs" />
     <Compile Include="Metadata\ModelConventions\PropertiesConvention.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\InternalsVisibleTo.cs" />

--- a/src/EntityFramework.Core/Metadata/Internal/InternalMetadataBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/InternalMetadataBuilder.cs
@@ -23,10 +23,9 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             _metadata = metadata;
         }
 
-        public virtual bool Annotation([NotNull] string annotation, [NotNull] string value, ConfigurationSource configurationSource)
+        public virtual bool Annotation([NotNull] string annotation, [CanBeNull] string value, ConfigurationSource configurationSource)
         {
             Check.NotEmpty(annotation, nameof(annotation));
-            Check.NotEmpty(value, nameof(value));
 
             var existingValue = Metadata[annotation];
             if (existingValue != null)
@@ -37,7 +36,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                     existingConfigurationSource = ConfigurationSource.Explicit;
                 }
 
-                if (existingValue != value
+                if ((value == null || existingValue != value)
                     && !configurationSource.Overrides(existingConfigurationSource))
                 {
                     return false;
@@ -46,8 +45,16 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 configurationSource = configurationSource.Max(existingConfigurationSource);
             }
 
-            _annotationSources.Value[annotation] = configurationSource;
-            _metadata[annotation] = value;
+            if (value != null)
+            {
+                _annotationSources.Value[annotation] = configurationSource;
+                _metadata[annotation] = value;
+            }
+            else
+            {
+                _annotationSources.Value.Remove(annotation);
+                _metadata.RemoveAnnotation(new Annotation(annotation, "_"));
+            }
 
             return true;
         }

--- a/src/EntityFramework.Core/Metadata/ModelBuilderFactory.cs
+++ b/src/EntityFramework.Core/Metadata/ModelBuilderFactory.cs
@@ -20,10 +20,15 @@ namespace Microsoft.Data.Entity.Metadata
             var conventions = new ConventionSet();
 
             conventions.EntityTypeAddedConventions.Add(new PropertiesConvention());
-            conventions.EntityTypeAddedConventions.Add(new KeyConvention());
+            conventions.EntityTypeAddedConventions.Add(new KeyDiscoveryConvention());
             conventions.EntityTypeAddedConventions.Add(new RelationshipDiscoveryConvention());
 
+            var keyConvention = new KeyConvention();
+            conventions.KeyAddedConventions.Add(keyConvention);
+
             conventions.ForeignKeyAddedConventions.Add(new ForeignKeyPropertyDiscoveryConvention());
+
+            conventions.ForeignKeyRemovedConventions.Add(keyConvention);
 
             return conventions;
         }

--- a/src/EntityFramework.Core/Metadata/ModelConventions/ConventionDispatcher.cs
+++ b/src/EntityFramework.Core/Metadata/ModelConventions/ConventionDispatcher.cs
@@ -34,6 +34,33 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
             return entityBuilder;
         }
 
+        public virtual InternalKeyBuilder OnKeyAdded([NotNull] InternalKeyBuilder keyBuilder)
+        {
+            Check.NotNull(keyBuilder, nameof(keyBuilder));
+
+            foreach (var keyConvention in _conventionSet.KeyAddedConventions)
+            {
+                keyBuilder = keyConvention.Apply(keyBuilder);
+                if (keyBuilder == null)
+                {
+                    break;
+                }
+            }
+
+            return keyBuilder;
+        }
+
+        public virtual void OnForeignKeyRemoved([NotNull] InternalEntityBuilder entityBuilder, [NotNull] ForeignKey foreignKey)
+        {
+            Check.NotNull(entityBuilder, nameof(entityBuilder));
+            Check.NotNull(foreignKey, nameof(foreignKey));
+
+            foreach (var foreignKeyConvention in _conventionSet.ForeignKeyRemovedConventions)
+            {
+                foreignKeyConvention.Apply(entityBuilder, foreignKey);
+            }
+        }
+
         public virtual InternalRelationshipBuilder OnRelationshipAdded([NotNull] InternalRelationshipBuilder relationshipBuilder)
         {
             Check.NotNull(relationshipBuilder, nameof(relationshipBuilder));

--- a/src/EntityFramework.Core/Metadata/ModelConventions/ConventionSet.cs
+++ b/src/EntityFramework.Core/Metadata/ModelConventions/ConventionSet.cs
@@ -9,6 +9,10 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
     {
         public virtual IList<IEntityTypeConvention> EntityTypeAddedConventions { get; } = new List<IEntityTypeConvention>();
 
+        public virtual IList<IKeyConvention> KeyAddedConventions { get; } = new List<IKeyConvention>();
+
         public virtual IList<IRelationshipConvention> ForeignKeyAddedConventions { get; } = new List<IRelationshipConvention>();
+
+        public virtual IList<IForeignKeyRemovedConvention> ForeignKeyRemovedConventions { get; } = new List<IForeignKeyRemovedConvention>();
     }
 }

--- a/src/EntityFramework.Core/Metadata/ModelConventions/IForeignKeyRemovedConvention.cs
+++ b/src/EntityFramework.Core/Metadata/ModelConventions/IForeignKeyRemovedConvention.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata.Internal;
+
+namespace Microsoft.Data.Entity.Metadata.ModelConventions
+{
+    public interface IForeignKeyRemovedConvention
+    {
+        void Apply([NotNull] InternalEntityBuilder entityBuilder, [NotNull] ForeignKey foreignKey);
+    }
+}

--- a/src/EntityFramework.Core/Metadata/ModelConventions/IKeyConvention.cs
+++ b/src/EntityFramework.Core/Metadata/ModelConventions/IKeyConvention.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata.Internal;
+
+namespace Microsoft.Data.Entity.Metadata.ModelConventions
+{
+    public interface IKeyConvention
+    {
+        InternalKeyBuilder Apply([NotNull] InternalKeyBuilder keyBuilder);
+    }
+}

--- a/src/EntityFramework.Core/Metadata/ModelConventions/KeyConvention.cs
+++ b/src/EntityFramework.Core/Metadata/ModelConventions/KeyConvention.cs
@@ -1,82 +1,44 @@
-// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
-using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Metadata.ModelConventions
 {
-    public class KeyConvention : IEntityTypeConvention
+    public class KeyConvention : IKeyConvention, IForeignKeyRemovedConvention
     {
-        private const string KeySuffix = "Id";
+        public virtual InternalKeyBuilder Apply(InternalKeyBuilder keyBuilder)
+        {
+            Check.NotNull(keyBuilder, nameof(keyBuilder));
 
-        public virtual InternalEntityBuilder Apply(InternalEntityBuilder entityBuilder)
+            ConfigureKeyProperties(keyBuilder.ModelBuilder.Entity(keyBuilder.Metadata.EntityType.Name, ConfigurationSource.Convention),
+                keyBuilder.Metadata.Properties);
+
+            return keyBuilder;
+        }
+
+        protected virtual void ConfigureKeyProperties([NotNull] InternalEntityBuilder entityBuilder, [NotNull] IReadOnlyList<Property> properties)
         {
             Check.NotNull(entityBuilder, nameof(entityBuilder));
-            var entityType = entityBuilder.Metadata;
-
-            var keyProperties = DiscoverKeyProperties(entityType);
-            if (keyProperties.Count != 0
-                && entityBuilder.PrimaryKey(keyProperties.Select(p => p.Name).ToList(), ConfigurationSource.Convention) != null)
+            Check.NotNull(properties, nameof(properties));
+            foreach (var property in properties.Where(property => !entityBuilder.Metadata.ForeignKeys.SelectMany(fk => fk.Properties).Contains(property)))
             {
-                foreach (var property in keyProperties)
-                {
-                    ConfigureKeyProperty(entityBuilder.Property(property.PropertyType, property.Name, ConfigurationSource.Convention));
-                }
+                entityBuilder.Property(property.PropertyType, property.Name, ConfigurationSource.Convention).GenerateValueOnAdd(true, ConfigurationSource.Convention);
             }
-
-            return entityBuilder;
-        }
-
-        public virtual IReadOnlyList<Property> DiscoverKeyProperties([NotNull] EntityType entityType)
-        {
-            Check.NotNull(entityType, nameof(entityType));
-
-            // TODO: Honor [Key]
-            // Issue #213
-            var keyProperties = entityType.Properties
-                .Where(p => string.Equals(p.Name, KeySuffix, StringComparison.OrdinalIgnoreCase))
-                .ToList();
-
-            if (keyProperties.Count == 0)
-            {
-                keyProperties = entityType.Properties.Where(
-                    p => string.Equals(p.Name, entityType.SimpleName + KeySuffix, StringComparison.OrdinalIgnoreCase))
-                    .ToList();
-            }
-
-            if (keyProperties.Count > 1)
-            {
-                //TODO - add in logging using resource Strings.MultiplePropertiesMatchedAsKeys()
-                return Enumerable.Empty<Property>().ToList();
-            }
-
-            return keyProperties;
-        }
-
-        protected virtual void ConfigureKeyProperty([NotNull] InternalPropertyBuilder propertyBuilder)
-        {
-            Check.NotNull(propertyBuilder, nameof(propertyBuilder));
-
-            propertyBuilder.GenerateValueOnAdd(true, ConfigurationSource.Convention);
-
             // TODO: Nullable, Sequence
             // Issue #213
         }
 
-        private static bool IsCommonInteger(Type type)
+        public virtual void Apply(InternalEntityBuilder entityBuilder, ForeignKey foreignKey)
         {
-            type = type.UnwrapNullableType();
+            Check.NotNull(entityBuilder, nameof(entityBuilder));
+            Check.NotNull(foreignKey, nameof(foreignKey));
 
-            return type == typeof(int)
-                   || type == typeof(long)
-                   || type == typeof(short)
-                   || type == typeof(byte);
+            ConfigureKeyProperties(entityBuilder, foreignKey.Properties);
         }
     }
 }

--- a/src/EntityFramework.Core/Metadata/ModelConventions/KeyDiscoveryConvention.cs
+++ b/src/EntityFramework.Core/Metadata/ModelConventions/KeyDiscoveryConvention.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata.Internal;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Metadata.ModelConventions
+{
+    public class KeyDiscoveryConvention : IEntityTypeConvention
+    {
+        private const string KeySuffix = "Id";
+
+        public virtual InternalEntityBuilder Apply(InternalEntityBuilder entityBuilder)
+        {
+            Check.NotNull(entityBuilder, nameof(entityBuilder));
+            var entityType = entityBuilder.Metadata;
+
+            var keyProperties = DiscoverKeyProperties(entityType);
+            if (keyProperties.Count != 0)
+            {
+                entityBuilder.PrimaryKey(keyProperties.Select(p => p.Name).ToList(), ConfigurationSource.Convention);
+            }
+
+            return entityBuilder;
+        }
+
+        public virtual IReadOnlyList<Property> DiscoverKeyProperties([NotNull] EntityType entityType)
+        {
+            Check.NotNull(entityType, nameof(entityType));
+
+            // TODO: Honor [Key]
+            // Issue #213
+            var keyProperties = entityType.Properties
+                .Where(p => string.Equals(p.Name, KeySuffix, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            if (keyProperties.Count == 0)
+            {
+                keyProperties = entityType.Properties.Where(
+                    p => string.Equals(p.Name, entityType.SimpleName + KeySuffix, StringComparison.OrdinalIgnoreCase))
+                    .ToList();
+            }
+
+            if (keyProperties.Count > 1)
+            {
+                //TODO - add in logging using resource Strings.MultiplePropertiesMatchedAsKeys()
+                return new Property[0];
+            }
+
+            return keyProperties;
+        }
+    }
+}

--- a/src/EntityFramework.Relational.Design/ReverseEngineering/DbContextCodeGenerator.cs
+++ b/src/EntityFramework.Relational.Design/ReverseEngineering/DbContextCodeGenerator.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering
                 {
                     new Tuple<string, string>("ModelBuilder", "modelBuilder")
                 };
-        private static readonly KeyConvention _keyConvention = new KeyConvention();
+        private static readonly KeyDiscoveryConvention _keyDiscoveryConvention = new KeyDiscoveryConvention();
 
         private List<string> _usedNamespaces = new List<string>()
                 {
@@ -229,7 +229,7 @@ namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering
             Check.NotNull(sb, nameof(sb));
 
             var conventionKeyProperties =
-                _keyConvention.DiscoverKeyProperties((EntityType)key.EntityType);
+                _keyDiscoveryConvention.DiscoverKeyProperties((EntityType)key.EntityType);
             if (conventionKeyProperties == null
                 || !Enumerable.SequenceEqual(
                         key.Properties.OrderBy(p => p.Name),

--- a/src/EntityFramework.SqlServer/EntityFramework.SqlServer.csproj
+++ b/src/EntityFramework.SqlServer/EntityFramework.SqlServer.csproj
@@ -81,6 +81,7 @@
     <Compile Include="Metadata\ISqlServerKeyExtensions.cs" />
     <Compile Include="Metadata\ISqlServerModelExtensions.cs" />
     <Compile Include="Metadata\ISqlServerPropertyExtensions.cs" />
+    <Compile Include="Metadata\ModelConventions\SqlServerValueGenerationStrategyConvention.cs" />
     <Compile Include="Metadata\ReadOnlySqlServerEntityTypeExtensions.cs" />
     <Compile Include="Metadata\ReadOnlySqlServerForeignKeyExtensions.cs" />
     <Compile Include="Metadata\ReadOnlySqlServerIndexExtensions.cs" />

--- a/src/EntityFramework.SqlServer/Metadata/ModelConventions/SqlServerValueGenerationStrategyConvention.cs
+++ b/src/EntityFramework.SqlServer/Metadata/ModelConventions/SqlServerValueGenerationStrategyConvention.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Metadata.Internal;
+using Microsoft.Data.Entity.Metadata.ModelConventions;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.SqlServer.Metadata.ModelConventions
+{
+    public class SqlServerValueGenerationStrategyConvention : IKeyConvention, IForeignKeyRemovedConvention, IRelationshipConvention
+    {
+        public virtual InternalKeyBuilder Apply(InternalKeyBuilder keyBuilder)
+        {
+            Check.NotNull(keyBuilder, nameof(keyBuilder));
+
+            var key = keyBuilder.Metadata;
+
+            ConfigureValueGenerationStrategy(
+                keyBuilder.ModelBuilder.Entity(key.EntityType.Name, ConfigurationSource.Convention),
+                key.Properties,
+                true);
+
+            return keyBuilder;
+        }
+
+        protected virtual void ConfigureValueGenerationStrategy([NotNull] InternalEntityBuilder entityBuilder, [NotNull] IReadOnlyList<Property> properties, bool generateValue)
+        {
+            Check.NotNull(entityBuilder, nameof(entityBuilder));
+            Check.NotNull(properties, nameof(properties));
+
+            if (entityBuilder.Metadata.TryGetPrimaryKey(properties) != null
+                && properties.Count == 1
+                && properties.First().PropertyType.IsInteger()
+                && properties.First().GenerateValueOnAdd == generateValue)
+            {
+                entityBuilder.Property(properties.First().PropertyType, properties.First().Name, ConfigurationSource.Convention)
+                    .Annotation(SqlServerAnnotationNames.Prefix + SqlServerAnnotationNames.ValueGeneration,
+                        generateValue ? SqlServerValueGenerationStrategy.Default.ToString() : null,
+                        ConfigurationSource.Convention);
+            }
+        }
+
+        public virtual void Apply(InternalEntityBuilder entityBuilder, ForeignKey foreignKey)
+        {
+            Check.NotNull(entityBuilder, nameof(entityBuilder));
+            Check.NotNull(foreignKey, nameof(foreignKey));
+
+            var properties = foreignKey.Properties;
+
+            if (properties.Any(e => e.GenerateValueOnAdd == true))
+            {
+                ConfigureValueGenerationStrategy(entityBuilder, properties, true);
+            }
+        }
+
+        public virtual InternalRelationshipBuilder Apply(InternalRelationshipBuilder relationshipBuilder)
+        {
+            ConfigureValueGenerationStrategy(
+                relationshipBuilder.ModelBuilder.Entity(relationshipBuilder.Metadata.EntityType.Name, ConfigurationSource.Convention),
+                relationshipBuilder.Metadata.Properties,
+                false);
+
+            return relationshipBuilder;
+        }
+    }
+}

--- a/src/EntityFramework.SqlServer/Metadata/ReadOnlySqlServerPropertyExtensions.cs
+++ b/src/EntityFramework.SqlServer/Metadata/ReadOnlySqlServerPropertyExtensions.cs
@@ -57,7 +57,10 @@ namespace Microsoft.Data.Entity.SqlServer.Metadata
             {
                 // TODO: Issue #777: Non-string annotations
                 var value = Property[SqlServerValueGenerationAnnotation];
-                return value == null ? null : (SqlServerValueGenerationStrategy?)Enum.Parse(typeof(SqlServerValueGenerationStrategy), value);
+                var strategy = value == null ? null : (SqlServerValueGenerationStrategy?)Enum.Parse(typeof(SqlServerValueGenerationStrategy), value);
+                return strategy == SqlServerValueGenerationStrategy.Default
+                    ? (Property.EntityType.Model.SqlServer().ValueGenerationStrategy ?? SqlServerValueGenerationStrategy.Identity)
+                    : strategy;
             }
         }
 
@@ -75,9 +78,7 @@ namespace Microsoft.Data.Entity.SqlServer.Metadata
         {
             var modelExtensions = Property.EntityType.Model.SqlServer();
 
-            if (ValueGenerationStrategy != SqlServerValueGenerationStrategy.Sequence
-                && (ValueGenerationStrategy != null
-                    || modelExtensions.ValueGenerationStrategy != SqlServerValueGenerationStrategy.Sequence))
+            if (ValueGenerationStrategy != SqlServerValueGenerationStrategy.Sequence)
             {
                 return null;
             }

--- a/src/EntityFramework.SqlServer/Metadata/SqlServerPropertyBuilder.cs
+++ b/src/EntityFramework.SqlServer/Metadata/SqlServerPropertyBuilder.cs
@@ -92,5 +92,23 @@ namespace Microsoft.Data.Entity.SqlServer.Metadata
 
             return this;
         }
+
+        public virtual SqlServerPropertyBuilder UseDefaultValueGeneration()
+        {
+            _property.SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.Default;
+            _property.SqlServer().SequenceName = null;
+            _property.SqlServer().SequenceSchema = null;
+
+            return this;
+        }
+
+        public virtual SqlServerPropertyBuilder UseNoValueGeneration()
+        {
+            _property.SqlServer().ValueGenerationStrategy = null;
+            _property.SqlServer().SequenceName = null;
+            _property.SqlServer().SequenceSchema = null;
+
+            return this;
+        }
     }
 }

--- a/src/EntityFramework.SqlServer/Metadata/SqlServerValueGenerationStrategy.cs
+++ b/src/EntityFramework.SqlServer/Metadata/SqlServerValueGenerationStrategy.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Data.Entity.SqlServer.Metadata
 {
     public enum SqlServerValueGenerationStrategy
     {
+        Default,
         Sequence,
         Identity
     }

--- a/src/EntityFramework.SqlServer/Migrations/SqlServerModelDiffer.cs
+++ b/src/EntityFramework.SqlServer/Migrations/SqlServerModelDiffer.cs
@@ -121,13 +121,7 @@ namespace Microsoft.Data.Entity.SqlServer.Migrations
         }
 
         // TODO: Move to metadata API?
-        // See Issue #1271: Principal keys need to generate values on add, but the database should only have one Identity column.
-        private SqlServerValueGenerationStrategy? GetValueGenerationStrategy(IProperty property) =>
-            property.SqlServer().ValueGenerationStrategy
-            ?? property.EntityType.Model.SqlServer().ValueGenerationStrategy
-            ?? (property.GenerateValueOnAdd && property.PropertyType.IsInteger() && property.IsPrimaryKey()
-                ? SqlServerValueGenerationStrategy.Identity
-                : default(SqlServerValueGenerationStrategy?));
+        private SqlServerValueGenerationStrategy? GetValueGenerationStrategy(IProperty property) => property.SqlServer().ValueGenerationStrategy;
 
         #endregion
 

--- a/src/EntityFramework.SqlServer/SqlServerModelBuilderFactory.cs
+++ b/src/EntityFramework.SqlServer/SqlServerModelBuilderFactory.cs
@@ -2,10 +2,25 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Metadata.ModelConventions;
+using Microsoft.Data.Entity.SqlServer.Metadata.ModelConventions;
 
 namespace Microsoft.Data.Entity.SqlServer
 {
     public class SqlServerModelBuilderFactory : ModelBuilderFactory, ISqlServerModelBuilderFactory
     {
+        protected override ConventionSet CreateConventionSet()
+        {
+            var conventions = base.CreateConventionSet();
+
+            var sqlServerValueGenerationStrategyConvention = new SqlServerValueGenerationStrategyConvention();
+            conventions.KeyAddedConventions.Add(sqlServerValueGenerationStrategyConvention);
+
+            conventions.ForeignKeyAddedConventions.Add(sqlServerValueGenerationStrategyConvention);
+
+            conventions.ForeignKeyRemovedConventions.Add(sqlServerValueGenerationStrategyConvention);
+
+            return conventions;
+        }
     }
 }

--- a/src/EntityFramework.SqlServer/SqlServerValueGeneratorSelector.cs
+++ b/src/EntityFramework.SqlServer/SqlServerValueGeneratorSelector.cs
@@ -38,8 +38,7 @@ namespace Microsoft.Data.Entity.SqlServer
         {
             Check.NotNull(property, nameof(property));
 
-            var strategy = property.SqlServer().ValueGenerationStrategy
-                           ?? property.EntityType.Model.SqlServer().ValueGenerationStrategy;
+            var strategy = property.SqlServer().ValueGenerationStrategy;
 
             if (property.PropertyType.IsInteger()
                 && strategy == SqlServerValueGenerationStrategy.Sequence)

--- a/test/EntityFramework.Core.FunctionalTests/ComplexNavigationsQueryFixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/ComplexNavigationsQueryFixtureBase.cs
@@ -19,8 +19,6 @@ namespace Microsoft.Data.Entity.FunctionalTests
             modelBuilder.Entity<Level3>().Key(e => e.Id);
             modelBuilder.Entity<Level4>().Key(e => e.Id);
 
-            modelBuilder.Entity<Level1>().Property(e => e.Id).GenerateValueOnAdd(false);
-            modelBuilder.Entity<Level2>().Property(e => e.Id).GenerateValueOnAdd(false);
             modelBuilder.Entity<Level1>().HasOne(e => e.OneToOne_Required_PK).WithOne(e => e.OneToOne_Required_PK_Inverse).ReferencedKey<Level1>(e => e.Id).Required(true);
             modelBuilder.Entity<Level1>().HasOne(e => e.OneToOne_Optional_PK).WithOne(e => e.OneToOne_Optional_PK_Inverse).ReferencedKey<Level1>(e => e.Id).Required(false);
             modelBuilder.Entity<Level1>().HasOne(e => e.OneToOne_Required_FK).WithOne(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level2>(e => e.Level1_Required_Id).Required(true);
@@ -33,8 +31,6 @@ namespace Microsoft.Data.Entity.FunctionalTests
             // issue #1417
             //modelBuilder.Entity<Level1>().HasOne(e => e.OneToOne_Optional_Self).WithOne(); 
 
-            modelBuilder.Entity<Level2>().Property(e => e.Id).GenerateValueOnAdd(false);
-            modelBuilder.Entity<Level2>().Property(e => e.Id).GenerateValueOnAdd(false);
             modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Required_PK).WithOne(e => e.OneToOne_Required_PK_Inverse).ReferencedKey<Level2>(e => e.Id).Required(true);
             modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Optional_PK).WithOne(e => e.OneToOne_Optional_PK_Inverse).ReferencedKey<Level2>(e => e.Id).Required(false);
             modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Required_FK).WithOne(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level3>(e => e.Level2_Required_Id).Required(true);
@@ -49,8 +45,6 @@ namespace Microsoft.Data.Entity.FunctionalTests
             // issue #1417
             //modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Optional_Self).WithOne(); 
 
-            modelBuilder.Entity<Level3>().Property(e => e.Id).GenerateValueOnAdd(false);
-            modelBuilder.Entity<Level3>().Property(e => e.Id).GenerateValueOnAdd(false);
             modelBuilder.Entity<Level3>().HasOne(e => e.OneToOne_Required_PK).WithOne(e => e.OneToOne_Required_PK_Inverse).ReferencedKey<Level3>(e => e.Id).Required(true);
             modelBuilder.Entity<Level3>().HasOne(e => e.OneToOne_Optional_PK).WithOne(e => e.OneToOne_Optional_PK_Inverse).ReferencedKey<Level3>(e => e.Id).Required(false);
             modelBuilder.Entity<Level3>().HasOne(e => e.OneToOne_Required_FK).WithOne(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level4>(e => e.Level3_Required_Id).Required(true);
@@ -63,8 +57,6 @@ namespace Microsoft.Data.Entity.FunctionalTests
             // issue #1417
             //modelBuilder.Entity<Level3>().HasOne(e => e.OneToOne_Optional_Self).WithOne();
 
-            modelBuilder.Entity<Level4>().Property(e => e.Id).GenerateValueOnAdd(false);
-            modelBuilder.Entity<Level4>().Property(e => e.Id).GenerateValueOnAdd(false);
             modelBuilder.Entity<Level4>().HasMany(e => e.OneToMany_Required_Self).WithOne(e => e.OneToMany_Required_Self_Inverse).Required(true);
             modelBuilder.Entity<Level4>().HasMany(e => e.OneToMany_Optional_Self).WithOne(e => e.OneToMany_Optional_Self_Inverse).Required(false);
         }

--- a/test/EntityFramework.Core.FunctionalTests/FixupTest.cs
+++ b/test/EntityFramework.Core.FunctionalTests/FixupTest.cs
@@ -245,19 +245,13 @@ namespace Microsoft.Data.Entity.FunctionalTests
             {
                 modelBuilder.Entity<Product>(b =>
                     {
-                        b.Property(e => e.Id).GenerateValueOnAdd(false);
                         b.HasMany(e => e.SpecialOffers).WithOne(e => e.Product);
                     });
 
                 modelBuilder.Entity<Category>(b =>
                     {
-                        b.Property(e => e.Id).GenerateValueOnAdd(false);
                         b.HasMany(e => e.Products).WithOne(e => e.Category);
                     });
-
-                modelBuilder.Entity<SpecialOffer>()
-                    .Property(e => e.Id)
-                    .GenerateValueOnAdd(false);
             }
 
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)

--- a/test/EntityFramework.Core.FunctionalTests/GearsOfWarQueryFixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/GearsOfWarQueryFixtureBase.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             modelBuilder.Entity<Gear>(b =>
                 {
                     b.Key(g => new { g.Nickname, g.SquadId });
+
                     b.HasOne(g => g.CityOfBirth).WithMany(c => c.BornGears).ForeignKey(g => g.CityOrBirthName).Required();
                     b.HasMany(g => g.Reports).WithOne().ForeignKey(g => new { g.LeaderNickname, g.LeaderSquadId });
                     b.HasOne(g => g.Tag).WithOne(t => t.Gear).ForeignKey<CogTag>(t => new { t.GearNickName, t.GearSquadId });
@@ -28,14 +29,12 @@ namespace Microsoft.Data.Entity.FunctionalTests
             modelBuilder.Entity<CogTag>(b =>
                 {
                     b.Key(t => t.Id);
-                    b.Property(t => t.Id).GenerateValueOnAdd();
                 });
 
             modelBuilder.Entity<Squad>(b =>
                 {
                     b.Key(s => s.Id);
                     b.HasMany(s => s.Members).WithOne(g => g.Squad).ForeignKey(g => g.SquadId);
-                    b.Property(t => t.Id).GenerateValueOnAdd();
                 });
 
             modelBuilder.Entity<Weapon>(b =>

--- a/test/EntityFramework.Core.FunctionalTests/MonsterFixupTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/MonsterFixupTestBase.cs
@@ -1689,20 +1689,25 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
         private SnapshotMonsterContext CreateSnapshotMonsterContext(IServiceProvider serviceProvider, string databaseName = SnapshotDatabaseName)
         {
-            return new SnapshotMonsterContext(serviceProvider, CreateOptions(databaseName), OnModelCreating);
+            return new SnapshotMonsterContext(serviceProvider, CreateOptions(databaseName),
+                OnModelCreating<SnapshotMonsterContext.ProductPhoto, SnapshotMonsterContext.ProductReview>);
         }
 
         private ChangedChangingMonsterContext CreateChangedChangingMonsterContext(IServiceProvider serviceProvider, string databaseName = FullNotifyDatabaseName)
         {
-            return new ChangedChangingMonsterContext(serviceProvider, CreateOptions(databaseName), OnModelCreating);
+            return new ChangedChangingMonsterContext(serviceProvider, CreateOptions(databaseName),
+                OnModelCreating<ChangedChangingMonsterContext.ProductPhoto, ChangedChangingMonsterContext.ProductReview>);
         }
 
         private ChangedOnlyMonsterContext CreateChangedOnlyMonsterContext(IServiceProvider serviceProvider, string databaseName = ChangedOnlyDatabaseName)
         {
-            return new ChangedOnlyMonsterContext(serviceProvider, CreateOptions(databaseName), OnModelCreating);
+            return new ChangedOnlyMonsterContext(serviceProvider, CreateOptions(databaseName),
+                OnModelCreating<ChangedOnlyMonsterContext.ProductPhoto, ChangedOnlyMonsterContext.ProductReview>);
         }
 
-        protected virtual void OnModelCreating(ModelBuilder builder)
+        public virtual void OnModelCreating<TProductPhoto, TProductReview>(ModelBuilder builder)
+            where TProductPhoto : class
+            where TProductReview : class
         {
         }
 

--- a/test/EntityFramework.Core.FunctionalTests/OneToOneQueryFixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/OneToOneQueryFixtureBase.cs
@@ -7,16 +7,11 @@ namespace Microsoft.Data.Entity.FunctionalTests
 {
     public abstract class OneToOneQueryFixtureBase
     {
-        protected static Model CreateModel()
-        {
-            var model = new Model();
-            var modelBuilder = new ModelBuilderFactory().CreateConventionBuilder(model);
 
+        protected virtual void OnModelCreating(ModelBuilder modelBuilder)
+        {
             modelBuilder
                 .Entity<Address>(e => e.HasOne(a => a.Resident).WithOne(p => p.Address));
-
-            // TODO: Bug #1116
-            modelBuilder.Entity<Address>().Property(a => a.Id).GenerateValueOnAdd(false);
 
             modelBuilder.Entity<Address2>().Property<int>("PersonId");
 
@@ -25,7 +20,6 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     e => e.HasOne(p => p.Address).WithOne(a => a.Resident)
                         .ForeignKey(typeof(Address2), "PersonId"));
 
-            return model;
         }
 
         protected static void AddTestData(DbContext context)

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/MonsterContext`.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/MonsterContext`.cs
@@ -218,42 +218,17 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
 
             modelBuilder.Entity<TBarcodeDetail>().Key(e => e.Code);
 
-            // TODO: Key should not get by-convention value generation if it is dependent of identifying relationship
-            modelBuilder.Entity<TResolution>()
-                .Property(e => e.ResolutionId)
-                .GenerateValueOnAdd(false);
-
             modelBuilder.Entity<TSuspiciousActivity>();
             modelBuilder.Entity<TLastLogin>().Key(e => e.Username);
             modelBuilder.Entity<TMessage>().Key(e => new { e.MessageId, e.FromUsername });
 
-            modelBuilder.Entity<TOrderNote>(b =>
-                {
-                    b.Key(e => e.NoteId);
-                    // TODO: Key should get by-convention value generation even if key is not discovered by convention
-                    b.Property(e => e.NoteId).GenerateValueOnAdd();
-                });
+            modelBuilder.Entity<TOrderNote>().Key(e => e.NoteId);
 
             modelBuilder.Entity<TProductDetail>().Key(e => e.ProductId);
 
-            modelBuilder.Entity<TProductWebFeature>(b =>
-                {
-                    b.Key(e => e.FeatureId);
-                    // TODO: Key should get by-convention value generation even if key is not discovered by convention
-                    b.Property(e => e.FeatureId).GenerateValueOnAdd();
-                });
+            modelBuilder.Entity<TProductWebFeature>().Key(e => e.FeatureId);
 
             modelBuilder.Entity<TSupplierLogo>().Key(e => e.SupplierId);
-
-            // TODO: Key should not get by-convention value generation if it is dependent of identifying relationship
-            modelBuilder.Entity<TCustomerInfo>()
-                .Property(e => e.CustomerInfoId)
-                .GenerateValueOnAdd(false);
-
-            // TODO: Key should not get by-convention value generation if it is dependent of identifying relationship
-            modelBuilder.Entity<TComputerDetail>()
-                .Property(e => e.ComputerDetailId)
-                .GenerateValueOnAdd(false);
 
             modelBuilder.Entity<TLicense>().Key(e => e.Name);
 
@@ -287,6 +262,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
             modelBuilder.Entity<TOrderLine>(b =>
                 {
                     b.Key(e => new { e.OrderId, e.ProductId });
+
                     b.HasOne(e => (TProduct)e.Product).WithMany().ForeignKey(e => e.ProductId);
                 });
 
@@ -310,30 +286,23 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
 
                     b.HasOne(e => (TResolution)e.Resolution).WithOne(e => (TComplaint)e.Complaint)
                         .ReferencedKey<TComplaint>(e => e.AlternateId);
-
-                    // Should not be needed: see Issue #1271
-                    b.Property(e => e.AlternateId).GenerateValueOnAdd();
                 });
 
             modelBuilder.Entity<TProductPhoto>(b =>
                 {
-                    b.Key(e => new { e.ProductId, e.PhotoId });
-                    // TODO: Key should get by-convention value generation even if key is not discovered by convention
-                    b.Property(e => e.PhotoId).GenerateValueOnAdd();
+                    b.Key(e => new { e.PhotoId, e.ProductId });
 
                     b.HasMany(e => (IEnumerable<TProductWebFeature>)e.Features).WithOne(e => (TProductPhoto)e.Photo)
-                        .ForeignKey(e => new { e.ProductId, e.PhotoId })
-                        .ReferencedKey(e => new { e.ProductId, e.PhotoId });
+                        .ForeignKey(e => new { e.PhotoId, e.ProductId })
+                        .ReferencedKey(e => new { e.PhotoId, e.ProductId });
                 });
 
             modelBuilder.Entity<TProductReview>(b =>
                 {
-                    b.Key(e => new { e.ProductId, e.ReviewId });
-                    // TODO: Key should get by-convention value generation even if key is not discovered by convention
-                    b.Property(e => e.ReviewId).GenerateValueOnAdd();
+                    b.Key(e => new { e.ReviewId, e.ProductId });
 
                     b.HasMany(e => (IEnumerable<TProductWebFeature>)e.Features).WithOne(e => (TProductReview)e.Review)
-                        .ForeignKey(e => new { e.ProductId, e.ReviewId });
+                        .ForeignKey(e => new { e.ReviewId, e.ProductId });
                 });
 
             modelBuilder.Entity<TLogin>(b =>

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
@@ -1801,20 +1801,25 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         {
             var builder = TestHelpers.Instance.CreateConventionBuilder();
 
-            builder.Entity<Product>()
-                .HasOne(e => e.Tag).WithOne(e => e.Product)
-                .ReferencedKey<Product>(e => e.TagId)
-                .ForeignKey<ProductTag>(e => e.ProductId);
+            builder.Entity<Product>(b =>
+                {
+                    b.HasOne(e => e.Tag).WithOne(e => e.Product)
+                        .ReferencedKey<Product>(e => e.TagId)
+                        .ForeignKey<ProductTag>(e => e.ProductId);
+                    b.Property(e => e.TagId).GenerateValueOnAdd(false);
+                });
 
             builder.Entity<Category>(b =>
                 {
                     b.HasMany(e => e.Products).WithOne(e => e.Category)
                         .ForeignKey(e => e.DependentId)
                         .ReferencedKey(e => e.PrincipalId);
+                    b.Property(e => e.PrincipalId).GenerateValueOnAdd(false);
 
                     b.HasOne(e => e.Tag).WithOne(e => e.Category)
                         .ForeignKey<CategoryTag>(e => e.CategoryId)
                         .ReferencedKey<Category>(e => e.TagId);
+                    b.Property(e => e.TagId).GenerateValueOnAdd(false);
                 });
 
             builder.Entity<Person>()
@@ -2021,20 +2026,26 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         {
             var builder = TestHelpers.Instance.CreateConventionBuilder();
 
-            builder.Entity<NotifyingProduct>()
-                .HasOne(e => e.Tag).WithOne(e => e.Product)
-                .ReferencedKey<NotifyingProduct>(e => e.TagId)
-                .ForeignKey<NotifyingProductTag>(e => e.ProductId);
+            builder.Entity<NotifyingProduct>(b =>
+                {
+                    b.HasOne(e => e.Tag).WithOne(e => e.Product)
+                        .ReferencedKey<NotifyingProduct>(e => e.TagId)
+                        .ForeignKey<NotifyingProductTag>(e => e.ProductId);
+                    b.Property(e => e.TagId).GenerateValueOnAdd(false);
+                });
+
 
             builder.Entity<NotifyingCategory>(b =>
                 {
                     b.HasMany(e => e.Products).WithOne(e => e.Category)
                         .ForeignKey(e => e.DependentId)
                         .ReferencedKey(e => e.PrincipalId);
+                    b.Property(e => e.PrincipalId).GenerateValueOnAdd(false);
 
                     b.HasOne(e => e.Tag).WithOne(e => e.Category)
                         .ForeignKey<NotifyingCategoryTag>(e => e.CategoryId)
                         .ReferencedKey<NotifyingCategory>(e => e.TagId);
+                    b.Property(e => e.TagId).GenerateValueOnAdd(false);
                 });
 
             builder.Entity<NotifyingPerson>()

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntityEntryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntityEntryTest.cs
@@ -1373,10 +1373,6 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
                 .WithOne(e => e.Root)
                 .ForeignKey<FirstDependent>(e => e.Id);
 
-            modelBuilder.Entity<Root>().Property(e => e.Id).GenerateValueOnAdd();
-            modelBuilder.Entity<FirstDependent>().Property(e => e.Id).GenerateValueOnAdd(false);
-            modelBuilder.Entity<SecondDependent>().Property(e => e.Id).GenerateValueOnAdd(false);
-
             return modelBuilder.Model;
         }
 

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/KeyValueEntityTrackerTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/KeyValueEntityTrackerTest.cs
@@ -135,12 +135,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
                 modelBuilder.Entity<Stoat>();
                 modelBuilder.Entity<StoatInACoat>();
 
-                modelBuilder.Entity<CompositeStoat>(b =>
-                    {
-                        b.Key(e => new { e.Id1, e.Id2 });
-                        b.Property(e => e.Id1).GenerateValueOnAdd();
-                        b.Property(e => e.Id2).GenerateValueOnAdd();
-                    });
+                modelBuilder.Entity<CompositeStoat>().Key(e => new { e.Id1, e.Id2 });
             }
         }
     }

--- a/test/EntityFramework.Core.Tests/EntityFramework.Core.Tests.csproj
+++ b/test/EntityFramework.Core.Tests/EntityFramework.Core.Tests.csproj
@@ -131,8 +131,9 @@
     <Compile Include="Metadata\Internal\InternalPropertyBuilderTest.cs" />
     <Compile Include="Metadata\Internal\InternalRelationshipBuilderTest.cs" />
     <Compile Include="Metadata\MetadataBuilderTest.cs" />
-    <Compile Include="Metadata\ModelConventions\ConventionsDispatcherTest.cs" />
+    <Compile Include="Metadata\ModelConventions\ConventionDispatcherTest.cs" />
     <Compile Include="Metadata\ModelConventions\ForeignKeyPropertyDiscoveryConventionTest.cs" />
+    <Compile Include="Metadata\ModelConventions\KeyConventionTest.cs" />
     <Compile Include="Metadata\ModelConventions\RelationshipDiscoveryConventionTest.cs" />
     <Compile Include="Metadata\NavigationExtensionsTest.cs" />
     <Compile Include="Extensions\QueryableExtensionsTest.cs" />
@@ -160,7 +161,7 @@
     <Compile Include="Metadata\NavigationTest.cs" />
     <Compile Include="Metadata\ObjectArrayValueReaderTest.cs" />
     <Compile Include="Metadata\PropertyTest.cs" />
-    <Compile Include="Metadata\ModelConventions\KeyConventionTest.cs" />
+    <Compile Include="Metadata\ModelConventions\KeyDiscoveryConventionTest.cs" />
     <Compile Include="Metadata\ModelConventions\PropertiesConventionTest.cs" />
     <Compile Include="Query\TaskResultAsyncEnumerableTest.cs" />
     <Compile Include="Storage\DataStoreSelectorTest.cs" />

--- a/test/EntityFramework.Core.Tests/Metadata/Internal/InternalMetadataBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/Internal/InternalMetadataBuilderTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
+using Microsoft.Data.Entity.Infrastructure;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Metadata.Internal
@@ -42,6 +43,21 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
             Assert.True(builder.Annotation("Foo", "2", ConfigurationSource.Explicit));
             Assert.Equal("2", metadata.Annotations.Single().Value);
+        }
+
+        [Fact]
+        public void Annotation_set_explicitly_can_not_be_removed_by_convention()
+        {
+            var builder = CreateInternalMetadataBuilder();
+            var metadata = builder.Metadata;
+            metadata["Foo"] = "1";
+
+            Assert.False(builder.Annotation("Foo", null, ConfigurationSource.Convention));
+
+            Assert.Equal("1", metadata.Annotations.Single().Value);
+
+            Assert.True(builder.Annotation("Foo", null, ConfigurationSource.Explicit));
+            Assert.Equal(0, metadata.Annotations.Count());
         }
     }
 }

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/KeyConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/KeyConventionTest.cs
@@ -1,191 +1,218 @@
-// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Metadata.ModelConventions;
-using Moq;
-using Moq.Protected;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
 {
     public class KeyConventionTest
     {
-        private class EntityWithNoId
-        {
-            public string Name { get; set; }
-            public DateTime ModifiedDate { get; set; }
-        }
-
-        [Fact]
-        public void ConfigureKey_is_noop_when_zero_key_properties()
-        {
-            var entityBuilder = CreateInternalEntityBuilder<EntityWithNoId>();
-
-            Assert.Same(entityBuilder, new KeyConvention().Apply(entityBuilder));
-
-            var key = entityBuilder.Metadata.TryGetPrimaryKey();
-            Assert.Null(key);
-        }
-
-        [Fact]
-        public void ConfigureKey_handles_multiple_key_properties()
-        {
-            var entityBuilder = CreateInternalEntityBuilder<EntityWithNoId>();
-            var convention = new Mock<KeyConvention> { CallBase = true };
-            convention.Setup(c => c.DiscoverKeyProperties(It.IsAny<EntityType>()))
-                .Returns<EntityType>(t => t.Properties.ToList());
-
-            Assert.Same(entityBuilder, convention.Object.Apply(entityBuilder));
-
-            var key = entityBuilder.Metadata.TryGetPrimaryKey();
-            Assert.NotNull(key);
-            Assert.Equal(new[] { "ModifiedDate", "Name" }, key.Properties.Select(p => p.Name));
-        }
-
-        private class EntityWithId
+        public class SampleEntity
         {
             public int Id { get; set; }
+            public string Title { get; set; }
         }
 
-        [Fact]
-        public void DiscoverKeyProperties_discovers_id()
-        {
-            var entityBuilder = CreateInternalEntityBuilder<EntityWithId>();
-
-            Assert.Same(entityBuilder, new KeyConvention().Apply(entityBuilder));
-
-            var key = entityBuilder.Metadata.TryGetPrimaryKey();
-            Assert.NotNull(key);
-            Assert.Equal(new[] { "Id" }, key.Properties.Select(p => p.Name));
-            Assert.Equal(true, key.Properties.Single().GenerateValueOnAdd);
-        }
-
-        private class EntityWithTypeId
-        {
-            public int EntityWithTypeIdId { get; set; }
-        }
-
-        [Fact]
-        public void DiscoverKeyProperties_discovers_type_id()
-        {
-            var entityBuilder = CreateInternalEntityBuilder<EntityWithTypeId>();
-
-            Assert.Same(entityBuilder, new KeyConvention().Apply(entityBuilder));
-
-            var key = entityBuilder.Metadata.TryGetPrimaryKey();
-            Assert.NotNull(key);
-            Assert.Equal(new[] { "EntityWithTypeIdId" }, key.Properties.Select(p => p.Name));
-            Assert.Equal(true, key.Properties.Single().GenerateValueOnAdd);
-        }
-
-        private class EntityWithIdAndTypeId
+        public class ReferencedEntity
         {
             public int Id { get; set; }
-            public int EntityWithIdAndTypeIdId { get; set; }
+            public int SampleEntityId { get; set; }
         }
 
         [Fact]
-        public void DiscoverKeyProperties_prefers_id_over_type_id()
+        public void GenerateValueOnAdd_flag_is_set_for_key_properties()
         {
-            var entityBuilder = CreateInternalEntityBuilder<EntityWithIdAndTypeId>();
+            var modelBuilder = createInternalModelBuilder();
+            var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
 
-            Assert.Same(entityBuilder, new KeyConvention().Apply(entityBuilder));
+            var properties = new List<string> { "Id", "Title" };
+            var keyBuilder = entityBuilder.Key(properties, ConfigurationSource.Convention);
 
-            var key = entityBuilder.Metadata.TryGetPrimaryKey();
-            Assert.NotNull(key);
-            Assert.Equal(new[] { "Id" }, key.Properties.Select(p => p.Name));
-            Assert.Equal(true, key.Properties.Single().GenerateValueOnAdd);
-        }
+            Assert.Same(keyBuilder, new KeyConvention().Apply(keyBuilder));
 
-        private class EntityWithMultipleIds
-        {
-            public int ID { get; set; }
-            public int Id { get; set; }
-        }
+            var keyProperties = keyBuilder.Metadata.Properties;
 
-        [Fact]
-        public void DiscoverKeyProperties_does_not_discover_key_when_multiple_ids()
-        {
-            var entityBuilder = CreateInternalEntityBuilder<EntityWithMultipleIds>();
+            Assert.NotNull(keyProperties[0].GenerateValueOnAdd);
+            Assert.NotNull(keyProperties[1].GenerateValueOnAdd);
 
-            Assert.Same(entityBuilder, new KeyConvention().Apply(entityBuilder));
-
-            var key = entityBuilder.Metadata.TryGetPrimaryKey();
-            Assert.Null(key);
-        }
-
-        private class EntityWithGenericKey<T>
-        {
-            public T Id { get; set; }
+            Assert.True(keyProperties[0].GenerateValueOnAdd.Value);
+            Assert.True(keyProperties[1].GenerateValueOnAdd.Value);
         }
 
         [Fact]
-        public void ConfigureKeyProperty_sets_generation_strategy_only_when_guid_or_common_integer()
+        public void GenerateValueOnAdd_flag_is_not_set_for_foreign_key()
         {
-            ConfigureKeyProperty_generation_strategy<Guid>();
-            ConfigureKeyProperty_generation_strategy<long>();
-            ConfigureKeyProperty_generation_strategy<int>();
-            ConfigureKeyProperty_generation_strategy<short>();
-            ConfigureKeyProperty_generation_strategy<byte>();
-            ConfigureKeyProperty_generation_strategy<long?>();
-            ConfigureKeyProperty_generation_strategy<int?>();
-            ConfigureKeyProperty_generation_strategy<short?>();
-            ConfigureKeyProperty_generation_strategy<byte?>();
-            ConfigureKeyProperty_generation_strategy<string>();
-            ConfigureKeyProperty_generation_strategy<Enum1>();
-            ConfigureKeyProperty_generation_strategy<Enum1?>();
-            ConfigureKeyProperty_generation_strategy<bool>();
-            ConfigureKeyProperty_generation_strategy<bool?>();
-            ConfigureKeyProperty_generation_strategy<sbyte>();
-            ConfigureKeyProperty_generation_strategy<uint>();
-            ConfigureKeyProperty_generation_strategy<ulong>();
-            ConfigureKeyProperty_generation_strategy<ushort>();
-            ConfigureKeyProperty_generation_strategy<decimal>();
-            ConfigureKeyProperty_generation_strategy<float>();
-            ConfigureKeyProperty_generation_strategy<DateTime>();
-        }
+            var modelBuilder = createInternalModelBuilder();
 
-        private void ConfigureKeyProperty_generation_strategy<T>()
-        {
-            var entityBuilder = CreateInternalEntityBuilder<EntityWithGenericKey<T>>();
+            var principalEntityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
+            var referencedEntityBuilder = modelBuilder.Entity(typeof(ReferencedEntity), ConfigurationSource.Convention);
 
-            Assert.Same(entityBuilder, new KeyConvention().Apply(entityBuilder));
+            var properties = new List<string> { "SampleEntityId" };
+            principalEntityBuilder.Relationship(
+                principalEntityBuilder,
+                referencedEntityBuilder,
+                null,
+                null,
+                referencedEntityBuilder.GetOrCreateProperties(properties, ConfigurationSource.Convention),
+                null,
+                ConfigurationSource.Convention);
 
-            var property = entityBuilder.Metadata.TryGetProperty("Id");
-            Assert.NotNull(property);
-            Assert.True(property.GenerateValueOnAdd.Value);
-        }
+            var keyBuilder = referencedEntityBuilder.Key(properties, ConfigurationSource.Convention);
 
-        private enum Enum1
-        {
+            Assert.Same(keyBuilder, new KeyConvention().Apply(keyBuilder));
+
+            var keyProperties = keyBuilder.Metadata.Properties;
+
+            Assert.False(keyProperties[0].GenerateValueOnAdd);
         }
 
         [Fact]
-        public void ConfigureKeyProperty_does_not_override_generation_strategy_when_configured_explicitly()
+        public void GenerateValueOnAdd_flag_is_set_for_property_which_are_not_part_of_any_foreign_key()
         {
-            var entityBuilder = CreateInternalEntityBuilder<EntityWithGenericKey<Guid>>();
-            var property = entityBuilder.Metadata.TryGetProperty("Id");
-            property.GenerateValueOnAdd = false;
+            var modelBuilder = createInternalModelBuilder();
 
-            Assert.Same(entityBuilder, new KeyConvention().Apply(entityBuilder));
+            var principalEntityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
+            var referencedEntityBuilder = modelBuilder.Entity(typeof(ReferencedEntity), ConfigurationSource.Convention);
 
-            Assert.Equal(false, property.GenerateValueOnAdd);
+            var properties = new List<string> { "SampleEntityId" };
+            principalEntityBuilder.Relationship(
+                principalEntityBuilder,
+                referencedEntityBuilder,
+                null,
+                null,
+                referencedEntityBuilder.GetOrCreateProperties(properties, ConfigurationSource.Convention),
+                null,
+                ConfigurationSource.Convention);
+
+            var keyBuilder = referencedEntityBuilder.Key(new List<string> { "Id", "SampleEntityId" }, ConfigurationSource.Convention);
+
+            Assert.Same(keyBuilder, new KeyConvention().Apply(keyBuilder));
+
+            var keyProperties = keyBuilder.Metadata.Properties;
+
+            Assert.True(keyProperties[0].GenerateValueOnAdd);
+            Assert.False(keyProperties[1].GenerateValueOnAdd);
         }
 
-        private static InternalEntityBuilder CreateInternalEntityBuilder<T>()
+        [Fact]
+        public void GenerateValueOnAdd_flag_is_not_set_for_properties_which_are_part_of_a_foreign_key()
         {
-            var modelBuilder = new InternalModelBuilder(new Model());
-            var entityBuilder = modelBuilder.Entity(typeof(T), ConfigurationSource.Convention);
+            var modelBuilder = createInternalModelBuilder();
 
-            new PropertiesConvention().Apply(entityBuilder);
+            var principalEntityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
+            var referencedEntityBuilder = modelBuilder.Entity(typeof(ReferencedEntity), ConfigurationSource.Convention);
 
-            return entityBuilder;
+            var properties = new List<string> { "Id", "SampleEntityId" };
+            principalEntityBuilder.Relationship(
+                principalEntityBuilder,
+                referencedEntityBuilder,
+                null,
+                null,
+                referencedEntityBuilder.GetOrCreateProperties(properties, ConfigurationSource.Convention),
+                null,
+                ConfigurationSource.Convention);
+
+            var keyBuilder = referencedEntityBuilder.Key(new List<string> { "SampleEntityId" }, ConfigurationSource.Convention);
+
+            Assert.Same(keyBuilder, new KeyConvention().Apply(keyBuilder));
+
+            var keyProperties = keyBuilder.Metadata.Properties;
+
+            Assert.False(keyProperties[0].GenerateValueOnAdd);
+        }
+
+        [Fact]
+        public void KeyConvention_does_not_override_GenerateValueOnAddFlag_when_configured_explicitly()
+        {
+            var modelBuilder = createInternalModelBuilder();
+            var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
+
+            var properties = new List<string> { "Id" };
+            entityBuilder.Property(typeof(int), "Id", ConfigurationSource.Convention).GenerateValueOnAdd(false, ConfigurationSource.Explicit);
+
+            var keyBuilder = entityBuilder.Key(properties, ConfigurationSource.Convention);
+
+            Assert.Same(keyBuilder, new KeyConvention().Apply(keyBuilder));
+
+            var keyProperties = keyBuilder.Metadata.Properties;
+
+            Assert.False(keyProperties[0].GenerateValueOnAdd.Value);
+        }
+
+        [Fact]
+        public void GenerateValueOnAdd_flag_is_turned_off_when_foreign_key_is_added()
+        {
+            var modelBuilder = createInternalModelBuilder();
+
+            var principalEntityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
+            var referencedEntityBuilder = modelBuilder.Entity(typeof(ReferencedEntity), ConfigurationSource.Convention);
+
+            var properties = new List<string> { "SampleEntityId" };
+            var keyBuilder = referencedEntityBuilder.Key(properties, ConfigurationSource.Convention);
+
+            Assert.Same(keyBuilder, new KeyConvention().Apply(keyBuilder));
+
+            var keyProperties = keyBuilder.Metadata.Properties;
+
+            Assert.True(keyProperties[0].GenerateValueOnAdd);
+
+            principalEntityBuilder.Relationship(
+                principalEntityBuilder,
+                referencedEntityBuilder,
+                null,
+                null,
+                referencedEntityBuilder.GetOrCreateProperties(properties, ConfigurationSource.Convention),
+                null,
+                ConfigurationSource.Convention);
+
+            Assert.False(keyProperties[0].GenerateValueOnAdd);
+        }
+
+        [Fact]
+        public void GenerateValueOnAdd_flag_is_set_when_foreign_key_is_removed()
+        {
+            var modelBuilder = createInternalModelBuilder();
+
+            var principalEntityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
+            var referencedEntityBuilder = modelBuilder.Entity(typeof(ReferencedEntity), ConfigurationSource.Convention);
+
+            var properties = new List<string> { "SampleEntityId" };
+            var keyBuilder = referencedEntityBuilder.Key(properties, ConfigurationSource.Convention);
+
+            Assert.Same(keyBuilder, new KeyConvention().Apply(keyBuilder));
+
+            var keyProperties = keyBuilder.Metadata.Properties;
+
+            Assert.True(keyProperties[0].GenerateValueOnAdd);
+
+            var relationshipBuilder = principalEntityBuilder.Relationship(
+                principalEntityBuilder,
+                referencedEntityBuilder,
+                null,
+                null,
+                referencedEntityBuilder.GetOrCreateProperties(properties, ConfigurationSource.Convention),
+                null,
+                ConfigurationSource.Convention);
+
+            Assert.False(keyProperties[0].GenerateValueOnAdd);
+
+            referencedEntityBuilder.RemoveRelationship(relationshipBuilder.Metadata, ConfigurationSource.Convention);
+
+            Assert.True(keyProperties[0].GenerateValueOnAdd);
+        }
+
+        private static InternalModelBuilder createInternalModelBuilder()
+        {
+            var conventions = new ConventionSet();
+            conventions.EntityTypeAddedConventions.Add(new PropertiesConvention());
+            conventions.EntityTypeAddedConventions.Add(new KeyDiscoveryConvention());
+            conventions.ForeignKeyRemovedConventions.Add(new KeyConvention());
+
+            return new InternalModelBuilder(new Model(), conventions);
         }
     }
 }

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/KeyDiscoveryConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/KeyDiscoveryConventionTest.cs
@@ -1,0 +1,130 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Data.Entity.Internal;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Metadata.Internal;
+using Microsoft.Data.Entity.Metadata.ModelConventions;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
+{
+    public class KeyDiscoveryConventionTest
+    {
+        private class EntityWithNoId
+        {
+            public string Name { get; set; }
+            public DateTime ModifiedDate { get; set; }
+        }
+
+        [Fact]
+        public void Primary_key_is_not_set_when_zero_key_properties()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<EntityWithNoId>();
+
+            Assert.Same(entityBuilder, new KeyDiscoveryConvention().Apply(entityBuilder));
+
+            var key = entityBuilder.Metadata.TryGetPrimaryKey();
+            Assert.Null(key);
+        }
+
+        [Fact]
+        public void Composite_primary_key_is_set_when_multiple_key_properties()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<EntityWithNoId>();
+            var convention = new Mock<KeyDiscoveryConvention> { CallBase = true };
+            convention.Setup(c => c.DiscoverKeyProperties(It.IsAny<EntityType>()))
+                .Returns<EntityType>(t => t.Properties.ToList());
+
+            Assert.Same(entityBuilder, convention.Object.Apply(entityBuilder));
+
+            var key = entityBuilder.Metadata.TryGetPrimaryKey();
+            Assert.NotNull(key);
+            Assert.Equal(new[] { "ModifiedDate", "Name" }, key.Properties.Select(p => p.Name));
+        }
+
+        private class EntityWithId
+        {
+            public int Id { get; set; }
+        }
+
+        [Fact]
+        public void DiscoverKeyProperties_discovers_id()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<EntityWithId>();
+
+            Assert.Same(entityBuilder, new KeyDiscoveryConvention().Apply(entityBuilder));
+
+            var key = entityBuilder.Metadata.TryGetPrimaryKey();
+            Assert.NotNull(key);
+            Assert.Equal(new[] { "Id" }, key.Properties.Select(p => p.Name));
+        }
+
+        private class EntityWithTypeId
+        {
+            public int EntityWithTypeIdId { get; set; }
+        }
+
+        [Fact]
+        public void DiscoverKeyProperties_discovers_type_id()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<EntityWithTypeId>();
+
+            Assert.Same(entityBuilder, new KeyDiscoveryConvention().Apply(entityBuilder));
+
+            var key = entityBuilder.Metadata.TryGetPrimaryKey();
+            Assert.NotNull(key);
+            Assert.Equal(new[] { "EntityWithTypeIdId" }, key.Properties.Select(p => p.Name));
+        }
+
+        private class EntityWithIdAndTypeId
+        {
+            public int Id { get; set; }
+            public int EntityWithIdAndTypeIdId { get; set; }
+        }
+
+        [Fact]
+        public void DiscoverKeyProperties_prefers_id_over_type_id()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<EntityWithIdAndTypeId>();
+
+            Assert.Same(entityBuilder, new KeyDiscoveryConvention().Apply(entityBuilder));
+
+            var key = entityBuilder.Metadata.TryGetPrimaryKey();
+            Assert.NotNull(key);
+            Assert.Equal(new[] { "Id" }, key.Properties.Select(p => p.Name));
+        }
+
+        private class EntityWithMultipleIds
+        {
+            public int ID { get; set; }
+            public int Id { get; set; }
+        }
+
+        [Fact]
+        public void DiscoverKeyProperties_does_not_discover_key_when_multiple_ids()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<EntityWithMultipleIds>();
+
+            Assert.Same(entityBuilder, new KeyDiscoveryConvention().Apply(entityBuilder));
+
+            var key = entityBuilder.Metadata.TryGetPrimaryKey();
+            Assert.Null(key);
+        }
+
+        private static InternalEntityBuilder CreateInternalEntityBuilder<T>()
+        {
+            var modelBuilder = new InternalModelBuilder(new Model());
+            var entityBuilder = modelBuilder.Entity(typeof(T), ConfigurationSource.Convention);
+
+            new PropertiesConvention().Apply(entityBuilder);
+
+            return entityBuilder;
+        }
+    }
+}

--- a/test/EntityFramework.CrossStore.FunctionalTests/TestModels/CrossStoreContext.cs
+++ b/test/EntityFramework.CrossStore.FunctionalTests/TestModels/CrossStoreContext.cs
@@ -30,7 +30,6 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
                             .ForSqlServer(b => { eb.Property(e => e.Id).ForSqlServer().UseSequence(); });
 
                         eb.Property(typeof(string), SimpleEntity.ShadowPropertyName);
-                        eb.Property(e => e.Id).GenerateValueOnAdd(false);
                         eb.Key(e => e.Id);
                     });
         }

--- a/test/EntityFramework.InMemory.FunctionalTests/CompositeKeyEndToEndTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/CompositeKeyEndToEndTest.cs
@@ -186,18 +186,9 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
             {
                 modelBuilder.Entity<Pegasus>().Key(e => new { e.Id1, e.Id2 });
 
-                modelBuilder.Entity<Unicorn>(b =>
-                    {
-                        b.Key(e => new { e.Id1, e.Id2, e.Id3 });
-                        b.Property(e => e.Id1).GenerateValueOnAdd();
-                        b.Property(e => e.Id3).GenerateValueOnAdd();
-                    });
+                modelBuilder.Entity<Unicorn>().Key(e => new { e.Id1, e.Id2, e.Id3 });
 
-                modelBuilder.Entity<EarthPony>(b =>
-                    {
-                        b.Key(e => new { e.Id1, e.Id2 });
-                        b.Property(e => e.Id1).GenerateValueOnAdd();
-                    });
+                modelBuilder.Entity<EarthPony>().Key(e => new { e.Id1, e.Id2 });
             }
         }
 

--- a/test/EntityFramework.InMemory.FunctionalTests/OneToOneQueryInMemoryFixture.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/OneToOneQueryInMemoryFixture.cs
@@ -20,11 +20,10 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
                     .AddEntityFramework()
                     .AddInMemoryStore()
                     .ServiceCollection()
+                    .AddSingleton(TestInMemoryModelSource.GetFactory(OnModelCreating))
                     .BuildServiceProvider();
 
-            var model = CreateModel();
-
-            var optionsBuilder = new DbContextOptionsBuilder().UseModel(model);
+            var optionsBuilder = new DbContextOptionsBuilder();
             optionsBuilder.UseInMemoryStore();
             _options = optionsBuilder.Options;
 

--- a/test/EntityFramework.Relational.FunctionalTests/F1RelationalFixture.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/F1RelationalFixture.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
                 .Entity<Team>(b =>
                     {
                         b.Key(c => c.Id);
+
                         b.ForRelational().Table("Teams");
                     });
 

--- a/test/EntityFramework.Relational.FunctionalTests/TransactionFixtureBase.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/TransactionFixtureBase.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
 
         public abstract DbContext CreateContext(DbConnection connection);
 
-        protected void OnModelCreating(ModelBuilder modelBuilder)
+        public virtual void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder.Entity<TransactionCustomer>(ps =>
                 {

--- a/test/EntityFramework.SqlServer.FunctionalTests/BatchingTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/BatchingTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using Microsoft.Data.Entity.FunctionalTests;
 using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.SqlServer.Metadata;
 using Microsoft.Framework.DependencyInjection;
 using Xunit;
 
@@ -46,7 +47,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
             protected override void OnModelCreating(ModelBuilder modelBuilder)
             {
-                modelBuilder.Entity<Blog>().Property(b => b.Id).GenerateValueOnAdd(generateValue: false);
+                modelBuilder.Entity<Blog>().Property(b => b.Id).GenerateValueOnAdd(generateValue: false).ForSqlServer(b => b.UseNoValueGeneration());
             }
         }
 

--- a/test/EntityFramework.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerFixture.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerFixture.cs
@@ -3,6 +3,8 @@
 
 using System;
 using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.SqlServer.Metadata;
 using Microsoft.Framework.DependencyInjection;
 
 namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
@@ -43,7 +45,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
             modelBuilder.Entity<BuiltInNonNullableDataTypes>(b =>
                 {
-                    b.Property(dt => dt.Id).GenerateValueOnAdd(false);
+                    b.Property(dt => dt.Id).GenerateValueOnAdd(false).ForSqlServer(p => p.UseNoValueGeneration());
                     b.Ignore(dt => dt.TestUnsignedInt16);
                     b.Ignore(dt => dt.TestUnsignedInt32);
                     b.Ignore(dt => dt.TestUnsignedInt64);
@@ -53,7 +55,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
             modelBuilder.Entity<BuiltInNullableDataTypes>(b =>
                 {
-                    b.Property(dt => dt.Id).GenerateValueOnAdd(false);
+                    b.Property(dt => dt.Id).GenerateValueOnAdd(false).ForSqlServer(p => p.UseNoValueGeneration());
                     b.Ignore(dt => dt.TestNullableUnsignedInt16);
                     b.Ignore(dt => dt.TestNullableUnsignedInt32);
                     b.Ignore(dt => dt.TestNullableUnsignedInt64);

--- a/test/EntityFramework.SqlServer.FunctionalTests/CompositeKeyEndToEndTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/CompositeKeyEndToEndTest.cs
@@ -202,21 +202,18 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             protected override void OnModelCreating(ModelBuilder modelBuilder)
             {
                 modelBuilder.Entity<Pegasus>().Key(e => new { e.Id1, e.Id2 });
-                modelBuilder.Entity<Unicorn>().Key(e => new { e.Id1, e.Id2, e.Id3 });
-                modelBuilder.Entity<EarthPony>().Key(e => new { e.Id1, e.Id2 });
 
-                var unicornType = modelBuilder.Model.GetEntityType(typeof(Unicorn));
+                modelBuilder.Entity<Unicorn>(b =>
+                    {
+                        b.Key(e => new { e.Id1, e.Id2, e.Id3 });
+                        b.Property(e => e.Id1).ForSqlServer().UseIdentity();
+                    });
 
-                var id1 = unicornType.GetProperty("Id1");
-                id1.GenerateValueOnAdd = true;
-
-                var id3 = unicornType.GetProperty("Id3");
-                id3.GenerateValueOnAdd = true;
-
-                var earthType = modelBuilder.Model.GetEntityType(typeof(EarthPony));
-
-                var id = earthType.GetProperty("Id1");
-                id.GenerateValueOnAdd = true;
+                modelBuilder.Entity<EarthPony>(b =>
+                {
+                    b.Key(e => new { e.Id1, e.Id2});
+                    b.Property(e => e.Id1).ForSqlServer().UseIdentity();
+                });
             }
         }
 

--- a/test/EntityFramework.SqlServer.FunctionalTests/MonsterFixupSqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/MonsterFixupSqlServerTest.cs
@@ -75,5 +75,14 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 }
             }
         }
+
+        public override void OnModelCreating<TProductPhoto, TProductReview>(ModelBuilder builder)
+        {
+            base.OnModelCreating<TProductPhoto, TProductReview>(builder);
+
+            builder.Entity<TProductPhoto>().Property(typeof(int), "PhotoId").ForSqlServer().UseIdentity();
+            builder.Entity<TProductReview>().Property(typeof(int), "ReviewId").ForSqlServer().UseIdentity();
+        }
     }
+
 }

--- a/test/EntityFramework.SqlServer.FunctionalTests/OneToOneQuerySqlServerFixture.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/OneToOneQuerySqlServerFixture.cs
@@ -22,13 +22,13 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                     .AddEntityFramework()
                     .AddSqlServer()
                     .ServiceCollection()
+                    .AddSingleton(TestSqlServerModelSource.GetFactory(OnModelCreating))
                     .AddInstance<ILoggerFactory>(new TestSqlLoggerFactory())
                     .BuildServiceProvider();
 
-            var model = CreateModel();
             var database = SqlServerTestStore.CreateScratch();
 
-            var optionsBuilder = new DbContextOptionsBuilder().UseModel(model);
+            var optionsBuilder = new DbContextOptionsBuilder();
             optionsBuilder.UseSqlServer(database.Connection.ConnectionString);
             _options = optionsBuilder.Options;
 
@@ -44,5 +44,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         {
             return new DbContext(_serviceProvider, _options);
         }
+
     }
 }

--- a/test/EntityFramework.SqlServer.FunctionalTests/TransactionSqlServerFixture.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/TransactionSqlServerFixture.cs
@@ -4,7 +4,9 @@
 using System;
 using System.Data.Common;
 using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Relational.FunctionalTests;
+using Microsoft.Data.Entity.SqlServer.Metadata;
 using Microsoft.Framework.DependencyInjection;
 
 namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
@@ -61,6 +63,12 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             optionsBuilder.UseSqlServer(connection);
 
             return new DbContext(_serviceProvider, optionsBuilder.Options);
+        }
+
+        public override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.Entity<TransactionCustomer>().Property(c => c.Id).ForSqlServer(b => b.UseNoValueGeneration());
         }
     }
 }

--- a/test/EntityFramework.SqlServer.Tests/EntityFramework.SqlServer.Tests.csproj
+++ b/test/EntityFramework.SqlServer.Tests/EntityFramework.SqlServer.Tests.csproj
@@ -78,6 +78,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ApiConsistencyTest.cs" />
+    <Compile Include="Metadata\ModelConventions\SqlServerValueGenerationStrategyConventionTest.cs" />
     <Compile Include="Metadata\SqlServerBuilderExtensionsTest.cs" />
     <Compile Include="Metadata\SqlServerMetadataExtensionsTest.cs" />
     <Compile Include="Migrations\SqlServerHistoryRepositoryTest.cs" />

--- a/test/EntityFramework.SqlServer.Tests/Metadata/ModelConventions/SqlServerValueGenerationStrategyConventionTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/Metadata/ModelConventions/SqlServerValueGenerationStrategyConventionTest.cs
@@ -1,0 +1,205 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Metadata.Internal;
+using Microsoft.Data.Entity.Metadata.ModelConventions;
+using Microsoft.Data.Entity.SqlServer.Metadata;
+using Microsoft.Data.Entity.SqlServer.Metadata.ModelConventions;
+using Xunit;
+
+namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata.ModelConventions
+{
+    class SqlServerValueGenerationStrategyConventionTest
+    {
+        public class SampleEntity
+        {
+            public int Id { get; set; }
+            public int Number { get; set; }
+            public string Name { get; set; }
+        }
+
+        public class ReferencedEntity
+        {
+            public int Id { get; set; }
+            public int SampleEntityId { get; set; }
+        }
+
+
+        [Fact]
+        public void Default_annotation_is_set_for_primary_key()
+        {
+            var modelBuilder = createInternalModelBuilder();
+            var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
+
+            var keyBuilder = entityBuilder.PrimaryKey(new List<string> { "Id" }, ConfigurationSource.Convention);
+
+            Assert.Same(keyBuilder, new SqlServerValueGenerationStrategyConvention().Apply(keyBuilder));
+
+            var property = keyBuilder.Metadata.Properties.First();
+
+            Assert.Equal(1, property.Annotations.Count());
+            Assert.Equal(SqlServerValueGenerationStrategy.Default.ToString(), property[SqlServerAnnotationNames.Prefix + SqlServerAnnotationNames.ValueGeneration]);
+        }
+
+        [Fact]
+        public void Default_annotation_is_not_set_for_non_primary_key()
+        {
+            var modelBuilder = createInternalModelBuilder();
+            var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
+
+            var keyBuilder = entityBuilder.Key(new List<string> { "Number" }, ConfigurationSource.Convention);
+
+            Assert.Same(keyBuilder, new SqlServerValueGenerationStrategyConvention().Apply(keyBuilder));
+
+            Assert.Equal(0, keyBuilder.Metadata.Properties[0].Annotations.Count());
+        }
+
+        [Fact]
+        public void No_annotation_set_when_composite_primary_key()
+        {
+            var modelBuilder = createInternalModelBuilder();
+            var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
+
+            var keyBuilder = entityBuilder.PrimaryKey(new List<string> { "Id", "Number" }, ConfigurationSource.Convention);
+
+            Assert.Same(keyBuilder, new SqlServerValueGenerationStrategyConvention().Apply(keyBuilder));
+
+            var keyProperties = keyBuilder.Metadata.Properties;
+
+            Assert.Equal(0, keyProperties[0].Annotations.Count());
+            Assert.Equal(0, keyProperties[1].Annotations.Count());
+        }
+
+        [Fact]
+        public void No_annotation_set_when_primary_key_property_is_non_integer()
+        {
+            var modelBuilder = createInternalModelBuilder();
+            var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
+
+            var keyBuilder = entityBuilder.PrimaryKey(new List<string> { "Name" }, ConfigurationSource.Convention);
+
+            Assert.Same(keyBuilder, new SqlServerValueGenerationStrategyConvention().Apply(keyBuilder));
+
+            Assert.Equal(0, keyBuilder.Metadata.Properties[0].Annotations.Count());
+        }
+
+        [Fact]
+        public void No_annotation_set_when_primary_key_property_has_generate_value_false()
+        {
+            var modelBuilder = createInternalModelBuilder();
+            var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
+
+            var keyBuilder = entityBuilder.PrimaryKey(new List<string> { "Id" }, ConfigurationSource.Convention);
+            keyBuilder.Metadata.Properties.First().GenerateValueOnAdd = false;
+
+            Assert.Same(keyBuilder, new SqlServerValueGenerationStrategyConvention().Apply(keyBuilder));
+
+            Assert.Equal(0, keyBuilder.Metadata.Properties[0].Annotations.Count());
+        }
+
+        [Fact]
+        public void Convention_does_not_override_annotation_when_configured_explicitly()
+        {
+            var modelBuilder = createInternalModelBuilder();
+            var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
+
+            var keyBuilder = entityBuilder.PrimaryKey(new List<string> { "Id" }, ConfigurationSource.Convention);
+            keyBuilder.Metadata.Properties.First().SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.Identity;;
+
+            Assert.Same(keyBuilder, new SqlServerValueGenerationStrategyConvention().Apply(keyBuilder));
+
+            Assert.Equal(1, keyBuilder.Metadata.Properties[0].Annotations.Count());
+            Assert.Equal(SqlServerValueGenerationStrategy.Identity.ToString(), keyBuilder.Metadata.Properties[0].Annotations.First().Value);
+        }
+
+        [Fact]
+        public void Annotation_is_removed_when_foreign_key_is_added()
+        {
+            var modelBuilder = createInternalModelBuilder();
+
+            var principalEntityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
+            var referencedEntityBuilder = modelBuilder.Entity(typeof(ReferencedEntity), ConfigurationSource.Convention);
+
+            var properties = new List<string> { "Id" };
+            var keyBuilder = referencedEntityBuilder.PrimaryKey(properties, ConfigurationSource.Convention);
+
+            Assert.Same(keyBuilder, new SqlServerValueGenerationStrategyConvention().Apply(keyBuilder));
+
+            var keyProperties = keyBuilder.Metadata.Properties;
+
+            Assert.Equal(1, keyProperties[0].Annotations.Count());
+            Assert.Equal(SqlServerValueGenerationStrategy.Default.ToString(), keyProperties[0].Annotations.First().Value);
+
+            principalEntityBuilder.Relationship(
+                principalEntityBuilder,
+                referencedEntityBuilder,
+                null,
+                null,
+                referencedEntityBuilder.GetOrCreateProperties(properties, ConfigurationSource.Convention),
+                null,
+                ConfigurationSource.Convention);
+
+            Assert.Equal(0, keyProperties[0].Annotations.Count());
+        }
+
+        [Fact]
+        public void Annotation_is_added_when_foreign_key_is_removed_and_key_is_primary_key()
+        {
+            var modelBuilder = createInternalModelBuilder();
+
+            var principalEntityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
+            var referencedEntityBuilder = modelBuilder.Entity(typeof(ReferencedEntity), ConfigurationSource.Convention);
+
+            var properties = new List<string> { "Id" };
+            var keyBuilder = referencedEntityBuilder.PrimaryKey(properties, ConfigurationSource.Convention);
+
+            Assert.Same(keyBuilder, new SqlServerValueGenerationStrategyConvention().Apply(keyBuilder));
+
+            var keyProperties = keyBuilder.Metadata.Properties;
+
+            Assert.Equal(1, keyProperties[0].Annotations.Count());
+            Assert.Equal(SqlServerValueGenerationStrategy.Default.ToString(), keyProperties[0].Annotations.First().Value);
+
+            var relationshipBuilder = principalEntityBuilder.Relationship(
+                principalEntityBuilder,
+                referencedEntityBuilder,
+                null,
+                null,
+                referencedEntityBuilder.GetOrCreateProperties(properties, ConfigurationSource.Convention),
+                null,
+                ConfigurationSource.Convention);
+
+            Assert.Equal(0, keyProperties[0].Annotations.Count());
+
+            referencedEntityBuilder.RemoveRelationship(relationshipBuilder.Metadata, ConfigurationSource.Convention);
+
+            Assert.Same(keyBuilder, new SqlServerValueGenerationStrategyConvention().Apply(keyBuilder));
+
+            Assert.Equal(1, keyProperties[0].Annotations.Count());
+            Assert.Equal(SqlServerValueGenerationStrategy.Default.ToString(), keyProperties[0].Annotations.First().Value);
+
+        }
+
+        private static InternalModelBuilder createInternalModelBuilder()
+        {
+            var conventions = new ConventionSet();
+
+            conventions.EntityTypeAddedConventions.Add(new PropertiesConvention());
+            conventions.EntityTypeAddedConventions.Add(new KeyDiscoveryConvention());
+
+            var keyConvention = new KeyConvention();
+
+            conventions.KeyAddedConventions.Add(keyConvention);
+            conventions.ForeignKeyRemovedConventions.Add(keyConvention);
+
+            var sqlServerValueGenerationStrategyConvention = new SqlServerValueGenerationStrategyConvention();
+            conventions.ForeignKeyAddedConventions.Add(sqlServerValueGenerationStrategyConvention);
+            conventions.ForeignKeyRemovedConventions.Add(sqlServerValueGenerationStrategyConvention);
+
+            return new InternalModelBuilder(new Model(), conventions);
+        }
+    }
+}

--- a/test/EntityFramework.SqlServer.Tests/Metadata/SqlServerMetadataExtensionsTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/Metadata/SqlServerMetadataExtensionsTest.cs
@@ -876,7 +876,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
         }
 
         [Fact]
-        public void TryGetSequence_returns_sequence_model_is_marked_for_sequence_generation()
+        public void TryGetSequence_returns_sequence_property_is_marked_for_default_generation_and_model_is_marked_for_sequence_generation()
         {
             var modelBuilder = new BasicModelBuilder();
 
@@ -888,6 +888,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             modelBuilder.Model.SqlServer().AddOrReplaceSequence(new Sequence("DaneelOlivaw"));
             modelBuilder.Model.SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.Sequence;
             property.SqlServer().SequenceName = "DaneelOlivaw";
+            property.SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.Default;
 
             Assert.Equal("DaneelOlivaw", property.SqlServer().TryGetSequence().Name);
             Assert.Equal("DaneelOlivaw", ((IProperty)property).SqlServer().TryGetSequence().Name);
@@ -912,7 +913,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
         }
 
         [Fact]
-        public void TryGetSequence_returns_sequence_model_is_marked_for_sequence_generation_and_model_has_name()
+        public void TryGetSequence_returns_sequence_property_is_marked_for_default_generation_and_model_is_marked_for_sequence_generation_and_model_has_name()
         {
             var modelBuilder = new BasicModelBuilder();
 
@@ -924,6 +925,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             modelBuilder.Model.SqlServer().AddOrReplaceSequence(new Sequence("DaneelOlivaw"));
             modelBuilder.Model.SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.Sequence;
             modelBuilder.Model.SqlServer().DefaultSequenceName = "DaneelOlivaw";
+            property.SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.Default;
 
             Assert.Equal("DaneelOlivaw", property.SqlServer().TryGetSequence().Name);
             Assert.Equal("DaneelOlivaw", ((IProperty)property).SqlServer().TryGetSequence().Name);
@@ -964,6 +966,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             modelBuilder.Model.SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.Sequence;
             property.SqlServer().SequenceName = "DaneelOlivaw";
             property.SqlServer().SequenceSchema = "R";
+            property.SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.Default;
 
             Assert.Equal("DaneelOlivaw", property.SqlServer().TryGetSequence().Name);
             Assert.Equal("DaneelOlivaw", ((IProperty)property).SqlServer().TryGetSequence().Name);
@@ -1006,6 +1009,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             modelBuilder.Model.SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.Sequence;
             modelBuilder.Model.SqlServer().DefaultSequenceName = "DaneelOlivaw";
             modelBuilder.Model.SqlServer().DefaultSequenceSchema = "R";
+            property.SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.Default;
 
             Assert.Equal("DaneelOlivaw", property.SqlServer().TryGetSequence().Name);
             Assert.Equal("DaneelOlivaw", ((IProperty)property).SqlServer().TryGetSequence().Name);

--- a/test/EntityFramework.SqlServer.Tests/SqlServerValueGeneratorCacheTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerValueGeneratorCacheTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.SqlServer.Metadata;
 using Microsoft.Data.Entity.Tests;
 using Microsoft.Data.Entity.ValueGeneration;
 using Microsoft.Framework.DependencyInjection;
@@ -90,6 +91,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                 .Entity<Robot>()
                 .Property(e => e.Id)
                 .GenerateValueOnAdd()
+                .ForSqlServer(b => b.UseDefaultValueGeneration())
                 .Metadata;
 
             var cache = new SqlServerValueGeneratorCache();
@@ -105,6 +107,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                 .Entity<Robot>()
                 .Property(e => e.Id)
                 .GenerateValueOnAdd()
+                .ForSqlServer(b => b.UseDefaultValueGeneration())
                 .Metadata;
 
             var cache = new SqlServerValueGeneratorCache();
@@ -154,6 +157,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                 .Entity<Robot>()
                 .Property(e => e.Id)
                 .GenerateValueOnAdd()
+                .ForSqlServer(b => b.UseDefaultValueGeneration())
                 .Metadata;
 
             var cache = new SqlServerValueGeneratorCache();
@@ -190,6 +194,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                 .Entity<Robot>()
                 .Property(e => e.Id)
                 .GenerateValueOnAdd()
+                .ForSqlServer(b => b.UseDefaultValueGeneration())
                 .Metadata;
 
             var cache = new SqlServerValueGeneratorCache();
@@ -233,6 +238,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                 .Entity<Robot>()
                 .Property(e => e.Id)
                 .GenerateValueOnAdd()
+                .ForSqlServer(b => b.UseDefaultValueGeneration())
                 .Metadata;
 
             var cache = new SqlServerValueGeneratorCache();
@@ -248,6 +254,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                 .Entity<Robot>()
                 .Property(e => e.Id)
                 .GenerateValueOnAdd()
+                .ForSqlServer(b => b.UseDefaultValueGeneration())
                 .Metadata;
 
             var cache = new SqlServerValueGeneratorCache();
@@ -297,6 +304,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                 .Entity<Robot>()
                 .Property(e => e.Id)
                 .GenerateValueOnAdd()
+                .ForSqlServer(b => b.UseDefaultValueGeneration())
                 .Metadata;
 
             var cache = new SqlServerValueGeneratorCache();
@@ -316,6 +324,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                 .Entity<Robot>()
                 .Property(e => e.Id)
                 .GenerateValueOnAdd()
+                .ForSqlServer(b => b.UseDefaultValueGeneration())
                 .Metadata;
 
             var cache = new SqlServerValueGeneratorCache();
@@ -345,6 +354,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                 .Entity<Robot>()
                 .Property(e => e.Id)
                 .GenerateValueOnAdd()
+                .ForSqlServer(b => b.UseDefaultValueGeneration())
                 .Metadata;
 
             var cache = new SqlServerValueGeneratorCache();
@@ -379,6 +389,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                 .Entity<Robot>()
                 .Property(e => e.Id)
                 .GenerateValueOnAdd()
+                .ForSqlServer(b => b.UseDefaultValueGeneration())
                 .Metadata;
 
             var cache = new SqlServerValueGeneratorCache();

--- a/test/EntityFramework.SqlServer.Tests/SqlServerValueGeneratorSelectorTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerValueGeneratorSelectorTest.cs
@@ -90,18 +90,31 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                 Assert.Throws<NotSupportedException>(() => selector.Select(entityType.GetProperty("Float"))).Message);
         }
 
+        [Fact]
+        public void Does_not_return_generator_configured_on_model_when_default_is_not_set_on_property()
+        {
+            var model = SqlServerTestHelpers.Instance.BuildModelFor<AnEntity>();
+            model.SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.Sequence;
+            var entityType = model.GetEntityType(typeof(AnEntity));
+
+            var selector = SqlServerTestHelpers.Instance.CreateContextServices(model).GetRequiredService<ISqlServerValueGeneratorSelector>();
+
+            Assert.IsType<TemporaryIntegerValueGenerator<int>>(selector.Select(entityType.GetProperty("Id")));
+        }
+
         private static Model BuildModel(bool generateValues = true)
         {
             var model = SqlServerTestHelpers.Instance.BuildModelFor<AnEntity>();
             var entityType = model.GetEntityType(typeof(AnEntity));
 
-            entityType.GetProperty("AlwaysIdentity").SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.Identity;
-            entityType.GetProperty("AlwaysSequence").SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.Sequence;
-
             foreach (var property in entityType.Properties)
             {
                 property.GenerateValueOnAdd = generateValues;
+                property.SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.Default;
             }
+
+            entityType.GetProperty("AlwaysIdentity").SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.Identity;
+            entityType.GetProperty("AlwaysSequence").SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.Sequence;
 
             return model;
         }


### PR DESCRIPTION
Implements #1271 
Added KeyConvention to set GenerateValueOnAdd flag(s) as true whenever new key is added.
If new key is existing foreign key then flag(s) are not set.
If foreign key is set on existing key then flag(s) are changed to false.
If foreign key is removed then the convention is run again on the key.

Resolves #1126 
In SqlServer provider,
for PK with only 1 property which is of common integer type, we assign SqlServerValueGenerationStrategy.Default annotation. Which is a pointer that this property can use Identity. If property level or model level value generation strategy is assigned then we use it otherwise Identity will be used as value generation strategy.
For all other cases, composite PK or PK with non-int property, we do nothing.

fixes #1116 
Due to above conventions, now the dependent end of FK doesn't have auto-generated value so there is no identity key in dependent table. ModelSnapshot still has Default as value generation strategy annotated which is valid model. And that whole area will change soon. Verified through sample project.