### PR TITLE
Add support for property conventions

### DIFF
--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -148,6 +148,7 @@
     <Compile Include="DbContext.cs" />
     <Compile Include="DbContextOptionsBuilder.cs" />
     <Compile Include="DbContextOptionsBuilder`.cs" />
+    <Compile Include="Metadata\ModelConventions\IPropertyConvention.cs" />
     <Compile Include="Metadata\ModelConventions\IModelConvention.cs" />
     <Compile Include="Query\AnnotateQueryExtensions.cs" />
     <Compile Include="Infrastructure\CoreOptionsExtension.cs" />
@@ -202,7 +203,7 @@
     <Compile Include="Metadata\KeyExtensions.cs" />
     <Compile Include="Metadata\ModelConventions\ConventionDispatcher.cs" />
     <Compile Include="Metadata\ModelConventions\ConventionSet.cs" />
-    <Compile Include="Metadata\ModelConventions\IRelationshipConvention.cs" />
+    <Compile Include="Metadata\ModelConventions\IForeignKeyConvention.cs" />
     <Compile Include="Metadata\NullableEnumClrPropertySetter.cs" />
     <Compile Include="Metadata\CollectionTypeFactory.cs" />
     <Compile Include="Metadata\ForeignKeyExtensions.cs" />
@@ -325,7 +326,7 @@
     <Compile Include="Metadata\Property.cs" />
     <Compile Include="Metadata\ModelConventions\IEntityTypeConvention.cs" />
     <Compile Include="Metadata\ModelConventions\KeyDiscoveryConvention.cs" />
-    <Compile Include="Metadata\ModelConventions\PropertiesConvention.cs" />
+    <Compile Include="Metadata\ModelConventions\PropertyDiscoveryConvention.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\InternalsVisibleTo.cs" />
     <Compile Include="Properties\Strings.Designer.cs">

--- a/src/EntityFramework.Core/Metadata/Internal/InternalEntityBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/InternalEntityBuilder.cs
@@ -79,8 +79,8 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 () => newPrimaryKey,
                 () => Metadata.SetPrimaryKey(properties),
                 key => new InternalKeyBuilder(key, ModelBuilder),
-                onNewKeyAdded: ModelBuilder.ConventionDispatcher.OnKeyAdded,
-                configurationSource: configurationSource);
+                ModelBuilder.ConventionDispatcher.OnKeyAdded,
+                configurationSource);
 
             ReplaceConventionShadowKeys(keyBuilder.Metadata);
 
@@ -151,8 +151,8 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 () => Metadata.TryGetKey(properties),
                 () => Metadata.AddKey(properties),
                 key => new InternalKeyBuilder(key, ModelBuilder),
-                onNewKeyAdded: ModelBuilder.ConventionDispatcher.OnKeyAdded,
-                configurationSource: configurationSource);
+                ModelBuilder.ConventionDispatcher.OnKeyAdded,
+                configurationSource);
         }
 
         public virtual ConfigurationSource? RemoveKey([NotNull] Key key, ConfigurationSource configurationSource)
@@ -208,6 +208,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                     () => Metadata.TryGetProperty(propertyName),
                     () => Metadata.AddProperty(propertyName, propertyType, shadowProperty),
                     property => new InternalPropertyBuilder(property, ModelBuilder, configurationSource),
+                    ModelBuilder.ConventionDispatcher.OnPropertyAdded,
                     configurationSource);
             }
 
@@ -969,7 +970,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
             if (!existingForeignKey)
             {
-                builder = ModelBuilder.ConventionDispatcher.OnRelationshipAdded(builder);
+                builder = ModelBuilder.ConventionDispatcher.OnForeignKeyAdded(builder);
             }
 
             return builder;

--- a/src/EntityFramework.Core/Metadata/ModelBuilderFactory.cs
+++ b/src/EntityFramework.Core/Metadata/ModelBuilderFactory.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Data.Entity.Metadata
         {
             var conventions = new ConventionSet();
 
-            conventions.EntityTypeAddedConventions.Add(new PropertiesConvention());
+            conventions.EntityTypeAddedConventions.Add(new PropertyDiscoveryConvention());
             conventions.EntityTypeAddedConventions.Add(new KeyDiscoveryConvention());
             conventions.EntityTypeAddedConventions.Add(new RelationshipDiscoveryConvention());
 

--- a/src/EntityFramework.Core/Metadata/ModelConventions/ConventionDispatcher.cs
+++ b/src/EntityFramework.Core/Metadata/ModelConventions/ConventionDispatcher.cs
@@ -34,6 +34,22 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
             return entityBuilder;
         }
 
+        public virtual InternalPropertyBuilder OnPropertyAdded([NotNull] InternalPropertyBuilder propertyBuilder)
+        {
+            Check.NotNull(propertyBuilder, nameof(propertyBuilder));
+
+            foreach (var entityTypeConvention in _conventionSet.PropertyAddedConventions)
+            {
+                propertyBuilder = entityTypeConvention.Apply(propertyBuilder);
+                if (propertyBuilder == null)
+                {
+                    break;
+                }
+            }
+
+            return propertyBuilder;
+        }
+
         public virtual InternalKeyBuilder OnKeyAdded([NotNull] InternalKeyBuilder keyBuilder)
         {
             Check.NotNull(keyBuilder, nameof(keyBuilder));
@@ -61,7 +77,7 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
             }
         }
 
-        public virtual InternalRelationshipBuilder OnRelationshipAdded([NotNull] InternalRelationshipBuilder relationshipBuilder)
+        public virtual InternalRelationshipBuilder OnForeignKeyAdded([NotNull] InternalRelationshipBuilder relationshipBuilder)
         {
             Check.NotNull(relationshipBuilder, nameof(relationshipBuilder));
 

--- a/src/EntityFramework.Core/Metadata/ModelConventions/ConventionSet.cs
+++ b/src/EntityFramework.Core/Metadata/ModelConventions/ConventionSet.cs
@@ -8,11 +8,9 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
     public class ConventionSet
     {
         public virtual IList<IEntityTypeConvention> EntityTypeAddedConventions { get; } = new List<IEntityTypeConvention>();
-
+        public virtual IList<IPropertyConvention> PropertyAddedConventions { get; } = new List<IPropertyConvention>();
         public virtual IList<IKeyConvention> KeyAddedConventions { get; } = new List<IKeyConvention>();
-
-        public virtual IList<IRelationshipConvention> ForeignKeyAddedConventions { get; } = new List<IRelationshipConvention>();
-
+        public virtual IList<IForeignKeyConvention> ForeignKeyAddedConventions { get; } = new List<IForeignKeyConvention>();
         public virtual IList<IForeignKeyRemovedConvention> ForeignKeyRemovedConventions { get; } = new List<IForeignKeyRemovedConvention>();
 
         public virtual IList<IModelConvention> ModelConventions { get; } = new List<IModelConvention>();

--- a/src/EntityFramework.Core/Metadata/ModelConventions/ForeignKeyPropertyDiscoveryConvention.cs
+++ b/src/EntityFramework.Core/Metadata/ModelConventions/ForeignKeyPropertyDiscoveryConvention.cs
@@ -8,7 +8,7 @@ using Microsoft.Data.Entity.Metadata.Internal;
 
 namespace Microsoft.Data.Entity.Metadata.ModelConventions
 {
-    public class ForeignKeyPropertyDiscoveryConvention : IRelationshipConvention
+    public class ForeignKeyPropertyDiscoveryConvention : IForeignKeyConvention
     {
         public virtual InternalRelationshipBuilder Apply(InternalRelationshipBuilder relationshipBuilder)
         {

--- a/src/EntityFramework.Core/Metadata/ModelConventions/IForeignKeyConvention.cs
+++ b/src/EntityFramework.Core/Metadata/ModelConventions/IForeignKeyConvention.cs
@@ -6,7 +6,7 @@ using Microsoft.Data.Entity.Metadata.Internal;
 
 namespace Microsoft.Data.Entity.Metadata.ModelConventions
 {
-    public interface IRelationshipConvention
+    public interface IForeignKeyConvention
     {
         InternalRelationshipBuilder Apply([NotNull] InternalRelationshipBuilder relationshipBuilder);
     }

--- a/src/EntityFramework.Core/Metadata/ModelConventions/IPropertyConvention.cs
+++ b/src/EntityFramework.Core/Metadata/ModelConventions/IPropertyConvention.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata.Internal;
+
+namespace Microsoft.Data.Entity.Metadata.ModelConventions
+{
+    public interface IPropertyConvention
+    {
+        InternalPropertyBuilder Apply([NotNull] InternalPropertyBuilder propertyBuilder);
+    }
+}

--- a/src/EntityFramework.Core/Metadata/ModelConventions/PropertyDiscoveryConvention.cs
+++ b/src/EntityFramework.Core/Metadata/ModelConventions/PropertyDiscoveryConvention.cs
@@ -8,7 +8,7 @@ using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Metadata.ModelConventions
 {
-    public class PropertiesConvention : IEntityTypeConvention
+    public class PropertyDiscoveryConvention : IEntityTypeConvention
     {
         public virtual InternalEntityBuilder Apply(InternalEntityBuilder entityBuilder)
         {

--- a/src/EntityFramework.SqlServer/Metadata/ModelConventions/SqlServerValueGenerationStrategyConvention.cs
+++ b/src/EntityFramework.SqlServer/Metadata/ModelConventions/SqlServerValueGenerationStrategyConvention.cs
@@ -12,7 +12,7 @@ using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.SqlServer.Metadata.ModelConventions
 {
-    public class SqlServerValueGenerationStrategyConvention : IKeyConvention, IForeignKeyRemovedConvention, IRelationshipConvention, IModelConvention
+    public class SqlServerValueGenerationStrategyConvention : IKeyConvention, IForeignKeyRemovedConvention, IForeignKeyConvention, IModelConvention
     {
         public virtual InternalKeyBuilder Apply(InternalKeyBuilder keyBuilder)
         {

--- a/test/EntityFramework.Core.Tests/EntityFramework.Core.Tests.csproj
+++ b/test/EntityFramework.Core.Tests/EntityFramework.Core.Tests.csproj
@@ -152,7 +152,7 @@
     <Compile Include="Metadata\ObjectArrayValueReaderTest.cs" />
     <Compile Include="Metadata\PropertyTest.cs" />
     <Compile Include="Metadata\ModelConventions\KeyDiscoveryConventionTest.cs" />
-    <Compile Include="Metadata\ModelConventions\PropertiesConventionTest.cs" />
+    <Compile Include="Metadata\ModelConventions\PropertyDiscoveryConventionTest.cs" />
     <Compile Include="Query\TaskResultAsyncEnumerableTest.cs" />
     <Compile Include="Storage\DataStoreSelectorTest.cs" />
     <Compile Include="TestExtensions.cs" />

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/KeyConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/KeyConventionTest.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
         private static InternalModelBuilder createInternalModelBuilder()
         {
             var conventions = new ConventionSet();
-            conventions.EntityTypeAddedConventions.Add(new PropertiesConvention());
+            conventions.EntityTypeAddedConventions.Add(new PropertyDiscoveryConvention());
             conventions.EntityTypeAddedConventions.Add(new KeyDiscoveryConvention());
             conventions.ForeignKeyRemovedConventions.Add(new KeyConvention());
 

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/KeyDiscoveryConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/KeyDiscoveryConventionTest.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             var modelBuilder = new InternalModelBuilder(new Model(), new ConventionSet());
             var entityBuilder = modelBuilder.Entity(typeof(T), ConfigurationSource.Convention);
 
-            new PropertiesConvention().Apply(entityBuilder);
+            new PropertyDiscoveryConvention().Apply(entityBuilder);
 
             return entityBuilder;
         }

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/PropertyDiscoveryConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/PropertyDiscoveryConventionTest.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
 {
-    public class PropertiesConventionTest
+    public class PropertyDiscoveryConventionTest
     {
         private class EntityWithInvalidProperties
         {
@@ -39,7 +39,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
         {
             var entityBuilder = CreateInternalEntityBuilder<EntityWithInvalidProperties>();
 
-            Assert.Same(entityBuilder, new PropertiesConvention().Apply(entityBuilder));
+            Assert.Same(entityBuilder, new PropertyDiscoveryConvention().Apply(entityBuilder));
 
             Assert.Empty(entityBuilder.Metadata.Properties);
         }
@@ -101,7 +101,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
         {
             var entityBuilder = CreateInternalEntityBuilder<EntityWithEveryPrimitive>();
 
-            Assert.Same(entityBuilder, new PropertiesConvention().Apply(entityBuilder));
+            Assert.Same(entityBuilder, new PropertyDiscoveryConvention().Apply(entityBuilder));
 
             Assert.Equal(
                 typeof(EntityWithEveryPrimitive)
@@ -120,7 +120,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
         {
             var entityBuilder = CreateInternalEntityBuilder<EntityWithNoPrimitives>();
 
-            Assert.Same(entityBuilder, new PropertiesConvention().Apply(entityBuilder));
+            Assert.Same(entityBuilder, new PropertyDiscoveryConvention().Apply(entityBuilder));
 
             Assert.Empty(entityBuilder.Metadata.Properties);
         }

--- a/test/EntityFramework.SqlServer.Tests/Metadata/ModelConventions/SqlServerValueGenerationStrategyConventionTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/Metadata/ModelConventions/SqlServerValueGenerationStrategyConventionTest.cs
@@ -197,7 +197,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata.ModelConventions
         {
             var conventions = new ConventionSet();
 
-            conventions.EntityTypeAddedConventions.Add(new PropertiesConvention());
+            conventions.EntityTypeAddedConventions.Add(new PropertyDiscoveryConvention());
             conventions.EntityTypeAddedConventions.Add(new KeyDiscoveryConvention());
 
             var keyConvention = new KeyConvention();


### PR DESCRIPTION
Rename PropertiesConvention to PropertyDiscoveryConvention
Rename IRelationshipConvention to IForeignKeyConvention