### PR TITLE
Clean up PerfTestRunner

### DIFF
--- a/test/EntityFramework.Microbenchmarks.Core/Extensions.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Extensions.cs
@@ -7,9 +7,8 @@ namespace EntityFramework.Microbenchmarks.Core
     {
         public static void RunTest(this TestDefinition definition)
         {
-            var runner = new PerfTestRunner();
-            runner.Register(definition);
-            runner.RunTests(TestConfig.Instance.ResultsDirectory);
+            var runner = new PerfTestRunner(definition);
+            runner.Run(TestConfig.Instance.ResultsDirectory);
         }
     }
 }

--- a/test/EntityFramework.Microbenchmarks.Core/PerformanceCaseResult.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/PerformanceCaseResult.cs
@@ -7,15 +7,8 @@ namespace EntityFramework.Microbenchmarks.Core
 {
     public class PerformanceCaseResult
     {
-        public PerformanceCaseResult()
-        {
-            Metrics = new PerformanceMetric[] { };
-            Failures = new string[] { };
-        }
-
         public DateTime StartTime { get; set; }
         public DateTime EndTime { get; set; }
-        public string[] Failures { get; set; }
         public PerformanceMetric[] Metrics { get; set; }
 
         public void StartTimer()


### PR DESCRIPTION
PerfTestRunner is only used to run one test at a time, but it's build in a way to allow run multiple tests at once. That's additional complexity that's not used and should be removed.

Resolves https://github.com/aspnet/EntityFramework/issues/1300

btw. When I run the tests locally the perf tests are not picked up. How do I run them?