### PR TITLE
Fix to Issues #1760 " - complex filter containing boolean expressions may produce invalid sql" and #1830 -  simplify negated expressions in query predicate

### DIFF
--- a/src/EntityFramework.Relational/EntityFramework.Relational.csproj
+++ b/src/EntityFramework.Relational/EntityFramework.Relational.csproj
@@ -145,7 +145,9 @@
     <Compile Include="Query\AsyncQueryMethodProvider.cs" />
     <Compile Include="Query\CommandBuilder.cs" />
     <Compile Include="Query\CommandParameter.cs" />
-    <Compile Include="Query\EqualityPredicateOptimizer.cs" />
+    <Compile Include="Query\ExpressionTreeVisitors\CompositeRelationalExpressionTreeVisitor.cs" />
+    <Compile Include="Query\ExpressionTreeVisitors\EqualityPredicateExpandingVisitor.cs" />
+    <Compile Include="Query\ExpressionTreeVisitors\EqualityPredicateInExpressionOptimizer.cs" />
     <Compile Include="Query\Expressions\AggregateExpression.cs" />
     <Compile Include="Query\Expressions\DiscriminatorPredicateExpression.cs" />
     <Compile Include="Query\Expressions\InExpression.cs" />
@@ -155,6 +157,7 @@
     <Compile Include="Query\Expressions\MinExpression.cs" />
     <Compile Include="Query\Expressions\SumExpression.cs" />
     <Compile Include="Query\Expressions\TableExpressionBase.cs" />
+    <Compile Include="Query\ExpressionTreeVisitors\PredicateNegationExpressionOptimizer.cs" />
     <Compile Include="Query\ExpressionTreeVisitors\SqlTranslatingExpressionTreeVisitor.cs" />
     <Compile Include="Query\AsyncIncludeCollectionIterator.cs" />
     <Compile Include="Query\ExpressionTreeVisitors\IncludeExpressionTreeVisitor.cs" />

--- a/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/CompositeRelationalExpressionTreeVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/CompositeRelationalExpressionTreeVisitor.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Remotion.Linq.Parsing;
+
+namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
+{
+    public class CompositePredicateExpressionTreeVisitor : ExpressionTreeVisitor
+    {
+        public override Expression VisitExpression(
+            [NotNull]Expression expression)
+        {
+            var currentExpression = expression;
+            var inExpressionOptimized = 
+                new EqualityPredicateInExpressionOptimizer().VisitExpression(currentExpression);
+
+            if (inExpressionOptimized != null)
+            {
+                currentExpression = inExpressionOptimized;
+            }
+
+            var equalityExpanded = 
+                new EqualityPredicateExpandingVisitor().VisitExpression(currentExpression);
+
+            if (equalityExpanded != null)
+            {
+                currentExpression = equalityExpanded;
+            }
+
+            var negationOptimized =
+                new PredicateNegationExpressionOptimizer().VisitExpression(currentExpression);
+
+            if (negationOptimized != null)
+            {
+                currentExpression = negationOptimized;
+            }
+
+            return currentExpression;
+        }
+    }
+}

--- a/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/EqualityPredicateExpandingVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/EqualityPredicateExpandingVisitor.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq.Expressions;
+using Microsoft.Data.Entity.Relational.Query.Expressions;
+using JetBrains.Annotations;
+using Remotion.Linq.Parsing;
+
+namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
+{
+    public class EqualityPredicateExpandingVisitor : ExpressionTreeVisitor
+    {
+        protected override Expression VisitBinaryExpression(
+            [NotNull]BinaryExpression expression)
+        {
+            if ((expression.NodeType == ExpressionType.Equal
+                || expression.NodeType == ExpressionType.NotEqual)
+                && expression.Left.Type == typeof(bool)
+                && expression.Right.Type == typeof(bool))
+            {
+                var complexLeft = !(expression.Left is ColumnExpression
+                    || expression.Left is ParameterExpression 
+                    || expression.Left is ConstantExpression);
+
+                var complexRight = !(expression.Right is ColumnExpression
+                    || expression.Right is ParameterExpression
+                    || expression.Right is ConstantExpression);
+
+                if (complexLeft || complexRight)
+                { 
+                    var left = VisitExpression(expression.Left);
+                    var right = VisitExpression(expression.Right);
+
+                    return expression.NodeType == ExpressionType.Equal ?
+                        Expression.OrElse(
+                            Expression.AndAlso(
+                                left,
+                                right),
+                            Expression.AndAlso(
+                                Expression.Not(expression.Left),
+                                Expression.Not(right)))
+                        : Expression.OrElse(
+                            Expression.AndAlso(
+                                left,
+                                Expression.Not(right)),
+                            Expression.AndAlso(
+                                Expression.Not(left),
+                                right));
+                }
+            }
+
+            return base.VisitBinaryExpression(expression);
+        }
+    }
+}

--- a/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/EqualityPredicateInExpressionOptimizer.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/EqualityPredicateInExpressionOptimizer.cs
@@ -10,9 +10,9 @@ using Microsoft.Data.Entity.Utilities;
 using Remotion.Linq.Parsing;
 using System.Collections.Generic;
 
-namespace Microsoft.Data.Entity.Relational.Query
+namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
 {
-    public class EqualityPredicateOptimizer : ExpressionTreeVisitor
+    public class EqualityPredicateInExpressionOptimizer : ExpressionTreeVisitor
     {
         protected override Expression VisitBinaryExpression(
             [NotNull] BinaryExpression binaryExpression)

--- a/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/PredicateNegationExpressionOptimizer.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/PredicateNegationExpressionOptimizer.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Remotion.Linq.Parsing;
+
+namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
+{
+    public class PredicateNegationExpressionOptimizer : ExpressionTreeVisitor
+    {
+        private static Dictionary<ExpressionType, ExpressionType> _nodeTypeMapping
+            = new Dictionary<ExpressionType, ExpressionType>
+            {
+                { ExpressionType.GreaterThan, ExpressionType.LessThanOrEqual },
+                { ExpressionType.GreaterThanOrEqual, ExpressionType.LessThan },
+                { ExpressionType.LessThanOrEqual, ExpressionType.GreaterThan },
+                { ExpressionType.LessThan, ExpressionType.GreaterThanOrEqual },
+            };
+
+        protected override Expression VisitBinaryExpression(
+            [NotNull]BinaryExpression expression)
+        {
+            var currentExpression = expression;
+            if (currentExpression.NodeType == ExpressionType.Equal 
+                || currentExpression.NodeType == ExpressionType.NotEqual)
+            {
+                var leftUnary = currentExpression.Left as UnaryExpression;
+                if (leftUnary != null && leftUnary.NodeType == ExpressionType.Not)
+                {
+                    currentExpression = currentExpression.NodeType == ExpressionType.Equal
+                        ? Expression.MakeBinary(
+                            ExpressionType.NotEqual, leftUnary.Operand, currentExpression.Right)
+                        : Expression.MakeBinary(
+                            ExpressionType.Equal, leftUnary.Operand, currentExpression.Right);
+                }
+
+                var rightUnary = currentExpression.Right as UnaryExpression;
+                if (rightUnary != null && rightUnary.NodeType == ExpressionType.Not)
+                {
+                    currentExpression = currentExpression.NodeType == ExpressionType.Equal
+                        ? Expression.MakeBinary(
+                            ExpressionType.NotEqual, currentExpression.Left, rightUnary.Operand)
+                        : Expression.MakeBinary(
+                            ExpressionType.Equal, currentExpression.Left, rightUnary.Operand);
+                }
+            }
+
+            return base.VisitBinaryExpression(currentExpression);
+        }
+
+        protected override Expression VisitUnaryExpression(
+            [NotNull]UnaryExpression expression)
+        {
+            if (expression.NodeType == ExpressionType.Not)
+            {
+                var innerUnary = expression.Operand as UnaryExpression;
+                if (innerUnary != null && innerUnary.NodeType == ExpressionType.Not)
+                {
+                    return VisitExpression(innerUnary.Operand);
+                }
+
+                var innerBinary = expression.Operand as BinaryExpression;
+                if (innerBinary != null)
+                {
+                    if (innerBinary.NodeType == ExpressionType.AndAlso)
+                    {
+                        return VisitExpression(
+                            Expression.MakeBinary(
+                                ExpressionType.OrElse,
+                                Expression.Not(innerBinary.Left), 
+                                Expression.Not(innerBinary.Right)));
+                    }
+
+                    if (innerBinary.NodeType == ExpressionType.OrElse)
+                    {
+                        return VisitExpression(
+                            Expression.MakeBinary(
+                                ExpressionType.AndAlso,
+                                Expression.Not(innerBinary.Left),
+                                Expression.Not(innerBinary.Right)));
+                    }
+
+                    if (_nodeTypeMapping.ContainsKey(innerBinary.NodeType))
+                    {
+                        return VisitExpression(
+                            Expression.MakeBinary(
+                                _nodeTypeMapping[innerBinary.NodeType],
+                                innerBinary.Left,
+                                innerBinary.Right));
+                    }
+                }
+            }
+
+            return base.VisitUnaryExpression(expression);
+        }
+    }
+}

--- a/src/EntityFramework.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EntityFramework.Relational/Query/RelationalQueryModelVisitor.cs
@@ -83,12 +83,12 @@ namespace Microsoft.Data.Entity.Relational.Query
         {
             base.VisitQueryModel(queryModel);
 
-            var predicateOptimizer = new EqualityPredicateOptimizer();
+            var compositePredicateVisitor = new CompositePredicateExpressionTreeVisitor();
 
             foreach (var selectExpression in _queriesBySource.Values.Where(se => se.Predicate != null))
             {
                 selectExpression.Predicate
-                    = predicateOptimizer.VisitExpression(selectExpression.Predicate);
+                    = compositePredicateVisitor.VisitExpression(selectExpression.Predicate);
             }
         }
 

--- a/src/EntityFramework.Relational/Query/Sql/DefaultSqlQueryGenerator.cs
+++ b/src/EntityFramework.Relational/Query/Sql/DefaultSqlQueryGenerator.cs
@@ -261,7 +261,7 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
             _sql.Append(" IN (");
 
             VisitInExpressionValues(inExpression.Values);
-            
+
             _sql.Append(")");
 
             return inExpression;
@@ -302,8 +302,8 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
                     var parameterValue = _parameterValues[inParameter.Name];
                     var valuesCollection = parameterValue as IEnumerable;
 
-                    if (valuesCollection != null 
-                        && parameterValue.GetType() != typeof(string) 
+                    if (valuesCollection != null
+                        && parameterValue.GetType() != typeof(string)
                         && parameterValue.GetType() != typeof(byte[]))
                     {
                         foreach (var value in valuesCollection)
@@ -433,110 +433,109 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
             Check.NotNull(binaryExpression, nameof(binaryExpression));
 
             var maybeNullComparisonExpression = TransformNullComparison(binaryExpression);
-
             if (maybeNullComparisonExpression != null)
             {
                 VisitExpression(maybeNullComparisonExpression);
+
+                return maybeNullComparisonExpression;
             }
-            else
+
+            var needClosingParen = false;
+
+            var leftBinaryExpression = binaryExpression.Left as BinaryExpression;
+
+            if (leftBinaryExpression != null
+                && leftBinaryExpression.NodeType != binaryExpression.NodeType)
             {
-                var needClosingParen = false;
+                _sql.Append("(");
 
-                var leftBinaryExpression = binaryExpression.Left as BinaryExpression;
+                needClosingParen = true;
+            }
 
-                if (leftBinaryExpression != null
-                    && leftBinaryExpression.NodeType != binaryExpression.NodeType)
-                {
-                    _sql.Append("(");
+            VisitExpression(binaryExpression.Left);
 
-                    needClosingParen = true;
-                }
+            if (binaryExpression.IsLogicalOperation()
+                && (binaryExpression.Left is ColumnExpression
+                    || binaryExpression.Left is ParameterExpression))
+            {
+                _sql.Append(" = 1");
+            }
 
-                VisitExpression(binaryExpression.Left);
+            if (needClosingParen)
+            {
+                _sql.Append(")");
+            }
 
-                if (binaryExpression.IsLogicalOperation()
-                    && (binaryExpression.Left is ColumnExpression
-                        || binaryExpression.Left is ParameterExpression))
-                {
-                    _sql.Append(" = 1");
-                }
+            string op;
 
-                if (needClosingParen)
-                {
-                    _sql.Append(")");
-                }
+            switch (binaryExpression.NodeType)
+            {
+                case ExpressionType.Equal:
+                    op = " = ";
+                    break;
+                case ExpressionType.NotEqual:
+                    op = " <> ";
+                    break;
+                case ExpressionType.GreaterThan:
+                    op = " > ";
+                    break;
+                case ExpressionType.GreaterThanOrEqual:
+                    op = " >= ";
+                    break;
+                case ExpressionType.LessThan:
+                    op = " < ";
+                    break;
+                case ExpressionType.LessThanOrEqual:
+                    op = " <= ";
+                    break;
+                case ExpressionType.AndAlso:
+                    op = " AND ";
+                    break;
+                case ExpressionType.OrElse:
+                    op = " OR ";
+                    break;
+                case ExpressionType.Add:
+                    op = " " + ConcatOperator + " ";
+                    break;
+                case ExpressionType.Subtract:
+                    op = " - ";
+                    break;
+                case ExpressionType.Multiply:
+                    op = " * ";
+                    break;
+                case ExpressionType.Divide:
+                    op = " / ";
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
 
-                string op;
+            _sql.Append(op);
 
-                switch (binaryExpression.NodeType)
-                {
-                    case ExpressionType.Equal:
-                        op = " = ";
-                        break;
-                    case ExpressionType.NotEqual:
-                        op = " <> ";
-                        break;
-                    case ExpressionType.GreaterThan:
-                        op = " > ";
-                        break;
-                    case ExpressionType.GreaterThanOrEqual:
-                        op = " >= ";
-                        break;
-                    case ExpressionType.LessThan:
-                        op = " < ";
-                        break;
-                    case ExpressionType.LessThanOrEqual:
-                        op = " <= ";
-                        break;
-                    case ExpressionType.AndAlso:
-                        op = " AND ";
-                        break;
-                    case ExpressionType.OrElse:
-                        op = " OR ";
-                        break;
-                    case ExpressionType.Add:
-                        op = " " + ConcatOperator + " ";
-                        break;
-                    case ExpressionType.Subtract:
-                        op = " - ";
-                        break;
-                    case ExpressionType.Multiply:
-                        op = " * ";
-                        break;
-                    case ExpressionType.Divide:
-                        op = " / ";
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException();
-                }
+            needClosingParen = false;
 
-                _sql.Append(op);
+            var rightBinaryExpression = binaryExpression.Right as BinaryExpression;
 
-                needClosingParen = false;
+            if (rightBinaryExpression != null
+                && rightBinaryExpression.NodeType != binaryExpression.NodeType)
+            {
+                _sql.Append("(");
 
-                var rightBinaryExpression = binaryExpression.Right as BinaryExpression;
+                needClosingParen = true;
+            }
 
-                if (rightBinaryExpression != null
-                    && rightBinaryExpression.NodeType != binaryExpression.NodeType)
-                {
-                    _sql.Append("(");
+            VisitExpression(binaryExpression.Right);
 
-                    needClosingParen = true;
-                }
+            if (binaryExpression.IsLogicalOperation()
+                && (binaryExpression.Right is ColumnExpression
+                    || binaryExpression.Right is ParameterExpression))
+            {
+                _sql.Append(" = 1");
+            }
 
-                VisitExpression(binaryExpression.Right);
-
-                if (binaryExpression.IsLogicalOperation()
-                    && (binaryExpression.Right is ColumnExpression
-                        || binaryExpression.Right is ParameterExpression))
-                {
-                    _sql.Append(" = 1");
-                }
-
-                if (needClosingParen)
-                {
-                    _sql.Append(")");
-                }
+            if (needClosingParen)
+            {
+                _sql.Append(")");
             }
 
             return binaryExpression;
@@ -647,17 +646,19 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
                     return VisitNotInExpression(inExpression);
                 }
 
-                var isColumnOperand = unaryExpression.Operand is ColumnExpression;
+                var isColumnOrParameterOperand = 
+                    unaryExpression.Operand is ColumnExpression 
+                    || unaryExpression.Operand is ParameterExpression;
 
-                if (!isColumnOperand)
+                if (!isColumnOrParameterOperand)
                 {
-                    _sql.Append("NOT ");
+                    _sql.Append("NOT(");
+                    VisitExpression(unaryExpression.Operand);
+                    _sql.Append(")");
                 }
-
-                VisitExpression(unaryExpression.Operand);
-
-                if (isColumnOperand)
+                else
                 {
+                    VisitExpression(unaryExpression.Operand);
                     _sql.Append(" = 0");
                 }
 
@@ -689,7 +690,10 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
         {
             _sql.Append(ParameterPrefix + parameterExpression.Name);
 
-            _parameters.Add(parameterExpression.Name);
+            if (!_parameters.Contains(parameterExpression.Name))
+            {
+                _parameters.Add(parameterExpression.Name);
+            }
 
             return parameterExpression;
         }

--- a/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
@@ -911,6 +911,62 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
+        public virtual void Where_bool_member_compared_to_binary_expression()
+        {
+            AssertQuery<Product>(ps => ps.Where(p => p.Discontinued == (p.ProductID > 50)), entryCount: 44);
+        }
+
+        [Fact]
+        public virtual void Where_not_bool_member_compared_to_not_bool_member()
+        {
+            AssertQuery<Product>(ps => ps.Where(p => !p.Discontinued == !p.Discontinued), entryCount: 77);
+        }
+
+        [Fact]
+        public virtual void Where_negated_boolean_expression_compared_to_another_negated_boolean_expression()
+        {
+            AssertQuery<Product>(ps => ps.Where(p => !(p.ProductID > 50) == !(p.ProductID > 20)), entryCount: 47);
+        }
+
+        [Fact]
+        public virtual void Where_not_bool_member_compared_to_binary_expression()
+        {
+            AssertQuery<Product>(ps => ps.Where(p => !p.Discontinued == (p.ProductID > 50)), entryCount: 33);
+        }
+
+        [Fact]
+        public virtual void Where_bool_parameter_compared_to_binary_expression()
+        {
+            bool prm = true;
+            AssertQuery<Product>(ps => ps.Where(p => (p.ProductID > 50) != prm), entryCount: 50);
+        }
+
+        [Fact]
+        public virtual void Where_bool_member_and_parameter_compared_to_binary_expression_nested()
+        {
+            bool prm = true;
+            AssertQuery<Product>(ps => ps.Where(p => p.Discontinued == ((p.ProductID > 50) != prm)), entryCount: 33);
+        }
+
+        [Fact]
+        public virtual void Where_de_morgan_or_optimizated()
+        {
+            AssertQuery<Product>(ps => ps.Where(p => !(p.Discontinued || (p.ProductID < 20))), entryCount: 53);
+        }
+
+        [Fact]
+        public virtual void Where_de_morgan_and_optimizated()
+        {
+            AssertQuery<Product>(ps => ps.Where(p => !(p.Discontinued && (p.ProductID < 20))), entryCount: 74);
+        }
+
+        [Fact]
+        public virtual void Where_complex_negated_expression_optimized()
+        {
+            AssertQuery<Product>(ps => ps.Where(p => !(!(!p.Discontinued && (p.ProductID < 60)) || !(p.ProductID > 30))), entryCount: 27);
+        }
+
+        [Fact]
         public virtual void Where_short_member_comparison()
         {
             AssertQuery<Product>(ps => ps.Where(p => p.UnitsInStock > 10), entryCount: 63);

--- a/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -672,12 +672,12 @@ FROM [Orders] AS [o]",
 
             Assert.Equal(
                 @"SELECT CASE WHEN (
-    NOT EXISTS (
+    NOT(EXISTS (
         SELECT 1
         FROM [Customers] AS [c]
-        WHERE NOT [c].[ContactName] LIKE 'A' + '%'
+        WHERE NOT([c].[ContactName] LIKE 'A' + '%')
     )
-) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END",
+    )) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END",
                 Sql);
         }
 
@@ -1596,7 +1596,7 @@ WHERE [p].[Discontinued] = 0",
             Assert.Equal(
                 @"SELECT [p].[Discontinued], [p].[ProductID], [p].[ProductName], [p].[UnitsInStock]
 FROM [Products] AS [p]
-WHERE NOT NOT [p].[Discontinued] = 1",
+WHERE [p].[Discontinued] = 1",
                 Sql);
         }
 
@@ -1641,6 +1641,105 @@ WHERE [p].[Discontinued] = 1",
                 @"SELECT [p].[Discontinued], [p].[ProductID], [p].[ProductName], [p].[UnitsInStock]
 FROM [Products] AS [p]
 WHERE (([p].[ProductID] > 100) AND [p].[Discontinued] = 1) OR ([p].[Discontinued] = 1)",
+                Sql);
+        }
+
+        public override void Where_bool_member_compared_to_binary_expression()
+        {
+            base.Where_bool_member_compared_to_binary_expression();
+
+            Assert.Equal(
+                @"SELECT [p].[Discontinued], [p].[ProductID], [p].[ProductName], [p].[UnitsInStock]
+FROM [Products] AS [p]
+WHERE ([p].[Discontinued] = 1 AND ([p].[ProductID] > 50)) OR ([p].[Discontinued] = 0 AND ([p].[ProductID] <= 50))",
+                Sql);
+        }
+
+        public override void Where_not_bool_member_compared_to_binary_expression()
+        {
+            base.Where_not_bool_member_compared_to_binary_expression();
+
+            Assert.Equal(
+                @"SELECT [p].[Discontinued], [p].[ProductID], [p].[ProductName], [p].[UnitsInStock]
+FROM [Products] AS [p]
+WHERE ([p].[Discontinued] = 0 AND ([p].[ProductID] > 50)) OR ([p].[Discontinued] = 1 AND ([p].[ProductID] <= 50))",
+                Sql);
+        }
+
+        public override void Where_not_bool_member_compared_to_not_bool_member()
+        {
+            base.Where_not_bool_member_compared_to_not_bool_member();
+
+            Assert.Equal(
+                @"SELECT [p].[Discontinued], [p].[ProductID], [p].[ProductName], [p].[UnitsInStock]
+FROM [Products] AS [p]
+WHERE ([p].[Discontinued] = 0 AND [p].[Discontinued] = 0) OR ([p].[Discontinued] = 1 AND [p].[Discontinued] = 1)",
+                Sql);
+        }
+
+        public override void Where_negated_boolean_expression_compared_to_another_negated_boolean_expression()
+        {
+            base.Where_negated_boolean_expression_compared_to_another_negated_boolean_expression();
+
+            Assert.Equal(
+                @"SELECT [p].[Discontinued], [p].[ProductID], [p].[ProductName], [p].[UnitsInStock]
+FROM [Products] AS [p]
+WHERE (([p].[ProductID] <= 50) AND ([p].[ProductID] <= 20)) OR (([p].[ProductID] > 50) AND ([p].[ProductID] > 20))",
+                Sql);
+        }
+
+        public override void Where_bool_parameter_compared_to_binary_expression()
+        {
+            base.Where_bool_parameter_compared_to_binary_expression();
+
+            Assert.Equal(
+                @"SELECT [p].[Discontinued], [p].[ProductID], [p].[ProductName], [p].[UnitsInStock]
+FROM [Products] AS [p]
+WHERE (([p].[ProductID] > 50) AND @__prm_0 = 0) OR (([p].[ProductID] <= 50) AND @__prm_0 = 1)",
+                Sql);
+        }
+
+        public override void Where_bool_member_and_parameter_compared_to_binary_expression_nested()
+        {
+            base.Where_bool_member_and_parameter_compared_to_binary_expression_nested();
+
+            Assert.Equal(
+                @"SELECT [p].[Discontinued], [p].[ProductID], [p].[ProductName], [p].[UnitsInStock]
+FROM [Products] AS [p]
+WHERE ([p].[Discontinued] = 1 AND ((([p].[ProductID] > 50) AND @__prm_0 = 0) OR (([p].[ProductID] <= 50) AND @__prm_0 = 1))) OR ([p].[Discontinued] = 0 AND (([p].[ProductID] <= 50) OR @__prm_0 = 1) AND (([p].[ProductID] > 50) OR @__prm_0 = 0))",
+                Sql);
+        }
+
+        public override void Where_de_morgan_or_optimizated()
+        {
+            base.Where_de_morgan_or_optimizated();
+
+            Assert.Equal(
+                @"SELECT [p].[Discontinued], [p].[ProductID], [p].[ProductName], [p].[UnitsInStock]
+FROM [Products] AS [p]
+WHERE [p].[Discontinued] = 0 AND ([p].[ProductID] >= 20)",
+                Sql);
+        }
+
+        public override void Where_de_morgan_and_optimizated()
+        {
+            base.Where_de_morgan_and_optimizated();
+
+            Assert.Equal(
+                @"SELECT [p].[Discontinued], [p].[ProductID], [p].[ProductName], [p].[UnitsInStock]
+FROM [Products] AS [p]
+WHERE [p].[Discontinued] = 0 OR ([p].[ProductID] >= 20)",
+                Sql);
+        }
+
+        public override void Where_complex_negated_expression_optimized()
+        {
+            base.Where_complex_negated_expression_optimized();
+
+            Assert.Equal(
+                @"SELECT [p].[Discontinued], [p].[ProductID], [p].[ProductName], [p].[UnitsInStock]
+FROM [Products] AS [p]
+WHERE [p].[Discontinued] = 0 AND ([p].[ProductID] < 60) AND ([p].[ProductID] > 30)",
                 Sql);
         }
 


### PR DESCRIPTION
#1760 - Query :: complex filter containing boolean expressions may produce invalid sql
#1830 - Query :: simplify negated expressions in query predicate

#1760:
Problem is when comparing expressions which are not simple (constant, parameter, column), e.g
products.Where(p => p.Discontinued == (p.ProductID > 100)). Naive translation produces invalid sql.

Fix is to expand those comparisons like so:
(a == b) => (a && b) || (!a && !b)
(a != b) => (!a && b) || (a && !b)

This is done before sql generation for perf reasons (result tree gets cached, sql does not).

#1830:
Since #1760 introduces additional (negated) expressions, we want to optimize them as much as possible.
This checkin handles the following optimizations:
!(!a) => a
!a == b => a != b
!a != b => a == b
!(a && b) => !a || !b
!(a || b) => !a && !b
!(a > b) => a <= b
!(a >= b) => a < b
!(a < b) => a >= b
!(a <= b) => a > b

Also fix some minor bugs where necessary parentheses would not be produced during sql generation