### PR TITLE
Fix to #1726 - using boolProperty.Equals(true) in filter produces invalid sql

### DIFF
--- a/src/EntityFramework.Relational/Query/Methods/EqualsTranslator.cs
+++ b/src/EntityFramework.Relational/Query/Methods/EqualsTranslator.cs
@@ -9,10 +9,39 @@ namespace Microsoft.Data.Entity.Relational.Query.Methods
     {
         public virtual Expression Translate(MethodCallExpression methodCallExpression)
         {
-            return methodCallExpression.Method.Name == "Equals"
-                   && methodCallExpression.Arguments.Count == 1
-                ? Expression.Equal(methodCallExpression.Object, methodCallExpression.Arguments[0])
-                : null;
+            if (methodCallExpression.Method.Name == "Equals" && methodCallExpression.Arguments.Count == 1)
+            {
+                bool isBooleanOperand = methodCallExpression.Object.Type == typeof(bool);
+
+                var operand = isBooleanOperand 
+                    ? TranslateBooleanEqualsArgument(methodCallExpression.Object) 
+                    : methodCallExpression.Object;
+
+                var argument = isBooleanOperand
+                    ? TranslateBooleanEqualsArgument(methodCallExpression.Arguments[0])
+                    : methodCallExpression.Arguments[0];
+
+                return Expression.Equal(operand, argument);
+            }
+
+            return null;
+        }
+
+        private Expression TranslateBooleanEqualsArgument(Expression expression)
+        {
+            var binaryExpression = expression as BinaryExpression;
+            if (binaryExpression != null && binaryExpression.NodeType == ExpressionType.Equal)
+            {
+                var rightConstant = binaryExpression.Right as ConstantExpression;
+                if (rightConstant != null 
+                    && rightConstant.Type == typeof(bool) 
+                    && (bool)rightConstant.Value)
+                {
+                    return binaryExpression.Left;
+                }
+            }
+
+            return expression;
         }
     }
 }

--- a/test/EntityFramework.Core.FunctionalTests/GearsOfWarQueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/GearsOfWarQueryTestBase.cs
@@ -120,5 +120,45 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 Assert.Equal(2, result.Single().CityOfBirth.StationedGears.Count);
             }
         }
+
+        [Fact]
+        public virtual void Where_Equals_method_property_constant()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Cities.Where(c => c.IsCapital.Equals(true));
+                var result = query.ToList();
+
+                Assert.Equal(1, result.Count);
+                Assert.Equal("Ephyra", result.Single().Name);
+            }
+        }
+
+        [Fact]
+        public virtual void Where_not_Equals_method_parameter_property()
+        {
+            using (var context = CreateContext())
+            {
+                var prm = true;
+                var query = context.Cities.Where(c => !prm.Equals(c.IsCapital));
+                var result = query.ToList();
+
+                Assert.Equal(3, result.Count);
+                Assert.False(result.Select(c => c.Name).Contains("Ephyra"));
+            }
+        }
+
+        [Fact]
+        public virtual void Where_Equals_method_property_property()
+        {
+            using (var context = CreateContext())
+            {
+                var prm = true;
+                var query = context.Cities.Where(c => c.IsCapital.Equals(c.IsCapital));
+                var result = query.ToList();
+
+                Assert.Equal(4, result.Count);
+            }
+        }
     }
 }

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/GearsOfWarModel/City.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/GearsOfWarModel/City.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel
         // non-integer key with not conventional name
         public string Name { get; set; }
         public string Location { get; set; }
+        public bool IsCapital { get; set; }
 
         public List<Gear> BornGears { get; set; }
         public List<Gear> StationedGears { get; set; }

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/GearsOfWarModel/GearsOfWarModelInitializer.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/GearsOfWarModel/GearsOfWarModelInitializer.cs
@@ -35,26 +35,30 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel
                 var jacinto = new City
                     {
                         Location = "Jacinto's location",
-                        Name = "Jacinto"
-                    };
+                        Name = "Jacinto",
+                        IsCapital = false,
+                };
 
                 var ephyra = new City
                     {
                         Location = "Ephyra's location",
-                        Name = "Ephyra"
+                        Name = "Ephyra",
+                        IsCapital = true,
                     };
 
                 var hanover = new City
                     {
                         Location = "Hanover's location",
-                        Name = "Hanover"
-                    };
+                        Name = "Hanover",
+                        IsCapital = false,
+                };
 
                 var unknown = new City
                     {
                         Location = "Unknown",
-                        Name = "Unknown"
-                    };
+                        Name = "Unknown",
+                        IsCapital = false,
+                };
 
                 context.Cities.Add(jacinto);
                 context.Cities.Add(ephyra);

--- a/test/EntityFramework.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -75,7 +75,8 @@ INNER JOIN (
     LEFT JOIN [Gear] AS [g] ON ([t].[GearNickName] = [g].[Nickname] AND [t].[GearSquadId] = [g].[SquadId])
     LEFT JOIN [Squad] AS [s] ON [g].[SquadId] = [s].[Id]
 ) AS [s] ON [g].[SquadId] = [s].[Id]
-ORDER BY [s].[Id]", Sql);
+ORDER BY [s].[Id]", 
+                Sql);
         }
 
         public override void Include_multiple_one_to_one_optional_and_one_to_one_required()
@@ -86,7 +87,8 @@ ORDER BY [s].[Id]", Sql);
                 @"SELECT [t].[GearNickName], [t].[GearSquadId], [t].[Id], [t].[Note], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Nickname], [g].[Rank], [g].[SquadId], [s].[Id], [s].[InternalNumber], [s].[Name]
 FROM [CogTag] AS [t]
 LEFT JOIN [Gear] AS [g] ON ([t].[GearNickName] = [g].[Nickname] AND [t].[GearSquadId] = [g].[SquadId])
-LEFT JOIN [Squad] AS [s] ON [g].[SquadId] = [s].[Id]", Sql);
+LEFT JOIN [Squad] AS [s] ON [g].[SquadId] = [s].[Id]", 
+                Sql);
         }
 
         public override void Include_multiple_circular()
@@ -94,7 +96,7 @@ LEFT JOIN [Squad] AS [s] ON [g].[SquadId] = [s].[Id]", Sql);
             base.Include_multiple_circular();
 
             Assert.Equal(
-                @"SELECT [g].[AssignedCityName], [g].[CityOrBirthName], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Nickname], [g].[Rank], [g].[SquadId], [c].[Location], [c].[Name]
+                @"SELECT [g].[AssignedCityName], [g].[CityOrBirthName], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Nickname], [g].[Rank], [g].[SquadId], [c].[IsCapital], [c].[Location], [c].[Name]
 FROM [Gear] AS [g]
 INNER JOIN [City] AS [c] ON [g].[CityOrBirthName] = [c].[Name]
 ORDER BY [c].[Name]
@@ -115,7 +117,7 @@ ORDER BY [c].[Name]",
             base.Include_multiple_circular_with_filter();
 
             Assert.Equal(
-                @"SELECT [g].[AssignedCityName], [g].[CityOrBirthName], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Nickname], [g].[Rank], [g].[SquadId], [c].[Location], [c].[Name]
+                @"SELECT [g].[AssignedCityName], [g].[CityOrBirthName], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Nickname], [g].[Rank], [g].[SquadId], [c].[IsCapital], [c].[Location], [c].[Name]
 FROM [Gear] AS [g]
 INNER JOIN [City] AS [c] ON [g].[CityOrBirthName] = [c].[Name]
 WHERE [g].[Nickname] = 'Marcus'
@@ -130,6 +132,39 @@ INNER JOIN (
     WHERE [g].[Nickname] = 'Marcus'
 ) AS [c] ON [g].[AssignedCityName] = [c].[Name]
 ORDER BY [c].[Name]",
+                Sql);
+        }
+
+        public override void Where_Equals_method_property_constant()
+        {
+            base.Where_Equals_method_property_constant();
+
+            Assert.Equal(
+@"SELECT [c].[IsCapital], [c].[Location], [c].[Name]
+FROM [City] AS [c]
+WHERE [c].[IsCapital] = 1", 
+                Sql);
+        }
+
+        public override void Where_not_Equals_method_parameter_property()
+        {
+            base.Where_not_Equals_method_parameter_property();
+
+            Assert.Equal(
+@"SELECT [c].[IsCapital], [c].[Location], [c].[Name]
+FROM [City] AS [c]
+WHERE NOT @__prm_0 = [c].[IsCapital]",
+                Sql);
+        }
+
+        public override void Where_Equals_method_property_property()
+        {
+            base.Where_Equals_method_property_property();
+
+            Assert.Equal(
+@"SELECT [c].[IsCapital], [c].[Location], [c].[Name]
+FROM [City] AS [c]
+WHERE [c].[IsCapital] = [c].[IsCapital]",
                 Sql);
         }
 


### PR DESCRIPTION
Problem was that we have special treatment for boolean to support queries like Where(c => c.MyBoolProperty). However this breaks for Where(c => c.MyBoolProperty.Equals(true/my_variable/other_bool_property).
Fix is to recognize this pattern in EqualsTranslator and compensate accordingly for boolean arguments.