### PR TITLE
Make AsyncFromSqlQueryTestBase abstract

### DIFF
--- a/test/EntityFramework.Relational.FunctionalTests/AsyncFromSqlQueryTestBase.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/AsyncFromSqlQueryTestBase.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace Microsoft.Data.Entity.Relational.FunctionalTests
 {
-    public class AsyncFromSqlQueryTestBase<TFixture> : IClassFixture<TFixture>
+    public abstract class AsyncFromSqlQueryTestBase<TFixture> : IClassFixture<TFixture>
         where TFixture : NorthwindQueryFixtureBase, new()
     {
         [Fact]


### PR DESCRIPTION
So that TestDriven.NET runner does not attempt to run the tests and fail.