### PR TITLE
Bring back SQLite (Resolves #1953)

### DIFF
--- a/EntityFramework.sln
+++ b/EntityFramework.sln
@@ -53,6 +53,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EntityFramework.Relational.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EntityFramework.SqlServer.Design.Tests", "test\EntityFramework.SqlServer.Design.Tests\EntityFramework.SqlServer.Design.Tests.csproj", "{AC579BD1-6646-4A68-8C49-60E36EFF20A1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EntityFramework.Sqlite", "src\EntityFramework.Sqlite\EntityFramework.Sqlite.csproj", "{E340807B-ECBB-41DF-A164-23FE833C76DE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EntityFramework.Sqlite.Tests", "test\EntityFramework.Sqlite.Tests\EntityFramework.Sqlite.Tests.csproj", "{4E8D7833-A710-41A9-BD77-DF985D41857C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -151,6 +155,14 @@ Global
 		{AC579BD1-6646-4A68-8C49-60E36EFF20A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AC579BD1-6646-4A68-8C49-60E36EFF20A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AC579BD1-6646-4A68-8C49-60E36EFF20A1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E340807B-ECBB-41DF-A164-23FE833C76DE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E340807B-ECBB-41DF-A164-23FE833C76DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E340807B-ECBB-41DF-A164-23FE833C76DE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E340807B-ECBB-41DF-A164-23FE833C76DE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4E8D7833-A710-41A9-BD77-DF985D41857C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4E8D7833-A710-41A9-BD77-DF985D41857C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4E8D7833-A710-41A9-BD77-DF985D41857C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4E8D7833-A710-41A9-BD77-DF985D41857C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -179,5 +191,7 @@ Global
 		{9AFDF1FA-1710-48E3-9802-7AB9DAC91B35} = {35BED7DE-CA6F-41EA-91E3-25CA7295C7B9}
 		{A8B8291A-2E63-48DC-A19E-41AF9E50F22D} = {547020C0-976F-4542-81CE-7FD465595614}
 		{AC579BD1-6646-4A68-8C49-60E36EFF20A1} = {547020C0-976F-4542-81CE-7FD465595614}
+		{E340807B-ECBB-41DF-A164-23FE833C76DE} = {35BED7DE-CA6F-41EA-91E3-25CA7295C7B9}
+		{4E8D7833-A710-41A9-BD77-DF985D41857C} = {547020C0-976F-4542-81CE-7FD465595614}
 	EndGlobalSection
 EndGlobal

--- a/makefile.shade
+++ b/makefile.shade
@@ -14,6 +14,9 @@ k-standard-goals
   for each='var projectFile in Files.Include("src/**/*.csproj").Include("test/**/*.csproj")'
     exec program='${buildProgram}' commandline='${projectFile} /t:WritePackageReferences /v:m /nologo /p:Configuration=${E("Configuration")}'
 
+#nuget-restore target='initialize' if='!IsMono && !IsTeamCity'
+  exec-clr program='.nuget/NuGet.exe' commandline='restore EntityFramework.sln'
+
 @{
     var packagesDir = Environment.GetEnvironmentVariable("DNX_PACKAGES")
         ?? Path.Combine(

--- a/src/EntityFramework.Relational/RelationalDataStoreCreator.cs
+++ b/src/EntityFramework.Relational/RelationalDataStoreCreator.cs
@@ -12,23 +12,54 @@ namespace Microsoft.Data.Entity.Relational
     {
         public abstract bool Exists();
 
-        public abstract Task<bool> ExistsAsync(CancellationToken cancellationToken = default(CancellationToken));
+        public virtual Task<bool> ExistsAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return Task.FromResult(Exists());
+        }
 
         public abstract void Create();
 
-        public abstract Task CreateAsync(CancellationToken cancellationToken = default(CancellationToken));
+        public virtual Task CreateAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            Create();
+
+            return Task.FromResult(0);
+        }
 
         public abstract void Delete();
 
-        public abstract Task DeleteAsync(CancellationToken cancellationToken = default(CancellationToken));
+        public virtual Task DeleteAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            Delete();
+
+            return Task.FromResult(0);
+        }
 
         public abstract void CreateTables(IModel model);
 
-        public abstract Task CreateTablesAsync(IModel model, CancellationToken cancellationToken = default(CancellationToken));
+        public virtual Task CreateTablesAsync(IModel model, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            CreateTables(model);
+
+            return Task.FromResult(0);
+        }
 
         public abstract bool HasTables();
 
-        public abstract Task<bool> HasTablesAsync(CancellationToken cancellationToken = default(CancellationToken));
+        public virtual Task<bool> HasTablesAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return Task.FromResult(HasTables());
+        }
 
         public virtual bool EnsureDeleted(IModel model)
         {

--- a/src/EntityFramework.Relational/RelationalDatabase.cs
+++ b/src/EntityFramework.Relational/RelationalDatabase.cs
@@ -13,11 +13,11 @@ using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.Relational
 {
-    public abstract class RelationalDatabase : Database, IAccessor<IMigrator>
+    public class RelationalDatabase : Database, IAccessor<IMigrator>
     {
         private readonly IMigrator _migrator;
 
-        protected RelationalDatabase(
+        public RelationalDatabase(
             [NotNull] DbContext context,
             [NotNull] IRelationalDataStoreCreator dataStoreCreator,
             [NotNull] IRelationalConnection connection,
@@ -54,23 +54,23 @@ namespace Microsoft.Data.Entity.Relational
 
         public virtual void CreateTables() => RelationalDataStoreCreator.CreateTables(Model);
 
-        public virtual Task CreateTablesAsync(CancellationToken cancellationToken = default(CancellationToken)) 
+        public virtual Task CreateTablesAsync(CancellationToken cancellationToken = default(CancellationToken))
             => RelationalDataStoreCreator.CreateTablesAsync(Model, cancellationToken);
 
         public virtual void Delete() => RelationalDataStoreCreator.Delete();
 
-        public virtual Task DeleteAsync(CancellationToken cancellationToken = default(CancellationToken)) 
+        public virtual Task DeleteAsync(CancellationToken cancellationToken = default(CancellationToken))
             => RelationalDataStoreCreator.DeleteAsync(cancellationToken);
 
-        public virtual bool Exists() 
+        public virtual bool Exists()
             => RelationalDataStoreCreator.Exists();
 
-        public virtual Task<bool> ExistsAsync(CancellationToken cancellationToken = default(CancellationToken)) 
+        public virtual Task<bool> ExistsAsync(CancellationToken cancellationToken = default(CancellationToken))
             => RelationalDataStoreCreator.ExistsAsync(cancellationToken);
 
         public virtual bool HasTables() => RelationalDataStoreCreator.HasTables();
 
-        public virtual Task<bool> HasTablesAsync(CancellationToken cancellationToken = default(CancellationToken)) 
+        public virtual Task<bool> HasTablesAsync(CancellationToken cancellationToken = default(CancellationToken))
             => RelationalDataStoreCreator.HasTablesAsync(cancellationToken);
 
         private IRelationalDataStoreCreator RelationalDataStoreCreator => (IRelationalDataStoreCreator)((IAccessor<IDataStoreCreator>)this).Service;

--- a/src/EntityFramework.Sqlite/EntityFramework.Sqlite.csproj
+++ b/src/EntityFramework.Sqlite/EntityFramework.Sqlite.csproj
@@ -1,0 +1,141 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="..\..\tools\EntityFramework.props" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{E340807B-ECBB-41DF-A164-23FE833C76DE}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Microsoft.Data.Entity.Sqlite</RootNamespace>
+    <AssemblyName>EntityFramework.Sqlite</AssemblyName>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TargetFrameworkProfile>Profile7</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Data.Common">
+      <TargetFramework>portable-wpa81+wp80+win80+net45+aspnetcore50</TargetFramework>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Data.Sqlite" />
+    <PackageReference Include="Microsoft.Framework.DependencyInjection" />
+    <PackageReference Include="Microsoft.Framework.DependencyInjection.Interfaces" />
+    <PackageReference Include="Microsoft.Framework.Logging.Interfaces" />
+    <PackageReference Include="Remotion.Linq">
+      <TargetFramework>portable-net45+win+wpa81+wp80</TargetFramework>
+    </PackageReference>
+    <ProjectReference Include="..\EntityFramework.Core\EntityFramework.Core.csproj">
+      <Project>{71415cec-8111-4c73-8751-512d22f10602}</Project>
+      <Name>EntityFramework.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\EntityFramework.Relational\EntityFramework.Relational.csproj">
+      <Project>{75c5a774-a3f3-43eb-97d3-dbe0cf2825d8}</Project>
+      <Name>EntityFramework.Relational</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\tools\Resources.cs">
+      <Link>Properties\Resources.cs</Link>
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>Resources.tt</DependentUpon>
+    </Compile>
+    <Compile Include="..\Shared\Check.cs">
+      <Link>Utilities\Check.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\SharedTypeExtensions.cs">
+      <Link>Extensions\SharedTypeExtensions.cs</Link>
+    </Compile>
+    <Compile Include="Extensions\SqliteDbContextOptionsBuilderExtensions.cs" />
+    <Compile Include="Extensions\SqliteEntityFrameworkServicesBuilderExtensions.cs" />
+    <Compile Include="ISqliteConnection.cs" />
+    <Compile Include="ISqliteDatabaseFactory.cs" />
+    <Compile Include="ISqliteDataStore.cs" />
+    <Compile Include="ISqliteDataStoreCreator.cs" />
+    <Compile Include="ISqliteDataStoreServices.cs" />
+    <Compile Include="ISqliteTypeMapper.cs" />
+    <Compile Include="Metadata\SqliteModelBuilderFactory.cs" />
+    <Compile Include="Migrations\ISqliteHistoryRepository.cs" />
+    <Compile Include="Migrations\ISqliteMigrationSqlGenerator.cs" />
+    <Compile Include="Metadata\ISqliteModelBuilderFactory.cs" />
+    <Compile Include="Migrations\ISqliteModelDiffer.cs" />
+    <Compile Include="ISqliteModelSource.cs" />
+    <Compile Include="Query\ISqliteQueryContextFactory.cs" />
+    <Compile Include="ISqliteSqlGenerator.cs" />
+    <Compile Include="Migrations\SqliteHistoryRepository.cs" />
+    <Compile Include="Migrations\SqliteMigrationSqlGenerator.cs" />
+    <Compile Include="Migrations\SqliteModelDiffer.cs" />
+    <Compile Include="Query\ISqliteValueReaderFactoryFactory.cs" />
+    <Compile Include="Query\SqliteQueryCompilationContext.cs" />
+    <Compile Include="Query\SqliteQueryContextFactory.cs" />
+    <Compile Include="Query\SqliteQueryGenerator.cs" />
+    <Compile Include="Query\SqliteValueReaderFactory.cs" />
+    <Compile Include="Query\SqliteValueReaderFactoryFactory.cs" />
+    <Compile Include="SqliteDatabaseFactory.cs" />
+    <Compile Include="SqliteDataStoreConnection.cs" />
+    <Compile Include="SqliteDataStoreCreator.cs" />
+    <Compile Include="SqliteModelSource.cs" />
+    <Compile Include="SqliteSqlGenerator.cs" />
+    <Compile Include="SqliteTypeMapper.cs" />
+    <Compile Include="Update\ISqliteBatchExecutor.cs" />
+    <Compile Include="Update\ISqliteCommandBatchPreparer.cs" />
+    <Compile Include="Update\ISqliteModificationCommandBatchFactory.cs" />
+    <Compile Include="Update\SqliteBatchExecutor.cs" />
+    <Compile Include="Update\SqliteModificationCommandBatch.cs" />
+    <Compile Include="Update\SqliteCommandBatchPreparer.cs" />
+    <Compile Include="Update\SqliteModificationCommandBatchFactory.cs" />
+    <Compile Include="ValueGeneration\ISqliteValueGeneratorCache.cs" />
+    <Compile Include="ValueGeneration\ISqliteValueGeneratorSelector.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\InternalsVisibleTo.cs" />
+    <Compile Include="..\Shared\CodeAnnotations.cs">
+      <Link>Utilities\CodeAnnotations.cs</Link>
+    </Compile>
+    <Compile Include="SqliteDataStore.cs" />
+    <Compile Include="SqliteDataStoreServices.cs" />
+    <Compile Include="SqliteDataStoreSource.cs" />
+    <Compile Include="SqliteOptionsExtension.cs" />
+    <Compile Include="ValueGeneration\SqliteValueGeneratorCache.cs" />
+    <Compile Include="ValueGeneration\SqliteValueGeneratorSelector.cs" />
+    <Content Include="..\..\tools\Resources.tt">
+      <Link>Properties\Resources.tt</Link>
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>Resources.cs</LastGenOutput>
+    </Content>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/EntityFramework.Sqlite/EntityFramework.Sqlite.xproj
+++ b/src/EntityFramework.Sqlite/EntityFramework.Sqlite.xproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>bbc614fd-9b0b-41d1-9eb5-eff6f375161d</ProjectGuid>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/EntityFramework.Sqlite/Extensions/SqliteDbContextOptionsBuilderExtensions.cs
+++ b/src/EntityFramework.Sqlite/Extensions/SqliteDbContextOptionsBuilderExtensions.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Data.Common;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Relational;
+using Microsoft.Data.Entity.Sqlite;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity
+{
+    public static class SqliteDbContextOptionsBuilderExtensions
+    {
+        public static RelationalDbContextOptionsBuilder UseSqlite([NotNull] this DbContextOptionsBuilder options, [NotNull] string connectionString)
+        {
+            Check.NotNull(options, nameof(options));
+            Check.NotEmpty(connectionString, nameof(connectionString));
+
+            var extension = GetOrCreateExtension(options);
+            extension.ConnectionString = connectionString;
+            ((IOptionsBuilderExtender)options).AddOrUpdateExtension(extension);
+
+            return new RelationalDbContextOptionsBuilder(options);
+        }
+
+        public static RelationalDbContextOptionsBuilder UseSqlite([NotNull] this DbContextOptionsBuilder options, [NotNull] DbConnection connection)
+        {
+            Check.NotNull(options, nameof(options));
+            Check.NotNull(connection, nameof(connection));
+
+            var extension = GetOrCreateExtension(options);
+            extension.Connection = connection;
+            ((IOptionsBuilderExtender)options).AddOrUpdateExtension(extension);
+
+            return new RelationalDbContextOptionsBuilder(options);
+        }
+
+        private static SqliteOptionsExtension GetOrCreateExtension(DbContextOptionsBuilder options)
+        {
+            var existingExtension = options.Options.FindExtension<SqliteOptionsExtension>();
+
+            return existingExtension != null
+                ? new SqliteOptionsExtension(existingExtension)
+                : new SqliteOptionsExtension();
+        }
+    }
+}

--- a/src/EntityFramework.Sqlite/Extensions/SqliteEntityFrameworkServicesBuilderExtensions.cs
+++ b/src/EntityFramework.Sqlite/Extensions/SqliteEntityFrameworkServicesBuilderExtensions.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Relational;
+using Microsoft.Data.Entity.Sqlite;
+using Microsoft.Data.Entity.Sqlite.Metadata;
+using Microsoft.Data.Entity.Sqlite.Migrations;
+using Microsoft.Data.Entity.Sqlite.Query;
+using Microsoft.Data.Entity.Sqlite.Update;
+using Microsoft.Data.Entity.Sqlite.ValueGeneration;
+using Microsoft.Data.Entity.Storage;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Framework.DependencyInjection
+{
+    public static class SqliteEntityFrameworkServicesBuilderExtensions
+    {
+        public static EntityFrameworkServicesBuilder AddSqlite([NotNull] this EntityFrameworkServicesBuilder services)
+        {
+            Check.NotNull(services, nameof(services));
+
+            ((IAccessor<IServiceCollection>)services.AddRelational()).Service
+                .AddSingleton<IDataStoreSource, SqliteDataStoreSource>()
+                .TryAdd(new ServiceCollection()
+                    .AddSingleton<ISqliteModelBuilderFactory, SqliteModelBuilderFactory>()
+                    .AddSingleton<ISqliteValueGeneratorCache, SqliteValueGeneratorCache>()
+                    .AddSingleton<ISqliteSqlGenerator, SqliteSqlGenerator>()
+                    .AddScoped<ISqlStatementExecutor, SqlStatementExecutor>()
+                    .AddScoped<ISqliteTypeMapper, SqliteTypeMapper>()
+                    .AddSingleton<ISqliteModificationCommandBatchFactory, SqliteModificationCommandBatchFactory>()
+                    .AddScoped<ISqliteCommandBatchPreparer, SqliteCommandBatchPreparer>()
+                    .AddSingleton<ISqliteModelSource, SqliteModelSource>()
+                    .AddSingleton<ISqliteValueReaderFactoryFactory, SqliteValueReaderFactoryFactory>()
+                    .AddScoped<ISqliteQueryContextFactory, SqliteQueryContextFactory>()
+                    .AddScoped<ISqliteValueGeneratorSelector, SqliteValueGeneratorSelector>()
+                    .AddScoped<ISqliteBatchExecutor, SqliteBatchExecutor>()
+                    .AddScoped<ISqliteDataStoreServices, SqliteDataStoreServices>()
+                    .AddScoped<ISqliteDataStore, SqliteDataStore>()
+                    .AddScoped<ISqliteConnection, SqliteDataStoreConnection>()
+                    .AddScoped<ISqliteModelDiffer, SqliteModelDiffer>()
+                    .AddScoped<ISqliteDatabaseFactory, SqliteDatabaseFactory>()
+                    .AddScoped<ISqliteMigrationSqlGenerator, SqliteMigrationSqlGenerator>()
+                    .AddScoped<ISqliteDataStoreCreator, SqliteDataStoreCreator>()
+                    .AddScoped<ISqliteHistoryRepository, SqliteHistoryRepository>());
+
+            return services;
+        }
+    }
+}

--- a/src/EntityFramework.Sqlite/ISqliteConnection.cs
+++ b/src/EntityFramework.Sqlite/ISqliteConnection.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Relational;
+
+namespace Microsoft.Data.Entity.Sqlite
+{
+    public interface ISqliteConnection : IRelationalConnection
+    {
+    }
+}

--- a/src/EntityFramework.Sqlite/ISqliteDataStore.cs
+++ b/src/EntityFramework.Sqlite/ISqliteDataStore.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Relational;
+
+namespace Microsoft.Data.Entity.Sqlite
+{
+    public interface ISqliteDataStore : IRelationalDataStore
+    {
+    }
+}

--- a/src/EntityFramework.Sqlite/ISqliteDataStoreCreator.cs
+++ b/src/EntityFramework.Sqlite/ISqliteDataStoreCreator.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Relational;
+
+namespace Microsoft.Data.Entity.Sqlite
+{
+    public interface ISqliteDataStoreCreator : IRelationalDataStoreCreator
+    {
+    }
+}

--- a/src/EntityFramework.Sqlite/ISqliteDataStoreServices.cs
+++ b/src/EntityFramework.Sqlite/ISqliteDataStoreServices.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Relational;
+
+namespace Microsoft.Data.Entity.Sqlite
+{
+    public interface ISqliteDataStoreServices : IRelationalDataStoreServices
+    {
+    }
+}

--- a/src/EntityFramework.Sqlite/ISqliteDatabaseFactory.cs
+++ b/src/EntityFramework.Sqlite/ISqliteDatabaseFactory.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Infrastructure;
+
+namespace Microsoft.Data.Entity.Sqlite
+{
+    public interface ISqliteDatabaseFactory : IDatabaseFactory
+    {
+    }
+}

--- a/src/EntityFramework.Sqlite/ISqliteModelSource.cs
+++ b/src/EntityFramework.Sqlite/ISqliteModelSource.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Infrastructure;
+
+namespace Microsoft.Data.Entity.Sqlite
+{
+    public interface ISqliteModelSource : IModelSource
+    {
+    }
+}

--- a/src/EntityFramework.Sqlite/ISqliteSqlGenerator.cs
+++ b/src/EntityFramework.Sqlite/ISqliteSqlGenerator.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Relational;
+
+namespace Microsoft.Data.Entity.Sqlite
+{
+    public interface ISqliteSqlGenerator : ISqlGenerator
+    {
+    }
+}

--- a/src/EntityFramework.Sqlite/ISqliteTypeMapper.cs
+++ b/src/EntityFramework.Sqlite/ISqliteTypeMapper.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Relational;
+
+namespace Microsoft.Data.Entity.Sqlite
+{
+    public interface ISqliteTypeMapper : IRelationalTypeMapper
+    {
+    }
+}

--- a/src/EntityFramework.Sqlite/Metadata/ISqliteModelBuilderFactory.cs
+++ b/src/EntityFramework.Sqlite/Metadata/ISqliteModelBuilderFactory.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Metadata.Builders;
+
+namespace Microsoft.Data.Entity.Sqlite.Metadata
+{
+    public interface ISqliteModelBuilderFactory : IModelBuilderFactory
+    {
+    }
+}

--- a/src/EntityFramework.Sqlite/Metadata/SqliteModelBuilderFactory.cs
+++ b/src/EntityFramework.Sqlite/Metadata/SqliteModelBuilderFactory.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Metadata.Builders;
+
+namespace Microsoft.Data.Entity.Sqlite.Metadata
+{
+    public class SqliteModelBuilderFactory : ModelBuilderFactory, ISqliteModelBuilderFactory
+    {
+    }
+}

--- a/src/EntityFramework.Sqlite/Migrations/ISqliteHistoryRepository.cs
+++ b/src/EntityFramework.Sqlite/Migrations/ISqliteHistoryRepository.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Relational.Migrations.History;
+
+namespace Microsoft.Data.Entity.Sqlite.Migrations
+{
+    public interface ISqliteHistoryRepository : IHistoryRepository
+    {
+    }
+}

--- a/src/EntityFramework.Sqlite/Migrations/ISqliteMigrationSqlGenerator.cs
+++ b/src/EntityFramework.Sqlite/Migrations/ISqliteMigrationSqlGenerator.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Relational.Migrations.Sql;
+
+namespace Microsoft.Data.Entity.Sqlite.Migrations
+{
+    public interface ISqliteMigrationSqlGenerator : IMigrationSqlGenerator
+    {
+    }
+}

--- a/src/EntityFramework.Sqlite/Migrations/ISqliteModelDiffer.cs
+++ b/src/EntityFramework.Sqlite/Migrations/ISqliteModelDiffer.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Relational.Migrations.Infrastructure;
+
+namespace Microsoft.Data.Entity.Sqlite.Migrations
+{
+    public interface ISqliteModelDiffer : IModelDiffer
+    {
+    }
+}

--- a/src/EntityFramework.Sqlite/Migrations/SqliteHistoryRepository.cs
+++ b/src/EntityFramework.Sqlite/Migrations/SqliteHistoryRepository.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Data.Entity.Relational.Migrations.History;
+using Microsoft.Data.Entity.Relational.Migrations.Operations;
+
+namespace Microsoft.Data.Entity.Sqlite.Migrations
+{
+    public class SqliteHistoryRepository : ISqliteHistoryRepository
+    {
+        public virtual string BeginIfExists(string migrationId)
+        {
+            throw new NotImplementedException();
+        }
+
+        public virtual string BeginIfNotExists(string migrationId)
+        {
+            throw new NotImplementedException();
+        }
+
+        public virtual string Create(bool ifNotExists)
+        {
+            throw new NotImplementedException();
+        }
+
+        public virtual string EndIf()
+        {
+            throw new NotImplementedException();
+        }
+
+        public virtual bool Exists()
+        {
+            throw new NotImplementedException();
+        }
+
+        public virtual IReadOnlyList<IHistoryRow> GetAppliedMigrations()
+        {
+            throw new NotImplementedException();
+        }
+
+        public virtual MigrationOperation GetDeleteOperation(string migrationId)
+        {
+            throw new NotImplementedException();
+        }
+
+        public virtual MigrationOperation GetInsertOperation(IHistoryRow row)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/EntityFramework.Sqlite/Migrations/SqliteMigrationSqlGenerator.cs
+++ b/src/EntityFramework.Sqlite/Migrations/SqliteMigrationSqlGenerator.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Relational;
+using Microsoft.Data.Entity.Relational.Migrations.Operations;
+using Microsoft.Data.Entity.Relational.Migrations.Sql;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Sqlite.Migrations
+{
+    public class SqliteMigrationSqlGenerator : MigrationSqlGenerator, ISqliteMigrationSqlGenerator
+    {
+        private readonly ISqliteSqlGenerator _sql;
+
+        public SqliteMigrationSqlGenerator(
+            [NotNull] ISqliteSqlGenerator sqlGenerator)
+            : base(sqlGenerator)
+        {
+            _sql = sqlGenerator;
+        }
+
+        public override void Generate(DropIndexOperation operation, IModel model, SqlBatchBuilder builder)
+        {
+            Check.NotNull(operation, nameof(operation));
+            Check.NotNull(builder, nameof(builder));
+
+            builder
+                .Append("DROP INDEX ")
+                .Append(_sql.DelimitIdentifier(operation.Name));
+        }
+
+        public override void Generate(RenameSequenceOperation operation, IModel model, SqlBatchBuilder builder)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Generate(RenameColumnOperation operation, IModel model, SqlBatchBuilder builder)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Generate(RenameTableOperation operation, IModel model, SqlBatchBuilder builder)
+        {
+            Check.NotNull(operation, nameof(operation));
+            Check.NotNull(builder, nameof(builder));
+
+            builder
+                .Append("ALTER TABLE ")
+                .Append(_sql.DelimitIdentifier(operation.Name))
+                .Append(" RENAME TO ")
+                .Append(_sql.DelimitIdentifier(operation.NewName));
+        }
+
+        public override void Generate(RenameIndexOperation operation, IModel model, SqlBatchBuilder builder)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Generate(AlterColumnOperation operation, IModel model, SqlBatchBuilder builder)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/EntityFramework.Sqlite/Migrations/SqliteModelDiffer.cs
+++ b/src/EntityFramework.Sqlite/Migrations/SqliteModelDiffer.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Relational.Migrations.Infrastructure;
+
+namespace Microsoft.Data.Entity.Sqlite.Migrations
+{
+    public class SqliteModelDiffer : ModelDiffer, ISqliteModelDiffer
+    {
+        public SqliteModelDiffer([NotNull] ISqliteTypeMapper typeMapper)
+            : base(typeMapper)
+        {
+        }
+    }
+}

--- a/src/EntityFramework.Sqlite/Properties/AssemblyInfo.cs
+++ b/src/EntityFramework.Sqlite/Properties/AssemblyInfo.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+using System.Resources;
+
+[assembly: NeutralResourcesLanguage("en-US")]
+[assembly: AssemblyMetadata("Serviceable", "True")]

--- a/src/EntityFramework.Sqlite/Properties/InternalsVisibleTo.cs
+++ b/src/EntityFramework.Sqlite/Properties/InternalsVisibleTo.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if !INTERNALS_INVISIBLE
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("EntityFramework.Sqlite.Tests")]
+
+// for Moq
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
+
+#endif

--- a/src/EntityFramework.Sqlite/Query/ISqliteQueryContextFactory.cs
+++ b/src/EntityFramework.Sqlite/Query/ISqliteQueryContextFactory.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Relational.Query;
+
+namespace Microsoft.Data.Entity.Sqlite.Query
+{
+    public interface ISqliteQueryContextFactory : IRelationalQueryContextFactory
+    {
+    }
+}

--- a/src/EntityFramework.Sqlite/Query/ISqliteValueReaderFactoryFactory.cs
+++ b/src/EntityFramework.Sqlite/Query/ISqliteValueReaderFactoryFactory.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Relational;
+
+namespace Microsoft.Data.Entity.Sqlite.Query
+{
+    public interface ISqliteValueReaderFactoryFactory : IRelationalValueReaderFactoryFactory
+    {
+    }
+}

--- a/src/EntityFramework.Sqlite/Query/SqliteQueryCompilationContext.cs
+++ b/src/EntityFramework.Sqlite/Query/SqliteQueryCompilationContext.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.ChangeTracking.Internal;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Metadata.Internal;
+using Microsoft.Data.Entity.Query;
+using Microsoft.Data.Entity.Relational.Query;
+using Microsoft.Data.Entity.Relational.Query.Expressions;
+using Microsoft.Data.Entity.Relational.Query.Methods;
+using Microsoft.Data.Entity.Relational.Query.Sql;
+using Microsoft.Framework.Logging;
+
+namespace Microsoft.Data.Entity.Sqlite.Query
+{
+    public class SqliteQueryCompilationContext : RelationalQueryCompilationContext
+    {
+        public SqliteQueryCompilationContext(
+            [NotNull] IModel model,
+            [NotNull] ILogger logger,
+            [NotNull] ILinqOperatorProvider linqOperatorProvider,
+            [NotNull] IResultOperatorHandler resultOperatorHandler,
+            [NotNull] IEntityMaterializerSource entityMaterializerSource,
+            [NotNull] IEntityKeyFactorySource entityKeyFactorySource,
+            [NotNull] IQueryMethodProvider queryMethodProvider,
+            [NotNull] IMethodCallTranslator methodCallTranslator,
+            [NotNull] ISqliteValueReaderFactoryFactory valueReaderFactoryFactory)
+            : base(
+                  model,
+                  logger,
+                  linqOperatorProvider,
+                  resultOperatorHandler,
+                  entityMaterializerSource,
+                  entityKeyFactorySource,
+                  queryMethodProvider,
+                  methodCallTranslator,
+                  valueReaderFactoryFactory)
+        {
+        }
+
+        public override ISqlQueryGenerator CreateSqlQueryGenerator(SelectExpression selectExpression) =>
+            new SqliteQueryGenerator(selectExpression);
+    }
+}

--- a/src/EntityFramework.Sqlite/Query/SqliteQueryContextFactory.cs
+++ b/src/EntityFramework.Sqlite/Query/SqliteQueryContextFactory.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.ChangeTracking.Internal;
+using Microsoft.Data.Entity.Metadata.Internal;
+using Microsoft.Data.Entity.Relational.Query;
+using Microsoft.Framework.Logging;
+
+namespace Microsoft.Data.Entity.Sqlite.Query
+{
+    public class SqliteQueryContextFactory : RelationalQueryContextFactory, ISqliteQueryContextFactory
+    {
+        public SqliteQueryContextFactory(
+            [NotNull] IStateManager stateManager,
+            [NotNull] IEntityKeyFactorySource entityKeyFactorySource,
+            [NotNull] IClrCollectionAccessorSource collectionAccessorSource,
+            [NotNull] IClrAccessorSource<IClrPropertySetter> propertySetterSource,
+            [NotNull] ISqliteConnection connection,
+            [NotNull] ILoggerFactory loggerFactory)
+            : base(
+                stateManager,
+                entityKeyFactorySource,
+                collectionAccessorSource,
+                propertySetterSource,
+                connection,
+                loggerFactory)
+        {
+        }
+    }
+}

--- a/src/EntityFramework.Sqlite/Query/SqliteQueryGenerator.cs
+++ b/src/EntityFramework.Sqlite/Query/SqliteQueryGenerator.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Relational.Query.Expressions;
+using Microsoft.Data.Entity.Relational.Query.Sql;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Sqlite.Query
+{
+    public class SqliteQueryGenerator : DefaultSqlQueryGenerator
+    {
+        protected override string ConcatOperator => "||";
+
+        public SqliteQueryGenerator([NotNull] SelectExpression selectExpression)
+            : base(selectExpression)
+        {
+        }
+
+        protected override void GenerateTop(SelectExpression selectExpression)
+        {
+            // Handled by GenerateLimitOffset
+        }
+
+        protected override void GenerateLimitOffset(SelectExpression selectExpression)
+        {
+            Check.NotNull(selectExpression, nameof(selectExpression));
+
+            if (selectExpression.Limit != null || selectExpression.Offset != null)
+            {
+                Sql.AppendLine()
+                    .Append("LIMIT ")
+                    .Append(selectExpression.Limit ?? -1);
+
+                if (selectExpression.Offset != null)
+                {
+                    Sql.Append(" OFFSET ")
+                        .Append(selectExpression.Offset);
+                }
+            }
+        }
+    }
+}

--- a/src/EntityFramework.Sqlite/Query/SqliteValueReaderFactory.cs
+++ b/src/EntityFramework.Sqlite/Query/SqliteValueReaderFactory.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Data.Common;
+using Microsoft.Data.Entity.Relational;
+using Microsoft.Data.Entity.Storage;
+
+namespace Microsoft.Data.Entity.Sqlite.Query
+{
+    public class SqliteValueReaderFactory : IRelationalValueReaderFactory
+    {
+        public virtual IValueReader CreateValueReader(DbDataReader dataReader) => new RelationalTypedValueReader(dataReader);
+    }
+}

--- a/src/EntityFramework.Sqlite/Query/SqliteValueReaderFactoryFactory.cs
+++ b/src/EntityFramework.Sqlite/Query/SqliteValueReaderFactoryFactory.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Relational;
+
+namespace Microsoft.Data.Entity.Sqlite.Query
+{
+    public class SqliteValueReaderFactoryFactory : ISqliteValueReaderFactoryFactory
+    {
+        public virtual IRelationalValueReaderFactory CreateValueReaderFactory() => new SqliteValueReaderFactory();
+    }
+}

--- a/src/EntityFramework.Sqlite/SqliteDataStore.cs
+++ b/src/EntityFramework.Sqlite/SqliteDataStore.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.ChangeTracking.Internal;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Metadata.Internal;
+using Microsoft.Data.Entity.Query;
+using Microsoft.Data.Entity.Relational;
+using Microsoft.Data.Entity.Relational.Query;
+using Microsoft.Data.Entity.Relational.Query.Methods;
+using Microsoft.Data.Entity.Sqlite.Query;
+using Microsoft.Data.Entity.Sqlite.Update;
+using Microsoft.Framework.Logging;
+
+namespace Microsoft.Data.Entity.Sqlite
+{
+    public class SqliteDataStore : RelationalDataStore, ISqliteDataStore
+    {
+        public SqliteDataStore(
+            [NotNull] IModel model,
+            [NotNull] IEntityKeyFactorySource entityKeyFactorySource,
+            [NotNull] IEntityMaterializerSource entityMaterializerSource,
+            [NotNull] ISqliteConnection connection,
+            [NotNull] ISqliteCommandBatchPreparer batchPreparer,
+            [NotNull] ISqliteBatchExecutor batchExecutor,
+            [NotNull] IDbContextOptions options,
+            [NotNull] ILoggerFactory loggerFactory,
+            [NotNull] ISqliteValueReaderFactoryFactory valueReaderFactoryFactory)
+            : base(
+                  model,
+                  entityKeyFactorySource,
+                  entityMaterializerSource,
+                  connection,
+                  batchPreparer,
+                  batchExecutor,
+                  options,
+                  loggerFactory,
+                  valueReaderFactoryFactory)
+        {
+        }
+
+        protected override RelationalQueryCompilationContext CreateQueryCompilationContext(
+            ILinqOperatorProvider linqOperatorProvider,
+            IResultOperatorHandler resultOperatorHandler,
+            IQueryMethodProvider queryMethodProvider,
+            IMethodCallTranslator methodCallTranslator) =>
+            new SqliteQueryCompilationContext(
+                Model,
+                Logger,
+                linqOperatorProvider,
+                resultOperatorHandler,
+                EntityMaterializerSource,
+                EntityKeyFactorySource,
+                queryMethodProvider,
+                methodCallTranslator,
+                (ISqliteValueReaderFactoryFactory)ValueReaderFactoryFactory);
+    }
+}

--- a/src/EntityFramework.Sqlite/SqliteDataStoreConnection.cs
+++ b/src/EntityFramework.Sqlite/SqliteDataStoreConnection.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Data.Common;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Relational;
+using Microsoft.Data.Sqlite;
+using Microsoft.Framework.Logging;
+
+namespace Microsoft.Data.Entity.Sqlite
+{
+    public class SqliteDataStoreConnection : RelationalConnection, ISqliteConnection
+    {
+        public SqliteDataStoreConnection([NotNull] IDbContextOptions options, [NotNull] ILoggerFactory loggerFactory)
+            : base(options, loggerFactory)
+        {
+        }
+
+        protected override DbConnection CreateDbConnection() => new SqliteConnection(ConnectionString);
+    }
+}

--- a/src/EntityFramework.Sqlite/SqliteDataStoreCreator.cs
+++ b/src/EntityFramework.Sqlite/SqliteDataStoreCreator.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Relational;
+using Microsoft.Data.Entity.Relational.Migrations.Infrastructure;
+using Microsoft.Data.Entity.Sqlite.Migrations;
+using Microsoft.Data.Entity.Utilities;
+
+#if NET45 || DNX451 || DNXCORE50
+using System.IO;
+#else
+using System;
+using System.Reflection;
+#endif
+
+
+namespace Microsoft.Data.Entity.Sqlite
+{
+    public class SqliteDataStoreCreator : RelationalDataStoreCreator, ISqliteDataStoreCreator
+    {
+        private const int SQLITE_CANTOPEN = 14;
+
+        private readonly ISqliteConnection _connection;
+        private readonly IModelDiffer _modelDiffer;
+        private readonly ISqliteMigrationSqlGenerator _migrationSqlGenerator;
+        private readonly ISqlStatementExecutor _executor;
+
+        public SqliteDataStoreCreator(
+            [NotNull] ISqliteConnection connection,
+            [NotNull] IModelDiffer modelDiffer,
+            [NotNull] ISqliteMigrationSqlGenerator migrationSqlGenerator,
+            [NotNull] ISqlStatementExecutor sqlStatementExecutor)
+        {
+            Check.NotNull(connection, nameof(connection));
+            Check.NotNull(modelDiffer, nameof(modelDiffer));
+            Check.NotNull(migrationSqlGenerator, nameof(migrationSqlGenerator));
+            Check.NotNull(sqlStatementExecutor, nameof(sqlStatementExecutor));
+
+            _connection = connection;
+            _modelDiffer = modelDiffer;
+            _migrationSqlGenerator = migrationSqlGenerator;
+            _executor = sqlStatementExecutor;
+        }
+
+        public override void Create()
+        {
+            _connection.Open();
+            _connection.Close();
+        }
+
+        public override void CreateTables(IModel model)
+        {
+            Check.NotNull(model, nameof(model));
+
+            var operations = _modelDiffer.GetDifferences(null, model);
+            var statements = _migrationSqlGenerator.Generate(operations, model);
+            _executor.ExecuteNonQuery(_connection, null, statements);
+        }
+
+
+        public override bool Exists() => true;
+
+        public override bool HasTables()
+        {
+            var count = (long)_executor.ExecuteScalar(
+                _connection,
+                null,
+                "SELECT COUNT(*) FROM \"sqlite_master\" WHERE \"type\" = 'table' AND \"rootpage\" IS NOT NULL;");
+
+            return count != 0;
+        }
+
+        public override void Delete()
+        {
+            string path = null;
+
+            _connection.Open();
+            try
+            {
+                path = _connection.DbConnection.DataSource;
+                _connection.Close();
+            }
+            catch
+            {
+            }
+
+            if (path != null)
+            {
+#if NET45 || DNX451 || DNXCORE50
+                File.Delete(path);
+#else
+                // TODO: Remove with netcore451
+                Type.GetType("System.IO.File").GetRuntimeMethod("Delete", new[] { typeof(string) }).Invoke(null, new[] { path });
+#endif
+            }
+        }
+    }
+}

--- a/src/EntityFramework.Sqlite/SqliteDataStoreServices.cs
+++ b/src/EntityFramework.Sqlite/SqliteDataStoreServices.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata.Builders;
+using Microsoft.Data.Entity.Query;
+using Microsoft.Data.Entity.Relational;
+using Microsoft.Data.Entity.Relational.Migrations.History;
+using Microsoft.Data.Entity.Relational.Migrations.Infrastructure;
+using Microsoft.Data.Entity.Relational.Migrations.Sql;
+using Microsoft.Data.Entity.Sqlite.Metadata;
+using Microsoft.Data.Entity.Sqlite.Migrations;
+using Microsoft.Data.Entity.Sqlite.Query;
+using Microsoft.Data.Entity.Sqlite.ValueGeneration;
+using Microsoft.Data.Entity.Storage;
+using Microsoft.Data.Entity.Utilities;
+using Microsoft.Data.Entity.ValueGeneration;
+using Microsoft.Framework.DependencyInjection;
+
+namespace Microsoft.Data.Entity.Sqlite
+{
+    public class SqliteDataStoreServices : ISqliteDataStoreServices
+    {
+        private readonly IServiceProvider _services;
+
+        public SqliteDataStoreServices([NotNull] IServiceProvider services)
+        {
+            Check.NotNull(services, nameof(services));
+
+            _services = services;
+        }
+
+        public virtual IDataStoreConnection Connection => _services.GetRequiredService<ISqliteConnection>();
+        public virtual IDataStoreCreator Creator => _services.GetRequiredService<ISqliteDataStoreCreator>();
+        public virtual IDatabaseFactory DatabaseFactory => _services.GetRequiredService<ISqliteDatabaseFactory>();
+        public virtual IHistoryRepository HistoryRepository => _services.GetRequiredService<ISqliteHistoryRepository>();
+        public virtual IMigrationSqlGenerator MigrationSqlGenerator => _services.GetRequiredService<ISqliteMigrationSqlGenerator>();
+        public virtual IModelBuilderFactory ModelBuilderFactory => _services.GetRequiredService<ISqliteModelBuilderFactory>();
+        public virtual IModelDiffer ModelDiffer => _services.GetRequiredService<ISqliteModelDiffer>();
+        public virtual IModelSource ModelSource => _services.GetRequiredService<ISqliteModelSource>();
+        public virtual IQueryContextFactory QueryContextFactory => _services.GetRequiredService<ISqliteQueryContextFactory>();
+        public virtual IRelationalConnection RelationalConnection => _services.GetRequiredService<ISqliteConnection>();
+        public virtual ISqlGenerator SqlGenerator => _services.GetRequiredService<ISqliteSqlGenerator>();
+        public virtual IDataStore Store => _services.GetRequiredService<ISqliteDataStore>();
+        public virtual IValueGeneratorSelector ValueGeneratorSelector => _services.GetRequiredService<ISqliteValueGeneratorSelector>();
+    }
+}

--- a/src/EntityFramework.Sqlite/SqliteDataStoreSource.cs
+++ b/src/EntityFramework.Sqlite/SqliteDataStoreSource.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Storage;
+
+namespace Microsoft.Data.Entity.Sqlite
+{
+    public class SqliteDataStoreSource : DataStoreSource<SqliteDataStore, ISqliteDataStoreServices, SqliteOptionsExtension>
+    {
+        public override void AutoConfigure(DbContextOptionsBuilder optionsBuilder)
+        {
+        }
+    }
+}

--- a/src/EntityFramework.Sqlite/SqliteDatabaseFactory.cs
+++ b/src/EntityFramework.Sqlite/SqliteDatabaseFactory.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Relational;
+using Microsoft.Data.Entity.Relational.Migrations;
+using Microsoft.Data.Entity.Utilities;
+using Microsoft.Framework.Logging;
+
+namespace Microsoft.Data.Entity.Sqlite
+{
+    public class SqliteDatabaseFactory : ISqliteDatabaseFactory
+    {
+        private readonly DbContext _context;
+        private readonly ISqliteDataStoreCreator _dataStoreCreator;
+        private readonly ISqliteConnection _connection;
+        private readonly IMigrator _migrator;
+        private readonly ILoggerFactory _loggerFactory;
+
+        public SqliteDatabaseFactory(
+            [NotNull] DbContext context,
+            [NotNull] ISqliteDataStoreCreator dataStoreCreator,
+            [NotNull] ISqliteConnection connection,
+            [NotNull] IMigrator migrator,
+            [NotNull] ILoggerFactory loggerFactory)
+        {
+            Check.NotNull(context, nameof(context));
+            Check.NotNull(dataStoreCreator, nameof(dataStoreCreator));
+            Check.NotNull(connection, nameof(connection));
+            Check.NotNull(migrator, nameof(migrator));
+            Check.NotNull(loggerFactory, nameof(loggerFactory));
+
+            _context = context;
+            _dataStoreCreator = dataStoreCreator;
+            _connection = connection;
+            _migrator = migrator;
+            _loggerFactory = loggerFactory;
+        }
+
+        public virtual Database CreateDatabase() =>
+            new RelationalDatabase(_context, _dataStoreCreator, _connection, _migrator, _loggerFactory);
+    }
+}

--- a/src/EntityFramework.Sqlite/SqliteModelSource.cs
+++ b/src/EntityFramework.Sqlite/SqliteModelSource.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Internal;
+
+namespace Microsoft.Data.Entity.Sqlite
+{
+    public class SqliteModelSource : ModelSource, ISqliteModelSource
+    {
+        public SqliteModelSource([NotNull] IDbSetFinder setFinder, [NotNull] IModelValidator modelValidator)
+            : base(setFinder, modelValidator)
+        {
+        }
+    }
+}

--- a/src/EntityFramework.Sqlite/SqliteOptionsExtension.cs
+++ b/src/EntityFramework.Sqlite/SqliteOptionsExtension.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Relational;
+using Microsoft.Data.Entity.Utilities;
+using Microsoft.Framework.DependencyInjection;
+
+namespace Microsoft.Data.Entity.Sqlite
+{
+    public class SqliteOptionsExtension : RelationalOptionsExtension
+    {
+        public SqliteOptionsExtension()
+        {
+        }
+
+        public SqliteOptionsExtension([NotNull] SqliteOptionsExtension copyFrom)
+            : base(copyFrom)
+        {
+        }
+
+        public override void ApplyServices(EntityFrameworkServicesBuilder builder)
+        {
+            Check.NotNull(builder, nameof(builder));
+
+            builder.AddSqlite();
+        }
+    }
+}

--- a/src/EntityFramework.Sqlite/SqliteSqlGenerator.cs
+++ b/src/EntityFramework.Sqlite/SqliteSqlGenerator.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Text;
+using Microsoft.Data.Entity.Relational;
+using Microsoft.Data.Entity.Relational.Update;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Sqlite
+{
+    public class SqliteSqlGenerator : SqlGenerator, ISqliteSqlGenerator
+    {
+        protected override void AppendIdentityWhereCondition(StringBuilder builder, ColumnModification columnModification)
+        {
+            Check.NotNull(builder, nameof(builder));
+            Check.NotNull(columnModification, nameof(columnModification));
+
+            builder
+                .Append(DelimitIdentifier(columnModification.ColumnName))
+                .Append(" = ")
+                .Append("last_insert_rowid()");
+        }
+
+        public override void AppendSelectAffectedCountCommand(StringBuilder builder, string tableName, string schemaName)
+        {
+            Check.NotNull(builder, nameof(builder));
+            Check.NotEmpty(tableName, nameof(tableName));
+
+            builder
+                .Append("SELECT changes()")
+                .Append(BatchCommandSeparator)
+                .AppendLine();
+        }
+
+        protected override void AppendRowsAffectedWhereCondition(StringBuilder builder, int expectedRowsAffected)
+        {
+            Check.NotNull(builder, nameof(builder));
+
+            builder.Append("changes() = " + expectedRowsAffected);
+        }
+    }
+}

--- a/src/EntityFramework.Sqlite/SqliteTypeMapper.cs
+++ b/src/EntityFramework.Sqlite/SqliteTypeMapper.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Data;
+using Microsoft.Data.Entity.Relational;
+
+namespace Microsoft.Data.Entity.Sqlite
+{
+    public class SqliteTypeMapper : RelationalTypeMapper, ISqliteTypeMapper
+    {
+        private static readonly RelationalTypeMapping _integer = new RelationalTypeMapping("INTEGER", DbType.Int64);
+        private static readonly RelationalTypeMapping _real = new RelationalTypeMapping("REAL", DbType.Double);
+        private static readonly RelationalTypeMapping _blob = new RelationalTypeMapping("BLOB", DbType.Binary);
+        private static readonly RelationalTypeMapping _text = new RelationalTypeMapping("TEXT", DbType.String);
+
+        public override RelationalTypeMapping GetTypeMapping(
+            string specifiedType,
+            string storageName,
+            Type propertyType,
+            bool isKey,
+            bool isConcurrencyToken)
+        {
+            propertyType = propertyType.UnwrapNullableType();
+
+            if (propertyType == typeof(bool)
+                || propertyType == typeof(byte)
+                || propertyType == typeof(char)
+                || propertyType == typeof(int)
+                || propertyType == typeof(long)
+                || propertyType == typeof(sbyte)
+                || propertyType == typeof(short)
+                || propertyType == typeof(uint)
+                || propertyType == typeof(ulong)
+                || propertyType == typeof(ushort))
+            {
+                return _integer;
+            }
+            else if (propertyType == typeof(byte[])
+                || propertyType == typeof(Guid))
+            {
+                return _blob;
+            }
+            else if (propertyType == typeof(DateTime)
+                || propertyType == typeof(DateTimeOffset)
+                || propertyType == typeof(decimal)
+                || propertyType == typeof(TimeSpan)
+                || propertyType == typeof(string))
+            {
+                return _text;
+            }
+            else if (propertyType == typeof(double)
+                || propertyType == typeof(float))
+            {
+                return _real;
+            }
+
+            throw new NotSupportedException(Strings.UnsupportedType(storageName, propertyType.Name));
+        }
+    }
+}

--- a/src/EntityFramework.Sqlite/Update/ISqliteBatchExecutor.cs
+++ b/src/EntityFramework.Sqlite/Update/ISqliteBatchExecutor.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Relational.Update;
+
+namespace Microsoft.Data.Entity.Sqlite.Update
+{
+    public interface ISqliteBatchExecutor : IBatchExecutor
+    {
+    }
+}

--- a/src/EntityFramework.Sqlite/Update/ISqliteCommandBatchPreparer.cs
+++ b/src/EntityFramework.Sqlite/Update/ISqliteCommandBatchPreparer.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Relational.Update;
+
+namespace Microsoft.Data.Entity.Sqlite.Update
+{
+    public interface ISqliteCommandBatchPreparer : ICommandBatchPreparer
+    {
+    }
+}

--- a/src/EntityFramework.Sqlite/Update/ISqliteModificationCommandBatchFactory.cs
+++ b/src/EntityFramework.Sqlite/Update/ISqliteModificationCommandBatchFactory.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Relational.Update;
+
+namespace Microsoft.Data.Entity.Sqlite.Update
+{
+    public interface ISqliteModificationCommandBatchFactory : IModificationCommandBatchFactory
+    {
+    }
+}

--- a/src/EntityFramework.Sqlite/Update/SqliteBatchExecutor.cs
+++ b/src/EntityFramework.Sqlite/Update/SqliteBatchExecutor.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Relational.Update;
+using Microsoft.Framework.Logging;
+
+namespace Microsoft.Data.Entity.Sqlite.Update
+{
+    public class SqliteBatchExecutor : BatchExecutor, ISqliteBatchExecutor
+    {
+        public SqliteBatchExecutor(
+            [NotNull] ISqliteTypeMapper typeMapper,
+            [NotNull] DbContext context,
+            [NotNull] ILoggerFactory loggerFactory)
+            : base(typeMapper, context, loggerFactory)
+        {
+        }
+    }
+}

--- a/src/EntityFramework.Sqlite/Update/SqliteCommandBatchPreparer.cs
+++ b/src/EntityFramework.Sqlite/Update/SqliteCommandBatchPreparer.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Relational.Metadata;
+using Microsoft.Data.Entity.Relational.Update;
+using Microsoft.Data.Entity.Sqlite.Query;
+
+namespace Microsoft.Data.Entity.Sqlite.Update
+{
+    public class SqliteCommandBatchPreparer : CommandBatchPreparer, ISqliteCommandBatchPreparer
+    {
+        public SqliteCommandBatchPreparer(
+            [NotNull] ISqliteModificationCommandBatchFactory modificationCommandBatchFactory,
+            [NotNull] IParameterNameGeneratorFactory parameterNameGeneratorFactory,
+            [NotNull] IComparer<ModificationCommand> modificationCommandComparer,
+            [NotNull] IBoxedValueReaderSource boxedValueReaderSource,
+            [NotNull] ISqliteValueReaderFactoryFactory valueReaderFactoryFactory)
+            : base(
+                  modificationCommandBatchFactory,
+                  parameterNameGeneratorFactory,
+                  modificationCommandComparer,
+                  boxedValueReaderSource,
+                  valueReaderFactoryFactory)
+        {
+        }
+
+        public override IRelationalEntityTypeExtensions GetEntityTypeExtensions(IEntityType entityType) =>
+            entityType.Relational();
+        public override IRelationalPropertyExtensions GetPropertyExtensions(IProperty property) => property.Relational();
+    }
+}

--- a/src/EntityFramework.Sqlite/Update/SqliteModificationCommandBatch.cs
+++ b/src/EntityFramework.Sqlite/Update/SqliteModificationCommandBatch.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Relational;
+using Microsoft.Data.Entity.Relational.Metadata;
+using Microsoft.Data.Entity.Relational.Update;
+
+namespace Microsoft.Data.Entity.Sqlite.Update
+{
+    public class SqliteModificationCommandBatch : SingularModificationCommandBatch
+    {
+        public SqliteModificationCommandBatch([NotNull] ISqlGenerator sqlGenerator)
+            : base(sqlGenerator)
+        {
+        }
+
+        public override IRelationalPropertyExtensions GetPropertyExtensions(IProperty property) => property.Relational();
+    }
+}

--- a/src/EntityFramework.Sqlite/Update/SqliteModificationCommandBatchFactory.cs
+++ b/src/EntityFramework.Sqlite/Update/SqliteModificationCommandBatchFactory.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Relational.Update;
+
+namespace Microsoft.Data.Entity.Sqlite.Update
+{
+    public class SqliteModificationCommandBatchFactory : ModificationCommandBatchFactory, ISqliteModificationCommandBatchFactory
+    {
+        public SqliteModificationCommandBatchFactory([NotNull] ISqliteSqlGenerator sqlGenerator)
+            : base(sqlGenerator)
+        {
+        }
+
+        public override ModificationCommandBatch Create(IDbContextOptions options) =>
+            new SqliteModificationCommandBatch(SqlGenerator);
+    }
+}

--- a/src/EntityFramework.Sqlite/ValueGeneration/ISqliteValueGeneratorCache.cs
+++ b/src/EntityFramework.Sqlite/ValueGeneration/ISqliteValueGeneratorCache.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.ValueGeneration;
+
+namespace Microsoft.Data.Entity.Sqlite.ValueGeneration
+{
+    public interface ISqliteValueGeneratorCache : IValueGeneratorCache
+    {
+    }
+}

--- a/src/EntityFramework.Sqlite/ValueGeneration/ISqliteValueGeneratorSelector.cs
+++ b/src/EntityFramework.Sqlite/ValueGeneration/ISqliteValueGeneratorSelector.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.ValueGeneration;
+
+namespace Microsoft.Data.Entity.Sqlite.ValueGeneration
+{
+    public interface ISqliteValueGeneratorSelector : IValueGeneratorSelector
+    {
+    }
+}

--- a/src/EntityFramework.Sqlite/ValueGeneration/SqliteValueGeneratorCache.cs
+++ b/src/EntityFramework.Sqlite/ValueGeneration/SqliteValueGeneratorCache.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.ValueGeneration;
+
+namespace Microsoft.Data.Entity.Sqlite.ValueGeneration
+{
+    public class SqliteValueGeneratorCache : ValueGeneratorCache, ISqliteValueGeneratorCache
+    {
+    }
+}

--- a/src/EntityFramework.Sqlite/ValueGeneration/SqliteValueGeneratorSelector.cs
+++ b/src/EntityFramework.Sqlite/ValueGeneration/SqliteValueGeneratorSelector.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Utilities;
+using Microsoft.Data.Entity.ValueGeneration;
+
+namespace Microsoft.Data.Entity.Sqlite.ValueGeneration
+{
+    public class SqliteValueGeneratorSelector : ValueGeneratorSelector, ISqliteValueGeneratorSelector
+    {
+        private readonly ISqliteValueGeneratorCache _cache;
+
+        public SqliteValueGeneratorSelector([NotNull] ISqliteValueGeneratorCache cache)
+        {
+            Check.NotNull(cache, nameof(cache));
+
+            _cache = cache;
+        }
+
+        public override ValueGenerator Select(IProperty property)
+        {
+            Check.NotNull(property, nameof(property));
+
+            return _cache.GetOrAdd(property, Create);
+        }
+    }
+}

--- a/src/EntityFramework.Sqlite/project.json
+++ b/src/EntityFramework.Sqlite/project.json
@@ -1,0 +1,18 @@
+{
+    "version": "7.0.0-*",
+    "description": "SQLite data store for Entity Framework.",
+    "compilationOptions": {
+        "warningsAsErrors": true
+    },
+    "dependencies": {
+        "EntityFramework.Relational": "7.0.0-*",
+        "Microsoft.Data.Sqlite": "1.0.0-*"
+    },
+    "compile": "..\\Shared\\*.cs",
+    "frameworks": {
+        "net451": { },
+        "dnx451": { },
+        "dnxcore50": { },
+        ".NETPortable,Version=v4.5,Profile=Profile7": { }
+    }
+}

--- a/test/EntityFramework.Sqlite.Tests/ApiConsistencyTest.cs
+++ b/test/EntityFramework.Sqlite.Tests/ApiConsistencyTest.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+
+namespace Microsoft.Data.Entity.Sqlite
+{
+    public class ApiConsistencyTest : ApiConsistencyTestBase
+    {
+        protected override Assembly TargetAssembly => typeof(SqliteDataStore).Assembly;
+    }
+}

--- a/test/EntityFramework.Sqlite.Tests/EntityFramework.Sqlite.Tests.csproj
+++ b/test/EntityFramework.Sqlite.Tests/EntityFramework.Sqlite.Tests.csproj
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.core.2.0.0-rc3-build2880\build\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.0.0-rc3-build2880\build\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="..\..\tools\EntityFramework.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{4E8D7833-A710-41A9-BD77-DF985D41857C}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Microsoft.Data.Entity.Sqlite</RootNamespace>
+    <AssemblyName>EntityFramework.Sqlite.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>7ce5139e</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <PackageReference Include="Ix-Async">
+      <TargetFramework>net45</TargetFramework>
+      <Assemblies>System.Interactive.Async</Assemblies>
+    </PackageReference>
+    <PackageReference Include="System.Data.Common">
+      <TargetFramework>net45</TargetFramework>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Data.Sqlite">
+      <TargetFramework>net45</TargetFramework>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Framework.DependencyInjection">
+      <TargetFramework>net45</TargetFramework>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Framework.DependencyInjection.Interfaces">
+      <TargetFramework>net45</TargetFramework>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Framework.Logging">
+      <TargetFramework>net45</TargetFramework>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Framework.Logging.Interfaces">
+      <TargetFramework>net45</TargetFramework>
+    </PackageReference>
+    <PackageReference Include="Moq">
+      <TargetFramework>net40</TargetFramework>
+    </PackageReference>
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.abstractions.2.0.0-rc3-build2880\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.assert, Version=2.0.0.2880, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.assert.2.0.0-rc3-build2880\lib\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.0.0.2880, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.0.0-rc3-build2880\lib\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ApiConsistencyTest.cs" />
+    <Compile Include="Extensions\SqliteDbContextOptionsBuilderExtensionsTest.cs" />
+    <Compile Include="SqliteSqlGeneratorTest.cs" />
+    <None Include="packages.config" />
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\EntityFramework.Core\EntityFramework.Core.csproj">
+      <Project>{71415cec-8111-4c73-8751-512d22f10602}</Project>
+      <Name>EntityFramework.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\EntityFramework.Relational\EntityFramework.Relational.csproj">
+      <Project>{75c5a774-a3f3-43eb-97d3-dbe0cf2825d8}</Project>
+      <Name>EntityFramework.Relational</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\EntityFramework.Sqlite\EntityFramework.Sqlite.csproj">
+      <Project>{e340807b-ecbb-41df-a164-23fe833c76de}</Project>
+      <Name>EntityFramework.Sqlite</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\EntityFramework.Core.FunctionalTests\EntityFramework.Core.FunctionalTests.csproj">
+      <Project>{6ab933c7-de2a-45f2-bdc6-e71a01ef7756}</Project>
+      <Name>EntityFramework.Core.FunctionalTests</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\EntityFramework.Core.Tests\EntityFramework.Core.Tests.csproj">
+      <Project>{ef361118-7d0d-453e-ada4-2f24fbee196c}</Project>
+      <Name>EntityFramework.Core.Tests</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\EntityFramework.Relational.Tests\EntityFramework.Relational.Tests.csproj">
+      <Project>{001005b3-d16f-4399-9265-a67d619652bd}</Project>
+      <Name>EntityFramework.Relational.Tests</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.0.0-rc3-build2880\build\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.0.0-rc3-build2880\build\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/test/EntityFramework.Sqlite.Tests/Extensions/SqliteDbContextOptionsBuilderExtensionsTest.cs
+++ b/test/EntityFramework.Sqlite.Tests/Extensions/SqliteDbContextOptionsBuilderExtensionsTest.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.Data.Sqlite;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Sqlite.Extensions
+{
+    public class SqliteDbContextOptionsBuilderExtensionsTest
+    {
+        [Fact]
+        public void Can_add_extension_with_connection_string()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder();
+            optionsBuilder.UseSqlite("Database=Crunchie");
+
+            var extension = optionsBuilder.Options.Extensions.OfType<SqliteOptionsExtension>().Single();
+
+            Assert.Equal("Database=Crunchie", extension.ConnectionString);
+            Assert.Null(extension.Connection);
+        }
+
+        [Fact]
+        public void Can_add_extension_with_connection_string_using_generic_options()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder<DbContext>();
+            optionsBuilder.UseSqlite("Database=Whisper");
+
+            var extension = optionsBuilder.Options.Extensions.OfType<SqliteOptionsExtension>().Single();
+
+            Assert.Equal("Database=Whisper", extension.ConnectionString);
+            Assert.Null(extension.Connection);
+        }
+
+        [Fact]
+        public void Can_add_extension_with_connection()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder();
+            var connection = new SqliteConnection();
+
+            optionsBuilder.UseSqlite(connection);
+
+            var extension = optionsBuilder.Options.Extensions.OfType<SqliteOptionsExtension>().Single();
+
+            Assert.Same(connection, extension.Connection);
+            Assert.Null(extension.ConnectionString);
+        }
+
+        [Fact]
+        public void Can_add_extension_with_connection_using_generic_options()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder<DbContext>();
+            var connection = new SqliteConnection();
+
+            optionsBuilder.UseSqlite(connection);
+
+            var extension = optionsBuilder.Options.Extensions.OfType<SqliteOptionsExtension>().Single();
+
+            Assert.Same(connection, extension.Connection);
+            Assert.Null(extension.ConnectionString);
+        }
+    }
+}

--- a/test/EntityFramework.Sqlite.Tests/SqliteSqlGeneratorTest.cs
+++ b/test/EntityFramework.Sqlite.Tests/SqliteSqlGeneratorTest.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Relational;
+using Microsoft.Data.Entity.Relational.Tests;
+
+namespace Microsoft.Data.Entity.Sqlite
+{
+    public class SqliteSqlGeneratorTest : SqlGeneratorTestBase
+    {
+        protected override ISqlGenerator CreateSqlGenerator() => new SqliteSqlGenerator();
+        protected override string RowsAffected => "changes()";
+        protected override string Identity => "last_insert_rowid()";
+    }
+}

--- a/test/EntityFramework.Sqlite.Tests/packages.config
+++ b/test/EntityFramework.Sqlite.Tests/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="xunit" version="2.0.0-rc3-build2880" targetFramework="net45" userInstalled="true" />
+  <package id="xunit.abstractions" version="2.0.0-rc3-build2880" targetFramework="net45" userInstalled="true" />
+  <package id="xunit.assert" version="2.0.0-rc3-build2880" targetFramework="net45" userInstalled="true" />
+  <package id="xunit.core" version="2.0.0-rc3-build2880" targetFramework="net45" userInstalled="true" />
+  <package id="xunit.extensibility.core" version="2.0.0-rc3-build2880" targetFramework="net45" userInstalled="true" />
+</packages>

--- a/test/EntityFramework.Sqlite.Tests/project.json
+++ b/test/EntityFramework.Sqlite.Tests/project.json
@@ -1,0 +1,12 @@
+{
+    "dependencies": {
+        "EntityFramework.Relational.Tests": "1.0.0",
+        "EntityFramework.Sqlite": "7.0.0-*"
+    },
+    "commands": {
+        "test": "xunit.runner.aspnet"
+    },
+    "frameworks": {
+        "dnx451": { }
+    }
+}


### PR DESCRIPTION
It's pretty crippled at the moment. Things like `.Count()` don't work because the provider returns a boxed `long` that we try to cast to an `int`. There also seems to be something wrong with the `LIKE` operator (possibly an encoding issue). Migrations isn't implemented (but `.EnsureCreated()` should more-or-less work). ...just to name a few.