### PR TITLE
Fix for #1726 - using boolProperty.Equals(true) in filter produces invalid sql

### DIFF
--- a/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/FilteringExpressionTreeVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/FilteringExpressionTreeVisitor.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
         private readonly RelationalQueryModelVisitor _queryModelVisitor;
 
         private bool _requiresClientEval;
-        private bool _inBinaryEqualityExpression;
 
         public FilteringExpressionTreeVisitor([NotNull] RelationalQueryModelVisitor queryModelVisitor)
         {
@@ -36,14 +35,10 @@ namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
                 case ExpressionType.Equal:
                 case ExpressionType.NotEqual:
                 {
-                    _inBinaryEqualityExpression = true;
-
                     var structuralComparisonExpression
                         = UnfoldStructuralComparison(
                             binaryExpression.NodeType,
                             ProcessComparisonExpression(binaryExpression));
-
-                    _inBinaryEqualityExpression = false;
 
                     return structuralComparisonExpression;
                 }
@@ -205,10 +200,7 @@ namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
 
                 if (columnExpression != null)
                 {
-                    return !_inBinaryEqualityExpression
-                           && columnExpression.Type == typeof(bool)
-                        ? (Expression)Expression.Equal(columnExpression, Expression.Constant(true))
-                        : columnExpression;
+                    return columnExpression;
                 }
             }
 
@@ -234,10 +226,7 @@ namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
 
             if (columnExpression != null)
             {
-                return !_inBinaryEqualityExpression
-                       && columnExpression.Type == typeof(bool)
-                    ? (Expression)Expression.Equal(columnExpression, Expression.Constant(true))
-                    : columnExpression;
+                return columnExpression;
             }
 
             _requiresClientEval = true;

--- a/src/EntityFramework.Relational/Query/Sql/DefaultSqlQueryGenerator.cs
+++ b/src/EntityFramework.Relational/Query/Sql/DefaultSqlQueryGenerator.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
         private Expression _binaryExpression;
         private List<string> _parameters;
         private IDictionary<string, object> _parameterValues;
+        private Stack<bool> _insideFilter = new Stack<bool>();
 
         public virtual string GenerateSql(
             SelectExpression selectExpression, IDictionary<string, object> parameterValues)
@@ -50,6 +51,8 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
             Check.NotNull(selectExpression, nameof(selectExpression));
 
             IDisposable subQueryIndent = null;
+
+            _insideFilter.Push(false);
 
             if (selectExpression.Alias != null)
             {
@@ -98,7 +101,16 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
                 _sql.AppendLine()
                     .Append("WHERE ");
 
+                _insideFilter.Push(true);
+
                 VisitExpression(selectExpression.Predicate);
+
+                if (selectExpression.Predicate is ColumnExpression)
+                {
+                    _sql.Append(" = 1");
+                }
+
+                _insideFilter.Pop();
             }
 
             if (selectExpression.OrderBy.Any())
@@ -137,6 +149,8 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
                     .Append(") AS ")
                     .Append(DelimitIdentifier(selectExpression.Alias));
             }
+
+            _insideFilter.Pop();
 
             return selectExpression;
         }
@@ -386,6 +400,13 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
 
                 VisitExpression(binaryExpression.Left);
 
+                if (binaryExpression.IsLogicalOperation() 
+                    && binaryExpression.Left is ColumnExpression 
+                    && _insideFilter.Peek())
+                {
+                    _sql.Append(" = 1");
+                }
+
                 string op;
 
                 switch (binaryExpression.NodeType)
@@ -424,6 +445,13 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
                 _sql.Append(op);
 
                 VisitExpression(binaryExpression.Right);
+
+                if (binaryExpression.IsLogicalOperation()
+                    && binaryExpression.Right is ColumnExpression
+                    && _insideFilter.Peek())
+                {
+                    _sql.Append(" = 1");
+                }
 
                 if (binaryExpression.IsLogicalOperation())
                 {
@@ -536,7 +564,15 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
             {
                 _sql.Append("NOT ");
 
-                return VisitExpression(unaryExpression.Operand);
+                var result = VisitExpression(unaryExpression.Operand);
+
+                if (unaryExpression.Operand is ColumnExpression
+                    && _insideFilter.Peek())
+                {
+                    _sql.Append(" = 1");
+                }
+
+                return result;
             }
 
             if (unaryExpression.NodeType == ExpressionType.Convert)

--- a/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
@@ -800,6 +800,12 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
+        public virtual void Where_bool_member_negated_twice()
+        {
+            AssertQuery<Product>(ps => ps.Where(p => !!(p.Discontinued == true)), entryCount: 8);
+        }
+
+        [Fact]
         public virtual void Where_bool_member_shadow()
         {
             AssertQuery<Product>(ps => ps.Where(p => p.Property<bool>("Discontinued")), entryCount: 8);
@@ -809,6 +815,18 @@ namespace Microsoft.Data.Entity.FunctionalTests
         public virtual void Where_bool_member_false_shadow()
         {
             AssertQuery<Product>(ps => ps.Where(p => !p.Property<bool>("Discontinued")), entryCount: 69);
+        }
+
+        [Fact]
+        public virtual void Where_bool_member_equals_constant()
+        {
+            AssertQuery<Product>(ps => ps.Where(p => p.Discontinued.Equals(true)), entryCount: 8);
+        }
+
+        [Fact]
+        public virtual void Where_bool_member_in_complex_predicate()
+        {
+            AssertQuery<Product>(ps => ps.Where(p => p.ProductID > 100 && p.Discontinued || (p.Discontinued == true)), entryCount: 8);
         }
 
         [Fact]

--- a/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -1540,6 +1540,17 @@ WHERE NOT [p].[Discontinued] = 1",
                 Sql);
         }
 
+        public override void Where_bool_member_negated_twice()
+        {
+            base.Where_bool_member_negated_twice();
+
+            Assert.Equal(
+                @"SELECT [p].[Discontinued], [p].[ProductID], [p].[ProductName], [p].[UnitsInStock]
+FROM [Products] AS [p]
+WHERE NOT NOT [p].[Discontinued] = 1",
+                Sql);
+        }
+
         public override void Where_bool_member_shadow()
         {
             base.Where_bool_member_shadow();
@@ -1559,6 +1570,28 @@ WHERE [p].[Discontinued] = 1",
                 @"SELECT [p].[Discontinued], [p].[ProductID], [p].[ProductName], [p].[UnitsInStock]
 FROM [Products] AS [p]
 WHERE NOT [p].[Discontinued] = 1",
+                Sql);
+        }
+
+        public override void Where_bool_member_equals_constant()
+        {
+            base.Where_bool_member_equals_constant();
+
+            Assert.Equal(
+                @"SELECT [p].[Discontinued], [p].[ProductID], [p].[ProductName], [p].[UnitsInStock]
+FROM [Products] AS [p]
+WHERE [p].[Discontinued] = 1",
+                Sql);
+        }
+
+        public override void Where_bool_member_in_complex_predicate()
+        {
+            base.Where_bool_member_in_complex_predicate();
+
+            Assert.Equal(
+                @"SELECT [p].[Discontinued], [p].[ProductID], [p].[ProductName], [p].[UnitsInStock]
+FROM [Products] AS [p]
+WHERE (([p].[ProductID] > 100 AND [p].[Discontinued] = 1) OR [p].[Discontinued] = 1)",
                 Sql);
         }
 


### PR DESCRIPTION
Problem was that we have special treatment for boolean to support queries like Where(c => c.MyBoolProperty). However this breaks for Where(c => c.MyBoolProperty.Equals(true/my_variable/other_bool_property).
Fix is to revert the previous change and instead compensate in the sql generation phase - adding " = 1" terms for 'naked' column expressions as well as column expressions inside logical expression, inside WHERE predicate.

things like: products.Where(p => p.Discontinued == (p.ProductID > 100)) are still broken but the main scenarios works fine.