### PR TITLE
Fix to #1858 - Filter missing if wrong type passed in

### DIFF
--- a/src/EntityFramework.Core/Query/CompiledQueryCache.cs
+++ b/src/EntityFramework.Core/Query/CompiledQueryCache.cs
@@ -210,8 +210,9 @@ namespace Microsoft.Data.Entity.Query
                 {
                     var unaryExpression = (UnaryExpression)expression;
 
-                    if (unaryExpression.Type.IsNullableType()
+                    if ((unaryExpression.Type.IsNullableType() 
                         && !unaryExpression.Operand.Type.IsNullableType())
+                        || unaryExpression.Type == typeof(object))
                     {
                         e = unaryExpression.Operand;
                     }
@@ -240,7 +241,11 @@ namespace Microsoft.Data.Entity.Query
 
                         _queryContext.ParameterValues.Add(parameterName, parameterValue);
 
-                        return Expression.Parameter(expression.Type, parameterName);
+                        return e.Type == expression.Type
+                            ? Expression.Parameter(e.Type, parameterName)
+                            : (Expression)Expression.Convert(
+                                Expression.Parameter(e.Type, parameterName),
+                                expression.Type);
                     }
                     catch (Exception exception)
                     {

--- a/src/EntityFramework.Relational/Properties/Strings.Designer.cs
+++ b/src/EntityFramework.Relational/Properties/Strings.Designer.cs
@@ -324,6 +324,14 @@ namespace Microsoft.Data.Entity.Relational
             get { return GetString("AmbientTransaction"); }
         }
 
+        /// <summary>
+        /// Possible unintended use of method Equals(object) for arguments of different types: '{left}', '{right}'. This comparison will always return 'false'.
+        /// </summary>
+        public static string PossibleUnintendedUseOfEquals([CanBeNull] object left, [CanBeNull] object right)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("PossibleUnintendedUseOfEquals", "left", "right"), left, right);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EntityFramework.Relational/Properties/Strings.resx
+++ b/src/EntityFramework.Relational/Properties/Strings.resx
@@ -234,4 +234,7 @@
   <data name="AmbientTransaction" xml:space="preserve">
     <value>An ambient transaction has been detected. Connections opened by Entity Framework will not be enlisted in ambient transactions. To suppress this warning call SuppressAmbientTransactionWarning() when overriding DbContext.OnConfiguring.</value>
   </data>
+  <data name="PossibleUnintendedUseOfEquals" xml:space="preserve">
+    <value>Possible unintended use of method Equals(object) for arguments of different types: '{left}', '{right}'. This comparison will always return 'false'.</value>
+  </data>
 </root>

--- a/src/EntityFramework.Relational/Query/Methods/CompositeMethodCallTranslator.cs
+++ b/src/EntityFramework.Relational/Query/Methods/CompositeMethodCallTranslator.cs
@@ -2,14 +2,23 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq.Expressions;
+using Microsoft.Framework.Logging;
+using JetBrains.Annotations;
 
 namespace Microsoft.Data.Entity.Relational.Query.Methods
 {
     public class CompositeMethodCallTranslator : IMethodCallTranslator
     {
+        private ILogger _logger;
+
+        public CompositeMethodCallTranslator([NotNull]ILogger logger)
+        {
+            _logger = logger;
+        }
+
         public virtual Expression Translate(MethodCallExpression methodCallExpression)
         {
-            return new EqualsTranslator().Translate(methodCallExpression)
+            return new EqualsTranslator(_logger).Translate(methodCallExpression)
                    ?? new StartsWithTranslator().Translate(methodCallExpression)
                    ?? new EndsWithTranslator().Translate(methodCallExpression)
                    ?? new ContainsTranslator().Translate(methodCallExpression);

--- a/src/EntityFramework.Relational/Query/Methods/EqualsTranslator.cs
+++ b/src/EntityFramework.Relational/Query/Methods/EqualsTranslator.cs
@@ -1,18 +1,60 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq.Expressions;
+using Microsoft.Framework.Logging;
+using JetBrains.Annotations;
 
 namespace Microsoft.Data.Entity.Relational.Query.Methods
 {
     public class EqualsTranslator : IMethodCallTranslator
     {
+        private ILogger _logger;
+
+        public EqualsTranslator([NotNull]ILogger logger)
+        {
+            _logger = logger;
+        }
+
         public virtual Expression Translate(MethodCallExpression methodCallExpression)
         {
-            return methodCallExpression.Method.Name == "Equals"
-                   && methodCallExpression.Arguments.Count == 1
-                ? Expression.Equal(methodCallExpression.Object, methodCallExpression.Arguments[0])
-                : null;
+            if (methodCallExpression.Method.Name == "Equals"
+                && methodCallExpression.Arguments.Count == 1)
+            {
+                var argument = methodCallExpression.Arguments[0];
+                var @object = methodCallExpression.Object;
+                if (methodCallExpression.Method.GetParameters()[0].ParameterType == typeof(object)
+                    && @object.Type != argument.Type)
+                {
+                    var unaryArgument = argument as UnaryExpression;
+                    if (unaryArgument != null && argument.NodeType == ExpressionType.Convert)
+                    {
+                        argument = unaryArgument.Operand;
+                    }
+
+                    var unwrappedObjectType = @object.Type.UnwrapNullableType();
+                    var unwrappedArgumentType = argument.Type.UnwrapNullableType();
+                    if (unwrappedObjectType == unwrappedArgumentType)
+                    {
+                        return Expression.Equal(
+                            Expression.Convert(@object, unwrappedObjectType),
+                            Expression.Convert(argument, unwrappedArgumentType));
+                    }
+
+                    _logger.LogInformation(
+                        Strings.PossibleUnintendedUseOfEquals(
+                            methodCallExpression.Object.ToString(), 
+                            argument.ToString()));
+
+                    // Equals(object) always returns false if when comparing objects of different types
+                    return Expression.Constant(false);
+                }
+
+                return Expression.Equal(methodCallExpression.Object, argument);
+            }
+
+            return null;
         }
     }
 }

--- a/src/EntityFramework.Relational/RelationalDataStore.cs
+++ b/src/EntityFramework.Relational/RelationalDataStore.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Data.Entity.Relational
                     new LinqOperatorProvider(),
                     new RelationalResultOperatorHandler(),
                     new QueryMethodProvider(),
-                    new CompositeMethodCallTranslator());
+                    new CompositeMethodCallTranslator(Logger));
 
             return queryCompilationContext
                 .CreateQueryModelVisitor()
@@ -100,7 +100,7 @@ namespace Microsoft.Data.Entity.Relational
                     new AsyncLinqOperatorProvider(),
                     new RelationalResultOperatorHandler(),
                     new AsyncQueryMethodProvider(),
-                    new CompositeMethodCallTranslator());
+                    new CompositeMethodCallTranslator(Logger));
 
             return queryCompilationContext
                 .CreateQueryModelVisitor()

--- a/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
@@ -692,6 +692,83 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
+        public virtual void Where_equals_using_object_overload_on_mismatched_types()
+        {
+            long longPrm = 1;
+
+            AssertQuery<Employee>(
+                es => es.Where(e => e.EmployeeID.Equals(longPrm)),
+                entryCount: 0);
+        }
+
+        [Fact]
+        public virtual void Where_equals_using_int_overload_on_mismatched_types()
+        {
+            short shortPrm = 1;
+
+            AssertQuery<Employee>(
+                es => es.Where(e => e.EmployeeID.Equals(shortPrm)),
+                entryCount: 1);
+        }
+
+        [Fact]
+        public virtual void Where_equals_on_mismatched_types_nullable_int_long()
+        {
+            long longPrm = 2;
+
+            AssertQuery<Employee>(
+                es => es.Where(e => e.ReportsTo.Equals(longPrm)),
+                entryCount: 0);
+
+            AssertQuery<Employee>(
+                es => es.Where(e => longPrm.Equals(e.ReportsTo)),
+                entryCount: 0);
+        }
+
+        [Fact]
+        public virtual void Where_equals_on_mismatched_types_int_nullable_int()
+        {
+            int intPrm = 2;
+
+            AssertQuery<Employee>(
+                es => es.Where(e => e.ReportsTo.Equals(intPrm)),
+                entryCount: 5);
+
+            AssertQuery<Employee>(
+                es => es.Where(e => intPrm.Equals(e.ReportsTo)),
+                entryCount: 5);
+
+        }
+
+        [Fact]
+        public virtual void Where_equals_on_mismatched_types_nullable_long_nullable_int()
+        {
+            long? nullableLongPrm = 2;
+
+            AssertQuery<Employee>(
+                es => es.Where(e => nullableLongPrm.Equals(e.ReportsTo)),
+                entryCount: 0);
+
+            AssertQuery<Employee>(
+                es => es.Where(e => e.ReportsTo.Equals(nullableLongPrm)),
+                entryCount: 0);
+        }
+
+        [Fact]
+        public virtual void Where_equals_on_matched_nullable_int_types()
+        {
+            int? nullableIntPrm = 2;
+
+            AssertQuery<Employee>(
+                es => es.Where(e => nullableIntPrm.Equals(e.ReportsTo)),
+                entryCount: 5);
+
+            AssertQuery<Employee>(
+                es => es.Where(e => e.ReportsTo.Equals(nullableIntPrm)),
+                entryCount: 5);
+        }
+
+        [Fact]
         public virtual void Where_comparison_nullable_type_not_null()
         {
             AssertQuery<Employee>(

--- a/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -1004,6 +1004,113 @@ WHERE [e].[EmployeeID] = 1",
                 Sql);
         }
 
+        public override void Where_equals_using_object_overload_on_mismatched_types()
+        {
+            base.Where_equals_using_object_overload_on_mismatched_types();
+
+            Assert.Equal(
+                @"SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Employees] AS [e]
+WHERE 1 = 0",
+                Sql);
+
+            Assert.True(TestSqlLoggerFactory.Log.Contains(
+                "Possible unintended use of method Equals(object) for arguments of different types: 'e.EmployeeID', '__longPrm_0'. This comparison will always return 'false'."));
+        }
+
+        public override void Where_equals_using_int_overload_on_mismatched_types()
+        {
+            base.Where_equals_using_int_overload_on_mismatched_types();
+
+            Assert.Equal(
+                @"__p_0: 1
+
+SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Employees] AS [e]
+WHERE [e].[EmployeeID] = @__p_0",
+                Sql);
+        }
+
+        public override void Where_equals_on_mismatched_types_int_nullable_int()
+        {
+            base.Where_equals_on_mismatched_types_int_nullable_int();
+
+            Assert.Equal(
+                @"__intPrm_0: 2
+
+SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Employees] AS [e]
+WHERE [e].[ReportsTo] = @__intPrm_0
+
+__intPrm_0: 2
+
+SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Employees] AS [e]
+WHERE @__intPrm_0 = [e].[ReportsTo]",
+                Sql);
+        }
+
+        public override void Where_equals_on_mismatched_types_nullable_int_long()
+        {
+            base.Where_equals_on_mismatched_types_nullable_int_long();
+
+            Assert.Equal(
+                @"SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Employees] AS [e]
+WHERE 1 = 0
+
+SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Employees] AS [e]
+WHERE 1 = 0",
+                Sql);
+
+           Assert.True(TestSqlLoggerFactory.Log.Contains(
+                "Possible unintended use of method Equals(object) for arguments of different types: 'e.ReportsTo', '__longPrm_0'. This comparison will always return 'false'."));
+
+           Assert.True(TestSqlLoggerFactory.Log.Contains(
+                "Possible unintended use of method Equals(object) for arguments of different types: '__longPrm_0', 'e.ReportsTo'. This comparison will always return 'false'."));
+        }
+
+        public override void Where_equals_on_mismatched_types_nullable_long_nullable_int()
+        {
+            base.Where_equals_on_mismatched_types_nullable_long_nullable_int();
+
+            Assert.Equal(
+                @"SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Employees] AS [e]
+WHERE 1 = 0
+
+SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Employees] AS [e]
+WHERE 1 = 0",
+                Sql);
+
+           Assert.True(TestSqlLoggerFactory.Log.Contains(
+                 "Possible unintended use of method Equals(object) for arguments of different types: '__nullableLongPrm_0', 'e.ReportsTo'. This comparison will always return 'false'."));
+
+            Assert.True(TestSqlLoggerFactory.Log.Contains(
+                 "Possible unintended use of method Equals(object) for arguments of different types: 'e.ReportsTo', '__nullableLongPrm_0'. This comparison will always return 'false'."));
+        }
+
+        public override void Where_equals_on_matched_nullable_int_types()
+        {
+            base.Where_equals_on_matched_nullable_int_types();
+
+            Assert.Equal(
+                @"__nullableIntPrm_0: 2
+
+SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Employees] AS [e]
+WHERE @__nullableIntPrm_0 = [e].[ReportsTo]
+
+__nullableIntPrm_0: 2
+
+SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+FROM [Employees] AS [e]
+WHERE [e].[ReportsTo] = @__nullableIntPrm_0",
+                Sql);
+        }
+
         public override void Where_string_length()
         {
             base.Where_string_length();


### PR DESCRIPTION
Issue is for queries that use Equals(object) method for comparison. C# will return false whenever objects of different types are compared using this method, even if the underlying values are identical after conversion to one of the types.
If arguments are nullable (e.g. int?), nullability is ignored for the purpose of the comparison. E.g. 'int?' and 'int' may result in positive comparison, int? and int? as well, int? and long? will always return false.

Fix is to mimic this behavior, as well as log warning that use of Equals(object) on two objects of different types was probably not intentional.
Another fix is in the way we evaluate parameters. Before we if parameter was wrapped in the Convert node, we would evaluate it's type to the type it was converted to. In case of Equals(object), and probably other cases as well, this causes creation of parameters typed as object, which always get evaluated on the client (since we don't know how to translate parameter/constant of type 'object'.

Fix is to evaluate parameters to it's original type, and wrap the parameter into Convert node afterward. This way we preserver the intended typing but given parameters can be evaluated on the server.