### PR TITLE
React to Configuration API changes

### DIFF
--- a/test/EntityFramework.Core.Tests/DbContextOptionsParserTest.cs
+++ b/test/EntityFramework.Core.Tests/DbContextOptionsParserTest.cs
@@ -16,13 +16,12 @@ namespace Microsoft.Data.Entity.Tests
         [Fact]
         public void Connection_string_is_found_using_context_name()
         {
-            var config = new Configuration
-                {
+            var config = new Configuration(
                     new MemoryConfigurationSource
                         {
                             { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "MyConnectionString" }
                         }
-                };
+                );
 
             var rawOptions = new DbContextOptionsParser().ReadRawOptions(config, typeof(MyContext), new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
 
@@ -34,12 +33,12 @@ namespace Microsoft.Data.Entity.Tests
         public void Connection_string_is_found_using_context_full_name()
         {
             var config = new Configuration
-                {
+                (
                     new MemoryConfigurationSource
                         {
                             { "EntityFramework:" + typeof(MyContext).FullName + ":ConnectionString", "MyConnectionString" }
                         }
-                };
+                );
 
             var rawOptions = new DbContextOptionsParser().ReadRawOptions(config, typeof(MyContext), new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
 
@@ -51,12 +50,12 @@ namespace Microsoft.Data.Entity.Tests
         public void Connection_string_is_found_using_context_name_generic()
         {
             var config = new Configuration
-                {
+                (
                     new MemoryConfigurationSource
                         {
                             { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "MyConnectionString" }
                         }
-                };
+                );
 
             var rawOptions = new DbContextOptionsParser().ReadRawOptions<MyContext>(config, new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
 
@@ -68,12 +67,12 @@ namespace Microsoft.Data.Entity.Tests
         public void Connection_string_is_found_using_context_full_name_generic()
         {
             var config = new Configuration
-                {
+                (
                     new MemoryConfigurationSource
                         {
                             { "EntityFramework:" + typeof(MyContext).FullName + ":ConnectionString", "MyConnectionString" }
                         }
-                };
+                );
 
             var rawOptions = new DbContextOptionsParser().ReadRawOptions<MyContext>(config, new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
 
@@ -89,13 +88,13 @@ namespace Microsoft.Data.Entity.Tests
         public void Indirect_connection_string_can_be_specified_with_name()
         {
             var config = new Configuration
-                {
+                (
                     new MemoryConfigurationSource
                         {
                             { "Data:DefaultConnection:ConnectionString", "MyConnectionString" },
                             { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "Name=Data:DefaultConnection:ConnectionString" }
                         }
-                };
+                );
 
             var rawOptions = new DbContextOptionsParser().ReadRawOptions(config, typeof(MyContext), new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
 
@@ -107,13 +106,13 @@ namespace Microsoft.Data.Entity.Tests
         public void Indirect_connection_string_is_read_case_insensitively()
         {
             var config = new Configuration
-                {
+                (
                     new MemoryConfigurationSource
                         {
                             { "Data:DefaultConnection:ConnectionString", "MyConnectionString" },
                             { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "name=Data:DefaultConnection:ConnectionString" }
                         }
-                };
+                );
 
             var rawOptions = new DbContextOptionsParser().ReadRawOptions(config, typeof(MyContext), new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
 
@@ -125,13 +124,13 @@ namespace Microsoft.Data.Entity.Tests
         public void Indirect_connection_string_is_read_removing_whitespaces()
         {
             var config = new Configuration
-                {
+                (
                     new MemoryConfigurationSource
                         {
                             { "Data:DefaultConnection:ConnectionString", "MyConnectionString" },
                             { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "name = Data:DefaultConnection:ConnectionString" }
                         }
-                };
+                );
 
             var rawOptions = new DbContextOptionsParser().ReadRawOptions(config, typeof(MyContext), new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
 
@@ -143,13 +142,13 @@ namespace Microsoft.Data.Entity.Tests
         public void Indirect_connection_string_must_have_only_one_equal_sign()
         {
             var config = new Configuration
-                {
+                (
                     new MemoryConfigurationSource
                         {
                             { "Data:DefaultConnection:ConnectionString", "MyConnectionString" },
                             { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "Name=Data:DefaultConnection:ConnectionString;Key=Value" }
                         }
-                };
+                );
 
             var rawOptions = new DbContextOptionsParser().ReadRawOptions(config, typeof(MyContext), new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
 
@@ -161,13 +160,13 @@ namespace Microsoft.Data.Entity.Tests
         public void Single_key_value_pair_does_not_cause_redirection_if_key_is_not_name()
         {
             var config = new Configuration
-                {
+                (
                     new MemoryConfigurationSource
                         {
                             { "Data:DefaultConnection:ConnectionString", "MyConnectionString" },
                             { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "Data Source=Data:DefaultConnection:ConnectionString" }
                         }
-                };
+                );
 
             var rawOptions = new DbContextOptionsParser().ReadRawOptions(config, typeof(MyContext), new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
 
@@ -179,13 +178,13 @@ namespace Microsoft.Data.Entity.Tests
         public void Connection_string_starting_with_equal_sign_does_not_cause_redirection()
         {
             var config = new Configuration
-                {
+                (
                     new MemoryConfigurationSource
                         {
                             { "Data:DefaultConnection:ConnectionString", "MyConnectionString" },
                             { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "=Data:DefaultConnection:ConnectionString" }
                         }
-                };
+                );
 
             var rawOptions = new DbContextOptionsParser().ReadRawOptions(config, typeof(MyContext), new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
 
@@ -197,12 +196,12 @@ namespace Microsoft.Data.Entity.Tests
         public void Equal_sign_as_connection_string_does_not_cause_redirection()
         {
             var config = new Configuration
-                {
+                (
                     new MemoryConfigurationSource
                         {
                             { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "=" }
                         }
-                };
+                );
 
             var rawOptions = new DbContextOptionsParser().ReadRawOptions(config, typeof(MyContext), new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
 
@@ -214,12 +213,12 @@ namespace Microsoft.Data.Entity.Tests
         public void Throws_when_indirect_connection_string_is_not_found()
         {
             var config = new Configuration
-                {
+                (
                     new MemoryConfigurationSource
                         {
                             { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "Name=MyConnection" }
                         }
-                };
+                );
 
             Assert.Equal(Strings.ConnectionStringNotFound("MyConnection"),
                 Assert.Throws<InvalidOperationException>(() =>
@@ -230,12 +229,12 @@ namespace Microsoft.Data.Entity.Tests
         public void Throws_when_indirect_connection_string_is_empty()
         {
             var config = new Configuration
-                {
+                (
                     new MemoryConfigurationSource
                         {
                             { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "Name=" }
                         }
-                };
+                );
 
             Assert.Equal(Strings.ConnectionStringNotFound(""),
                 Assert.Throws<InvalidOperationException>(() =>
@@ -246,12 +245,12 @@ namespace Microsoft.Data.Entity.Tests
         public void Existing_options_are_updated()
         {
             var config = new Configuration
-                {
+                (
                     new MemoryConfigurationSource
                         {
                             { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "MyConnectionString" }
                         }
-                };
+                );
 
             var currentOptions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { { "Foo", "Goo" } };
 
@@ -266,12 +265,12 @@ namespace Microsoft.Data.Entity.Tests
         public void Existing_options_are_updated_generic()
         {
             var config = new Configuration
-                {
+                (
                     new MemoryConfigurationSource
                         {
                             { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "MyConnectionString" }
                         }
-                };
+                );
 
             var currentOptions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { { "Foo", "Goo" } };
 
@@ -286,12 +285,12 @@ namespace Microsoft.Data.Entity.Tests
         public void Key_searching_is_case_insensitive()
         {
             var config = new Configuration
-                {
+                (
                     new MemoryConfigurationSource
                         {
                             { "entityFramework:" + typeof(MyContext).Name + ":connectionString", "MyConnectionString" }
                         }
-                };
+                );
 
             var rawOptions = new DbContextOptionsParser().ReadRawOptions(config, typeof(MyContext), new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
 
@@ -303,7 +302,7 @@ namespace Microsoft.Data.Entity.Tests
         public void Nested_keys_are_read_using_context_name()
         {
             var config = new Configuration
-                {
+                (
                     new MemoryConfigurationSource
                         {
                             { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "MyConnectionString" },
@@ -312,7 +311,7 @@ namespace Microsoft.Data.Entity.Tests
                             { "EntityFramework:" + typeof(MyContext).Name + ":SomeProvider:ProviderSpecificOption", "OptionValue" },
                             { "EntityFramework:" + typeof(MyContext).Name + ":Level1:Level2:Level3", "NestedLevelValue" }
                         }
-                };
+                );
 
             var rawOptions = new DbContextOptionsParser().ReadRawOptions(config, typeof(MyContext), new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
 
@@ -328,7 +327,7 @@ namespace Microsoft.Data.Entity.Tests
         public void Nested_keys_are_read_using_context_full_name()
         {
             var config = new Configuration
-                {
+                (
                     new MemoryConfigurationSource
                         {
                             { "EntityFramework:" + typeof(MyContext).FullName + ":ConnectionString", "MyConnectionString" },
@@ -337,7 +336,7 @@ namespace Microsoft.Data.Entity.Tests
                             { "EntityFramework:" + typeof(MyContext).FullName + ":SomeProvider:ProviderSpecificOption", "OptionValue" },
                             { "EntityFramework:" + typeof(MyContext).FullName + ":Level1:Level2:Level3", "NestedLevelValue" }
                         }
-                };
+                );
 
             var rawOptions = new DbContextOptionsParser().ReadRawOptions(config, typeof(MyContext), new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
 
@@ -353,7 +352,7 @@ namespace Microsoft.Data.Entity.Tests
         public void Nested_keys_are_read_using_context_name_generic()
         {
             var config = new Configuration
-                {
+                (
                     new MemoryConfigurationSource
                         {
                             { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "MyConnectionString" },
@@ -362,7 +361,7 @@ namespace Microsoft.Data.Entity.Tests
                             { "EntityFramework:" + typeof(MyContext).Name + ":SomeProvider:ProviderSpecificOption", "OptionValue" },
                             { "EntityFramework:" + typeof(MyContext).Name + ":Level1:Level2:Level3", "NestedLevelValue" }
                         }
-                };
+                );
 
             var rawOptions = new DbContextOptionsParser().ReadRawOptions<MyContext>(config, new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
 
@@ -378,7 +377,7 @@ namespace Microsoft.Data.Entity.Tests
         public void Nested_keys_are_read_using_context_full_name_generic()
         {
             var config = new Configuration
-                {
+                (
                     new MemoryConfigurationSource
                         {
                             { "EntityFramework:" + typeof(MyContext).FullName + ":ConnectionString", "MyConnectionString" },
@@ -387,7 +386,7 @@ namespace Microsoft.Data.Entity.Tests
                             { "EntityFramework:" + typeof(MyContext).FullName + ":SomeProvider:ProviderSpecificOption", "OptionValue" },
                             { "EntityFramework:" + typeof(MyContext).FullName + ":Level1:Level2:Level3", "NestedLevelValue" }
                         }
-                };
+                );
 
             var rawOptions = new DbContextOptionsParser().ReadRawOptions<MyContext>(config, new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
 
@@ -427,13 +426,13 @@ namespace Microsoft.Data.Entity.Tests
         public void For_same_key_context_full_name_takes_precedence_over_context_name()
         {
             var config = new Configuration
-                {
+                (
                     new MemoryConfigurationSource
                         {
                             { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "ContextNameConnectionString" },
                             { "EntityFramework:" + typeof(MyContext).FullName + ":ConnectionString", "ContextFullNameConnectionString" }
                         }
-                };
+                );
 
             var rawOptions = new DbContextOptionsParser().ReadRawOptions(config, typeof(MyContext), new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
 

--- a/test/EntityFramework.SqlServer.FunctionalTests/ConnectionSpecificationTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/ConnectionSpecificationTest.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         public async void Can_specify_dereferenced_connection_string_in_config()
         {
             var configuration = new Configuration
-                {
+                (
                     new MemoryConfigurationSource
                         {
                             {
@@ -123,7 +123,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                                 "EntityFramework:" + typeof(StringInConfigContext).Name + ":ConnectionString", "Name=Data:DefaultConnection:ConnectionString"
                             }
                         }
-                };
+                );
 
             var serviceCollection = new ServiceCollection();
             serviceCollection
@@ -146,14 +146,14 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         public async void Can_specify_connection_string_in_config()
         {
             var configuration = new Configuration
-                {
+                (
                     new MemoryConfigurationSource
                         {
                             {
                                 "EntityFramework:" + typeof(StringInConfigContext).Name + ":ConnectionString", SqlServerNorthwindContext.ConnectionString
                             }
                         }
-                };
+                );
 
             var serviceCollection = new ServiceCollection();
             serviceCollection
@@ -176,9 +176,9 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         public void Throws_if_no_connection_found_in_config()
         {
             var configuration = new Configuration
-                {
+                (
                     new MemoryConfigurationSource()
-                };
+                );
 
             var serviceCollection = new ServiceCollection();
             serviceCollection
@@ -238,7 +238,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         public async void Can_specify_dereferenced_connection_string_in_config_without_UseSqlServer()
         {
             var configuration = new Configuration
-                {
+                (
                     new MemoryConfigurationSource
                         {
                             {
@@ -248,7 +248,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                                 "EntityFramework:" + typeof(NoUseSqlServerContext).Name + ":ConnectionString", "Name=Data:DefaultConnection:ConnectionString"
                             }
                         }
-                };
+                );
 
             var serviceCollection = new ServiceCollection();
             serviceCollection
@@ -271,14 +271,14 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         public async void Can_specify_connection_string_in_config_without_UseSqlServer()
         {
             var configuration = new Configuration
-                {
+                (
                     new MemoryConfigurationSource
                         {
                             {
                                 "EntityFramework:" + typeof(NoUseSqlServerContext).Name + ":ConnectionString", SqlServerNorthwindContext.ConnectionString
                             }
                         }
-                };
+                );
 
             var serviceCollection = new ServiceCollection();
             serviceCollection
@@ -301,9 +301,9 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         public void Throws_if_no_connection_found_in_config_without_UseSqlServer()
         {
             var configuration = new Configuration
-                {
+                (
                     new MemoryConfigurationSource()
-                };
+                );
 
             var serviceCollection = new ServiceCollection();
             serviceCollection


### PR DESCRIPTION
Configuration is no longer an IEnumerable of IConfigurationSource. The constructor now accepts `params IEnumerable<IConfigurationSource>`