### PR TITLE
Sanitize SQL generated by SqlServerSequenceValueGenerator

### DIFF
--- a/src/EntityFramework.Relational/ISqlGenerator.cs
+++ b/src/EntityFramework.Relational/ISqlGenerator.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Data.Entity.Relational
         string GenerateLiteral(DateTime literal);
         string GenerateLiteral(DateTimeOffset literal);
         string GenerateLiteral<T>([CanBeNull] T? literal) where T : struct;
+        string GenerateNextSequenceValueOperation([NotNull] string sequenceName);
         void AppendBatchHeader([NotNull] StringBuilder commandStringBuilder);
         void AppendDeleteOperation([NotNull] StringBuilder commandStringBuilder, [NotNull] ModificationCommand command);
         void AppendInsertOperation([NotNull] StringBuilder commandStringBuilder, [NotNull] ModificationCommand command);

--- a/src/EntityFramework.Relational/SqlGenerator.cs
+++ b/src/EntityFramework.Relational/SqlGenerator.cs
@@ -414,5 +414,11 @@ namespace Microsoft.Data.Entity.Relational
             literal != null
                 ? string.Format(CultureInfo.InvariantCulture, "{0}", literal)
                 : "NULL";
+        public virtual string GenerateNextSequenceValueOperation(string sequenceName)
+        {
+            Check.NotNull(sequenceName, nameof(sequenceName));
+
+            return "SELECT NEXT VALUE FOR " + DelimitIdentifier(sequenceName);
+        }
     }
 }

--- a/src/EntityFramework.SqlServer/SqlServerSequenceValueGeneratorFactory.cs
+++ b/src/EntityFramework.SqlServer/SqlServerSequenceValueGeneratorFactory.cs
@@ -13,17 +13,22 @@ namespace Microsoft.Data.Entity.SqlServer
     public class SqlServerSequenceValueGeneratorFactory
     {
         private readonly SqlStatementExecutor _executor;
+        private readonly ISqlServerSqlGenerator _sqlGenerator;
 
-        public SqlServerSequenceValueGeneratorFactory([NotNull] SqlStatementExecutor executor)
+        public SqlServerSequenceValueGeneratorFactory(
+            [NotNull] SqlStatementExecutor executor,
+            [NotNull] ISqlServerSqlGenerator sqlGenerator)
         {
             Check.NotNull(executor, nameof(executor));
+            Check.NotNull(sqlGenerator, nameof(sqlGenerator));
 
             _executor = executor;
+            _sqlGenerator = sqlGenerator;
         }
 
         public virtual ValueGenerator Create(
-            [NotNull] IProperty property, 
-            [NotNull] SqlServerSequenceValueGeneratorState generatorState, 
+            [NotNull] IProperty property,
+            [NotNull] SqlServerSequenceValueGeneratorState generatorState,
             [NotNull] ISqlServerConnection connection)
         {
             Check.NotNull(property, nameof(property));
@@ -32,42 +37,42 @@ namespace Microsoft.Data.Entity.SqlServer
 
             if (property.ClrType.UnwrapNullableType() == typeof(long))
             {
-                return new SqlServerSequenceValueGenerator<long>(_executor, generatorState, connection);
+                return new SqlServerSequenceValueGenerator<long>(_executor, _sqlGenerator, generatorState, connection);
             }
 
             if (property.ClrType.UnwrapNullableType() == typeof(int))
             {
-                return new SqlServerSequenceValueGenerator<int>(_executor, generatorState, connection);
+                return new SqlServerSequenceValueGenerator<int>(_executor, _sqlGenerator, generatorState, connection);
             }
 
             if (property.ClrType.UnwrapNullableType() == typeof(short))
             {
-                return new SqlServerSequenceValueGenerator<short>(_executor, generatorState, connection);
+                return new SqlServerSequenceValueGenerator<short>(_executor, _sqlGenerator, generatorState, connection);
             }
 
             if (property.ClrType.UnwrapNullableType() == typeof(byte))
             {
-                return new SqlServerSequenceValueGenerator<byte>(_executor, generatorState, connection);
+                return new SqlServerSequenceValueGenerator<byte>(_executor, _sqlGenerator, generatorState, connection);
             }
 
             if (property.ClrType.UnwrapNullableType() == typeof(ulong))
             {
-                return new SqlServerSequenceValueGenerator<ulong>(_executor, generatorState, connection);
+                return new SqlServerSequenceValueGenerator<ulong>(_executor, _sqlGenerator, generatorState, connection);
             }
 
             if (property.ClrType.UnwrapNullableType() == typeof(uint))
             {
-                return new SqlServerSequenceValueGenerator<uint>(_executor, generatorState, connection);
+                return new SqlServerSequenceValueGenerator<uint>(_executor, _sqlGenerator, generatorState, connection);
             }
 
             if (property.ClrType.UnwrapNullableType() == typeof(ushort))
             {
-                return new SqlServerSequenceValueGenerator<ushort>(_executor, generatorState, connection);
+                return new SqlServerSequenceValueGenerator<ushort>(_executor, _sqlGenerator, generatorState, connection);
             }
 
             if (property.ClrType.UnwrapNullableType() == typeof(sbyte))
             {
-                return new SqlServerSequenceValueGenerator<sbyte>(_executor, generatorState, connection);
+                return new SqlServerSequenceValueGenerator<sbyte>(_executor, _sqlGenerator, generatorState, connection);
             }
 
             throw new ArgumentException(Internal.Strings.InvalidValueGeneratorFactoryProperty(

--- a/test/EntityFramework.Relational.Tests/SqlGeneratorTestBase.cs
+++ b/test/EntityFramework.Relational.Tests/SqlGeneratorTestBase.cs
@@ -343,6 +343,16 @@ namespace Microsoft.Data.Entity.Relational.Tests
             Assert.Equal("42", literal);
         }
 
+        [Fact]
+        public virtual void GenerateNextSequenceValueOperation_returns_statement_with_sanatized_sequence()
+        {
+            var statement = CreateSqlGenerator().GenerateNextSequenceValueOperation("sequence" + CloseDelimeter + "; --");
+
+            Assert.Equal(
+                "SELECT NEXT VALUE FOR " + OpenDelimeter + "sequence" + CloseDelimeter + CloseDelimeter + "; --" + CloseDelimeter,
+                statement);
+        }
+
         protected abstract ISqlGenerator CreateSqlGenerator();
 
         protected abstract string RowsAffected { get; }

--- a/test/EntityFramework.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
@@ -72,7 +72,11 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             const int poolSize = 3;
 
             var state = new SqlServerSequenceValueGeneratorState("Foo", blockSize, poolSize);
-            var generator = new SqlServerSequenceValueGenerator<TValue>(new FakeSqlStatementExecutor(blockSize), state, CreateConnection());
+            var generator = new SqlServerSequenceValueGenerator<TValue>(
+                new FakeSqlStatementExecutor(blockSize),
+                new SqlServerSqlGenerator(),
+                state,
+                CreateConnection());
 
             var generatedValues = new List<TValue>();
             for (var i = 0; i < 27; i++)
@@ -137,6 +141,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             var serviceProvider = SqlServerTestHelpers.Instance.CreateServiceProvider();
             var state = new SqlServerSequenceValueGeneratorState("Foo", blockSize, poolSize);
             var executor = new FakeSqlStatementExecutor(blockSize);
+            var sqlGenerator = new SqlServerSqlGenerator();
 
             var tests = new Action[threadCount];
             var generatedValues = new List<long>[threadCount];
@@ -149,7 +154,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                         for (var j = 0; j < valueCount; j++)
                         {
                             var connection = CreateConnection(serviceProvider);
-                            var generator = new SqlServerSequenceValueGenerator<long>(executor, state, connection);
+                            var generator = new SqlServerSequenceValueGenerator<long>(executor, sqlGenerator, state, connection);
 
                             generatedValues[testNumber].Add(generator.Next());
                         }
@@ -165,7 +170,11 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         public void Does_not_generate_temp_values()
         {
             var state = new SqlServerSequenceValueGeneratorState("Foo", 4, 3);
-            var generator = new SqlServerSequenceValueGenerator<int>(new FakeSqlStatementExecutor(4), state, CreateConnection());
+            var generator = new SqlServerSequenceValueGenerator<int>(
+                new FakeSqlStatementExecutor(4),
+                new SqlServerSqlGenerator(),
+                state,
+                CreateConnection());
 
             Assert.False(generator.GeneratesTemporaryValues);
         }


### PR DESCRIPTION
Using the ```ISqlServerSqlGenerator``` to sanitize the sequence name.
@ajcvickers @bricelam 