### PR TITLE
[TINY] Adding tests for All operator with predicate being partially client eval and partially server eval

### DIFF
--- a/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
@@ -202,6 +202,27 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
+        public virtual void All_client()
+        {
+            AssertQuery<Customer>(
+                cs => cs.All(c => c.IsLondon));
+        }
+
+        [Fact]
+        public virtual void All_client_and_server_top_level()
+        {
+            AssertQuery<Customer>(
+                cs => cs.All(c => c.CustomerID != "Foo" && c.IsLondon));
+        }
+
+        [Fact]
+        public virtual void All_client_or_server_top_level()
+        {
+            AssertQuery<Customer>(
+                cs => cs.All(c => c.CustomerID != "Foo" || c.IsLondon));
+        }
+
+        [Fact]
         public virtual void Select_into()
         {
             AssertQuery<Customer>(

--- a/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -741,6 +741,33 @@ FROM [Orders] AS [o]",
                 Sql);
         }
 
+        //public override void All_client()
+        //{
+        //    base.All_client();
+
+        //    Assert.Equal(
+        //        @"",
+        //        Sql);
+        //}
+
+        //public override void All_client_and_server_top_level()
+        //{
+        //    base.All_client_and_server_top_level();
+
+        //    Assert.Equal(
+        //        @"",
+        //        Sql);
+        //}
+
+        //public override void All_client_or_server_top_level()
+        //{
+        //    base.All_client_or_server_top_level();
+
+        //    Assert.Equal(
+        //        @"",
+        //        Sql);
+        //}
+
         public override void Select_scalar()
         {
             base.Select_scalar();


### PR DESCRIPTION
currently we push everything to the client