### PR TITLE
Remove parameterless and internal ModelBuilder constructors

### DIFF
--- a/src/EntityFramework.Core/Metadata/BasicModelBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/BasicModelBuilder.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Metadata.Internal;
+using Microsoft.Data.Entity.Metadata.ModelConventions;
 using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Metadata
@@ -22,14 +23,7 @@ namespace Microsoft.Data.Entity.Metadata
         {
             Check.NotNull(model, nameof(model));
 
-            _builder = new InternalModelBuilder(model);
-        }
-
-        protected internal BasicModelBuilder([NotNull] InternalModelBuilder internalBuilder)
-        {
-            Check.NotNull(internalBuilder, nameof(internalBuilder));
-
-            _builder = internalBuilder;
+            _builder = new InternalModelBuilder(model, new ConventionSet());
         }
 
         public virtual Model Model

--- a/src/EntityFramework.Core/Metadata/IModelBuilderFactory.cs
+++ b/src/EntityFramework.Core/Metadata/IModelBuilderFactory.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Data.Entity.Metadata
 {
     public interface IModelBuilderFactory
     {
+        ModelBuilder CreateConventionBuilder();
         ModelBuilder CreateConventionBuilder([NotNull] Model model);
     }
 }

--- a/src/EntityFramework.Core/Metadata/Internal/InternalModelBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/InternalModelBuilder.cs
@@ -20,11 +20,6 @@ namespace Microsoft.Data.Entity.Metadata.Internal
         private readonly LazyRef<Dictionary<string, ConfigurationSource>> _ignoredEntityTypeNames =
             new LazyRef<Dictionary<string, ConfigurationSource>>(() => new Dictionary<string, ConfigurationSource>());
 
-        public InternalModelBuilder([NotNull] Model metadata)
-            : this(metadata, new ConventionSet())
-        {
-        }
-
         public InternalModelBuilder([NotNull] Model metadata, [NotNull] ConventionSet conventions)
             : base(metadata)
         {

--- a/src/EntityFramework.Core/Metadata/ModelBuilderFactory.cs
+++ b/src/EntityFramework.Core/Metadata/ModelBuilderFactory.cs
@@ -8,11 +8,16 @@ namespace Microsoft.Data.Entity.Metadata
 {
     public class ModelBuilderFactory : IModelBuilderFactory
     {
+        public virtual ModelBuilder CreateConventionBuilder()
+        {
+            return new ModelBuilder(CreateConventionSet());
+        }
+
         public virtual ModelBuilder CreateConventionBuilder(Model model)
         {
             Check.NotNull(model, nameof(model));
 
-            return new ModelBuilder(model, CreateConventionSet());
+            return new ModelBuilder(CreateConventionSet(), model);
         }
 
         protected virtual ConventionSet CreateConventionSet()

--- a/src/EntityFramework.Core/ModelBuilder.cs
+++ b/src/EntityFramework.Core/ModelBuilder.cs
@@ -33,54 +33,32 @@ namespace Microsoft.Data.Entity
         // Issue #213
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="ModelBuilder" /> class with an empty model.
-        ///     The builder will not use any conventions and the entire model must be explicitly configured.
-        ///     To specify conventions to be used, use a constructor that accepts a <see cref="ConventionSet" />.
-        /// </summary>
-        public ModelBuilder()
-            : this(new Model())
-        {
-        }
-
-        /// <summary>
         ///     Initializes a new instance of the <see cref="ModelBuilder" /> class that will
-        ///     configure an existing model. The builder will not use any conventions and the
-        ///     entire model must be explicitly configured. To specify conventions to be used,
-        ///     use a constructor that accepts a <see cref="ConventionSet" />.
+        ///     apply a set of conventions. Consider using a <see cref="IModelBuilderFactory" /> to
+        ///     create a ModelBuilder with appropriate conventions configured.
         /// </summary>
-        /// <param name="model"> The model to be configured. </param>
-        public ModelBuilder([NotNull] Model model)
-            : this(model, new ConventionSet())
-        {
-            Check.NotNull(model, nameof(model));
-        }
-
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="ModelBuilder" /> class that will
-        ///     configure an existing model and apply a set of conventions.
-        /// </summary>
-        /// <param name="model"> The model to be configured. </param>
         /// <param name="conventions"> The conventions to be applied to the model. </param>
-        public ModelBuilder([NotNull] Model model, [NotNull] ConventionSet conventions)
+        public ModelBuilder([NotNull] ConventionSet conventions)
+        {
+            Check.NotNull(conventions, nameof(conventions));
+
+            _builder = new InternalModelBuilder(new Model(), conventions);
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="ModelBuilder" /> class that will
+        ///     configure an existing model and apply a set of conventions. Consider using a
+        ///     <see cref="IModelBuilderFactory" /> to create a ModelBuilder with appropriate
+        ///     conventions configured.
+        /// </summary>
+        /// <param name="conventions"> The conventions to be applied to the model. </param>
+        /// <param name="model"> The model to be configured. </param>
+        public ModelBuilder([NotNull] ConventionSet conventions, [NotNull] Model model)
         {
             Check.NotNull(model, nameof(model));
             Check.NotNull(conventions, nameof(conventions));
 
             _builder = new InternalModelBuilder(model, conventions);
-        }
-
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="ModelBuilder" /> class that will
-        ///     configure an existing model. The builder will not use any conventions and the
-        ///     entire model must be explicitly configured. To specify conventions to be used,
-        ///     use a constructor that accepts a <see cref="ConventionSet" />.
-        /// </summary>
-        /// <param name="internalBuilder"> The internal builder being used to configure the model. </param>
-        protected internal ModelBuilder([NotNull] InternalModelBuilder internalBuilder)
-        {
-            Check.NotNull(internalBuilder, nameof(internalBuilder));
-
-            _builder = internalBuilder;
         }
 
         /// <summary>

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/NavigationFixerTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/NavigationFixerTest.cs
@@ -909,8 +909,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
         private static IModel BuildModel()
         {
-            var model = new Model();
-            var builder = new ModelBuilderFactory().CreateConventionBuilder(model);
+            var builder = new ModelBuilderFactory().CreateConventionBuilder();
 
             builder.Entity<Product>(b =>
                 {
@@ -941,7 +940,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             builder.Entity<ProductTag>();
 
-            return model;
+            return builder.Model;
         }
 
         private static INavigationFixer CreateNavigationFixer(IServiceProvider contextServices)

--- a/test/EntityFramework.Core.Tests/Metadata/BasicModelBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/BasicModelBuilderTest.cs
@@ -937,15 +937,6 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Equal("V1", entityType.Indexes.Last()["A1"]);
         }
 
-        [Fact]
-        public void Can_convert_to_convention_builder()
-        {
-            var model = new Model();
-            var modelBuilder = new BasicModelBuilder(model);
-
-            Assert.Same(model, new ModelBuilder(modelBuilder.Model).Model);
-        }
-
         private class Customer
         {
             public int Id { get; set; }

--- a/test/EntityFramework.Core.Tests/Metadata/Internal/InternalEntityBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/Internal/InternalEntityBuilderTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Data.Entity.Internal;
+using Microsoft.Data.Entity.Metadata.ModelConventions;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Metadata.Internal
@@ -1334,7 +1335,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
         private InternalModelBuilder CreateModelBuilder()
         {
-            return new InternalModelBuilder(new Model());
+            return new InternalModelBuilder(new Model(), new ConventionSet());
         }
 
         private class Order

--- a/test/EntityFramework.Core.Tests/Metadata/Internal/InternalIndexBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/Internal/InternalIndexBuilderTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Reflection;
+using Microsoft.Data.Entity.Metadata.ModelConventions;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Metadata.Internal
@@ -41,7 +42,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
         private InternalIndexBuilder CreateInternalIndexBuilder()
         {
-            var modelBuilder = new InternalModelBuilder(new Model());
+            var modelBuilder = new InternalModelBuilder(new Model(), new ConventionSet());
             var entityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
 
             return entityBuilder.Index(new[] { Customer.IdProperty, Customer.NameProperty }, ConfigurationSource.Explicit);

--- a/test/EntityFramework.Core.Tests/Metadata/Internal/InternalMetadataBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/Internal/InternalMetadataBuilderTest.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata.ModelConventions;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Metadata.Internal
@@ -11,7 +12,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
     {
         private InternalMetadataBuilder<Model> CreateInternalMetadataBuilder()
         {
-            return new InternalModelBuilder(new Model());
+            return new InternalModelBuilder(new Model(), new ConventionSet());
         }
 
         [Fact]

--- a/test/EntityFramework.Core.Tests/Metadata/Internal/InternalModelBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/Internal/InternalModelBuilderTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Data.Entity.Internal;
+using Microsoft.Data.Entity.Metadata.ModelConventions;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Metadata.Internal
@@ -236,7 +237,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
         protected virtual InternalModelBuilder CreateModelBuilder(Model model = null)
         {
-            return new InternalModelBuilder(model ?? new Model());
+            return new InternalModelBuilder(model ?? new Model(), new ConventionSet());
         }
 
         private class Customer

--- a/test/EntityFramework.Core.Tests/Metadata/Internal/InternalPropertyBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/Internal/InternalPropertyBuilderTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Reflection;
+using Microsoft.Data.Entity.Metadata.ModelConventions;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Metadata.Internal
@@ -181,7 +182,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
         [Fact]
         public void Can_only_override_existing_Shadow_value_explicitly()
         {
-            var modelBuilder = new InternalModelBuilder(new Model());
+            var modelBuilder = new InternalModelBuilder(new Model(), new ConventionSet());
             var entityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
             var builder = entityBuilder.Property(Customer.NameProperty.PropertyType, Customer.NameProperty.Name, ConfigurationSource.Explicit);
             var metadata = builder.Metadata;
@@ -228,7 +229,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
         private InternalPropertyBuilder CreateInternalPropertyBuilder()
         {
-            var modelBuilder = new InternalModelBuilder(new Model());
+            var modelBuilder = new InternalModelBuilder(new Model(), new ConventionSet());
             var entityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Convention);
             return entityBuilder.Property(Customer.NameProperty, ConfigurationSource.Convention);
         }

--- a/test/EntityFramework.Core.Tests/Metadata/Internal/InternalRelationshipBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/Internal/InternalRelationshipBuilderTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Metadata.Internal;
+using Microsoft.Data.Entity.Metadata.ModelConventions;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Tests.Metadata.Internal
@@ -209,7 +210,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Internal
 
         private InternalModelBuilder CreateInternalModelBuilder()
         {
-            return new InternalModelBuilder(new Model());
+            return new InternalModelBuilder(new Model(), new ConventionSet());
         }
 
         private class Order

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/ForeignKeyPropertyDiscoveryConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/ForeignKeyPropertyDiscoveryConventionTest.cs
@@ -940,7 +940,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
 
         private static InternalModelBuilder BuildModel()
         {
-            var modelBuilder = new InternalModelBuilder(new Model());
+            var modelBuilder = new InternalModelBuilder(new Model(), new ConventionSet());
 
             var principalType = modelBuilder.Entity(typeof(PrincipalEntity), ConfigurationSource.Explicit);
             principalType.PrimaryKey(new[] { "PeeKay" }, ConfigurationSource.Explicit);

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/KeyDiscoveryConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/KeyDiscoveryConventionTest.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
 
         private static InternalEntityBuilder CreateInternalEntityBuilder<T>()
         {
-            var modelBuilder = new InternalModelBuilder(new Model());
+            var modelBuilder = new InternalModelBuilder(new Model(), new ConventionSet());
             var entityBuilder = modelBuilder.Entity(typeof(T), ConfigurationSource.Convention);
 
             new PropertiesConvention().Apply(entityBuilder);

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/PropertiesConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/PropertiesConventionTest.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
 
         private static InternalEntityBuilder CreateInternalEntityBuilder<T>()
         {
-            var modelBuilder = new InternalModelBuilder(new Model());
+            var modelBuilder = new InternalModelBuilder(new Model(), new ConventionSet());
             var entityBuilder = modelBuilder.Entity(typeof(T), ConfigurationSource.Convention);
 
             return entityBuilder;

--- a/test/EntityFramework.Core.Tests/Metadata/NonGenericRelationshipBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/NonGenericRelationshipBuilderTest.cs
@@ -7,6 +7,7 @@ using System.ComponentModel;
 using System.Linq;
 using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Metadata.ModelConventions;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Tests.Metadata
@@ -19,7 +20,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_finds_existing_navs_and_uses_associated_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Metadata.AddForeignKey(
                 model.GetEntityType(typeof(Order)).GetProperty("CustomerId"),
@@ -57,7 +58,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_finds_existing_nav_to_principal_and_uses_associated_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Metadata.AddForeignKey(
                 model.GetEntityType(typeof(Order)).GetProperty("CustomerId"),
@@ -94,7 +95,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_finds_existing_nav_to_dependent_and_uses_associated_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Metadata.AddForeignKey(
                 model.GetEntityType(typeof(Order)).GetProperty("CustomerId"),
@@ -131,7 +132,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_creates_both_navs_and_uses_existing_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Metadata.AddForeignKey(
                 model.GetEntityType(typeof(Order)).GetProperty("CustomerId"),
@@ -166,7 +167,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_creates_both_navs_and_creates_new_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Property(e => e.CustomerId);
 
@@ -202,7 +203,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_create_unidirectional_nav_and_new_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Property(e => e.CustomerId);
 
@@ -237,7 +238,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_create_unidirectional_from_other_end_nav_and_new_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Property(e => e.CustomerId);
 
@@ -273,7 +274,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_create_relationship_with_no_navigations()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Property(e => e.CustomerId);
 
@@ -307,7 +308,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_creates_both_navs_and_uses_specified_FK_even_if_found_by_convention()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Property(e => e.CustomerId);
 
@@ -345,7 +346,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_creates_both_navs_and_uses_existing_FK_not_found_by_convention()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Metadata.AddForeignKey(
                 model.GetEntityType(typeof(Pickle)).GetProperty("BurgerId"),
@@ -382,7 +383,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_creates_both_navs_and_creates_FK_specified()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Property(e => e.BurgerId);
 
@@ -420,7 +421,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_create_unidirectional_nav_and_specified_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Property(e => e.BurgerId);
 
@@ -457,7 +458,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_create_unidirectional_from_other_end_nav_and_specified_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Property(e => e.BurgerId);
 
@@ -494,7 +495,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_create_relationship_with_no_navigations_and_specified_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Property(e => e.BurgerId);
 
@@ -530,7 +531,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_creates_both_navs_and_creates_shadow_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Property(e => e.BurgerId);
 
@@ -569,7 +570,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_create_unidirectional_nav_with_shadow_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Property(e => e.BurgerId);
 
@@ -607,7 +608,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_create_unidirectional_from_other_end_nav_with_shadow_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Property(e => e.BurgerId);
 
@@ -645,7 +646,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_create_relationship_with_no_navigations_with_shadow_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Property(e => e.BurgerId);
 
@@ -682,7 +683,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_creates_both_navs_and_matches_shadow_FK_property_by_convention()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Property<int>("BigMakId");
 
@@ -718,7 +719,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_creates_both_navs_and_new_FK_when_uniqueness_does_not_match()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Metadata.AddForeignKey(
                 model.GetEntityType(typeof(Pickle)).GetProperty("BurgerId"),
@@ -760,7 +761,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_use_explicitly_specified_PK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Property(e => e.CustomerId);
 
@@ -800,7 +801,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_use_non_PK_principal()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>(b =>
                 {
                     b.Key(c => c.Id);
@@ -849,7 +850,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_have_both_convention_properties_specified()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>(b =>
                 {
                     b.Key(c => c.Id);
@@ -894,7 +895,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_have_both_convention_properties_specified_in_any_order()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>(b =>
                 {
                     b.Key(c => c.Id);
@@ -939,7 +940,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_have_FK_by_convention_specified_with_explicit_principal_key()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>(b =>
                 {
                     b.Key(c => c.Id);
@@ -989,7 +990,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_have_FK_by_convention_specified_with_explicit_principal_key_in_any_order()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>(b =>
                 {
                     b.Key(c => c.Id);
@@ -1039,7 +1040,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_have_principal_key_by_convention_specified_with_explicit_PK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>(b =>
                 {
                     b.Key(c => c.Id);
@@ -1089,7 +1090,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_have_principal_key_by_convention_specified_with_explicit_PK_in_any_order()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>(b =>
                 {
                     b.Key(c => c.Id);
@@ -1139,7 +1140,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_finds_existing_navs_and_uses_associated_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Metadata.AddForeignKey(
                 model.GetEntityType(typeof(Order)).GetProperty("CustomerId"),
@@ -1177,7 +1178,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_finds_existing_nav_to_principal_and_uses_associated_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Metadata.AddForeignKey(
                 model.GetEntityType(typeof(Order)).GetProperty("CustomerId"),
@@ -1214,7 +1215,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_finds_existing_nav_to_dependent_and_uses_associated_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Metadata.AddForeignKey(
                 model.GetEntityType(typeof(Order)).GetProperty("CustomerId"),
@@ -1251,7 +1252,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_creates_both_navs_and_uses_existing_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Metadata.AddForeignKey(
                 model.GetEntityType(typeof(Order)).GetProperty("CustomerId"),
@@ -1286,7 +1287,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_creates_both_navs_and_creates_new_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Property(e => e.CustomerId);
 
@@ -1322,7 +1323,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_create_unidirectional_nav_and_new_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Property(e => e.CustomerId);
 
@@ -1358,7 +1359,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_create_unidirectional_from_other_end_nav_and_new_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Property(e => e.CustomerId);
 
@@ -1393,7 +1394,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_create_relationship_with_no_navigations()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Property(e => e.CustomerId);
 
@@ -1427,7 +1428,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_creates_both_navs_and_uses_specified_FK_even_if_found_by_convention()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Property(e => e.CustomerId);
 
@@ -1465,7 +1466,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_creates_both_navs_and_uses_existing_FK_not_found_by_convention()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Metadata.AddForeignKey(
                 model.GetEntityType(typeof(Pickle)).GetProperty("BurgerId"),
@@ -1502,7 +1503,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_creates_both_navs_and_creates_FK_specified()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Property(e => e.BurgerId);
 
@@ -1540,7 +1541,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_create_unidirectional_nav_and_specified_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Property(e => e.BurgerId);
 
@@ -1577,7 +1578,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_create_unidirectional_from_other_end_nav_and_specified_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Property(e => e.BurgerId);
 
@@ -1614,7 +1615,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_create_relationship_with_no_navigations_and_specified_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Property(e => e.BurgerId);
 
@@ -1650,7 +1651,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_creates_both_navs_and_creates_shadow_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Property(e => e.BurgerId);
 
@@ -1689,7 +1690,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_create_unidirectional_nav_with_shadow_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Property(e => e.BurgerId);
 
@@ -1727,7 +1728,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_create_unidirectional_from_other_end_nav_with_shadow_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Property(e => e.BurgerId);
 
@@ -1765,7 +1766,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_create_relationship_with_no_navigations_with_shadow_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Property(e => e.BurgerId);
 
@@ -1802,7 +1803,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_creates_both_navs_and_matches_shadow_FK_by_convention()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Property<int>("BigMakId");
 
@@ -1838,7 +1839,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_creates_both_navs_and_new_FK_if_uniqueness_does_not_match()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Metadata.AddForeignKey(
                 model.GetEntityType(typeof(Pickle)).GetProperty("BurgerId"),
@@ -1880,7 +1881,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_use_explicitly_specified_PK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Property(e => e.CustomerId);
 
@@ -1920,7 +1921,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_use_non_PK_principal()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>(b =>
                 {
                     b.Key(c => c.Id);
@@ -1969,7 +1970,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_have_both_convention_properties_specified()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>(b =>
                 {
                     b.Key(c => c.Id);
@@ -2014,7 +2015,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_have_both_convention_properties_specified_in_any_order()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>(b =>
                 {
                     b.Key(c => c.Id);
@@ -2059,7 +2060,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_have_FK_by_convention_specified_with_explicit_principal_key()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>(b =>
                 {
                     b.Key(c => c.Id);
@@ -2109,7 +2110,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_have_FK_by_convention_specified_with_explicit_principal_key_in_any_order()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>(b =>
                 {
                     b.Key(c => c.Id);
@@ -2159,7 +2160,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_have_principal_key_by_convention_specified_with_explicit_PK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>(b =>
                 {
                     b.Key(c => c.Id);
@@ -2209,7 +2210,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_have_principal_key_by_convention_specified_with_explicit_PK_in_any_order()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>(b =>
                 {
                     b.Key(c => c.Id);
@@ -2259,7 +2260,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_finds_existing_navs_and_uses_associated_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<CustomerDetails>().Metadata.AddForeignKey(
                 model.GetEntityType(typeof(CustomerDetails)).GetProperty("Id"),
@@ -2298,7 +2299,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_finds_existing_nav_to_principal_and_uses_associated_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<CustomerDetails>().Metadata.AddForeignKey(
                 model.GetEntityType(typeof(CustomerDetails)).GetProperty("Id"),
@@ -2336,7 +2337,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_finds_existing_nav_to_dependent_and_uses_associated_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<CustomerDetails>().Metadata.AddForeignKey(
                 model.GetEntityType(typeof(CustomerDetails)).GetProperty("Id"),
@@ -2374,7 +2375,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_creates_both_navs_and_uses_existing_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<CustomerDetails>().Key(e => e.Id);
             modelBuilder.Entity<CustomerDetails>().Metadata.AddForeignKey(
@@ -2411,7 +2412,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_creates_both_navs_and_creates_new_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<CustomerDetails>().Key(e => e.Id);
 
@@ -2447,7 +2448,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_creates_both_navs_and_uses_existing_FK_when_not_PK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Order>().Key(c => c.OrderId);
             modelBuilder.Entity<OrderDetails>().Key(e => e.Id);
             modelBuilder.Entity<OrderDetails>().Metadata.AddForeignKey(
@@ -2484,7 +2485,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_creates_both_navs_and_creates_new_FK_when_not_PK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Order>().Key(c => c.OrderId);
             modelBuilder.Entity<OrderDetails>(b =>
                 {
@@ -2524,7 +2525,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_can_create_unidirectional_nav_and_new_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<CustomerDetails>().Key(e => e.Id);
 
@@ -2559,7 +2560,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_can_create_unidirectional_from_other_end_nav_and_new_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<CustomerDetails>().Key(e => e.Id);
 
@@ -2595,7 +2596,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_can_create_relationship_with_no_navigations()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<CustomerDetails>().Key(e => e.Id);
 
@@ -2629,7 +2630,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_creates_both_navs_and_uses_specified_FK_even_if_found_by_convention()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Order>().Key(c => c.OrderId);
             modelBuilder.Entity<OrderDetails>(b =>
                 {
@@ -2671,7 +2672,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_creates_both_navs_and_uses_specified_FK_even_if_PK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<CustomerDetails>().Key(e => e.Id);
 
@@ -2709,7 +2710,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_creates_both_navs_and_uses_existing_FK_not_found_by_convention()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Bun>().Metadata.AddForeignKey(
                 model.GetEntityType(typeof(Bun)).GetProperty("BurgerId"),
@@ -2747,7 +2748,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_creates_both_navs_and_creates_FK_specified()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Bun>().Property(e => e.BurgerId);
 
@@ -2785,7 +2786,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_can_create_unidirectional_nav_and_specified_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Bun>().Property(e => e.BurgerId);
 
@@ -2822,7 +2823,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_can_create_unidirectional_from_other_end_nav_and_specified_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Bun>().Property(e => e.BurgerId);
 
@@ -2859,7 +2860,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_can_create_relationship_with_no_navigations_and_specified_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Bun>().Property(e => e.BurgerId);
 
@@ -2895,7 +2896,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_creates_both_navs_and_new_FK_when_uniqueness_does_not_match()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Bun>().Metadata.AddForeignKey(
                 model.GetEntityType(typeof(Bun)).GetProperty("BurgerId"),
@@ -2937,7 +2938,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_principal_and_dependent_can_be_flipped_with_existing_FK_still_used()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Order>().Key(c => c.OrderId);
             modelBuilder.Entity<OrderDetails>().Key(e => e.Id);
             modelBuilder.Entity<OrderDetails>().Metadata.AddForeignKey(
@@ -2976,7 +2977,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_principal_and_dependent_can_be_flipped_with_FK_still_found_by_convention()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Order>().Key(c => c.OrderId);
             modelBuilder.Entity<OrderDetails>(b =>
                 {
@@ -3018,7 +3019,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Unidirectional_from_other_end_OneToOne_principal_and_dependent_can_be_flipped()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<CustomerDetails>().Key(e => e.Id);
 
@@ -3055,7 +3056,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Unidirectional_OneToOne_principal_and_dependent_can_be_flipped()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<CustomerDetails>().Key(e => e.Id);
 
@@ -3092,7 +3093,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void No_navigation_OneToOne_principal_and_dependent_can_be_flipped()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<CustomerDetails>().Key(e => e.Id);
 
@@ -3128,7 +3129,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_principal_and_dependent_can_be_flipped_with_PK_FK_still_used()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<CustomerDetails>().Key(e => e.Id);
 
@@ -3166,7 +3167,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_can_have_PK_explicitly_specified()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<CustomerDetails>().Key(e => e.Id);
 
@@ -3206,7 +3207,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_can_use_alternate_principal_key()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>(b =>
                 {
                     b.Key(c => c.Id);
@@ -3255,7 +3256,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_can_have_both_convention_keys_specified_explicitly()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Order>().Key(c => c.OrderId);
             modelBuilder.Entity<OrderDetails>(b =>
                 {
@@ -3300,7 +3301,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_can_have_both_convention_keys_specified_explicitly_in_any_order()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Order>().Key(c => c.OrderId);
             modelBuilder.Entity<OrderDetails>(b =>
                 {
@@ -3345,7 +3346,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_can_have_both_keys_specified_explicitly()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>(b =>
                 {
                     b.Key(c => c.Id);
@@ -3395,7 +3396,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_can_have_both_keys_specified_explicitly_in_any_order()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>(b =>
                 {
                     b.Key(c => c.Id);
@@ -3445,7 +3446,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_principal_and_dependent_can_be_flipped_using_principal_with_existing_FK_still_used()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Order>().Key(c => c.OrderId);
             modelBuilder.Entity<OrderDetails>().Key(e => e.Id);
             modelBuilder.Entity<OrderDetails>().Metadata.AddForeignKey(
@@ -3484,7 +3485,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_principal_and_dependent_can_be_flipped_using_principal_with_FK_still_found_by_convention()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Order>().Key(c => c.OrderId);
             modelBuilder.Entity<OrderDetails>(b =>
                 {
@@ -3526,7 +3527,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_principal_and_dependent_can_be_flipped_in_both_ways()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Order>().Key(c => c.OrderId);
             modelBuilder.Entity<OrderDetails>(b =>
                 {
@@ -3569,7 +3570,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_principal_and_dependent_can_be_flipped_in_both_ways_in_any_order()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Order>().Key(c => c.OrderId);
             modelBuilder.Entity<OrderDetails>(b =>
                 {
@@ -3612,7 +3613,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Unidirectional_from_other_end_OneToOne_principal_and_dependent_can_be_flipped_using_principal()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<CustomerDetails>().Key(e => e.Id);
 
@@ -3649,7 +3650,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Unidirectional_OneToOne_principal_and_dependent_can_be_flipped_using_principal()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<CustomerDetails>().Key(e => e.Id);
 
@@ -3686,7 +3687,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void No_navigation_OneToOne_principal_and_dependent_can_be_flipped_using_principal()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<CustomerDetails>().Key(e => e.Id);
 
@@ -3748,7 +3749,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_creates_both_navs_and_uses_existing_composite_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             var tomatoType = model.GetEntityType(typeof(Tomato));
             modelBuilder.Entity<Tomato>().Metadata.AddForeignKey(
@@ -3786,7 +3787,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_creates_both_navs_and_creates_composite_FK_specified()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             modelBuilder.Entity<Tomato>(b =>
                 {
@@ -3830,7 +3831,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_use_alternate_composite_key()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>(b =>
                 {
                     b.Key(c => new { c.Id1, c.Id2 });
@@ -3889,7 +3890,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_use_alternate_composite_key_in_any_order()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>(b =>
                 {
                     b.Key(c => new { c.Id1, c.Id2 });
@@ -3948,7 +3949,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_create_unidirectional_nav_and_specified_composite_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             modelBuilder.Entity<Tomato>(b =>
                 {
@@ -3991,7 +3992,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_create_unidirectional_from_other_end_nav_and_specified_composite_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             modelBuilder.Entity<Tomato>(b =>
                 {
@@ -4034,7 +4035,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_create_relationship_with_no_navigations_and_specified_composite_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             modelBuilder.Entity<Tomato>(b =>
                 {
@@ -4076,7 +4077,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_creates_both_navs_and_uses_existing_composite_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             var tomatoType = model.GetEntityType(typeof(Tomato));
             modelBuilder.Entity<Tomato>().Metadata.AddForeignKey(
@@ -4114,7 +4115,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_creates_both_navs_and_creates_composite_FK_specified()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             modelBuilder.Entity<Tomato>(b =>
                 {
@@ -4158,7 +4159,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_use_alternate_composite_key()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>(b =>
                 {
                     b.Key(c => new { c.Id1, c.Id2 });
@@ -4217,7 +4218,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_use_alternate_composite_key_in_any_order()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>(b =>
                 {
                     b.Key(c => new { c.Id1, c.Id2 });
@@ -4276,7 +4277,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_create_unidirectional_nav_and_specified_composite_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             modelBuilder.Entity<Tomato>(b =>
                 {
@@ -4319,7 +4320,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_create_unidirectional_from_other_end_nav_and_specified_composite_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             modelBuilder.Entity<Tomato>(b =>
                 {
@@ -4362,7 +4363,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_create_relationship_with_no_navigations_and_specified_composite_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             modelBuilder.Entity<Tomato>(b =>
                 {
@@ -4404,7 +4405,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_creates_both_navs_and_uses_existing_composite_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             var bunType = model.GetEntityType(typeof(ToastedBun));
             modelBuilder.Entity<ToastedBun>().Metadata.AddForeignKey(
@@ -4443,7 +4444,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_creates_both_navs_and_creates_composite_FK_specified()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             modelBuilder.Entity<ToastedBun>(b =>
                 {
@@ -4487,7 +4488,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_can_use_alternate_composite_key()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>(b =>
                 {
                     b.Key(c => new { c.Id1, c.Id2 });
@@ -4546,7 +4547,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_can_use_alternate_composite_key_in_any_order()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>(b =>
                 {
                     b.Key(c => new { c.Id1, c.Id2 });
@@ -4605,7 +4606,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_uses_composite_PK_for_FK_by_convention()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             modelBuilder.Entity<Moostard>().Key(c => new { c.Id1, c.Id2 });
 
@@ -4644,7 +4645,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_can_be_flipped_and_composite_PK_is_still_used_by_convention()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             modelBuilder.Entity<Moostard>().Key(c => new { c.Id1, c.Id2 });
 
@@ -4684,7 +4685,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_can_be_flipped_using_principal_and_composite_PK_is_still_used_by_convention()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             modelBuilder.Entity<Moostard>().Key(c => new { c.Id1, c.Id2 });
 
@@ -4724,7 +4725,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_can_create_unidirectional_nav_and_specified_composite_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             modelBuilder.Entity<ToastedBun>(b =>
                 {
@@ -4767,7 +4768,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_can_create_unidirectional_from_other_end_nav_and_specified_composite_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             modelBuilder.Entity<ToastedBun>(b =>
                 {
@@ -4810,7 +4811,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_can_create_relationship_with_no_navigations_and_specified_composite_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             modelBuilder.Entity<ToastedBun>(b =>
                 {

--- a/test/EntityFramework.Core.Tests/Metadata/StringRelationshipBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/StringRelationshipBuilderTest.cs
@@ -7,6 +7,7 @@ using System.ComponentModel;
 using System.Linq;
 using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Metadata.ModelConventions;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Tests.Metadata
@@ -19,7 +20,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_finds_existing_navs_and_uses_associated_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Metadata.AddForeignKey(
                 model.GetEntityType(typeof(Order)).GetProperty("CustomerId"),
@@ -57,7 +58,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_finds_existing_nav_to_principal_and_uses_associated_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Metadata.AddForeignKey(
                 model.GetEntityType(typeof(Order)).GetProperty("CustomerId"),
@@ -94,7 +95,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_finds_existing_nav_to_dependent_and_uses_associated_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Metadata.AddForeignKey(
                 model.GetEntityType(typeof(Order)).GetProperty("CustomerId"),
@@ -131,7 +132,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_creates_both_navs_and_uses_existing_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Metadata.AddForeignKey(
                 model.GetEntityType(typeof(Order)).GetProperty("CustomerId"),
@@ -166,7 +167,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_creates_both_navs_and_creates_new_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Property(e => e.CustomerId);
 
@@ -202,7 +203,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_create_unidirectional_nav_and_new_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Property(e => e.CustomerId);
 
@@ -237,7 +238,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_create_unidirectional_from_other_end_nav_and_new_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Property(e => e.CustomerId);
 
@@ -273,7 +274,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_create_relationship_with_no_navigations()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Property(e => e.CustomerId);
 
@@ -307,7 +308,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_creates_both_navs_and_uses_specified_FK_even_if_found_by_convention()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Property(e => e.CustomerId);
 
@@ -345,7 +346,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_creates_both_navs_and_uses_existing_FK_not_found_by_convention()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Metadata.AddForeignKey(
                 model.GetEntityType(typeof(Pickle)).GetProperty("BurgerId"),
@@ -382,7 +383,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_creates_both_navs_and_creates_FK_specified()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Property(e => e.BurgerId);
 
@@ -420,7 +421,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_create_unidirectional_nav_and_specified_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Property(e => e.BurgerId);
 
@@ -457,7 +458,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_create_unidirectional_from_other_end_nav_and_specified_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Property(e => e.BurgerId);
 
@@ -494,7 +495,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_create_relationship_with_no_navigations_and_specified_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Property(e => e.BurgerId);
 
@@ -530,7 +531,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_creates_both_navs_and_creates_shadow_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Property(e => e.BurgerId);
 
@@ -569,7 +570,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_create_unidirectional_nav_with_shadow_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Property(e => e.BurgerId);
 
@@ -607,7 +608,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_create_unidirectional_from_other_end_nav_with_shadow_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Property(e => e.BurgerId);
 
@@ -645,7 +646,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_create_relationship_with_no_navigations_with_shadow_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Property(e => e.BurgerId);
 
@@ -682,7 +683,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_creates_both_navs_and_matches_shadow_FK_property_by_convention()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Property<int>("BigMakId");
 
@@ -718,7 +719,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_creates_both_navs_and_new_FK_when_uniqueness_does_not_match()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Metadata.AddForeignKey(
                 model.GetEntityType(typeof(Pickle)).GetProperty("BurgerId"),
@@ -760,7 +761,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_use_explicitly_specified_PK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Property(e => e.CustomerId);
 
@@ -800,7 +801,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_use_non_PK_principal()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>(b =>
                 {
                     b.Key(c => c.Id);
@@ -849,7 +850,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_have_both_convention_properties_specified()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>(b =>
                 {
                     b.Key(c => c.Id);
@@ -894,7 +895,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_have_both_convention_properties_specified_in_any_order()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>(b =>
                 {
                     b.Key(c => c.Id);
@@ -939,7 +940,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_have_FK_by_convention_specified_with_explicit_principal_key()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>(b =>
                 {
                     b.Key(c => c.Id);
@@ -989,7 +990,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_have_FK_by_convention_specified_with_explicit_principal_key_in_any_order()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>(b =>
                 {
                     b.Key(c => c.Id);
@@ -1039,7 +1040,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_have_principal_key_by_convention_specified_with_explicit_PK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>(b =>
                 {
                     b.Key(c => c.Id);
@@ -1089,7 +1090,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_have_principal_key_by_convention_specified_with_explicit_PK_in_any_order()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>(b =>
                 {
                     b.Key(c => c.Id);
@@ -1139,7 +1140,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_finds_existing_navs_and_uses_associated_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Metadata.AddForeignKey(
                 model.GetEntityType(typeof(Order)).GetProperty("CustomerId"),
@@ -1177,7 +1178,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_finds_existing_nav_to_principal_and_uses_associated_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Metadata.AddForeignKey(
                 model.GetEntityType(typeof(Order)).GetProperty("CustomerId"),
@@ -1214,7 +1215,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_finds_existing_nav_to_dependent_and_uses_associated_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Metadata.AddForeignKey(
                 model.GetEntityType(typeof(Order)).GetProperty("CustomerId"),
@@ -1251,7 +1252,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_creates_both_navs_and_uses_existing_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Metadata.AddForeignKey(
                 model.GetEntityType(typeof(Order)).GetProperty("CustomerId"),
@@ -1286,7 +1287,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_creates_both_navs_and_creates_new_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Property(e => e.CustomerId);
 
@@ -1322,7 +1323,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_create_unidirectional_nav_and_new_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Property(e => e.CustomerId);
 
@@ -1358,7 +1359,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_create_unidirectional_from_other_end_nav_and_new_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Property(e => e.CustomerId);
 
@@ -1393,7 +1394,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_create_relationship_with_no_navigations()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Property(e => e.CustomerId);
 
@@ -1427,7 +1428,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_creates_both_navs_and_uses_specified_FK_even_if_found_by_convention()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Property(e => e.CustomerId);
 
@@ -1465,7 +1466,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_creates_both_navs_and_uses_existing_FK_not_found_by_convention()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Metadata.AddForeignKey(
                 model.GetEntityType(typeof(Pickle)).GetProperty("BurgerId"),
@@ -1502,7 +1503,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_creates_both_navs_and_creates_FK_specified()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Property(e => e.BurgerId);
 
@@ -1540,7 +1541,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_create_unidirectional_nav_and_specified_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Property(e => e.BurgerId);
 
@@ -1577,7 +1578,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_create_unidirectional_from_other_end_nav_and_specified_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Property(e => e.BurgerId);
 
@@ -1614,7 +1615,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_create_relationship_with_no_navigations_and_specified_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Property(e => e.BurgerId);
 
@@ -1650,7 +1651,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_creates_both_navs_and_creates_shadow_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Property(e => e.BurgerId);
 
@@ -1689,7 +1690,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_create_unidirectional_nav_with_shadow_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Property(e => e.BurgerId);
 
@@ -1727,7 +1728,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_create_unidirectional_from_other_end_nav_with_shadow_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Property(e => e.BurgerId);
 
@@ -1765,7 +1766,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_create_relationship_with_no_navigations_with_shadow_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Property(e => e.BurgerId);
 
@@ -1802,7 +1803,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_creates_both_navs_and_matches_shadow_FK_by_convention()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Property<int>("BigMakId");
 
@@ -1838,7 +1839,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_creates_both_navs_and_new_FK_if_uniqueness_does_not_match()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Pickle>().Metadata.AddForeignKey(
                 model.GetEntityType(typeof(Pickle)).GetProperty("BurgerId"),
@@ -1880,7 +1881,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_use_explicitly_specified_PK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<Order>().Property(e => e.CustomerId);
 
@@ -1920,7 +1921,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_use_non_PK_principal()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>(b =>
                 {
                     b.Key(c => c.Id);
@@ -1969,7 +1970,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_have_both_convention_properties_specified()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>(b =>
                 {
                     b.Key(c => c.Id);
@@ -2014,7 +2015,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_have_both_convention_properties_specified_in_any_order()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>(b =>
                 {
                     b.Key(c => c.Id);
@@ -2059,7 +2060,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_have_FK_by_convention_specified_with_explicit_principal_key()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>(b =>
                 {
                     b.Key(c => c.Id);
@@ -2109,7 +2110,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_have_FK_by_convention_specified_with_explicit_principal_key_in_any_order()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>(b =>
                 {
                     b.Key(c => c.Id);
@@ -2159,7 +2160,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_have_principal_key_by_convention_specified_with_explicit_PK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>(b =>
                 {
                     b.Key(c => c.Id);
@@ -2209,7 +2210,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_have_principal_key_by_convention_specified_with_explicit_PK_in_any_order()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>(b =>
                 {
                     b.Key(c => c.Id);
@@ -2259,7 +2260,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_finds_existing_navs_and_uses_associated_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<CustomerDetails>().Metadata.AddForeignKey(
                 model.GetEntityType(typeof(CustomerDetails)).GetProperty("Id"),
@@ -2298,7 +2299,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_finds_existing_nav_to_principal_and_uses_associated_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<CustomerDetails>().Metadata.AddForeignKey(
                 model.GetEntityType(typeof(CustomerDetails)).GetProperty("Id"),
@@ -2336,7 +2337,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_finds_existing_nav_to_dependent_and_uses_associated_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<CustomerDetails>().Metadata.AddForeignKey(
                 model.GetEntityType(typeof(CustomerDetails)).GetProperty("Id"),
@@ -2374,7 +2375,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_creates_both_navs_and_uses_existing_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<CustomerDetails>().Key(e => e.Id);
             modelBuilder.Entity<CustomerDetails>().Metadata.AddForeignKey(
@@ -2411,7 +2412,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_creates_both_navs_and_creates_new_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<CustomerDetails>().Key(e => e.Id);
 
@@ -2447,7 +2448,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_creates_both_navs_and_uses_existing_FK_when_not_PK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Order>().Key(c => c.OrderId);
             modelBuilder.Entity<OrderDetails>().Key(e => e.Id);
             modelBuilder.Entity<OrderDetails>().Metadata.AddForeignKey(
@@ -2484,7 +2485,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_creates_both_navs_and_creates_new_FK_when_not_PK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Order>().Key(c => c.OrderId);
             modelBuilder.Entity<OrderDetails>(b =>
                 {
@@ -2524,7 +2525,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_can_create_unidirectional_nav_and_new_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<CustomerDetails>().Key(e => e.Id);
 
@@ -2559,7 +2560,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_can_create_unidirectional_from_other_end_nav_and_new_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<CustomerDetails>().Key(e => e.Id);
 
@@ -2595,7 +2596,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_can_create_relationship_with_no_navigations()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<CustomerDetails>().Key(e => e.Id);
 
@@ -2629,7 +2630,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_creates_both_navs_and_uses_specified_FK_even_if_found_by_convention()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Order>().Key(c => c.OrderId);
             modelBuilder.Entity<OrderDetails>(b =>
                 {
@@ -2671,7 +2672,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_creates_both_navs_and_uses_specified_FK_even_if_PK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<CustomerDetails>().Key(e => e.Id);
 
@@ -2709,7 +2710,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_creates_both_navs_and_uses_existing_FK_not_found_by_convention()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Bun>().Metadata.AddForeignKey(
                 model.GetEntityType(typeof(Bun)).GetProperty("BurgerId"),
@@ -2747,7 +2748,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_creates_both_navs_and_creates_FK_specified()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Bun>().Property(e => e.BurgerId);
 
@@ -2785,7 +2786,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_can_create_unidirectional_nav_and_specified_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Bun>().Property(e => e.BurgerId);
 
@@ -2822,7 +2823,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_can_create_unidirectional_from_other_end_nav_and_specified_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Bun>().Property(e => e.BurgerId);
 
@@ -2859,7 +2860,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_can_create_relationship_with_no_navigations_and_specified_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Bun>().Property(e => e.BurgerId);
 
@@ -2895,7 +2896,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_creates_both_navs_and_new_FK_when_uniqueness_does_not_match()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>().Key(c => c.Id);
             modelBuilder.Entity<Bun>().Metadata.AddForeignKey(
                 model.GetEntityType(typeof(Bun)).GetProperty("BurgerId"),
@@ -2937,7 +2938,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_principal_and_dependent_can_be_flipped_with_existing_FK_still_used()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Order>().Key(c => c.OrderId);
             modelBuilder.Entity<OrderDetails>().Key(e => e.Id);
             modelBuilder.Entity<OrderDetails>().Metadata.AddForeignKey(
@@ -2976,7 +2977,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_principal_and_dependent_can_be_flipped_with_FK_still_found_by_convention()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Order>().Key(c => c.OrderId);
             modelBuilder.Entity<OrderDetails>(b =>
                 {
@@ -3018,7 +3019,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Unidirectional_from_other_end_OneToOne_principal_and_dependent_can_be_flipped()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<CustomerDetails>().Key(e => e.Id);
 
@@ -3055,7 +3056,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Unidirectional_OneToOne_principal_and_dependent_can_be_flipped()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<CustomerDetails>().Key(e => e.Id);
 
@@ -3092,7 +3093,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void No_navigation_OneToOne_principal_and_dependent_can_be_flipped()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<CustomerDetails>().Key(e => e.Id);
 
@@ -3128,7 +3129,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_principal_and_dependent_can_be_flipped_with_PK_FK_still_used()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<CustomerDetails>().Key(e => e.Id);
 
@@ -3166,7 +3167,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_can_have_PK_explicitly_specified()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<CustomerDetails>().Key(e => e.Id);
 
@@ -3206,7 +3207,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_can_use_alternate_principal_key()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>(b =>
                 {
                     b.Key(c => c.Id);
@@ -3255,7 +3256,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_can_have_both_convention_keys_specified_explicitly()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Order>().Key(c => c.OrderId);
             modelBuilder.Entity<OrderDetails>(b =>
                 {
@@ -3300,7 +3301,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_can_have_both_convention_keys_specified_explicitly_in_any_order()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Order>().Key(c => c.OrderId);
             modelBuilder.Entity<OrderDetails>(b =>
                 {
@@ -3345,7 +3346,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_can_have_both_keys_specified_explicitly()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>(b =>
                 {
                     b.Key(c => c.Id);
@@ -3395,7 +3396,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_can_have_both_keys_specified_explicitly_in_any_order()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<BigMak>(b =>
                 {
                     b.Key(c => c.Id);
@@ -3445,7 +3446,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_principal_and_dependent_can_be_flipped_using_principal_with_existing_FK_still_used()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Order>().Key(c => c.OrderId);
             modelBuilder.Entity<OrderDetails>().Key(e => e.Id);
             modelBuilder.Entity<OrderDetails>().Metadata.AddForeignKey(
@@ -3484,7 +3485,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_principal_and_dependent_can_be_flipped_using_principal_with_FK_still_found_by_convention()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Order>().Key(c => c.OrderId);
             modelBuilder.Entity<OrderDetails>(b =>
                 {
@@ -3526,7 +3527,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_principal_and_dependent_can_be_flipped_in_both_ways()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Order>().Key(c => c.OrderId);
             modelBuilder.Entity<OrderDetails>(b =>
                 {
@@ -3569,7 +3570,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_principal_and_dependent_can_be_flipped_in_both_ways_in_any_order()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Order>().Key(c => c.OrderId);
             modelBuilder.Entity<OrderDetails>(b =>
                 {
@@ -3612,7 +3613,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Unidirectional_from_other_end_OneToOne_principal_and_dependent_can_be_flipped_using_principal()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<CustomerDetails>().Key(e => e.Id);
 
@@ -3649,7 +3650,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Unidirectional_OneToOne_principal_and_dependent_can_be_flipped_using_principal()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<CustomerDetails>().Key(e => e.Id);
 
@@ -3686,7 +3687,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void No_navigation_OneToOne_principal_and_dependent_can_be_flipped_using_principal()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Customer>().Key(c => c.Id);
             modelBuilder.Entity<CustomerDetails>().Key(e => e.Id);
 
@@ -3748,7 +3749,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_creates_both_navs_and_uses_existing_composite_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             var tomatoType = model.GetEntityType(typeof(Tomato));
             modelBuilder.Entity<Tomato>().Metadata.AddForeignKey(
@@ -3786,7 +3787,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_creates_both_navs_and_creates_composite_FK_specified()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             modelBuilder.Entity<Tomato>(b =>
                 {
@@ -3830,7 +3831,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_use_alternate_composite_key()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>(b =>
                 {
                     b.Key(c => new { c.Id1, c.Id2 });
@@ -3889,7 +3890,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_use_alternate_composite_key_in_any_order()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>(b =>
                 {
                     b.Key(c => new { c.Id1, c.Id2 });
@@ -3948,7 +3949,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_create_unidirectional_nav_and_specified_composite_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             modelBuilder.Entity<Tomato>(b =>
                 {
@@ -3991,7 +3992,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_create_unidirectional_from_other_end_nav_and_specified_composite_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             modelBuilder.Entity<Tomato>(b =>
                 {
@@ -4034,7 +4035,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToMany_can_create_relationship_with_no_navigations_and_specified_composite_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             modelBuilder.Entity<Tomato>(b =>
                 {
@@ -4076,7 +4077,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_creates_both_navs_and_uses_existing_composite_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             var tomatoType = model.GetEntityType(typeof(Tomato));
             modelBuilder.Entity<Tomato>().Metadata.AddForeignKey(
@@ -4114,7 +4115,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_creates_both_navs_and_creates_composite_FK_specified()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             modelBuilder.Entity<Tomato>(b =>
                 {
@@ -4158,7 +4159,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_use_alternate_composite_key()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>(b =>
                 {
                     b.Key(c => new { c.Id1, c.Id2 });
@@ -4217,7 +4218,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_use_alternate_composite_key_in_any_order()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>(b =>
                 {
                     b.Key(c => new { c.Id1, c.Id2 });
@@ -4276,7 +4277,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_create_unidirectional_nav_and_specified_composite_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             modelBuilder.Entity<Tomato>(b =>
                 {
@@ -4319,7 +4320,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_create_unidirectional_from_other_end_nav_and_specified_composite_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             modelBuilder.Entity<Tomato>(b =>
                 {
@@ -4362,7 +4363,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void ManyToOne_can_create_relationship_with_no_navigations_and_specified_composite_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             modelBuilder.Entity<Tomato>(b =>
                 {
@@ -4404,7 +4405,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_creates_both_navs_and_uses_existing_composite_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             var bunType = model.GetEntityType(typeof(ToastedBun));
             modelBuilder.Entity<ToastedBun>().Metadata.AddForeignKey(
@@ -4443,7 +4444,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_creates_both_navs_and_creates_composite_FK_specified()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             modelBuilder.Entity<ToastedBun>(b =>
                 {
@@ -4487,7 +4488,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_can_use_alternate_composite_key()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>(b =>
                 {
                     b.Key(c => new { c.Id1, c.Id2 });
@@ -4546,7 +4547,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_can_use_alternate_composite_key_in_any_order()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>(b =>
                 {
                     b.Key(c => new { c.Id1, c.Id2 });
@@ -4605,7 +4606,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_uses_composite_PK_for_FK_by_convention()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             modelBuilder.Entity<Moostard>().Key(c => new { c.Id1, c.Id2 });
 
@@ -4644,7 +4645,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_can_be_flipped_and_composite_PK_is_still_used_by_convention()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             modelBuilder.Entity<Moostard>().Key(c => new { c.Id1, c.Id2 });
 
@@ -4684,7 +4685,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_can_be_flipped_using_principal_and_composite_PK_is_still_used_by_convention()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             modelBuilder.Entity<Moostard>().Key(c => new { c.Id1, c.Id2 });
 
@@ -4724,7 +4725,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_can_create_unidirectional_nav_and_specified_composite_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             modelBuilder.Entity<ToastedBun>(b =>
                 {
@@ -4767,7 +4768,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_can_create_unidirectional_from_other_end_nav_and_specified_composite_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             modelBuilder.Entity<ToastedBun>(b =>
                 {
@@ -4810,7 +4811,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void OneToOne_can_create_relationship_with_no_navigations_and_specified_composite_FK()
         {
             var model = new Model();
-            var modelBuilder = new ModelBuilder(model);
+            var modelBuilder = new ModelBuilder(new ConventionSet(), model);
             modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
             modelBuilder.Entity<ToastedBun>(b =>
                 {

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest.cs
@@ -9,12 +9,59 @@ using System.Reflection;
 using Microsoft.Data.Entity.Builders;
 using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Metadata.Internal;
+using Microsoft.Data.Entity.Metadata.ModelConventions;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Tests.Metadata
 {
     public class ModelBuilderTest
     {
+        [Fact]
+        public void Can_create_a_model_builder_with_given_conventions_and_model()
+        {
+            var convention = new TestConvention();
+            var conventions = new ConventionSet();
+            conventions.EntityTypeAddedConventions.Add(convention);
+
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(conventions, model);
+
+            Assert.Same(model, modelBuilder.Model);
+
+            modelBuilder.Entity<Random>();
+
+            Assert.True(convention.Applied);
+            Assert.NotNull(model.GetEntityType(typeof(Random)));
+        }
+
+        [Fact]
+        public void Can_create_a_model_builder_with_given_conventions_only()
+        {
+            var convention = new TestConvention();
+            var conventions = new ConventionSet();
+            conventions.EntityTypeAddedConventions.Add(convention);
+
+            var modelBuilder = new ModelBuilder(conventions);
+
+            modelBuilder.Entity<Random>();
+
+            Assert.True(convention.Applied);
+            Assert.NotNull(modelBuilder.Model.GetEntityType(typeof(Random)));
+        }
+
+        private class TestConvention : IEntityTypeConvention
+        {
+            public bool Applied { get; set; }
+
+            public InternalEntityBuilder Apply(InternalEntityBuilder entityBuilder)
+            {
+                Applied = true;
+
+                return entityBuilder;
+            }
+        }
+
         [Fact]
         public void Can_get_entity_builder_for_clr_type()
         {


### PR DESCRIPTION
Per API review decisions, a parameterless ModelBuilder constructor that creates a ModelBuilder without conventions would be a pit of failure. Therefore, this constructor is removed and now a convention set must always be passed, which may be empty. Also verified it is pretty easy to create a ModelBuilderFactory for a given provider and get a convention builder from that.