### PR TITLE
Stop resolving most value generator factories from DI

### DIFF
--- a/src/EntityFramework.Core/Extensions/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/EntityFramework.Core/Extensions/EntityFrameworkServiceCollectionExtensions.cs
@@ -83,11 +83,6 @@ namespace Microsoft.Framework.DependencyInjection
                 .AddScoped<IPropertyListener>(p => p.GetService<ChangeDetector>());
 
             serviceCollection.TryAdd(new ServiceCollection()
-                .AddSingleton<TemporaryIntegerValueGeneratorFactory>()
-                .AddSingleton<ValueGeneratorFactory<TemporaryStringValueGenerator>>()
-                .AddSingleton<ValueGeneratorFactory<TemporaryBinaryValueGenerator>>()
-                .AddSingleton<ValueGeneratorFactory<GuidValueGenerator>>()
-                .AddSingleton<ValueGeneratorFactory<SequentialGuidValueGenerator>>()
                 .AddSingleton<DbSetFinder>()
                 .AddSingleton<DbSetInitializer>()
                 .AddSingleton<DbSetSource>()

--- a/src/EntityFramework.Core/ValueGeneration/ValueGeneratorSelector.cs
+++ b/src/EntityFramework.Core/ValueGeneration/ValueGeneratorSelector.cs
@@ -11,27 +11,17 @@ namespace Microsoft.Data.Entity.ValueGeneration
 {
     public abstract class ValueGeneratorSelector : IValueGeneratorSelector
     {
-        private readonly ValueGeneratorFactory<GuidValueGenerator> _guidFactory;
-        private readonly TemporaryIntegerValueGeneratorFactory _integerFactory;
-        private readonly ValueGeneratorFactory<TemporaryStringValueGenerator> _stringFactory;
-        private readonly ValueGeneratorFactory<TemporaryBinaryValueGenerator> _binaryFactory;
+        private readonly ValueGeneratorFactory<GuidValueGenerator> _guidFactory
+            = new ValueGeneratorFactory<GuidValueGenerator>();
 
-        protected ValueGeneratorSelector(
-            [NotNull] ValueGeneratorFactory<GuidValueGenerator> guidFactory, 
-            [NotNull] TemporaryIntegerValueGeneratorFactory integerFactory, 
-            [NotNull] ValueGeneratorFactory<TemporaryStringValueGenerator> stringFactory, 
-            [NotNull] ValueGeneratorFactory<TemporaryBinaryValueGenerator> binaryFactory)
-        {
-            Check.NotNull(guidFactory, nameof(guidFactory));
-            Check.NotNull(integerFactory, nameof(integerFactory));
-            Check.NotNull(stringFactory, nameof(stringFactory));
-            Check.NotNull(binaryFactory, nameof(binaryFactory));
+        private readonly TemporaryIntegerValueGeneratorFactory _integerFactory
+            = new TemporaryIntegerValueGeneratorFactory();
 
-            _guidFactory = guidFactory;
-            _integerFactory = integerFactory;
-            _stringFactory = stringFactory;
-            _binaryFactory = binaryFactory;
-        }
+        private readonly ValueGeneratorFactory<TemporaryStringValueGenerator> _stringFactory
+            = new ValueGeneratorFactory<TemporaryStringValueGenerator>();
+
+        private readonly ValueGeneratorFactory<TemporaryBinaryValueGenerator> _binaryFactory
+            = new ValueGeneratorFactory<TemporaryBinaryValueGenerator>();
 
         public abstract ValueGenerator Select(IProperty property);
 

--- a/src/EntityFramework.InMemory/InMemoryValueGeneratorSelector.cs
+++ b/src/EntityFramework.InMemory/InMemoryValueGeneratorSelector.cs
@@ -3,31 +3,22 @@
 
 using System;
 using JetBrains.Annotations;
-using Microsoft.Data.Entity.ValueGeneration;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Utilities;
+using Microsoft.Data.Entity.ValueGeneration;
 
 namespace Microsoft.Data.Entity.InMemory
 {
     public class InMemoryValueGeneratorSelector : ValueGeneratorSelector, IInMemoryValueGeneratorSelector
     {
         private readonly IInMemoryValueGeneratorCache _cache;
-        private readonly InMemoryIntegerValueGeneratorFactory _inMemoryFactory;
+        private readonly InMemoryIntegerValueGeneratorFactory _inMemoryFactory = new InMemoryIntegerValueGeneratorFactory();
 
-        public InMemoryValueGeneratorSelector(
-            [NotNull] IInMemoryValueGeneratorCache cache,
-            [NotNull] ValueGeneratorFactory<GuidValueGenerator> guidFactory,
-            [NotNull] InMemoryIntegerValueGeneratorFactory inMemoryFactory,
-            [NotNull] TemporaryIntegerValueGeneratorFactory integerFactory,
-            [NotNull] ValueGeneratorFactory<TemporaryStringValueGenerator> stringFactory,
-            [NotNull] ValueGeneratorFactory<TemporaryBinaryValueGenerator> binaryFactory)
-            : base(guidFactory, integerFactory, stringFactory, binaryFactory)
+        public InMemoryValueGeneratorSelector([NotNull] IInMemoryValueGeneratorCache cache)
         {
             Check.NotNull(cache, nameof(cache));
-            Check.NotNull(inMemoryFactory, nameof(inMemoryFactory));
 
             _cache = cache;
-            _inMemoryFactory = inMemoryFactory;
         }
 
         public override ValueGenerator Select(IProperty property)

--- a/src/EntityFramework.SqlServer/SqlServerValueGeneratorSelector.cs
+++ b/src/EntityFramework.SqlServer/SqlServerValueGeneratorSelector.cs
@@ -14,28 +14,23 @@ namespace Microsoft.Data.Entity.SqlServer
     {
         private readonly ISqlServerValueGeneratorCache _cache;
         private readonly SqlServerSequenceValueGeneratorFactory _sequenceFactory;
-        private readonly ValueGeneratorFactory<SequentialGuidValueGenerator> _sequentialGuidFactory;
+
+        private readonly ValueGeneratorFactory<SequentialGuidValueGenerator> _sequentialGuidFactory 
+            = new ValueGeneratorFactory<SequentialGuidValueGenerator>();
+
         private readonly ISqlServerConnection _connection;
 
         public SqlServerValueGeneratorSelector(
             [NotNull] ISqlServerValueGeneratorCache cache,
-            [NotNull] ValueGeneratorFactory<GuidValueGenerator> guidFactory,
-            [NotNull] TemporaryIntegerValueGeneratorFactory integerFactory,
-            [NotNull] ValueGeneratorFactory<TemporaryStringValueGenerator> stringFactory,
-            [NotNull] ValueGeneratorFactory<TemporaryBinaryValueGenerator> binaryFactory,
             [NotNull] SqlServerSequenceValueGeneratorFactory sequenceFactory,
-            [NotNull] ValueGeneratorFactory<SequentialGuidValueGenerator> sequentialGuidFactory,
             [NotNull] ISqlServerConnection connection)
-            : base(guidFactory, integerFactory, stringFactory, binaryFactory)
         {
             Check.NotNull(cache, nameof(cache));
             Check.NotNull(sequenceFactory, nameof(sequenceFactory));
-            Check.NotNull(sequentialGuidFactory, nameof(sequentialGuidFactory));
             Check.NotNull(connection, nameof(connection));
 
             _cache = cache;
             _sequenceFactory = sequenceFactory;
-            _sequentialGuidFactory = sequentialGuidFactory;
             _connection = connection;
         }
 

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntityEntryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntityEntryTest.cs
@@ -1236,7 +1236,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var entityType = model.GetEntityType(typeof(SomeEntity).FullName);
 
             var customServices = new ServiceCollection()
-                .AddSingleton<InMemoryIntegerValueGeneratorFactory, InMemoryTemporaryValueGeneratorFactory>();
+                .AddSingleton<IInMemoryValueGeneratorSelector, TestInMemoryValueGeneratorSelector>();
 
             var entry = CreateInternalEntry(
                 TestHelpers.Instance.CreateContextServices(customServices, model),
@@ -1322,7 +1322,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var entityType = model.GetEntityType(typeof(SecondDependent));
 
             var customServices = new ServiceCollection()
-                .AddSingleton<InMemoryIntegerValueGeneratorFactory, InMemoryTemporaryValueGeneratorFactory>();
+                .AddSingleton<IInMemoryValueGeneratorSelector, TestInMemoryValueGeneratorSelector>();
 
             var entry = CreateInternalEntry(
                 TestHelpers.Instance.CreateContextServices(customServices, model),
@@ -1380,11 +1380,20 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             return modelBuilder.Model;
         }
 
-        private class InMemoryTemporaryValueGeneratorFactory : InMemoryIntegerValueGeneratorFactory
+        public class TestInMemoryValueGeneratorSelector : InMemoryValueGeneratorSelector
         {
+            private readonly TemporaryIntegerValueGeneratorFactory _inMemoryFactory = new TemporaryIntegerValueGeneratorFactory();
+
+            public TestInMemoryValueGeneratorSelector(IInMemoryValueGeneratorCache cache)
+                : base(cache)
+            {
+            }
+
             public override ValueGenerator Create(IProperty property)
             {
-                return new TemporaryIntegerValueGeneratorFactory().Create(property);
+                return property.PropertyType == typeof(int)
+                    ? _inMemoryFactory.Create(property)
+                    : base.Create(property);
             }
         }
 

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/SidecarTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/SidecarTest.cs
@@ -374,7 +374,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             entity = entity ?? new Banana { Name = "Stand", Fk = 88 };
 
             var customServices = new ServiceCollection()
-                .AddSingleton<InMemoryIntegerValueGeneratorFactory, InMemoryTemporaryValueGeneratorFactory>();
+                .AddSingleton<IInMemoryValueGeneratorSelector, TestInMemoryValueGeneratorSelector>();
 
             var entry = TestHelpers.Instance.CreateContextServices(customServices, _model)
                 .GetRequiredService<StateManager>()
@@ -465,11 +465,20 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             public string Fk2 { get; set; }
         }
 
-        private class InMemoryTemporaryValueGeneratorFactory : InMemoryIntegerValueGeneratorFactory
+        public class TestInMemoryValueGeneratorSelector : InMemoryValueGeneratorSelector
         {
+            private readonly TemporaryIntegerValueGeneratorFactory _inMemoryFactory = new TemporaryIntegerValueGeneratorFactory();
+
+            public TestInMemoryValueGeneratorSelector(IInMemoryValueGeneratorCache cache)
+                : base(cache)
+            {
+            }
+
             public override ValueGenerator Create(IProperty property)
             {
-                return new TemporaryIntegerValueGeneratorFactory().Create(property);
+                return property.PropertyType == typeof(int)
+                    ? _inMemoryFactory.Create(property)
+                    : base.Create(property);
             }
         }
     }

--- a/test/EntityFramework.Core.Tests/Extensions/EntityServiceCollectionExtensionsTest.cs
+++ b/test/EntityFramework.Core.Tests/Extensions/EntityServiceCollectionExtensionsTest.cs
@@ -24,11 +24,6 @@ namespace Microsoft.Data.Entity.Tests
         [Fact]
         public virtual void Services_wire_up_correctly()
         {
-            VerifySingleton<TemporaryIntegerValueGeneratorFactory>();
-            VerifySingleton<ValueGeneratorFactory<TemporaryStringValueGenerator>>();
-            VerifySingleton<ValueGeneratorFactory<TemporaryBinaryValueGenerator>>();
-            VerifySingleton<ValueGeneratorFactory<GuidValueGenerator>>();
-            VerifySingleton<ValueGeneratorFactory<SequentialGuidValueGenerator>>();
             VerifySingleton<DbSetFinder>();
             VerifySingleton<DbSetInitializer>();
             VerifySingleton<DbSetSource>();

--- a/test/EntityFramework.Core.Tests/ValueGeneration/ValueGeneratorSelectorTest.cs
+++ b/test/EntityFramework.Core.Tests/ValueGeneration/ValueGeneratorSelectorTest.cs
@@ -95,15 +95,6 @@ namespace Microsoft.Data.Entity.Tests.ValueGeneration
 
         private class ConcreteValueGeneratorSelector : ValueGeneratorSelector
         {
-            public ConcreteValueGeneratorSelector(
-                ValueGeneratorFactory<GuidValueGenerator> guidFactory, 
-                TemporaryIntegerValueGeneratorFactory integerFactory, 
-                ValueGeneratorFactory<TemporaryStringValueGenerator> stringFactory, 
-                ValueGeneratorFactory<TemporaryBinaryValueGenerator> binaryFactory)
-                : base(guidFactory, integerFactory, stringFactory, binaryFactory)
-            {
-            }
-
             public override ValueGenerator Select(IProperty property)
             {
                 return Create(property);

--- a/test/EntityFramework.InMemory.Tests/InMemoryEntityServicesBuilderExtensionsTest.cs
+++ b/test/EntityFramework.InMemory.Tests/InMemoryEntityServicesBuilderExtensionsTest.cs
@@ -19,7 +19,6 @@ namespace Microsoft.Data.Entity.InMemory.Tests
             // In memory dingletones
             VerifySingleton<IInMemoryModelBuilderFactory>();
             VerifySingleton<IInMemoryValueGeneratorCache>();
-            VerifySingleton<InMemoryIntegerValueGeneratorFactory>();
             VerifySingleton<InMemoryDatabase>();
             VerifySingleton<IInMemoryModelSource>();
 


### PR DESCRIPTION
The selector is resolved from DI and is the appropriate place to make a change to which generator is used. Resolving most of the factories from DI does not add value.