### PR TITLE
API review change: disallow calling generic ForeignKey/PrincipalKey when...

### DIFF
--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -148,6 +148,7 @@
     <Compile Include="DbContext.cs" />
     <Compile Include="DbContextOptionsBuilder.cs" />
     <Compile Include="DbContextOptionsBuilder`.cs" />
+    <Compile Include="Metadata\Builders\TypedReferenceReferenceBuilder.cs" />
     <Compile Include="Metadata\ModelConventions\IPropertyConvention.cs" />
     <Compile Include="Metadata\ModelConventions\IModelConvention.cs" />
     <Compile Include="Query\AnnotateQueryExtensions.cs" />

--- a/src/EntityFramework.Core/Metadata/Builders/ReferenceNavigationBuilder`.cs
+++ b/src/EntityFramework.Core/Metadata/Builders/ReferenceNavigationBuilder`.cs
@@ -69,8 +69,8 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         ///     configured without a navigation property on the other end of the relationship.
         /// </param>
         /// <returns> An object to further configure the relationship. </returns>
-        public virtual ReferenceReferenceBuilder InverseReference([CanBeNull] Expression<Func<TRelatedEntity, TEntity>> inverseReference = null)
-            => new ReferenceReferenceBuilder(InverseReferenceBuilder(inverseReference?.GetPropertyAccess().Name));
+        public virtual TypedReferenceReferenceBuilder InverseReference([CanBeNull] Expression<Func<TRelatedEntity, TEntity>> inverseReference = null)
+            => new TypedReferenceReferenceBuilder(InverseReferenceBuilder(inverseReference?.GetPropertyAccess().Name));
 
         /// <summary>
         ///     Configures this as a one-to-many relationship.

--- a/src/EntityFramework.Relational/RelationalBuilderExtensions.cs
+++ b/src/EntityFramework.Relational/RelationalBuilderExtensions.cs
@@ -105,63 +105,101 @@ namespace Microsoft.Data.Entity
         }
 
         public static RelationalForeignKeyBuilder ForRelational(
-            [NotNull] this ReferenceCollectionBuilder foreignKeyBuilder)
+            [NotNull] this ReferenceCollectionBuilder referenceCollectionBuilder)
         {
-            Check.NotNull(foreignKeyBuilder, nameof(foreignKeyBuilder));
+            Check.NotNull(referenceCollectionBuilder, nameof(referenceCollectionBuilder));
 
-            return new RelationalForeignKeyBuilder(foreignKeyBuilder.Metadata);
+            return new RelationalForeignKeyBuilder(referenceCollectionBuilder.Metadata);
         }
 
         public static ReferenceCollectionBuilder ForRelational(
-            [NotNull] this ReferenceCollectionBuilder foreignKeyBuilder,
+            [NotNull] this ReferenceCollectionBuilder referenceCollectionBuilder,
             [NotNull] Action<RelationalForeignKeyBuilder> builderAction)
         {
-            Check.NotNull(foreignKeyBuilder, nameof(foreignKeyBuilder));
+            Check.NotNull(referenceCollectionBuilder, nameof(referenceCollectionBuilder));
             Check.NotNull(builderAction, nameof(builderAction));
 
-            builderAction(ForRelational(foreignKeyBuilder));
+            builderAction(ForRelational(referenceCollectionBuilder));
 
-            return foreignKeyBuilder;
+            return referenceCollectionBuilder;
+        }
+
+        public static ReferenceCollectionBuilder<TEntity, TRelatedEntity> ForRelational<TEntity, TRelatedEntity>(
+            [NotNull] this ReferenceCollectionBuilder<TEntity, TRelatedEntity> referenceCollectionBuilder,
+            [NotNull] Action<RelationalForeignKeyBuilder> builderAction)
+            where TEntity : class
+        {
+            Check.NotNull(referenceCollectionBuilder, nameof(referenceCollectionBuilder));
+            Check.NotNull(builderAction, nameof(builderAction));
+
+            builderAction(ForRelational(referenceCollectionBuilder));
+
+            return referenceCollectionBuilder;
         }
 
         public static RelationalForeignKeyBuilder ForRelational(
-            [NotNull] this CollectionReferenceBuilder foreignKeyBuilder)
+            [NotNull] this CollectionReferenceBuilder collectionReferenceBuilder)
         {
-            Check.NotNull(foreignKeyBuilder, nameof(foreignKeyBuilder));
+            Check.NotNull(collectionReferenceBuilder, nameof(collectionReferenceBuilder));
 
-            return new RelationalForeignKeyBuilder(foreignKeyBuilder.Metadata);
+            return new RelationalForeignKeyBuilder(collectionReferenceBuilder.Metadata);
         }
 
         public static CollectionReferenceBuilder ForRelational(
-            [NotNull] this CollectionReferenceBuilder foreignKeyBuilder,
+            [NotNull] this CollectionReferenceBuilder collectionReferenceBuilder,
             [NotNull] Action<RelationalForeignKeyBuilder> builderAction)
         {
-            Check.NotNull(foreignKeyBuilder, nameof(foreignKeyBuilder));
+            Check.NotNull(collectionReferenceBuilder, nameof(collectionReferenceBuilder));
             Check.NotNull(builderAction, nameof(builderAction));
 
-            builderAction(ForRelational(foreignKeyBuilder));
+            builderAction(ForRelational(collectionReferenceBuilder));
 
-            return foreignKeyBuilder;
+            return collectionReferenceBuilder;
+        }
+
+        public static CollectionReferenceBuilder<TEntity, TRelatedEntity> ForRelational<TEntity, TRelatedEntity>(
+            [NotNull] this CollectionReferenceBuilder<TEntity, TRelatedEntity> collectionReferenceBuilder,
+            [NotNull] Action<RelationalForeignKeyBuilder> builderAction)
+            where TEntity : class
+        {
+            Check.NotNull(collectionReferenceBuilder, nameof(collectionReferenceBuilder));
+            Check.NotNull(builderAction, nameof(builderAction));
+
+            builderAction(ForRelational(collectionReferenceBuilder));
+
+            return collectionReferenceBuilder;
         }
 
         public static RelationalForeignKeyBuilder ForRelational(
-            [NotNull] this ReferenceReferenceBuilder foreignKeyBuilder)
+            [NotNull] this ReferenceReferenceBuilder referenceReferenceBuilder)
         {
-            Check.NotNull(foreignKeyBuilder, nameof(foreignKeyBuilder));
+            Check.NotNull(referenceReferenceBuilder, nameof(referenceReferenceBuilder));
 
-            return new RelationalForeignKeyBuilder(foreignKeyBuilder.Metadata);
+            return new RelationalForeignKeyBuilder(referenceReferenceBuilder.Metadata);
         }
 
         public static ReferenceReferenceBuilder ForRelational(
-            [NotNull] this ReferenceReferenceBuilder foreignKeyBuilder,
+            [NotNull] this ReferenceReferenceBuilder referenceReferenceBuilder,
             [NotNull] Action<RelationalForeignKeyBuilder> builderAction)
         {
-            Check.NotNull(foreignKeyBuilder, nameof(foreignKeyBuilder));
+            Check.NotNull(referenceReferenceBuilder, nameof(referenceReferenceBuilder));
             Check.NotNull(builderAction, nameof(builderAction));
 
-            builderAction(ForRelational(foreignKeyBuilder));
+            builderAction(ForRelational(referenceReferenceBuilder));
 
-            return foreignKeyBuilder;
+            return referenceReferenceBuilder;
+        }
+
+        public static TypedReferenceReferenceBuilder ForRelational(
+            [NotNull] this TypedReferenceReferenceBuilder referenceReferenceBuilder,
+            [NotNull] Action<RelationalForeignKeyBuilder> builderAction)
+        {
+            Check.NotNull(referenceReferenceBuilder, nameof(referenceReferenceBuilder));
+            Check.NotNull(builderAction, nameof(builderAction));
+
+            builderAction(ForRelational(referenceReferenceBuilder));
+
+            return referenceReferenceBuilder;
         }
 
         public static RelationalModelBuilder ForRelational(

--- a/src/EntityFramework.SqlServer/SqlServerBuilderExtensions.cs
+++ b/src/EntityFramework.SqlServer/SqlServerBuilderExtensions.cs
@@ -105,63 +105,101 @@ namespace Microsoft.Data.Entity
         }
 
         public static SqlServerForeignKeyBuilder ForSqlServer(
-            [NotNull] this ReferenceCollectionBuilder foreignKeyBuilder)
+            [NotNull] this ReferenceCollectionBuilder referenceCollectionBuilder)
         {
-            Check.NotNull(foreignKeyBuilder, nameof(foreignKeyBuilder));
+            Check.NotNull(referenceCollectionBuilder, nameof(referenceCollectionBuilder));
 
-            return new SqlServerForeignKeyBuilder(foreignKeyBuilder.Metadata);
+            return new SqlServerForeignKeyBuilder(referenceCollectionBuilder.Metadata);
         }
 
         public static ReferenceCollectionBuilder ForSqlServer(
-            [NotNull] this ReferenceCollectionBuilder foreignKeyBuilder,
+            [NotNull] this ReferenceCollectionBuilder referenceCollectionBuilder,
             [NotNull] Action<SqlServerForeignKeyBuilder> builderAction)
         {
-            Check.NotNull(foreignKeyBuilder, nameof(foreignKeyBuilder));
+            Check.NotNull(referenceCollectionBuilder, nameof(referenceCollectionBuilder));
             Check.NotNull(builderAction, nameof(builderAction));
 
-            builderAction(ForSqlServer(foreignKeyBuilder));
+            builderAction(ForSqlServer(referenceCollectionBuilder));
 
-            return foreignKeyBuilder;
+            return referenceCollectionBuilder;
+        }
+
+        public static ReferenceCollectionBuilder<TEntity, TRelatedEntity> ForSqlServer<TEntity, TRelatedEntity>(
+            [NotNull] this ReferenceCollectionBuilder<TEntity, TRelatedEntity> referenceCollectionBuilder,
+            [NotNull] Action<SqlServerForeignKeyBuilder> builderAction)
+            where TEntity : class
+        {
+            Check.NotNull(referenceCollectionBuilder, nameof(referenceCollectionBuilder));
+            Check.NotNull(builderAction, nameof(builderAction));
+
+            builderAction(ForSqlServer(referenceCollectionBuilder));
+
+            return referenceCollectionBuilder;
         }
 
         public static SqlServerForeignKeyBuilder ForSqlServer(
-            [NotNull] this CollectionReferenceBuilder foreignKeyBuilder)
+            [NotNull] this CollectionReferenceBuilder collectionReferenceBuilder)
         {
-            Check.NotNull(foreignKeyBuilder, nameof(foreignKeyBuilder));
+            Check.NotNull(collectionReferenceBuilder, nameof(collectionReferenceBuilder));
 
-            return new SqlServerForeignKeyBuilder(foreignKeyBuilder.Metadata);
+            return new SqlServerForeignKeyBuilder(collectionReferenceBuilder.Metadata);
         }
 
         public static CollectionReferenceBuilder ForSqlServer(
-            [NotNull] this CollectionReferenceBuilder foreignKeyBuilder,
+            [NotNull] this CollectionReferenceBuilder collectionReferenceBuilder,
             [NotNull] Action<SqlServerForeignKeyBuilder> builderAction)
         {
-            Check.NotNull(foreignKeyBuilder, nameof(foreignKeyBuilder));
+            Check.NotNull(collectionReferenceBuilder, nameof(collectionReferenceBuilder));
             Check.NotNull(builderAction, nameof(builderAction));
 
-            builderAction(ForSqlServer(foreignKeyBuilder));
+            builderAction(ForSqlServer(collectionReferenceBuilder));
 
-            return foreignKeyBuilder;
+            return collectionReferenceBuilder;
+        }
+
+        public static CollectionReferenceBuilder<TEntity, TRelatedEntity> ForSqlServer<TEntity, TRelatedEntity>(
+            [NotNull] this CollectionReferenceBuilder<TEntity, TRelatedEntity> collectionReferenceBuilder,
+            [NotNull] Action<SqlServerForeignKeyBuilder> builderAction)
+            where TEntity : class
+        {
+            Check.NotNull(collectionReferenceBuilder, nameof(collectionReferenceBuilder));
+            Check.NotNull(builderAction, nameof(builderAction));
+
+            builderAction(ForSqlServer(collectionReferenceBuilder));
+
+            return collectionReferenceBuilder;
         }
 
         public static SqlServerForeignKeyBuilder ForSqlServer(
-            [NotNull] this ReferenceReferenceBuilder foreignKeyBuilder)
+            [NotNull] this ReferenceReferenceBuilder referenceReferenceBuilder)
         {
-            Check.NotNull(foreignKeyBuilder, nameof(foreignKeyBuilder));
+            Check.NotNull(referenceReferenceBuilder, nameof(referenceReferenceBuilder));
 
-            return new SqlServerForeignKeyBuilder(foreignKeyBuilder.Metadata);
+            return new SqlServerForeignKeyBuilder(referenceReferenceBuilder.Metadata);
         }
 
         public static ReferenceReferenceBuilder ForSqlServer(
-            [NotNull] this ReferenceReferenceBuilder foreignKeyBuilder,
+            [NotNull] this ReferenceReferenceBuilder referenceReferenceBuilder,
             [NotNull] Action<SqlServerForeignKeyBuilder> builderAction)
         {
-            Check.NotNull(foreignKeyBuilder, nameof(foreignKeyBuilder));
+            Check.NotNull(referenceReferenceBuilder, nameof(referenceReferenceBuilder));
             Check.NotNull(builderAction, nameof(builderAction));
 
-            builderAction(ForSqlServer(foreignKeyBuilder));
+            builderAction(ForSqlServer(referenceReferenceBuilder));
 
-            return foreignKeyBuilder;
+            return referenceReferenceBuilder;
+        }
+
+        public static TypedReferenceReferenceBuilder ForSqlServer(
+            [NotNull] this TypedReferenceReferenceBuilder referenceReferenceBuilder,
+            [NotNull] Action<SqlServerForeignKeyBuilder> builderAction)
+        {
+            Check.NotNull(referenceReferenceBuilder, nameof(referenceReferenceBuilder));
+            Check.NotNull(builderAction, nameof(builderAction));
+
+            builderAction(ForSqlServer(referenceReferenceBuilder));
+
+            return referenceReferenceBuilder;
         }
 
         public static SqlServerModelBuilder ForSqlServer(

--- a/test/EntityFramework.Relational.Tests/Metadata/RelationalBuilderExtensionsTest.cs
+++ b/test/EntityFramework.Relational.Tests/Metadata/RelationalBuilderExtensionsTest.cs
@@ -789,6 +789,53 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
             ValidateSchemaNamedSpecificSequence(sequence);
         }
 
+        [Fact]
+        public void ForRelational_methods_dont_break_out_of_the_generics()
+        {
+            var modelBuilder = CreateConventionModelBuilder();
+
+            AssertIsGeneric(
+                modelBuilder
+                    .Entity<Customer>()
+                    .ForRelational(b => { }));
+
+            AssertIsGeneric(
+                modelBuilder
+                    .Entity<Customer>().Collection(e => e.Orders)
+                    .InverseReference(e => e.Customer)
+                    .ForRelational(b => { }));
+
+            AssertIsGeneric(
+                modelBuilder
+                    .Entity<Order>()
+                    .Reference(e => e.Customer)
+                    .InverseCollection(e => e.Orders)
+                    .ForRelational(b => { }));
+
+            AssertIsGeneric(
+                modelBuilder
+                    .Entity<Order>()
+                    .Reference(e => e.Details)
+                    .InverseReference(e => e.Order)
+                    .ForRelational(b => { }));
+        }
+
+        private void AssertIsGeneric(EntityTypeBuilder<Customer> _)
+        {
+        }
+
+        private void AssertIsGeneric(ReferenceCollectionBuilder<Customer, Order> _)
+        {
+        }
+
+        private void AssertIsGeneric(CollectionReferenceBuilder<Order, Customer> _)
+        {
+        }
+
+        private void AssertIsGeneric(TypedReferenceReferenceBuilder _)
+        {
+        }
+
         protected virtual ModelBuilder CreateConventionModelBuilder()
         {
             return RelationalTestHelpers.Instance.CreateConventionBuilder();

--- a/test/EntityFramework.SqlServer.Tests/Metadata/SqlServerBuilderExtensionsTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/Metadata/SqlServerBuilderExtensionsTest.cs
@@ -1576,6 +1576,53 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             ValidateSchemaNamedSpecificSequence(sequence);
         }
 
+        [Fact]
+        public void ForSqlServer_methods_dont_break_out_of_the_generics()
+        {
+            var modelBuilder = CreateConventionModelBuilder();
+
+            AssertIsGeneric(
+                modelBuilder
+                    .Entity<Customer>()
+                    .ForSqlServer(b => { }));
+
+            AssertIsGeneric(
+                modelBuilder
+                    .Entity<Customer>().Collection(e => e.Orders)
+                    .InverseReference(e => e.Customer)
+                    .ForSqlServer(b => { }));
+
+            AssertIsGeneric(
+                modelBuilder
+                    .Entity<Order>()
+                    .Reference(e => e.Customer)
+                    .InverseCollection(e => e.Orders)
+                    .ForSqlServer(b => { }));
+
+            AssertIsGeneric(
+                modelBuilder
+                    .Entity<Order>()
+                    .Reference(e => e.Details)
+                    .InverseReference(e => e.Order)
+                    .ForSqlServer(b => { }));
+        }
+
+        private void AssertIsGeneric(EntityTypeBuilder<Customer> _)
+        {
+        }
+
+        private void AssertIsGeneric(ReferenceCollectionBuilder<Customer, Order> _)
+        {
+        }
+
+        private void AssertIsGeneric(CollectionReferenceBuilder<Order, Customer> _)
+        {
+        }
+
+        private void AssertIsGeneric(TypedReferenceReferenceBuilder _)
+        {
+        }
+
         protected virtual ModelBuilder CreateConventionModelBuilder()
         {
             return SqlServerTestHelpers.Instance.CreateConventionBuilder();


### PR DESCRIPTION
... you didn't use an expression to get the builder

Also added a couple of new extension methods to avoid breaking out of typed sub-builders.