### PR TITLE
Use core Identity concept and convention for SQL Server keys

### DIFF
--- a/src/EntityFramework.SqlServer/Metadata/ModelConventions/SqlServerValueGenerationStrategyConvention.cs
+++ b/src/EntityFramework.SqlServer/Metadata/ModelConventions/SqlServerValueGenerationStrategyConvention.cs
@@ -1,79 +1,20 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using JetBrains.Annotations;
-using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Metadata.ModelConventions;
-using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.SqlServer.Metadata.ModelConventions
 {
-    public class SqlServerValueGenerationStrategyConvention : IKeyConvention, IForeignKeyRemovedConvention, IForeignKeyConvention, IModelConvention
+    public class SqlServerValueGenerationStrategyConvention : IModelConvention
     {
-        public virtual InternalKeyBuilder Apply(InternalKeyBuilder keyBuilder)
-        {
-            Check.NotNull(keyBuilder, nameof(keyBuilder));
-
-            var key = keyBuilder.Metadata;
-
-            ConfigureValueGenerationStrategy(
-                keyBuilder.ModelBuilder.Entity(key.EntityType.Name, ConfigurationSource.Convention),
-                key.Properties,
-                true);
-
-            return keyBuilder;
-        }
-
-        protected virtual void ConfigureValueGenerationStrategy([NotNull] InternalEntityTypeBuilder entityTypeBuilder, [NotNull] IReadOnlyList<Property> properties, bool generateValue)
-        {
-            Check.NotNull(entityTypeBuilder, nameof(entityTypeBuilder));
-            Check.NotNull(properties, nameof(properties));
-
-            if (entityTypeBuilder.Metadata.FindPrimaryKey(properties) != null
-                && properties.Count == 1
-                && properties.First().ClrType.IsInteger()
-                && properties.First().GenerateValueOnAdd == generateValue)
-            {
-                entityTypeBuilder.Property(properties.First().ClrType, properties.First().Name, ConfigurationSource.Convention)
-                    .Annotation(SqlServerAnnotationNames.Prefix + SqlServerAnnotationNames.ValueGeneration,
-                        generateValue ? SqlServerValueGenerationStrategy.Default.ToString() : null,
-                        ConfigurationSource.Convention);
-            }
-        }
-
-        public virtual void Apply(InternalEntityTypeBuilder entityTypeBuilder, ForeignKey foreignKey)
-        {
-            Check.NotNull(entityTypeBuilder, nameof(entityTypeBuilder));
-            Check.NotNull(foreignKey, nameof(foreignKey));
-
-            var properties = foreignKey.Properties;
-
-            if (properties.Any(e => e.GenerateValueOnAdd == true))
-            {
-                ConfigureValueGenerationStrategy(entityTypeBuilder, properties, true);
-            }
-        }
-
-        public virtual InternalRelationshipBuilder Apply(InternalRelationshipBuilder relationshipBuilder)
-        {
-            ConfigureValueGenerationStrategy(
-                relationshipBuilder.ModelBuilder.Entity(relationshipBuilder.Metadata.EntityType.Name, ConfigurationSource.Convention),
-                relationshipBuilder.Metadata.Properties,
-                false);
-
-            return relationshipBuilder;
-        }
-
         public virtual InternalModelBuilder Apply(InternalModelBuilder modelBuilder)
         {
             modelBuilder.Annotation(
                 SqlServerAnnotationNames.Prefix + SqlServerAnnotationNames.ValueGeneration,
                 SqlServerValueGenerationStrategy.Sequence.ToString(),
                 ConfigurationSource.Convention);
+
             return modelBuilder;
         }
     }

--- a/src/EntityFramework.SqlServer/Metadata/ReadOnlySqlServerPropertyExtensions.cs
+++ b/src/EntityFramework.SqlServer/Metadata/ReadOnlySqlServerPropertyExtensions.cs
@@ -57,7 +57,9 @@ namespace Microsoft.Data.Entity.SqlServer.Metadata
                     ? null
                     : (SqlServerValueGenerationStrategy?)Enum.Parse(typeof(SqlServerValueGenerationStrategy), value);
 
-                return strategy == SqlServerValueGenerationStrategy.Default
+                return (strategy == null
+                        && Property.StoreGeneratedPattern == StoreGeneratedPattern.Identity)
+                       || strategy == SqlServerValueGenerationStrategy.Default
                     ? Property.EntityType.Model.SqlServer().ValueGenerationStrategy
                     : strategy;
             }

--- a/src/EntityFramework.SqlServer/SqlServerModelBuilderFactory.cs
+++ b/src/EntityFramework.SqlServer/SqlServerModelBuilderFactory.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Metadata.Builders;
 using Microsoft.Data.Entity.Metadata.ModelConventions;
 using Microsoft.Data.Entity.SqlServer.Metadata.ModelConventions;
@@ -14,14 +13,7 @@ namespace Microsoft.Data.Entity.SqlServer
         {
             var conventions = base.CreateConventionSet();
 
-            var sqlServerValueGenerationStrategyConvention = new SqlServerValueGenerationStrategyConvention();
-            conventions.KeyAddedConventions.Add(sqlServerValueGenerationStrategyConvention);
-
-            conventions.ForeignKeyAddedConventions.Add(sqlServerValueGenerationStrategyConvention);
-
-            conventions.ForeignKeyRemovedConventions.Add(sqlServerValueGenerationStrategyConvention);
-
-            conventions.ModelConventions.Add(sqlServerValueGenerationStrategyConvention);
+            conventions.ModelConventions.Add(new SqlServerValueGenerationStrategyConvention());
 
             return conventions;
         }

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntityEntryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntityEntryTest.cs
@@ -1370,10 +1370,17 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
                 .ForeignKey<SecondDependent>(e => e.Id);
 
             modelBuilder
-                .Entity<Root>()
-                .Reference(e => e.First)
-                .InverseReference(e => e.Root)
-                .ForeignKey<FirstDependent>(e => e.Id);
+                .Entity<Root>(b =>
+                    {
+                        b.Property(e => e.Id)
+                            .StoreGeneratedPattern(StoreGeneratedPattern.None);
+
+                        b.Reference(e => e.First)
+                            .InverseReference(e => e.Root)
+                            .ForeignKey<FirstDependent>(e => e.Id);
+
+                    });
+
 
             return modelBuilder.Model;
         }

--- a/test/EntityFramework.SqlServer.Tests/Metadata/ModelConventions/SqlServerValueGenerationStrategyConventionTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/Metadata/ModelConventions/SqlServerValueGenerationStrategyConventionTest.cs
@@ -1,188 +1,15 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Data.Entity.Metadata;
-using Microsoft.Data.Entity.Metadata.Internal;
-using Microsoft.Data.Entity.Metadata.ModelConventions;
 using Microsoft.Data.Entity.SqlServer.Metadata;
-using Microsoft.Data.Entity.SqlServer.Metadata.ModelConventions;
 using Xunit;
 
 namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata.ModelConventions
 {
-    class SqlServerValueGenerationStrategyConventionTest
+    public class SqlServerValueGenerationStrategyConventionTest
     {
-        public class SampleEntity
-        {
-            public int Id { get; set; }
-            public int Number { get; set; }
-            public string Name { get; set; }
-        }
-
-        public class ReferencedEntity
-        {
-            public int Id { get; set; }
-            public int SampleEntityId { get; set; }
-        }
-
-
-        [Fact]
-        public void Default_annotation_is_set_for_primary_key()
-        {
-            var modelBuilder = createInternalModelBuilder();
-            var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
-
-            var keyBuilder = entityBuilder.PrimaryKey(new List<string> { "Id" }, ConfigurationSource.Convention);
-
-            Assert.Same(keyBuilder, new SqlServerValueGenerationStrategyConvention().Apply(keyBuilder));
-
-            var property = keyBuilder.Metadata.Properties.First();
-
-            Assert.Equal(1, property.Annotations.Count());
-            Assert.Equal(SqlServerValueGenerationStrategy.Default.ToString(), property[SqlServerAnnotationNames.Prefix + SqlServerAnnotationNames.ValueGeneration]);
-        }
-
-        [Fact]
-        public void Default_annotation_is_not_set_for_non_primary_key()
-        {
-            var modelBuilder = createInternalModelBuilder();
-            var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
-
-            var keyBuilder = entityBuilder.Key(new List<string> { "Number" }, ConfigurationSource.Convention);
-
-            Assert.Same(keyBuilder, new SqlServerValueGenerationStrategyConvention().Apply(keyBuilder));
-
-            Assert.Equal(0, keyBuilder.Metadata.Properties[0].Annotations.Count());
-        }
-
-        [Fact]
-        public void No_annotation_set_when_composite_primary_key()
-        {
-            var modelBuilder = createInternalModelBuilder();
-            var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
-
-            var keyBuilder = entityBuilder.PrimaryKey(new List<string> { "Id", "Number" }, ConfigurationSource.Convention);
-
-            Assert.Same(keyBuilder, new SqlServerValueGenerationStrategyConvention().Apply(keyBuilder));
-
-            var keyProperties = keyBuilder.Metadata.Properties;
-
-            Assert.Equal(0, keyProperties[0].Annotations.Count());
-            Assert.Equal(0, keyProperties[1].Annotations.Count());
-        }
-
-        [Fact]
-        public void No_annotation_set_when_primary_key_property_is_non_integer()
-        {
-            var modelBuilder = createInternalModelBuilder();
-            var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
-
-            var keyBuilder = entityBuilder.PrimaryKey(new List<string> { "Name" }, ConfigurationSource.Convention);
-
-            Assert.Same(keyBuilder, new SqlServerValueGenerationStrategyConvention().Apply(keyBuilder));
-
-            Assert.Equal(0, keyBuilder.Metadata.Properties[0].Annotations.Count());
-        }
-
-        [Fact]
-        public void No_annotation_set_when_primary_key_property_has_generate_value_false()
-        {
-            var modelBuilder = createInternalModelBuilder();
-            var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
-
-            var keyBuilder = entityBuilder.PrimaryKey(new List<string> { "Id" }, ConfigurationSource.Convention);
-            keyBuilder.Metadata.Properties.First().GenerateValueOnAdd = false;
-
-            Assert.Same(keyBuilder, new SqlServerValueGenerationStrategyConvention().Apply(keyBuilder));
-
-            Assert.Equal(0, keyBuilder.Metadata.Properties[0].Annotations.Count());
-        }
-
-        [Fact]
-        public void Convention_does_not_override_annotation_when_configured_explicitly()
-        {
-            var modelBuilder = createInternalModelBuilder();
-            var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
-
-            var keyBuilder = entityBuilder.PrimaryKey(new List<string> { "Id" }, ConfigurationSource.Convention);
-            keyBuilder.Metadata.Properties.First().SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.Identity;
-
-            Assert.Same(keyBuilder, new SqlServerValueGenerationStrategyConvention().Apply(keyBuilder));
-
-            Assert.Equal(1, keyBuilder.Metadata.Properties[0].Annotations.Count());
-            Assert.Equal(SqlServerValueGenerationStrategy.Identity.ToString(), keyBuilder.Metadata.Properties[0].Annotations.First().Value);
-        }
-
-        [Fact]
-        public void Annotation_is_removed_when_foreign_key_is_added()
-        {
-            var modelBuilder = createInternalModelBuilder();
-
-            var principalEntityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
-            var referencedEntityBuilder = modelBuilder.Entity(typeof(ReferencedEntity), ConfigurationSource.Convention);
-
-            var properties = new List<string> { "Id" };
-            var keyBuilder = referencedEntityBuilder.PrimaryKey(properties, ConfigurationSource.Convention);
-
-            Assert.Same(keyBuilder, new SqlServerValueGenerationStrategyConvention().Apply(keyBuilder));
-
-            var keyProperties = keyBuilder.Metadata.Properties;
-
-            Assert.Equal(1, keyProperties[0].Annotations.Count());
-            Assert.Equal(SqlServerValueGenerationStrategy.Default.ToString(), keyProperties[0].Annotations.First().Value);
-
-            principalEntityBuilder.Relationship(
-                principalEntityBuilder,
-                referencedEntityBuilder,
-                null,
-                null,
-                referencedEntityBuilder.GetOrCreateProperties(properties, ConfigurationSource.Convention),
-                null,
-                ConfigurationSource.Convention);
-
-            Assert.Equal(0, keyProperties[0].Annotations.Count());
-        }
-
-        [Fact]
-        public void Annotation_is_added_when_foreign_key_is_removed_and_key_is_primary_key()
-        {
-            var modelBuilder = createInternalModelBuilder();
-
-            var principalEntityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
-            var referencedEntityBuilder = modelBuilder.Entity(typeof(ReferencedEntity), ConfigurationSource.Convention);
-
-            var properties = new List<string> { "Id" };
-            var keyBuilder = referencedEntityBuilder.PrimaryKey(properties, ConfigurationSource.Convention);
-
-            Assert.Same(keyBuilder, new SqlServerValueGenerationStrategyConvention().Apply(keyBuilder));
-
-            var keyProperties = keyBuilder.Metadata.Properties;
-
-            Assert.Equal(1, keyProperties[0].Annotations.Count());
-            Assert.Equal(SqlServerValueGenerationStrategy.Default.ToString(), keyProperties[0].Annotations.First().Value);
-
-            var relationshipBuilder = principalEntityBuilder.Relationship(
-                principalEntityBuilder,
-                referencedEntityBuilder,
-                null,
-                null,
-                referencedEntityBuilder.GetOrCreateProperties(properties, ConfigurationSource.Convention),
-                null,
-                ConfigurationSource.Convention);
-
-            Assert.Equal(0, keyProperties[0].Annotations.Count());
-
-            referencedEntityBuilder.RemoveRelationship(relationshipBuilder.Metadata, ConfigurationSource.Convention);
-
-            Assert.Same(keyBuilder, new SqlServerValueGenerationStrategyConvention().Apply(keyBuilder));
-
-            Assert.Equal(1, keyProperties[0].Annotations.Count());
-            Assert.Equal(SqlServerValueGenerationStrategy.Default.ToString(), keyProperties[0].Annotations.First().Value);
-
-        }
-
         [Fact]
         public void Annotation_is_added_when_conventional_model_builder_is_used()
         {
@@ -190,26 +17,6 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata.ModelConventions
 
             Assert.Equal(1, model.Annotations.Count());
             Assert.Equal(SqlServerValueGenerationStrategy.Sequence.ToString(), model.Annotations.First().Value);
-
-        }
-
-        private static InternalModelBuilder createInternalModelBuilder()
-        {
-            var conventions = new ConventionSet();
-
-            conventions.EntityTypeAddedConventions.Add(new PropertyDiscoveryConvention());
-            conventions.EntityTypeAddedConventions.Add(new KeyDiscoveryConvention());
-
-            var keyConvention = new KeyConvention();
-
-            conventions.KeyAddedConventions.Add(keyConvention);
-            conventions.ForeignKeyRemovedConventions.Add(keyConvention);
-
-            var sqlServerValueGenerationStrategyConvention = new SqlServerValueGenerationStrategyConvention();
-            conventions.ForeignKeyAddedConventions.Add(sqlServerValueGenerationStrategyConvention);
-            conventions.ForeignKeyRemovedConventions.Add(sqlServerValueGenerationStrategyConvention);
-
-            return new InternalModelBuilder(new Model(), conventions);
         }
     }
 }

--- a/test/EntityFramework.SqlServer.Tests/SqlServerValueGeneratorSelectorTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerValueGeneratorSelectorTest.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         }
 
         [Fact]
-        public void Does_not_return_generator_configured_on_model_when_default_is_not_set_on_property()
+        public void Returns_generator_configured_on_model_when_property_is_Identity()
         {
             var model = SqlServerTestHelpers.Instance.BuildModelFor<AnEntity>();
             model.SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.Sequence;
@@ -99,7 +99,21 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
 
             var selector = SqlServerTestHelpers.Instance.CreateContextServices(model).GetRequiredService<ISqlServerValueGeneratorSelector>();
 
-            Assert.IsType<TemporaryIntegerValueGenerator<int>>(selector.Select(entityType.GetProperty("Id")));
+            Assert.IsType<SqlServerSequenceValueGenerator<int>>(selector.Select(entityType.GetProperty("Id")));
+        }
+
+        [Fact]
+        public void Does_not_return_generator_configured_on_model_when_default_is_not_set_on_property()
+        {
+            var model = SqlServerTestHelpers.Instance.BuildModelFor<AnEntity>();
+            model.SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.Sequence;
+            var entityType = model.GetEntityType(typeof(AnEntity));
+            var property = entityType.GetProperty("Id");
+            property.StoreGeneratedPattern = StoreGeneratedPattern.None;
+
+            var selector = SqlServerTestHelpers.Instance.CreateContextServices(model).GetRequiredService<ISqlServerValueGeneratorSelector>();
+
+            Assert.IsType<TemporaryIntegerValueGenerator<int>>(selector.Select(property));
         }
 
         private static Model BuildModel(bool generateValues = true)


### PR DESCRIPTION
Core model building now has a convention to set StoreGeneratedPattern.Identity for non-composite primary keys that are not themselves a dependent property of some other key. This information can now be used by SQL Server instead of it having its own convention to do exactly the same thing.