### PR TITLE
[SMALL] Additional fix to Issue 1747 - Multi-select with Contains() does not generate SQL

### DIFF
--- a/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/EqualityPredicateInExpressionOptimizer.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/EqualityPredicateInExpressionOptimizer.cs
@@ -9,6 +9,7 @@ using Microsoft.Data.Entity.Relational.Query.Expressions;
 using Microsoft.Data.Entity.Utilities;
 using Remotion.Linq.Parsing;
 using System.Collections.Generic;
+using Remotion.Linq.Clauses.Expressions;
 
 namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
 {

--- a/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
@@ -2731,6 +2731,22 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
+        public virtual void Contains_with_local_collection_empty_closure()
+        {
+            string[] ids = new string[0];
+
+            AssertQuery<Customer>(cs =>
+                cs.Where(c => ids.Contains(c.CustomerID)), entryCount: 0);
+        }
+
+        [Fact]
+        public virtual void Contains_with_local_collection_empty_inline()
+        {
+            AssertQuery<Customer>(cs =>
+                cs.Where(c => !(new List<string> { }.Contains(c.CustomerID))), entryCount: 91);
+        }
+
+        [Fact]
         public virtual void Contains_top_level()
         {
             AssertQuery<Customer>(cs =>

--- a/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -2231,6 +2231,28 @@ WHERE [c].[CustomerID] IN ('ALFKI', 'ABC'')); GO; DROP TABLE Orders; GO; --', 'A
                 Sql);
         }
 
+        public override void Contains_with_local_collection_empty_closure()
+        {
+            base.Contains_with_local_collection_empty_closure();
+
+            Assert.Equal(
+    @"SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE 1 = 0",
+        Sql);
+        }
+
+        public override void Contains_with_local_collection_empty_inline()
+        {
+            base.Contains_with_local_collection_empty_inline();
+
+            Assert.Equal(
+    @"SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE 1 = 1",
+                Sql);
+        }
+
         public QuerySqlServerTest(NorthwindQuerySqlServerFixture fixture)
             : base(fixture)
         {


### PR DESCRIPTION
Problem is we were not handling the case where user would pass empty collection as argument to contains - we would produce invalid sql.
Fix is to check for number of arguments to InExpression before producing a relevant sql.
This has to happen during sql generation, since we need to know the values of the parameters.