### PR TITLE
Fixes for code issues in code generated by Reverse Engineering

### DIFF
--- a/src/EntityFramework.Relational.Design/CodeGeneration/CSharpUtilities.cs
+++ b/src/EntityFramework.Relational.Design/CodeGeneration/CSharpUtilities.cs
@@ -213,7 +213,15 @@ namespace Microsoft.Data.Entity.Relational.Design.CodeGeneration
         public virtual string GenerateCSharpIdentifier(
             [NotNull] string identifier, [CanBeNull]ICollection<string> existingIdentifiers)
         {
+            return GenerateCSharpIdentifier(identifier, existingIdentifiers, Uniquifier);
+        }
+
+        public virtual string GenerateCSharpIdentifier(
+            [NotNull] string identifier, [CanBeNull]ICollection<string> existingIdentifiers,
+            [NotNull] Func<string, ICollection<string>, string> uniquifier)
+        {
             Check.NotEmpty(identifier, nameof(identifier));
+            Check.NotNull(uniquifier, nameof(uniquifier));
 
             var invalidCharsRegex
                 = new Regex(@"[^\p{Ll}\p{Lu}\p{Lt}\p{Lo}\p{Nd}\p{Nl}\p{Mn}\p{Mc}\p{Cf}\p{Pc}\p{Lm}]");
@@ -234,15 +242,25 @@ namespace Microsoft.Data.Entity.Relational.Design.CodeGeneration
                 proposedIdentifier = "_" + proposedIdentifier;
             }
 
-            string finalIdentifier = proposedIdentifier;
-            if (existingIdentifiers != null)
+            return uniquifier(proposedIdentifier, existingIdentifiers);
+        }
+
+        public virtual string Uniquifier(
+            [NotNull] string proposedIdentifier, [CanBeNull]ICollection<string> existingIdentifiers)
+        {
+            Check.NotEmpty(proposedIdentifier, nameof(proposedIdentifier));
+
+            if (existingIdentifiers == null)
             {
-                var suffix = 1;
-                while (existingIdentifiers.Contains(finalIdentifier))
-                {
-                    finalIdentifier = proposedIdentifier + suffix.ToString();
-                    suffix++;
-                }
+                return proposedIdentifier;
+            }
+
+            string finalIdentifier = proposedIdentifier;
+            var suffix = 1;
+            while (existingIdentifiers.Contains(finalIdentifier))
+            {
+                finalIdentifier = proposedIdentifier + suffix.ToString();
+                suffix++;
             }
 
             return finalIdentifier;

--- a/src/EntityFramework.Relational.Design/Utilities/ModelUtilities.cs
+++ b/src/EntityFramework.Relational.Design/Utilities/ModelUtilities.cs
@@ -41,18 +41,17 @@ namespace Microsoft.Data.Entity.Relational.Design.Utilities
             Check.NotNull(entityType, nameof(entityType));
 
             var primaryKeyProperties =
-                entityType.GetPrimaryKey().Properties.ToList();
+                ((EntityType)entityType).FindPrimaryKey()?.Properties.ToList()
+                ?? new List<Property>();
 
             foreach (var property in primaryKeyProperties)
             {
                 yield return property;
             }
 
-            var foreignKeyProperties = entityType.GetForeignKeys().SelectMany(fk => fk.Properties).Distinct().ToList();
             foreach (var property in
                 entityType.GetProperties()
                 .Except(primaryKeyProperties)
-                .Except(foreignKeyProperties)
                 .OrderBy(p => p.Name))
             {
                 yield return property;

--- a/src/EntityFramework.SqlServer.Design/ReverseEngineering/SqlServerMetadataModelProvider.cs
+++ b/src/EntityFramework.SqlServer.Design/ReverseEngineering/SqlServerMetadataModelProvider.cs
@@ -32,6 +32,8 @@ namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering
         public const string AnnotationNamePrincipalEndNavPropName = AnnotationPrefix + "PrincipalEndNavPropName";
         public const string AnnotationNameEntityTypeError = AnnotationPrefix + "EntityTypeError";
 
+        public const string NavigationNameUniquifyingSuffix = "Navigation";
+
         private ILogger _logger;
         private ModelUtilities _modelUtilities;
         private SqlServerLiteralUtilities _sqlServerLiteralUtilities;
@@ -431,7 +433,8 @@ namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering
                     var dependentEndNavigationPropertyName =
                         CSharpUtilities.Instance.GenerateCSharpIdentifier(
                             dependentEndNavigationPropertyCandidateName,
-                            dependentEndExistingIdentifiers);
+                            dependentEndExistingIdentifiers,
+                            NavigationUniquifier);
                     foreignKey.AddAnnotation(
                         AnnotationNameDependentEndNavPropName,
                         dependentEndNavigationPropertyName);
@@ -447,7 +450,8 @@ namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering
                         var principalEndNavigationPropertyName =
                             CSharpUtilities.Instance.GenerateCSharpIdentifier(
                                 principalEndNavigationPropertyCandidateName,
-                                principalEndExistingIdentifiers);
+                                principalEndExistingIdentifiers,
+                                NavigationUniquifier);
                         foreignKey.AddAnnotation(
                             AnnotationNamePrincipalEndNavPropName,
                             principalEndNavigationPropertyName);
@@ -496,6 +500,27 @@ namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering
             Check.NotNull(listOfColumnIds, nameof(listOfColumnIds));
 
             return string.Join(string.Empty, listOfColumnIds.OrderBy(columnId => columnId));
+        }
+
+
+        public virtual string NavigationUniquifier(
+            [NotNull] string proposedIdentifier, [CanBeNull]ICollection<string> existingIdentifiers)
+        {
+            if (existingIdentifiers == null
+                || !existingIdentifiers.Contains(proposedIdentifier))
+            {
+                return proposedIdentifier;
+            }
+
+            string finalIdentifier = proposedIdentifier + NavigationNameUniquifyingSuffix;
+            var suffix = 1;
+            while (existingIdentifiers.Contains(finalIdentifier))
+            {
+                finalIdentifier = proposedIdentifier + suffix.ToString();
+                suffix++;
+            }
+
+            return finalIdentifier;
         }
 
         public virtual void ApplyPropertyProperties(


### PR DESCRIPTION
RevEng fixes for Beta-4. Fixes issues #1928, #1934, #1937 & #1938.

Adding 'Context' to DbContext name, changing layout of generated code, adding FK properties to model and referencing FK properties in navigation configurations.