### PR TITLE
Use generic ReadValue in update pipeline and key factories

### DIFF
--- a/src/EntityFramework.Core/ChangeTracking/Internal/EntityKeyFactorySource.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/EntityKeyFactorySource.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Utilities;
 
@@ -14,38 +15,43 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 {
     public class EntityKeyFactorySource
     {
-        private readonly ThreadSafeDictionaryCache<IProperty, EntityKeyFactory> _cache
-            = new ThreadSafeDictionaryCache<IProperty, EntityKeyFactory>();
+        private readonly IBoxedValueReaderSource _boxedValueReaderSource;
+
+        private readonly ThreadSafeDictionaryCache<IReadOnlyList<IProperty>, EntityKeyFactory> _cache
+            = new ThreadSafeDictionaryCache<IReadOnlyList<IProperty>, EntityKeyFactory>(
+                new ReferenceEnumerableEqualityComparer<IReadOnlyList<IProperty>, IProperty>());
+
+        public EntityKeyFactorySource([NotNull] IBoxedValueReaderSource boxedValueReaderSource)
+        {
+            _boxedValueReaderSource = boxedValueReaderSource;
+        }
 
         public virtual EntityKeyFactory GetKeyFactory([NotNull] IReadOnlyList<IProperty> keyProperties)
-        {
-            Check.NotNull(keyProperties, nameof(keyProperties));
+            => _cache.GetOrAdd(
+                keyProperties,
+                k =>
+                    {
+                        if (k.Count == 1)
+                        {
+                            var keyProperty = k[0];
+                            var keyType = keyProperty.PropertyType;
 
-            if (keyProperties.Count == 1)
-            {
-                var keyProperty = keyProperties[0];
-                var keyType = keyProperty.PropertyType;
-
-                // Use composite key for anything with structural (e.g. byte[]) properties even if they are
-                // not composite because it is setup to do structural comparisons and the generic typing
-                // advantages of the simple key don't really apply anyway.
-                if (!typeof(IStructuralEquatable).GetTypeInfo().IsAssignableFrom(keyType.GetTypeInfo()))
-                {
-                    return _cache.GetOrAdd(
-                        keyProperty,
-                        t =>
+                            // Use composite key for anything with structural (e.g. byte[]) properties even if they are
+                            // not composite because it is setup to do structural comparisons and the generic typing
+                            // advantages of the simple key don't really apply anyway.
+                            if (!typeof(IStructuralEquatable).GetTypeInfo().IsAssignableFrom(keyType.GetTypeInfo()))
                             {
                                 var sentinel = keyProperty.SentinelValue;
 
                                 return (EntityKeyFactory)(keyType.IsNullableType()
                                     ? Activator.CreateInstance(typeof(SimpleEntityKeyFactory<>).MakeGenericType(keyType.UnwrapNullableType()), sentinel)
                                     : Activator.CreateInstance(typeof(SimpleEntityKeyFactory<>).MakeGenericType(keyType), sentinel));
-                            });
-                }
-            }
+                            }
+                        }
 
-            // Consider caching these factories for perf
-            return new CompositeEntityKeyFactory(keyProperties.Select(k => k.SentinelValue).ToList());
-        }
+                        return new CompositeEntityKeyFactory(
+                            k.Select(p => p.SentinelValue).ToList(),
+                            k.Select(p => _boxedValueReaderSource.GetReader(p)).ToList());
+                    });
     }
 }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/InternalEntityEntryFactory.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/InternalEntityEntryFactory.cs
@@ -10,23 +10,10 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 {
     public class InternalEntityEntryFactory
     {
-        private readonly EntityMaterializerSource _materializerSource;
         private readonly EntityEntryMetadataServices _metadataServices;
 
-        /// <summary>
-        ///     This constructor is intended only for use when creating test doubles that will override members
-        ///     with mocked or faked behavior. Use of this constructor for other purposes may result in unexpected
-        ///     behavior including but not limited to throwing <see cref="NullReferenceException" />.
-        /// </summary>
-        protected InternalEntityEntryFactory()
+        public InternalEntityEntryFactory([NotNull] EntityEntryMetadataServices metadataServices)
         {
-        }
-
-        public InternalEntityEntryFactory(
-            [NotNull] EntityMaterializerSource materializerSource,
-            [NotNull] EntityEntryMetadataServices metadataServices)
-        {
-            _materializerSource = materializerSource;
             _metadataServices = metadataServices;
         }
 

--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -125,6 +125,8 @@
     <Compile Include="Infrastructure\CoreOptionsExtension.cs" />
     <Compile Include="Infrastructure\DbContextOptions.cs" />
     <Compile Include="Infrastructure\DbContextOptions`.cs" />
+    <Compile Include="Infrastructure\IBoxedValueReader.cs" />
+    <Compile Include="Infrastructure\IBoxedValueReaderSource.cs" />
     <Compile Include="Infrastructure\IDatabaseFactory.cs" />
     <Compile Include="Infrastructure\IDbContextOptions.cs" />
     <Compile Include="Infrastructure\IOptionsBuilderExtender.cs" />
@@ -140,6 +142,8 @@
     <Compile Include="Internal\LoggingModelValidator.cs" />
     <Compile Include="Internal\ModelSource.cs" />
     <Compile Include="Internal\ModelValidator.cs" />
+    <Compile Include="Internal\BoxedValueReaderSource.cs" />
+    <Compile Include="Internal\GenericBoxedValueReader.cs" />
     <Compile Include="Metadata\IModelBuilderFactory.cs" />
     <Compile Include="ModelBuilder.cs" />
     <Compile Include="Query\EntityLoadInfo.cs" />
@@ -314,6 +318,7 @@
     <Compile Include="Utilities\Multigraph.cs" />
     <Compile Include="Utilities\PropertyInfoExtensions.cs" />
     <Compile Include="Utilities\ReferenceEqualityComparer.cs" />
+    <Compile Include="Utilities\ReferenceEnumerableEqualityComparer.cs" />
     <Compile Include="Utilities\ThreadSafeDictionaryCache.cs" />
     <Compile Include="Utilities\ThreadSafeLazyRef.cs" />
     <Compile Include="Utilities\TypeExtensions.cs" />

--- a/src/EntityFramework.Core/Extensions/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/EntityFramework.Core/Extensions/EntityFrameworkServiceCollectionExtensions.cs
@@ -99,6 +99,7 @@ namespace Microsoft.Framework.DependencyInjection
                 .AddSingleton<ICompiledQueryCache, CompiledQueryCache>()
                 .AddSingleton<ILoggerFactory, LoggerFactory>()
                 .AddSingleton<DbContextOptionsParser>()
+                .AddSingleton<IBoxedValueReaderSource, BoxedValueReaderSource>()
                 .AddScoped<KeyPropagator>()
                 .AddScoped<NavigationFixer>()
                 .AddScoped<StateManager>()

--- a/src/EntityFramework.Core/Infrastructure/IBoxedValueReader.cs
+++ b/src/EntityFramework.Core/Infrastructure/IBoxedValueReader.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+
+namespace Microsoft.Data.Entity.Infrastructure
+{
+    public interface IBoxedValueReader
+    {
+        object ReadValue([NotNull] IValueReader valueReader, int index);
+    }
+}

--- a/src/EntityFramework.Core/Infrastructure/IBoxedValueReaderSource.cs
+++ b/src/EntityFramework.Core/Infrastructure/IBoxedValueReaderSource.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Internal;
+using Microsoft.Data.Entity.Metadata;
+
+namespace Microsoft.Data.Entity.Infrastructure
+{
+    public interface IBoxedValueReaderSource
+    {
+        IBoxedValueReader GetReader([NotNull] IProperty property);
+    }
+}

--- a/src/EntityFramework.Core/Internal/BoxedValueReaderSource.cs
+++ b/src/EntityFramework.Core/Internal/BoxedValueReaderSource.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Internal
+{
+    public class BoxedValueReaderSource : IBoxedValueReaderSource
+    {
+        private static readonly MethodInfo _genericCreate
+            = typeof(BoxedValueReaderSource).GetTypeInfo().GetDeclaredMethods("CreateGeneric").Single();
+
+        private readonly ThreadSafeDictionaryCache<Type, IBoxedValueReader> _cache
+            = new ThreadSafeDictionaryCache<Type, IBoxedValueReader>();
+
+        public virtual IBoxedValueReader GetReader(IProperty property)
+            => _cache.GetOrAdd(Check.NotNull(property, nameof(property)).PropertyType.UnwrapNullableType(), Create);
+
+        private IBoxedValueReader Create(Type type)
+            => (IBoxedValueReader)_genericCreate.MakeGenericMethod(type).Invoke(this, null);
+
+        protected IBoxedValueReader CreateGeneric<TValue>() => new GenericBoxedValueReader<TValue>();
+    }
+}

--- a/src/EntityFramework.Core/Internal/GenericBoxedValueReader.cs
+++ b/src/EntityFramework.Core/Internal/GenericBoxedValueReader.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
+
+namespace Microsoft.Data.Entity.Internal
+{
+    public class GenericBoxedValueReader<TValue> : IBoxedValueReader
+    {
+        public virtual object ReadValue(IValueReader valueReader, int index)
+            => valueReader.IsNull(index) ? null : (object)valueReader.ReadValue<TValue>(index);
+    }
+}

--- a/src/EntityFramework.Core/Internal/ServiceProviderCache.cs
+++ b/src/EntityFramework.Core/Internal/ServiceProviderCache.cs
@@ -36,12 +36,10 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         private static long CalculateHash(ServiceDescriptor descriptor)
-        {
-            return ((((long)descriptor.Lifetime * 397)
-                     ^ descriptor.ServiceType.GetHashCode()) * 397)
-                   ^ (descriptor.ImplementationInstance
-                      ?? descriptor.ImplementationType
-                      ?? (object)descriptor.ImplementationFactory).GetHashCode();
-        }
+            => ((((long)descriptor.Lifetime * 397)
+                 ^ descriptor.ServiceType.GetHashCode()) * 397)
+               ^ (descriptor.ImplementationInstance
+                  ?? descriptor.ImplementationType
+                  ?? (object)descriptor.ImplementationFactory).GetHashCode();
     }
 }

--- a/src/EntityFramework.Core/Metadata/ClrAccessorSource.cs
+++ b/src/EntityFramework.Core/Metadata/ClrAccessorSource.cs
@@ -22,14 +22,7 @@ namespace Microsoft.Data.Entity.Metadata
         {
             Check.NotNull(property, nameof(property));
 
-            var clrPropertySetter = property as TAccessor;
-
-            if (clrPropertySetter != null)
-            {
-                return clrPropertySetter;
-            }
-
-            return GetAccessor(property.EntityType.Type, property.Name);
+            return property as TAccessor ?? GetAccessor(property.EntityType.Type, property.Name);
         }
 
         public virtual TAccessor GetAccessor([NotNull] Type declaringType, [NotNull] string propertyName)

--- a/src/EntityFramework.Core/Metadata/ObjectArrayValueReader.cs
+++ b/src/EntityFramework.Core/Metadata/ObjectArrayValueReader.cs
@@ -17,15 +17,9 @@ namespace Microsoft.Data.Entity.Metadata
             _valueBuffer = valueBuffer;
         }
 
-        public virtual bool IsNull(int index)
-        {
-            return _valueBuffer[index] == null;
-        }
+        public virtual bool IsNull(int index) => _valueBuffer[index] == null;
 
-        public virtual T ReadValue<T>(int index)
-        {
-            return (T)_valueBuffer[index];
-        }
+        public virtual T ReadValue<T>(int index) => (T)_valueBuffer[index];
 
         public virtual int Count => _valueBuffer.Length;
     }

--- a/src/EntityFramework.Core/Utilities/ReferenceEnumerableEqualityComparer.cs
+++ b/src/EntityFramework.Core/Utilities/ReferenceEnumerableEqualityComparer.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Data.Entity.Utilities
+{
+    public sealed class ReferenceEnumerableEqualityComparer<TEnumerable, TValue> : IEqualityComparer<TEnumerable>
+        where TEnumerable : IEnumerable<TValue>
+    {
+        public bool Equals(TEnumerable left, TEnumerable right) => left.SequenceEqual(right);
+
+        public int GetHashCode(TEnumerable values) => values.Aggregate(0, (t, v) => (t * 397) ^ v.GetHashCode());
+    }
+}

--- a/src/EntityFramework.Core/Utilities/ReferenceEqualityComparer.cs
+++ b/src/EntityFramework.Core/Utilities/ReferenceEqualityComparer.cs
@@ -14,14 +14,8 @@ namespace Microsoft.Data.Entity.Utilities
 
         public static ReferenceEqualityComparer Instance { get; } = new ReferenceEqualityComparer();
 
-        bool IEqualityComparer<object>.Equals(object x, object y)
-        {
-            return ReferenceEquals(x, y);
-        }
+        bool IEqualityComparer<object>.Equals(object x, object y) => ReferenceEquals(x, y);
 
-        int IEqualityComparer<object>.GetHashCode(object obj)
-        {
-            return RuntimeHelpers.GetHashCode(obj);
-        }
+        int IEqualityComparer<object>.GetHashCode(object obj) => RuntimeHelpers.GetHashCode(obj);
     }
 }

--- a/src/EntityFramework.Relational/Query/OffsetValueReaderDecorator.cs
+++ b/src/EntityFramework.Relational/Query/OffsetValueReaderDecorator.cs
@@ -20,15 +20,9 @@ namespace Microsoft.Data.Entity.Relational.Query
             _offset = offset;
         }
 
-        public virtual bool IsNull(int index)
-        {
-            return _valueReader.IsNull(_offset + index);
-        }
+        public virtual bool IsNull(int index) => _valueReader.IsNull(_offset + index);
 
-        public virtual T ReadValue<T>(int index)
-        {
-            return _valueReader.ReadValue<T>(_offset + index);
-        }
+        public virtual T ReadValue<T>(int index) => _valueReader.ReadValue<T>(_offset + index);
 
         public virtual int Count => _valueReader.Count;
     }

--- a/src/EntityFramework.Relational/RelationalTypedValueReader.cs
+++ b/src/EntityFramework.Relational/RelationalTypedValueReader.cs
@@ -19,19 +19,10 @@ namespace Microsoft.Data.Entity.Relational
             _dataReader = dataReader;
         }
 
-        public virtual bool IsNull(int index)
-        {
-            return _dataReader.IsDBNull(index);
-        }
+        public virtual bool IsNull(int index) => _dataReader.IsDBNull(index);
 
-        public virtual T ReadValue<T>(int index)
-        {
-            return _dataReader.GetFieldValue<T>(index);
-        }
+        public virtual T ReadValue<T>(int index) => _dataReader.GetFieldValue<T>(index);
 
-        public virtual int Count
-        {
-            get { return _dataReader.FieldCount; }
-        }
+        public virtual int Count => _dataReader.FieldCount;
     }
 }

--- a/src/EntityFramework.Relational/Update/CommandBatchPreparer.cs
+++ b/src/EntityFramework.Relational/Update/CommandBatchPreparer.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Data.Entity.Relational.Update
         private readonly ModificationCommandBatchFactory _modificationCommandBatchFactory;
         private readonly ParameterNameGeneratorFactory _parameterNameGeneratorFactory;
         private readonly ModificationCommandComparer _modificationCommandComparer;
+        private readonly IBoxedValueReaderSource _boxedValueReaderSource;
 
         /// <summary>
         ///     This constructor is intended only for use when creating test doubles that will override members
@@ -31,15 +32,18 @@ namespace Microsoft.Data.Entity.Relational.Update
         protected CommandBatchPreparer(
             [NotNull] ModificationCommandBatchFactory modificationCommandBatchFactory,
             [NotNull] ParameterNameGeneratorFactory parameterNameGeneratorFactory,
-            [NotNull] ModificationCommandComparer modificationCommandComparer)
+            [NotNull] ModificationCommandComparer modificationCommandComparer,
+            [NotNull] IBoxedValueReaderSource boxedValueReaderSource)
         {
             Check.NotNull(modificationCommandBatchFactory, nameof(modificationCommandBatchFactory));
             Check.NotNull(parameterNameGeneratorFactory, nameof(parameterNameGeneratorFactory));
             Check.NotNull(modificationCommandComparer, nameof(modificationCommandComparer));
+            Check.NotNull(boxedValueReaderSource, nameof(boxedValueReaderSource));
 
             _modificationCommandBatchFactory = modificationCommandBatchFactory;
             _parameterNameGeneratorFactory = parameterNameGeneratorFactory;
             _modificationCommandComparer = modificationCommandComparer;
+            _boxedValueReaderSource = boxedValueReaderSource;
         }
 
         public virtual IEnumerable<ModificationCommandBatch> BatchCommands([NotNull] IReadOnlyList<InternalEntityEntry> entries, [NotNull] IDbContextOptions options)
@@ -78,7 +82,8 @@ namespace Microsoft.Data.Entity.Relational.Update
                     GetEntityTypeExtensions(e.EntityType).Table,
                     GetEntityTypeExtensions(e.EntityType).Schema,
                     parameterNameGenerator,
-                    GetPropertyExtensions)
+                    GetPropertyExtensions,
+                    _boxedValueReaderSource)
                     .AddEntry(e));
         }
 

--- a/src/EntityFramework.SqlServer/Update/SqlServerCommandBatchPreparer.cs
+++ b/src/EntityFramework.SqlServer/Update/SqlServerCommandBatchPreparer.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Relational.Metadata;
 using Microsoft.Data.Entity.Relational.Update;
@@ -14,8 +15,9 @@ namespace Microsoft.Data.Entity.SqlServer.Update
         public SqlServerCommandBatchPreparer(
             [NotNull] SqlServerModificationCommandBatchFactory modificationCommandBatchFactory,
             [NotNull] ParameterNameGeneratorFactory parameterNameGeneratorFactory,
-            [NotNull] ModificationCommandComparer modificationCommandComparer)
-            : base(modificationCommandBatchFactory, parameterNameGeneratorFactory, modificationCommandComparer)
+            [NotNull] ModificationCommandComparer modificationCommandComparer,
+            [NotNull] IBoxedValueReaderSource boxedValueReaderSource)
+            : base(modificationCommandBatchFactory, parameterNameGeneratorFactory, modificationCommandComparer, boxedValueReaderSource)
         {
         }
 

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/CompositeEntityKeyFactoryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/CompositeEntityKeyFactoryTest.cs
@@ -3,6 +3,8 @@
 
 using System;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Framework.DependencyInjection;
 using Xunit;
@@ -23,7 +25,10 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             var entry = stateManager.GetOrCreateEntry(entity);
 
-            var key = (CompositeEntityKey)new CompositeEntityKeyFactory(new object[] { 0, null, null }).Create(type, type.GetPrimaryKey().Properties, entry);
+            var key = (CompositeEntityKey)new CompositeEntityKeyFactory(
+                new object[] { 0, null, null },
+                new IBoxedValueReader[] { new GenericBoxedValueReader<int>(), new GenericBoxedValueReader<string>(), new GenericBoxedValueReader<Random>() })
+                .Create(type, type.GetPrimaryKey().Properties, entry);
 
             Assert.Equal(new object[] { 7, "Ate", random }, key.Value);
         }
@@ -40,8 +45,10 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             var entry = stateManager.GetOrCreateEntry(entity);
 
-            var key = (CompositeEntityKey)new CompositeEntityKeyFactory(new object[] { 0, null, null }).Create(
-                type, new[] { type.GetProperty("P6"), type.GetProperty("P5") }, entry);
+            var key = (CompositeEntityKey)new CompositeEntityKeyFactory(
+                new object[] { null, null },
+                new IBoxedValueReader[] { new GenericBoxedValueReader<Random>(), new GenericBoxedValueReader<string>() })
+                .Create(type, new[] { type.GetProperty("P6"), type.GetProperty("P5") }, entry);
 
             Assert.Equal(new object[] { random, "Ate" }, key.Value);
         }
@@ -61,8 +68,10 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var sidecar = new RelationshipsSnapshot(entry);
             sidecar[type.GetProperty("P4")] = 77;
 
-            var key = (CompositeEntityKey)new CompositeEntityKeyFactory(new object[] { 0, null, null }).Create(
-                type, new[] { type.GetProperty("P6"), type.GetProperty("P4"), type.GetProperty("P5") }, sidecar);
+            var key = (CompositeEntityKey)new CompositeEntityKeyFactory(
+                new object[] { null, 0, null },
+                new IBoxedValueReader[] { new GenericBoxedValueReader<Random>(), new GenericBoxedValueReader<int>(), new GenericBoxedValueReader<string>() })
+                .Create(type, new[] { type.GetProperty("P6"), type.GetProperty("P4"), type.GetProperty("P5") }, sidecar);
 
             Assert.Equal(new object[] { random, 77, "Ate" }, key.Value);
         }
@@ -79,7 +88,12 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             var entry = stateManager.GetOrCreateEntry(entity);
 
-            Assert.Equal(EntityKey.InvalidEntityKey, new CompositeEntityKeyFactory(new object[] { 0, null, null }).Create(type, type.GetPrimaryKey().Properties, entry));
+            Assert.Equal(
+                EntityKey.InvalidEntityKey,
+                new CompositeEntityKeyFactory(
+                    new object[] { 0, null, null },
+                    new IBoxedValueReader[] { new GenericBoxedValueReader<int>(), new GenericBoxedValueReader<string>(), new GenericBoxedValueReader<Random>() })
+                    .Create(type, type.GetPrimaryKey().Properties, entry));
         }
 
         [Fact]
@@ -95,7 +109,10 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             Assert.Equal(
                 EntityKey.InvalidEntityKey,
-                new CompositeEntityKeyFactory(new object[] { 0, null, null }).Create(type, type.GetPrimaryKey().Properties, entry));
+                new CompositeEntityKeyFactory(
+                    new object[] { 0, null, null },
+                    new IBoxedValueReader[] { new GenericBoxedValueReader<int>(), new GenericBoxedValueReader<string>(), new GenericBoxedValueReader<Random>() })
+                    .Create(type, type.GetPrimaryKey().Properties, entry));
         }
 
         [Fact]
@@ -111,7 +128,10 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             Assert.Equal(
                 EntityKey.InvalidEntityKey,
-                new CompositeEntityKeyFactory(new object[] { 7, null, null }).Create(type, type.GetPrimaryKey().Properties, entry));
+                new CompositeEntityKeyFactory(
+                    new object[] { 7, null, null },
+                    new IBoxedValueReader[] { new GenericBoxedValueReader<int>(), new GenericBoxedValueReader<string>(), new GenericBoxedValueReader<Random>() })
+                    .Create(type, type.GetPrimaryKey().Properties, entry));
         }
 
         [Fact]
@@ -121,7 +141,9 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             Assert.Equal(
                 EntityKey.InvalidEntityKey,
-                new CompositeEntityKeyFactory(new object[] { 0, null, null })
+                new CompositeEntityKeyFactory(
+                    new object[] { 0, null, null },
+                    new IBoxedValueReader[] { new GenericBoxedValueReader<int>(), new GenericBoxedValueReader<string>(), new GenericBoxedValueReader<Random>() })
                     .Create(type, type.GetPrimaryKey().Properties, new ObjectArrayValueReader(new object[] { 0, "Ate", new Random() })));
         }
 
@@ -132,7 +154,9 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             Assert.Equal(
                 EntityKey.InvalidEntityKey,
-                new CompositeEntityKeyFactory(new object[] { 7, null, null })
+                new CompositeEntityKeyFactory(
+                    new object[] { 7, null, null },
+                    new IBoxedValueReader[] { new GenericBoxedValueReader<int>(), new GenericBoxedValueReader<string>(), new GenericBoxedValueReader<Random>() })
                     .Create(type, type.GetPrimaryKey().Properties, new ObjectArrayValueReader(new object[] { 7, "Ate", new Random() })));
         }
 
@@ -144,8 +168,10 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             var random = new Random();
 
-            var key = (CompositeEntityKey)new CompositeEntityKeyFactory(new object[] { 0, null, null }).Create(
-                type, type.GetPrimaryKey().Properties, new ObjectArrayValueReader(new object[] { 7, "Ate", random }));
+            var key = (CompositeEntityKey)new CompositeEntityKeyFactory(
+                new object[] { 0, null, null },
+                new IBoxedValueReader[] { new GenericBoxedValueReader<int>(), new GenericBoxedValueReader<string>(), new GenericBoxedValueReader<Random>() })
+                .Create(type, type.GetPrimaryKey().Properties, new ObjectArrayValueReader(new object[] { 7, "Ate", random }));
 
             Assert.Equal(new object[] { 7, "Ate", random }, key.Value);
         }
@@ -158,10 +184,13 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             var random = new Random();
 
-            var key = (CompositeEntityKey)new CompositeEntityKeyFactory(new object[] { 0, null, null }).Create(
-                type,
-                new[] { type.GetProperty("P6"), type.GetProperty("P5") },
-                new ObjectArrayValueReader(new object[] { null, null, null, null, "Ate", random }));
+            var key = (CompositeEntityKey)new CompositeEntityKeyFactory(
+                new object[] { null, null },
+                new IBoxedValueReader[] { new GenericBoxedValueReader<Random>(), new GenericBoxedValueReader<string>() })
+                .Create(
+                    type,
+                    new[] { type.GetProperty("P6"), type.GetProperty("P5") },
+                    new ObjectArrayValueReader(new object[] { null, null, null, null, "Ate", random }));
 
             Assert.Equal(new object[] { random, "Ate" }, key.Value);
         }
@@ -174,10 +203,13 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             var random = new Random();
 
-            var key = new CompositeEntityKeyFactory(new object[] { 0, null, null }).Create(
-                type,
-                new[] { type.GetProperty("P6"), type.GetProperty("P5") },
-                new ObjectArrayValueReader(new object[] { 7, "Ate", random, 77, null, random }));
+            var key = new CompositeEntityKeyFactory(
+                new object[] { null, null },
+                new IBoxedValueReader[] { new GenericBoxedValueReader<Random>(), new GenericBoxedValueReader<string>() })
+                .Create(
+                    type,
+                    new[] { type.GetProperty("P6"), type.GetProperty("P5") },
+                    new ObjectArrayValueReader(new object[] { 7, "Ate", random, 77, null, random }));
 
             Assert.Equal(EntityKey.InvalidEntityKey, key);
         }

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/EntityKeyFactorySourceTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/EntityKeyFactorySourceTest.cs
@@ -3,8 +3,8 @@
 
 using System;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
+using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
-using Moq;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
@@ -14,95 +14,130 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Returns_a_simple_entity_key_factory_for_single_property()
         {
-            var keyMock = new Mock<IProperty>();
-            keyMock.Setup(m => m.PropertyType).Returns(typeof(int));
+            var property = GetEntityType().GetProperty("Id");
 
-            Assert.IsType<SimpleEntityKeyFactory<int>>(CreateKeyFactorySource().GetKeyFactory(new[] { keyMock.Object }));
+            Assert.IsType<SimpleEntityKeyFactory<int>>(CreateKeyFactorySource().GetKeyFactory(new[] { property }));
         }
 
         [Fact]
         public void Returns_a_simple_entity_key_factory_for_single_nullable_property()
         {
-            var keyMock = new Mock<IProperty>();
-            keyMock.Setup(m => m.PropertyType).Returns(typeof(int?));
+            var property = GetEntityType().GetProperty("NullableInt");
 
-            Assert.IsType<SimpleEntityKeyFactory<int>>(CreateKeyFactorySource().GetKeyFactory(new[] { keyMock.Object }));
+            Assert.IsType<SimpleEntityKeyFactory<int>>(CreateKeyFactorySource().GetKeyFactory(new[] { property }));
         }
 
         [Fact]
         public void Returns_different_simple_entity_key_factory_for_different_properties()
         {
-            var keyMock1 = new Mock<IProperty>();
-            keyMock1.Setup(m => m.PropertyType).Returns(typeof(Guid));
-
-            var keyMock2 = new Mock<IProperty>();
-            keyMock2.Setup(m => m.PropertyType).Returns(typeof(Guid));
+            var entityType = GetEntityType();
+            var property1 = entityType.GetProperty("Guid1");
+            var property2 = entityType.GetProperty("Guid2");
 
             var factorySource = CreateKeyFactorySource();
-            Assert.NotSame(factorySource.GetKeyFactory(new[] { keyMock1.Object }), factorySource.GetKeyFactory(new[] { keyMock2.Object }));
+            Assert.NotSame(factorySource.GetKeyFactory(new[] { property1 }), factorySource.GetKeyFactory(new[] { property2 }));
         }
 
         [Fact]
         public void Returns_different_simple_nullable_entity_key_factory_for_different_properties()
         {
-            var keyMock1 = new Mock<IProperty>();
-            keyMock1.Setup(m => m.PropertyType).Returns(typeof(Guid?));
-
-            var keyMock2 = new Mock<IProperty>();
-            keyMock2.Setup(m => m.PropertyType).Returns(typeof(Guid?));
+            var entityType = GetEntityType();
+            var property1 = entityType.GetProperty("NullableGuid1");
+            var property2 = entityType.GetProperty("NullableGuid2");
 
             var factorySource = CreateKeyFactorySource();
-            Assert.NotSame(factorySource.GetKeyFactory(new[] { keyMock1.Object }), factorySource.GetKeyFactory(new[] { keyMock2.Object }));
+            Assert.NotSame(factorySource.GetKeyFactory(new[] { property1 }), factorySource.GetKeyFactory(new[] { property2 }));
         }
 
         [Fact]
         public void Returns_same_simple_entity_key_factory_for_same_property()
         {
-            var keyMock = new Mock<IProperty>();
-            keyMock.Setup(m => m.PropertyType).Returns(typeof(Guid));
+            var property = GetEntityType().GetProperty("Guid1");
 
             var factorySource = CreateKeyFactorySource();
-            Assert.Same(factorySource.GetKeyFactory(new[] { keyMock.Object }), factorySource.GetKeyFactory(new[] { keyMock.Object }));
+            Assert.Same(factorySource.GetKeyFactory(new[] { property }), factorySource.GetKeyFactory(new[] { property }));
         }
 
         [Fact]
         public void Returns_same_nullable_simple_entity_key_factory_for_same_property()
         {
-            var keyMock = new Mock<IProperty>();
-            keyMock.Setup(m => m.PropertyType).Returns(typeof(Guid?));
+            var property = GetEntityType().GetProperty("NullableGuid1");
 
             var factorySource = CreateKeyFactorySource();
-            Assert.Same(factorySource.GetKeyFactory(new[] { keyMock.Object }), factorySource.GetKeyFactory(new[] { keyMock.Object }));
+            Assert.Same(factorySource.GetKeyFactory(new[] { property }), factorySource.GetKeyFactory(new[] { property }));
         }
 
         [Fact]
         public void Returns_a_composite_entity_key_factory_for_composite_property_key()
         {
+            var entityType = GetEntityType();
+            var property1 = entityType.GetProperty("Id");
+            var property2 = entityType.GetProperty("String");
+
             Assert.IsType<CompositeEntityKeyFactory>(
-                CreateKeyFactorySource().GetKeyFactory(new[] { new Mock<IProperty>().Object, new Mock<IProperty>().Object }));
+                CreateKeyFactorySource().GetKeyFactory(new[] { property1, property2 }));
+        }
+
+        [Fact]
+        public void Returns_same_composite_entity_key_factory_for_same_properties()
+        {
+            var entityType = GetEntityType();
+            var property1 = entityType.GetProperty("Id");
+            var property2 = entityType.GetProperty("String");
+
+            var factorySource = CreateKeyFactorySource();
+            Assert.Same(factorySource.GetKeyFactory(new[] { property1, property2 }), factorySource.GetKeyFactory(new[] { property1, property2 }));
         }
 
         [Fact]
         public void Returns_a_simple_entity_key_factory_for_single_reference_property()
         {
-            var keyMock = new Mock<IProperty>();
-            keyMock.Setup(m => m.PropertyType).Returns(typeof(string));
+            var property = GetEntityType().GetProperty("String");
 
-            Assert.IsType<SimpleEntityKeyFactory<string>>(CreateKeyFactorySource().GetKeyFactory(new[] { keyMock.Object }));
+            Assert.IsType<SimpleEntityKeyFactory<string>>(CreateKeyFactorySource().GetKeyFactory(new[] { property }));
         }
 
         [Fact]
         public void Returns_a_composite_entity_key_factory_for_single_structural_property()
         {
-            var keyMock = new Mock<IProperty>();
-            keyMock.Setup(m => m.PropertyType).Returns(typeof(byte[]));
+            var property = GetEntityType().GetProperty("ByteArray");
 
-            Assert.IsType<CompositeEntityKeyFactory>(CreateKeyFactorySource().GetKeyFactory(new[] { keyMock.Object }));
+            Assert.IsType<CompositeEntityKeyFactory>(CreateKeyFactorySource().GetKeyFactory(new[] { property }));
+        }
+
+        [Fact]
+        public void Returns_same_composite_entity_key_factory_for_same_structural_property()
+        {
+            var property = GetEntityType().GetProperty("ByteArray");
+
+            var factorySource = CreateKeyFactorySource();
+            Assert.Same(factorySource.GetKeyFactory(new[] { property }), factorySource.GetKeyFactory(new[] { property }));
         }
 
         private static EntityKeyFactorySource CreateKeyFactorySource()
         {
-            return new EntityKeyFactorySource();
+            return new EntityKeyFactorySource(new BoxedValueReaderSource());
+        }
+
+        private static IEntityType GetEntityType()
+        {
+            var builder = TestHelpers.Instance.CreateConventionBuilder();
+
+            builder.Entity<ScissorSister>();
+
+            return builder.Model.GetEntityType(typeof(ScissorSister));
+        }
+
+        private class ScissorSister
+        {
+            public int Id { get; set; }
+            public int? NullableInt { get; set; }
+            public string String { get; set; }
+            public Guid Guid1 { get; set; }
+            public Guid Guid2 { get; set; }
+            public Guid? NullableGuid1 { get; set; }
+            public Guid? NullableGuid2 { get; set; }
+            public byte[] ByteArray { get; set; }
         }
     }
 }

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntityEntryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntityEntryTest.cs
@@ -1424,7 +1424,6 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             return contextServices.GetRequiredService<InternalEntityEntrySubscriber>().SnapshotAndSubscribe(
                 new InternalEntityEntryFactory(
-                    contextServices.GetRequiredService<EntityMaterializerSource>(),
                     contextServices.GetRequiredService<EntityEntryMetadataServices>())
                     .Create(contextServices.GetRequiredService<StateManager>(), entityType, entity));
         }
@@ -1433,7 +1432,6 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             return contextServices.GetRequiredService<InternalEntityEntrySubscriber>().SnapshotAndSubscribe(
                 new InternalEntityEntryFactory(
-                    contextServices.GetRequiredService<EntityMaterializerSource>(),
                     contextServices.GetRequiredService<EntityEntryMetadataServices>())
                     .Create(contextServices.GetRequiredService<StateManager>(), entityType, entity, valueReader));
         }

--- a/test/EntityFramework.Core.Tests/EntityFramework.Core.Tests.csproj
+++ b/test/EntityFramework.Core.Tests/EntityFramework.Core.Tests.csproj
@@ -110,7 +110,7 @@
     <Compile Include="DbSetySourceTest.cs" />
     <Compile Include="DbContextOptionsTest.cs" />
     <Compile Include="EntitySetFinderTest.cs" />
-    <Compile Include="Extensions\EntityServiceCollectionExtensionsTest.cs" />
+    <Compile Include="Extensions\EntityFrameworkServiceCollectionExtensionsTest.cs" />
     <Compile Include="Extensions\ForeignKeyExtensionsTest.cs" />
     <Compile Include="Extensions\ServiceProviderExtensionsTest.cs" />
     <Compile Include="Extensions\TaskExtensionsTest.cs" />
@@ -118,6 +118,7 @@
     <Compile Include="Infrastructure\LoggingModelValidatorTest.cs" />
     <Compile Include="Infrastructure\NonThrowingModelValidatorTest.cs" />
     <Compile Include="Infrastructure\ThrowingModelValidatorTest.cs" />
+    <Compile Include="Internal\BoxedValueReaderSourceTest.cs" />
     <Compile Include="Metadata\BasicModelBuilderTest.cs" />
     <Compile Include="Metadata\CollectionTyoeFactoryTest.cs" />
     <Compile Include="Metadata\EntityTypeExtensionsTest.cs" />

--- a/test/EntityFramework.Core.Tests/Extensions/EntityFrameworkServiceCollectionExtensionsTest.cs
+++ b/test/EntityFramework.Core.Tests/Extensions/EntityFrameworkServiceCollectionExtensionsTest.cs
@@ -18,7 +18,7 @@ using Xunit;
 
 namespace Microsoft.Data.Entity.Tests
 {
-    public class EntityServiceCollectionExtensionsTest : IDisposable
+    public class EntityFrameworkServiceCollectionExtensionsTest : IDisposable
     {
         [Fact]
         public virtual void Services_wire_up_correctly()
@@ -41,6 +41,7 @@ namespace Microsoft.Data.Entity.Tests
             VerifySingleton<EntityEntryMetadataServices>();
             VerifySingleton<ICompiledQueryCache>();
             VerifySingleton<ILoggerFactory>();
+            VerifySingleton<IBoxedValueReaderSource>();
 
             VerifyCached<IModelBuilderFactory>();
             VerifyCached<IModel>();
@@ -91,7 +92,7 @@ namespace Microsoft.Data.Entity.Tests
         private readonly DbContext _firstContext;
         private readonly DbContext _secondContext;
 
-        public EntityServiceCollectionExtensionsTest()
+        public EntityFrameworkServiceCollectionExtensionsTest()
         {
             _serviceProvider = GetServices().BuildServiceProvider();
             _firstContext = CreateContext(_serviceProvider);

--- a/test/EntityFramework.Core.Tests/Internal/BoxedValueReaderSourceTest.cs
+++ b/test/EntityFramework.Core.Tests/Internal/BoxedValueReaderSourceTest.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Internal;
+using Microsoft.Data.Entity.Metadata;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Tests.Internal
+{
+    public class BoxedValueReaderSourceTest
+    {
+        [Fact]
+        public void Returns_generic_value_reader_for_given_property_type()
+            => Assert.IsType<GenericBoxedValueReader<int>>(new BoxedValueReaderSource().GetReader(GetEntityType().GetProperty("Id")));
+
+        [Fact]
+        public void Always_returns_non_nullable_value_reader_for_given_property_type()
+            => Assert.IsType<GenericBoxedValueReader<int>>(new BoxedValueReaderSource().GetReader(GetEntityType().GetProperty("NullableInt")));
+
+        [Fact]
+        public void Returns_same_value_reader_for_same_property_type()
+        {
+            var entityType = GetEntityType();
+            var property1 = entityType.GetProperty("Id");
+            var property2 = entityType.GetProperty("NullableInt");
+
+            var source = new BoxedValueReaderSource();
+            Assert.Same(source.GetReader(property1), source.GetReader(property2));
+        }
+
+        private static IEntityType GetEntityType()
+        {
+            var builder = TestHelpers.Instance.CreateConventionBuilder();
+
+            builder.Entity<ScissorSister>();
+
+            return builder.Model.GetEntityType(typeof(ScissorSister));
+        }
+
+        private class ScissorSister
+        {
+            public int Id { get; set; }
+            public int? NullableInt { get; set; }
+        }
+    }
+}

--- a/test/EntityFramework.InMemory.Tests/EntityFramework.InMemory.Tests.csproj
+++ b/test/EntityFramework.InMemory.Tests/EntityFramework.InMemory.Tests.csproj
@@ -71,7 +71,7 @@
     <Compile Include="InMemoryDataStoreCreatorTest.cs" />
     <Compile Include="InMemoryDataStoreSourceTest.cs" />
     <Compile Include="InMemoryDataStoreTest.cs" />
-    <Compile Include="InMemoryEntityServicesBuilderExtensionsTest.cs" />
+    <Compile Include="InMemoryEntityFrameworkServicesBuilderExtensionsTest.cs" />
     <Compile Include="InMemoryValueGeneratorSelectorTest.cs" />
     <Compile Include="InMemoryIntegerValueGeneratorTest.cs" />
     <Compile Include="InMemoryTestHelpers.cs" />

--- a/test/EntityFramework.InMemory.Tests/InMemoryEntityFrameworkServicesBuilderExtensionsTest.cs
+++ b/test/EntityFramework.InMemory.Tests/InMemoryEntityFrameworkServicesBuilderExtensionsTest.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Microsoft.Data.Entity.InMemory.Tests
 {
-    public class InMemoryEntityServicesBuilderExtensionsTest : EntityServiceCollectionExtensionsTest
+    public class InMemoryEntityFrameworkServicesBuilderExtensionsTest : EntityFrameworkServiceCollectionExtensionsTest
     {
         [Fact]
         public override void Services_wire_up_correctly()

--- a/test/EntityFramework.Relational.Tests/SqlGeneratorTestBase.cs
+++ b/test/EntityFramework.Relational.Tests/SqlGeneratorTestBase.cs
@@ -5,6 +5,8 @@ using System;
 using System.Linq;
 using System.Text;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Relational.Metadata;
 using Microsoft.Data.Entity.Relational.Update;
@@ -304,15 +306,15 @@ namespace Microsoft.Data.Entity.Relational.Tests
             var columnModifications = new[]
                 {
                     new ColumnModification(
-                        entry, idProperty, idProperty.Relational(), generator, identityKey, !identityKey, true, false),
+                        entry, idProperty, idProperty.Relational(), generator, new GenericBoxedValueReader<int>() , identityKey, !identityKey, true, false),
                     new ColumnModification(
-                        entry, nameProperty, nameProperty.Relational(), generator, false, true, false, false),
+                        entry, nameProperty, nameProperty.Relational(), generator, null, false, true, false, false),
                     new ColumnModification(
-                        entry, quacksProperty, quacksProperty.Relational(), generator, false, true, false, false),
+                        entry, quacksProperty, quacksProperty.Relational(), generator, null, false, true, false, false),
                     new ColumnModification(
-                        entry, computedProperty, computedProperty.Relational(), generator, isComputed, false, false, false),
+                        entry, computedProperty, computedProperty.Relational(), generator, new GenericBoxedValueReader<int>(), isComputed, false, false, false),
                     new ColumnModification(
-                        entry, concurrencyProperty, concurrencyProperty.Relational(), generator, false, true, false, false)
+                        entry, concurrencyProperty, concurrencyProperty.Relational(), generator, null, false, true, false, false)
                 };
 
             if (defaultsOnly)
@@ -321,7 +323,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
             }
 
             Func<IProperty, IRelationalPropertyExtensions> func = p => p.Relational();
-            var commandMock = new Mock<ModificationCommand>("Ducks", SchemaName, new ParameterNameGenerator(), func) { CallBase = true };
+            var commandMock = new Mock<ModificationCommand>("Ducks", SchemaName, new ParameterNameGenerator(), func, new BoxedValueReaderSource()) { CallBase = true };
             commandMock.Setup(m => m.ColumnModifications).Returns(columnModifications);
 
             return commandMock.Object;
@@ -340,19 +342,19 @@ namespace Microsoft.Data.Entity.Relational.Tests
             var columnModifications = new[]
                 {
                     new ColumnModification(
-                        entry, idProperty, idProperty.Relational(), generator, false, false, true, true),
+                        entry, idProperty, idProperty.Relational(), generator, null, false, false, true, true),
                     new ColumnModification(
-                        entry, nameProperty, nameProperty.Relational(), generator, false, true, false, false),
+                        entry, nameProperty, nameProperty.Relational(), generator, null, false, true, false, false),
                     new ColumnModification(
-                        entry, quacksProperty, quacksProperty.Relational(), generator, false, true, false, false),
+                        entry, quacksProperty, quacksProperty.Relational(), generator, null, false, true, false, false),
                     new ColumnModification(
-                        entry, computedProperty, computedProperty.Relational(), generator, isComputed, false, false, false),
+                        entry, computedProperty, computedProperty.Relational(), generator, new GenericBoxedValueReader<int>(), isComputed, false, false, false),
                     new ColumnModification(
-                        entry, concurrencyProperty, concurrencyProperty.Relational(), generator, false, true, false, concurrencyToken)
+                        entry, concurrencyProperty, concurrencyProperty.Relational(), generator, null, false, true, false, concurrencyToken)
                 };
 
             Func<IProperty, IRelationalPropertyExtensions> func = p => p.Relational();
-            var commandMock = new Mock<ModificationCommand>("Ducks", SchemaName, new ParameterNameGenerator(), func) { CallBase = true };
+            var commandMock = new Mock<ModificationCommand>("Ducks", SchemaName, new ParameterNameGenerator(), func, new BoxedValueReaderSource()) { CallBase = true };
             commandMock.Setup(m => m.ColumnModifications).Returns(columnModifications);
 
             return commandMock.Object;
@@ -368,13 +370,13 @@ namespace Microsoft.Data.Entity.Relational.Tests
             var columnModifications = new[]
                 {
                     new ColumnModification(
-                        entry, idProperty, idProperty.Relational(), generator, false, false, true, true),
+                        entry, idProperty, idProperty.Relational(), generator, null, false, false, true, true),
                     new ColumnModification(
-                        entry, concurrencyProperty, concurrencyProperty.Relational(), generator, false, false, false, concurrencyToken)
+                        entry, concurrencyProperty, concurrencyProperty.Relational(), generator, null, false, false, false, concurrencyToken)
                 };
 
             Func<IProperty, IRelationalPropertyExtensions> func = p => p.Relational();
-            var commandMock = new Mock<ModificationCommand>("Ducks", SchemaName, new ParameterNameGenerator(), func) { CallBase = true };
+            var commandMock = new Mock<ModificationCommand>("Ducks", SchemaName, new ParameterNameGenerator(), func, new BoxedValueReaderSource()) { CallBase = true };
             commandMock.Setup(m => m.ColumnModifications).Returns(columnModifications);
 
             return commandMock.Object;

--- a/test/EntityFramework.Relational.Tests/Update/ColumnModificationTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/ColumnModificationTest.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Data.Entity.ChangeTracking.Internal;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Relational.Metadata;
 using Microsoft.Data.Entity.Relational.Update;
@@ -20,6 +22,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
                 new Mock<IProperty>().Object,
                 new Mock<IRelationalPropertyExtensions>().Object,
                 new ParameterNameGenerator(),
+                new GenericBoxedValueReader<int>(),
                 isRead: true,
                 isWrite: true,
                 isKey: true,
@@ -47,6 +50,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
                 new Mock<IProperty>().Object,
                 new Mock<IRelationalPropertyExtensions>().Object,
                 new ParameterNameGenerator(),
+                null,
                 isRead: false,
                 isWrite: false,
                 isKey: false,
@@ -70,6 +74,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
                 new Mock<IProperty>().Object,
                 new Mock<IRelationalPropertyExtensions>().Object,
                 new ParameterNameGenerator(),
+                null,
                 isRead: false,
                 isWrite: false,
                 isKey: false,
@@ -90,6 +95,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
                 new Mock<IProperty>().Object,
                 new Mock<IRelationalPropertyExtensions>().Object,
                 new ParameterNameGenerator(),
+                null,
                 isRead: false,
                 isWrite: false,
                 isKey: false,
@@ -110,6 +116,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
                 property,
                 property.Relational(),
                 new ParameterNameGenerator(),
+                null,
                 isRead: false,
                 isWrite: false,
                 isKey: false,

--- a/test/EntityFramework.Relational.Tests/Update/CommandBatchPreparerTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/CommandBatchPreparerTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Relational.Metadata;
 using Microsoft.Data.Entity.Relational.Update;
@@ -270,7 +271,8 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
 
             return new TestCommandBatchPreparer(modificationCommandBatchFactory,
                 new ParameterNameGeneratorFactory(),
-                new ModificationCommandComparer());
+                new ModificationCommandComparer(),
+                new BoxedValueReaderSource());
         }
 
         private static IModel CreateSimpleFKModel()
@@ -335,8 +337,9 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             public TestCommandBatchPreparer(
                 ModificationCommandBatchFactory modificationCommandBatchFactory,
                 ParameterNameGeneratorFactory parameterNameGeneratorFactory,
-                ModificationCommandComparer modificationCommandComparer)
-                : base(modificationCommandBatchFactory, parameterNameGeneratorFactory, modificationCommandComparer)
+                ModificationCommandComparer modificationCommandComparer,
+                IBoxedValueReaderSource boxedValueReaderSource)
+                : base(modificationCommandBatchFactory, parameterNameGeneratorFactory, modificationCommandComparer, boxedValueReaderSource)
             {
             }
 

--- a/test/EntityFramework.Relational.Tests/Update/ModificationCommandComparerTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/ModificationCommandComparerTest.cs
@@ -32,19 +32,19 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             var entry1 = stateManager.GetOrCreateEntry(new object());
             entry1[key] = 1;
             entry1.SetEntityState(EntityState.Added);
-            var modificationCommandAdded = new ModificationCommand("A", null, new ParameterNameGenerator(), p => p.Relational());
+            var modificationCommandAdded = new ModificationCommand("A", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource());
             modificationCommandAdded.AddEntry(entry1);
 
             var entry2 = stateManager.GetOrCreateEntry(new object());
             entry2[key] = 2;
             entry2.SetEntityState(EntityState.Modified);
-            var modificationCommandModified = new ModificationCommand("A", null, new ParameterNameGenerator(), p => p.Relational());
+            var modificationCommandModified = new ModificationCommand("A", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource());
             modificationCommandModified.AddEntry(entry2);
 
             var entry3 = stateManager.GetOrCreateEntry(new object());
             entry3[key] = 3;
             entry3.SetEntityState(EntityState.Deleted);
-            var modificationCommandDeleted = new ModificationCommand("A", null, new ParameterNameGenerator(), p => p.Relational());
+            var modificationCommandDeleted = new ModificationCommand("A", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource());
             modificationCommandDeleted.AddEntry(entry3);
 
             var mCC = new ModificationCommandComparer();
@@ -52,32 +52,32 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             Assert.True(0 == mCC.Compare(modificationCommandAdded, modificationCommandAdded));
             Assert.True(0 == mCC.Compare(null, null));
             Assert.True(0 == mCC.Compare(
-                new ModificationCommand("A", "dbo", new ParameterNameGenerator(), p => p.Relational()),
-                new ModificationCommand("A", "dbo", new ParameterNameGenerator(), p => p.Relational())));
+                new ModificationCommand("A", "dbo", new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource()),
+                new ModificationCommand("A", "dbo", new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource())));
 
-            Assert.True(0 > mCC.Compare(null, new ModificationCommand("A", null, new ParameterNameGenerator(), p => p.Relational())));
-            Assert.True(0 < mCC.Compare(new ModificationCommand("A", null, new ParameterNameGenerator(), p => p.Relational()), null));
-
-            Assert.True(0 > mCC.Compare(
-                new ModificationCommand("A", null, new ParameterNameGenerator(), p => p.Relational()),
-                new ModificationCommand("A", "dbo", new ParameterNameGenerator(), p => p.Relational())));
-            Assert.True(0 < mCC.Compare(
-                new ModificationCommand("A", "dbo", new ParameterNameGenerator(), p => p.Relational()),
-                new ModificationCommand("A", null, new ParameterNameGenerator(), p => p.Relational())));
+            Assert.True(0 > mCC.Compare(null, new ModificationCommand("A", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource())));
+            Assert.True(0 < mCC.Compare(new ModificationCommand("A", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource()), null));
 
             Assert.True(0 > mCC.Compare(
-                new ModificationCommand("A", "dbo", new ParameterNameGenerator(), p => p.Relational()),
-                new ModificationCommand("A", "foo", new ParameterNameGenerator(), p => p.Relational())));
+                new ModificationCommand("A", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource()),
+                new ModificationCommand("A", "dbo", new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource())));
             Assert.True(0 < mCC.Compare(
-                new ModificationCommand("A", "foo", new ParameterNameGenerator(), p => p.Relational()),
-                new ModificationCommand("A", "dbo", new ParameterNameGenerator(), p => p.Relational())));
+                new ModificationCommand("A", "dbo", new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource()),
+                new ModificationCommand("A", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource())));
 
             Assert.True(0 > mCC.Compare(
-                new ModificationCommand("A", null, new ParameterNameGenerator(), p => p.Relational()),
-                new ModificationCommand("B", null, new ParameterNameGenerator(), p => p.Relational())));
+                new ModificationCommand("A", "dbo", new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource()),
+                new ModificationCommand("A", "foo", new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource())));
             Assert.True(0 < mCC.Compare(
-                new ModificationCommand("B", null, new ParameterNameGenerator(), p => p.Relational()),
-                new ModificationCommand("A", null, new ParameterNameGenerator(), p => p.Relational())));
+                new ModificationCommand("A", "foo", new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource()),
+                new ModificationCommand("A", "dbo", new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource())));
+
+            Assert.True(0 > mCC.Compare(
+                new ModificationCommand("A", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource()),
+                new ModificationCommand("B", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource())));
+            Assert.True(0 < mCC.Compare(
+                new ModificationCommand("B", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource()),
+                new ModificationCommand("A", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource())));
 
             Assert.True(0 > mCC.Compare(modificationCommandModified, modificationCommandAdded));
             Assert.True(0 < mCC.Compare(modificationCommandAdded, modificationCommandModified));

--- a/test/EntityFramework.Relational.Tests/Update/ModificationCommandTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/ModificationCommandTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
+using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Relational.Update;
 using Xunit;
@@ -17,7 +18,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             var entry = Createentry(EntityState.Added, generateKeyValues: true);
             entry.MarkAsTemporary(entry.EntityType.GetPrimaryKey().Properties[0]);
 
-            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational());
+            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource());
             command.AddEntry(entry);
 
             Assert.Equal("T1", command.TableName);
@@ -34,6 +35,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             Assert.True(columnMod.IsKey);
             Assert.True(columnMod.IsRead);
             Assert.False(columnMod.IsWrite);
+            Assert.IsType<GenericBoxedValueReader<int>>(columnMod.BoxedValueReader);
 
             columnMod = command.ColumnModifications[1];
 
@@ -44,6 +46,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             Assert.False(columnMod.IsKey);
             Assert.False(columnMod.IsRead);
             Assert.True(columnMod.IsWrite);
+            Assert.Null(columnMod.BoxedValueReader);
         }
 
         [Fact]
@@ -52,7 +55,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             var entry = Createentry(EntityState.Added, generateKeyValues: true);
             entry.MarkAsTemporary(entry.EntityType.GetPrimaryKey().Properties[0], isTemporary: false);
 
-            var command = new ModificationCommand("T1",null, new ParameterNameGenerator(), p => p.Relational());
+            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource());
             command.AddEntry(entry);
 
             Assert.Equal("T1", command.TableName);
@@ -69,6 +72,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             Assert.True(columnMod.IsKey);
             Assert.False(columnMod.IsRead);
             Assert.True(columnMod.IsWrite);
+            Assert.Null(columnMod.BoxedValueReader);
 
             columnMod = command.ColumnModifications[1];
 
@@ -79,6 +83,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             Assert.False(columnMod.IsKey);
             Assert.False(columnMod.IsRead);
             Assert.True(columnMod.IsWrite);
+            Assert.Null(columnMod.BoxedValueReader);
         }
 
         [Fact]
@@ -86,7 +91,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         {
             var entry = Createentry(EntityState.Added);
 
-            var command = new ModificationCommand("T1",null, new ParameterNameGenerator(), p => p.Relational());
+            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource());
             command.AddEntry(entry);
 
             Assert.Equal("T1", command.TableName);
@@ -103,6 +108,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             Assert.True(columnMod.IsKey);
             Assert.False(columnMod.IsRead);
             Assert.True(columnMod.IsWrite);
+            Assert.Null(columnMod.BoxedValueReader);
 
             columnMod = command.ColumnModifications[1];
 
@@ -113,6 +119,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             Assert.False(columnMod.IsKey);
             Assert.False(columnMod.IsRead);
             Assert.True(columnMod.IsWrite);
+            Assert.Null(columnMod.BoxedValueReader);
         }
 
         [Fact]
@@ -120,7 +127,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         {
             var entry = Createentry(EntityState.Modified, generateKeyValues: true);
 
-            var command = new ModificationCommand("T1",null, new ParameterNameGenerator(), p => p.Relational());
+            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource());
             command.AddEntry(entry);
 
             Assert.Equal("T1", command.TableName);
@@ -137,6 +144,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             Assert.True(columnMod.IsKey);
             Assert.False(columnMod.IsRead);
             Assert.False(columnMod.IsWrite);
+            Assert.Null(columnMod.BoxedValueReader);
 
             columnMod = command.ColumnModifications[1];
 
@@ -147,6 +155,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             Assert.False(columnMod.IsKey);
             Assert.False(columnMod.IsRead);
             Assert.True(columnMod.IsWrite);
+            Assert.Null(columnMod.BoxedValueReader);
         }
 
         [Fact]
@@ -154,7 +163,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         {
             var entry = Createentry(EntityState.Modified);
 
-            var command = new ModificationCommand("T1",null, new ParameterNameGenerator(), p => p.Relational());
+            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource());
             command.AddEntry(entry);
 
             Assert.Equal("T1", command.TableName);
@@ -171,6 +180,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             Assert.True(columnMod.IsKey);
             Assert.False(columnMod.IsRead);
             Assert.False(columnMod.IsWrite);
+            Assert.Null(columnMod.BoxedValueReader);
 
             columnMod = command.ColumnModifications[1];
 
@@ -181,6 +191,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             Assert.False(columnMod.IsKey);
             Assert.False(columnMod.IsRead);
             Assert.True(columnMod.IsWrite);
+            Assert.Null(columnMod.BoxedValueReader);
         }
 
         [Fact]
@@ -188,7 +199,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         {
             var entry = Createentry(EntityState.Modified, computeNonKeyValue: true);
 
-            var command = new ModificationCommand("T1",null, new ParameterNameGenerator(), p => p.Relational());
+            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource());
             command.AddEntry(entry);
 
             Assert.Equal("T1", command.TableName);
@@ -205,6 +216,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             Assert.True(columnMod.IsKey);
             Assert.False(columnMod.IsRead);
             Assert.False(columnMod.IsWrite);
+            Assert.Null(columnMod.BoxedValueReader);
 
             columnMod = command.ColumnModifications[1];
 
@@ -215,6 +227,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             Assert.False(columnMod.IsKey);
             Assert.True(columnMod.IsRead);
             Assert.False(columnMod.IsWrite);
+            Assert.IsType<GenericBoxedValueReader<string>>(columnMod.BoxedValueReader);
         }
 
         [Fact]
@@ -222,7 +235,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         {
             var entry = Createentry(EntityState.Deleted);
 
-            var command = new ModificationCommand("T1",null, new ParameterNameGenerator(), p => p.Relational());
+            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource());
             command.AddEntry(entry);
 
             Assert.Equal("T1", command.TableName);
@@ -239,6 +252,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             Assert.True(columnMod.IsKey);
             Assert.False(columnMod.IsRead);
             Assert.False(columnMod.IsWrite);
+            Assert.Null(columnMod.BoxedValueReader);
         }
 
         [Fact]
@@ -246,7 +260,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         {
             var entry = Createentry(EntityState.Deleted, computeNonKeyValue: true);
 
-            var command = new ModificationCommand("T1",null, new ParameterNameGenerator(), p => p.Relational());
+            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource());
             command.AddEntry(entry);
 
             Assert.Equal("T1", command.TableName);
@@ -263,6 +277,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             Assert.True(columnMod.IsKey);
             Assert.False(columnMod.IsRead);
             Assert.False(columnMod.IsWrite);
+            Assert.Null(columnMod.BoxedValueReader);
 
             columnMod = command.ColumnModifications[1];
 
@@ -273,6 +288,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             Assert.False(columnMod.IsKey);
             Assert.False(columnMod.IsRead);
             Assert.False(columnMod.IsWrite);
+            Assert.Null(columnMod.BoxedValueReader);
         }
 
         [Fact]
@@ -280,7 +296,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         {
             var entry = Createentry(EntityState.Unchanged);
 
-            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational());
+            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource());
 
             Assert.Equal(
                 Strings.ModificationFunctionInvalidEntityState(EntityState.Unchanged),
@@ -292,7 +308,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         {
             var entry = Createentry(EntityState.Detached);
 
-            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational());
+            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource());
 
             Assert.Equal(
                 Strings.ModificationFunctionInvalidEntityState(EntityState.Detached),
@@ -305,7 +321,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             var entry = Createentry(
                 EntityState.Deleted, generateKeyValues: true, computeNonKeyValue: true);
 
-            var command = new ModificationCommand("T1",null, new ParameterNameGenerator(), p => p.Relational());
+            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource());
             command.AddEntry(entry);
 
             Assert.False(command.RequiresResultPropagation);
@@ -317,7 +333,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             var entry = Createentry(
                 EntityState.Added, generateKeyValues: true, computeNonKeyValue: true);
 
-            var command = new ModificationCommand("T1",null, new ParameterNameGenerator(), p => p.Relational());
+            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource());
             command.AddEntry(entry);
 
             Assert.True(command.RequiresResultPropagation);
@@ -328,7 +344,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         {
             var entry = Createentry(EntityState.Added);
 
-            var command = new ModificationCommand("T1",null, new ParameterNameGenerator(), p => p.Relational());
+            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource());
             command.AddEntry(entry);
 
             Assert.False(command.RequiresResultPropagation);
@@ -340,7 +356,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             var entry = Createentry(
                 EntityState.Modified, generateKeyValues: true, computeNonKeyValue: true);
 
-            var command = new ModificationCommand("T1",null, new ParameterNameGenerator(), p => p.Relational());
+            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource());
             command.AddEntry(entry);
 
             Assert.True(command.RequiresResultPropagation);
@@ -351,7 +367,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         {
             var entry = Createentry(EntityState.Modified, generateKeyValues: true);
 
-            var command = new ModificationCommand("T1",null, new ParameterNameGenerator(), p => p.Relational());
+            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource());
             command.AddEntry(entry);
 
             Assert.False(command.RequiresResultPropagation);

--- a/test/EntityFramework.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
@@ -9,6 +9,8 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Relational.Metadata;
 using Microsoft.Data.Entity.Relational.Update;
@@ -25,7 +27,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         [Fact]
         public void AddCommand_adds_command_if_possible()
         {
-            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational());
+            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource());
 
             var batch = new ModificationCommandBatchFake();
             batch.AddCommand(command);
@@ -42,7 +44,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         [Fact]
         public void AddCommand_does_not_add_command_if_not_possible()
         {
-            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational());
+            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource());
 
             var batch = new ModificationCommandBatchFake();
             batch.AddCommand(command);
@@ -58,7 +60,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         [Fact]
         public void AddCommand_does_not_add_command_if_resulting_sql_is_invalid()
         {
-            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational());
+            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource());
 
             var batch = new ModificationCommandBatchFake();
             batch.AddCommand(command);
@@ -76,7 +78,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         {
             var entry = CreateEntry(EntityState.Added);
 
-            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational());
+            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource());
             command.AddEntry(entry);
 
             var sqlGeneratorMock = new Mock<SqlGenerator>();
@@ -94,7 +96,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         {
             var entry = CreateEntry(EntityState.Modified, generateKeyValues: true);
 
-            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational());
+            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource());
             command.AddEntry(entry);
 
             var sqlGeneratorMock = new Mock<SqlGenerator>();
@@ -112,7 +114,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         {
             var entry = CreateEntry(EntityState.Deleted);
 
-            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational());
+            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource());
             command.AddEntry(entry);
 
             var sqlGeneratorMock = new Mock<SqlGenerator>();
@@ -130,7 +132,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         {
             var entry = CreateEntry(EntityState.Added);
 
-            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational());
+            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource());
             command.AddEntry(entry);
 
             var fakeSqlGenerator = new FakeSqlGenerator();
@@ -179,7 +181,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         public async Task ExecuteAsync_executes_batch_commands_and_consumes_reader()
         {
             var entry = CreateEntry(EntityState.Added);
-            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational());
+            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource());
             command.AddEntry(entry);
 
             var mockReader = CreateDataReaderMock();
@@ -198,7 +200,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             var entry = CreateEntry(EntityState.Added, generateKeyValues: true);
             entry.MarkAsTemporary(entry.EntityType.GetPrimaryKey().Properties[0]);
 
-            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational());
+            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource());
             command.AddEntry(entry);
 
             var batch = new ModificationCommandBatchFake(CreateDataReaderMock(new[] { "Col1" }, new List<object[]> { new object[] { 42 } }).Object);
@@ -217,7 +219,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
                 EntityState.Added, generateKeyValues: true, computeNonKeyValue: true);
             entry.MarkAsTemporary(entry.EntityType.GetPrimaryKey().Properties[0]);
 
-            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational());
+            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource());
             command.AddEntry(entry);
 
             var batch = new ModificationCommandBatchFake(CreateDataReaderMock(new[] { "Col1", "Col2" }, new List<object[]> { new object[] { 42, "FortyTwo" } }).Object);
@@ -235,7 +237,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             var entry = CreateEntry(
                 EntityState.Modified, generateKeyValues: true, computeNonKeyValue: true);
 
-            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational());
+            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource());
             command.AddEntry(entry);
 
             var batch = new ModificationCommandBatchFake(CreateDataReaderMock(new[] { "Col2" }, new List<object[]> { new object[] { "FortyTwo" } }).Object);
@@ -253,7 +255,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             var entry = CreateEntry(EntityState.Added, generateKeyValues: true);
             entry.MarkAsTemporary(entry.EntityType.GetPrimaryKey().Properties[0]);
 
-            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational());
+            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource());
             command.AddEntry(entry);
 
             var mockReader = CreateDataReaderMock(new[] { "Col1" }, new List<object[]>
@@ -274,7 +276,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         {
             var entry = CreateEntry(EntityState.Added);
 
-            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational());
+            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource());
             command.AddEntry(entry);
 
             var batch = new ModificationCommandBatchFake(CreateDataReaderMock(new[] { "Col1" }, new List<object[]> { new object[] { 42 } }).Object);
@@ -295,7 +297,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             var entry = CreateEntry(EntityState.Added, generateKeyValues: true);
             entry.MarkAsTemporary(entry.EntityType.GetPrimaryKey().Properties[0]);
 
-            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational());
+            var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational(), new BoxedValueReaderSource());
             command.AddEntry(entry);
 
             var batch = new ModificationCommandBatchFake(CreateDataReaderMock(new[] { "Col1" }, new List<object[]>()).Object);
@@ -326,7 +328,9 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
                             entry,
                             property,
                             property.Relational(),
-                            new ParameterNameGenerator(), false, true, false, false)
+                            new ParameterNameGenerator(), 
+                            null,
+                            false, true, false, false)
                     });
             batch.AddCommand(commandMock1.Object);
 
@@ -338,7 +342,9 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
                             entry,
                             property,
                             property.Relational(),
-                            new ParameterNameGenerator(), false, true, false, false)
+                            new ParameterNameGenerator(), 
+                            null,
+                            false, true, false, false)
                     });
             batch.AddCommand(commandMock2.Object);
 
@@ -366,7 +372,9 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
                     entry,
                     property,
                     property.Relational(),
-                    new ParameterNameGenerator(), false, true, false, false),
+                    new ParameterNameGenerator(), 
+                    null,
+                    false, true, false, false),
                 new RelationalTypeMapper());
 
             Assert.Equal(1, dbCommandMock.Object.Parameters.Count);
@@ -386,7 +394,9 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
                     entry,
                     property,
                     property.Relational(),
-                    new ParameterNameGenerator(), false, false, false, true),
+                    new ParameterNameGenerator(), 
+                    null,
+                    false, false, false, true),
                 new RelationalTypeMapper());
 
             Assert.Equal(1, dbCommandMock.Object.Parameters.Count);
@@ -406,7 +416,9 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
                     entry,
                     property,
                     property.Relational(),
-                    new ParameterNameGenerator(), false, true, false, true),
+                    new ParameterNameGenerator(), 
+                    null,
+                    false, true, false, true),
                 new RelationalTypeMapper());
 
             Assert.Equal(2, dbCommandMock.Object.Parameters.Count);
@@ -426,7 +438,9 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
                     entry,
                     property,
                     property.Relational(),
-                    new ParameterNameGenerator(), true, false, false, false),
+                    new ParameterNameGenerator(), 
+                    new GenericBoxedValueReader<int>(),
+                    true, false, false, false),
                 new RelationalTypeMapper());
 
             Assert.Equal(0, dbCommandMock.Object.Parameters.Count);

--- a/test/EntityFramework.SqlServer.FunctionalTests/CommandConfigurationTests.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/CommandConfigurationTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.FunctionalTests;
 using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Query;
 using Microsoft.Data.Entity.Relational;
@@ -121,7 +122,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 new LinqOperatorProvider(),
                 new RelationalResultOperatorHandler(),
                 source,
-                new EntityKeyFactorySource(),
+                new EntityKeyFactorySource(new BoxedValueReaderSource()),
                 new AsyncQueryMethodProvider(),
                 new CompositeMethodCallTranslator());
 

--- a/test/EntityFramework.SqlServer.Tests/EntityFramework.SqlServer.Tests.csproj
+++ b/test/EntityFramework.SqlServer.Tests/EntityFramework.SqlServer.Tests.csproj
@@ -89,7 +89,7 @@
     <Compile Include="SqlServerOptionsExtensionTest.cs" />
     <Compile Include="SqlServerConnectionTest.cs" />
     <Compile Include="SqlServerDataStoreSourceTest.cs" />
-    <Compile Include="SqlServerEntityServicesBuilderExtensionsTest.cs" />
+    <Compile Include="SqlServerEntityFrameworkServicesBuilderExtensionsTest.cs" />
     <Compile Include="SqlServerSequenceValueGeneratorTest.cs" />
     <Compile Include="SqlServerSqlGeneratorTest.cs" />
     <Compile Include="SqlServerTypeMapperTest.cs" />

--- a/test/EntityFramework.SqlServer.Tests/SqlServerEntityFrameworkServicesBuilderExtensionsTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerEntityFrameworkServicesBuilderExtensionsTest.cs
@@ -18,7 +18,7 @@ using Xunit;
 
 namespace Microsoft.Data.Entity.SqlServer.Tests
 {
-    public class SqlServerEntityServicesBuilderExtensionsTest : EntityServiceCollectionExtensionsTest
+    public class SqlServerEntityFrameworkServicesBuilderExtensionsTest : EntityFrameworkServiceCollectionExtensionsTest
     {
         [Fact]
         public override void Services_wire_up_correctly()

--- a/test/EntityFramework.SqlServer.Tests/Update/SqlServerModificationCommandBatchFactoryTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/Update/SqlServerModificationCommandBatchFactoryTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Relational;
 using Microsoft.Data.Entity.Relational.Update;
 using Microsoft.Data.Entity.SqlServer.Update;
@@ -23,8 +24,8 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Update
 
             var batch = factory.Create(optionsBuilder.Options);
 
-            Assert.True(factory.AddCommand(batch, new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.SqlServer())));
-            Assert.False(factory.AddCommand(batch, new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.SqlServer())));
+            Assert.True(factory.AddCommand(batch, new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.SqlServer(), new BoxedValueReaderSource())));
+            Assert.False(factory.AddCommand(batch, new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.SqlServer(), new BoxedValueReaderSource())));
         }
 
         [Fact]
@@ -37,8 +38,8 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Update
 
             var batch = factory.Create(optionsBuilder.Options);
 
-            Assert.True(factory.AddCommand(batch, new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.SqlServer())));
-            Assert.True(factory.AddCommand(batch, new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.SqlServer())));
+            Assert.True(factory.AddCommand(batch, new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.SqlServer(), new BoxedValueReaderSource())));
+            Assert.True(factory.AddCommand(batch, new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.SqlServer(), new BoxedValueReaderSource())));
         }
 
         [Fact]
@@ -51,8 +52,8 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Update
 
             var batch = factory.Create(optionsBuilder.Options);
 
-            Assert.True(factory.AddCommand(batch, new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.SqlServer())));
-            Assert.True(factory.AddCommand(batch, new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.SqlServer())));
+            Assert.True(factory.AddCommand(batch, new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.SqlServer(), new BoxedValueReaderSource())));
+            Assert.True(factory.AddCommand(batch, new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.SqlServer(), new BoxedValueReaderSource())));
         }
 
         [Fact]
@@ -69,8 +70,8 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Update
 
             var batch = factory.Create(optionsBuilder.Options);
 
-            Assert.True(factory.AddCommand(batch, new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.SqlServer())));
-            Assert.True(factory.AddCommand(batch, new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.SqlServer())));
+            Assert.True(factory.AddCommand(batch, new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.SqlServer(), new BoxedValueReaderSource())));
+            Assert.True(factory.AddCommand(batch, new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.SqlServer(), new BoxedValueReaderSource())));
         }
 
         private class TestRelationalOptionsExtension : RelationalOptionsExtension

--- a/test/EntityFramework.SqlServer.Tests/Update/SqlServerModificationCommandBatchTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/Update/SqlServerModificationCommandBatchTest.cs
@@ -1,7 +1,8 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.Data.Entity.Relational;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Relational.Update;
 using Microsoft.Data.Entity.SqlServer.Update;
 using Xunit;
@@ -15,8 +16,8 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Update
         {
             var batch = new SqlServerModificationCommandBatch(new SqlServerSqlGenerator(), 1);
 
-            Assert.True(batch.AddCommand(new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.SqlServer())));
-            Assert.False(batch.AddCommand(new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.SqlServer())));
+            Assert.True(batch.AddCommand(new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.SqlServer(), new BoxedValueReaderSource())));
+            Assert.False(batch.AddCommand(new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.SqlServer(), new BoxedValueReaderSource())));
         }
     }
 }


### PR DESCRIPTION
This change allows cached delegates to be created that will call the generic IValueReader.ReadValue method using the type of the property. This means that when a RelationalTypedValueReader is used the generic GetFieldValue method will be called on the underlying data reader, thereby giving the provider the contextual information needed to create objects of the correct type in cases where this cannot be determined by the database metadata alone.

This mechanism is being used in the update pipeline and for key generation. It is not yet being used in query or for reading shadow state properties.