### PR TITLE
Allow configuring a relationship to an entity type without a primary key

### DIFF
--- a/src/EntityFramework.Core/Metadata/ForeignKey.cs
+++ b/src/EntityFramework.Core/Metadata/ForeignKey.cs
@@ -17,16 +17,7 @@ namespace Microsoft.Data.Entity.Metadata
         private readonly Key _referencedKey;
 
         private bool _isRequiredSet;
-
-        /// <summary>
-        ///     This constructor is intended only for use when creating test doubles that will override members
-        ///     with mocked or faked behavior. Use of this constructor for other purposes may result in unexpected
-        ///     behavior including but not limited to throwing <see cref="NullReferenceException" />.
-        /// </summary>
-        protected ForeignKey()
-        {
-        }
-
+        
         public ForeignKey(
             [NotNull] IReadOnlyList<Property> dependentProperties,
             [NotNull] Key referencedKey,
@@ -41,24 +32,7 @@ namespace Microsoft.Data.Entity.Metadata
 
             var principalProperties = referencedKey.Properties;
 
-            if (principalProperties.Count != dependentProperties.Count)
-            {
-                throw new ArgumentException(
-                    Strings.ForeignKeyCountMismatch(
-                        Property.Format(dependentProperties),
-                        dependentProperties[0].EntityType.Name,
-                        Property.Format(principalProperties),
-                        referencedKey.EntityType.Name));
-            }
-
-            if (!principalProperties.Select(p => p.UnderlyingType)
-                .SequenceEqual(dependentProperties.Select(p => p.UnderlyingType)))
-            {
-                throw new ArgumentException(
-                    Strings.ForeignKeyTypeMismatch(
-                        Property.Format(dependentProperties),
-                        dependentProperties[0].EntityType.Name, referencedKey.EntityType.Name));
-            }
+            Property.EnsureCompatible(principalProperties, dependentProperties);
 
             if (referencedEntityType?.Keys.Contains(referencedKey) == false)
             {

--- a/src/EntityFramework.Core/Metadata/Internal/InternalModelBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/InternalModelBuilder.cs
@@ -107,8 +107,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             ConfigurationSource ignoredConfigurationSource;
             if (_ignoredEntityTypeNames.Value.TryGetValue(name, out ignoredConfigurationSource))
             {
-                if (!configurationSource.Overrides(ignoredConfigurationSource)
-                    || configurationSource == ignoredConfigurationSource)
+                if (ignoredConfigurationSource.Overrides(configurationSource))
                 {
                     return true;
                 }

--- a/src/EntityFramework.Core/Metadata/Internal/InternalRelationshipBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/InternalRelationshipBuilder.cs
@@ -342,6 +342,30 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             return ReplaceForeignKey(configurationSource, principalProperties: properties);
         }
 
+        public virtual InternalRelationshipBuilder UpdateReferencedKey([NotNull] IReadOnlyList<Property> properties,
+            ConfigurationSource configurationSource)
+        {
+            if (Metadata.ReferencedProperties.SequenceEqual(properties))
+            {
+                return this;
+            }
+
+            if (_referencedKeyConfigurationSource != null
+                && _referencedKeyConfigurationSource.Value.Overrides(configurationSource))
+            {
+                return null;
+            }
+
+            if (_foreignKeyPropertiesConfigurationSource.HasValue
+                && _foreignKeyPropertiesConfigurationSource.Value.Overrides(configurationSource)
+                && !Property.AreCompatible(properties, Metadata.Properties))
+            {
+                return null;
+            }
+
+            return ReplaceForeignKey(configurationSource, principalProperties: properties);
+        }
+
         public virtual InternalRelationshipBuilder ReferencedKey(
             [NotNull] Type specifiedPrincipalType,
             [NotNull] IReadOnlyList<PropertyInfo> properties,

--- a/src/EntityFramework.Core/Metadata/ModelConventions/ForeignKeyPropertyDiscoveryConvention.cs
+++ b/src/EntityFramework.Core/Metadata/ModelConventions/ForeignKeyPropertyDiscoveryConvention.cs
@@ -57,8 +57,7 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
             {
                 var dependentPkProperties = foreignKey.EntityType.TryGetPrimaryKey()?.Properties;
                 if (dependentPkProperties != null
-                    && dependentPkProperties.Select(p => p.UnderlyingType)
-                        .SequenceEqual(foreignKey.ReferencedKey.Properties.Select(p => p.UnderlyingType)))
+                    && Property.AreCompatible(foreignKey.ReferencedKey.Properties, dependentPkProperties))
                 {
                     return dependentPkProperties;
                 }

--- a/src/EntityFramework.Core/Properties/Strings.Designer.cs
+++ b/src/EntityFramework.Core/Properties/Strings.Designer.cs
@@ -797,14 +797,6 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
-        /// The principal entity type '{entityType}' requires a key to be defined.
-        /// </summary>
-        public static string PrincipalEntityTypeRequiresKey([CanBeNull] object entityType)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("PrincipalEntityTypeRequiresKey", "entityType"), entityType);
-        }
-
-        /// <summary>
         /// The entity type '{type}' provided for the argument '{argumentName}' must be a reference type.
         /// </summary>
         public static string InvalidEntityType([CanBeNull] object type, [CanBeNull] object argumentName)

--- a/src/EntityFramework.Core/Properties/Strings.resx
+++ b/src/EntityFramework.Core/Properties/Strings.resx
@@ -411,9 +411,6 @@
   <data name="NavigationAddedExplicitly" xml:space="preserve">
     <value>The navigation property '{navigation}' on entity type '{entityType}' could not be ignored because it has been explicitly added.</value>
   </data>
-  <data name="PrincipalEntityTypeRequiresKey" xml:space="preserve">
-    <value>The principal entity type '{entityType}' requires a key to be defined.</value>
-  </data>
   <data name="InvalidEntityType" xml:space="preserve">
     <value>The entity type '{type}' provided for the argument '{argumentName}' must be a reference type.</value>
   </data>

--- a/test/EntityFramework.Core.FunctionalTests/F1FixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/F1FixtureBase.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             //builder.ComplexType<Location>();
             modelBuilder.Entity<Chassis>(b =>
                 {
+                    b.Key(c => c.TeamId);
                     b.Property(e => e.Version)
                         .StoreComputed()
                         .ConcurrencyToken();
@@ -25,16 +26,6 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
             modelBuilder.Entity<Driver>(b =>
                 {
-                    b.Property(d => d.CarNumber);
-                    b.Property(d => d.Championships);
-                    b.Property(d => d.FastestLaps);
-                    b.Property(d => d.Name);
-                    b.Property(d => d.Podiums);
-                    b.Property(d => d.Poles);
-                    b.Property(d => d.Races);
-                    b.Property(d => d.TeamId);
-                    b.Property(d => d.Wins);
-
                     b.Property(e => e.Version)
                         .StoreComputed()
                         .ConcurrencyToken();
@@ -44,21 +35,15 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 {
                     b.Property(e => e.EngineSupplierId).ConcurrencyToken();
                     b.Property(e => e.Name).ConcurrencyToken();
-                    b.HasMany(e => e.Teams).WithOne(e => e.Engine);
-                    b.HasMany(e => e.Gearboxes).WithOne();
                 });
 
             // TODO: Complex type
             // .Property(c => c.StorageLocation);
             modelBuilder.Ignore<Location>();
 
-            modelBuilder.Entity<EngineSupplier>(b =>
-                {
-                    b.Property(e => e.Name);
-                    b.HasMany(e => e.Engines).WithOne(e => e.EngineSupplier);
-                });
+            modelBuilder.Entity<EngineSupplier>();
 
-            modelBuilder.Entity<Gearbox>(b => { b.Property(g => g.Name); });
+            modelBuilder.Entity<Gearbox>();
 
             // TODO: Complex type
             //builder
@@ -73,8 +58,6 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
             modelBuilder.Entity<Sponsor>(b =>
                 {
-                    b.Property(s => s.Name);
-
                     b.Property(e => e.Version)
                         .StoreComputed()
                         .ConcurrencyToken();
@@ -96,8 +79,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
                         .StoreComputed()
                         .ConcurrencyToken();
 
-                    b.HasMany(e => e.Drivers).WithOne(e => e.Team);
                     b.HasOne(e => e.Gearbox).WithOne().ForeignKey<Team>(e => e.GearboxId);
+                    b.HasOne(e => e.Chassis).WithOne(e => e.Team).ForeignKey<Chassis>(e => e.TeamId);
                 });
 
             modelBuilder.Entity<TestDriver>();

--- a/test/EntityFramework.Core.Tests/Metadata/ForeignKeyTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ForeignKeyTest.cs
@@ -17,8 +17,6 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var model = new Model();
 
             var referencedEntityType = model.AddEntityType("R");
-            var pk = referencedEntityType.AddProperty("Pk", typeof(int), shadowProperty: true);
-            
             var dependentEntityType = model.AddEntityType("D");
             var fk = dependentEntityType.AddProperty("Fk", typeof(int), shadowProperty: true);
 
@@ -62,7 +60,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             Assert.Equal(
                 Strings.ForeignKeyCountMismatch("{'P1', 'P2'}", "D", "{'Id'}", "P"),
-                Assert.Throws<ArgumentException>(
+                Assert.Throws<InvalidOperationException>(
                     () => new ForeignKey(new[] { dependentProperty1, dependentProperty2 }, principalType.GetPrimaryKey())).Message);
         }
 
@@ -86,7 +84,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             Assert.Equal(
                 Strings.ForeignKeyTypeMismatch("{'P1', 'P2'}", "D", "P"),
-                Assert.Throws<ArgumentException>(
+                Assert.Throws<InvalidOperationException>(
                     () => new ForeignKey(new[] { dependentProperty1, dependentProperty2 }, principalType.GetPrimaryKey())).Message);
         }
 

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/ConventionDispatcherTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/ConventionDispatcherTest.cs
@@ -144,9 +144,11 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             var builder = new InternalModelBuilder(new Model(), conventions);
 
             var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
-            var foreignKeyMock = new Mock<ForeignKey>();
+            var foreignKey = new ForeignKey(
+                new[] { entityBuilder.Property(typeof(int), "FK", ConfigurationSource.Convention).Metadata },
+                entityBuilder.Key(new[] { entityBuilder.Property(typeof(int), "OrderId", ConfigurationSource.Convention).Metadata }, ConfigurationSource.Convention).Metadata);
             var conventionDispatcher = new ConventionDispatcher(conventions);
-            conventionDispatcher.OnForeignKeyRemoved(entityBuilder, foreignKeyMock.Object);
+            conventionDispatcher.OnForeignKeyRemoved(entityBuilder, foreignKey);
 
             Assert.True(foreignKeyRemoved);
         }

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/RelationshipDiscoveryConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/RelationshipDiscoveryConventionTest.cs
@@ -21,16 +21,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
 
             Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
 
-            Assert.Empty(entityBuilder.Metadata.Properties);
-            Assert.Empty(entityBuilder.Metadata.ForeignKeys);
-            Assert.Empty(entityBuilder.Metadata.Navigations);
-            // TODO: remove discovered entity types if no relationship discovered
-            Assert.Equal(2, entityBuilder.Metadata.Model.EntityTypes.Count);
-
-            var principalEntityType = entityBuilder.Metadata.Model.EntityTypes.Single(e => e.Type == typeof(OneToManyPrincipal));
-            Assert.Empty(principalEntityType.Properties);
-            Assert.Empty(principalEntityType.ForeignKeys);
-            Assert.Empty(principalEntityType.Navigations);
+            VerifyOneToManyDependent(entityBuilder, unidirectional: true, dependentHasPK: false);
         }
 
         [Fact]
@@ -40,16 +31,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
 
             Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
 
-            Assert.Empty(entityBuilder.Metadata.Properties);
-            Assert.Empty(entityBuilder.Metadata.ForeignKeys);
-            Assert.Empty(entityBuilder.Metadata.Navigations);
-            // TODO: remove discovered entity types if no relationship discovered
-            Assert.Equal(2, entityBuilder.Metadata.Model.EntityTypes.Count);
-
-            var principalEntityType = entityBuilder.Metadata.Model.EntityTypes.Single(e => e.Type == typeof(OneToManyPrincipal));
-            Assert.Empty(principalEntityType.Properties);
-            Assert.Empty(principalEntityType.ForeignKeys);
-            Assert.Empty(principalEntityType.Navigations);
+            VerifyOneToManyPrincipal(entityBuilder, unidirectional: true, dependentHasPK: false);
         }
 
         [Fact]

--- a/test/EntityFramework.Core.Tests/Metadata/NavigationTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/NavigationTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Data.Entity.Metadata;
-using Moq;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Tests.Metadata
@@ -12,58 +11,55 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         [Fact]
         public void Can_create_navigation_to_principal()
         {
-            var keyMock = new Mock<ForeignKey>();
-            keyMock.Setup(m => m.IsUnique).Returns(false);
-            var foreignKey = keyMock.Object;
+            var foreignKey = CreateForeignKey();
+            foreignKey.IsUnique = false;
 
             var navigation = new Navigation("Deception", foreignKey, pointsToPrincipal: true);
 
             Assert.Same(foreignKey, navigation.ForeignKey);
             Assert.Equal("Deception", navigation.Name);
-            Assert.Null(navigation.EntityType);
+            Assert.NotNull(navigation.EntityType);
             Assert.True(navigation.PointsToPrincipal);
             Assert.False(navigation.IsCollection());
-
-            Assert.Same(foreignKey, ((INavigation)navigation).ForeignKey);
-            Assert.Null(((INavigation)navigation).EntityType);
         }
 
         [Fact]
         public void Can_create_navigation_to_unique_dependent()
         {
-            var keyMock = new Mock<ForeignKey>();
-            keyMock.Setup(m => m.IsUnique).Returns(true);
-            var foreignKey = keyMock.Object;
+            var foreignKey = CreateForeignKey();
+            foreignKey.IsUnique = true;
 
             var navigation = new Navigation("Deception", foreignKey, pointsToPrincipal: false);
 
             Assert.Same(foreignKey, navigation.ForeignKey);
             Assert.Equal("Deception", navigation.Name);
-            Assert.Null(navigation.EntityType);
+            Assert.NotNull(navigation.EntityType);
             Assert.False(navigation.PointsToPrincipal);
             Assert.False(navigation.IsCollection());
-
-            Assert.Same(foreignKey, ((INavigation)navigation).ForeignKey);
-            Assert.Null(((INavigation)navigation).EntityType);
         }
 
         [Fact]
         public void Can_create_navigation_to_collection_of_dependents()
         {
-            var keyMock = new Mock<ForeignKey>();
-            keyMock.Setup(m => m.IsUnique).Returns(false);
-            var foreignKey = keyMock.Object;
+            var foreignKey = CreateForeignKey();
+            foreignKey.IsUnique = false;
 
             var navigation = new Navigation("Deception", foreignKey, pointsToPrincipal: false);
 
             Assert.Same(foreignKey, navigation.ForeignKey);
             Assert.Equal("Deception", navigation.Name);
-            Assert.Null(navigation.EntityType);
+            Assert.NotNull(navigation.EntityType);
             Assert.False(navigation.PointsToPrincipal);
             Assert.True(navigation.IsCollection());
+        }
 
-            Assert.Same(foreignKey, ((INavigation)navigation).ForeignKey);
-            Assert.Null(((INavigation)navigation).EntityType);
+        private ForeignKey CreateForeignKey()
+        {
+            var model = new Model();
+            var entityType = model.AddEntityType("E");
+            var property = entityType.AddProperty("p", typeof(int), shadowProperty: true);
+            var key = entityType.SetPrimaryKey(property);
+            return new ForeignKey(new[] { property }, key);
         }
     }
 }

--- a/test/EntityFramework.Relational.FunctionalTests/F1RelationalFixture.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/F1RelationalFixture.cs
@@ -16,14 +16,12 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
             modelBuilder
                 .Entity<Chassis>(b =>
                     {
-                        b.Key(c => c.TeamId);
                         b.ForRelational().Table("Chassis");
                     });
 
             modelBuilder
                 .Entity<Team>(b =>
                     {
-                        b.Key(c => c.Id);
 
                         b.ForRelational().Table("Teams");
                     });
@@ -31,42 +29,36 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
             modelBuilder
                 .Entity<Driver>(b =>
                     {
-                        b.Key(c => c.Id);
                         b.ForRelational().Table("Drivers");
                     });
 
             modelBuilder
                 .Entity<Engine>(b =>
                     {
-                        b.Key(c => c.Id);
                         b.ForRelational().Table("Engines");
                     });
 
             modelBuilder
                 .Entity<EngineSupplier>(b =>
                     {
-                        b.Key(c => c.Id);
                         b.ForRelational().Table("EngineSuppliers");
                     });
 
             modelBuilder
                 .Entity<Gearbox>(b =>
                     {
-                        b.Key(c => c.Id);
                         b.ForRelational().Table("Gearboxes");
                     });
 
             modelBuilder
                 .Entity<Sponsor>(b =>
                     {
-                        b.Key(c => c.Id);
                         b.ForRelational().Table("Sponsors");
                     });
 
             modelBuilder
                 .Entity<TestDriver>(b =>
                     {
-                        b.Key(c => c.Id);
                         b.ForRelational().Table("TestDrivers");
                     });
 
@@ -74,9 +66,6 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
                 .Entity<TitleSponsor>()
                 .ForRelational()
                 .Table("TitleSponsors");
-
-            modelBuilder
-                .Entity<Team>().HasOne(e => e.Chassis).WithOne(e => e.Team);
         }
     }
 }


### PR DESCRIPTION
Remove shadow keys added by convention when the primary key is set
Update relationships when a new primary key is set

Fixes #1603