### PR TITLE
Value generation model validator

### DIFF
--- a/src/EntityFramework.Core/Internal/ModelValidator.cs
+++ b/src/EntityFramework.Core/Internal/ModelValidator.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.Data.Entity.Metadata;
 
@@ -9,7 +11,11 @@ namespace Microsoft.Data.Entity.Internal
 {
     public abstract class ModelValidator : IModelValidator
     {
-        public virtual void Validate(IModel model) => EnsureNoShadowKeys(model);
+        public override void Validate(IModel model)
+        {
+            EnsureNoShadowKeys(model);
+            EnsureValidForeignKeyChains(model);
+        }
 
         protected void EnsureNoShadowKeys(IModel model)
         {
@@ -42,6 +48,119 @@ namespace Microsoft.Data.Entity.Internal
                     }
                 }
             }
+        }
+
+        protected void EnsureValidForeignKeyChains(IModel model)
+        {
+            var verifiedProperties = new Dictionary<IProperty, IProperty>();
+            foreach (var entityType in model.EntityTypes)
+            {
+                foreach (var foreignKey in entityType.ForeignKeys)
+                {
+                    foreach (var referencedProperty in foreignKey.Properties)
+                    {
+                        string errorMessage;
+                        VerifyRootPrincipal(referencedProperty, verifiedProperties, ImmutableList<IForeignKey>.Empty, out errorMessage);
+                        if (errorMessage != null)
+                        {
+                            ShowError(errorMessage);
+                        }
+                    }
+                }
+            }
+        }
+
+        private IProperty VerifyRootPrincipal(
+            IProperty principalProperty,
+            Dictionary<IProperty, IProperty> verifiedProperties,
+            ImmutableList<IForeignKey> visitedForeignKeys,
+            out string errorMessage)
+        {
+            errorMessage = null;
+            IProperty rootPrincipal;
+            if (verifiedProperties.TryGetValue(principalProperty, out rootPrincipal))
+            {
+                return rootPrincipal;
+            }
+
+            var rootPrincipals = new Dictionary<IProperty, IForeignKey>();
+            foreach (var foreignKey in principalProperty.EntityType.ForeignKeys)
+            {
+                for (var index = 0; index < foreignKey.Properties.Count; index++)
+                {
+                    if (principalProperty == foreignKey.Properties[index])
+                    {
+                        var nextPrincipalProperty = foreignKey.ReferencedProperties[index];
+                        if (visitedForeignKeys.Contains(foreignKey))
+                        {
+                            var cycleStart = visitedForeignKeys.IndexOf(foreignKey);
+                            var cycle = visitedForeignKeys.GetRange(cycleStart, visitedForeignKeys.Count - cycleStart);
+                            errorMessage = Strings.CircularDependency(cycle.Select(fk => fk.ToString()).Join());
+                            continue;
+                        }
+                        else
+                        {
+                            rootPrincipal = VerifyRootPrincipal(nextPrincipalProperty, verifiedProperties, visitedForeignKeys.Add(foreignKey), out errorMessage);
+                            if (rootPrincipal == null)
+                            {
+                                if (principalProperty.GenerateValueOnAdd)
+                                {
+                                    rootPrincipals[principalProperty] = foreignKey;
+                                }
+                                continue;
+                            }
+
+                            if (principalProperty.GenerateValueOnAdd)
+                            {
+                                ShowError(Strings.ForeignKeyValueGenerationOnAdd(
+                                    principalProperty.Name,
+                                    principalProperty.EntityType.SimpleName,
+                                    Property.Format(foreignKey.Properties)));
+                                return principalProperty;
+                            }
+                        }
+
+                        rootPrincipals[rootPrincipal] = foreignKey;
+                    }
+                }
+            }
+
+            if (rootPrincipals.Count == 0)
+            {
+                if (errorMessage != null)
+                {
+                    return null;
+                }
+
+                if (!principalProperty.GenerateValueOnAdd)
+                {
+                    ShowError(Strings.PrincipalKeyNoValueGenerationOnAdd(principalProperty.Name, principalProperty.EntityType.SimpleName));
+                    return null;
+                }
+
+                return principalProperty;
+            }
+
+            if (rootPrincipals.Count > 1)
+            {
+                var firstRoot = rootPrincipals.Keys.ElementAt(0);
+                var secondRoot = rootPrincipals.Keys.ElementAt(1);
+                ShowWarning(Strings.MultipleRootPrincipals(
+                    rootPrincipals[firstRoot].EntityType.SimpleName,
+                    Property.Format(rootPrincipals[firstRoot].Properties),
+                    firstRoot.EntityType.SimpleName,
+                    firstRoot.Name,
+                    Property.Format(rootPrincipals[secondRoot].Properties),
+                    secondRoot.EntityType.SimpleName,
+                    secondRoot.Name));
+
+                return firstRoot;
+            }
+
+            errorMessage = null;
+            rootPrincipal = rootPrincipals.Keys.Single();
+            verifiedProperties[principalProperty] = rootPrincipal;
+            return rootPrincipal;
         }
 
         protected virtual void ShowError(string message)

--- a/src/EntityFramework.Core/Metadata/Internal/InternalEntityBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/InternalEntityBuilder.cs
@@ -1045,7 +1045,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 if (principalKey == null)
                 {
                     var principalKeyProperty = CreateUniqueProperty(
-                        "Id",
+                        "TempId",
                         typeof(int),
                         principalEntityTypeBuilder,
                         isRequired);

--- a/src/EntityFramework.Core/Properties/Strings.Designer.cs
+++ b/src/EntityFramework.Core/Properties/Strings.Designer.cs
@@ -853,6 +853,30 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
+        /// The property '{property}' on entity type '{entityType}' has value generation on add enabled and it is included in the foreign key {foreignKey}. Foreign key properties should not have value generation on add enabled unless they are part of a cycle where they are the only properties with value generation on add enabled.
+        /// </summary>
+        public static string ForeignKeyValueGenerationOnAdd([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object foreignKey)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("ForeignKeyValueGenerationOnAdd", "property", "entityType", "foreignKey"), property, entityType, foreignKey);
+        }
+
+        /// <summary>
+        /// The root principal property found by following to foreign key chain starting on entity type '{entityType}' with {firstForeignKey} is '{firstEntityType}'.'{firstRootProperty}', which is different from the root principal property found by following to foreign key chain starting with {secondForeignKey} - '{secondEntityType}'.'{secondRootProperty}'
+        /// </summary>
+        public static string MultipleRootPrincipals([CanBeNull] object entityType, [CanBeNull] object firstForeignKey, [CanBeNull] object firstEntityType, [CanBeNull] object firstRootProperty, [CanBeNull] object secondForeignKey, [CanBeNull] object secondEntityType, [CanBeNull] object secondRootProperty)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("MultipleRootPrincipals", "entityType", "firstForeignKey", "firstEntityType", "firstRootProperty", "secondForeignKey", "secondEntityType", "secondRootProperty"), entityType, firstForeignKey, firstEntityType, firstRootProperty, secondForeignKey, secondEntityType, secondRootProperty);
+        }
+
+        /// <summary>
+        /// The property '{property}' on entity type '{entityType}' does not have value generation on add enabled and it is referenced by at least one foreign key. Properties referenced by foreign keys should have value generation on add enabled.
+        /// </summary>
+        public static string PrincipalKeyNoValueGenerationOnAdd([CanBeNull] object property, [CanBeNull] object entityType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("PrincipalKeyNoValueGenerationOnAdd", "property", "entityType"), property, entityType);
+        }
+
+        /// <summary>
         /// An exception was thrown while attempting to evaluate the LINQ query parameter expression '{expression}'.
         /// </summary>
         public static string ExpressionParameterizationException([CanBeNull] object expression)

--- a/src/EntityFramework.Core/Properties/Strings.resx
+++ b/src/EntityFramework.Core/Properties/Strings.resx
@@ -432,6 +432,15 @@
   <data name="ShadowKey" xml:space="preserve">
     <value>The key {key} on entity type '{entityType}' contains properties in shadow state - {shadowProperties}.</value>
   </data>
+  <data name="ForeignKeyValueGenerationOnAdd" xml:space="preserve">
+    <value>The property '{property}' on entity type '{entityType}' has value generation on add enabled and it is included in the foreign key {foreignKey}. Foreign key properties should not have value generation on add enabled unless they are part of a cycle where they are the only properties with value generation on add enabled.</value>
+  </data>
+  <data name="MultipleRootPrincipals" xml:space="preserve">
+    <value>The root principal property found by following to foreign key chain starting on entity type '{entityType}' with {firstForeignKey} is '{firstEntityType}'.'{firstRootProperty}', which is different from the root principal property found by following to foreign key chain starting with {secondForeignKey} - '{secondEntityType}'.'{secondRootProperty}'</value>
+  </data>
+  <data name="PrincipalKeyNoValueGenerationOnAdd" xml:space="preserve">
+    <value>The property '{property}' on entity type '{entityType}' does not have value generation on add enabled and it is referenced by at least one foreign key. Properties referenced by foreign keys should have value generation on add enabled.</value>
+  </data>
   <data name="ExpressionParameterizationException" xml:space="preserve">
     <value>An exception was thrown while attempting to evaluate the LINQ query parameter expression '{expression}'.</value>
   </data>

--- a/test/EntityFramework.Core.FunctionalTests/InheritanceFixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/InheritanceFixtureBase.cs
@@ -14,11 +14,15 @@ namespace Microsoft.Data.Entity.FunctionalTests
             var model = modelBuilder.Model;
 
             var country = model.AddEntityType(typeof(Country));
-            var countryKey = country.SetPrimaryKey(country.AddProperty("Id", typeof(int)));
+            var countryIdProperty = country.AddProperty("Id", typeof(int));
+            countryIdProperty.GenerateValueOnAdd = true;
+            var countryKey = country.SetPrimaryKey(countryIdProperty);
             country.AddProperty("Name", typeof(string));
 
             var animal = model.AddEntityType(typeof(Animal));
-            var animalKey = animal.SetPrimaryKey(animal.AddProperty("Species", typeof(string)));
+            var animalSpeciesProperty = animal.AddProperty("Species", typeof(string));
+            animalSpeciesProperty.GenerateValueOnAdd = true;
+            var animalKey = animal.SetPrimaryKey(animalSpeciesProperty);
             animal.AddProperty("Name", typeof(string));
             var countryFk = animal.AddForeignKey(animal.AddProperty("CountryId", typeof(int)), countryKey);
 

--- a/test/EntityFramework.Core.Tests/Infrastructure/ModelValidatorTest.cs
+++ b/test/EntityFramework.Core.Tests/Infrastructure/ModelValidatorTest.cs
@@ -20,6 +20,254 @@ namespace Microsoft.Data.Entity.Tests.Infrastructure
             VerifyWarning(Strings.ShadowKey("{'Id'}", "E", "{'Id'}"), model);
         }
 
+        [Fact]
+        public virtual void Detects_self_referencing_properties()
+        {
+            var model = new Model();
+            var entityA = model.AddEntityType(typeof(A));
+            var keyA = CreateKey(entityA);
+
+            CreateForeignKey(keyA, keyA);
+
+            VerifyError(Strings.CircularDependency("'A' {'P0'} -> 'A' {'P0'}"), model);
+        }
+
+        [Fact]
+        public virtual void Detects_foreign_key_cycles()
+        {
+            var model = new Model();
+            var entityA = model.AddEntityType(typeof(A));
+            var keyA = CreateKey(entityA);
+            var entityB = model.AddEntityType(typeof(B));
+            var keyB = CreateKey(entityB);
+
+            CreateForeignKey(keyA, keyB);
+            CreateForeignKey(keyB, keyA);
+            
+            VerifyError(Strings.CircularDependency("'A' {'P0'} -> 'B' {'P0'}, 'B' {'P0'} -> 'A' {'P0'}"), model);
+        }
+
+        [Fact]
+        public virtual void Passes_on_escapable_foreign_key_cycles()
+        {
+            var model = new Model();
+            var entityA = model.AddEntityType(typeof(A));
+            var keyA1 = CreateKey(entityA);
+            var keyA2 = CreateKey(entityA, startingPropertyIndex: 0, propertyCount: 2);
+            var entityB = model.AddEntityType(typeof(B));
+            var keyB1 = CreateKey(entityB);
+            var keyB2 = CreateKey(entityB, startingPropertyIndex: 1, propertyCount: 2);
+
+            CreateForeignKey(keyA1, keyB1);
+            CreateForeignKey(keyB1, keyA1);
+            CreateForeignKey(keyA2, keyB2);
+
+            Validate(model);
+        }
+
+        [Fact]
+        public virtual void Passes_on_escapable_foreign_key_cycles_not_starting_at_hub()
+        {
+            var model = new Model();
+            var entityA = model.AddEntityType(typeof(A));
+            var keyA1 = CreateKey(entityA);
+            var keyA2 = CreateKey(entityA, startingPropertyIndex: 1, propertyCount: 2);
+            var entityB = model.AddEntityType(typeof(B));
+            var keyB1 = CreateKey(entityB);
+            var keyB2 = CreateKey(entityB, startingPropertyIndex: 0, propertyCount: 2);
+
+            CreateForeignKey(keyA1, keyB1);
+            CreateForeignKey(keyB1, keyA1);
+            CreateForeignKey(keyB2, keyA2);
+
+            Validate(model);
+        }
+
+        [Fact]
+        public virtual void Passes_on_foreign_key_cycle_with_one_GenerateOnAdd()
+        {
+            var model = new Model();
+            var entityA = model.AddEntityType(typeof(A));
+            var keyA = CreateKey(entityA);
+            var entityB = model.AddEntityType(typeof(B));
+            var keyB = CreateKey(entityB);
+
+            CreateForeignKey(keyA, keyB);
+            CreateForeignKey(keyB, keyA);
+
+            keyA.Properties[0].GenerateValueOnAdd = true;
+
+            Validate(model);
+        }
+
+        [Fact]
+        public virtual void Detects_foreign_key_cycle_with_two_GenerateOnAdd()
+        {
+            var model = new Model();
+            var entityA = model.AddEntityType(typeof(A));
+            var keyA = CreateKey(entityA);
+            var entityB = model.AddEntityType(typeof(B));
+            var keyB = CreateKey(entityB);
+
+            CreateForeignKey(keyA, keyB);
+            CreateForeignKey(keyB, keyA);
+            
+            keyA.Properties[0].GenerateValueOnAdd = true;
+            keyB.Properties[0].GenerateValueOnAdd = true;
+
+            VerifyError(Strings.ForeignKeyValueGenerationOnAdd("P0", "A", "{'P0'}"), model);
+        }
+
+        [Fact]
+        public virtual void Detects_GenerateOnAdd_on_foreign_key_properties()
+        {
+            var model = new Model();
+            var entityA = model.AddEntityType(typeof(A));
+            var keyA = CreateKey(entityA);
+            var entityB = model.AddEntityType(typeof(B));
+            var keyB = CreateKey(entityB);
+
+            CreateForeignKey(keyA, keyB);
+
+            keyA.Properties[0].GenerateValueOnAdd = true;
+
+            VerifyError(Strings.ForeignKeyValueGenerationOnAdd("P0", "A", "{'P0'}"), model);
+        }
+
+        [Fact]
+        public virtual void Detects_GenerateOnAdd_on_referenced_foreign_key_properties()
+        {
+            var model = new Model();
+            var entityA = model.AddEntityType(typeof(A));
+            var keyA1 = CreateKey(entityA);
+            var keyA2 = CreateKey(entityA);
+            var entityB = model.AddEntityType(typeof(B));
+            var keyB = CreateKey(entityB);
+
+            CreateForeignKey(keyA1, keyB);
+            CreateForeignKey(keyB, keyA2);
+
+            keyB.Properties[0].GenerateValueOnAdd = true;
+
+            VerifyError(Strings.ForeignKeyValueGenerationOnAdd("P0", "B", "{'P0'}"), model);
+        }
+
+        [Fact]
+        public virtual void Detects_GenerateOnAdd_not_set_on_principal_key_properties()
+        {
+            var model = new Model();
+            var entityA = model.AddEntityType(typeof(A));
+            var keyA = CreateKey(entityA);
+            var entityB = model.AddEntityType(typeof(B));
+            var keyB = CreateKey(entityB);
+
+            CreateForeignKey(keyA, keyB);
+
+            keyB.Properties[0].GenerateValueOnAdd = false;
+
+            VerifyError(Strings.PrincipalKeyNoValueGenerationOnAdd("P0", "B"), model);
+        }
+
+        [Fact]
+        public virtual void Detects_multiple_root_principal_properties()
+        {
+            var model = new Model();
+            var entityA = model.AddEntityType(typeof(A));
+            var keyA1 = CreateKey(entityA);
+            var keyA2 = CreateKey(entityA, startingPropertyIndex: 0, propertyCount: 2);
+            var entityB = model.AddEntityType(typeof(B));
+            var keyB1 = CreateKey(entityB);
+            var keyB2 = CreateKey(entityB, startingPropertyIndex: 1, propertyCount: 2);
+
+            CreateForeignKey(keyA1, keyB1);
+            CreateForeignKey(keyA2, keyB2);
+
+            VerifyWarning(Strings.MultipleRootPrincipals("A", "{'P0'}", "B", "P0", "{'P0', 'P1'}", "B", "P1"), model);
+        }
+
+        [Fact]
+        public virtual void Pases_on_double_reference_to_root_principal_property()
+        {
+            var model = new Model();
+            var entityA = model.AddEntityType(typeof(A));
+            var keyA1 = CreateKey(entityA);
+            var keyA2 = CreateKey(entityA, startingPropertyIndex: 0, propertyCount: 2);
+            var entityB = model.AddEntityType(typeof(B));
+            var keyB1 = CreateKey(entityB);
+            var keyB2 = CreateKey(entityB, startingPropertyIndex: 0, propertyCount: 2);
+
+            CreateForeignKey(keyA1, keyB1);
+            CreateForeignKey(keyA2, keyB2);
+
+            Validate(model);
+        }
+
+        [Fact]
+        public virtual void Pases_on_diamond_path_to_root_principal_property()
+        {
+            var model = new Model();
+            var entityA = model.AddEntityType(typeof(A));
+            var keyA1 = CreateKey(entityA);
+            var keyA2 = CreateKey(entityA, startingPropertyIndex: 0, propertyCount: 2);
+            var keyA3 = CreateKey(entityA);
+            var keyA4 = CreateKey(entityA, startingPropertyIndex: 2, propertyCount: 2);
+            var entityB = model.AddEntityType(typeof(B));
+            var keyB1 = CreateKey(entityB);
+            var keyB2 = CreateKey(entityB, startingPropertyIndex: 1, propertyCount: 2);
+
+            CreateForeignKey(keyA1, keyB1);
+            CreateForeignKey(keyA2, keyB2);
+
+            CreateForeignKey(keyB1, keyA3);
+            CreateForeignKey(keyB2, keyA4);
+
+            Validate(model);
+        }
+
+        private Key CreateKey(EntityType entityType, int startingPropertyIndex = -1, int propertyCount = 1)
+        {
+            if (startingPropertyIndex == -1)
+            {
+                startingPropertyIndex = entityType.PropertyCount;
+            }
+            var keyProperties = new Property[propertyCount];
+            for (int i = 0; i < propertyCount; i++)
+            {
+                keyProperties[i] = entityType.GetOrAddProperty("P" + (startingPropertyIndex + i), typeof(int?));
+                keyProperties[i].GenerateValueOnAdd = true;
+            }
+            return entityType.AddKey(keyProperties);
+        }
+
+        private ForeignKey CreateForeignKey(Key dependentKey, Key principalKey)
+        {
+            var foreignKey = dependentKey.EntityType.AddForeignKey(dependentKey.Properties, principalKey);
+            foreignKey.IsUnique = true;
+            foreignKey.IsRequired = false;
+            foreach (var property in dependentKey.Properties)
+            {
+                property.GenerateValueOnAdd = false;
+            }
+
+            return foreignKey;
+        }
+
+        private class A
+        {
+            public int? P0 { get; set; }
+            public int? P1 { get; set; }
+            public int? P2 { get; set; }
+            public int? P3 { get; set; }
+        }
+
+        private class B
+        {
+            public int? P0 { get; set; }
+            public int? P1 { get; set; }
+            public int? P2 { get; set; }
+            public int? P3 { get; set; }
+        }
+
         protected virtual void Validate(IModel model) => CreateModelValidator().Validate(model);
 
         protected abstract void VerifyWarning(string expectedMessage, IModel model);


### PR DESCRIPTION
Add a model validation rule to ensure there is one and only one root principal property with value generation on add enabled in a foreign key chain.