### PR TITLE
Fix to 1742 - sometimes we produce invalid parameter name.

### DIFF
--- a/src/EntityFramework.Core/Query/CompiledQueryCache.cs
+++ b/src/EntityFramework.Core/Query/CompiledQueryCache.cs
@@ -229,6 +229,12 @@ namespace Microsoft.Data.Entity.Query
 
                         var parameterValue = Evaluate(e, out parameterName);
 
+                        var compilerPrefixIndex = parameterName.LastIndexOf(">");
+                        if (compilerPrefixIndex != -1)
+                        {
+                            parameterName = parameterName.Substring(compilerPrefixIndex + 1);
+                        }
+
                         parameterName
                             = string.Format("{0}{1}_{2}",
                                 CompiledQueryParameterPrefix,

--- a/test/EntityFramework.SqlServer.FunctionalTests/QueryBugsTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/QueryBugsTest.cs
@@ -352,6 +352,47 @@ Queen of the Andals and the Rhoynar and the First Men, Khaleesi of the Great Gra
             }
         }
 
+        [Fact]
+        public void Compiler_generated_local_closure_produces_valid_parameter_name_1742()
+        {
+            Execute1742(new CustomerDetails_1742 { FirstName = "Foo", LastName = "Bar" });
+        }
+
+        public void Execute1742(CustomerDetails_1742 details)
+        {
+            var loggingFactory = new TestSqlLoggerFactory();
+            var serviceProvider = new ServiceCollection()
+                .AddEntityFramework()
+                .AddSqlServer().
+                ServiceCollection()
+                .AddInstance<ILoggerFactory>(loggingFactory)
+                .BuildServiceProvider();
+
+            using (var ctx = new MyContext925(serviceProvider))
+            {
+                var firstName = details.FirstName;
+
+                var query = ctx.Customers.Where(c => c.FirstName == firstName && c.LastName == details.LastName).ToList();
+
+                var expectedSql =
+@"__firstName_0: Foo
+__8__locals1_details_LastName_1: Bar
+
+SELECT [c].[FirstName], [c].[LastName]
+FROM [Customer] AS [c]
+WHERE ([c].[FirstName] = @__firstName_0) AND ([c].[LastName] = @__8__locals1_details_LastName_1)";
+
+                Assert.Equal(expectedSql, TestSqlLoggerFactory.Sql);
+            }
+        }
+
+        public class CustomerDetails_1742
+        {
+            public string FirstName { get; set; }
+            public string LastName { get; set; }
+        }
+
+
         private readonly SqlServerFixture _fixture;
 
         public QueryBugsTest(SqlServerFixture fixture)


### PR DESCRIPTION
Problem is that for some (quite complicated) cases we would produce invalid parameter name. We try to generate the parameter name based ProperyInfo/FieldInfo path of the MemberExpression. Most of the time this is correct, but sometimes compiler can generate names like:
((QueryBugsTest+<>c__DisplayClass21_0).CS$<>8__locals1).details).LastName, which would produce name with invalid characters (e.g. CS$<>8__locals1_details_LastName)

Fix is to remove the compiler generated prefix.