### PR TITLE
Workarounds to support Mono

### DIFF
--- a/src/EntityFramework.Core/Extensions/EntityFrameworkQueryableExtensions.cs
+++ b/src/EntityFramework.Core/Extensions/EntityFrameworkQueryableExtensions.cs
@@ -2187,7 +2187,7 @@ namespace System.Linq
         internal static readonly MethodInfo ThenIncludeAfterCollectionMethodInfo
             = typeof(EntityFrameworkQueryableExtensions)
                 .GetTypeInfo().GetDeclaredMethods(nameof(EntityFrameworkQueryableExtensions.ThenInclude))
-                .Single(mi => mi.GetParameters()[0].ParameterType.GenericTypeArguments[1].IsConstructedGenericType);
+                .Single(mi => !mi.GetParameters()[0].ParameterType.GenericTypeArguments[1].IsGenericParameter);
 
         internal static readonly MethodInfo ThenIncludeAfterReferenceMethodInfo
             = typeof(EntityFrameworkQueryableExtensions)

--- a/src/EntityFramework.Relational/RelationalTypedValueReader.cs
+++ b/src/EntityFramework.Relational/RelationalTypedValueReader.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Data.Entity.Relational
 
         public virtual bool IsNull(int index) => _dataReader.IsDBNull(index);
 
-        public virtual T ReadValue<T>(int index) => _dataReader.GetFieldValue<T>(index);
+        public virtual T ReadValue<T>(int index) => (T)_dataReader.GetValue(index);
 
         public virtual int Count => _dataReader.FieldCount;
     }

--- a/test/EntityFramework.Relational.Tests/RelationalTypedValueReaderTest.cs
+++ b/test/EntityFramework.Relational.Tests/RelationalTypedValueReaderTest.cs
@@ -26,8 +26,8 @@ namespace Microsoft.Data.Entity.Relational.Tests
         public void Can_read_value()
         {
             var readerMock = new Mock<DbDataReader>();
-            readerMock.Setup(m => m.GetFieldValue<int>(0)).Returns(77);
-            readerMock.Setup(m => m.GetFieldValue<string>(1)).Returns("Smokey");
+            readerMock.Setup(m => m.GetValue(0)).Returns(77);
+            readerMock.Setup(m => m.GetValue(1)).Returns("Smokey");
 
             var reader = new RelationalTypedValueReader(readerMock.Object);
 


### PR DESCRIPTION
Two workarounds needed...

**ThenInclude method location**
IsConstructedGenericType is returning different results on Mono so adjusting logic to something that works.
New logic for the collection overload just uses a "not" of the logic to find the reference overload.

**Remove use of DbDataReader.GetFieldValue<T>**
There is a bug in Mono where `GetFieldValue<T>` is overridden in `SqlDataReader` to throw even though there is now a base implementation that would work.
I've opened an issue against Mono to fix this - https://bugzilla.xamarin.com/show_bug.cgi?id=28662
**This is just a temporary workaround that will need to be done in a better way since we want the generic to help with type detection on SQLite and possibly other providers.**