### PR TITLE
Couple of small tweaks to DbContextOptionsBuilder

### DIFF
--- a/src/EntityFramework.Core/DbContextOptionsBuilder.cs
+++ b/src/EntityFramework.Core/DbContextOptionsBuilder.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
-using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Utilities;
 
@@ -26,6 +26,8 @@ namespace Microsoft.Data.Entity
         }
 
         public virtual DbContextOptions Options => _options;
+
+        public virtual bool IsConfigured => _options.Extensions.Any();
 
         public virtual DbContextOptionsBuilder UseModel([NotNull] IModel model)
         {

--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -138,6 +138,7 @@
     <Compile Include="Internal\DbSetFinder.cs" />
     <Compile Include="Internal\DbSetInitializer.cs" />
     <Compile Include="Internal\DbSetSource.cs" />
+    <Compile Include="Internal\EntityFrameworkConfigurationExtensions.cs" />
     <Compile Include="Internal\IModelValidator.cs" />
     <Compile Include="Internal\LoggingModelValidator.cs" />
     <Compile Include="Internal\ModelSource.cs" />

--- a/src/EntityFramework.Core/Infrastructure/DbContextOptions`.cs
+++ b/src/EntityFramework.Core/Infrastructure/DbContextOptions`.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Utilities;
+using Microsoft.Framework.ConfigurationModel;
 
 namespace Microsoft.Data.Entity.Infrastructure
 {
@@ -13,14 +14,15 @@ namespace Microsoft.Data.Entity.Infrastructure
         where TContext : DbContext
     {
         public DbContextOptions()
-            : base(new Dictionary<string, string>(), new Dictionary<Type, IDbContextOptionsExtension>())
+            : base(new Dictionary<string, string>(), new Dictionary<Type, IDbContextOptionsExtension>(), null)
         {
         }
 
         public DbContextOptions(
             [NotNull] IReadOnlyDictionary<string, string> rawOptions,
-            [NotNull] IReadOnlyDictionary<Type, IDbContextOptionsExtension> extensions)
-            : base(rawOptions, extensions)
+            [NotNull] IReadOnlyDictionary<Type, IDbContextOptionsExtension> extensions,
+            [CanBeNull] IConfiguration configuration)
+            : base(rawOptions, extensions, configuration)
         {
         }
 
@@ -31,7 +33,7 @@ namespace Microsoft.Data.Entity.Infrastructure
             var extensions = Extensions.ToDictionary(p => p.GetType(), p => p);
             extensions[typeof(TExtension)] = extension;
 
-            return new DbContextOptions<TContext>(RawOptions, extensions);
+            return new DbContextOptions<TContext>(RawOptions, extensions, Configuration);
         }
     }
 }

--- a/src/EntityFramework.Core/Internal/DbContextOptionsParser.cs
+++ b/src/EntityFramework.Core/Internal/DbContextOptionsParser.cs
@@ -13,7 +13,6 @@ namespace Microsoft.Data.Entity.Internal
     public class DbContextOptionsParser
     {
         private const string EntityFrameworkKey = "EntityFramework";
-        private const string ConnectionStringKey = "ConnectionString";
 
         public static DbContextOptions<TContext> DbContextOptionsFactory<TContext>(
             [NotNull] IServiceProvider serviceProvider,
@@ -25,7 +24,8 @@ namespace Microsoft.Data.Entity.Internal
 
             var options = new DbContextOptions<TContext>(
                 parser.ReadRawOptions<TContext>(configuration),
-                new Dictionary<Type, IDbContextOptionsExtension>());
+                new Dictionary<Type, IDbContextOptionsExtension>(),
+                configuration);
 
             if (optionsAction != null)
             {
@@ -67,24 +67,6 @@ namespace Microsoft.Data.Entity.Internal
                         string.Concat(contextKey, Constants.KeyDelimiter, key),
                         string.Concat(keyPrefix, key, Constants.KeyDelimiter));
                     continue;
-                }
-
-                if (key.Equals(ConnectionStringKey, StringComparison.OrdinalIgnoreCase))
-                {
-                    // Check if the value is redirection to other key
-                    var firstequals = value.IndexOf('=');
-                    if ((firstequals > 0)
-                        && (value.IndexOf('=', firstequals + 1) < 0)
-                        && (value.Substring(0, firstequals).Trim().Equals(
-                            "name", StringComparison.OrdinalIgnoreCase)))
-                    {
-                        var redirectionKey = value.Substring(firstequals + 1).Trim();
-                        if (string.IsNullOrEmpty(redirectionKey)
-                            || !configuration.TryGet(redirectionKey, out value))
-                        {
-                            throw new InvalidOperationException(Strings.ConnectionStringNotFound(redirectionKey));
-                        }
-                    }
                 }
 
                 options[string.Concat(keyPrefix, key)] = value;

--- a/src/EntityFramework.Core/Internal/EntityFrameworkConfigurationExtensions.cs
+++ b/src/EntityFramework.Core/Internal/EntityFrameworkConfigurationExtensions.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.Framework.ConfigurationModel;
+
+namespace Microsoft.Data.Entity.Internal
+{
+    public static class EntityFrameworkConfigurationExtensions
+    {
+        public static string ResolveConnectionString([CanBeNull] this IConfiguration configuration, [NotNull] string connectionString)
+        {
+            var firstequals = connectionString.IndexOf('=');
+            if ((firstequals > 0)
+                && (connectionString.IndexOf('=', firstequals + 1) < 0)
+                && (connectionString.Substring(0, firstequals).Trim().Equals(
+                    "name", StringComparison.OrdinalIgnoreCase)))
+            {
+                var redirectionKey = connectionString.Substring(firstequals + 1).Trim();
+                if (configuration == null
+                    || string.IsNullOrEmpty(redirectionKey)
+                    || !configuration.TryGet(redirectionKey, out connectionString))
+                {
+                    throw new InvalidOperationException(Strings.ConnectionStringNotFound(redirectionKey));
+                }
+            }
+
+            return connectionString;
+        }
+    }
+}

--- a/test/EntityFramework.Core.Tests/DbContextOptionsParserTest.cs
+++ b/test/EntityFramework.Core.Tests/DbContextOptionsParserTest.cs
@@ -1,10 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
 using System.IO;
-using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Internal;
 using Microsoft.Framework.ConfigurationModel;
 using Xunit;
@@ -18,10 +15,10 @@ namespace Microsoft.Data.Entity.Tests
         {
             var config = new Configuration
                 (
-                    new MemoryConfigurationSource
-                        {
-                            { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "MyConnectionString" }
-                        }
+                new MemoryConfigurationSource
+                    {
+                        { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "MyConnectionString" }
+                    }
                 );
 
             var rawOptions = new DbContextOptionsParser().ReadRawOptions<MyContext>(config);
@@ -36,10 +33,10 @@ namespace Microsoft.Data.Entity.Tests
         {
             var config = new Configuration
                 (
-                    new MemoryConfigurationSource
-                        {
-                            { "EntityFramework:" + typeof(MyContext).FullName + ":ConnectionString", "MyConnectionString" }
-                        }
+                new MemoryConfigurationSource
+                    {
+                        { "EntityFramework:" + typeof(MyContext).FullName + ":ConnectionString", "MyConnectionString" }
+                    }
                 );
 
             var rawOptions = new DbContextOptionsParser().ReadRawOptions<MyContext>(config);
@@ -53,171 +50,14 @@ namespace Microsoft.Data.Entity.Tests
         }
 
         [Fact]
-        public void Indirect_connection_string_can_be_specified_with_name()
-        {
-            var config = new Configuration
-                (
-                    new MemoryConfigurationSource
-                        {
-                            { "Data:DefaultConnection:ConnectionString", "MyConnectionString" },
-                            { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "Name=Data:DefaultConnection:ConnectionString" }
-                        }
-                );
-
-            var rawOptions = new DbContextOptionsParser().ReadRawOptions<MyContext>(config);
-
-            Assert.Equal(1, rawOptions.Count);
-            Assert.Equal("MyConnectionString", rawOptions["ConnectionString"]);
-        }
-
-        [Fact]
-        public void Indirect_connection_string_is_read_case_insensitively()
-        {
-            var config = new Configuration
-                (
-                    new MemoryConfigurationSource
-                        {
-                            { "Data:DefaultConnection:ConnectionString", "MyConnectionString" },
-                            { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "name=Data:DefaultConnection:ConnectionString" }
-                        }
-                );
-
-            var rawOptions = new DbContextOptionsParser().ReadRawOptions<MyContext>(config);
-
-            Assert.Equal(1, rawOptions.Count);
-            Assert.Equal("MyConnectionString", rawOptions["ConnectionString"]);
-        }
-
-        [Fact]
-        public void Indirect_connection_string_is_read_removing_whitespaces()
-        {
-            var config = new Configuration
-                (
-                    new MemoryConfigurationSource
-                        {
-                            { "Data:DefaultConnection:ConnectionString", "MyConnectionString" },
-                            { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "name = Data:DefaultConnection:ConnectionString" }
-                        }
-                );
-
-            var rawOptions = new DbContextOptionsParser().ReadRawOptions<MyContext>(config);
-
-            Assert.Equal(1, rawOptions.Count);
-            Assert.Equal("MyConnectionString", rawOptions["ConnectionString"]);
-        }
-
-        [Fact]
-        public void Indirect_connection_string_must_have_only_one_equal_sign()
-        {
-            var config = new Configuration
-                (
-                    new MemoryConfigurationSource
-                        {
-                            { "Data:DefaultConnection:ConnectionString", "MyConnectionString" },
-                            { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "Name=Data:DefaultConnection:ConnectionString;Key=Value" }
-                        }
-                );
-
-            var rawOptions = new DbContextOptionsParser().ReadRawOptions<MyContext>(config);
-
-            Assert.Equal(1, rawOptions.Count);
-            Assert.Equal("Name=Data:DefaultConnection:ConnectionString;Key=Value", rawOptions["ConnectionString"]);
-        }
-
-        [Fact]
-        public void Single_key_value_pair_does_not_cause_redirection_if_key_is_not_name()
-        {
-            var config = new Configuration
-                (
-                    new MemoryConfigurationSource
-                        {
-                            { "Data:DefaultConnection:ConnectionString", "MyConnectionString" },
-                            { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "Data Source=Data:DefaultConnection:ConnectionString" }
-                        }
-                );
-
-            var rawOptions = new DbContextOptionsParser().ReadRawOptions<MyContext>(config);
-
-            Assert.Equal(1, rawOptions.Count);
-            Assert.Equal("Data Source=Data:DefaultConnection:ConnectionString", rawOptions["ConnectionString"]);
-        }
-
-        [Fact]
-        public void Connection_string_starting_with_equal_sign_does_not_cause_redirection()
-        {
-            var config = new Configuration
-                (
-                    new MemoryConfigurationSource
-                        {
-                            { "Data:DefaultConnection:ConnectionString", "MyConnectionString" },
-                            { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "=Data:DefaultConnection:ConnectionString" }
-                        }
-                );
-
-            var rawOptions = new DbContextOptionsParser().ReadRawOptions<MyContext>(config);
-
-            Assert.Equal(1, rawOptions.Count);
-            Assert.Equal("=Data:DefaultConnection:ConnectionString", rawOptions["ConnectionString"]);
-        }
-
-        [Fact]
-        public void Equal_sign_as_connection_string_does_not_cause_redirection()
-        {
-            var config = new Configuration
-                (
-                    new MemoryConfigurationSource
-                        {
-                            { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "=" }
-                        }
-                );
-
-            var rawOptions = new DbContextOptionsParser().ReadRawOptions<MyContext>(config);
-
-            Assert.Equal(1, rawOptions.Count);
-            Assert.Equal("=", rawOptions["ConnectionString"]);
-        }
-
-        [Fact]
-        public void Throws_when_indirect_connection_string_is_not_found()
-        {
-            var config = new Configuration
-                (
-                    new MemoryConfigurationSource
-                        {
-                            { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "Name=MyConnection" }
-                        }
-                );
-
-            Assert.Equal(Strings.ConnectionStringNotFound("MyConnection"),
-                Assert.Throws<InvalidOperationException>(() =>
-                    new DbContextOptionsParser().ReadRawOptions<MyContext>(config)).Message);
-        }
-
-        [Fact]
-        public void Throws_when_indirect_connection_string_is_empty()
-        {
-            var config = new Configuration
-                (
-                    new MemoryConfigurationSource
-                        {
-                            { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "Name=" }
-                        }
-                );
-
-            Assert.Equal(Strings.ConnectionStringNotFound(""),
-                Assert.Throws<InvalidOperationException>(() =>
-                    new DbContextOptionsParser().ReadRawOptions<MyContext>(config)).Message);
-        }
-
-        [Fact]
         public void Key_searching_is_case_insensitive()
         {
             var config = new Configuration
                 (
-                    new MemoryConfigurationSource
-                        {
-                            { "entityFramework:" + typeof(MyContext).Name + ":connectionString", "MyConnectionString" }
-                        }
+                new MemoryConfigurationSource
+                    {
+                        { "entityFramework:" + typeof(MyContext).Name + ":connectionString", "MyConnectionString" }
+                    }
                 );
 
             var rawOptions = new DbContextOptionsParser().ReadRawOptions<MyContext>(config);
@@ -231,14 +71,14 @@ namespace Microsoft.Data.Entity.Tests
         {
             var config = new Configuration
                 (
-                    new MemoryConfigurationSource
-                        {
-                            { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "MyConnectionString" },
-                            { "EntityFramework:" + typeof(MyContext).Name + ":SqlServer:MaxBatchSize", "1" },
-                            { "EntityFramework:" + typeof(MyContext).Name + ":SqlServer:AnotherSqlServerOption", "SqlServerOptionValue" },
-                            { "EntityFramework:" + typeof(MyContext).Name + ":SomeProvider:ProviderSpecificOption", "OptionValue" },
-                            { "EntityFramework:" + typeof(MyContext).Name + ":Level1:Level2:Level3", "NestedLevelValue" }
-                        }
+                new MemoryConfigurationSource
+                    {
+                        { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "MyConnectionString" },
+                        { "EntityFramework:" + typeof(MyContext).Name + ":SqlServer:MaxBatchSize", "1" },
+                        { "EntityFramework:" + typeof(MyContext).Name + ":SqlServer:AnotherSqlServerOption", "SqlServerOptionValue" },
+                        { "EntityFramework:" + typeof(MyContext).Name + ":SomeProvider:ProviderSpecificOption", "OptionValue" },
+                        { "EntityFramework:" + typeof(MyContext).Name + ":Level1:Level2:Level3", "NestedLevelValue" }
+                    }
                 );
 
             var rawOptions = new DbContextOptionsParser().ReadRawOptions<MyContext>(config);
@@ -256,14 +96,14 @@ namespace Microsoft.Data.Entity.Tests
         {
             var config = new Configuration
                 (
-                    new MemoryConfigurationSource
-                        {
-                            { "EntityFramework:" + typeof(MyContext).FullName + ":ConnectionString", "MyConnectionString" },
-                            { "EntityFramework:" + typeof(MyContext).FullName + ":SqlServer:MaxBatchSize", "1" },
-                            { "EntityFramework:" + typeof(MyContext).FullName + ":SqlServer:AnotherSqlServerOption", "SqlServerOptionValue" },
-                            { "EntityFramework:" + typeof(MyContext).FullName + ":SomeProvider:ProviderSpecificOption", "OptionValue" },
-                            { "EntityFramework:" + typeof(MyContext).FullName + ":Level1:Level2:Level3", "NestedLevelValue" }
-                        }
+                new MemoryConfigurationSource
+                    {
+                        { "EntityFramework:" + typeof(MyContext).FullName + ":ConnectionString", "MyConnectionString" },
+                        { "EntityFramework:" + typeof(MyContext).FullName + ":SqlServer:MaxBatchSize", "1" },
+                        { "EntityFramework:" + typeof(MyContext).FullName + ":SqlServer:AnotherSqlServerOption", "SqlServerOptionValue" },
+                        { "EntityFramework:" + typeof(MyContext).FullName + ":SomeProvider:ProviderSpecificOption", "OptionValue" },
+                        { "EntityFramework:" + typeof(MyContext).FullName + ":Level1:Level2:Level3", "NestedLevelValue" }
+                    }
                 );
 
             var rawOptions = new DbContextOptionsParser().ReadRawOptions<MyContext>(config);
@@ -281,14 +121,14 @@ namespace Microsoft.Data.Entity.Tests
         {
             var config = new Configuration
                 (
-                    new MemoryConfigurationSource
-                        {
-                            { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "MyConnectionString" },
-                            { "EntityFramework:" + typeof(MyContext).Name + ":SqlServer:MaxBatchSize", "1" },
-                            { "EntityFramework:" + typeof(MyContext).Name + ":SqlServer:AnotherSqlServerOption", "SqlServerOptionValue" },
-                            { "EntityFramework:" + typeof(MyContext).Name + ":SomeProvider:ProviderSpecificOption", "OptionValue" },
-                            { "EntityFramework:" + typeof(MyContext).Name + ":Level1:Level2:Level3", "NestedLevelValue" }
-                        }
+                new MemoryConfigurationSource
+                    {
+                        { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "MyConnectionString" },
+                        { "EntityFramework:" + typeof(MyContext).Name + ":SqlServer:MaxBatchSize", "1" },
+                        { "EntityFramework:" + typeof(MyContext).Name + ":SqlServer:AnotherSqlServerOption", "SqlServerOptionValue" },
+                        { "EntityFramework:" + typeof(MyContext).Name + ":SomeProvider:ProviderSpecificOption", "OptionValue" },
+                        { "EntityFramework:" + typeof(MyContext).Name + ":Level1:Level2:Level3", "NestedLevelValue" }
+                    }
                 );
 
             var rawOptions = new DbContextOptionsParser().ReadRawOptions<MyContext>(config);
@@ -306,14 +146,14 @@ namespace Microsoft.Data.Entity.Tests
         {
             var config = new Configuration
                 (
-                    new MemoryConfigurationSource
-                        {
-                            { "EntityFramework:" + typeof(MyContext).FullName + ":ConnectionString", "MyConnectionString" },
-                            { "EntityFramework:" + typeof(MyContext).FullName + ":SqlServer:MaxBatchSize", "1" },
-                            { "EntityFramework:" + typeof(MyContext).FullName + ":SqlServer:AnotherSqlServerOption", "SqlServerOptionValue" },
-                            { "EntityFramework:" + typeof(MyContext).FullName + ":SomeProvider:ProviderSpecificOption", "OptionValue" },
-                            { "EntityFramework:" + typeof(MyContext).FullName + ":Level1:Level2:Level3", "NestedLevelValue" }
-                        }
+                new MemoryConfigurationSource
+                    {
+                        { "EntityFramework:" + typeof(MyContext).FullName + ":ConnectionString", "MyConnectionString" },
+                        { "EntityFramework:" + typeof(MyContext).FullName + ":SqlServer:MaxBatchSize", "1" },
+                        { "EntityFramework:" + typeof(MyContext).FullName + ":SqlServer:AnotherSqlServerOption", "SqlServerOptionValue" },
+                        { "EntityFramework:" + typeof(MyContext).FullName + ":SomeProvider:ProviderSpecificOption", "OptionValue" },
+                        { "EntityFramework:" + typeof(MyContext).FullName + ":Level1:Level2:Level3", "NestedLevelValue" }
+                    }
                 );
 
             var rawOptions = new DbContextOptionsParser().ReadRawOptions<MyContext>(config);
@@ -355,11 +195,11 @@ namespace Microsoft.Data.Entity.Tests
         {
             var config = new Configuration
                 (
-                    new MemoryConfigurationSource
-                        {
-                            { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "ContextNameConnectionString" },
-                            { "EntityFramework:" + typeof(MyContext).FullName + ":ConnectionString", "ContextFullNameConnectionString" }
-                        }
+                new MemoryConfigurationSource
+                    {
+                        { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "ContextNameConnectionString" },
+                        { "EntityFramework:" + typeof(MyContext).FullName + ":ConnectionString", "ContextFullNameConnectionString" }
+                    }
                 );
 
             var rawOptions = new DbContextOptionsParser().ReadRawOptions<MyContext>(config);

--- a/test/EntityFramework.Core.Tests/DbContextOptionsTest.cs
+++ b/test/EntityFramework.Core.Tests/DbContextOptionsTest.cs
@@ -3,7 +3,6 @@
 
 using System.Linq;
 using Microsoft.Data.Entity.Infrastructure;
-using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
 using Xunit;
 
@@ -59,6 +58,18 @@ namespace Microsoft.Data.Entity.Tests
             Assert.Contains(extension2, optionsBuilder.Options.Extensions);
 
             Assert.Same(extension2, optionsBuilder.Options.FindExtension<FakeDbContextOptionsExtension1>());
+        }
+
+        [Fact]
+        public void IsConfigured_returns_true_if_any_extensions_have_been_added()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder();
+
+            Assert.False(optionsBuilder.IsConfigured);
+
+            ((IOptionsBuilderExtender)optionsBuilder).AddOrUpdateExtension(new FakeDbContextOptionsExtension2());
+
+            Assert.True(optionsBuilder.IsConfigured);
         }
 
         private class FakeDbContextOptionsExtension1 : IDbContextOptionsExtension

--- a/test/EntityFramework.Core.Tests/DbContextTest.cs
+++ b/test/EntityFramework.Core.Tests/DbContextTest.cs
@@ -2030,7 +2030,9 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.NotNull(contextOptions);
                 var rawOptions = ((IDbContextOptions)contextOptions).RawOptions;
                 Assert.Equal(1, rawOptions.Count);
-                Assert.Equal("MyConnectionString", rawOptions["ConnectionString"]);
+                Assert.Equal("Name=Data:DefaultConnection:ConnectionString", rawOptions["ConnectionString"]);
+
+                Assert.Equal("MyConnectionString", config.ResolveConnectionString(rawOptions["ConnectionString"]));
             }
         }
 

--- a/test/EntityFramework.Core.Tests/EntityFramework.Core.Tests.csproj
+++ b/test/EntityFramework.Core.Tests/EntityFramework.Core.Tests.csproj
@@ -109,6 +109,7 @@
     <Compile Include="DbSetTest.cs" />
     <Compile Include="DbSetySourceTest.cs" />
     <Compile Include="DbContextOptionsTest.cs" />
+    <Compile Include="EntityFrameworkConfigurationExtensionsTest.cs" />
     <Compile Include="EntitySetFinderTest.cs" />
     <Compile Include="Extensions\EntityFrameworkServiceCollectionExtensionsTest.cs" />
     <Compile Include="Extensions\ForeignKeyExtensionsTest.cs" />

--- a/test/EntityFramework.Core.Tests/EntityFrameworkConfigurationExtensionsTest.cs
+++ b/test/EntityFramework.Core.Tests/EntityFrameworkConfigurationExtensionsTest.cs
@@ -1,0 +1,186 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Data.Entity.Internal;
+using Microsoft.Framework.ConfigurationModel;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Tests
+{
+    public class EntityFrameworkConfigurationExtensionsTest
+    {
+        [Fact]
+        public void Indirect_connection_string_can_be_specified_with_name()
+        {
+            var config = new Configuration
+                (
+                new MemoryConfigurationSource
+                    {
+                        { "Data:DefaultConnection:ConnectionString", "MyConnectionString" },
+                        { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "Name=Data:DefaultConnection:ConnectionString" }
+                    }
+                );
+
+            var rawOptions = new DbContextOptionsParser().ReadRawOptions<MyContext>(config);
+
+            Assert.Equal(1, rawOptions.Count);
+            Assert.Equal("MyConnectionString", config.ResolveConnectionString(config.ResolveConnectionString(rawOptions["ConnectionString"])));
+        }
+
+        [Fact]
+        public void Indirect_connection_string_is_read_case_insensitively()
+        {
+            var config = new Configuration
+                (
+                new MemoryConfigurationSource
+                    {
+                        { "Data:DefaultConnection:ConnectionString", "MyConnectionString" },
+                        { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "name=Data:DefaultConnection:ConnectionString" }
+                    }
+                );
+
+            var rawOptions = new DbContextOptionsParser().ReadRawOptions<MyContext>(config);
+
+            Assert.Equal(1, rawOptions.Count);
+            Assert.Equal("MyConnectionString", config.ResolveConnectionString(config.ResolveConnectionString(rawOptions["ConnectionString"])));
+        }
+
+        [Fact]
+        public void Indirect_connection_string_is_read_removing_whitespaces()
+        {
+            var config = new Configuration
+                (
+                new MemoryConfigurationSource
+                    {
+                        { "Data:DefaultConnection:ConnectionString", "MyConnectionString" },
+                        { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "name = Data:DefaultConnection:ConnectionString" }
+                    }
+                );
+
+            var rawOptions = new DbContextOptionsParser().ReadRawOptions<MyContext>(config);
+
+            Assert.Equal(1, rawOptions.Count);
+            Assert.Equal("MyConnectionString", config.ResolveConnectionString(rawOptions["ConnectionString"]));
+        }
+
+        [Fact]
+        public void Indirect_connection_string_must_have_only_one_equal_sign()
+        {
+            var config = new Configuration
+                (
+                new MemoryConfigurationSource
+                    {
+                        { "Data:DefaultConnection:ConnectionString", "MyConnectionString" },
+                        { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "Name=Data:DefaultConnection:ConnectionString;Key=Value" }
+                    }
+                );
+
+            var rawOptions = new DbContextOptionsParser().ReadRawOptions<MyContext>(config);
+
+            Assert.Equal(1, rawOptions.Count);
+            Assert.Equal("Name=Data:DefaultConnection:ConnectionString;Key=Value", config.ResolveConnectionString(rawOptions["ConnectionString"]));
+        }
+
+        [Fact]
+        public void Single_key_value_pair_does_not_cause_redirection_if_key_is_not_name()
+        {
+            var config = new Configuration
+                (
+                new MemoryConfigurationSource
+                    {
+                        { "Data:DefaultConnection:ConnectionString", "MyConnectionString" },
+                        { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "Data Source=Data:DefaultConnection:ConnectionString" }
+                    }
+                );
+
+            var rawOptions = new DbContextOptionsParser().ReadRawOptions<MyContext>(config);
+
+            Assert.Equal(1, rawOptions.Count);
+            Assert.Equal("Data Source=Data:DefaultConnection:ConnectionString", config.ResolveConnectionString(rawOptions["ConnectionString"]));
+        }
+
+        [Fact]
+        public void Connection_string_starting_with_equal_sign_does_not_cause_redirection()
+        {
+            var config = new Configuration
+                (
+                new MemoryConfigurationSource
+                    {
+                        { "Data:DefaultConnection:ConnectionString", "MyConnectionString" },
+                        { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "=Data:DefaultConnection:ConnectionString" }
+                    }
+                );
+
+            var rawOptions = new DbContextOptionsParser().ReadRawOptions<MyContext>(config);
+
+            Assert.Equal(1, rawOptions.Count);
+            Assert.Equal("=Data:DefaultConnection:ConnectionString", config.ResolveConnectionString(rawOptions["ConnectionString"]));
+        }
+
+        [Fact]
+        public void Equal_sign_as_connection_string_does_not_cause_redirection()
+        {
+            var config = new Configuration
+                (
+                new MemoryConfigurationSource
+                    {
+                        { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "=" }
+                    }
+                );
+
+            var rawOptions = new DbContextOptionsParser().ReadRawOptions<MyContext>(config);
+
+            Assert.Equal(1, rawOptions.Count);
+            Assert.Equal("=", config.ResolveConnectionString(rawOptions["ConnectionString"]));
+        }
+
+        [Fact]
+        public void Throws_when_indirect_connection_string_is_not_found()
+        {
+            var config = new Configuration
+                (
+                new MemoryConfigurationSource
+                    {
+                        { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "Name=MyConnection" }
+                    }
+                );
+
+            var connectionString = new DbContextOptionsParser().ReadRawOptions<MyContext>(config)["ConnectionString"];
+
+            Assert.Equal(Strings.ConnectionStringNotFound("MyConnection"),
+                Assert.Throws<InvalidOperationException>(() =>
+                    config.ResolveConnectionString(connectionString)).Message);
+        }
+
+        [Fact]
+        public void Throws_when_indirect_connection_string_is_empty()
+        {
+            var config = new Configuration
+                (
+                new MemoryConfigurationSource
+                    {
+                        { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "Name=" }
+                    }
+                );
+
+            var connectionString = new DbContextOptionsParser().ReadRawOptions<MyContext>(config)["ConnectionString"];
+
+            Assert.Equal(Strings.ConnectionStringNotFound(""),
+                Assert.Throws<InvalidOperationException>(() =>
+                    config.ResolveConnectionString(connectionString)).Message);
+        }
+
+        [Fact]
+        public void Throws_when_indirect_connection_string_is_used_without_configuration()
+        {
+            Assert.Equal(Strings.ConnectionStringNotFound("Aero"),
+                Assert.Throws<InvalidOperationException>(() =>
+                    EntityFrameworkConfigurationExtensions.ResolveConnectionString(null, "name=Aero")).Message);
+        }
+
+        private class MyContext : DbContext
+        {
+        }
+    }
+}

--- a/test/EntityFramework.Relational.Tests/RelationalOptionsExtensionTest.cs
+++ b/test/EntityFramework.Relational.Tests/RelationalOptionsExtensionTest.cs
@@ -207,7 +207,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
 
         private static DbContextOptions<DbContext> CreateOptions(IReadOnlyDictionary<string, string> rawOptions)
         {
-            return new DbContextOptions<DbContext>(rawOptions, new Dictionary<Type, IDbContextOptionsExtension>());
+            return new DbContextOptions<DbContext>(rawOptions, new Dictionary<Type, IDbContextOptionsExtension>(), null);
         }
 
         private class TestRelationalOptionsExtension : RelationalOptionsExtension

--- a/test/EntityFramework.SqlServer.Tests/Update/SqlServerModificationCommandBatchFactoryTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/Update/SqlServerModificationCommandBatchFactoryTest.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Update
 
             var rawOptions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { { "MaxBatchSize", "1" } };
             var optionsExtension = new TestRelationalOptionsExtension(
-                new DbContextOptions<DbContext>(rawOptions, new Dictionary<Type, IDbContextOptionsExtension>()));
+                new DbContextOptions<DbContext>(rawOptions, new Dictionary<Type, IDbContextOptionsExtension>(), null));
 
             var optionsBuilder = new DbContextOptionsBuilder();
             ((IOptionsBuilderExtender)optionsBuilder).AddOrUpdateExtension(optionsExtension);


### PR DESCRIPTION
- Add IsConfigured property which returns true if any UseXxx method has been called--in other words, if any extension has been added
- Allow name=Foo syntax for connection strings to be used in the UseSqlServer extension methods