### PR TITLE
Enhance the ForeignKeyPropertyDiscoveryConvention to choose the best...

### DIFF
--- a/src/EntityFramework.Core/Metadata/ForeignKeyExtensions.cs
+++ b/src/EntityFramework.Core/Metadata/ForeignKeyExtensions.cs
@@ -36,6 +36,14 @@ namespace Microsoft.Data.Entity.Metadata
                 navigation => navigation.ForeignKey == foreignKey && !navigation.PointsToPrincipal);
         }
 
+        public static bool IsSelfReferencing(
+            [NotNull] this ForeignKey foreignKey)
+        {
+            Check.NotNull(foreignKey, nameof(foreignKey));
+
+            return foreignKey.EntityType == foreignKey.ReferencedEntityType;
+        }
+
         public static bool IsCompatible(
             [NotNull] this ForeignKey foreignKey,
             [NotNull] EntityType principalType,

--- a/src/EntityFramework.Core/Metadata/Internal/InternalEntityBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/InternalEntityBuilder.cs
@@ -817,7 +817,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             navigationToPrincipalName = navigationToPrincipalName == "" ? null : navigationToPrincipalName;
             navigationToDependentName = navigationToDependentName == "" ? null : navigationToDependentName;
 
-            var builder = Relationship(
+            return Relationship(
                 principalEntityTypeBuilder,
                 dependentEntityTypeBuilder,
                 navigationToPrincipalName,
@@ -826,8 +826,6 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 null,
                 configurationSource,
                 isUnique);
-
-            return builder;
         }
 
         public virtual InternalRelationshipBuilder Relationship(
@@ -1209,14 +1207,20 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             public InternalRelationshipBuilder Attach()
             {
                 var newRelationship = Relationship.Attach(RelationshipConfigurationSource);
+                var inverted = Relationship.Metadata.EntityType != newRelationship.Metadata.EntityType;
                 if (NavigationToPrincipalName != null)
                 {
-                    newRelationship = newRelationship.NavigationToPrincipal(NavigationToPrincipalName, RelationshipConfigurationSource);
+                    newRelationship = inverted
+                        ? newRelationship.NavigationToDependent(NavigationToPrincipalName, RelationshipConfigurationSource)
+                        : newRelationship.NavigationToPrincipal(NavigationToPrincipalName, RelationshipConfigurationSource);
                 }
 
+                inverted = Relationship.Metadata.EntityType != newRelationship.Metadata.EntityType;
                 if (NavigationToDependentName != null)
                 {
-                    newRelationship = newRelationship.NavigationToDependent(NavigationToDependentName, RelationshipConfigurationSource);
+                    newRelationship = inverted
+                        ? newRelationship.NavigationToPrincipal(NavigationToDependentName, RelationshipConfigurationSource)
+                        : newRelationship.NavigationToDependent(NavigationToDependentName, RelationshipConfigurationSource);
                 }
 
                 return newRelationship;

--- a/src/EntityFramework.Core/ModelBuilder.cs
+++ b/src/EntityFramework.Core/ModelBuilder.cs
@@ -957,24 +957,24 @@ namespace Microsoft.Data.Entity
                 /// <returns> The internal builder to further configure the relationship. </returns>
                 protected InternalRelationshipBuilder WithOneBuilder(string inverseReferenceName)
                 {
-                    var isSelfReferencing = Metadata.EntityType == Metadata.ReferencedEntityType;
-                    var inverseToPrincipal = !isSelfReferencing
-                                             && Metadata.EntityType == RelatedEntityType
-                                             && (string.IsNullOrEmpty(ReferenceName) || Metadata.GetNavigationToDependent()?.Name == ReferenceName);
-
-                    Debug.Assert(inverseToPrincipal
-                                 || (Metadata.ReferencedEntityType == RelatedEntityType
-                                     && (string.IsNullOrEmpty(ReferenceName) || Metadata.GetNavigationToPrincipal()?.Name == ReferenceName)));
-
                     var builder = Builder;
                     if (!((IForeignKey)Metadata).IsUnique)
                     {
-                        Debug.Assert(!inverseToPrincipal);
+                        Debug.Assert(Metadata.GetNavigationToPrincipal()?.Name == ReferenceName);
 
                         builder = builder.NavigationToDependent(null, ConfigurationSource.Explicit);
                     }
 
                     builder = builder.Unique(true, ConfigurationSource.Explicit);
+                    var foreignKey = builder.Metadata;
+
+                    var inverseToPrincipal = !foreignKey.IsSelfReferencing()
+                                             && foreignKey.EntityType == RelatedEntityType
+                                             && foreignKey.GetNavigationToDependent()?.Name == ReferenceName;
+
+                    Debug.Assert(inverseToPrincipal
+                                 || (foreignKey.ReferencedEntityType == RelatedEntityType
+                                     && foreignKey.GetNavigationToPrincipal()?.Name == ReferenceName));
 
                     builder = inverseToPrincipal
                         ? builder.NavigationToPrincipal(inverseReferenceName, ConfigurationSource.Explicit, strictPreferExisting: false)

--- a/src/EntityFramework.SqlServer.Design/ReverseEngineering/SqlServerMetadataModelProvider.cs
+++ b/src/EntityFramework.SqlServer.Design/ReverseEngineering/SqlServerMetadataModelProvider.cs
@@ -437,7 +437,7 @@ namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering
                         dependentEndNavigationPropertyName);
                     dependentEndExistingIdentifiers.Add(dependentEndNavigationPropertyName);
 
-                    if (foreignKey.ReferencedEntityType != foreignKey.EntityType)
+                    if (!foreignKey.IsSelfReferencing())
                     {
                         // set up the name of the navigation property on the principal end of the foreign key
                         var principalEndExistingIdentifiers =

--- a/test/EntityFramework.Core.FunctionalTests/MonsterFixupTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/MonsterFixupTestBase.cs
@@ -53,25 +53,24 @@ namespace Microsoft.Data.Entity.FunctionalTests
         public virtual void Can_build_monster_model_and_seed_data_using_all_navigations()
         {
             const string databaseName = SnapshotDatabaseName + "_AllNavs";
-            Can_build_monster_model_and_seed_data_using_all_navigations_test(p => CreateSnapshotMonsterContext(p, databaseName), databaseName);
+            Can_build_monster_model_and_seed_data_using_all_navigations_test(p => CreateSnapshotMonsterContext(p, databaseName));
         }
 
         [Fact]
         public virtual void Can_build_monster_model_with_full_notification_entities_and_seed_data_using_all_navigations()
         {
             const string databaseName = FullNotifyDatabaseName + "_AllNavs";
-            Can_build_monster_model_and_seed_data_using_all_navigations_test(p => CreateChangedChangingMonsterContext(p, databaseName), databaseName);
+            Can_build_monster_model_and_seed_data_using_all_navigations_test(p => CreateChangedChangingMonsterContext(p, databaseName));
         }
 
         [Fact]
         public virtual void Can_build_monster_model_with_changed_only_notification_entities_and_seed_data_using_all_navigations()
         {
             const string databaseName = ChangedOnlyDatabaseName + "_AllNavs";
-            Can_build_monster_model_and_seed_data_using_all_navigations_test(p => CreateChangedOnlyMonsterContext(p, databaseName), databaseName);
+            Can_build_monster_model_and_seed_data_using_all_navigations_test(p => CreateChangedOnlyMonsterContext(p, databaseName));
         }
 
-        private void Can_build_monster_model_and_seed_data_using_all_navigations_test(
-            Func<IServiceProvider, MonsterContext> createContext, string databaseName)
+        private void Can_build_monster_model_and_seed_data_using_all_navigations_test(Func<IServiceProvider, MonsterContext> createContext)
         {
             var serviceProvider = CreateServiceProvider();
 
@@ -91,25 +90,24 @@ namespace Microsoft.Data.Entity.FunctionalTests
         public virtual void Can_build_monster_model_and_seed_data_using_dependent_navigations()
         {
             const string databaseName = SnapshotDatabaseName + "_DependentNavs";
-            Can_build_monster_model_and_seed_data_using_dependent_navigations_test(p => CreateSnapshotMonsterContext(p, databaseName), databaseName);
+            Can_build_monster_model_and_seed_data_using_dependent_navigations_test(p => CreateSnapshotMonsterContext(p, databaseName));
         }
 
         [Fact]
         public virtual void Can_build_monster_model_with_full_notification_entities_and_seed_data_using_dependent_navigations()
         {
             const string databaseName = FullNotifyDatabaseName + "_DependentNavs";
-            Can_build_monster_model_and_seed_data_using_dependent_navigations_test(p => CreateChangedChangingMonsterContext(p, databaseName), databaseName);
+            Can_build_monster_model_and_seed_data_using_dependent_navigations_test(p => CreateChangedChangingMonsterContext(p, databaseName));
         }
 
         [Fact]
         public virtual void Can_build_monster_model_with_changed_only_notification_entities_and_seed_data_using_dependent_navigations()
         {
             const string databaseName = ChangedOnlyDatabaseName + "_DependentNavs";
-            Can_build_monster_model_and_seed_data_using_dependent_navigations_test(p => CreateChangedOnlyMonsterContext(p, databaseName), databaseName);
+            Can_build_monster_model_and_seed_data_using_dependent_navigations_test(p => CreateChangedOnlyMonsterContext(p, databaseName));
         }
 
-        private void Can_build_monster_model_and_seed_data_using_dependent_navigations_test(
-            Func<IServiceProvider, MonsterContext> createContext, string databaseName)
+        private void Can_build_monster_model_and_seed_data_using_dependent_navigations_test(Func<IServiceProvider, MonsterContext> createContext)
         {
             var serviceProvider = CreateServiceProvider();
 
@@ -129,25 +127,24 @@ namespace Microsoft.Data.Entity.FunctionalTests
         public virtual void Can_build_monster_model_and_seed_data_using_principal_navigations()
         {
             const string databaseName = SnapshotDatabaseName + "_PrincipalNavs";
-            Can_build_monster_model_and_seed_data_using_principal_navigations_test(p => CreateSnapshotMonsterContext(p, databaseName), databaseName);
+            Can_build_monster_model_and_seed_data_using_principal_navigations_test(p => CreateSnapshotMonsterContext(p, databaseName));
         }
 
         //[Fact] TODO: Support INotifyCollectionChanged (Issue #445) so that collection change detection without DetectChanges works
         public virtual void Can_build_monster_model_with_full_notification_entities_and_seed_data_using_principal_navigations()
         {
             const string databaseName = FullNotifyDatabaseName + "_PrincipalNavs";
-            Can_build_monster_model_and_seed_data_using_principal_navigations_test(p => CreateChangedChangingMonsterContext(p, databaseName), databaseName);
+            Can_build_monster_model_and_seed_data_using_principal_navigations_test(p => CreateChangedChangingMonsterContext(p, databaseName));
         }
 
         //[Fact] TODO: Support INotifyCollectionChanged (Issue #445) so that collection change detection without DetectChanges works
         public virtual void Can_build_monster_model_with_changed_only_notification_entities_and_seed_data_using_principal_navigations()
         {
             const string databaseName = ChangedOnlyDatabaseName + "_PrincipalNavs";
-            Can_build_monster_model_and_seed_data_using_principal_navigations_test(p => CreateChangedOnlyMonsterContext(p, databaseName), databaseName);
+            Can_build_monster_model_and_seed_data_using_principal_navigations_test(p => CreateChangedOnlyMonsterContext(p, databaseName));
         }
 
-        private void Can_build_monster_model_and_seed_data_using_principal_navigations_test(
-            Func<IServiceProvider, MonsterContext> createContext, string databaseName)
+        private void Can_build_monster_model_and_seed_data_using_principal_navigations_test(Func<IServiceProvider, MonsterContext> createContext)
         {
             var serviceProvider = CreateServiceProvider();
 
@@ -167,25 +164,24 @@ namespace Microsoft.Data.Entity.FunctionalTests
         public virtual void Can_build_monster_model_and_seed_data_using_navigations_with_deferred_add()
         {
             const string databaseName = SnapshotDatabaseName + "_AllNavsDeferred";
-            Can_build_monster_model_and_seed_data_using_navigations_with_deferred_add_test(p => CreateSnapshotMonsterContext(p, databaseName), databaseName);
+            Can_build_monster_model_and_seed_data_using_navigations_with_deferred_add_test(p => CreateSnapshotMonsterContext(p, databaseName));
         }
 
         [Fact]
         public virtual void Can_build_monster_model_with_full_notification_entities_and_seed_data_using_navigations_with_deferred_add()
         {
             const string databaseName = FullNotifyDatabaseName + "_AllNavsDeferred";
-            Can_build_monster_model_and_seed_data_using_navigations_with_deferred_add_test(p => CreateChangedChangingMonsterContext(p, databaseName), databaseName);
+            Can_build_monster_model_and_seed_data_using_navigations_with_deferred_add_test(p => CreateChangedChangingMonsterContext(p, databaseName));
         }
 
         [Fact]
         public virtual void Can_build_monster_model_with_changed_only_notification_entities_and_seed_data_using_navigations_with_deferred_add()
         {
             const string databaseName = ChangedOnlyDatabaseName + "_AllNavsDeferred";
-            Can_build_monster_model_and_seed_data_using_navigations_with_deferred_add_test(p => CreateChangedOnlyMonsterContext(p, databaseName), databaseName);
+            Can_build_monster_model_and_seed_data_using_navigations_with_deferred_add_test(p => CreateChangedOnlyMonsterContext(p, databaseName));
         }
 
-        private void Can_build_monster_model_and_seed_data_using_navigations_with_deferred_add_test(
-            Func<IServiceProvider, MonsterContext> createContext, string databaseName)
+        private void Can_build_monster_model_and_seed_data_using_navigations_with_deferred_add_test(Func<IServiceProvider, MonsterContext> createContext)
         {
             var serviceProvider = CreateServiceProvider();
 
@@ -205,25 +201,24 @@ namespace Microsoft.Data.Entity.FunctionalTests
         public virtual async Task Store_generated_values_are_discarded_if_saving_changes_fails()
         {
             const string databaseName = SnapshotDatabaseName + "_Bad";
-            await Store_generated_values_are_discarded_if_saving_changes_fails_test(p => CreateSnapshotMonsterContext(p, databaseName), databaseName);
+            await Store_generated_values_are_discarded_if_saving_changes_fails_test(p => CreateSnapshotMonsterContext(p, databaseName));
         }
 
         [Fact]
         public virtual async Task Store_generated_values_are_discarded_if_saving_changes_fails_with_full_notification_entities()
         {
             const string databaseName = FullNotifyDatabaseName + "_Bad";
-            await Store_generated_values_are_discarded_if_saving_changes_fails_test(p => CreateChangedChangingMonsterContext(p, databaseName), databaseName);
+            await Store_generated_values_are_discarded_if_saving_changes_fails_test(p => CreateChangedChangingMonsterContext(p, databaseName));
         }
 
         [Fact]
         public virtual async Task Store_generated_values_are_discarded_if_saving_changes_fails_with_changed_only_notification_entities()
         {
             const string databaseName = ChangedOnlyDatabaseName + "_Bad";
-            await Store_generated_values_are_discarded_if_saving_changes_fails_test(p => CreateChangedOnlyMonsterContext(p, databaseName), databaseName);
+            await Store_generated_values_are_discarded_if_saving_changes_fails_test(p => CreateChangedOnlyMonsterContext(p, databaseName));
         }
 
-        private async Task Store_generated_values_are_discarded_if_saving_changes_fails_test(
-            Func<IServiceProvider, MonsterContext> createContext, string databaseName)
+        private async Task Store_generated_values_are_discarded_if_saving_changes_fails_test(Func<IServiceProvider, MonsterContext> createContext)
         {
             var serviceProvider = CreateServiceProvider(throwingStateManager: true);
 

--- a/test/EntityFramework.Core.FunctionalTests/OneToOneQueryFixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/OneToOneQueryFixtureBase.cs
@@ -1,17 +1,15 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.Data.Entity.Metadata;
-
 namespace Microsoft.Data.Entity.FunctionalTests
 {
     public abstract class OneToOneQueryFixtureBase
     {
-
         protected virtual void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder
-                .Entity<Address>(e => e.HasOne(a => a.Resident).WithOne(p => p.Address));
+                .Entity<Address>(e => e.HasOne(a => a.Resident).WithOne(p => p.Address)
+                    .ReferencedKey<Person>(person => person.Id));
 
             modelBuilder.Entity<Address2>().Property<int>("PersonId");
 
@@ -19,7 +17,6 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 .Entity<Person2>(
                     e => e.HasOne(p => p.Address).WithOne(a => a.Resident)
                         .ForeignKey(typeof(Address2), "PersonId"));
-
         }
 
         protected static void AddTestData(DbContext context)

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/NavigationFixerTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/NavigationFixerTest.cs
@@ -6,10 +6,8 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
-using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Framework.DependencyInjection;
-using Moq;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal

--- a/test/EntityFramework.Core.Tests/Metadata/MetadataBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/MetadataBuilderTest.cs
@@ -356,12 +356,13 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         }
 
         [Fact]
-        public void Can_write_convention_ont_to_many_builder_extension()
+        public void Can_write_convention_one_to_one_builder_extension()
         {
             var builder = CreateModelBuilder();
 
             var returnedBuilder = builder
                 .Entity<Avatar>().HasOne(e => e.Gunter).WithOne(e => e.Avatar)
+                .ReferencedKey<Gunter>(e => e.Id)
                 .OneToOneBuilderExtension("V1")
                 .OneToOneBuilderExtension("V2");
 
@@ -721,12 +722,13 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         }
 
         [Fact]
-        public void Can_write_convention_ont_to_many_builder_extension_with_common_name()
+        public void Can_write_convention_one_to_one_builder_extension_with_common_name()
         {
             var builder = CreateModelBuilder();
 
             var returnedBuilder = builder
                 .Entity<Avatar>().HasOne(e => e.Gunter).WithOne(e => e.Avatar)
+                .ReferencedKey<Gunter>(e => e.Id)
                 .SharedNameExtension("V1")
                 .SharedNameExtension("V2");
 


### PR DESCRIPTION
... candidate for the principal end of a non-self-referencing one-to-one relationship.

The dependent entity type will be choosen according to the following heuristics:
1. Entity type with non-shadow properties that can be used in the foreign key and are not in the primary key
2. Entity type without navigation
3. Entity type which primary key is not principal in any relationship
4. Second entity type by alphabetical order