### PR TITLE
Fix to #1747 - Multi-select with Contains() does not generate SQL

### DIFF
--- a/src/EntityFramework.Relational/Query/EqualityPredicateOptimizer.cs
+++ b/src/EntityFramework.Relational/Query/EqualityPredicateOptimizer.cs
@@ -91,6 +91,7 @@ namespace Microsoft.Data.Entity.Relational.Query
                     = VisitExpression(binaryExpression.Right) as TInExpression;
 
                 if (rightInExpression != null
+                    && rightInExpression.Values != null
                     && leftColumnExpression.Equals(rightInExpression.Column))
                 {
                     return inExpressionFactory(
@@ -106,7 +107,8 @@ namespace Microsoft.Data.Entity.Relational.Query
                 var leftInExpression
                     = VisitExpression(binaryExpression.Left) as TInExpression;
 
-                if (leftInExpression != null
+                if (leftInExpression != null 
+                    && leftInExpression.Values != null
                     && rightColumnExpression.Equals(leftInExpression.Column))
                 {
                     return inExpressionFactory(

--- a/src/EntityFramework.Relational/Query/Expressions/InExpression.cs
+++ b/src/EntityFramework.Relational/Query/Expressions/InExpression.cs
@@ -15,9 +15,28 @@ namespace Microsoft.Data.Entity.Relational.Query.Expressions
         public InExpression(
             [NotNull] ColumnExpression column,
             [NotNull] IReadOnlyList<Expression> values)
-            : base(
+            : this(
                 Check.NotNull(column, nameof(column)),
-                Check.NotNull(values, nameof(values)))
+                Check.NotNull(values, nameof(values)),
+                null)
+        {
+        }
+
+        public InExpression(
+            [NotNull] ColumnExpression column,
+            [NotNull] ParameterExpression parameter)
+            : this(
+                  Check.NotNull(column, nameof(column)),
+                  null,
+                  Check.NotNull(parameter, nameof(parameter)))
+        {
+        }
+
+        internal InExpression(
+            ColumnExpression column, 
+            IReadOnlyList<Expression> values, 
+            ParameterExpression parameter)
+            : base(column, values, parameter)
         {
         }
 

--- a/src/EntityFramework.Relational/Query/Expressions/InExpressionBase.cs
+++ b/src/EntityFramework.Relational/Query/Expressions/InExpressionBase.cs
@@ -14,18 +14,20 @@ namespace Microsoft.Data.Entity.Relational.Query.Expressions
     {
         protected InExpressionBase(
             [NotNull] ColumnExpression column,
-            [NotNull] IReadOnlyList<Expression> values)
+            [CanBeNull] IReadOnlyList<Expression> values,
+            [CanBeNull] ParameterExpression parameter)
             : base(typeof(bool))
         {
             Check.NotNull(column, nameof(column));
-            Check.NotNull(values, nameof(values));
 
             Column = column;
             Values = values;
+            ParameterArgument = parameter;
         }
 
         public virtual ColumnExpression Column { get; }
         public virtual IReadOnlyList<Expression> Values { get; }
+        public virtual ParameterExpression ParameterArgument { get; }
 
         protected override Expression VisitChildren(ExpressionTreeVisitor visitor)
         {

--- a/src/EntityFramework.Relational/Query/Expressions/NotInExpression.cs
+++ b/src/EntityFramework.Relational/Query/Expressions/NotInExpression.cs
@@ -15,9 +15,28 @@ namespace Microsoft.Data.Entity.Relational.Query.Expressions
         public NotInExpression(
             [NotNull] ColumnExpression column,
             [NotNull] IReadOnlyList<Expression> values)
-            : base(
+            : this(
                 Check.NotNull(column, nameof(column)),
-                Check.NotNull(values, nameof(values)))
+                Check.NotNull(values, nameof(values)),
+                null)
+        {
+        }
+
+        public NotInExpression(
+            [NotNull] ColumnExpression column,
+            [NotNull] ParameterExpression parameter)
+            : this(
+                  Check.NotNull(column, nameof(column)),
+                  null,
+                  Check.NotNull(parameter, nameof(parameter)))
+        {
+        }
+
+        internal NotInExpression(
+            ColumnExpression column,
+            IReadOnlyList<Expression> values,
+            ParameterExpression parameter)
+            : base(column, values, parameter)
         {
         }
 

--- a/src/EntityFramework.Relational/Query/Sql/ISqlExpressionVisitor.cs
+++ b/src/EntityFramework.Relational/Query/Sql/ISqlExpressionVisitor.cs
@@ -26,6 +26,6 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
         Expression VisitMinExpression([NotNull] MinExpression minExpression);
         Expression VisitMaxExpression([NotNull] MaxExpression maxExpression);
         Expression VisitInExpression([NotNull] InExpression inExpression);
-        Expression VisitNotInExpression([NotNull] NotInExpression inExpression);
+        Expression VisitNotInExpression([NotNull] NotInExpression notInExpression);
     }
 }

--- a/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
@@ -2476,12 +2476,59 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
-        public virtual void Contains_with_local_collection()
+        public virtual void Contains_with_local_array_parameter()
         {
             string[] ids = { "ABCDE", "ALFKI" };
             AssertQuery<Customer>(cs =>
                 cs.Where(c => ids.Contains(c.CustomerID)), entryCount: 1);
         }
+
+        [Fact]
+        public virtual void Contains_with_local_array_constant()
+        {
+            AssertQuery<Customer>(cs =>
+                cs.Where(c => new[] { "ABCDE", "ALFKI" }.Contains(c.CustomerID)), entryCount: 1);
+        }
+
+        [Fact]
+        public virtual void Contains_with_local_list_parameter()
+        {
+            var ids = new List<string> { "ABCDE", "ALFKI" };
+            AssertQuery<Customer>(cs =>
+                cs.Where(c => ids.Contains(c.CustomerID)), entryCount: 1);
+        }
+
+        [Fact]
+        public virtual void Contains_with_local_list_constant()
+        {
+            AssertQuery<Customer>(cs =>
+                cs.Where(c => new List<string>{ "ABCDE", "ALFKI" }.Contains(c.CustomerID)), entryCount: 1);
+        }
+
+        [Fact]
+        public virtual void Contains_with_local_collection_false()
+        {
+            string[] ids = { "ABCDE", "ALFKI" };
+            AssertQuery<Customer>(cs =>
+                cs.Where(c => !ids.Contains(c.CustomerID)), entryCount: 90);
+        }
+
+        [Fact]
+        public virtual void Contains_with_local_collection_complex_predicate_and()
+        {
+            string[] ids = { "ABCDE", "ALFKI" };
+            AssertQuery<Customer>(cs =>
+                cs.Where(c => (c.CustomerID == "ALFKI" || c.CustomerID == "ABCDE") && ids.Contains(c.CustomerID)), entryCount: 1);
+        }
+
+        [Fact]
+        public virtual void Contains_with_local_collection_complex_predicate_or()
+        {
+            string[] ids = { "ABCDE", "ALFKI" };
+            AssertQuery<Customer>(cs =>
+                cs.Where(c => ids.Contains(c.CustomerID) || (c.CustomerID == "ALFKI" || c.CustomerID == "ABCDE")), entryCount: 1);
+        }
+
 
         [Fact]
         public virtual void Contains_top_level()

--- a/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -1932,6 +1932,84 @@ WHERE ([o].[CustomerID] = 'QUICK' AND [o].[OrderDate] > @__p_0)",
                 Sql);
         }
 
+        public override void Contains_with_local_array_parameter()
+        {
+            base.Contains_with_local_array_parameter();
+
+            Assert.Equal(
+    @"SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] IN ('ABCDE', 'ALFKI')",
+                Sql);
+        }
+
+        public override void Contains_with_local_array_constant()
+        {
+            base.Contains_with_local_array_constant();
+
+            Assert.Equal(
+    @"SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] IN ('ABCDE', 'ALFKI')",
+                Sql);
+        }
+
+        public override void Contains_with_local_list_parameter()
+        {
+            base.Contains_with_local_list_parameter();
+
+            Assert.Equal(
+    @"SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] IN ('ABCDE', 'ALFKI')",
+                Sql);
+        }
+
+        public override void Contains_with_local_list_constant()
+        {
+            base.Contains_with_local_list_constant();
+
+            Assert.Equal(
+    @"SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] IN ('ABCDE', 'ALFKI')",
+                Sql);
+        }
+
+        public override void Contains_with_local_collection_false()
+        {
+            base.Contains_with_local_collection_false();
+
+            Assert.Equal(
+    @"SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] NOT IN ('ABCDE', 'ALFKI')",
+                Sql);
+        }
+
+        public override void Contains_with_local_collection_complex_predicate_and()
+        {
+            base.Contains_with_local_collection_complex_predicate_and();
+
+            Assert.Equal(
+    @"SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE ([c].[CustomerID] IN ('ALFKI', 'ABCDE') AND [c].[CustomerID] IN ('ABCDE', 'ALFKI'))",
+                Sql);
+        }
+
+        public override void Contains_with_local_collection_complex_predicate_or()
+        {
+            base.Contains_with_local_collection_complex_predicate_or();
+
+            Assert.Equal(
+    @"SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE ([c].[CustomerID] IN ('ABCDE', 'ALFKI') OR [c].[CustomerID] IN ('ALFKI', 'ABCDE'))",
+                Sql);
+        }
+
+
         public QuerySqlServerTest(NorthwindQuerySqlServerFixture fixture)
             : base(fixture)
         {


### PR DESCRIPTION
Fix is to translate Where(c => [list_of_constants].Constains(c.SomeProperty)) to
c.SomeProperty IN ( [list_of_constants)

We also translate !Contains... into NOT IN. Relinq converts Contains call into subquery, so we are detecting this pattern in the FilteringExpressionTreeVisitor and translate it accordingly. Argument to contains in this case will always be in the form of parameter. Parameter values are wired in during SQL generation.