### PR TITLE
Migrations: Fix generated AddForeignKey calls (Fixes #1612)

### DIFF
--- a/src/EntityFramework.Commands/Migrations/CSharpMigrationOperationGenerator.cs
+++ b/src/EntityFramework.Commands/Migrations/CSharpMigrationOperationGenerator.cs
@@ -103,9 +103,16 @@ namespace Microsoft.Data.Entity.Commands.Migrations
 
             if (operation.PrincipalColumns.Any())
             {
-                builder
-                    .Append(", principalColumns: ")
-                    .Append(_code.Literal(operation.PrincipalColumns));
+                if (operation.PrincipalColumns.Count == 1)
+                {
+                    builder.Append(", principalColumn: ");
+                }
+                else
+                {
+                    builder.Append(", principalColumns: ");
+                }
+
+                builder.Append(_code.Literal(operation.PrincipalColumns));
             }
 
             if (operation.CascadeDelete)
@@ -454,8 +461,10 @@ namespace Microsoft.Data.Entity.Commands.Migrations
 
                         if (i != operation.Columns.Count - 1)
                         {
-                            builder.AppendLine(",");
+                            builder.Append(",");
                         }
+
+                        builder.AppendLine();
                     }
                 }
 
@@ -535,15 +544,22 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                     if (foreignKey.PrincipalSchema != null)
                     {
                         builder
-                            .Append(", ")
+                            .Append(", principalSchema: ")
                             .Append(_code.Literal(foreignKey.PrincipalSchema));
                     }
 
                     if (foreignKey.PrincipalColumns.Any())
                     {
-                        builder
-                            .Append(", ")
-                            .Append(_code.Literal(foreignKey.PrincipalColumns));
+                        if (foreignKey.PrincipalColumns.Count == 1)
+                        {
+                            builder.Append(", principalColumn: ");
+                        }
+                        else
+                        {
+                            builder.Append(", principalColumns: ");
+                        }
+
+                        builder.Append(_code.Literal(foreignKey.PrincipalColumns));
                     }
 
                     if (foreignKey.CascadeDelete)

--- a/src/EntityFramework.Relational/Migrations/Builders/MigrationBuilder.cs
+++ b/src/EntityFramework.Relational/Migrations/Builders/MigrationBuilder.cs
@@ -320,9 +320,9 @@ namespace Microsoft.Data.Entity.Relational.Migrations.Builders
             [NotNull] string table,
             [NotNull] string column,
             [CanBeNull] string schema = null,
-            bool clustered = false,
+            bool unique = false,
             [CanBeNull] IReadOnlyDictionary<string, string> annotations = null) =>
-                CreateIndex(name, table, new[] { column }, schema, clustered, annotations);
+                CreateIndex(name, table, new[] { column }, schema, unique, annotations);
 
         // TODO: Is name really required?
         public virtual void CreateIndex(

--- a/src/EntityFramework.Relational/Migrations/Builders/TableBuilder.cs
+++ b/src/EntityFramework.Relational/Migrations/Builders/TableBuilder.cs
@@ -74,8 +74,25 @@ namespace Microsoft.Data.Entity.Relational.Migrations.Builders
         public virtual TableBuilder<TColumns> ForeignKey(
             [NotNull] Expression<Func<TColumns, object>> dependentKeyExpression,
             [NotNull] string principalTable,
+            [NotNull] string principalColumn,
             [CanBeNull] string principalSchema = null,
+            bool cascadeDelete = false,
+            [CanBeNull] string name = null,
+            [CanBeNull] IReadOnlyDictionary<string, string> annotations = null) =>
+            ForeignKey(
+                dependentKeyExpression,
+                principalTable,
+                new[] { principalColumn },
+                principalSchema,
+                cascadeDelete,
+                name,
+                annotations);
+
+        public virtual TableBuilder<TColumns> ForeignKey(
+            [NotNull] Expression<Func<TColumns, object>> dependentKeyExpression,
+            [NotNull] string principalTable,
             [CanBeNull] IReadOnlyList<string> principalColumns = null,
+            [CanBeNull] string principalSchema = null,
             bool cascadeDelete = false,
             [CanBeNull] string name = null,
             [CanBeNull] IReadOnlyDictionary<string, string> annotations = null)

--- a/test/EntityFramework.Commands.FunctionalTests/EntityFramework.Commands.FunctionalTests.csproj
+++ b/test/EntityFramework.Commands.FunctionalTests/EntityFramework.Commands.FunctionalTests.csproj
@@ -95,6 +95,7 @@
       <Link>Handlers.cs</Link>
     </Compile>
     <Compile Include="ExecutorTest.cs" />
+    <Compile Include="Migrations\OperationCompilationTest.cs" />
     <Compile Include="TestUtilities\BuildReference.cs" />
     <Compile Include="TestUtilities\BuildFileResult.cs" />
     <Compile Include="TestUtilities\BuildSource.cs" />
@@ -108,6 +109,14 @@
     <ProjectReference Include="..\..\src\EntityFramework.Commands\EntityFramework.Commands.csproj">
       <Project>{10ca97eb-e724-4f08-86af-f301f2b0bfff}</Project>
       <Name>EntityFramework.Commands</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\EntityFramework.Core\EntityFramework.Core.csproj">
+      <Project>{71415cec-8111-4c73-8751-512d22f10602}</Project>
+      <Name>EntityFramework.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\EntityFramework.Relational\EntityFramework.Relational.csproj">
+      <Project>{75c5a774-a3f3-43eb-97d3-dbe0cf2825d8}</Project>
+      <Name>EntityFramework.Relational</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\src\EntityFramework.SqlServer\EntityFramework.SqlServer.csproj">
       <Project>{04e6620b-5b41-45fe-981a-f40eb7686b0e}</Project>

--- a/test/EntityFramework.Commands.FunctionalTests/Migrations/OperationCompilationTest.cs
+++ b/test/EntityFramework.Commands.FunctionalTests/Migrations/OperationCompilationTest.cs
@@ -1,0 +1,269 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Data.Entity.Commands.TestUtilities;
+using Microsoft.Data.Entity.Commands.Utilities;
+using Microsoft.Data.Entity.Relational.Migrations.Operations;
+using Microsoft.Data.Entity.Utilities;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Commands.Migrations
+{
+    public class OperationCompilationTest
+    {
+        private static string EOL => Environment.NewLine;
+
+        [Fact]
+        public void AddForeignKeyOperation_required_args()
+        {
+            Test(
+                new AddForeignKeyOperation(
+                    "Post",
+                    /*dependentSchema:*/ null,
+                    /*name:*/ null,
+                    new[] { "BlogId" },
+                    "Blog",
+                    principalSchema: null,
+                    principalColumns: null,
+                    cascadeDelete: false),
+                "mb.AddForeignKey(\"Post\", \"BlogId\", \"Blog\");" + EOL,
+                o =>
+                {
+                    Assert.Equal("Post", o.DependentTable);
+                    Assert.Equal(new[] { "BlogId" }, o.DependentColumns);
+                    Assert.Equal("Blog", o.PrincipalTable);
+                });
+        }
+
+        [Fact]
+        public void AddForeignKeyOperation_all_args()
+        {
+            Test(
+                new AddForeignKeyOperation(
+                    "Post",
+                    "dbo",
+                    "FK_Post_Blog_BlogId",
+                    new[] { "BlogId" },
+                    "Blog",
+                    "my",
+                    new[] { "Id" },
+                    cascadeDelete: true),
+                "mb.AddForeignKey(\"Post\", \"BlogId\", \"Blog\", dependentSchema: \"dbo\", principalSchema: \"my\", principalColumn: \"Id\", cascadeDelete: true, name: \"FK_Post_Blog_BlogId\");" + EOL,
+                o =>
+                {
+                    Assert.Equal("Post", o.DependentTable);
+                    Assert.Equal("dbo", o.DependentSchema);
+                    Assert.Equal("FK_Post_Blog_BlogId", o.Name);
+                    Assert.Equal(new[] { "BlogId" }, o.DependentColumns);
+                    Assert.Equal("Blog", o.PrincipalTable);
+                    Assert.Equal("my", o.PrincipalSchema);
+                    Assert.Equal(new[] { "Id" }, o.PrincipalColumns);
+                    Assert.True(o.CascadeDelete);
+                });
+        }
+
+        [Fact]
+        public void AddForeignKeyOperation_composite()
+        {
+            Test(
+                new AddForeignKeyOperation(
+                    "Post",
+                    /*dependentSchema:*/ null,
+                    /*name:*/ null,
+                    new[] { "BlogId1", "BlogId2" },
+                    "Blog",
+                    /*principalSchema:*/ null,
+                    new[] { "Id1", "Id2" },
+                    cascadeDelete: false),
+                "mb.AddForeignKey(\"Post\", new[] { \"BlogId1\", \"BlogId2\" }, \"Blog\", principalColumns: new[] { \"Id1\", \"Id2\" });" + EOL,
+                o =>
+                {
+                    Assert.Equal("Post", o.DependentTable);
+                    Assert.Equal(new[] { "BlogId1", "BlogId2" }, o.DependentColumns);
+                    Assert.Equal("Blog", o.PrincipalTable);
+                    Assert.Equal(new[] { "Id1", "Id2" }, o.PrincipalColumns);
+                });
+        }
+
+        [Fact]
+        public void CreateTableOperation_ForeignKeys_required_args()
+        {
+            Test(
+                new CreateTableOperation("Post", schema: null)
+                {
+                    Columns =
+                    {
+                        new ColumnModel("BlogId", "int", nullable: false, defaultValue: null, defaultValueSql: null)
+                    },
+                    ForeignKeys =
+                    {
+                        new AddForeignKeyOperation(
+                            "Post",
+                            /*dependentSchema:*/ null,
+                            /*name:*/ null,
+                            new[] { "BlogId" },
+                            "Blog",
+                            principalSchema: null,
+                            principalColumns: null,
+                            cascadeDelete: false)
+                    }
+                },
+                "mb.CreateTable(" + EOL +
+                "    \"Post\"," + EOL +
+                "    x => new" + EOL +
+                "    {" + EOL +
+                "        BlogId = x.Column(\"int\")" + EOL +
+                "    })" + EOL +
+                "    .ForeignKey(x => x.BlogId, \"Blog\");" + EOL,
+                o =>
+                {
+                    Assert.Equal(1, o.ForeignKeys.Count);
+
+                    var fk = o.ForeignKeys.First();
+                    Assert.Equal("Post", fk.DependentTable);
+                    Assert.Equal(new[] { "BlogId" }, fk.DependentColumns.ToArray());
+                    Assert.Equal("Blog", fk.PrincipalTable);
+                });
+        }
+
+        [Fact]
+        public void CreateTableOperation_ForeignKeys_all_args()
+        {
+            Test(
+                new CreateTableOperation("Post", "dbo")
+                {
+                    Columns =
+                    {
+                        new ColumnModel("BlogId", "int", nullable: false, defaultValue: null, defaultValueSql: null)
+                    },
+                    ForeignKeys =
+                    {
+                        new AddForeignKeyOperation(
+                            "Post",
+                            "dbo",
+                            "FK_Post_Blog_BlogId",
+                            new[] { "BlogId" },
+                            "Blog",
+                            "my",
+                            new[] { "Id" },
+                            cascadeDelete: true)
+                    }
+                },
+                "mb.CreateTable(" + EOL +
+                "    \"Post\"," + EOL +
+                "    \"dbo\"," + EOL +
+                "    x => new" + EOL +
+                "    {" + EOL +
+                "        BlogId = x.Column(\"int\")" + EOL +
+                "    })" + EOL +
+                "    .ForeignKey(x => x.BlogId, \"Blog\", principalSchema: \"my\", principalColumn: \"Id\", cascadeDelete: true, name: \"FK_Post_Blog_BlogId\");" + EOL,
+                o =>
+                {
+                    Assert.Equal(1, o.ForeignKeys.Count);
+
+                    var fk = o.ForeignKeys.First();
+                    Assert.Equal("Post", fk.DependentTable);
+                    Assert.Equal("dbo", fk.DependentSchema);
+                    Assert.Equal("FK_Post_Blog_BlogId", fk.Name);
+                    Assert.Equal(new[] { "BlogId" }, fk.DependentColumns.ToArray());
+                    Assert.Equal("Blog", fk.PrincipalTable);
+                    Assert.Equal("my", fk.PrincipalSchema);
+                    Assert.Equal(new[] { "Id" }, fk.PrincipalColumns);
+                    Assert.True(fk.CascadeDelete);
+                });
+        }
+
+        [Fact]
+        public void CreateTableOperation_ForeignKeys_composite()
+        {
+            Test(
+                new CreateTableOperation("Post", schema: null)
+                {
+                    Columns =
+                    {
+                        new ColumnModel("BlogId1", "int", nullable: false, defaultValue: null, defaultValueSql: null),
+                        new ColumnModel("BlogId2", "int", nullable: false, defaultValue: null, defaultValueSql: null)
+                    },
+                    ForeignKeys =
+                    {
+                        new AddForeignKeyOperation(
+                            "Post",
+                            /*dependentSchema:*/ null,
+                            /*name:*/ null,
+                            new[] { "BlogId1", "BlogId2" },
+                            "Blog",
+                            /*principalSchema:*/ null,
+                            new[] { "Id1", "Id2" },
+                            cascadeDelete: false)
+                    }
+                },
+                "mb.CreateTable(" + EOL +
+                "    \"Post\"," + EOL +
+                "    x => new" + EOL +
+                "    {" + EOL +
+                "        BlogId1 = x.Column(\"int\")," + EOL +
+                "        BlogId2 = x.Column(\"int\")" + EOL +
+                "    })" + EOL +
+                "    .ForeignKey(x => new { x.BlogId1, x.BlogId2 }, \"Blog\", principalColumns: new[] { \"Id1\", \"Id2\" });" + EOL,
+                o =>
+                {
+                    Assert.Equal(1, o.ForeignKeys.Count);
+
+                    var fk = o.ForeignKeys.First();
+                    Assert.Equal("Post", fk.DependentTable);
+                    Assert.Equal(new[] { "BlogId1", "BlogId2" }, fk.DependentColumns.ToArray());
+                    Assert.Equal("Blog", fk.PrincipalTable);
+                    Assert.Equal(new[] { "Id1", "Id2" }, fk.PrincipalColumns);
+                });
+        }
+
+        private void Test<T>(T operation, string expectedCode, Action<T> assert)
+            where T : MigrationOperation
+        {
+            var generator = new CSharpMigrationOperationGenerator(new CSharpHelper());
+
+            var builder = new IndentedStringBuilder();
+            generator.Generate("mb", new[] { operation }, builder);
+            var code = builder.ToString();
+
+            Assert.Equal(expectedCode, code);
+
+            var build = new BuildSource
+            {
+                References =
+                {
+                    BuildReference.ByName("System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"),
+                    BuildReference.ByName("System.Linq.Expressions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"),
+                    BuildReference.ByName("System.Runtime, Version=4.0.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"),
+                    BuildReference.ByName("EntityFramework.Relational")
+                },
+                Source = @"
+                    using System.Collections.Generic;
+                    using Microsoft.Data.Entity.Relational.Migrations.Builders;
+                    using Microsoft.Data.Entity.Relational.Migrations.Operations;
+
+                    public static class OperationsFactory
+                    {
+                        public static IReadOnlyList<MigrationOperation> Create()
+                        {
+                            var mb = new MigrationBuilder();
+                            " + code + @"
+                            return mb.Operations;
+                        }
+                    }
+                "
+            };
+
+            var assembly = build.BuildInMemory();
+            var factoryType = assembly.GetType("OperationsFactory");
+            var createMethod = factoryType.GetMethod("Create");
+            var operations = (IReadOnlyList<MigrationOperation>)createMethod.Invoke(null, null);
+            var result = (T)operations.Single();
+
+            assert(result);
+        }
+    }
+}


### PR DESCRIPTION
I also sneaked in a fix to `CreateIndex`.