### PR TITLE
Use ChangeType instead of cast when reading

### DIFF
--- a/src/EntityFramework.Relational/RelationalObjectArrayValueReader.cs
+++ b/src/EntityFramework.Relational/RelationalObjectArrayValueReader.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Data.Entity.Relational
         {
             Debug.Assert(index >= 0 && index < Count);
 
-            return (T)_values[index];
+            return (T)Convert.ChangeType(_values[index], typeof(T));
         }
 
         public virtual int Count => _values.Length;


### PR DESCRIPTION
PostgreSQL has no byte type (tinyint), the accepted usage is to store bytes as smallint (2-byte). However, the resulting (boxed) short can't be downcast to byte. Modified to use Convert.ChangeType() instead.

I hope I'm not missing some other mechanism for custom conversion/casting of values returned from the database.