### PR TITLE
Extend read-only semantics per store generation discussion

### DIFF
--- a/src/EntityFramework.Core/Metadata/IProperty.cs
+++ b/src/EntityFramework.Core/Metadata/IProperty.cs
@@ -9,7 +9,8 @@ namespace Microsoft.Data.Entity.Metadata
     {
         Type ClrType { get; }
         bool IsNullable { get; }
-        bool IsReadOnly { get; }
+        bool IsReadOnlyBeforeSave { get; }
+        bool IsReadOnlyAfterSave { get; }
         StoreGeneratedPattern StoreGeneratedPattern { get; }
         bool IsValueGeneratedOnAdd { get; }
         int Index { get; }

--- a/src/EntityFramework.Core/Metadata/Property.cs
+++ b/src/EntityFramework.Core/Metadata/Property.cs
@@ -88,9 +88,17 @@ namespace Microsoft.Data.Entity.Metadata
 
         protected virtual StoreGeneratedPattern DefaultStoreGeneratedPattern => Metadata.StoreGeneratedPattern.None;
 
-        public virtual bool? IsReadOnly
+        public virtual bool? IsReadOnlyBeforeSave
         {
-            get { return GetFlag(PropertyFlags.IsReadOnly); }
+            get { return GetFlag(PropertyFlags.IsReadOnlyBeforeSave); }
+            set { SetFlag(value, PropertyFlags.IsReadOnlyBeforeSave); }
+        }
+
+        protected virtual bool DefaultIsReadOnlyBeforeSave => StoreGeneratedPattern == Metadata.StoreGeneratedPattern.Computed;
+
+        public virtual bool? IsReadOnlyAfterSave
+        {
+            get { return GetFlag(PropertyFlags.IsReadOnlyAfterSave); }
             set
             {
                 if (value.HasValue
@@ -99,11 +107,13 @@ namespace Microsoft.Data.Entity.Metadata
                 {
                     throw new NotSupportedException(Strings.KeyPropertyMustBeReadOnly(Name, EntityType.Name));
                 }
-                SetFlag(value, PropertyFlags.IsReadOnly);
+                SetFlag(value, PropertyFlags.IsReadOnlyAfterSave);
             }
         }
 
-        protected virtual bool DefaultIsReadOnly => this.IsKey();
+        protected virtual bool DefaultIsReadOnlyAfterSave
+            => StoreGeneratedPattern == Metadata.StoreGeneratedPattern.Computed
+               || this.IsKey();
 
         public virtual bool? GenerateValueOnAdd
         {
@@ -222,7 +232,9 @@ namespace Microsoft.Data.Entity.Metadata
 
         StoreGeneratedPattern IProperty.StoreGeneratedPattern => StoreGeneratedPattern ?? DefaultStoreGeneratedPattern;
 
-        bool IProperty.IsReadOnly => IsReadOnly ?? DefaultIsReadOnly;
+        bool IProperty.IsReadOnlyBeforeSave => IsReadOnlyBeforeSave ?? DefaultIsReadOnlyBeforeSave;
+
+        bool IProperty.IsReadOnlyAfterSave => IsReadOnlyAfterSave ?? DefaultIsReadOnlyAfterSave;
 
         bool IProperty.IsValueGeneratedOnAdd => GenerateValueOnAdd ?? DefaultGenerateValueOnAdd;
 
@@ -235,11 +247,12 @@ namespace Microsoft.Data.Entity.Metadata
         {
             IsConcurrencyToken = 1,
             IsNullable = 2,
-            IsReadOnly = 4,
-            IsIdentity = 8,
-            IsComputed = 16,
-            GenerateValueOnAdd = 32,
-            IsShadowProperty = 64
+            IsReadOnlyBeforeSave = 4,
+            IsReadOnlyAfterSave = 8,
+            IsIdentity = 16,
+            IsComputed = 32,
+            GenerateValueOnAdd = 64,
+            IsShadowProperty = 128
         }
     }
 }

--- a/src/EntityFramework.Core/Properties/Strings.Designer.cs
+++ b/src/EntityFramework.Core/Properties/Strings.Designer.cs
@@ -533,15 +533,31 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
-        /// The property '{property}' on entity type '{entityType}' is read-only and so cannot be modified or marked as modified.
+        /// The property '{property}' on entity type '{entityType}' is part of a key and so cannot be modified or marked as modified.
         /// </summary>
-        public static string PropertyReadOnly([CanBeNull] object property, [CanBeNull] object entityType)
+        public static string KeyReadOnly([CanBeNull] object property, [CanBeNull] object entityType)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("PropertyReadOnly", "property", "entityType"), property, entityType);
+            return string.Format(CultureInfo.CurrentCulture, GetString("KeyReadOnly", "property", "entityType"), property, entityType);
         }
 
         /// <summary>
-        /// The property '{property}' on entity type '{entityType}' cannot be marked as read-write because it is part of a key. Key properties are always read-only.
+        /// The property '{property}' on entity type '{entityType}' is defined to be read-only after it has been saved, but its value has been modified or marked as modified.
+        /// </summary>
+        public static string PropertyReadOnlyAfterSave([CanBeNull] object property, [CanBeNull] object entityType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("PropertyReadOnlyAfterSave", "property", "entityType"), property, entityType);
+        }
+
+        /// <summary>
+        /// The property '{property}' on entity type '{entityType}' is defined to be read-only before it is saved, but its value has been set to something other than a temporary or default value.
+        /// </summary>
+        public static string PropertyReadOnlyBeforeSave([CanBeNull] object property, [CanBeNull] object entityType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("PropertyReadOnlyBeforeSave", "property", "entityType"), property, entityType);
+        }
+
+        /// <summary>
+        /// The property '{property}' on entity type '{entityType}' must be marked as read-only after it has been saved because it is part of a key. Key properties are always read-only once an entity has been saved for the first time.
         /// </summary>
         public static string KeyPropertyMustBeReadOnly([CanBeNull] object property, [CanBeNull] object entityType)
         {

--- a/src/EntityFramework.Core/Properties/Strings.resx
+++ b/src/EntityFramework.Core/Properties/Strings.resx
@@ -309,11 +309,17 @@
   <data name="NavigationCannotCreateType" xml:space="preserve">
     <value>The type of navigation property '{navigation}' on entity type '{entityType}' is '{foundType}' for which it was not possible to create a concrete instance. Either initialize the property before use, add a public parameterless constructor to the type, or use a type which can be assigned a HashSet&lt;&gt; or List&lt;&gt;.</value>
   </data>
-  <data name="PropertyReadOnly" xml:space="preserve">
-    <value>The property '{property}' on entity type '{entityType}' is read-only and so cannot be modified or marked as modified.</value>
+  <data name="KeyReadOnly" xml:space="preserve">
+    <value>The property '{property}' on entity type '{entityType}' is part of a key and so cannot be modified or marked as modified.</value>
+  </data>
+  <data name="PropertyReadOnlyAfterSave" xml:space="preserve">
+    <value>The property '{property}' on entity type '{entityType}' is defined to be read-only after it has been saved, but its value has been modified or marked as modified.</value>
+  </data>
+  <data name="PropertyReadOnlyBeforeSave" xml:space="preserve">
+    <value>The property '{property}' on entity type '{entityType}' is defined to be read-only before it is saved, but its value has been set to something other than a temporary or default value.</value>
   </data>
   <data name="KeyPropertyMustBeReadOnly" xml:space="preserve">
-    <value>The property '{property}' on entity type '{entityType}' cannot be marked as read-write because it is part of a key. Key properties are always read-only.</value>
+    <value>The property '{property}' on entity type '{entityType}' must be marked as read-only after it has been saved because it is part of a key. Key properties are always read-only once an entity has been saved for the first time.</value>
   </data>
   <data name="DuplicateForeignKey" xml:space="preserve">
     <value>The foreign key {foreignKey} cannot be added to the entity type '{entityType}' because a foreign key on the same properties already exists.</value>

--- a/test/EntityFramework.Core.FunctionalTests/EntityFramework.Core.FunctionalTests.csproj
+++ b/test/EntityFramework.Core.FunctionalTests/EntityFramework.Core.FunctionalTests.csproj
@@ -96,6 +96,7 @@
     <Compile Include="F1FixtureBase.cs" />
     <Compile Include="QueryTestBase.cs" />
     <Compile Include="OptimisticConcurrencyTestBase.cs" />
+    <Compile Include="StoreGeneratedTestBase.cs" />
     <Compile Include="TestHelpers.cs" />
     <Compile Include="TestModelSource.cs" />
     <Compile Include="TestModels\ComplexNavigationsModel\ComplexNavigationsContext.cs" />

--- a/test/EntityFramework.Core.FunctionalTests/GraphUpdatesTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/GraphUpdatesTestBase.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.Data.Entity.ChangeTracking;
-using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Internal;
 using Xunit;
@@ -780,7 +779,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 newRoot.RequiredSingle = root.RequiredSingle;
 
                 Assert.Equal(
-                    Strings.PropertyReadOnly("Id", typeof(RequiredSingle1).FullName),
+                    Strings.KeyReadOnly("Id", typeof(RequiredSingle1).Name),
                     Assert.Throws<NotSupportedException>(() => context.SaveChanges()).Message);
             }
         }
@@ -1619,7 +1618,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 newRoot.RequiredSingleAk = root.RequiredSingleAk;
 
                 Assert.Equal(
-                    Strings.PropertyReadOnly("AlternateId", typeof(RequiredSingleAk1).FullName),
+                    Strings.KeyReadOnly("AlternateId", typeof(RequiredSingleAk1).Name),
                     Assert.Throws<NotSupportedException>(() => context.SaveChanges()).Message);
             }
         }

--- a/test/EntityFramework.Core.FunctionalTests/StoreGeneratedTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/StoreGeneratedTestBase.cs
@@ -1,0 +1,478 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.Data.Entity.ChangeTracking.Internal;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Internal;
+using Microsoft.Data.Entity.Metadata;
+using Xunit;
+
+namespace Microsoft.Data.Entity.FunctionalTests
+{
+    public abstract class StoreGeneratedTestBase<TTestStore, TFixture> : IClassFixture<TFixture>, IDisposable
+        where TTestStore : TestStore
+        where TFixture : StoreGeneratedTestBase<TTestStore, TFixture>.StoreGeneratedFixtureBase, new()
+    {
+        protected StoreGeneratedTestBase(TFixture fixture)
+        {
+            Fixture = fixture;
+            TestStore = Fixture.CreateTestStore();
+        }
+
+        [Fact]
+        public virtual void Identity_key_with_read_only_before_save_throws_if_explicit_values_set()
+        {
+            using (var context = CreateContext())
+            {
+                context.Add(new Gumball { Id = 1 });
+
+                Assert.Equal(
+                    Strings.PropertyReadOnlyBeforeSave("Id", "Gumball"),
+                    Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Identity_property_on_Added_entity_with_temporary_value_gets_value_from_store()
+        {
+            int id;
+
+            using (var context = CreateContext())
+            {
+                var entry = context.Add(new Gumball { Identity = "Masami" });
+                ((IAccessor<InternalEntityEntry>)entry).Service.MarkAsTemporary(entry.Property(e => e.Identity).Metadata);
+
+                context.SaveChanges();
+                id = entry.Entity.Id;
+
+                Assert.Equal("Banana Joe", entry.Entity.Identity);
+            }
+
+            using (var context = CreateContext())
+            {
+                Assert.Equal("Banana Joe", context.Gumballs.Single(e => e.Id == id).Identity);
+            }
+        }
+
+        [Fact]
+        public virtual void Identity_property_on_Added_entity_with_sentinal_value_gets_value_from_store()
+        {
+            int id;
+
+            using (var context = CreateContext())
+            {
+                var entity = context.Add(new Gumball()).Entity;
+
+                context.SaveChanges();
+                id = entity.Id;
+
+                Assert.Equal("Banana Joe", entity.Identity);
+            }
+
+            using (var context = CreateContext())
+            {
+                Assert.Equal("Banana Joe", context.Gumballs.Single(e => e.Id == id).Identity);
+            }
+        }
+
+        [Fact]
+        public virtual void Identity_property_on_Added_entity_with_read_only_before_save_throws_if_explicit_values_set()
+        {
+            using (var context = CreateContext())
+            {
+                context.Add(new Gumball { IdentityReadOnlyBeforeSave = "Masami" });
+
+                Assert.Equal(
+                    Strings.PropertyReadOnlyBeforeSave("IdentityReadOnlyBeforeSave", "Gumball"),
+                    Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Identity_property_on_Added_entity_can_have_value_set_explicitly()
+        {
+            int id;
+
+            using (var context = CreateContext())
+            {
+                var entity = context.Add(new Gumball { Identity = "Masami" }).Entity;
+
+                context.SaveChanges();
+                id = entity.Id;
+
+                Assert.Equal("Masami", entity.Identity);
+            }
+
+            using (var context = CreateContext())
+            {
+                Assert.Equal("Masami", context.Gumballs.Single(e => e.Id == id).Identity);
+            }
+        }
+
+        [Fact]
+        public virtual void Identity_property_on_Modified_entity_with_read_only_after_save_throws_if_value_is_in_modified_state()
+        {
+            int id;
+
+            using (var context = CreateContext())
+            {
+                var entity = context.Add(new Gumball()).Entity;
+
+                context.SaveChanges();
+                id = entity.Id;
+            }
+
+            using (var context = CreateContext())
+            {
+                var gumball = context.Gumballs.Single(e => e.Id == id);
+
+                Assert.Equal("Anton", gumball.IdentityReadOnlyAfterSave);
+
+                gumball.IdentityReadOnlyAfterSave = "Masami";
+                gumball.NotStoreGenerated = "Larry Needlemeye";
+
+                Assert.Equal(
+                    Strings.PropertyReadOnlyAfterSave("IdentityReadOnlyAfterSave", "Gumball"),
+                    Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Identity_property_on_Modified_entity_is_included_in_update_when_modified()
+        {
+            int id;
+
+            using (var context = CreateContext())
+            {
+                var entity = context.Add(new Gumball()).Entity;
+
+                context.SaveChanges();
+                id = entity.Id;
+            }
+
+            using (var context = CreateContext())
+            {
+                var gumball = context.Gumballs.Single(e => e.Id == id);
+
+                Assert.Equal("Banana Joe", gumball.Identity);
+
+                gumball.Identity = "Masami";
+                gumball.NotStoreGenerated = "Larry Needlemeye";
+
+                context.SaveChanges();
+
+                Assert.Equal("Masami", gumball.Identity);
+            }
+
+            using (var context = CreateContext())
+            {
+                Assert.Equal("Masami", context.Gumballs.Single(e => e.Id == id).Identity);
+            }
+        }
+
+        [Fact]
+        public virtual void Identity_property_on_Modified_entity_is_not_included_in_update_when_not_modified()
+        {
+            int id;
+
+            using (var context = CreateContext())
+            {
+                var entity = context.Add(new Gumball()).Entity;
+
+                context.SaveChanges();
+                id = entity.Id;
+            }
+
+            using (var context = CreateContext())
+            {
+                var gumball = context.Gumballs.Single(e => e.Id == id);
+
+                Assert.Equal("Banana Joe", gumball.Identity);
+
+                gumball.Identity = "Masami";
+                gumball.NotStoreGenerated = "Larry Needlemeye";
+
+                context.Entry(gumball).Property(e => e.Identity).OriginalValue = "Masami";
+                context.Entry(gumball).Property(e => e.Identity).IsModified = false;
+
+                context.SaveChanges();
+
+                Assert.Equal("Masami", gumball.Identity);
+            }
+
+            using (var context = CreateContext())
+            {
+                Assert.Equal("Banana Joe", context.Gumballs.Single(e => e.Id == id).Identity);
+            }
+        }
+
+        [Fact]
+        public virtual void Computed_property_on_Added_entity_with_temporary_value_gets_value_from_store()
+        {
+            int id;
+
+            using (var context = CreateContext())
+            {
+                var entry = context.Add(new Gumball { Computed = "Masami" });
+                ((IAccessor<InternalEntityEntry>)entry).Service.MarkAsTemporary(entry.Property(e => e.Computed).Metadata);
+
+                context.SaveChanges();
+                id = entry.Entity.Id;
+
+                Assert.Equal("Alan", entry.Entity.Computed);
+            }
+
+            using (var context = CreateContext())
+            {
+                Assert.Equal("Alan", context.Gumballs.Single(e => e.Id == id).Computed);
+            }
+        }
+
+        [Fact]
+        public virtual void Computed_property_on_Added_entity_with_sentinal_value_gets_value_from_store()
+        {
+            int id;
+
+            using (var context = CreateContext())
+            {
+                var entity = context.Add(new Gumball()).Entity;
+
+                context.SaveChanges();
+                id = entity.Id;
+
+                Assert.Equal("Alan", entity.Computed);
+            }
+
+            using (var context = CreateContext())
+            {
+                Assert.Equal("Alan", context.Gumballs.Single(e => e.Id == id).Computed);
+            }
+        }
+
+        [Fact]
+        public virtual void Computed_property_on_Added_entity_with_read_only_before_save_throws_if_explicit_values_set()
+        {
+            using (var context = CreateContext())
+            {
+                context.Add(new Gumball { ComputedReadOnlyBeforeSave = "Masami" });
+
+                Assert.Equal(
+                    Strings.PropertyReadOnlyBeforeSave("ComputedReadOnlyBeforeSave", "Gumball"),
+                    Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Computed_property_on_Added_entity_can_have_value_set_explicitly()
+        {
+            int id;
+
+            using (var context = CreateContext())
+            {
+                var entity = context.Add(new Gumball { Computed = "Masami" }).Entity;
+
+                context.SaveChanges();
+                id = entity.Id;
+
+                Assert.Equal("Masami", entity.Computed);
+            }
+
+            using (var context = CreateContext())
+            {
+                Assert.Equal("Masami", context.Gumballs.Single(e => e.Id == id).Computed);
+            }
+        }
+
+        [Fact]
+        public virtual void Computed_property_on_Modified_entity_with_read_only_after_save_throws_if_value_is_in_modified_state()
+        {
+            int id;
+
+            using (var context = CreateContext())
+            {
+                var entity = context.Add(new Gumball()).Entity;
+
+                context.SaveChanges();
+                id = entity.Id;
+            }
+
+            using (var context = CreateContext())
+            {
+                var gumball = context.Gumballs.Single(e => e.Id == id);
+
+                Assert.Equal("Tina Rex", gumball.ComputedReadOnlyAfterSave);
+
+                gumball.ComputedReadOnlyAfterSave = "Masami";
+                gumball.NotStoreGenerated = "Larry Needlemeye";
+
+                Assert.Equal(
+                    Strings.PropertyReadOnlyAfterSave("ComputedReadOnlyAfterSave", "Gumball"),
+                    Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Computed_property_on_Modified_entity_is_included_in_update_when_modified()
+        {
+            int id;
+
+            using (var context = CreateContext())
+            {
+                var entity = context.Add(new Gumball()).Entity;
+
+                context.SaveChanges();
+                id = entity.Id;
+            }
+
+            using (var context = CreateContext())
+            {
+                var gumball = context.Gumballs.Single(e => e.Id == id);
+
+                Assert.Equal("Alan", gumball.Computed);
+
+                gumball.Computed = "Masami";
+                gumball.NotStoreGenerated = "Larry Needlemeye";
+
+                context.SaveChanges();
+
+                Assert.Equal("Masami", gumball.Computed);
+            }
+
+            using (var context = CreateContext())
+            {
+                Assert.Equal("Masami", context.Gumballs.Single(e => e.Id == id).Computed);
+            }
+        }
+
+        [Fact]
+        public virtual void Computed_property_on_Modified_entity_is_read_from_store_when_not_modified()
+        {
+            int id;
+
+            using (var context = CreateContext())
+            {
+                var entity = context.Add(new Gumball()).Entity;
+
+                context.SaveChanges();
+                id = entity.Id;
+            }
+
+            using (var context = CreateContext())
+            {
+                var gumball = context.Gumballs.Single(e => e.Id == id);
+
+                Assert.Equal("Alan", gumball.Computed);
+
+                gumball.Computed = "Masami";
+                gumball.NotStoreGenerated = "Larry Needlemeye";
+
+                context.Entry(gumball).Property(e => e.Computed).OriginalValue = "Masami";
+                context.Entry(gumball).Property(e => e.Computed).IsModified = false;
+
+                context.SaveChanges();
+
+                Assert.Equal("Alan", gumball.Computed);
+            }
+
+            using (var context = CreateContext())
+            {
+                Assert.Equal("Alan", context.Gumballs.Single(e => e.Id == id).Computed);
+            }
+        }
+
+        protected class Gumball
+        {
+            public int Id { get; set; }
+            public string NotStoreGenerated { get; set; }
+
+            public string Identity { get; set; }
+            public string IdentityReadOnlyBeforeSave { get; set; }
+            public string IdentityReadOnlyAfterSave { get; set; }
+
+            public string Computed { get; set; }
+            public string ComputedReadOnlyBeforeSave { get; set; }
+            public string ComputedReadOnlyAfterSave { get; set; }
+        }
+
+        protected class StoreGeneratedContext : DbContext
+        {
+            public StoreGeneratedContext(IServiceProvider serviceProvider, DbContextOptions options)
+                : base(serviceProvider, options)
+            {
+            }
+
+            public DbSet<Gumball> Gumballs { get; set; }
+        }
+
+        protected StoreGeneratedContext CreateContext()
+        {
+            return (StoreGeneratedContext)Fixture.CreateContext(TestStore);
+        }
+
+        public void Dispose()
+        {
+            TestStore.Dispose();
+        }
+
+        protected TFixture Fixture { get; }
+
+        protected TTestStore TestStore { get; }
+
+        public abstract class StoreGeneratedFixtureBase
+        {
+            public abstract TTestStore CreateTestStore();
+
+            public abstract DbContext CreateContext(TTestStore testStore);
+
+            protected virtual void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<Gumball>(b =>
+                    {
+                        var property = b.Property(e => e.Id)
+                            .StoreGeneratedPattern(StoreGeneratedPattern.Identity)
+                            .Metadata;
+                        property.IsReadOnlyAfterSave = true;
+                        property.IsReadOnlyBeforeSave = true;
+
+                        property = b.Property(e => e.Identity)
+                            .StoreGeneratedPattern(StoreGeneratedPattern.Identity)
+                            .Metadata;
+                        property.IsReadOnlyAfterSave = false;
+                        property.IsReadOnlyBeforeSave = false;
+
+                        property = b.Property(e => e.IdentityReadOnlyBeforeSave)
+                            .StoreGeneratedPattern(StoreGeneratedPattern.Identity)
+                            .Metadata;
+                        property.IsReadOnlyAfterSave = false;
+                        property.IsReadOnlyBeforeSave = true;
+
+                        property = b.Property(e => e.IdentityReadOnlyAfterSave)
+                            .StoreGeneratedPattern(StoreGeneratedPattern.Identity)
+                            .Metadata;
+                        property.IsReadOnlyAfterSave = true;
+                        property.IsReadOnlyBeforeSave = false;
+
+                        property = b.Property(e => e.Computed)
+                            .StoreGeneratedPattern(StoreGeneratedPattern.Computed)
+                            .Metadata;
+                        property.IsReadOnlyAfterSave = false;
+                        property.IsReadOnlyBeforeSave = false;
+
+                        property = b.Property(e => e.ComputedReadOnlyBeforeSave)
+                            .StoreGeneratedPattern(StoreGeneratedPattern.Computed)
+                            .Metadata;
+                        property.IsReadOnlyAfterSave = false;
+                        property.IsReadOnlyBeforeSave = true;
+
+                        property = b.Property(e => e.ComputedReadOnlyAfterSave)
+                            .StoreGeneratedPattern(StoreGeneratedPattern.Computed)
+                            .Metadata;
+                        property.IsReadOnlyAfterSave = true;
+                        property.IsReadOnlyBeforeSave = false;
+                    });
+            }
+        }
+    }
+}

--- a/test/EntityFramework.Core.Tests/Metadata/PropertyTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/PropertyTest.cs
@@ -133,26 +133,60 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             var property = new Property("Name", typeof(string), new Model().AddEntityType(typeof(object)));
 
-            Assert.Null(property.IsReadOnly);
-            Assert.False(((IProperty)property).IsReadOnly);
+            Assert.Null(property.IsReadOnlyAfterSave);
+            Assert.False(((IProperty)property).IsReadOnlyAfterSave);
+            Assert.Null(property.IsReadOnlyBeforeSave);
+            Assert.False(((IProperty)property).IsReadOnlyBeforeSave);
         }
 
         [Fact]
-        public void Property_can_be_marked_as_read_only()
+        public void Property_can_be_marked_as_read_only_before_save()
         {
             var property 
                 = new Property("Name", typeof(string), new Model().AddEntityType(typeof(object)))
                 {
-                    IsReadOnly = true
+                    IsReadOnlyBeforeSave = true
                 };
 
-            Assert.True(property.IsReadOnly.Value);
+            Assert.True(property.IsReadOnlyBeforeSave.Value);
 
-            property.IsReadOnly = false;
-            Assert.False(property.IsReadOnly.Value);
+            property.IsReadOnlyBeforeSave = false;
+            Assert.False(property.IsReadOnlyBeforeSave.Value);
 
-            property.IsReadOnly = null;
-            Assert.Null(property.IsReadOnly);
+            property.IsReadOnlyBeforeSave = null;
+            Assert.Null(property.IsReadOnlyBeforeSave);
+        }
+
+        [Fact]
+        public void Property_can_be_marked_as_read_only_after_save()
+        {
+            var property
+                = new Property("Name", typeof(string), new Model().AddEntityType(typeof(object)))
+                {
+                    IsReadOnlyAfterSave = true
+                };
+
+            Assert.True(property.IsReadOnlyAfterSave.Value);
+
+            property.IsReadOnlyAfterSave = false;
+            Assert.False(property.IsReadOnlyAfterSave.Value);
+
+            property.IsReadOnlyAfterSave = null;
+            Assert.Null(property.IsReadOnlyAfterSave);
+        }
+
+        [Fact]
+        public void Property_can_be_marked_as_read_only_always()
+        {
+            var property
+                = new Property("Name", typeof(string), new Model().AddEntityType(typeof(object)))
+                {
+                    IsReadOnlyBeforeSave = true,
+                    IsReadOnlyAfterSave = true
+                };
+
+            Assert.True(property.IsReadOnlyBeforeSave.Value);
+            Assert.True(property.IsReadOnlyAfterSave.Value);
         }
 
         [Fact]

--- a/test/EntityFramework.InMemory.FunctionalTests/EntityFramework.InMemory.FunctionalTests.csproj
+++ b/test/EntityFramework.InMemory.FunctionalTests/EntityFramework.InMemory.FunctionalTests.csproj
@@ -89,6 +89,7 @@
     <Compile Include="AsyncQueryInMemoryTest.cs" />
     <Compile Include="QueryInMemoryTest.cs" />
     <Compile Include="ShadowStateUpdateTest.cs" />
+    <Compile Include="StoreGeneratedInMemoryTest.cs" />
     <Compile Include="TestInMemoryModelSource.cs" />
     <None Include="packages.config" />
     <None Include="project.json" />

--- a/test/EntityFramework.InMemory.FunctionalTests/StoreGeneratedInMemoryTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/StoreGeneratedInMemoryTest.cs
@@ -1,0 +1,138 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Framework.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.Data.Entity.InMemory.FunctionalTests
+{
+    public class StoreGeneratedInMemoryTest
+        : StoreGeneratedTestBase<InMemoryTestStore, StoreGeneratedInMemoryTest.StoreGeneratedInMemoryFixture>
+    {
+        public StoreGeneratedInMemoryTest(StoreGeneratedInMemoryFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        [Fact]
+        public override void Identity_key_with_read_only_before_save_throws_if_explicit_values_set()
+        {
+            // In-memory store does not support store generation 
+        }
+
+        [Fact]
+        public override void Identity_property_on_Added_entity_with_temporary_value_gets_value_from_store()
+        {
+            // In-memory store does not support store generation 
+        }
+
+        [Fact]
+        public override void Identity_property_on_Added_entity_with_sentinal_value_gets_value_from_store()
+        {
+            // In-memory store does not support store generation 
+        }
+
+        [Fact]
+        public override void Identity_property_on_Modified_entity_with_read_only_after_save_throws_if_value_is_in_modified_state()
+        {
+            // In-memory store does not support store generation 
+        }
+
+        [Fact]
+        public override void Identity_property_on_Modified_entity_is_included_in_update_when_modified()
+        {
+            // In-memory store does not support store generation 
+        }
+
+        [Fact]
+        public override void Identity_property_on_Modified_entity_is_not_included_in_update_when_not_modified()
+        {
+            // In-memory store does not support store generation 
+        }
+
+        [Fact]
+        public override void Computed_property_on_Added_entity_with_temporary_value_gets_value_from_store()
+        {
+            // In-memory store does not support store generation 
+        }
+
+        [Fact]
+        public override void Computed_property_on_Added_entity_with_sentinal_value_gets_value_from_store()
+        {
+            // In-memory store does not support store generation 
+        }
+
+        [Fact]
+        public override void Computed_property_on_Modified_entity_with_read_only_after_save_throws_if_value_is_in_modified_state()
+        {
+            // In-memory store does not support store generation 
+        }
+
+        [Fact]
+        public override void Computed_property_on_Modified_entity_is_included_in_update_when_modified()
+        {
+            // In-memory store does not support store generation 
+        }
+
+        [Fact]
+        public override void Computed_property_on_Modified_entity_is_read_from_store_when_not_modified()
+        {
+            // In-memory store does not support store generation 
+        }
+
+        public class StoreGeneratedInMemoryFixture : StoreGeneratedFixtureBase
+        {
+            private const string DatabaseName = "StoreGeneratedTest";
+
+            private readonly IServiceProvider _serviceProvider;
+
+            public StoreGeneratedInMemoryFixture()
+            {
+                _serviceProvider = new ServiceCollection()
+                    .AddEntityFramework()
+                    .AddInMemoryStore()
+                    .ServiceCollection()
+                    .AddSingleton(TestInMemoryModelSource.GetFactory(OnModelCreating))
+                    .BuildServiceProvider();
+            }
+
+            public override InMemoryTestStore CreateTestStore()
+            {
+                return InMemoryTestStore.GetOrCreateShared(DatabaseName, () =>
+                    {
+                        var optionsBuilder = new DbContextOptionsBuilder();
+                        optionsBuilder.UseInMemoryStore();
+
+                        using (var context = new StoreGeneratedContext(_serviceProvider, optionsBuilder.Options))
+                        {
+                            context.Database.EnsureDeleted();
+                            context.Database.EnsureCreated();
+                        }
+                    });
+            }
+
+            public override DbContext CreateContext(InMemoryTestStore testStore)
+            {
+                var optionsBuilder = new DbContextOptionsBuilder();
+                optionsBuilder.UseInMemoryStore();
+
+                var context = new StoreGeneratedContext(_serviceProvider, optionsBuilder.Options);
+
+                return context;
+            }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                base.OnModelCreating(modelBuilder);
+
+                modelBuilder.Entity<Gumball>(b =>
+                    {
+                        // In-memory store does not support store generation of keys
+                        b.Property(e => e.Id).Metadata.IsReadOnlyBeforeSave = false;
+                    });
+            }
+        }
+    }
+}

--- a/test/EntityFramework.SqlServer.FunctionalTests/DefaultValuesTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/DefaultValuesTest.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             {
                 modelBuilder.Entity<KettleChips>()
                     .Property(e => e.BestBuyDate)
-                    .StoreGeneratedPattern(StoreGeneratedPattern.Computed)
+                    .StoreGeneratedPattern(StoreGeneratedPattern.Identity)
                     .ForRelational().DefaultValue(new DateTime(2035, 9, 25));
             }
         }

--- a/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
+++ b/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
@@ -121,6 +121,7 @@
     <Compile Include="SentinelGraphUpdatesSqlServerTest.cs" />
     <Compile Include="MonsterFixupSqlServerTest.cs" />
     <Compile Include="SqlServerTestStore.cs" />
+    <Compile Include="StoreGeneratedSqlServerTestBase.cs" />
     <Compile Include="TransactionSqlServerFixture.cs" />
     <Compile Include="TransactionSqlServerTest.cs" />
     <Compile Include="TestModels\SqlServerNorthwindContext.cs" />

--- a/test/EntityFramework.SqlServer.FunctionalTests/StoreGeneratedSqlServerTestBase.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/StoreGeneratedSqlServerTestBase.cs
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Framework.DependencyInjection;
+
+namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
+{
+    public class StoreGeneratedSqlServerTest
+        : StoreGeneratedTestBase<SqlServerTestStore, StoreGeneratedSqlServerTest.StoreGeneratedSqlServerFixture>
+    {
+        public StoreGeneratedSqlServerTest(StoreGeneratedSqlServerFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        public class StoreGeneratedSqlServerFixture : StoreGeneratedFixtureBase
+        {
+            private const string DatabaseName = "StoreGeneratedTest";
+
+            private readonly IServiceProvider _serviceProvider;
+
+            public StoreGeneratedSqlServerFixture()
+            {
+                _serviceProvider = new ServiceCollection()
+                    .AddEntityFramework()
+                    .AddSqlServer()
+                    .ServiceCollection()
+                    .AddSingleton(TestSqlServerModelSource.GetFactory(OnModelCreating))
+                    .BuildServiceProvider();
+            }
+
+            public override SqlServerTestStore CreateTestStore()
+            {
+                return SqlServerTestStore.GetOrCreateShared(DatabaseName, () =>
+                    {
+                        var optionsBuilder = new DbContextOptionsBuilder();
+                        optionsBuilder.UseSqlServer(SqlServerTestStore.CreateConnectionString(DatabaseName));
+
+                        using (var context = new StoreGeneratedContext(_serviceProvider, optionsBuilder.Options))
+                        {
+                            context.Database.EnsureDeleted();
+                            context.Database.EnsureCreated();
+                        }
+                    });
+            }
+
+            public override DbContext CreateContext(SqlServerTestStore testStore)
+            {
+                var optionsBuilder = new DbContextOptionsBuilder();
+                optionsBuilder.UseSqlServer(testStore.Connection);
+
+                var context = new StoreGeneratedContext(_serviceProvider, optionsBuilder.Options);
+                context.Database.AsRelational().Connection.UseTransaction(testStore.Transaction);
+
+                return context;
+            }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                base.OnModelCreating(modelBuilder);
+
+                modelBuilder.Entity<Gumball>(b =>
+                    {
+                        b.Property(e => e.Id)
+                            .ForSqlServer()
+                            .UseIdentity();
+
+                        b.Property(e => e.Identity)
+                            .ForRelational()
+                            .DefaultValue("Banana Joe");
+
+                        b.Property(e => e.IdentityReadOnlyBeforeSave)
+                            .ForRelational()
+                            .DefaultValue("Doughnut Sheriff");
+
+                        b.Property(e => e.IdentityReadOnlyAfterSave)
+                            .ForRelational()
+                            .DefaultValue("Anton");
+
+                        b.Property(e => e.Computed)
+                            .ForRelational()
+                            .DefaultValue("Alan");
+
+                        b.Property(e => e.ComputedReadOnlyBeforeSave)
+                            .ForRelational()
+                            .DefaultValue("Carmen");
+
+                        b.Property(e => e.ComputedReadOnlyAfterSave)
+                            .ForRelational()
+                            .DefaultValue("Tina Rex");
+                    });
+            }
+        }
+    }
+}


### PR DESCRIPTION
Note: the naming of the concepts and whether or not they should be in an enum can be discussed in API review.

This change adds the concept of being read-only before saving a new entity as well as the concept of being read-only when updating a new entity. It also moves the check to happen as part of SaveChanges so that properties can go through a temporary state of being modified. Key values cannot go through this temporary state since the state manager relies on their values not changing.

Also added functional tests for all combinations of read-only flags and store generated patterns.