### PR TITLE
Use named resources for PCL compat

### DIFF
--- a/src/EntityFramework.Commands/project.json
+++ b/src/EntityFramework.Commands/project.json
@@ -13,6 +13,9 @@
     },
     "compile": "..\\Shared\\*.cs",
     "exclude": "tools\\Handlers.cs",
+    "namedResource": {
+        "EntityFramework.Commands.Strings": "Properties/Strings.resx"
+    },
     "frameworks": {
         "net451": { },
         "dnx451": {

--- a/src/EntityFramework.Core/project.json
+++ b/src/EntityFramework.Core/project.json
@@ -14,6 +14,9 @@
         "System.Collections.Immutable": "1.1.33-beta"
     },
     "compile": "..\\Shared\\*.cs",
+    "namedResource": {
+        "EntityFramework.Core.Strings": "Properties/Strings.resx"
+    },
     "frameworks": {
         "net45": {
             "frameworkAssemblies": {

--- a/src/EntityFramework.InMemory/project.json
+++ b/src/EntityFramework.InMemory/project.json
@@ -8,6 +8,9 @@
         "EntityFramework.Core": "7.0.0-*"
     },
     "compile": "..\\Shared\\*.cs",
+    "namedResource": {
+        "EntityFramework.InMemory.Strings": "Properties/Strings.resx"
+    },
     "frameworks": {
         "net45": { },
         "dnx451": { },

--- a/src/EntityFramework.Relational.Design/project.json
+++ b/src/EntityFramework.Relational.Design/project.json
@@ -9,6 +9,9 @@
         "EntityFramework.Relational": "7.0.0-*"
     },
     "compile": "..\\Shared\\*.cs",
+    "namedResource": {
+        "EntityFramework.Relational.Design.Strings": "Properties/Strings.resx"
+    },
     "frameworks": {
         "net451": {
             "frameworkAssemblies": {

--- a/src/EntityFramework.Relational/project.json
+++ b/src/EntityFramework.Relational/project.json
@@ -8,6 +8,9 @@
         "EntityFramework.Core": "7.0.0-*"
     },
     "compile": "..\\Shared\\*.cs",
+    "namedResource": {
+        "EntityFramework.Relational.Strings": "Properties/Strings.resx"
+    },
     "frameworks": {
         "net451": {
             "frameworkAssemblies": {

--- a/src/EntityFramework.SqlServer.Design/project.json
+++ b/src/EntityFramework.SqlServer.Design/project.json
@@ -9,6 +9,9 @@
         "EntityFramework.SqlServer": "7.0.0-*"
     },
     "compile": "..\\Shared\\*.cs",
+    "namedResource": {
+        "EntityFramework.SqlServer.Design.Strings": "Properties/Strings.resx"
+    },
     "frameworks": {
         "net451": { },
         "dnx451": { },

--- a/src/EntityFramework.SqlServer/project.json
+++ b/src/EntityFramework.SqlServer/project.json
@@ -8,6 +8,9 @@
         "EntityFramework.Relational": "7.0.0-*"
     },
     "compile": "..\\Shared\\*.cs",
+    "namedResource": {
+        "EntityFramework.SqlServer.Strings": "Properties/Strings.resx"
+    },
     "frameworks": {
         "net451": { },
         "dnx451": { },


### PR DESCRIPTION
The names of the embedded resources emitted by the compiler changed.

For EF, instead of emitting
`EntityFramework.Commands.Strings.resource`, it emits `EntityFramework.Commands.Properties.Strings`. Using named resources, we can tell it to emit the expected name.

In response to:  https://github.com/aspnet/dnx/pull/1615

cc @davidfowl 
