### PR TITLE
Fix to #1726 - using boolProperty.Equals(true) in filter produces invalid sql (take 3)

### DIFF
--- a/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/FilteringExpressionTreeVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/FilteringExpressionTreeVisitor.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
         private readonly RelationalQueryModelVisitor _queryModelVisitor;
 
         private bool _requiresClientEval;
-        private bool _inBinaryEqualityExpression;
 
         public FilteringExpressionTreeVisitor([NotNull] RelationalQueryModelVisitor queryModelVisitor)
         {
@@ -36,14 +35,10 @@ namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
                 case ExpressionType.Equal:
                 case ExpressionType.NotEqual:
                 {
-                    _inBinaryEqualityExpression = true;
-
                     var structuralComparisonExpression
                         = UnfoldStructuralComparison(
                             binaryExpression.NodeType,
                             ProcessComparisonExpression(binaryExpression));
-
-                    _inBinaryEqualityExpression = false;
 
                     return structuralComparisonExpression;
                 }
@@ -205,10 +200,7 @@ namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
 
                 if (columnExpression != null)
                 {
-                    return !_inBinaryEqualityExpression
-                           && columnExpression.Type == typeof(bool)
-                        ? (Expression)Expression.Equal(columnExpression, Expression.Constant(true))
-                        : columnExpression;
+                    return columnExpression;
                 }
             }
 
@@ -234,10 +226,7 @@ namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
 
             if (columnExpression != null)
             {
-                return !_inBinaryEqualityExpression
-                       && columnExpression.Type == typeof(bool)
-                    ? (Expression)Expression.Equal(columnExpression, Expression.Constant(true))
-                    : columnExpression;
+                return columnExpression;
             }
 
             _requiresClientEval = true;

--- a/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
@@ -812,6 +812,18 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
+        public virtual void Where_bool_member_equals_constant()
+        {
+            AssertQuery<Product>(ps => ps.Where(p => p.Discontinued.Equals(true)), entryCount: 8);
+        }
+
+        [Fact]
+        public virtual void Where_bool_member_in_complex_predicate()
+        {
+            AssertQuery<Product>(ps => ps.Where(p => p.ProductID > 100 && p.Discontinued || (p.Discontinued == true)), entryCount: 8);
+        }
+
+        [Fact]
         public virtual void Where_short_member_comparison()
         {
             AssertQuery<Product>(ps => ps.Where(p => p.UnitsInStock > 10), entryCount: 63);

--- a/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -1562,6 +1562,28 @@ WHERE NOT [p].[Discontinued] = 1",
                 Sql);
         }
 
+        public override void Where_bool_member_equals_constant()
+        {
+            base.Where_bool_member_equals_constant();
+
+            Assert.Equal(
+                @"SELECT [p].[Discontinued], [p].[ProductID], [p].[ProductName], [p].[UnitsInStock]
+FROM [Products] AS [p]
+WHERE [p].[Discontinued] = 1",
+                Sql);
+        }
+
+        public override void Where_bool_member_in_complex_predicate()
+        {
+            base.Where_bool_member_in_complex_predicate();
+
+            Assert.Equal(
+                @"SELECT [p].[Discontinued], [p].[ProductID], [p].[ProductName], [p].[UnitsInStock]
+FROM [Products] AS [p]
+WHERE (([p].[ProductID] > 100 AND [p].[Discontinued] = 1) OR [p].[Discontinued] = 1)",
+                Sql);
+        }
+
         public override void Where_short_member_comparison()
         {
             base.Where_short_member_comparison();


### PR DESCRIPTION
Problem was that we have special treatment for boolean to support queries like Where(c => c.MyBoolProperty). However this breaks for Where(c => c.MyBoolProperty.Equals(true/my_variable/other_bool_property).

Fix is to revert the previous change and instead compensate in the sql generation phase - adding " = 1" terms for 'naked' column expressions as well as column expressions inside logical expression, inside WHERE predicate.

things like: products.Where(p => p.Discontinued == (p.ProductID > 100)) are still broken but the main scenarios works fine.