### PR TITLE
Add AnnotateQuery operator and FromSql extension method

### DIFF
--- a/src/EntityFramework.Core/DbSet`.cs
+++ b/src/EntityFramework.Core/DbSet`.cs
@@ -31,7 +31,8 @@ namespace Microsoft.Data.Entity
     ///     </para>
     /// </summary>
     /// <typeparam name="TEntity"> The type of entity being operated on by this set. </typeparam>
-    public abstract class DbSet<TEntity> : IOrderedQueryable<TEntity>, IAsyncEnumerableAccessor<TEntity>, IAccessor<IServiceProvider>
+    public abstract class DbSet<TEntity>
+        : IOrderedQueryable<TEntity>, IAsyncEnumerableAccessor<TEntity>, IAccessor<IServiceProvider>, IAnnotatableQueryable<TEntity>
         where TEntity : class
     {
         /// <summary>
@@ -274,6 +275,20 @@ namespace Microsoft.Data.Entity
         IServiceProvider IAccessor<IServiceProvider>.Service
         {
             get { throw new NotImplementedException(); }
+        }
+
+        /// <summary>
+        ///     <para>
+        ///         Adds a <see cref="QueryAnnotation"/> to the query.
+        ///     </para>
+        ///     <para>
+        ///         This method is intended for use by extension methods that need to add information to
+        ///         the expression tree.
+        ///     </para>
+        /// </summary>
+        IQueryable<TEntity> IAnnotatableQueryable<TEntity>.AnnotateQuery(object annotation)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -127,6 +127,7 @@
     <Compile Include="DbContext.cs" />
     <Compile Include="DbContextOptionsBuilder.cs" />
     <Compile Include="DbContextOptionsBuilder`.cs" />
+    <Compile Include="Query\AnnotateQueryExtensions.cs" />
     <Compile Include="Infrastructure\CoreOptionsExtension.cs" />
     <Compile Include="Infrastructure\DbContextOptions.cs" />
     <Compile Include="Infrastructure\DbContextOptions`.cs" />
@@ -134,6 +135,7 @@
     <Compile Include="Infrastructure\IBoxedValueReaderSource.cs" />
     <Compile Include="Infrastructure\IDatabaseFactory.cs" />
     <Compile Include="Infrastructure\IDbContextOptions.cs" />
+    <Compile Include="Infrastructure\IAnnotatableQueryable`.cs" />
     <Compile Include="Infrastructure\IOptionsBuilderExtender.cs" />
     <Compile Include="Infrastructure\EntityFrameworkServicesBuilder.cs" />
     <Compile Include="Infrastructure\IAccessor.cs" />
@@ -230,6 +232,8 @@
     <Compile Include="Query\ResultOperators\AsNoTrackingExpressionNode.cs" />
     <Compile Include="Query\ResultOperators\AsNoTrackingResultOperator.cs" />
     <Compile Include="Query\ExpressionTreeVisitors\TaskBlockingExpressionTreeVisitor.cs" />
+    <Compile Include="Query\ResultOperators\AnnotateQueryExpressionNode.cs" />
+    <Compile Include="Query\ResultOperators\AnnotateQueryResultOperator.cs" />
     <Compile Include="Query\ResultOperators\ThenIncludeExpressionNode.cs" />
     <Compile Include="Storage\DataStoreErrorLogState.cs" />
     <Compile Include="Storage\DataStoreException.cs" />

--- a/src/EntityFramework.Core/Infrastructure/Annotatable.cs
+++ b/src/EntityFramework.Core/Infrastructure/Annotatable.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Data.Entity.Infrastructure
 
         public virtual Annotation AddAnnotation([NotNull] string annotationName, [NotNull] string value)
         {
-            Check.NotNull(annotationName, nameof(annotationName));
+            Check.NotEmpty(annotationName, nameof(annotationName));
             Check.NotNull(value, nameof(value));
 
             var annotation = new Annotation(annotationName, value);

--- a/src/EntityFramework.Core/Infrastructure/IAnnotatableQueryable`.cs
+++ b/src/EntityFramework.Core/Infrastructure/IAnnotatableQueryable`.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using JetBrains.Annotations;
+
+namespace Microsoft.Data.Entity.Infrastructure
+{
+    public interface IAnnotatableQueryable<TEntity> where TEntity : class
+    {
+        IQueryable<TEntity> AnnotateQuery([NotNull] object annotation);
+    }
+}

--- a/src/EntityFramework.Core/Internal/InternalDbSet.cs
+++ b/src/EntityFramework.Core/Internal/InternalDbSet.cs
@@ -15,7 +15,8 @@ using Microsoft.Framework.DependencyInjection;
 
 namespace Microsoft.Data.Entity.Internal
 {
-    public class InternalDbSet<TEntity> : DbSet<TEntity>, IOrderedQueryable<TEntity>, IAsyncEnumerableAccessor<TEntity>, IAccessor<IServiceProvider>
+    public class InternalDbSet<TEntity>
+        : DbSet<TEntity>, IOrderedQueryable<TEntity>, IAsyncEnumerableAccessor<TEntity>, IAccessor<IServiceProvider>, IAnnotatableQueryable<TEntity>
         where TEntity : class
     {
         private readonly DbContext _context;
@@ -132,5 +133,12 @@ namespace Microsoft.Data.Entity.Internal
         IQueryProvider IQueryable.Provider => _entityQueryable.Value.Provider;
 
         IServiceProvider IAccessor<IServiceProvider>.Service => ((IAccessor<IServiceProvider>)_context).Service;
+
+        IQueryable<TEntity> IAnnotatableQueryable<TEntity>.AnnotateQuery([NotNull] object annotation)
+        {
+            Check.NotNull(annotation, nameof(annotation));
+
+            return _entityQueryable.Value.AnnotateQuery(annotation);
+        }
     }
 }

--- a/src/EntityFramework.Core/Properties/Strings.Designer.cs
+++ b/src/EntityFramework.Core/Properties/Strings.Designer.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Data.Entity.Internal
     using System.Globalization;
     using System.Reflection;
     using System.Resources;
-	using JetBrains.Annotations;
+    using JetBrains.Annotations;
 
     public static class Strings
     {

--- a/src/EntityFramework.Core/Query/AnnotateQueryExtensions.cs
+++ b/src/EntityFramework.Core/Query/AnnotateQueryExtensions.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Query
+{
+    public static class AnnotateQueryExtensions
+    {
+        internal static readonly MethodInfo AnnotateQueryMethodInfo
+            = typeof(AnnotateQueryExtensions)
+                .GetTypeInfo().GetDeclaredMethod(nameof(AnnotateQuery));
+
+        public static IQueryable<TEntity> AnnotateQuery<TEntity>([NotNull] this IQueryable<TEntity> source, [NotNull] object annotation) where TEntity : class
+        {
+            Check.NotNull(source, nameof(source));
+            Check.NotNull(annotation, nameof(annotation));
+
+            return source.Provider.CreateQuery<TEntity>(
+                Expression.Call(
+                    null,
+                    AnnotateQueryMethodInfo.MakeGenericMethod(typeof(TEntity)),
+                    new[] { source.Expression, Expression.Constant(annotation) }));
+        }
+    }
+}

--- a/src/EntityFramework.Core/Query/CompiledQueryCache.cs
+++ b/src/EntityFramework.Core/Query/CompiledQueryCache.cs
@@ -372,6 +372,9 @@ namespace Microsoft.Data.Entity.Query
                 = MethodInfoBasedNodeTypeRegistry.CreateFromTypes(searchedTypes);
 
             methodInfoBasedNodeTypeRegistry
+                .Register(AnnotateQueryExpressionNode.SupportedMethods, typeof(AnnotateQueryExpressionNode));
+
+            methodInfoBasedNodeTypeRegistry
                 .Register(AsNoTrackingExpressionNode.SupportedMethods, typeof(AsNoTrackingExpressionNode));
 
             methodInfoBasedNodeTypeRegistry

--- a/src/EntityFramework.Core/Query/ExpressionTreeVisitors/DefaultQueryExpressionTreeVisitor.cs
+++ b/src/EntityFramework.Core/Query/ExpressionTreeVisitors/DefaultQueryExpressionTreeVisitor.cs
@@ -1,10 +1,14 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Query.ResultOperators;
 using Microsoft.Data.Entity.Utilities;
+using Remotion.Linq.Clauses;
 using Remotion.Linq.Clauses.Expressions;
 
 namespace Microsoft.Data.Entity.Query.ExpressionTreeVisitors
@@ -21,6 +25,18 @@ namespace Microsoft.Data.Entity.Query.ExpressionTreeVisitors
         }
 
         public virtual EntityQueryModelVisitor QueryModelVisitor => _entityQueryModelVisitor;
+
+        protected virtual IEnumerable<TAnnotation> GetAnnotations<TAnnotation>([NotNull] IQuerySource querySource)
+        {
+            Check.NotNull(querySource, nameof(querySource));
+
+            return QueryModelVisitor.QueryCompilationContext.QueryAnnotations
+                .Where(annotation => annotation.QuerySource == querySource)
+                .Select(annotation => annotation.ResultOperator)
+                .OfType<AnnotateQueryResultOperator>()
+                .Select(resultOperator => resultOperator.Expression.Value)
+                .OfType<TAnnotation>();
+        }
 
         protected override Expression VisitSubQueryExpression(SubQueryExpression subQueryExpression)
         {

--- a/src/EntityFramework.Core/Query/QueryAnnotationExtractor.cs
+++ b/src/EntityFramework.Core/Query/QueryAnnotationExtractor.cs
@@ -31,7 +31,8 @@ namespace Microsoft.Data.Entity.Query
             foreach (var resultOperator
                 in queryModel.ResultOperators
                     .Where(ro => ro is IncludeResultOperator
-                                 || ro is AsNoTrackingResultOperator)
+                            || ro is AsNoTrackingResultOperator
+                            || ro is AnnotateQueryResultOperator)
                     .ToList())
             {
                 queryAnnotations.Add(

--- a/src/EntityFramework.Core/Query/QueryCompilationContext.cs
+++ b/src/EntityFramework.Core/Query/QueryCompilationContext.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Metadata;
@@ -11,6 +12,8 @@ namespace Microsoft.Data.Entity.Query
 {
     public abstract class QueryCompilationContext
     {
+        private ICollection<QueryAnnotation> _queryAnnotations;
+
         protected QueryCompilationContext(
             [NotNull] IModel model,
             [NotNull] ILogger logger,
@@ -45,6 +48,21 @@ namespace Microsoft.Data.Entity.Query
         public virtual IEntityMaterializerSource EntityMaterializerSource { get; }
 
         public virtual IEntityKeyFactorySource EntityKeyFactorySource { get; }
+
+        public virtual ICollection<QueryAnnotation> QueryAnnotations
+        {
+            get
+            {
+                return _queryAnnotations;
+            }
+            [param: NotNull]
+            set
+            {
+                Check.NotNull(value, nameof(value));
+
+                _queryAnnotations = value;
+            }
+        }
 
         public virtual EntityQueryModelVisitor CreateQueryModelVisitor() => CreateQueryModelVisitor(null);
 

--- a/src/EntityFramework.Core/Query/ResultOperators/AnnotateQueryExpressionNode.cs
+++ b/src/EntityFramework.Core/Query/ResultOperators/AnnotateQueryExpressionNode.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Utilities;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Parsing.Structure.IntermediateModel;
+
+namespace Microsoft.Data.Entity.Query.ResultOperators
+{
+    public class AnnotateQueryExpressionNode : ResultOperatorExpressionNodeBase
+    {
+        public static readonly MethodInfo[] SupportedMethods = { AnnotateQueryExtensions.AnnotateQueryMethodInfo };
+
+        private readonly ConstantExpression _annotationExpression;
+
+        public AnnotateQueryExpressionNode(
+            [NotNull] MethodCallExpressionParseInfo parseInfo,
+            [NotNull] ConstantExpression annotationExpression)
+            : base(
+                  Check.NotNull(parseInfo, nameof(parseInfo)),
+                  null,
+                  null)
+        {
+            Check.NotNull(annotationExpression, nameof(annotationExpression));
+
+            _annotationExpression = annotationExpression;
+        }
+
+        protected override ResultOperatorBase CreateResultOperator([NotNull] ClauseGenerationContext clauseGenerationContext)
+        {
+            Check.NotNull(clauseGenerationContext, nameof(clauseGenerationContext));
+
+            return new AnnotateQueryResultOperator(_annotationExpression);
+        }
+
+        public override Expression Resolve(
+            ParameterExpression inputParameter,
+            Expression expressionToBeResolved,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            Check.NotNull(inputParameter, nameof(inputParameter));
+            Check.NotNull(expressionToBeResolved, nameof(expressionToBeResolved));
+
+            return Source.Resolve(inputParameter, expressionToBeResolved, clauseGenerationContext);
+        }
+    }
+}

--- a/src/EntityFramework.Core/Query/ResultOperators/AnnotateQueryResultOperator.cs
+++ b/src/EntityFramework.Core/Query/ResultOperators/AnnotateQueryResultOperator.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Utilities;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.ExpressionTreeVisitors;
+using Remotion.Linq.Clauses.ResultOperators;
+using Remotion.Linq.Clauses.StreamedData;
+
+namespace Microsoft.Data.Entity.Query.ResultOperators
+{
+    public class AnnotateQueryResultOperator : SequenceTypePreservingResultOperatorBase
+    {
+        private readonly ConstantExpression _annotationExpression;
+
+        public AnnotateQueryResultOperator([NotNull] ConstantExpression annotationExpression)
+        {
+            Check.NotNull(annotationExpression, nameof(annotationExpression));
+
+            _annotationExpression = annotationExpression;
+        }
+
+        public virtual ConstantExpression Expression => _annotationExpression;
+
+        public override string ToString()
+        {
+            return "AnnotateQuery("
+                + FormattingExpressionTreeVisitor.Format(_annotationExpression)
+                + ")";
+        }
+
+        public override ResultOperatorBase Clone([NotNull] CloneContext cloneContext)
+        {
+            Check.NotNull(cloneContext, nameof(cloneContext));
+
+            return new AnnotateQueryResultOperator(_annotationExpression);
+        }
+
+        public override void TransformExpressions([NotNull] Func<Expression, Expression> transformation)
+        {
+        }
+
+        public override StreamedSequence ExecuteInMemory<T>([NotNull] StreamedSequence input)
+        {
+            return input;
+        }
+    }
+}

--- a/src/EntityFramework.Core/Utilities/IndentedStringBuilder.cs
+++ b/src/EntityFramework.Core/Utilities/IndentedStringBuilder.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.IO;
 using System.Text;
 using JetBrains.Annotations;
 
@@ -57,6 +58,23 @@ namespace Microsoft.Data.Entity.Utilities
 
             return this;
         }
+
+        public virtual IndentedStringBuilder AppendLines([NotNull] object o)
+        {
+            Check.NotNull(o, nameof(o));
+
+            using (var reader = new StringReader(o.ToString()))
+            {
+                string line;
+                while ((line = reader.ReadLine()) != null)
+                {
+                    AppendLine(line);
+                }
+            }
+
+            return this;
+        }
+
 
         public virtual IndentedStringBuilder IncrementIndent()
         {

--- a/src/EntityFramework.Relational/EntityFramework.Relational.csproj
+++ b/src/EntityFramework.Relational/EntityFramework.Relational.csproj
@@ -141,6 +141,7 @@
     <Compile Include="Migrations\Operations\RenameSequenceOperation.cs" />
     <Compile Include="Migrations\Operations\RenameTableOperation.cs" />
     <Compile Include="Migrations\Operations\SqlOperation.cs" />
+    <Compile Include="Query\Annotations\FromSqlAnnotation.cs" />
     <Compile Include="Query\AsyncQueryingEnumerable.cs" />
     <Compile Include="Query\AsyncQueryMethodProvider.cs" />
     <Compile Include="Query\CommandBuilder.cs" />
@@ -149,6 +150,7 @@
     <Compile Include="Query\ExpressionTreeVisitors\EqualityPredicateExpandingVisitor.cs" />
     <Compile Include="Query\ExpressionTreeVisitors\EqualityPredicateInExpressionOptimizer.cs" />
     <Compile Include="Query\Expressions\AggregateExpression.cs" />
+    <Compile Include="Query\Expressions\RawSqlDerivedTableExpression.cs" />
     <Compile Include="Query\Expressions\DiscriminatorPredicateExpression.cs" />
     <Compile Include="Query\Expressions\InExpression.cs" />
     <Compile Include="Query\Expressions\JoinExpressionBase.cs" />
@@ -206,6 +208,7 @@
     <Compile Include="RelationalDataStoreServiceFactories.cs" />
     <Compile Include="IRelationalDataStoreServices.cs" />
     <Compile Include="RelationalDbContextOptions.cs" />
+    <Compile Include="RelationalDbSetExtensions.cs" />
     <Compile Include="RelationalMetadataExtensions.cs" />
     <Compile Include="RelationalOptionsExtension.cs" />
     <Compile Include="RelationalConnection.cs" />

--- a/src/EntityFramework.Relational/Properties/Strings.Designer.cs
+++ b/src/EntityFramework.Relational/Properties/Strings.Designer.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Data.Entity.Relational
     using System.Globalization;
     using System.Reflection;
     using System.Resources;
-	using JetBrains.Annotations;
+    using JetBrains.Annotations;
 
     public static class Strings
     {

--- a/src/EntityFramework.Relational/Query/Annotations/FromSqlAnnotation.cs
+++ b/src/EntityFramework.Relational/Query/Annotations/FromSqlAnnotation.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Relational.Query.Annotations
+{
+    public class FromSqlAnnotation
+    {
+        public FromSqlAnnotation([NotNull] string sql)
+        {
+            Check.NotEmpty(sql, nameof(sql));
+
+            Sql = sql;
+        }
+
+        public virtual string Sql { get; }
+
+        public override string ToString()
+        {
+            return Sql;
+        }
+    }
+}

--- a/src/EntityFramework.Relational/Query/Expressions/RawSqlDerivedTableExpression.cs
+++ b/src/EntityFramework.Relational/Query/Expressions/RawSqlDerivedTableExpression.cs
@@ -10,26 +10,22 @@ using Remotion.Linq.Parsing;
 
 namespace Microsoft.Data.Entity.Relational.Query.Expressions
 {
-    public class TableExpression : TableExpressionBase
+    public class RawSqlDerivedTableExpression : TableExpressionBase
     {
-        public TableExpression(
-            [NotNull] string table,
-            [CanBeNull] string schema,
+        public RawSqlDerivedTableExpression(
+            [NotNull] string sql,
             [NotNull] string alias,
             [NotNull] IQuerySource querySource)
             : base(
-                Check.NotNull(querySource, nameof(querySource)),
-                Check.NotEmpty(alias, nameof(alias)))
+                  Check.NotNull(querySource, nameof(querySource)),
+                  Check.NotEmpty(alias, nameof(alias)))
         {
-            Check.NotEmpty(table, nameof(table));
+            Check.NotEmpty(sql, nameof(sql));
 
-            Table = table;
-            Schema = schema;
+            Sql = sql;
         }
 
-        public virtual string Table { get; }
-
-        public virtual string Schema { get; }
+        public virtual string Sql { get; }
 
         public override Expression Accept([NotNull] ExpressionTreeVisitor visitor)
         {
@@ -38,13 +34,13 @@ namespace Microsoft.Data.Entity.Relational.Query.Expressions
             var specificVisitor = visitor as ISqlExpressionVisitor;
 
             return specificVisitor != null
-                ? specificVisitor.VisitTableExpression(this)
+                ? specificVisitor.VisitRawSqlDerivedTableExpression(this)
                 : base.Accept(visitor);
         }
 
         public override string ToString()
         {
-            return Table + " " + Alias;
+            return Sql + " " + Alias;
         }
     }
 }

--- a/src/EntityFramework.Relational/Query/Sql/DefaultSqlQueryGenerator.cs
+++ b/src/EntityFramework.Relational/Query/Sql/DefaultSqlQueryGenerator.cs
@@ -178,6 +178,23 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
             }
         }
 
+        public virtual Expression VisitRawSqlDerivedTableExpression([NotNull] RawSqlDerivedTableExpression rawSqlDerivedTableExpression)
+        {
+            Check.NotNull(rawSqlDerivedTableExpression, nameof(rawSqlDerivedTableExpression));
+
+            _sql.AppendLine("(");
+
+            using (_sql.Indent())
+            {
+                _sql.AppendLines(rawSqlDerivedTableExpression.Sql);
+            }
+
+            _sql.Append(") AS ")
+                .Append(DelimitIdentifier(rawSqlDerivedTableExpression.Alias));
+
+            return rawSqlDerivedTableExpression;
+        }
+
         public virtual Expression VisitTableExpression(TableExpression tableExpression)
         {
             Check.NotNull(tableExpression, nameof(tableExpression));

--- a/src/EntityFramework.Relational/Query/Sql/ISqlExpressionVisitor.cs
+++ b/src/EntityFramework.Relational/Query/Sql/ISqlExpressionVisitor.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
         Expression VisitLiteralExpression([NotNull] LiteralExpression literalExpression);
         Expression VisitSelectExpression([NotNull] SelectExpression selectExpression);
         Expression VisitTableExpression([NotNull] TableExpression tableExpression);
+        Expression VisitRawSqlDerivedTableExpression([NotNull] RawSqlDerivedTableExpression rawSqlDerivedTableExpression);
         Expression VisitCrossJoinExpression([NotNull] CrossJoinExpression crossJoinExpression);
         Expression VisitInnerJoinExpression([NotNull] InnerJoinExpression innerJoinExpression);
         Expression VisitOuterJoinExpression([NotNull] LeftOuterJoinExpression leftOuterJoinExpression);

--- a/src/EntityFramework.Relational/RelationalDbSetExtensions.cs
+++ b/src/EntityFramework.Relational/RelationalDbSetExtensions.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Relational.Query.Annotations;
+using Microsoft.Data.Entity.Utilities;
+
+// ReSharper disable once CheckNamespace
+
+namespace Microsoft.Data.Entity
+{
+    public static class RelationalDbSetExtensions
+    {
+        public static IQueryable<TEntity> FromSql<TEntity>([NotNull]this DbSet<TEntity> dbSet, [NotNull]string sql)
+            where TEntity : class
+        {
+            Check.NotNull(dbSet, nameof(dbSet));
+            Check.NotEmpty(sql, nameof(sql));
+
+            return ((IAnnotatableQueryable<TEntity>)dbSet).AnnotateQuery(new FromSqlAnnotation(sql));
+        }
+    }
+}

--- a/test/EntityFramework.Core.FunctionalTests/AsyncQueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/AsyncQueryTestBase.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.Entity.FunctionalTests.TestModels.Northwind;
 using Microsoft.Data.Entity.Query;
+using Microsoft.Data.Entity.Tests;
 using Xunit;
 
 namespace Microsoft.Data.Entity.FunctionalTests
@@ -1703,7 +1704,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             using (var context = CreateContext())
             {
-                return AssertResults(
+                return TestHelpers.AssertResults(
                     new[] { await query(NorthwindData.Set<TItem>()) },
                     new[] { await query(context.Set<TItem>()) },
                     assertOrder);
@@ -1717,7 +1718,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             using (var context = CreateContext())
             {
-                return AssertResults(
+                return TestHelpers.AssertResults(
                     new[] { await query(NorthwindData.Set<TItem>()) },
                     new[] { await query(context.Set<TItem>()) },
                     assertOrder);
@@ -1731,7 +1732,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             using (var context = CreateContext())
             {
-                return AssertResults(
+                return TestHelpers.AssertResults(
                     new[] { await query(NorthwindData.Set<TItem>()) },
                     new[] { await query(context.Set<TItem>()) },
                     assertOrder);
@@ -1746,7 +1747,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             using (var context = CreateContext())
             {
-                return AssertResults(
+                return TestHelpers.AssertResults(
                     new[] { await query(NorthwindData.Set<TItem1>(), NorthwindData.Set<TItem2>()) },
                     new[] { await query(context.Set<TItem1>(), context.Set<TItem2>()) },
                     assertOrder);
@@ -1761,7 +1762,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             using (var context = CreateContext())
             {
-                return AssertResults(
+                return TestHelpers.AssertResults(
                     query(NorthwindData.Set<TItem>()).ToArray(),
                     await query(context.Set<TItem>()).ToArrayAsync(),
                     assertOrder,
@@ -1777,7 +1778,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             using (var context = CreateContext())
             {
-                return AssertResults(
+                return TestHelpers.AssertResults(
                     query(NorthwindData.Set<TItem>()).ToArray(),
                     await query(context.Set<TItem>()).ToArrayAsync(),
                     assertOrder,
@@ -1794,7 +1795,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             using (var context = CreateContext())
             {
-                return AssertResults(
+                return TestHelpers.AssertResults(
                     query(NorthwindData.Set<TItem1>(), NorthwindData.Set<TItem2>()).ToArray(),
                     await query(context.Set<TItem1>(), context.Set<TItem2>()).ToArrayAsync(),
                     assertOrder,
@@ -1811,7 +1812,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             using (var context = CreateContext())
             {
-                return AssertResults(
+                return TestHelpers.AssertResults(
                     query(NorthwindData.Set<TItem1>(), NorthwindData.Set<TItem2>(), NorthwindData.Set<TItem3>()).ToArray(),
                     await query(context.Set<TItem1>(), context.Set<TItem2>(), context.Set<TItem3>()).ToArrayAsync(),
                     assertOrder);
@@ -1824,7 +1825,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             using (var context = CreateContext())
             {
-                return AssertResults(
+                return TestHelpers.AssertResults(
                     query(NorthwindData.Set<TItem>()).ToArray(),
                     await query(context.Set<TItem>()).ToArrayAsync(),
                     assertOrder);
@@ -1837,7 +1838,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             using (var context = CreateContext())
             {
-                return AssertResults(
+                return TestHelpers.AssertResults(
                     query(NorthwindData.Set<TItem>()).ToArray(),
                     await query(context.Set<TItem>()).ToArrayAsync(),
                     assertOrder);
@@ -1850,49 +1851,11 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             using (var context = CreateContext())
             {
-                return AssertResults(
+                return TestHelpers.AssertResults(
                     query(NorthwindData.Set<TItem>()).ToArray(),
                     await query(context.Set<TItem>()).ToArrayAsync(),
                     assertOrder);
             }
-        }
-
-        private static int AssertResults<T>(
-            IList<T> l2oItems,
-            IList<T> efItems,
-            bool assertOrder,
-            Action<IList<T>, IList<T>> asserter = null)
-        {
-            Assert.Equal(l2oItems.Count, efItems.Count);
-
-            if (asserter != null)
-            {
-                asserter(l2oItems, efItems);
-            }
-            else
-            {
-                if (assertOrder)
-                {
-                    Assert.Equal(l2oItems, efItems);
-                }
-                else
-                {
-                    foreach (var l2oItem in l2oItems)
-                    {
-                        if (!efItems.Contains(l2oItem))
-                        {
-                            Assert.True(
-                                false,
-                                string.Format(
-                                    "\r\nL2o item: [{0}] not found in EF results:\r\n{1}",
-                                    l2oItem,
-                                    string.Join("\r\n", efItems)));
-                        }
-                    }
-                }
-            }
-
-            return l2oItems.Count;
         }
     }
 }

--- a/test/EntityFramework.Core.FunctionalTests/EntityFramework.Core.FunctionalTests.csproj
+++ b/test/EntityFramework.Core.FunctionalTests/EntityFramework.Core.FunctionalTests.csproj
@@ -188,6 +188,10 @@
       <Project>{71415CEC-8111-4C73-8751-512D22F10602}</Project>
       <Name>EntityFramework.Core</Name>
     </ProjectReference>
+    <ProjectReference Include="..\EntityFramework.Core.Tests\EntityFramework.Core.Tests.csproj">
+      <Project>{ef361118-7d0d-453e-ada4-2f24fbee196c}</Project>
+      <Name>EntityFramework.Core.Tests</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Data.Entity.FunctionalTests.TestModels.Northwind;
 using Microsoft.Data.Entity.Query;
+using Microsoft.Data.Entity.Tests;
 using Xunit;
 
 // ReSharper disable AccessToModifiedClosure
@@ -2763,7 +2764,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             using (var context = CreateContext())
             {
-                AssertResults(
+                TestHelpers.AssertResults(
                     new[] { query(NorthwindData.Set<TItem>()) },
                     new[] { query(context.Set<TItem>()) },
                     assertOrder);
@@ -2777,7 +2778,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             using (var context = CreateContext())
             {
-                AssertResults(
+                TestHelpers.AssertResults(
                     new[] { query(NorthwindData.Set<TItem>()) },
                     new[] { query(context.Set<TItem>()) },
                     assertOrder);
@@ -2791,7 +2792,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             using (var context = CreateContext())
             {
-                AssertResults(
+                TestHelpers.AssertResults(
                     new[] { query(NorthwindData.Set<TItem>()) },
                     new[] { query(context.Set<TItem>()) },
                     assertOrder);
@@ -2806,7 +2807,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             using (var context = CreateContext())
             {
-                AssertResults(
+                TestHelpers.AssertResults(
                     new[] { query(NorthwindData.Set<TItem1>(), NorthwindData.Set<TItem2>()) },
                     new[] { query(context.Set<TItem1>(), context.Set<TItem2>()) },
                     assertOrder);
@@ -2822,7 +2823,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             using (var context = CreateContext())
             {
-                AssertResults(
+                TestHelpers.AssertResults(
                     new[] { query(NorthwindData.Set<TItem1>(), NorthwindData.Set<TItem2>(), NorthwindData.Set<TItem3>()) },
                     new[] { query(context.Set<TItem1>(), context.Set<TItem2>(), context.Set<TItem3>()) },
                     assertOrder);
@@ -2837,7 +2838,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             using (var context = CreateContext())
             {
-                AssertResults(
+                TestHelpers.AssertResults(
                     query(NorthwindData.Set<TItem>()).ToArray(),
                     query(context.Set<TItem>()).ToArray(),
                     assertOrder,
@@ -2863,7 +2864,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             using (var context = CreateContext())
             {
-                AssertResults(
+                TestHelpers.AssertResults(
                     query(NorthwindData.Set<TItem1>(), NorthwindData.Set<TItem2>()).ToArray(),
                     query(context.Set<TItem1>(), context.Set<TItem2>()).ToArray(),
                     assertOrder,
@@ -2880,7 +2881,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             using (var context = CreateContext())
             {
-                AssertResults(
+                TestHelpers.AssertResults(
                     query(NorthwindData.Set<TItem1>(), NorthwindData.Set<TItem2>(), NorthwindData.Set<TItem3>()).ToArray(),
                     query(context.Set<TItem1>(), context.Set<TItem2>(), context.Set<TItem3>()).ToArray(),
                     assertOrder);
@@ -2893,7 +2894,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             using (var context = CreateContext())
             {
-                AssertResults(
+                TestHelpers.AssertResults(
                     query(NorthwindData.Set<TItem>()).ToArray(),
                     query(context.Set<TItem>()).ToArray(),
                     assertOrder);
@@ -2906,7 +2907,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             using (var context = CreateContext())
             {
-                AssertResults(
+                TestHelpers.AssertResults(
                     query(NorthwindData.Set<TItem>()).ToArray(),
                     query(context.Set<TItem>()).ToArray(),
                     assertOrder);
@@ -2922,7 +2923,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             using (var context = CreateContext())
             {
-                AssertResults(
+                TestHelpers.AssertResults(
                     l2oQuery(NorthwindData.Set<TItem>()).ToArray(),
                     efQuery(context.Set<TItem>()).ToArray(),
                     assertOrder);
@@ -2937,43 +2938,10 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             using (var context = CreateContext())
             {
-                AssertResults(
+                TestHelpers.AssertResults(
                     query(NorthwindData.Set<TItem>()).ToArray(),
                     query(context.Set<TItem>()).ToArray(),
                     assertOrder);
-            }
-        }
-
-        private static void AssertResults<T>(
-            IList<T> l2oItems,
-            IList<T> efItems,
-            bool assertOrder,
-            Action<IList<T>, IList<T>> asserter = null)
-        {
-            Assert.Equal(l2oItems.Count, efItems.Count);
-
-            if (asserter != null)
-            {
-                asserter(l2oItems, efItems);
-            }
-            else
-            {
-                if (assertOrder)
-                {
-                    Assert.Equal(l2oItems, efItems);
-                }
-                else
-                {
-                    foreach (var l2oItem in l2oItems)
-                    {
-                        Assert.True(
-                            efItems.Contains(l2oItem),
-                            string.Format(
-                                "\r\nL2o item: [{0}] not found in EF results: [{1}]...",
-                                l2oItem,
-                                string.Join(", ", efItems.Take(10))));
-                    }
-                }
             }
         }
     }

--- a/test/EntityFramework.Core.FunctionalTests/project.json
+++ b/test/EntityFramework.Core.FunctionalTests/project.json
@@ -1,5 +1,6 @@
 {
     "dependencies": {
+        "EntityFramework.Core.Tests": "1.0.0",
         "EntityFramework.InMemory": "7.0.0-*",
         "xunit.runner.aspnet": "2.0.0-aspnet-*"
     },

--- a/test/EntityFramework.Core.Tests/TestHelpers.cs
+++ b/test/EntityFramework.Core.Tests/TestHelpers.cs
@@ -2,10 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Framework.DependencyInjection;
+using Xunit;
 
 namespace Microsoft.Data.Entity.Tests
 {
@@ -178,6 +181,40 @@ namespace Microsoft.Data.Entity.Tests
             entry.SetEntityState(entityState);
 
             return entry;
+        }
+
+        public static int AssertResults<T>(
+            IList<T> expected,
+            IList<T> actual,
+            bool assertOrder,
+            Action<IList<T>, IList<T>> asserter = null)
+        {
+            Assert.Equal(expected.Count, actual.Count);
+
+            if (asserter != null)
+            {
+                asserter(expected, actual);
+            }
+            else
+            {
+                if (assertOrder)
+                {
+                    Assert.Equal(expected, actual);
+                }
+                else
+                {
+                    foreach (var expectedItem in expected)
+                    {
+                        Assert.True(
+                            actual.Contains(expectedItem),
+                            string.Format(
+                                "\r\nExpected item: [{0}] not found in results: [{1}]...",
+                                expectedItem,
+                                string.Join(", ", actual.Take(10))));
+                    }
+                }
+            }
+            return actual.Count;
         }
     }
 }

--- a/test/EntityFramework.Relational.FunctionalTests/AsyncFromSqlQueryTestBase.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/AsyncFromSqlQueryTestBase.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Data.Entity.FunctionalTests.TestModels.Northwind;
+using Microsoft.Data.Entity.Tests;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Relational.FunctionalTests
+{
+    public class AsyncFromSqlQueryTestBase<TFixture> : IClassFixture<TFixture>
+        where TFixture : NorthwindQueryFixtureBase, new()
+    {
+        [Fact]
+        public virtual async Task From_sql_queryable_simple()
+        {
+            Assert.Equal(91,
+                await AssertQuery<Customer>(
+                    cs => cs.FromSql("SELECT * FROM Customers"),
+                    cs => cs));
+        }
+
+        [Fact]
+        public virtual async Task From_sql_queryable_filter()
+        {
+            Assert.Equal(14,
+                await AssertQuery<Customer>(
+                    cs => cs.FromSql("SELECT * FROM Customers WHERE Customers.ContactName LIKE '%z%'"),
+                    cs => cs.Where(c => c.ContactName.Contains("z"))));
+        }
+
+        [Fact]
+        public virtual async Task From_sql_queryable_cached_by_query()
+        {
+            Assert.Equal(6,
+                await AssertQuery<Customer>(
+                    cs => cs.FromSql("SELECT * FROM Customers WHERE Customers.City = 'London'"),
+                    cs => cs.Where(c => c.City == "London")));
+
+            Assert.Equal(1,
+                await AssertQuery<Customer>(
+                    cs => cs.FromSql("SELECT * FROM Customers WHERE Customers.City = 'Seattle'"),
+                    cs => cs.Where(c => c.City == "Seattle")));
+        }
+
+        [Fact]
+        public virtual async Task From_sql_queryable_where_simple_closure_via_query_cache()
+        {
+            var title = "Sales Associate";
+
+            Assert.Equal(4,
+                await AssertQuery<Customer>(
+                    cs => cs.FromSql("SELECT * FROM Customers WHERE Customers.ContactName LIKE '%o%'").Where(c => c.ContactTitle == title),
+                    cs => cs.Where(c => c.ContactName.Contains("o")).Where(c => c.ContactTitle == title)));
+
+            title = "Sales Manager";
+
+            Assert.Equal(7,
+                await AssertQuery<Customer>(
+                    cs => cs.FromSql("SELECT * FROM Customers WHERE Customers.ContactName LIKE '%o%'").Where(c => c.ContactTitle == title),
+                    cs => cs.Where(c => c.ContactName.Contains("o")).Where(c => c.ContactTitle == title)));
+        }
+
+        protected NorthwindContext CreateContext()
+        {
+            return Fixture.CreateContext();
+        }
+
+        protected AsyncFromSqlQueryTestBase(TFixture fixture)
+        {
+            Fixture = fixture;
+        }
+
+        protected TFixture Fixture { get; }
+
+        private async Task<int> AssertQuery<TItem>(
+            Func<DbSet<TItem>, IQueryable<object>> relationalQuery,
+            Func<IQueryable<TItem>, IQueryable<object>> l2oQuery,
+            bool assertOrder = false,
+            Action<IList<object>, IList<object>> asserter = null)
+            where TItem : class
+        {
+            using (var context = CreateContext())
+            {
+                return TestHelpers.AssertResults(
+                    l2oQuery(NorthwindData.Set<TItem>()).ToArray(),
+                    await relationalQuery(context.Set<TItem>()).ToArrayAsync(),
+                    assertOrder,
+                    asserter);
+            }
+        }
+
+    }
+}

--- a/test/EntityFramework.Relational.FunctionalTests/EntityFramework.Relational.FunctionalTests.csproj
+++ b/test/EntityFramework.Relational.FunctionalTests/EntityFramework.Relational.FunctionalTests.csproj
@@ -74,6 +74,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AsyncFromSqlQueryTestBase.cs" />
     <Compile Include="MappingQueryTestBase.cs" />
     <Compile Include="MappingQueryFixtureBase.cs" />
     <Compile Include="NullSemanticsQueryRelationalFixture.cs" />
@@ -82,6 +83,7 @@
     <Compile Include="F1RelationalFixture.cs" />
     <Compile Include="GearsOfWarQueryRelationalFixture.cs" />
     <Compile Include="NorthwindQueryRelationalFixture.cs" />
+    <Compile Include="FromSqlQueryTestBase.cs" />
     <Compile Include="RelationalTestStore.cs" />
     <Compile Include="TestSqlLoggerFactory.cs" />
     <Compile Include="TransactionFixtureBase.cs" />
@@ -103,6 +105,10 @@
     <ProjectReference Include="..\EntityFramework.Core.FunctionalTests\EntityFramework.Core.FunctionalTests.csproj">
       <Project>{6ab933c7-de2a-45f2-bdc6-e71a01ef7756}</Project>
       <Name>EntityFramework.Core.FunctionalTests</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\EntityFramework.Core.Tests\EntityFramework.Core.Tests.csproj">
+      <Project>{ef361118-7d0d-453e-ada4-2f24fbee196c}</Project>
+      <Name>EntityFramework.Core.Tests</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/test/EntityFramework.Relational.FunctionalTests/FromSqlQueryTestBase.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/FromSqlQueryTestBase.cs
@@ -1,0 +1,128 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Data.Entity.FunctionalTests.TestModels.Northwind;
+using Microsoft.Data.Entity.Tests;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Relational.FunctionalTests
+{
+    public abstract class FromSqlQueryTestBase<TFixture> : IClassFixture<TFixture>
+        where TFixture : NorthwindQueryFixtureBase, new()
+    {
+        [Fact]
+        public virtual void From_sql_queryable_simple()
+        {
+            AssertQuery<Customer>(
+                cs => cs.FromSql("SELECT * FROM Customers"),
+                cs => cs,
+                entryCount: 91);
+        }
+
+        [Fact]
+        public virtual void From_sql_queryable_filter()
+        {
+            AssertQuery<Customer>(
+                cs => cs.FromSql("SELECT * FROM Customers WHERE Customers.ContactName LIKE '%z%'"),
+                cs => cs.Where(c => c.ContactName.Contains("z")),
+                entryCount: 14);
+        }
+
+        [Fact]
+        public virtual void From_sql_queryable_cached_by_query()
+        {
+            AssertQuery<Customer>(
+                cs => cs.FromSql("SELECT * FROM Customers WHERE Customers.City = 'London'"),
+                cs => cs.Where(c => c.City == "London"),
+                entryCount: 6);
+
+            AssertQuery<Customer>(
+                cs => cs.FromSql("SELECT * FROM Customers WHERE Customers.City = 'Seattle'"),
+                cs => cs.Where(c => c.City == "Seattle"),
+                entryCount: 1);
+        }
+
+        [Fact]
+        public virtual void From_sql_queryable_where_simple_closure_via_query_cache()
+        {
+            var title = "Sales Associate";
+
+            AssertQuery<Customer>(
+                cs => cs.FromSql("SELECT * FROM Customers WHERE Customers.ContactName LIKE '%o%'").Where(c => c.ContactTitle == title),
+                cs => cs.Where(c => c.ContactName.Contains("o")).Where(c => c.ContactTitle == title),
+                entryCount: 4);
+
+            title = "Sales Manager";
+
+            AssertQuery<Customer>(
+                cs => cs.FromSql("SELECT * FROM Customers WHERE Customers.ContactName LIKE '%o%'").Where(c => c.ContactTitle == title),
+                cs => cs.Where(c => c.ContactName.Contains("o")).Where(c => c.ContactTitle == title),
+                entryCount: 7);
+        }
+
+        [Fact]
+        public virtual void From_sql_queryable_with_multiple_line_query()
+        {
+            AssertQuery<Customer>(
+                cs => cs.FromSql(@"SELECT *
+FROM Customers
+WHERE Customers.City = 'London'"),
+                cs => cs.Where(c => c.City == "London"),
+                entryCount: 6);
+        }
+
+        [Fact]
+        public virtual void From_sql_annotations_do_not_modify_successive_calls()
+        {
+            using (var context = CreateContext())
+            {
+                TestHelpers.AssertResults(
+                    NorthwindData.Set<Customer>().Where(c => c.ContactName.Contains("z")).ToArray(),
+                    context.Customers.FromSql("SELECT * FROM Customers WHERE Customers.ContactName LIKE '%z%'").ToArray(),
+                    assertOrder: false);
+
+                Assert.Equal(14, context.ChangeTracker.Entries().Count());
+
+                TestHelpers.AssertResults(
+                    NorthwindData.Set<Customer>().ToArray(),
+                    context.Customers.ToArray(),
+                    assertOrder: false);
+
+                Assert.Equal(91, context.ChangeTracker.Entries().Count());
+            }
+        }
+
+        protected NorthwindContext CreateContext()
+        {
+            return Fixture.CreateContext();
+        }
+
+        protected FromSqlQueryTestBase(TFixture fixture)
+        {
+            Fixture = fixture;
+        }
+
+        protected TFixture Fixture { get; }
+
+        private void AssertQuery<TItem>(
+            Func<DbSet<TItem>, IQueryable<object>> relationalQuery,
+            Func<IQueryable<TItem>, IQueryable<object>> l2oQuery,
+            bool assertOrder = false,
+            int entryCount = 0)
+            where TItem : class
+        {
+            using (var context = CreateContext())
+            {
+                TestHelpers.AssertResults(
+                    l2oQuery(NorthwindData.Set<TItem>()).ToArray(),
+                    relationalQuery(context.Set<TItem>()).ToArray(),
+                    assertOrder);
+
+                Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
+            }
+        }
+    }
+}

--- a/test/EntityFramework.Relational.FunctionalTests/project.json
+++ b/test/EntityFramework.Relational.FunctionalTests/project.json
@@ -1,5 +1,6 @@
 {
     "dependencies": {
+        "EntityFramework.Core.Tests": "1.0.0",
         "EntityFramework.Core.FunctionalTests": "1.0.0",
         "EntityFramework.Relational": "7.0.0-*"
     },

--- a/test/EntityFramework.SqlServer.FunctionalTests/AsyncFromSqlQuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/AsyncFromSqlQuerySqlServerTest.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Relational.FunctionalTests;
+
+namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
+{
+    public class AsyncFromSqlQuerySqlServerTest : AsyncFromSqlQueryTestBase<NorthwindQuerySqlServerFixture>
+    {
+        public AsyncFromSqlQuerySqlServerTest(NorthwindQuerySqlServerFixture fixture)
+            : base(fixture)
+        {
+        }
+    }
+}

--- a/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
+++ b/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
@@ -80,8 +80,10 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AsyncFromSqlQuerySqlServerTest.cs" />
     <Compile Include="CommandConfigurationTests.cs" />
     <Compile Include="ComputedColumnTest.cs" />
+    <Compile Include="FromSqlQuerySqlServerTest.cs" />
     <Compile Include="NavigationTest.cs" />
     <Compile Include="InheritanceSqlServerFixture.cs" />
     <Compile Include="InheritanceSqlServerTest.cs" />

--- a/test/EntityFramework.SqlServer.FunctionalTests/FromSqlQuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/FromSqlQuerySqlServerTest.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Relational.FunctionalTests;
+using Xunit;
+
+namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
+{
+    public class FromSqlQuerySqlServerTest : FromSqlQueryTestBase<NorthwindQuerySqlServerFixture>
+    {
+        public override void From_sql_queryable_simple()
+        {
+            base.From_sql_queryable_simple();
+
+            Assert.Equal(
+                @"SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM (
+    SELECT * FROM Customers
+) AS [c]",
+                Sql);
+        }
+
+        public override void From_sql_queryable_filter()
+        {
+            base.From_sql_queryable_filter();
+
+            Assert.Equal(
+                @"SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM (
+    SELECT * FROM Customers WHERE Customers.ContactName LIKE '%z%'
+) AS [c]",
+                Sql);
+        }
+        public override void From_sql_queryable_cached_by_query()
+        {
+            base.From_sql_queryable_cached_by_query();
+
+            Assert.Equal(
+                @"SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM (
+    SELECT * FROM Customers WHERE Customers.City = 'London'
+) AS [c]
+
+SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM (
+    SELECT * FROM Customers WHERE Customers.City = 'Seattle'
+) AS [c]",
+                Sql);
+        }
+
+        public override void From_sql_queryable_where_simple_closure_via_query_cache()
+        {
+            base.From_sql_queryable_where_simple_closure_via_query_cache();
+
+            Assert.Equal(
+                @"SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM (
+    SELECT * FROM Customers WHERE Customers.ContactName LIKE '%o%'
+) AS [c]
+WHERE [c].[ContactTitle] = @__title_0
+
+SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM (
+    SELECT * FROM Customers WHERE Customers.ContactName LIKE '%o%'
+) AS [c]
+WHERE [c].[ContactTitle] = @__title_0",
+                Sql);
+        }
+
+        public override void From_sql_queryable_with_multiple_line_query()
+        {
+            base.From_sql_queryable_with_multiple_line_query();
+
+            Assert.Equal(
+                @"SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM (
+    SELECT *
+    FROM Customers
+    WHERE Customers.City = 'London'
+) AS [c]",
+                Sql);
+        }
+
+        public override void From_sql_annotations_do_not_modify_successive_calls()
+        {
+            base.From_sql_annotations_do_not_modify_successive_calls();
+
+            Assert.Equal(
+                @"SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM (
+    SELECT * FROM Customers WHERE Customers.ContactName LIKE '%z%'
+) AS [c]
+
+SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]",
+                Sql);
+        }
+
+        public FromSqlQuerySqlServerTest(NorthwindQuerySqlServerFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        private static string Sql => TestSqlLoggerFactory.Sql;
+    }
+}


### PR DESCRIPTION
New PR for ```FromSql``` functionality. This is still a bit rough, in particular still using ```string.Format``` for parameters on the raw SQL string, but shows the general pattern of raw SQL through ```QueryAnnotation```s
@anpete @divega 