### PR TITLE
Made RelationalLoggerExtensions public

### DIFF
--- a/src/EntityFramework.Relational/RelationalLoggerExtensions.cs
+++ b/src/EntityFramework.Relational/RelationalLoggerExtensions.cs
@@ -13,7 +13,7 @@ using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Framework.Logging
 {
-    internal static class RelationalLoggerExtensions
+    public static class RelationalLoggerExtensions
     {
         public static void LogSql([NotNull] this ILogger logger, [NotNull] string sql)
         {


### PR DESCRIPTION
While extending ReaderModificationCommandBatch and overring Execute(), it was impossible to use
RelationalLoggerExtensions.LogCommand().