### PR TITLE
API review change: Add generic builds for reference-reference and proper...

### DIFF
--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Metadata\Builders\KeyBuilder.cs" />
     <Compile Include="Metadata\Builders\CollectionReferenceBuilder.cs" />
     <Compile Include="Metadata\Builders\CollectionReferenceBuilder`.cs" />
+    <Compile Include="Metadata\Builders\PropertyBuilder`.cs" />
     <Compile Include="Metadata\Builders\ReferenceCollectionBuilder.cs" />
     <Compile Include="Metadata\Builders\ReferenceCollectionBuilder`.cs" />
     <Compile Include="Metadata\Builders\ReferenceReferenceBuilder.cs" />
@@ -148,6 +149,7 @@
     <Compile Include="DbContext.cs" />
     <Compile Include="DbContextOptionsBuilder.cs" />
     <Compile Include="DbContextOptionsBuilder`.cs" />
+    <Compile Include="Metadata\Builders\ReferenceReferenceBuilder`.cs" />
     <Compile Include="Metadata\ModelConventions\IPropertyConvention.cs" />
     <Compile Include="Metadata\ModelConventions\IModelConvention.cs" />
     <Compile Include="Query\AnnotateQueryExtensions.cs" />

--- a/src/EntityFramework.Core/Metadata/Builders/EntityTypeBuilder`.cs
+++ b/src/EntityFramework.Core/Metadata/Builders/EntityTypeBuilder`.cs
@@ -83,12 +83,12 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         ///     <c>t => t.Property1</c>).
         /// </param>
         /// <returns> An object that can be used to configure the property. </returns>
-        public virtual PropertyBuilder Property([NotNull] Expression<Func<TEntity, object>> propertyExpression)
+        public virtual PropertyBuilder<TProperty> Property<TProperty>([NotNull] Expression<Func<TEntity, TProperty>> propertyExpression)
         {
             Check.NotNull(propertyExpression, nameof(propertyExpression));
 
             var propertyInfo = propertyExpression.GetPropertyAccess();
-            return new PropertyBuilder(Builder.Property(propertyInfo, ConfigurationSource.Explicit));
+            return new PropertyBuilder<TProperty>(Builder.Property(propertyInfo, ConfigurationSource.Explicit));
         }
 
         /// <summary>

--- a/src/EntityFramework.Core/Metadata/Builders/PropertyBuilder`.cs
+++ b/src/EntityFramework.Core/Metadata/Builders/PropertyBuilder`.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata.Internal;
+using Microsoft.Data.Entity.ValueGeneration;
+
+namespace Microsoft.Data.Entity.Metadata.Builders
+{
+    /// <summary>
+    ///     <para>
+    ///         Provides a simple API for configuring a <see cref="Property" />.
+    ///     </para>
+    ///     <para>
+    ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
+    ///         and it is not designed to be directly constructed in your application code.
+    ///     </para>
+    /// </summary>
+    public class PropertyBuilder<TProperty> : PropertyBuilder
+    {
+        /// <summary>
+        ///     <para>
+        ///         Initializes a new instance of the <see cref="PropertyBuilder" /> class to configure a given
+        ///         property.
+        ///     </para>
+        ///     <para>
+        ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
+        ///         and it is not designed to be directly constructed in your application code.
+        ///     </para>
+        /// </summary>
+        /// <param name="builder"> Internal builder for the property being configured. </param>
+        public PropertyBuilder([NotNull] InternalPropertyBuilder builder)
+            : base(builder)
+        {
+        }
+
+        /// <summary>
+        ///     Adds or updates an annotation on the property. If an annotation with the key specified in
+        ///     <paramref name="annotation" /> already exists it's value will be updated.
+        /// </summary>
+        /// <param name="annotation"> The key of the annotation to be added or updated. </param>
+        /// <param name="value"> The value to be stored in the annotation. </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public new virtual PropertyBuilder<TProperty> Annotation([NotNull] string annotation, [NotNull] object value)
+            => (PropertyBuilder<TProperty>)base.Annotation(annotation, value);
+
+        /// <summary>
+        ///     Configures whether this property must have a value assigned or whether null is a valid value.
+        ///     A property can only be configured as non-required if it is based on a CLR type that can be
+        ///     assigned null.
+        /// </summary>
+        /// <param name="isRequired"> A value indicating whether the property is required. </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public new virtual PropertyBuilder<TProperty> Required(bool isRequired = true)
+            => (PropertyBuilder<TProperty>)base.Required(isRequired);
+
+        /// <summary>
+        ///     Configures the maximum length of data that can be stored in this property.
+        ///     Maximum length can only be set on array properties (including <see cref="string" /> properties).
+        /// </summary>
+        /// <param name="maxLength"> The maximum length of data allowed in the property. </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public new virtual PropertyBuilder<TProperty> MaxLength(int maxLength)
+            => (PropertyBuilder<TProperty>)base.MaxLength(maxLength);
+
+        /// <summary>
+        ///     Configures whether this property should be used as a concurrency token. When a property is configured
+        ///     as a concurrency token the value in the data store will be checked when an instance of this entity type
+        ///     is updated or deleted during <see cref="DbContext.SaveChanges" /> to ensure it has not changed since
+        ///     the instance was retrieved from the data store. If it has changed, an exception will be thrown and the
+        ///     changes will not be applied to the data store.
+        /// </summary>
+        /// <param name="isConcurrencyToken"> A value indicating whether this property is a concurrency token. </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public new virtual PropertyBuilder<TProperty> ConcurrencyToken(bool isConcurrencyToken = true)
+            => (PropertyBuilder<TProperty>)base.ConcurrencyToken(isConcurrencyToken);
+
+        /// <summary>
+        ///     Configures whether a value is generated for this property when a new instance of the entity type
+        ///     is added to a context. Data stores will typically register an appropriate
+        ///     <see cref="ValueGenerator" /> to handle generating values. This functionality is typically
+        ///     used for key values and is switched on by convention.
+        /// </summary>
+        /// <param name="generateValue"> A value indicating whether a value should be generated. </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public new virtual PropertyBuilder<TProperty> GenerateValueOnAdd(bool generateValue = true)
+            => (PropertyBuilder<TProperty>)base.GenerateValueOnAdd(generateValue);
+
+        /// <summary>
+        ///     Configures whether a value is generated for this property by the data store every time an
+        ///     instance of this entity type is saved (initial add and any subsequent updates).
+        /// </summary>
+        /// <param name="computed"> A value indicating whether a value is generated by the data store. </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public new virtual PropertyBuilder<TProperty> StoreComputed(bool computed = true)
+            => (PropertyBuilder<TProperty>)base.StoreComputed(computed);
+
+        /// <summary>
+        ///     Configures whether a default value is generated for this property by the store when an instance
+        ///     of this entity type is saved and no value has been set.
+        /// </summary>
+        /// <param name="useDefault">
+        ///     A value indicating whether a default value is generated by the data store when no value is set.
+        /// </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public new virtual PropertyBuilder<TProperty> UseStoreDefault(bool useDefault = true)
+            => (PropertyBuilder<TProperty>)base.UseStoreDefault(useDefault);
+    }
+}

--- a/src/EntityFramework.Core/Metadata/Builders/ReferenceNavigationBuilder`.cs
+++ b/src/EntityFramework.Core/Metadata/Builders/ReferenceNavigationBuilder`.cs
@@ -69,8 +69,8 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         ///     configured without a navigation property on the other end of the relationship.
         /// </param>
         /// <returns> An object to further configure the relationship. </returns>
-        public virtual ReferenceReferenceBuilder InverseReference([CanBeNull] Expression<Func<TRelatedEntity, TEntity>> inverseReference = null)
-            => new ReferenceReferenceBuilder(InverseReferenceBuilder(inverseReference?.GetPropertyAccess().Name));
+        public virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> InverseReference([CanBeNull] Expression<Func<TRelatedEntity, TEntity>> inverseReference = null)
+            => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(InverseReferenceBuilder(inverseReference?.GetPropertyAccess().Name));
 
         /// <summary>
         ///     Configures this as a one-to-many relationship.

--- a/src/EntityFramework.Core/Metadata/Builders/ReferenceReferenceBuilder`.cs
+++ b/src/EntityFramework.Core/Metadata/Builders/ReferenceReferenceBuilder`.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Infrastructure;
@@ -20,10 +21,8 @@ namespace Microsoft.Data.Entity.Metadata.Builders
     ///         entity type.
     ///     </para>
     /// </summary>
-    public class ReferenceReferenceBuilder : IAccessor<Model>, IAccessor<InternalRelationshipBuilder>
+    public class ReferenceReferenceBuilder<TEntity, TRelatedEntity> : ReferenceReferenceBuilder
     {
-        private readonly InternalRelationshipBuilder _builder;
-
         /// <summary>
         ///     <para>
         ///         Initializes a new instance of the <see cref="ReferenceReferenceBuilder" /> class.
@@ -35,26 +34,9 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         /// </summary>
         /// <param name="builder"> The internal builder being used to configure this relationship. </param>
         public ReferenceReferenceBuilder([NotNull] InternalRelationshipBuilder builder)
+            : base(builder)
         {
-            Check.NotNull(builder, nameof(builder));
-
-            _builder = builder;
         }
-
-        /// <summary>
-        ///     Gets the internal builder being used to configure this relationship.
-        /// </summary>
-        InternalRelationshipBuilder IAccessor<InternalRelationshipBuilder>.Service => _builder;
-
-        /// <summary>
-        ///     The foreign key that represents this relationship.
-        /// </summary>
-        public virtual ForeignKey Metadata => Builder.Metadata;
-
-        /// <summary>
-        ///     The model that this relationship belongs to.
-        /// </summary>
-        Model IAccessor<Model>.Service => Builder.ModelBuilder.Metadata;
 
         /// <summary>
         ///     Adds or updates an annotation on the relationship. If an annotation with the key specified in
@@ -63,15 +45,8 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         /// <param name="annotation"> The key of the annotation to be added or updated. </param>
         /// <param name="value"> The value to be stored in the annotation. </param>
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
-        public virtual ReferenceReferenceBuilder Annotation([NotNull] string annotation, [NotNull] object value)
-        {
-            Check.NotEmpty(annotation, nameof(annotation));
-            Check.NotNull(value, nameof(value));
-
-            Builder.Annotation(annotation, value, ConfigurationSource.Explicit);
-
-            return this;
-        }
+        public new virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> Annotation([NotNull] string annotation, [NotNull] object value)
+            => (ReferenceReferenceBuilder<TEntity, TRelatedEntity>)base.Annotation(annotation, value);
 
         /// <summary>
         ///     <para>
@@ -99,14 +74,14 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         ///     The name(s) of the foreign key property(s).
         /// </param>
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
-        public virtual ReferenceReferenceBuilder ForeignKey(
+        public new virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> ForeignKey(
             [NotNull] Type dependentEntityType,
             [NotNull] params string[] foreignKeyPropertyNames)
         {
             Check.NotNull(dependentEntityType, nameof(dependentEntityType));
             Check.NotNull(foreignKeyPropertyNames, nameof(foreignKeyPropertyNames));
 
-            return new ReferenceReferenceBuilder(Builder.ForeignKey(dependentEntityType, foreignKeyPropertyNames, ConfigurationSource.Explicit));
+            return new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(Builder.ForeignKey(dependentEntityType, foreignKeyPropertyNames, ConfigurationSource.Explicit));
         }
 
         /// <summary>
@@ -121,14 +96,81 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         /// </param>
         /// <param name="keyPropertyNames"> The name(s) of the reference key property(s). </param>
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
-        public virtual ReferenceReferenceBuilder PrincipalKey(
+        public new virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> PrincipalKey(
             [NotNull] Type principalEntityType,
             [NotNull] params string[] keyPropertyNames)
         {
             Check.NotNull(principalEntityType, nameof(principalEntityType));
             Check.NotNull(keyPropertyNames, nameof(keyPropertyNames));
 
-            return new ReferenceReferenceBuilder(Builder.PrincipalKey(principalEntityType, keyPropertyNames, ConfigurationSource.Explicit));
+            return new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(Builder.PrincipalKey(principalEntityType, keyPropertyNames, ConfigurationSource.Explicit));
+        }
+
+        /// <summary>
+        ///     <para>
+        ///         Configures the property(s) to use as the foreign key for this relationship.
+        ///     </para>
+        ///     <para>
+        ///         If <see cref="PrincipalKey{TPrincipalEntity}" />
+        ///         is not specified, then an attempt will be made to match the data type and order of foreign key
+        ///         properties against the primary key of the principal entity type. If they do not match, new shadow
+        ///         state properties that form a unique index will be
+        ///         added to the principal entity type to serve as the reference key.
+        ///         A shadow state property is one that does not have a corresponding property in the entity class. The
+        ///         current value for the property is stored in the <see cref="ChangeTracker" /> rather than being
+        ///         stored in instances of the entity class.
+        ///     </para>
+        /// </summary>
+        /// <typeparam name="TDependentEntity">
+        ///     The entity type that is the dependent in this relationship. That is, the type
+        ///     that has the foreign key properties.
+        /// </typeparam>
+        /// <param name="foreignKeyExpression">
+        ///     <para>
+        ///         A lambda expression representing the foreign key property(s) (<c>t => t.Id1</c>).
+        ///     </para>
+        ///     <para>
+        ///         If the foreign key is made up of multiple properties then specify an anonymous type including the
+        ///         properties (<c>t => new { t.Id1, t.Id2 }</c>). The order specified should match the order of
+        ///         corresponding keys in <see cref="PrincipalKey{TPrincipalEntity}" />.
+        ///     </para>
+        /// </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> ForeignKey<TDependentEntity>(
+            [NotNull] Expression<Func<TDependentEntity, object>> foreignKeyExpression)
+        {
+            Check.NotNull(foreignKeyExpression, nameof(foreignKeyExpression));
+
+            return new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
+                Builder.ForeignKey(typeof(TDependentEntity), foreignKeyExpression.GetPropertyAccessList(), ConfigurationSource.Explicit));
+        }
+
+        /// <summary>
+        ///     Configures the unique property(s) that this relationship targets. Typically you would only call this
+        ///     method if you want to use a property(s) other than the primary key as the principal property(s). If
+        ///     the specified property(s) is not already a unique index (or the primary key) then a new unique index
+        ///     will be introduced.
+        /// </summary>
+        /// <typeparam name="TPrincipalEntity">
+        ///     The entity type that is the principal in this relationship. That is, the type
+        ///     that has the reference key properties.
+        /// </typeparam>
+        /// <param name="keyExpression">
+        ///     <para>
+        ///         A lambda expression representing the reference key property(s) (<c>t => t.Id</c>).
+        ///     </para>
+        ///     <para>
+        ///         If the principal key is made up of multiple properties then specify an anonymous type including
+        ///         the properties (<c>t => new { t.Id1, t.Id2 }</c>).
+        ///     </para>
+        /// </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> PrincipalKey<TPrincipalEntity>(
+            [NotNull] Expression<Func<TPrincipalEntity, object>> keyExpression)
+        {
+            Check.NotNull(keyExpression, nameof(keyExpression));
+
+            return new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(Builder.PrincipalKey(typeof(TPrincipalEntity), keyExpression.GetPropertyAccessList(), ConfigurationSource.Explicit));
         }
 
         /// <summary>
@@ -137,8 +179,8 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         /// </summary>
         /// <param name="required"> A value indicating whether this is a required relationship. </param>
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
-        public virtual ReferenceReferenceBuilder Required(bool required = true)
-            => new ReferenceReferenceBuilder(Builder.Required(required, ConfigurationSource.Explicit));
+        public new virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> Required(bool required = true)
+            => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(Builder.Required(required, ConfigurationSource.Explicit));
 
         private InternalRelationshipBuilder Builder => ((IAccessor<InternalRelationshipBuilder>)this).Service;
     }

--- a/src/EntityFramework.Relational/RelationalBuilderExtensions.cs
+++ b/src/EntityFramework.Relational/RelationalBuilderExtensions.cs
@@ -33,6 +33,18 @@ namespace Microsoft.Data.Entity
             return propertyBuilder;
         }
 
+        public static PropertyBuilder<TProperty> ForRelational<TProperty>(
+            [NotNull] this PropertyBuilder<TProperty> propertyBuilder,
+            [NotNull] Action<RelationalPropertyBuilder> builderAction)
+        {
+            Check.NotNull(propertyBuilder, nameof(propertyBuilder));
+            Check.NotNull(builderAction, nameof(builderAction));
+
+            builderAction(ForRelational(propertyBuilder));
+
+            return propertyBuilder;
+        }
+
         public static RelationalEntityTypeBuilder ForRelational(
             [NotNull] this EntityTypeBuilder entityTypeBuilder)
         {
@@ -105,63 +117,101 @@ namespace Microsoft.Data.Entity
         }
 
         public static RelationalForeignKeyBuilder ForRelational(
-            [NotNull] this ReferenceCollectionBuilder foreignKeyBuilder)
+            [NotNull] this ReferenceCollectionBuilder referenceCollectionBuilder)
         {
-            Check.NotNull(foreignKeyBuilder, nameof(foreignKeyBuilder));
+            Check.NotNull(referenceCollectionBuilder, nameof(referenceCollectionBuilder));
 
-            return new RelationalForeignKeyBuilder(foreignKeyBuilder.Metadata);
+            return new RelationalForeignKeyBuilder(referenceCollectionBuilder.Metadata);
         }
 
         public static ReferenceCollectionBuilder ForRelational(
-            [NotNull] this ReferenceCollectionBuilder foreignKeyBuilder,
+            [NotNull] this ReferenceCollectionBuilder referenceCollectionBuilder,
             [NotNull] Action<RelationalForeignKeyBuilder> builderAction)
         {
-            Check.NotNull(foreignKeyBuilder, nameof(foreignKeyBuilder));
+            Check.NotNull(referenceCollectionBuilder, nameof(referenceCollectionBuilder));
             Check.NotNull(builderAction, nameof(builderAction));
 
-            builderAction(ForRelational(foreignKeyBuilder));
+            builderAction(ForRelational(referenceCollectionBuilder));
 
-            return foreignKeyBuilder;
+            return referenceCollectionBuilder;
+        }
+
+        public static ReferenceCollectionBuilder<TEntity, TRelatedEntity> ForRelational<TEntity, TRelatedEntity>(
+            [NotNull] this ReferenceCollectionBuilder<TEntity, TRelatedEntity> referenceCollectionBuilder,
+            [NotNull] Action<RelationalForeignKeyBuilder> builderAction)
+            where TEntity : class
+        {
+            Check.NotNull(referenceCollectionBuilder, nameof(referenceCollectionBuilder));
+            Check.NotNull(builderAction, nameof(builderAction));
+
+            builderAction(ForRelational(referenceCollectionBuilder));
+
+            return referenceCollectionBuilder;
         }
 
         public static RelationalForeignKeyBuilder ForRelational(
-            [NotNull] this CollectionReferenceBuilder foreignKeyBuilder)
+            [NotNull] this CollectionReferenceBuilder collectionReferenceBuilder)
         {
-            Check.NotNull(foreignKeyBuilder, nameof(foreignKeyBuilder));
+            Check.NotNull(collectionReferenceBuilder, nameof(collectionReferenceBuilder));
 
-            return new RelationalForeignKeyBuilder(foreignKeyBuilder.Metadata);
+            return new RelationalForeignKeyBuilder(collectionReferenceBuilder.Metadata);
         }
 
         public static CollectionReferenceBuilder ForRelational(
-            [NotNull] this CollectionReferenceBuilder foreignKeyBuilder,
+            [NotNull] this CollectionReferenceBuilder collectionReferenceBuilder,
             [NotNull] Action<RelationalForeignKeyBuilder> builderAction)
         {
-            Check.NotNull(foreignKeyBuilder, nameof(foreignKeyBuilder));
+            Check.NotNull(collectionReferenceBuilder, nameof(collectionReferenceBuilder));
             Check.NotNull(builderAction, nameof(builderAction));
 
-            builderAction(ForRelational(foreignKeyBuilder));
+            builderAction(ForRelational(collectionReferenceBuilder));
 
-            return foreignKeyBuilder;
+            return collectionReferenceBuilder;
+        }
+
+        public static CollectionReferenceBuilder<TEntity, TRelatedEntity> ForRelational<TEntity, TRelatedEntity>(
+            [NotNull] this CollectionReferenceBuilder<TEntity, TRelatedEntity> collectionReferenceBuilder,
+            [NotNull] Action<RelationalForeignKeyBuilder> builderAction)
+            where TEntity : class
+        {
+            Check.NotNull(collectionReferenceBuilder, nameof(collectionReferenceBuilder));
+            Check.NotNull(builderAction, nameof(builderAction));
+
+            builderAction(ForRelational(collectionReferenceBuilder));
+
+            return collectionReferenceBuilder;
         }
 
         public static RelationalForeignKeyBuilder ForRelational(
-            [NotNull] this ReferenceReferenceBuilder foreignKeyBuilder)
+            [NotNull] this ReferenceReferenceBuilder referenceReferenceBuilder)
         {
-            Check.NotNull(foreignKeyBuilder, nameof(foreignKeyBuilder));
+            Check.NotNull(referenceReferenceBuilder, nameof(referenceReferenceBuilder));
 
-            return new RelationalForeignKeyBuilder(foreignKeyBuilder.Metadata);
+            return new RelationalForeignKeyBuilder(referenceReferenceBuilder.Metadata);
         }
 
         public static ReferenceReferenceBuilder ForRelational(
-            [NotNull] this ReferenceReferenceBuilder foreignKeyBuilder,
+            [NotNull] this ReferenceReferenceBuilder referenceReferenceBuilder,
             [NotNull] Action<RelationalForeignKeyBuilder> builderAction)
         {
-            Check.NotNull(foreignKeyBuilder, nameof(foreignKeyBuilder));
+            Check.NotNull(referenceReferenceBuilder, nameof(referenceReferenceBuilder));
             Check.NotNull(builderAction, nameof(builderAction));
 
-            builderAction(ForRelational(foreignKeyBuilder));
+            builderAction(ForRelational(referenceReferenceBuilder));
 
-            return foreignKeyBuilder;
+            return referenceReferenceBuilder;
+        }
+
+        public static ReferenceReferenceBuilder<TEntity, TRelatedEntity> ForRelational<TEntity, TRelatedEntity>(
+            [NotNull] this ReferenceReferenceBuilder<TEntity, TRelatedEntity> referenceReferenceBuilder,
+            [NotNull] Action<RelationalForeignKeyBuilder> builderAction)
+        {
+            Check.NotNull(referenceReferenceBuilder, nameof(referenceReferenceBuilder));
+            Check.NotNull(builderAction, nameof(builderAction));
+
+            builderAction(ForRelational(referenceReferenceBuilder));
+
+            return referenceReferenceBuilder;
         }
 
         public static RelationalModelBuilder ForRelational(

--- a/src/EntityFramework.SqlServer/SqlServerBuilderExtensions.cs
+++ b/src/EntityFramework.SqlServer/SqlServerBuilderExtensions.cs
@@ -33,6 +33,18 @@ namespace Microsoft.Data.Entity
             return propertyBuilder;
         }
 
+        public static PropertyBuilder<TProperty> ForSqlServer<TProperty>(
+            [NotNull] this PropertyBuilder<TProperty> propertyBuilder,
+            [NotNull] Action<SqlServerPropertyBuilder> builderAction)
+        {
+            Check.NotNull(propertyBuilder, nameof(propertyBuilder));
+            Check.NotNull(builderAction, nameof(builderAction));
+
+            builderAction(ForSqlServer(propertyBuilder));
+
+            return propertyBuilder;
+        }
+
         public static SqlServerEntityTypeBuilder ForSqlServer(
             [NotNull] this EntityTypeBuilder entityTypeBuilder)
         {
@@ -105,63 +117,101 @@ namespace Microsoft.Data.Entity
         }
 
         public static SqlServerForeignKeyBuilder ForSqlServer(
-            [NotNull] this ReferenceCollectionBuilder foreignKeyBuilder)
+            [NotNull] this ReferenceCollectionBuilder referenceCollectionBuilder)
         {
-            Check.NotNull(foreignKeyBuilder, nameof(foreignKeyBuilder));
+            Check.NotNull(referenceCollectionBuilder, nameof(referenceCollectionBuilder));
 
-            return new SqlServerForeignKeyBuilder(foreignKeyBuilder.Metadata);
+            return new SqlServerForeignKeyBuilder(referenceCollectionBuilder.Metadata);
         }
 
         public static ReferenceCollectionBuilder ForSqlServer(
-            [NotNull] this ReferenceCollectionBuilder foreignKeyBuilder,
+            [NotNull] this ReferenceCollectionBuilder referenceCollectionBuilder,
             [NotNull] Action<SqlServerForeignKeyBuilder> builderAction)
         {
-            Check.NotNull(foreignKeyBuilder, nameof(foreignKeyBuilder));
+            Check.NotNull(referenceCollectionBuilder, nameof(referenceCollectionBuilder));
             Check.NotNull(builderAction, nameof(builderAction));
 
-            builderAction(ForSqlServer(foreignKeyBuilder));
+            builderAction(ForSqlServer(referenceCollectionBuilder));
 
-            return foreignKeyBuilder;
+            return referenceCollectionBuilder;
+        }
+
+        public static ReferenceCollectionBuilder<TEntity, TRelatedEntity> ForSqlServer<TEntity, TRelatedEntity>(
+            [NotNull] this ReferenceCollectionBuilder<TEntity, TRelatedEntity> referenceCollectionBuilder,
+            [NotNull] Action<SqlServerForeignKeyBuilder> builderAction)
+            where TEntity : class
+        {
+            Check.NotNull(referenceCollectionBuilder, nameof(referenceCollectionBuilder));
+            Check.NotNull(builderAction, nameof(builderAction));
+
+            builderAction(ForSqlServer(referenceCollectionBuilder));
+
+            return referenceCollectionBuilder;
         }
 
         public static SqlServerForeignKeyBuilder ForSqlServer(
-            [NotNull] this CollectionReferenceBuilder foreignKeyBuilder)
+            [NotNull] this CollectionReferenceBuilder collectionReferenceBuilder)
         {
-            Check.NotNull(foreignKeyBuilder, nameof(foreignKeyBuilder));
+            Check.NotNull(collectionReferenceBuilder, nameof(collectionReferenceBuilder));
 
-            return new SqlServerForeignKeyBuilder(foreignKeyBuilder.Metadata);
+            return new SqlServerForeignKeyBuilder(collectionReferenceBuilder.Metadata);
         }
 
         public static CollectionReferenceBuilder ForSqlServer(
-            [NotNull] this CollectionReferenceBuilder foreignKeyBuilder,
+            [NotNull] this CollectionReferenceBuilder collectionReferenceBuilder,
             [NotNull] Action<SqlServerForeignKeyBuilder> builderAction)
         {
-            Check.NotNull(foreignKeyBuilder, nameof(foreignKeyBuilder));
+            Check.NotNull(collectionReferenceBuilder, nameof(collectionReferenceBuilder));
             Check.NotNull(builderAction, nameof(builderAction));
 
-            builderAction(ForSqlServer(foreignKeyBuilder));
+            builderAction(ForSqlServer(collectionReferenceBuilder));
 
-            return foreignKeyBuilder;
+            return collectionReferenceBuilder;
+        }
+
+        public static CollectionReferenceBuilder<TEntity, TRelatedEntity> ForSqlServer<TEntity, TRelatedEntity>(
+            [NotNull] this CollectionReferenceBuilder<TEntity, TRelatedEntity> collectionReferenceBuilder,
+            [NotNull] Action<SqlServerForeignKeyBuilder> builderAction)
+            where TEntity : class
+        {
+            Check.NotNull(collectionReferenceBuilder, nameof(collectionReferenceBuilder));
+            Check.NotNull(builderAction, nameof(builderAction));
+
+            builderAction(ForSqlServer(collectionReferenceBuilder));
+
+            return collectionReferenceBuilder;
         }
 
         public static SqlServerForeignKeyBuilder ForSqlServer(
-            [NotNull] this ReferenceReferenceBuilder foreignKeyBuilder)
+            [NotNull] this ReferenceReferenceBuilder referenceReferenceBuilder)
         {
-            Check.NotNull(foreignKeyBuilder, nameof(foreignKeyBuilder));
+            Check.NotNull(referenceReferenceBuilder, nameof(referenceReferenceBuilder));
 
-            return new SqlServerForeignKeyBuilder(foreignKeyBuilder.Metadata);
+            return new SqlServerForeignKeyBuilder(referenceReferenceBuilder.Metadata);
         }
 
         public static ReferenceReferenceBuilder ForSqlServer(
-            [NotNull] this ReferenceReferenceBuilder foreignKeyBuilder,
+            [NotNull] this ReferenceReferenceBuilder referenceReferenceBuilder,
             [NotNull] Action<SqlServerForeignKeyBuilder> builderAction)
         {
-            Check.NotNull(foreignKeyBuilder, nameof(foreignKeyBuilder));
+            Check.NotNull(referenceReferenceBuilder, nameof(referenceReferenceBuilder));
             Check.NotNull(builderAction, nameof(builderAction));
 
-            builderAction(ForSqlServer(foreignKeyBuilder));
+            builderAction(ForSqlServer(referenceReferenceBuilder));
 
-            return foreignKeyBuilder;
+            return referenceReferenceBuilder;
+        }
+
+        public static ReferenceReferenceBuilder<TEntity, TRelatedEntity> ForSqlServer<TEntity, TRelatedEntity>(
+            [NotNull] this ReferenceReferenceBuilder<TEntity, TRelatedEntity> referenceReferenceBuilder,
+            [NotNull] Action<SqlServerForeignKeyBuilder> builderAction)
+        {
+            Check.NotNull(referenceReferenceBuilder, nameof(referenceReferenceBuilder));
+            Check.NotNull(builderAction, nameof(builderAction));
+
+            builderAction(ForSqlServer(referenceReferenceBuilder));
+
+            return referenceReferenceBuilder;
         }
 
         public static SqlServerModelBuilder ForSqlServer(

--- a/test/EntityFramework.Core.Tests/Metadata/MetadataBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/MetadataBuilderTest.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .PropertyBuilderExtension("V1")
                 .PropertyBuilderExtension("V2");
 
-            Assert.IsType<PropertyBuilder>(returnedBuilder);
+            Assert.IsType<PropertyBuilder<int>>(returnedBuilder);
 
             var model = builder.Model;
             var property = model.GetEntityType(typeof(Gunter)).GetProperty("Id");
@@ -204,7 +204,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .OneToOneBuilderExtension("V1")
                 .OneToOneBuilderExtension("V2");
 
-            Assert.IsType<ReferenceReferenceBuilder>(returnedBuilder);
+            Assert.IsType<ReferenceReferenceBuilder<Avatar, Gunter>>(returnedBuilder);
 
             var model = builder.Model;
             var foreignKey = model.GetEntityType(typeof(Avatar)).ForeignKeys.Single();
@@ -324,7 +324,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .SharedNameExtension("V1")
                 .SharedNameExtension("V2");
 
-            Assert.IsType<PropertyBuilder>(returnedBuilder);
+            Assert.IsType<PropertyBuilder<int>>(returnedBuilder);
 
             var model = builder.Model;
             var property = model.GetEntityType(typeof(Gunter)).GetProperty("Id");
@@ -406,7 +406,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .SharedNameExtension("V1")
                 .SharedNameExtension("V2");
 
-            Assert.IsType<ReferenceReferenceBuilder>(returnedBuilder);
+            Assert.IsType<ReferenceReferenceBuilder<Avatar, Gunter>>(returnedBuilder);
 
             var model = builder.Model;
             var foreignKey = model.GetEntityType(typeof(Avatar)).ForeignKeys.Single();

--- a/test/EntityFramework.Relational.Tests/Metadata/RelationalBuilderExtensionsTest.cs
+++ b/test/EntityFramework.Relational.Tests/Metadata/RelationalBuilderExtensionsTest.cs
@@ -789,6 +789,63 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
             ValidateSchemaNamedSpecificSequence(sequence);
         }
 
+        [Fact]
+        public void ForRelational_methods_dont_break_out_of_the_generics()
+        {
+            var modelBuilder = CreateConventionModelBuilder();
+
+            AssertIsGeneric(
+                modelBuilder
+                    .Entity<Customer>()
+                    .ForRelational(b => { }));
+
+            AssertIsGeneric(
+                modelBuilder
+                    .Entity<Customer>()
+                    .Property(e => e.Name)
+                    .ForRelational(b => { }));
+
+            AssertIsGeneric(
+                modelBuilder
+                    .Entity<Customer>().Collection(e => e.Orders)
+                    .InverseReference(e => e.Customer)
+                    .ForRelational(b => { }));
+
+            AssertIsGeneric(
+                modelBuilder
+                    .Entity<Order>()
+                    .Reference(e => e.Customer)
+                    .InverseCollection(e => e.Orders)
+                    .ForRelational(b => { }));
+
+            AssertIsGeneric(
+                modelBuilder
+                    .Entity<Order>()
+                    .Reference(e => e.Details)
+                    .InverseReference(e => e.Order)
+                    .ForRelational(b => { }));
+        }
+
+        private void AssertIsGeneric(EntityTypeBuilder<Customer> _)
+        {
+        }
+
+        private void AssertIsGeneric(PropertyBuilder<string> _)
+        {
+        }
+
+        private void AssertIsGeneric(ReferenceCollectionBuilder<Customer, Order> _)
+        {
+        }
+
+        private void AssertIsGeneric(CollectionReferenceBuilder<Order, Customer> _)
+        {
+        }
+
+        private void AssertIsGeneric(ReferenceReferenceBuilder<Order, OrderDetails> _)
+        {
+        }
+
         protected virtual ModelBuilder CreateConventionModelBuilder()
         {
             return RelationalTestHelpers.Instance.CreateConventionBuilder();

--- a/test/EntityFramework.SqlServer.Tests/Metadata/SqlServerBuilderExtensionsTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/Metadata/SqlServerBuilderExtensionsTest.cs
@@ -1576,6 +1576,63 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             ValidateSchemaNamedSpecificSequence(sequence);
         }
 
+        [Fact]
+        public void ForSqlServer_methods_dont_break_out_of_the_generics()
+        {
+            var modelBuilder = CreateConventionModelBuilder();
+
+            AssertIsGeneric(
+                modelBuilder
+                    .Entity<Customer>()
+                    .ForSqlServer(b => { }));
+
+            AssertIsGeneric(
+                modelBuilder
+                    .Entity<Customer>()
+                    .Property(e => e.Name)
+                    .ForSqlServer(b => { }));
+
+            AssertIsGeneric(
+                modelBuilder
+                    .Entity<Customer>().Collection(e => e.Orders)
+                    .InverseReference(e => e.Customer)
+                    .ForSqlServer(b => { }));
+
+            AssertIsGeneric(
+                modelBuilder
+                    .Entity<Order>()
+                    .Reference(e => e.Customer)
+                    .InverseCollection(e => e.Orders)
+                    .ForSqlServer(b => { }));
+
+            AssertIsGeneric(
+                modelBuilder
+                    .Entity<Order>()
+                    .Reference(e => e.Details)
+                    .InverseReference(e => e.Order)
+                    .ForSqlServer(b => { }));
+        }
+
+        private void AssertIsGeneric(EntityTypeBuilder<Customer> _)
+        {
+        }
+
+        private void AssertIsGeneric(PropertyBuilder<string> _)
+        {
+        }
+
+        private void AssertIsGeneric(ReferenceCollectionBuilder<Customer, Order> _)
+        {
+        }
+
+        private void AssertIsGeneric(CollectionReferenceBuilder<Order, Customer> _)
+        {
+        }
+
+        private void AssertIsGeneric(ReferenceReferenceBuilder<Order, OrderDetails> _)
+        {
+        }
+
         protected virtual ModelBuilder CreateConventionModelBuilder()
         {
             return SqlServerTestHelpers.Instance.CreateConventionBuilder();


### PR DESCRIPTION
...ties

This changes adds generic builders for ReferenceReference relationships and properties. In the former case, this doesn't really add any functionality, but it can be done since we decided to disallow calling the generic methods unless you came from a lambda.

In the latter case, this allows extension methods to be written agains t certain property types.