### PR TITLE
Add params object array overload to FromSql

### DIFF
--- a/src/EntityFramework.Relational/Query/Annotations/FromSqlAnnotation.cs
+++ b/src/EntityFramework.Relational/Query/Annotations/FromSqlAnnotation.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Utilities;
 
@@ -9,17 +10,28 @@ namespace Microsoft.Data.Entity.Relational.Query.Annotations
     public class FromSqlAnnotation
     {
         public FromSqlAnnotation([NotNull] string sql)
+            : this(sql, new object[0])
+        {
+        }
+
+        public FromSqlAnnotation([NotNull] string sql, [NotNull] object[] parameters)
         {
             Check.NotEmpty(sql, nameof(sql));
+            Check.NotNull(parameters, nameof(parameters));
 
             Sql = sql;
+            Parameters = parameters;
         }
 
         public virtual string Sql { get; }
 
+        public virtual object[] Parameters { get; }
+
         public override string ToString()
         {
-            return Sql;
+            return string.Format("\"{0}\" ({1})",
+                Sql,
+                string.Join(", ", Parameters.Select(p => p.ToString())));
         }
     }
 }

--- a/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/RelationalEntityQueryableExpressionTreeVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/RelationalEntityQueryableExpressionTreeVisitor.cs
@@ -91,6 +91,7 @@ namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
                 (fromSqlAnnotation != null)
                     ? (TableExpressionBase)new RawSqlDerivedTableExpression(
                         fromSqlAnnotation.Sql,
+                        fromSqlAnnotation.Parameters,
                         alias,
                         _querySource)
                     : new TableExpression(

--- a/src/EntityFramework.Relational/Query/Expressions/RawSqlDerivedTableExpression.cs
+++ b/src/EntityFramework.Relational/Query/Expressions/RawSqlDerivedTableExpression.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Data.Entity.Relational.Query.Expressions
     {
         public RawSqlDerivedTableExpression(
             [NotNull] string sql,
+            [NotNull] object[] parameters,
             [NotNull] string alias,
             [NotNull] IQuerySource querySource)
             : base(
@@ -21,11 +22,15 @@ namespace Microsoft.Data.Entity.Relational.Query.Expressions
                   Check.NotEmpty(alias, nameof(alias)))
         {
             Check.NotEmpty(sql, nameof(sql));
+            Check.NotNull(parameters, nameof(parameters));
 
             Sql = sql;
+            Parameters = parameters;
         }
 
         public virtual string Sql { get; }
+
+        public virtual object[] Parameters { get; }
 
         public override Expression Accept([NotNull] ExpressionTreeVisitor visitor)
         {

--- a/src/EntityFramework.Relational/Query/Sql/DefaultSqlQueryGenerator.cs
+++ b/src/EntityFramework.Relational/Query/Sql/DefaultSqlQueryGenerator.cs
@@ -186,7 +186,20 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
 
             using (_sql.Indent())
             {
-                _sql.AppendLines(rawSqlDerivedTableExpression.Sql);
+                var substitutions = new string[rawSqlDerivedTableExpression.Parameters.Count()];
+
+                for (var index = 0; index < rawSqlDerivedTableExpression.Parameters.Count(); index++)
+                {
+                    var parameterName = "p" + index;
+
+                    _parameters.Add(parameterName);
+                    _parameterValues.Add(parameterName, rawSqlDerivedTableExpression.Parameters[index]);
+                    substitutions[index] = ParameterPrefix + parameterName;
+                }
+
+                _sql.AppendLines(string.Format(
+                    rawSqlDerivedTableExpression.Sql,
+                    substitutions));
             }
 
             _sql.Append(") AS ")
@@ -669,8 +682,8 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
                     return VisitNotInExpression(inExpression);
                 }
 
-                var isColumnOrParameterOperand = 
-                    unaryExpression.Operand is ColumnExpression 
+                var isColumnOrParameterOperand =
+                    unaryExpression.Operand is ColumnExpression
                     || unaryExpression.Operand is ParameterExpression;
 
                 if (!isColumnOrParameterOperand)

--- a/src/EntityFramework.Relational/RelationalDbSetExtensions.cs
+++ b/src/EntityFramework.Relational/RelationalDbSetExtensions.cs
@@ -21,5 +21,16 @@ namespace Microsoft.Data.Entity
 
             return ((IAnnotatableQueryable<TEntity>)dbSet).AnnotateQuery(new FromSqlAnnotation(sql));
         }
+
+        public static IQueryable<TEntity> FromSql<TEntity>([NotNull]this DbSet<TEntity> dbSet, [NotNull]string sql, [NotNull] params object[] parameters)
+            where TEntity : class
+        {
+            Check.NotNull(dbSet, nameof(dbSet));
+            Check.NotEmpty(sql, nameof(sql));
+            Check.NotNull(parameters, nameof(parameters));
+
+            return ((IAnnotatableQueryable<TEntity>)dbSet).AnnotateQuery(
+                new FromSqlAnnotation(sql, parameters));
+        }
     }
 }

--- a/test/EntityFramework.Relational.FunctionalTests/FromSqlQueryTestBase.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/FromSqlQueryTestBase.cs
@@ -75,6 +75,39 @@ WHERE Customers.City = 'London'"),
         }
 
         [Fact]
+        public virtual void From_sql_queryable_with_params_parameters()
+        {
+            var city = "London";
+            var contactTitle = "Sales Representative";
+
+            AssertQuery<Customer>(
+                cs => cs.FromSql(@"SELECT * FROM Customers WHERE City = {0} AND ContactTitle = {1}", city, contactTitle),
+                cs => cs.Where(c => c.City == city && c.ContactTitle == contactTitle),
+                entryCount: 3);
+        }
+
+        [Fact]
+        public virtual void From_sql_queryable_with_params_parameters_does_not_collide_with_cache()
+        {
+            var city = "London";
+            var contactTitle = "Sales Representative";
+            var sql = @"SELECT * FROM Customers WHERE City = {0} AND ContactTitle = {1}";
+
+            AssertQuery<Customer>(
+                cs => cs.FromSql(sql, city, contactTitle),
+                cs => cs.Where(c => c.City == city && c.ContactTitle == contactTitle),
+                entryCount: 3);
+
+            city = "Madrid";
+            contactTitle = "Accounting Manager";
+
+            AssertQuery<Customer>(
+                cs => cs.FromSql(sql, city, contactTitle),
+                cs => cs.Where(c => c.City == city && c.ContactTitle == contactTitle),
+                entryCount: 2);
+        }
+
+        [Fact]
         public virtual void From_sql_annotations_do_not_modify_successive_calls()
         {
             using (var context = CreateContext())

--- a/test/EntityFramework.SqlServer.FunctionalTests/FromSqlQuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/FromSqlQuerySqlServerTest.cs
@@ -81,6 +81,36 @@ FROM (
                 Sql);
         }
 
+        public override void From_sql_queryable_with_params_parameters()
+        {
+            base.From_sql_queryable_with_params_parameters();
+
+            Assert.Equal(
+                @"SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM (
+    SELECT * FROM Customers WHERE City = @p0 AND ContactTitle = @p1
+) AS [c]",
+                Sql);
+        }
+
+        public override void From_sql_queryable_with_params_parameters_does_not_collide_with_cache()
+        {
+            base.From_sql_queryable_with_params_parameters_does_not_collide_with_cache();
+
+            Assert.Equal(
+                @"SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM (
+    SELECT * FROM Customers WHERE City = @p0 AND ContactTitle = @p1
+) AS [c]
+
+SELECT [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM (
+    SELECT * FROM Customers WHERE City = @p0 AND ContactTitle = @p1
+) AS [c]",
+                Sql);
+        }
+
+
         public override void From_sql_annotations_do_not_modify_successive_calls()
         {
             base.From_sql_annotations_do_not_modify_successive_calls();


### PR DESCRIPTION
I'm thinking we can normalize the different options (params array, anonymous type, and ```Dictionary<string, object>```) into a named parameter string in relational (where we have the extensions) and convert to the provider-specific format in the SqlQueryGenerator.

This is a first pass with just the ```FromSql(string, params object[])``` extension
@anpete @divega 