### PR TITLE
Fix ThenInclude method location for Mono

### DIFF
--- a/src/EntityFramework.Core/Extensions/EntityFrameworkQueryableExtensions.cs
+++ b/src/EntityFramework.Core/Extensions/EntityFrameworkQueryableExtensions.cs
@@ -2189,7 +2189,7 @@ namespace Microsoft.Data.Entity
         internal static readonly MethodInfo ThenIncludeAfterCollectionMethodInfo
             = typeof(EntityFrameworkQueryableExtensions)
                 .GetTypeInfo().GetDeclaredMethods(nameof(EntityFrameworkQueryableExtensions.ThenInclude))
-                .Single(mi => mi.GetParameters()[0].ParameterType.GenericTypeArguments[1].IsConstructedGenericType);
+                .Single(mi => !mi.GetParameters()[0].ParameterType.GenericTypeArguments[1].IsGenericParameter);
 
         internal static readonly MethodInfo ThenIncludeAfterReferenceMethodInfo
             = typeof(EntityFrameworkQueryableExtensions)


### PR DESCRIPTION
IsConstructedGenericType is returning different results on Mono so
adjusting logic to something that works.
New logic for the collection overload just uses a "not" of the logic to find the reference overload.
With this change the InMemory store works on Mono 3.12.1 (at least for basic scenarios).