### PR TITLE
Make ChangeTracker not resolved directly from DI

### DIFF
--- a/src/EntityFramework.Core/ChangeTracking/ChangeTrackerFactory.cs
+++ b/src/EntityFramework.Core/ChangeTracking/ChangeTrackerFactory.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.ChangeTracking.Internal;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.ChangeTracking
+{
+    public class ChangeTrackerFactory : IChangeTrackerFactory
+    {
+        private readonly IStateManager _stateManager;
+        private readonly IChangeDetector _changeDetector;
+        private readonly IEntityEntryGraphIterator _graphIterator;
+        private readonly DbContext _context;
+
+        public ChangeTrackerFactory(
+            [NotNull] IStateManager stateManager,
+            [NotNull] IChangeDetector changeDetector,
+            [NotNull] IEntityEntryGraphIterator graphIterator,
+            [NotNull] DbContext context)
+        {
+            Check.NotNull(stateManager, nameof(stateManager));
+            Check.NotNull(changeDetector, nameof(changeDetector));
+            Check.NotNull(graphIterator, nameof(graphIterator));
+            Check.NotNull(context, nameof(context));
+
+            _stateManager = stateManager;
+            _changeDetector = changeDetector;
+            _graphIterator = graphIterator;
+            _context = context;
+        }
+
+        public virtual ChangeTracker CreateChangeTracker()
+        {
+            return new ChangeTracker(_stateManager, _changeDetector, _graphIterator, _context);
+        }
+    }
+}

--- a/src/EntityFramework.Core/ChangeTracking/IChangeTrackerFactory.cs
+++ b/src/EntityFramework.Core/ChangeTracking/IChangeTrackerFactory.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Data.Entity.ChangeTracking
+{
+    public interface IChangeTrackerFactory
+    {
+        ChangeTracker CreateChangeTracker();
+    }
+}

--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -78,6 +78,8 @@
     <Compile Include="..\Shared\LoggingExtensions.cs">
       <Link>Extensions\Internal\LoggingExtensions.cs</Link>
     </Compile>
+    <Compile Include="ChangeTracking\ChangeTrackerFactory.cs" />
+    <Compile Include="ChangeTracking\IChangeTrackerFactory.cs" />
     <Compile Include="Metadata\Builders\CollectionNavigationBuilder.cs" />
     <Compile Include="Metadata\Builders\CollectionNavigationBuilder`.cs" />
     <Compile Include="Metadata\Builders\EntityTypeBuilder.cs" />

--- a/src/EntityFramework.Core/Extensions/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/EntityFramework.Core/Extensions/EntityFrameworkServiceCollectionExtensions.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Framework.DependencyInjection
                 .AddScoped<IInternalEntityEntrySubscriber, InternalEntityEntrySubscriber>()
                 .AddScoped<IValueGenerationManager, ValueGenerationManager>()
                 .AddScoped<IEntityQueryProvider, EntityQueryProvider>()
-                .AddScoped<ChangeTracker>()
+                .AddScoped<IChangeTrackerFactory, ChangeTrackerFactory>()
                 .AddScoped<IChangeDetector, ChangeDetector>()
                 .AddScoped<IEntityEntryGraphIterator, EntityEntryGraphIterator>()
                 .AddScoped<IDbContextServices, DbContextServices>()

--- a/test/EntityFramework.Core.Tests/Extensions/EntityFrameworkServiceCollectionExtensionsTest.cs
+++ b/test/EntityFramework.Core.Tests/Extensions/EntityFrameworkServiceCollectionExtensionsTest.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Data.Entity.Tests
             VerifyScoped<IInternalEntityEntrySubscriber>();
             VerifyScoped<IValueGenerationManager>();
             VerifyScoped<IEntityQueryProvider>();
-            VerifyScoped<ChangeTracker>();
+            VerifyScoped<IChangeTrackerFactory>();
             VerifyScoped<IChangeDetector>();
             VerifyScoped<IEntityEntryGraphIterator>();
             VerifyScoped<IDbContextServices>();


### PR DESCRIPTION
ChangeTracker is a top-level API class and makes use of API patterns rather than just being a service contract. It is therefore best not resolved directly from DI.