### PR TITLE
:penguin::apple: Additional workarounds to support Mono

### DIFF
--- a/src/EntityFramework.Relational/Query/QueryMethodProvider.cs
+++ b/src/EntityFramework.Relational/Query/QueryMethodProvider.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Data.Entity.Relational.Query
                 {
                     return enumerator.Current.IsDBNull(0)
                         ? default(TResult)
-                        : enumerator.Current.GetFieldValue<TResult>(0);
+                        : (TResult)enumerator.Current.GetValue(0);
                 }
             }
 

--- a/src/EntityFramework.Relational/Update/ReaderModificationCommandBatch.cs
+++ b/src/EntityFramework.Relational/Update/ReaderModificationCommandBatch.cs
@@ -356,7 +356,7 @@ namespace Microsoft.Data.Entity.Relational.Update
 
             if (reader.Read())
             {
-                var rowsAffected = reader.GetFieldValue<int>(0);
+                var rowsAffected = reader.GetInt32(0);
                 if (rowsAffected != expectedRowsAffected)
                 {
                     throw new DbUpdateConcurrencyException(
@@ -389,7 +389,7 @@ namespace Microsoft.Data.Entity.Relational.Update
 
             if (await reader.ReadAsync(cancellationToken).WithCurrentCulture())
             {
-                var rowsAffected = reader.GetFieldValue<int>(0);
+                var rowsAffected = reader.GetInt32(0);
                 if (rowsAffected != expectedRowsAffected)
                 {
                     throw new DbUpdateConcurrencyException(

--- a/test/EntityFramework.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
@@ -191,7 +191,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             await batch.ExecuteAsync(new Mock<RelationalTransaction>().Object, new RelationalTypeMapper(), new Mock<DbContext>().Object, new Mock<ILogger>().Object);
 
             mockReader.Verify(r => r.ReadAsync(It.IsAny<CancellationToken>()), Times.Once);
-            mockReader.Verify(r => r.GetFieldValue<int>(0), Times.Once);
+            mockReader.Verify(r => r.GetInt32(0), Times.Once);
         }
 
         [Fact]
@@ -546,6 +546,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             mockDataReader.Setup(r => r.FieldCount).Returns(columnNames.Length);
             mockDataReader.Setup(r => r.GetName(It.IsAny<int>())).Returns((int columnIdx) => columnNames[columnIdx]);
             mockDataReader.Setup(r => r.GetValue(It.IsAny<int>())).Returns((int columnIdx) => currentRow[columnIdx]);
+            mockDataReader.Setup(r => r.GetInt32(It.IsAny<int>())).Returns((int columnIdx) => (Int32)currentRow[columnIdx]);
             mockDataReader.Setup(r => r.GetFieldValue<int>(It.IsAny<int>())).Returns((int columnIdx) => (int)currentRow[columnIdx]);
             mockDataReader.Setup(r => r.GetFieldValue<string>(It.IsAny<int>())).Returns((int columnIdx) => (string)currentRow[columnIdx]);
             mockDataReader.Setup(r => r.GetFieldValue<object>(It.IsAny<int>())).Returns((int columnIdx) => currentRow[columnIdx]);


### PR DESCRIPTION
Additional changes related to workaround in 68d2f94b4696e9a0354c4bf55b598a2fe53b8128
Working around ```NotImplementedException``` thrown by Mono implementation of SqlClient
@divega @Eilon 