### PR TITLE
[TINY] Updating when we issue Table() & ColumnType() fluent APIs.

### DIFF
--- a/src/EntityFramework.Relational.Design/ReverseEngineering/DbContextCodeGenerator.cs
+++ b/src/EntityFramework.Relational.Design/ReverseEngineering/DbContextCodeGenerator.cs
@@ -302,7 +302,8 @@ namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering
         {
             Check.NotNull(entityType, nameof(entityType));
 
-            if ("dbo" != entityType.Relational().Schema)
+            if (entityType.Relational().Schema != null
+                && entityType.Relational().Schema != "dbo")
             {
                 return string.Format(CultureInfo.InvariantCulture, ".Table({0}, {1})",
                     CSharpUtilities.Instance.DelimitString(entityType.Relational().Table),
@@ -310,7 +311,7 @@ namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering
             }
 
             if (entityType.Relational().Table != null
-                && entityType.Relational().Table != entityType.Name)
+                && entityType.Relational().Table != entityType.SimpleName)
             {
                 return string.Format(CultureInfo.InvariantCulture, ".Table({0})",
                     CSharpUtilities.Instance.DelimitString(entityType.Relational().Table));

--- a/src/EntityFramework.Relational.Design/ReverseEngineering/DbContextCodeGenerator.cs
+++ b/src/EntityFramework.Relational.Design/ReverseEngineering/DbContextCodeGenerator.cs
@@ -475,10 +475,7 @@ namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering
         {
             Check.NotNull(property, nameof(property));
 
-            // output columnType if decimal or datetime2 to define precision and scale
-            var columnType = property.Relational().ColumnType;
-            if (columnType != null
-                && (columnType.StartsWith("decimal") || columnType.StartsWith("datetime2")))
+            if (property.Relational().ColumnType != null)
             {
                 return string.Format(CultureInfo.InvariantCulture,
                     ".ColumnType({0})",

--- a/src/EntityFramework.SqlServer.Design/ReverseEngineering/SqlServerMetadataModelProvider.cs
+++ b/src/EntityFramework.SqlServer.Design/ReverseEngineering/SqlServerMetadataModelProvider.cs
@@ -493,34 +493,18 @@ namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering
                 property.Relational().Column = tableColumn.ColumnName;
             }
 
-            string columnType = tableColumn.DataType;
-            if (tableColumn.MaxLength.HasValue && !DataTypesForMaxLengthNotAllowed.Contains(tableColumn.DataType))
-            {
-                if (tableColumn.MaxLength > 0)
-                {
-                    property.MaxLength = tableColumn.MaxLength;
-                }
-
-                if (DataTypesForMax.Contains(columnType) && tableColumn.MaxLength == -1)
-                {
-                    columnType += "(max)";
-                }
-                else
-                {
-                    columnType += "(" + tableColumn.MaxLength + ")";
-                }
-            }
-            else if (DataTypesForNumericPrecisionAndScale.Contains(tableColumn.DataType))
+            string columnType = null;
+            if (DataTypesForNumericPrecisionAndScale.Contains(tableColumn.DataType))
             {
                 if (tableColumn.NumericPrecision.HasValue)
                 {
                     if (tableColumn.Scale.HasValue)
                     {
-                        columnType += "(" + tableColumn.NumericPrecision.Value + ", " + tableColumn.Scale.Value + ")";
+                        columnType = tableColumn.DataType + "(" + tableColumn.NumericPrecision.Value + ", " + tableColumn.Scale.Value + ")";
                     }
                     else
                     {
-                        columnType += "(" + tableColumn.NumericPrecision.Value + ")";
+                        columnType = tableColumn.DataType + "(" + tableColumn.NumericPrecision.Value + ")";
                     }
                 }
             }
@@ -530,16 +514,19 @@ namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering
                 {
                     if (tableColumn.Scale.HasValue)
                     {
-                        columnType += "(" + tableColumn.DateTimePrecision.Value + ", " + tableColumn.Scale.Value + ")";
+                        columnType = tableColumn.DataType + "(" + tableColumn.DateTimePrecision.Value + ", " + tableColumn.Scale.Value + ")";
                     }
                     else
                     {
-                        columnType += "(" + tableColumn.DateTimePrecision.Value + ")";
+                        columnType = tableColumn.DataType + "(" + tableColumn.DateTimePrecision.Value + ")";
                     }
                 }
             }
 
-            property.Relational().ColumnType = columnType;
+            if (columnType != null)
+            {
+                property.Relational().ColumnType = columnType;
+            }
 
             if (tableColumn.IsIdentity)
             {


### PR DESCRIPTION
See issue #1668.

Minor update so that we don't attempt to use Table() API if reported Schema is null.