### PR TITLE
Fix to #1838 - Query :: implement CLR null semantics for query predicates

### DIFF
--- a/src/EntityFramework.Relational/EntityFramework.Relational.csproj
+++ b/src/EntityFramework.Relational/EntityFramework.Relational.csproj
@@ -149,6 +149,7 @@
     <Compile Include="Query\AsyncQueryMethodProvider.cs" />
     <Compile Include="Query\CommandBuilder.cs" />
     <Compile Include="Query\CommandParameter.cs" />
+    <Compile Include="Query\Expressions\NotNullableExpression.cs" />
     <Compile Include="Query\ExpressionTreeVisitors\CompositeRelationalExpressionTreeVisitor.cs" />
     <Compile Include="Query\ExpressionTreeVisitors\EqualityPredicateExpandingVisitor.cs" />
     <Compile Include="Query\ExpressionTreeVisitors\EqualityPredicateInExpressionOptimizer.cs" />
@@ -163,7 +164,11 @@
     <Compile Include="Query\Expressions\MinExpression.cs" />
     <Compile Include="Query\Expressions\SumExpression.cs" />
     <Compile Include="Query\Expressions\TableExpressionBase.cs" />
+    <Compile Include="Query\ExpressionTreeVisitors\NullableExpressionsExtractingVisitor.cs" />
+    <Compile Include="Query\ExpressionTreeVisitors\NullSemanticsExpressionVisitorBase.cs" />
     <Compile Include="Query\ExpressionTreeVisitors\PredicateNegationExpressionOptimizer.cs" />
+    <Compile Include="Query\ExpressionTreeVisitors\NullSemanticsExpandingVisitor.cs" />
+    <Compile Include="Query\ExpressionTreeVisitors\NullSemanticsOptimizedExpandingVisitor.cs" />
     <Compile Include="Query\ExpressionTreeVisitors\SqlTranslatingExpressionTreeVisitor.cs" />
     <Compile Include="Query\AsyncIncludeCollectionIterator.cs" />
     <Compile Include="Query\ExpressionTreeVisitors\IncludeExpressionTreeVisitor.cs" />
@@ -182,7 +187,6 @@
     <Compile Include="Query\Expressions\ExistsExpression.cs" />
     <Compile Include="Query\Expressions\InnerJoinExpression.cs" />
     <Compile Include="Query\Expressions\CrossJoinExpression.cs" />
-    <Compile Include="Query\Expressions\IsNotNullExpression.cs" />
     <Compile Include="Query\Expressions\IsNullExpression.cs" />
     <Compile Include="Query\Expressions\LikeExpression.cs" />
     <Compile Include="Query\Expressions\LiteralExpression.cs" />

--- a/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/NullSemanticsExpandingVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/NullSemanticsExpandingVisitor.cs
@@ -1,0 +1,525 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using Microsoft.Data.Entity.Relational.Query.Expressions;
+using JetBrains.Annotations;
+using Remotion.Linq.Clauses.Expressions;
+
+namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
+{
+    public class NullSemanticsExpandingVisitor : NullSemanticsExpressionVisitorBase
+    {
+        protected override Expression VisitBinaryExpression(BinaryExpression expression)
+        {
+            var left = VisitExpression(expression.Left);
+            var right = VisitExpression(expression.Right);
+            if (expression.NodeType == ExpressionType.Equal || expression.NodeType == ExpressionType.NotEqual)
+            {
+                var leftNullables = ExtractNullableExpressions(left);
+                var rightNullables = ExtractNullableExpressions(right);
+                var leftNullable = leftNullables.Count > 0;
+                var rightNullable = rightNullables.Count > 0;
+
+                Type conversionResultTypeLeft;
+                Type conversionResultTypeRight;
+                var unwrappedConvertLeft = UnwrapConvertExpression(left, out conversionResultTypeLeft);
+                var unwrappedConvertRight = UnwrapConvertExpression(right, out conversionResultTypeRight);
+
+                var leftUnary = unwrappedConvertLeft as UnaryExpression;
+                var leftNegated = leftUnary != null && leftUnary.NodeType == ExpressionType.Not;
+                var rightUnary = unwrappedConvertRight as UnaryExpression;
+                var rightNegated = rightUnary != null && rightUnary.NodeType == ExpressionType.Not;
+
+                var leftOperand = leftNegated
+                    ? conversionResultTypeLeft == null
+                        ? leftUnary.Operand
+                        : Expression.Convert(leftUnary.Operand, conversionResultTypeLeft)
+                    : left;
+
+                var rightOperand = rightNegated
+                    ? conversionResultTypeRight == null
+                        ? rightUnary.Operand
+                        : Expression.Convert(rightUnary.Operand, conversionResultTypeRight)
+                    : right;
+
+                if (expression.NodeType == ExpressionType.Equal)
+                {
+                    if (leftNullable && rightNullable)
+                    {
+                        if (leftNegated == rightNegated)
+                        {
+                            return ExpandNullableEqualNullable(leftOperand, rightOperand, leftNullables, rightNullables);
+                        }
+
+                        return ExpandNegatedNullableEqualNullable(leftOperand, rightOperand, leftNullables, rightNullables);
+                    }
+
+                    if (leftNullable && !rightNullable)
+                    {
+                        if (leftNegated == rightNegated)
+                        {
+                            return ExpandNullableEqualNonNullable(leftOperand, rightOperand, leftNullables);
+                        }
+
+                        return ExpandNegatedNullableEqualNonNullable(leftOperand, rightOperand, leftNullables);
+                    }
+
+                    if (!leftNullable && rightNullable)
+                    {
+                        if (leftNegated == rightNegated)
+                        {
+                            return ExpandNonNullableEqualNullable(leftOperand, rightOperand, rightNullables);
+                        }
+
+                        return ExpandNegatedNonNullableEqualNullable(leftOperand, rightOperand, rightNullables);
+                    }
+                }
+
+                if (expression.NodeType == ExpressionType.NotEqual)
+                {
+                    if (leftNullable && rightNullable)
+                    {
+                        if (leftNegated == rightNegated)
+                        {
+                            return ExpandNullableNotEqualNullable(leftOperand, rightOperand, leftNullables, rightNullables);
+                        }
+
+                        return ExpandNegatedNullableNotEqualNullable(leftOperand, rightOperand, leftNullables, rightNullables);
+                    }
+
+                    if (leftNullable && !rightNullable)
+                    {
+                        if (leftNegated == rightNegated)
+                        {
+                            return ExpandNullableNotEqualNonNullable(leftOperand, rightOperand, leftNullables);
+                        }
+
+                        return ExpandNegatedNullableNotEqualNonNullable(leftOperand, rightOperand, leftNullables);
+                    }
+
+                    if (!leftNullable && rightNullable)
+                    {
+                        if (leftNegated == rightNegated)
+                        {
+                            return ExpandNonNullableNotEqualNullable(leftOperand, rightOperand, rightNullables);
+                        }
+
+                        return ExpandNegatedNonNullableNotEqualNullable(leftOperand, rightOperand, rightNullables);
+                    }
+                }
+            }
+
+            if (left == expression.Left && right == expression.Right)
+            {
+                return expression;
+            }
+            else
+            {
+                return Expression.MakeBinary(expression.NodeType, left, right);
+            }
+        }
+
+        protected override Expression VisitExtensionExpression(ExtensionExpression expression)
+        {
+            var notNullableExpression = expression as NotNullableExpression;
+            if (notNullableExpression != null)
+            {
+                return expression;
+            }
+
+            return base.VisitExtensionExpression(expression);
+        }
+
+        private Expression UnwrapConvertExpression(Expression expression, out Type conversionResultType)
+        {
+            var unary = expression as UnaryExpression;
+            if (unary != null && unary.NodeType == ExpressionType.Convert)
+            {
+                conversionResultType = unary.Type;
+                return unary.Operand;
+            }
+
+            conversionResultType = null;
+            return expression;
+        }
+
+        private Expression ExpandNullableEqualNullable(
+            Expression left,
+            Expression right,
+            List<Expression> leftNullables,
+            List<Expression> rightNullables)
+        {
+            // ?a == ?b -> [(a == b) && (a != null && b != null)] || (a == null && b == null))
+            //
+            // a | b | F1 = a == b | F2 = (a != null && b != null) | F3 = F1 && F2 | 
+            //   |   |             |                               |               |
+            // 0 | 0 | 1           | 1                             | 1             |
+            // 0 | 1 | 0           | 1                             | 0             |
+            // 0 | N | N           | 0                             | 0             |
+            // 1 | 0 | 0           | 1                             | 0             |
+            // 1 | 1 | 1           | 1                             | 1             |
+            // 1 | N | N           | 0                             | 0             |
+            // N | 0 | N           | 0                             | 0             |
+            // N | 1 | N           | 0                             | 0             |
+            // N | N | N           | 0                             | 0             |
+            //
+            // a | b | F4 = (a == null && b == null) | Final = F3 OR F4 | 
+            //   |   |                               |                  |
+            // 0 | 0 | 0                             | 1 OR 0 = 1       |
+            // 0 | 1 | 0                             | 0 OR 0 = 0       |
+            // 0 | N | 0                             | 0 OR 0 = 0       |
+            // 1 | 0 | 0                             | 0 OR 0 = 0       |
+            // 1 | 1 | 0                             | 1 OR 0 = 1       |
+            // 1 | N | 0                             | 0 OR 0 = 0       |
+            // N | 0 | 0                             | 0 OR 0 = 0       |
+            // N | 1 | 0                             | 0 OR 0 = 0       |
+            // N | N | 1                             | 0 OR 1 = 1       |
+            return new NotNullableExpression(
+                Expression.OrElse(
+                    Expression.AndAlso(
+                        Expression.Equal(left, right),
+                        Expression.AndAlso(
+                            BuildIsNotNullExpression(leftNullables),
+                            BuildIsNotNullExpression(rightNullables)
+                        )
+                    ),
+                    Expression.AndAlso(
+                        BuildIsNullExpression(leftNullables),
+                        BuildIsNullExpression(rightNullables)
+                    )
+                )
+            );
+        }
+
+        private Expression ExpandNegatedNullableEqualNullable(
+            Expression left,
+            Expression right,
+            List<Expression> leftNullables,
+            List<Expression> rightNullables)
+        {
+            // !(?a) == ?b -> [(a != b) && (a != null && b != null)] || (a == null && b == null)
+            //
+            // a | b | F1 = a != b | F2 = (a != null && b != null) | F3 = F1 && F2 | 
+            //   |   |             |                               |               |
+            // 0 | 0 | 0           | 1                             | 0             |
+            // 0 | 1 | 1           | 1                             | 1             |
+            // 0 | N | N           | 0                             | 0             |
+            // 1 | 0 | 1           | 1                             | 1             |
+            // 1 | 1 | 0           | 1                             | 0             |
+            // 1 | N | N           | 0                             | 0             |
+            // N | 0 | N           | 0                             | 0             |
+            // N | 1 | N           | 0                             | 0             |
+            // N | N | N           | 0                             | 0             |
+            //
+            // a | b | F4 = (a == null && b == null) | Final = F3 OR F4 |
+            //   |   |                               |                  |
+            // 0 | 0 | 0                             | 0 OR 0 = 0       |
+            // 0 | 1 | 0                             | 1 OR 0 = 1       |
+            // 0 | N | 0                             | 0 OR 0 = 0       |
+            // 1 | 0 | 0                             | 1 OR 0 = 1       |
+            // 1 | 1 | 0                             | 0 OR 0 = 0       |
+            // 1 | N | 0                             | 0 OR 0 = 0       |
+            // N | 0 | 0                             | 0 OR 0 = 0       |
+            // N | 1 | 0                             | 0 OR 0 = 0       |
+            // N | N | 1                             | 0 OR 1 = 1       |
+            return new NotNullableExpression(
+                Expression.OrElse(
+                    Expression.AndAlso(
+                        Expression.NotEqual(left, right),
+                        Expression.AndAlso(
+                            BuildIsNotNullExpression(leftNullables),
+                            BuildIsNotNullExpression(rightNullables)
+                        )
+                    ),
+                    Expression.AndAlso(
+                        BuildIsNullExpression(leftNullables),
+                        BuildIsNullExpression(rightNullables)
+                    )
+                )
+            );
+        }
+
+        private Expression ExpandNullableEqualNonNullable(
+            Expression left,
+            Expression right,
+            List<Expression> leftNullables)
+        {
+            // ?a == b -> (a == b) && (a != null)
+            //
+            // a | b | F1 = a == b | F2 = (a != null) | Final = F1 && F2 | 
+            //   |   |             |                  |                  |
+            // 0 | 0 | 1           | 1                | 1                |
+            // 0 | 1 | 0           | 1                | 0                |
+            // 1 | 0 | 0           | 1                | 0                |
+            // 1 | 1 | 1           | 1                | 1                |
+            // N | 0 | N           | 0                | 0                |
+            // N | 1 | N           | 0                | 0                |
+            return new NotNullableExpression(
+                Expression.AndAlso(
+                    Expression.Equal(left, right),
+                    BuildIsNotNullExpression(leftNullables)
+                )
+            );
+        }
+
+        private Expression ExpandNegatedNullableEqualNonNullable(
+            Expression left,
+            Expression right,
+            List<Expression> leftNullables)
+        {
+            // !(?a) == b -> (a != b) && (a != null)
+            //
+            // a | b | F1 = a != b | F2 = (a != null) | Final = F1 && F2 | 
+            //   |   |             |                  |                  |
+            // 0 | 0 | 0           | 1                | 0                |
+            // 0 | 1 | 1           | 1                | 1                |
+            // 1 | 0 | 1           | 1                | 1                |
+            // 1 | 1 | 0           | 1                | 0                |
+            // N | 0 | N           | 0                | 0                |
+            // N | 1 | N           | 0                | 0                |
+            return new NotNullableExpression(
+                Expression.AndAlso(
+                    Expression.NotEqual(left, right),
+                    BuildIsNotNullExpression(leftNullables)
+                )
+            );
+        }
+
+        private Expression ExpandNonNullableEqualNullable(
+            Expression left,
+            Expression right,
+            List<Expression> rightNullables)
+        {
+            // a == ?b -> (a == b) && (b != null)
+            //
+            // a | b | F1 = a == b | F2 = (b != null) | Final = F1 && F2 | 
+            //   |   |             |                  |                  |
+            // 0 | 0 | 1           | 1                | 1                |
+            // 0 | 1 | 0           | 1                | 0                |
+            // 0 | N | N           | 0                | 0                |
+            // 1 | 0 | 0           | 1                | 0                |
+            // 1 | 1 | 1           | 1                | 1                |
+            // 1 | N | N           | 0                | 0                |
+            return new NotNullableExpression(
+                Expression.AndAlso(
+                    Expression.Equal(left, right),
+                    BuildIsNotNullExpression(rightNullables)
+                )
+            );
+        }
+
+        private Expression ExpandNegatedNonNullableEqualNullable(
+            Expression left,
+            Expression right,
+            List<Expression> rightNullables)
+        {
+            // !a == ?b -> (a != b) && (b != null)
+            //
+            // a | b | F1 = a != b | F2 = (b != null) | Final = F1 && F2 | 
+            //   |   |             |                  |                  |
+            // 0 | 0 | 0           | 1                | 0                |
+            // 0 | 1 | 1           | 1                | 1                |
+            // 0 | N | N           | 0                | 0                |
+            // 1 | 0 | 1           | 1                | 1                |
+            // 1 | 1 | 0           | 1                | 0                |
+            // 1 | N | N           | 0                | 0                |
+            return new NotNullableExpression(
+                Expression.AndAlso(
+                    Expression.NotEqual(left, right),
+                    BuildIsNotNullExpression(rightNullables)
+                )
+            );
+        }
+
+        private Expression ExpandNullableNotEqualNullable(
+            Expression left,
+            Expression right,
+            List<Expression> leftNullables,
+            List<Expression> rightNullables)
+        {
+            // ?a != ?b -> [(a != b) || (a == null || b == null)] && (a != null || b != null)]
+            //
+            // a | b | F1 = a != b | F2 = (a == null || b == null) | F3 = F1 && F2 | 
+            //   |   |             |                               |               |
+            // 0 | 0 | 0           | 0                             | 0             |
+            // 0 | 1 | 1           | 0                             | 1             |
+            // 0 | N | N           | 1                             | 1             |
+            // 1 | 0 | 1           | 0                             | 1             |
+            // 1 | 1 | 0           | 0                             | 0             |
+            // 1 | N | N           | 1                             | 1             |
+            // N | 0 | N           | 1                             | 1             |
+            // N | 1 | N           | 1                             | 1             |
+            // N | N | N           | 1                             | 1             |
+            //
+            // a | b | F4 = (a != null || b != null) | Final = F3 && F4 | 
+            //   |   |                               |                  |
+            // 0 | 0 | 1                             | 0 && 1 = 0       |
+            // 0 | 1 | 1                             | 1 && 1 = 1       |
+            // 0 | N | 1                             | 1 && 1 = 1       |
+            // 1 | 0 | 1                             | 1 && 1 = 1       |
+            // 1 | 1 | 1                             | 0 && 1 = 0       |
+            // 1 | N | 1                             | 1 && 1 = 1       |
+            // N | 0 | 1                             | 1 && 1 = 1       |
+            // N | 1 | 1                             | 1 && 1 = 1       |
+            // N | N | 0                             | 1 && 0 = 0       |
+            return new NotNullableExpression(
+                Expression.AndAlso(
+                    Expression.OrElse(
+                        Expression.NotEqual(left, right),
+                        Expression.OrElse(
+                            BuildIsNullExpression(leftNullables),
+                            BuildIsNullExpression(rightNullables)
+                        )
+                    ),
+                    Expression.OrElse(
+                        BuildIsNotNullExpression(leftNullables),
+                        BuildIsNotNullExpression(rightNullables)
+                    )
+                )
+            );
+        }
+
+        private Expression ExpandNegatedNullableNotEqualNullable(
+            Expression left,
+            Expression right,
+            List<Expression> leftNullables,
+            List<Expression> rightNullables)
+        {
+            // !(?a) != ?b -> [(a == b) || (a == null || b == null)] && (a != null || b != null)
+            //
+            // a | b | F1 = a == b | F2 = (a == null || b == null) | F3 = F1 || F2 | 
+            //   |   |             |                               |               |
+            // 0 | 0 | 1           | 0                             | 1             | 
+            // 0 | 1 | 0           | 0                             | 0             |
+            // 0 | N | N           | 1                             | 1             |
+            // 1 | 0 | 0           | 0                             | 0             |
+            // 1 | 1 | 1           | 0                             | 1             |
+            // 1 | N | N           | 1                             | 1             |
+            // N | 0 | N           | 1                             | 1             |
+            // N | 1 | N           | 1                             | 1             |
+            // N | N | N           | 1                             | 1             |
+            //
+            // a | b | F4 = (a != null || b != null) | Final = F3 && F4 |
+            //   |   |                               |                  |
+            // 0 | 0 | 1                             | 1 && 1 = 1       |
+            // 0 | 1 | 1                             | 0 && 1 = 0       |
+            // 0 | N | 1                             | 1 && 1 = 1       |
+            // 1 | 0 | 1                             | 0 && 1 = 0       |
+            // 1 | 1 | 1                             | 1 && 1 = 1       |
+            // 1 | N | 1                             | 1 && 1 = 1       |
+            // N | 0 | 1                             | 1 && 1 = 1       |
+            // N | 1 | 1                             | 1 && 1 = 1       |
+            // N | N | 0                             | 1 && 0 = 0       |
+            return new NotNullableExpression(
+                Expression.AndAlso(
+                    Expression.OrElse(
+                        Expression.Equal(left, right),
+                        Expression.OrElse(
+                            BuildIsNullExpression(leftNullables),
+                            BuildIsNullExpression(rightNullables)
+                        )
+                    ),
+                    Expression.OrElse(
+                        BuildIsNotNullExpression(leftNullables),
+                        BuildIsNotNullExpression(rightNullables)
+                    )
+                )
+            );
+        }
+
+        private Expression ExpandNullableNotEqualNonNullable(
+            Expression left,
+            Expression right,
+            List<Expression> leftNullables)
+        {
+            // ?a != b -> (a != b) || (a == null)
+            //
+            // a | b | F1 = a != b | F2 = (a == null) | Final = F1 OR F2 | 
+            //   |   |             |                  |                  |
+            // 0 | 0 | 0           | 0                | 0                |
+            // 0 | 1 | 1           | 0                | 1                |
+            // 1 | 0 | 1           | 0                | 1                |
+            // 1 | 1 | 0           | 0                | 0                |
+            // N | 0 | N           | 1                | 1                |
+            // N | 1 | N           | 1                | 1                |
+            return new NotNullableExpression(
+                Expression.OrElse(
+                    Expression.NotEqual(left, right),
+                    BuildIsNullExpression(leftNullables)
+                )
+            );
+        }
+
+        private Expression ExpandNegatedNullableNotEqualNonNullable(
+            Expression left,
+            Expression right,
+            List<Expression> leftNullables)
+        {
+            // !(?a) != b -> (a == b) || (a == null)
+            //
+            // a | b | F1 = a == b | F2 = (a == null) | F3 = F1 OR F2 | 
+            //   |   |             |                  |               |
+            // 0 | 0 | 1           | 0                | 1             |
+            // 0 | 1 | 0           | 0                | 0             |
+            // 1 | 0 | 0           | 0                | 0             |
+            // 1 | 1 | 1           | 0                | 1             |
+            // N | 0 | N           | 1                | 1             |
+            // N | 1 | N           | 1                | 1             |
+            return new NotNullableExpression(
+                Expression.OrElse(
+                    Expression.Equal(left, right),
+                    BuildIsNullExpression(leftNullables)
+                )
+            );
+        }
+
+        private Expression ExpandNonNullableNotEqualNullable(
+            Expression left,
+            Expression right,
+            List<Expression> rightNullables)
+        {
+            // a != ?b -> (a != b) || (b == null)
+            //
+            // a | b | F1 = a != b | F2 = (b == null) | F3 = F1 OR F2 | 
+            //   |   |             |                  |               |
+            // 0 | 0 | 0           | 0                | 0             |
+            // 0 | 1 | 1           | 0                | 1             |
+            // 0 | N | N           | 1                | 1             |
+            // 1 | 0 | 1           | 0                | 1             |
+            // 1 | 1 | 0           | 0                | 0             |
+            // 1 | N | N           | 1                | 1             |
+            return new NotNullableExpression(
+                Expression.OrElse(
+                    Expression.NotEqual(left, right),
+                    BuildIsNullExpression(rightNullables)
+                )
+            );
+        }
+
+        private Expression ExpandNegatedNonNullableNotEqualNullable(
+            Expression left,
+            Expression right,
+            List<Expression> rightNullables)
+        {
+            // !a != ?b -> (a == b) || (b == null)
+            //
+            // a | b | F1 = a == b | F2 = (b == null) | F3 = F1 OR F2 | 
+            //   |   |             |                  |               |
+            // 0 | 0 | 1           | 0                | 1             |
+            // 0 | 1 | 0           | 0                | 0             |
+            // 0 | N | N           | 1                | 1             |
+            // 1 | 0 | 0           | 0                | 0             |
+            // 1 | 1 | 1           | 0                | 1             |
+            // 1 | N | N           | 1                | 1             |
+            return new NotNullableExpression(
+                Expression.OrElse(
+                    Expression.Equal(left, right),
+                    BuildIsNullExpression(rightNullables)
+                )
+            );
+        }
+    }
+}

--- a/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/NullSemanticsExpressionVisitorBase.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/NullSemanticsExpressionVisitorBase.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using Microsoft.Data.Entity.Relational.Query.Expressions;
+using JetBrains.Annotations;
+using Remotion.Linq.Parsing;
+
+namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
+{
+    public abstract class NullSemanticsExpressionVisitorBase : ExpressionTreeVisitor
+    {
+        protected Expression BuildIsNullExpression(List<Expression> nullableExpressions)
+        {
+            if (nullableExpressions.Count == 0)
+            {
+                return Expression.Constant(false);
+            }
+
+            if (nullableExpressions.Count == 1)
+            {
+                return new IsNullExpression(nullableExpressions[0]);
+            }
+
+            Expression current = new IsNullExpression(nullableExpressions[0]);
+            for (int i = 1; i < nullableExpressions.Count; i++)
+            {
+                current = Expression.OrElse(current, new IsNullExpression(nullableExpressions[i]));
+            }
+
+            return current;
+        }
+
+        protected Expression BuildIsNotNullExpression(List<Expression> nullableExpressions)
+        {
+            if (nullableExpressions.Count == 0)
+            {
+                return Expression.Constant(true);
+            }
+
+            if (nullableExpressions.Count == 1)
+            {
+                return Expression.Not(new IsNullExpression(nullableExpressions[0]));
+            }
+
+            Expression current = nullableExpressions[0];
+            for (int i = 1; i < nullableExpressions.Count; i++)
+            {
+                current = Expression.AndAlso(current, Expression.Not(new IsNullExpression(nullableExpressions[i])));
+            }
+
+            return current;
+        }
+
+        protected List<Expression> ExtractNullableExpressions(Expression expression)
+        {
+            var nullableExpressionsExtractor = new NullableExpressionsExtractingVisitor();
+            nullableExpressionsExtractor.VisitExpression(expression);
+
+            return nullableExpressionsExtractor.NullableExpressions;
+        }
+    }
+}

--- a/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/NullSemanticsOptimizedExpandingVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/NullSemanticsOptimizedExpandingVisitor.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq.Expressions;
+
+namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
+{
+    public class NullSemanticsOptimizedExpandingVisitor : NullSemanticsExpressionVisitorBase
+    {
+        public virtual bool OptimizedExpansionPossible { get; set; }
+
+        public NullSemanticsOptimizedExpandingVisitor()
+        {
+            OptimizedExpansionPossible = true;
+        }
+
+        protected override Expression VisitBinaryExpression(BinaryExpression expression)
+        {
+            var left = VisitExpression(expression.Left);
+            var right = VisitExpression(expression.Right);
+
+            if (!OptimizedExpansionPossible)
+            {
+                return expression;
+            }
+
+            var leftNullables = ExtractNullableExpressions(left);
+            var rightNullables = ExtractNullableExpressions(right);
+            var leftNullable = leftNullables.Count > 0;
+            var rightNullable = rightNullables.Count > 0;
+
+            if (expression.NodeType == ExpressionType.Equal
+                && leftNullable 
+                && rightNullable)
+            {
+                return Expression.OrElse(
+                    Expression.Equal(left, right),
+                    Expression.AndAlso(
+                        BuildIsNullExpression(leftNullables),
+                        BuildIsNullExpression(rightNullables)));
+            }
+
+            if (expression.NodeType == ExpressionType.NotEqual
+                && (leftNullable || rightNullable))
+            {
+                OptimizedExpansionPossible = false;
+            }
+
+            if (left == expression.Left && right == expression.Right)
+            {
+                return expression;
+            }
+            else
+            {
+                return Expression.MakeBinary(expression.NodeType, left, right);
+            }
+        }
+
+        protected override Expression VisitUnaryExpression(UnaryExpression expression)
+        {
+            var operand = VisitExpression(expression.Operand);
+            if (!OptimizedExpansionPossible)
+            {
+                return expression;
+            }
+
+            if (expression.NodeType == ExpressionType.Not)
+            {
+                OptimizedExpansionPossible = false;
+            }
+
+            if (operand == expression.Operand)
+            {
+                return expression;
+            }
+            else
+            {
+                return Expression.MakeUnary(expression.NodeType, operand, expression.Type);
+            }
+        }
+    }
+}

--- a/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/NullableExpressionsExtractingVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/NullableExpressionsExtractingVisitor.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using Microsoft.Data.Entity.Relational.Query.Expressions;
+using Remotion.Linq.Clauses.Expressions;
+using Remotion.Linq.Parsing;
+using JetBrains.Annotations;
+
+namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
+{
+    public class NullableExpressionsExtractingVisitor : ExpressionTreeVisitor
+    {
+        public NullableExpressionsExtractingVisitor()
+        {
+            NullableExpressions = new List<Expression>();
+        }
+
+        public virtual List<Expression> NullableExpressions { get; private set; }
+
+        protected override Expression VisitConstantExpression(ConstantExpression expression)
+        {
+            if (expression.Value == null)
+            {
+                NullableExpressions.Add(expression);
+            }
+
+            return base.VisitConstantExpression(expression);
+        }
+
+        protected override Expression VisitExtensionExpression(ExtensionExpression expression)
+        {
+            var notNullableExpression = expression as NotNullableExpression;
+            if (notNullableExpression != null)
+            {
+                return expression;
+            }
+
+            var columnExpression = expression as ColumnExpression 
+                ?? expression.GetColumnExpression();
+
+            if (columnExpression != null && columnExpression.Property.IsNullable)
+            {
+                NullableExpressions.Add(expression);
+
+                return expression;
+            }
+
+            var isNullExpression = expression as IsNullExpression;
+            if (isNullExpression != null)
+            {
+                return expression;
+            }
+
+            var inExpression = expression as InExpression;
+            if (inExpression != null)
+            {
+                return expression;
+            }
+
+            var caseExpression = expression as CaseExpression;
+            if (caseExpression != null)
+            {
+                // TODO: for now, case expression always returns 0 or 1, therefore it can't be nullable
+                // this will change in the future when we support full expressiveness of case statements
+                return expression;
+            }
+
+            return base.VisitExtensionExpression(expression);
+        }
+    }
+}

--- a/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/PredicateNegationExpressionOptimizer.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/PredicateNegationExpressionOptimizer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
@@ -23,33 +24,66 @@ namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
             [NotNull]BinaryExpression expression)
         {
             var currentExpression = expression;
-            if (currentExpression.NodeType == ExpressionType.Equal 
+            if (currentExpression.NodeType == ExpressionType.Equal
                 || currentExpression.NodeType == ExpressionType.NotEqual)
             {
                 var leftUnary = currentExpression.Left as UnaryExpression;
                 if (leftUnary != null && leftUnary.NodeType == ExpressionType.Not)
                 {
-                    // e.g. !a == b -> a != b
-                    currentExpression = currentExpression.NodeType == ExpressionType.Equal
-                        ? Expression.MakeBinary(
-                            ExpressionType.NotEqual, leftUnary.Operand, currentExpression.Right)
-                        : Expression.MakeBinary(
-                            ExpressionType.Equal, leftUnary.Operand, currentExpression.Right);
+                    var leftNullable = ExtractNullableExpressions(leftUnary.Operand).Count > 0;
+                    var rightNullable = ExtractNullableExpressions(currentExpression.Right).Count > 0;
+
+                    if (!leftNullable && !rightNullable)
+                    {
+                        // e.g. !a == b -> a != b
+                        currentExpression = currentExpression.NodeType == ExpressionType.Equal
+                            ? Expression.MakeBinary(
+                                ExpressionType.NotEqual, leftUnary.Operand, currentExpression.Right)
+                            : Expression.MakeBinary(
+                                ExpressionType.Equal, leftUnary.Operand, currentExpression.Right);
+                    }
                 }
 
                 var rightUnary = currentExpression.Right as UnaryExpression;
                 if (rightUnary != null && rightUnary.NodeType == ExpressionType.Not)
                 {
-                    // e.g. a != !b -> a == b
-                    currentExpression = currentExpression.NodeType == ExpressionType.Equal
+                    var leftNullable = ExtractNullableExpressions(currentExpression.Left).Count > 0;
+                    var rightNullable = ExtractNullableExpressions(rightUnary).Count > 0;
+
+                    if (!leftNullable && !rightNullable)
+                    {
+                        // e.g. a != !b -> a == b
+                        currentExpression = currentExpression.NodeType == ExpressionType.Equal
                         ? Expression.MakeBinary(
                             ExpressionType.NotEqual, currentExpression.Left, rightUnary.Operand)
                         : Expression.MakeBinary(
                             ExpressionType.Equal, currentExpression.Left, rightUnary.Operand);
+                    }
                 }
             }
 
             return base.VisitBinaryExpression(currentExpression);
+        }
+
+        private Expression UnwrapConvert(Expression expression, out Type conversionType)
+        {
+            conversionType = null;
+            var unary = expression as UnaryExpression;
+            if (unary != null && unary.NodeType == ExpressionType.Convert)
+            {
+                conversionType = unary.Type;
+                return unary.Operand;
+            }
+
+            return expression;
+        }
+
+        private List<Expression> ExtractNullableExpressions(Expression expression)
+        {
+            var nullableExpressionsExtractor = new NullableExpressionsExtractingVisitor();
+            nullableExpressionsExtractor.VisitExpression(expression);
+
+            return nullableExpressionsExtractor.NullableExpressions;
         }
 
         protected override Expression VisitUnaryExpression(
@@ -67,6 +101,18 @@ namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
                 var innerBinary = expression.Operand as BinaryExpression;
                 if (innerBinary != null)
                 {
+                    if (innerBinary.NodeType == ExpressionType.Equal 
+                        || innerBinary.NodeType == ExpressionType.NotEqual)
+                    {
+                        // TODO: this is only valid for non-nullable terms, or if null semantics expansion is performed
+                        // if user opts-out of the null semantics, we should not apply this rule
+                        // !(a == b) -> a != b
+                        // !(a != b) -> a == b
+                        return innerBinary.NodeType == ExpressionType.Equal
+                            ? VisitExpression(Expression.NotEqual(innerBinary.Left, innerBinary.Right))
+                            : VisitExpression(Expression.Equal(innerBinary.Left, innerBinary.Right));
+                    }
+
                     if (innerBinary.NodeType == ExpressionType.AndAlso)
                     {
                         // !(a && b) -> !a || !b

--- a/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/SqlTranslatingExpressionTreeVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/SqlTranslatingExpressionTreeVisitor.cs
@@ -188,7 +188,7 @@ namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
                     {
                         return expressionType == ExpressionType.Equal
                             ? (Expression)new IsNullExpression(columnExpression)
-                            : new IsNotNullExpression(columnExpression);
+                            : Expression.Not(new IsNullExpression(columnExpression));
                     }
                 }
             }

--- a/src/EntityFramework.Relational/Query/Expressions/CaseExpression.cs
+++ b/src/EntityFramework.Relational/Query/Expressions/CaseExpression.cs
@@ -38,7 +38,9 @@ namespace Microsoft.Data.Entity.Relational.Query.Expressions
 
         protected override Expression VisitChildren(ExpressionTreeVisitor visitor)
         {
-            return this;
+            var when = visitor.VisitExpression(When);
+
+            return new CaseExpression(when);
         }
     }
 }

--- a/src/EntityFramework.Relational/Query/Expressions/NotNullableExpression.cs
+++ b/src/EntityFramework.Relational/Query/Expressions/NotNullableExpression.cs
@@ -1,21 +1,21 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Linq.Expressions;
-using JetBrains.Annotations;
-using Microsoft.Data.Entity.Relational.Query.Sql;
 using Microsoft.Data.Entity.Utilities;
+using JetBrains.Annotations;
 using Remotion.Linq.Clauses.Expressions;
 using Remotion.Linq.Parsing;
+using Microsoft.Data.Entity.Relational.Query.Sql;
+using System;
 
 namespace Microsoft.Data.Entity.Relational.Query.Expressions
 {
-    public class IsNotNullExpression : ExtensionExpression
+    public class NotNullableExpression : ExtensionExpression
     {
         private readonly Expression _operand;
 
-        public IsNotNullExpression([NotNull] Expression operand)
+        public NotNullableExpression([NotNull] Expression operand)
             : base(Check.NotNull(operand, nameof(operand)).Type)
         {
             _operand = operand;
@@ -26,27 +26,20 @@ namespace Microsoft.Data.Entity.Relational.Query.Expressions
             get { return _operand; }
         }
 
-        public override Expression Accept([NotNull] ExpressionTreeVisitor visitor)
-        {
-            Check.NotNull(visitor, nameof(visitor));
-
-            var specificVisitor = visitor as ISqlExpressionVisitor;
-
-            if (specificVisitor != null)
-            {
-                return specificVisitor.VisitIsNotNullExpression(this);
-            }
-
-            return base.Accept(visitor);
-        }
-
         protected override Expression VisitChildren(ExpressionTreeVisitor visitor)
         {
             var newExpression = visitor.VisitExpression(_operand);
 
             return newExpression != _operand
-                ? new IsNotNullExpression(newExpression)
+                ? new NotNullableExpression(newExpression)
                 : this;
+        }
+
+        public override bool CanReduce => true;
+
+        public override Expression Reduce()
+        {
+            return _operand;
         }
 
         public override Type Type

--- a/src/EntityFramework.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EntityFramework.Relational/Query/RelationalQueryModelVisitor.cs
@@ -86,7 +86,6 @@ namespace Microsoft.Data.Entity.Relational.Query
             base.VisitQueryModel(queryModel);
 
             var compositePredicateVisitor = new CompositePredicateExpressionTreeVisitor();
-
             foreach (var selectExpression in _queriesBySource.Values.Where(se => se.Predicate != null))
             {
                 selectExpression.Predicate

--- a/src/EntityFramework.Relational/Query/Sql/ISqlExpressionVisitor.cs
+++ b/src/EntityFramework.Relational/Query/Sql/ISqlExpressionVisitor.cs
@@ -12,7 +12,6 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
         Expression VisitColumnExpression([NotNull] ColumnExpression columnExpression);
         Expression VisitAliasExpression([NotNull] AliasExpression aliasExpression);
         Expression VisitIsNullExpression([NotNull] IsNullExpression isNullExpression);
-        Expression VisitIsNotNullExpression([NotNull] IsNotNullExpression isNotNullExpression);
         Expression VisitLikeExpression([NotNull] LikeExpression likeExpression);
         Expression VisitLiteralExpression([NotNull] LiteralExpression literalExpression);
         Expression VisitSelectExpression([NotNull] SelectExpression selectExpression);

--- a/src/EntityFramework.Relational/Utilities/ExpressionExtensions.cs
+++ b/src/EntityFramework.Relational/Utilities/ExpressionExtensions.cs
@@ -8,7 +8,7 @@ using Microsoft.Data.Entity.Utilities;
 
 // ReSharper disable once CheckNamespace
 
-namespace System.Linq
+namespace System.Linq.Expressions
 {
     public static class ExpressionExtensions
     {

--- a/test/EntityFramework.Core.FunctionalTests/NullSemanticsQueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/NullSemanticsQueryTestBase.cs
@@ -37,144 +37,225 @@ namespace Microsoft.Data.Entity.FunctionalTests
             TestStore.Dispose();
         }
 
-        ////[Fact]
+        [Fact]
         public virtual void Compare_bool_with_bool_equal()
         {
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => e.BoolA == e.BoolB));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => e.BoolA == e.NullableBoolB));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => e.NullableBoolA == e.BoolB));
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => e.NullableBoolA == e.NullableBoolB));
         }
 
-        ////[Fact]
+        [Fact]
         public virtual void Compare_negated_bool_with_bool_equal()
         {
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !e.BoolA == e.BoolB));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !e.BoolA == e.NullableBoolB));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !e.NullableBoolA == e.BoolB));
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !e.NullableBoolA == e.NullableBoolB));
         }
 
-        ////[Fact]
+        [Fact]
         public virtual void Compare_bool_with_negated_bool_equal()
         {
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => e.BoolA == !e.BoolB));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => e.BoolA == !e.NullableBoolB));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => e.NullableBoolA == !e.BoolB));
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => e.NullableBoolA == !e.NullableBoolB));
         }
 
-        ////[Fact]
+        [Fact]
         public virtual void Compare_negated_bool_with_negated_bool_equal()
         {
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !e.BoolA == !e.BoolB));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !e.BoolA == !e.NullableBoolB));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !e.NullableBoolA == !e.BoolB));
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !e.NullableBoolA == !e.NullableBoolB));
         }
 
-        ////[Fact]
-        public virtual void Compare_bool_with_bool_negated_equal()
+        [Fact]
+        public virtual void Compare_bool_with_bool_equal_negated()
         {
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !(e.BoolA == e.BoolB)));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !(e.BoolA == e.NullableBoolB)));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !(e.NullableBoolA == e.BoolB)));
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !(e.NullableBoolA == e.NullableBoolB)));
         }
 
-        ////[Fact]
-        public virtual void Compare_negated_bool_with_bool_negated_equal()
+        [Fact]
+        public virtual void Compare_negated_bool_with_bool_equal_negated()
         {
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !(!e.BoolA == e.BoolB)));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !(!e.BoolA == e.NullableBoolB)));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !(!e.NullableBoolA == e.BoolB)));
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !(!e.NullableBoolA == e.NullableBoolB)));
         }
 
-        ////[Fact]
-        public virtual void Compare_negated_bool_with_negated_bool_negated_equal()
+        [Fact]
+        public virtual void Compare_bool_with_negated_bool_equal_negated()
+        {
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !(e.BoolA == !e.BoolB)));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !(e.BoolA == !e.NullableBoolB)));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !(e.NullableBoolA == !e.BoolB)));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !(e.NullableBoolA == !e.NullableBoolB)));
+        }
+
+        [Fact]
+        public virtual void Compare_negated_bool_with_negated_bool_equal_negated()
         {
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !(!e.BoolA == !e.BoolB)));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !(!e.BoolA == !e.NullableBoolB)));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !(!e.NullableBoolA == !e.BoolB)));
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !(!e.NullableBoolA == !e.NullableBoolB)));
         }
 
-        ////[Fact]
+        [Fact]
         public virtual void Compare_bool_with_bool_not_equal()
         {
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => e.BoolA != e.BoolB));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => e.BoolA != e.NullableBoolB));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => e.NullableBoolA != e.BoolB));
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => e.NullableBoolA != e.NullableBoolB));
         }
 
-        ////[Fact]
+        [Fact]
         public virtual void Compare_negated_bool_with_bool_not_equal()
         {
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !e.BoolA != e.BoolB));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !e.BoolA != e.NullableBoolB));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !e.NullableBoolA != e.BoolB));
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !e.NullableBoolA != e.NullableBoolB));
         }
 
-        ////[Fact]
+        [Fact]
         public virtual void Compare_bool_with_negated_bool_not_equal()
         {
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => e.BoolA != !e.BoolB));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => e.BoolA != !e.NullableBoolB));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => e.NullableBoolA != !e.BoolB));
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => e.NullableBoolA != !e.NullableBoolB));
         }
 
-        ////[Fact]
+        [Fact]
         public virtual void Compare_negated_bool_with_negated_bool_not_equal()
         {
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !e.BoolA != !e.BoolB));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !e.BoolA != !e.NullableBoolB));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !e.NullableBoolA != !e.BoolB));
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !e.NullableBoolA != !e.NullableBoolB));
         }
 
-        ////[Fact]
-        public virtual void Compare_bool_with_bool_negated_not_equal()
+        [Fact]
+        public virtual void Compare_bool_with_bool_not_equal_negated()
         {
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !(e.BoolA != e.BoolB)));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !(e.BoolA != e.NullableBoolB)));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !(e.NullableBoolA != e.BoolB)));
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !(e.NullableBoolA != e.NullableBoolB)));
         }
 
-        ////[Fact]
-        public virtual void Compare_negated_bool_with_bool_negated_not_equal()
+        [Fact]
+        public virtual void Compare_negated_bool_with_bool_not_equal_negated()
         {
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !(!e.BoolA != e.BoolB)));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !(!e.BoolA != e.NullableBoolB)));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !(!e.NullableBoolA != e.BoolB)));
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !(!e.NullableBoolA != e.NullableBoolB)));
         }
 
-        ////[Fact]
-        public virtual void Compare_negated_bool_with_negated_bool_negated_not_equal()
+        [Fact]
+        public virtual void Compare_bool_with_negated_bool_not_equal_negated()
+        {
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !(e.BoolA != !e.BoolB)));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !(e.BoolA != !e.NullableBoolB)));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !(e.NullableBoolA != !e.BoolB)));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !(e.NullableBoolA != !e.NullableBoolB)));
+        }
+
+        [Fact]
+        public virtual void Compare_negated_bool_with_negated_bool_not_equal_negated()
         {
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !(!e.BoolA != !e.BoolB)));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !(!e.BoolA != !e.NullableBoolB)));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !(!e.NullableBoolA != !e.BoolB)));
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !(!e.NullableBoolA != !e.NullableBoolB)));
         }
 
-        ////[Fact]
+        [Fact]
         public virtual void Compare_complex_equal_equal_equal()
         {
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => (e.BoolA == e.BoolB) == (e.IntA == e.IntB)));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => (e.NullableBoolA == e.BoolB) == (e.IntA == e.NullableIntB)));
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => (e.NullableBoolA == e.NullableBoolB) == (e.NullableIntA == e.NullableIntB)));
         }
 
-        ////[Fact]
+        [Fact]
         public virtual void Compare_complex_equal_not_equal_equal()
         {
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => (e.BoolA == e.BoolB) != (e.IntA == e.IntB)));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => (e.NullableBoolA == e.BoolB) != (e.IntA == e.NullableIntB)));
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => (e.NullableBoolA == e.NullableBoolB) != (e.NullableIntA == e.NullableIntB)));
         }
 
-        ////[Fact]
+        [Fact]
         public virtual void Compare_complex_not_equal_equal_equal()
         {
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => (e.BoolA != e.BoolB) == (e.IntA == e.IntB)));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => (e.NullableBoolA != e.BoolB) == (e.IntA == e.NullableIntB)));
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => (e.NullableBoolA != e.NullableBoolB) == (e.NullableIntA == e.NullableIntB)));
         }
 
-        ////[Fact]
+        [Fact]
         public virtual void Compare_complex_not_equal_not_equal_equal()
         {
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => (e.BoolA != e.BoolB) != (e.IntA == e.IntB)));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => (e.NullableBoolA != e.BoolB) != (e.IntA == e.NullableIntB)));
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => (e.NullableBoolA != e.NullableBoolB) != (e.NullableIntA == e.NullableIntB)));
         }
 
-        ////[Fact]
+        [Fact]
         public virtual void Compare_complex_not_equal_equal_not_equal()
         {
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => (e.BoolA != e.BoolB) == (e.IntA != e.IntB)));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => (e.NullableBoolA != e.BoolB) == (e.IntA != e.NullableIntB)));
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => (e.NullableBoolA != e.NullableBoolB) == (e.NullableIntA != e.NullableIntB)));
         }
 
-        ////[Fact]
+        [Fact]
         public virtual void Compare_complex_not_equal_not_equal_not_equal()
         {
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => (e.BoolA != e.BoolB) != (e.IntA != e.IntB)));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => (e.NullableBoolA != e.BoolB) != (e.IntA != e.NullableIntB)));
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => (e.NullableBoolA != e.NullableBoolB) != (e.NullableIntA != e.NullableIntB)));
+        }
+
+        [Fact]
+        public virtual void Compare_nullable_with_null_parameter_equal()
+        {
+            string prm = null;
+
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => (e.NullableStringA == prm)));
+        }
+
+        [Fact]
+        public virtual void Compare_nullable_with_non_null_parameter_not_equal()
+        {
+            string prm = "Foo";
+
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => (e.NullableStringA == prm)));
+        }
+
+        [Fact]
+        public virtual void Join_uses_database_semantics()
+        {
+            using (var context = CreateContext())
+            {
+                var query = from e1 in context.Entities1
+                            join e2 in context.Entities2 on e1.NullableIntA equals e2.NullableIntB
+                            select new { Id1 = e1.Id, Id2 = e2.Id, e1.NullableIntA, e2.NullableIntB };
+
+                var result = query.ToList();
+            }
         }
 
         protected void AssertQuery<TItem>(Func<IQueryable<TItem>, IQueryable<TItem>> query)
@@ -185,9 +266,9 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
             expectedIds.AddRange(query(_oracleData.Set<TItem>().ToList().AsQueryable()).Select(e => e.Id).OrderBy(k => k));
 
-            using (var productContext = CreateContext())
+            using (var context = CreateContext())
             {
-                actualIds.AddRange(query(productContext.Set<TItem>()).Select(e => e.Id).ToList().OrderBy(k => k));
+                actualIds.AddRange(query(context.Set<TItem>()).Select(e => e.Id).ToList().OrderBy(k => k));
             }
 
             Assert.Equal(expectedIds.Count, actualIds.Count);

--- a/test/EntityFramework.SqlServer.FunctionalTests/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/NullSemanticsQuerySqlServerTest.cs
@@ -19,7 +19,551 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             base.Compare_bool_with_bool_equal();
 
             Assert.Equal(
-                @"TBD",
+                @"SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE [e].[BoolA] = [e].[BoolB]
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE [e].[BoolA] = [e].[NullableBoolB]
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE [e].[NullableBoolA] = [e].[BoolB]
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE ([e].[NullableBoolA] = [e].[NullableBoolB]) OR ([e].[NullableBoolA] IS NULL AND [e].[NullableBoolB] IS NULL)",
+                Sql);
+        }
+
+        public override void Compare_negated_bool_with_bool_equal()
+        {
+            base.Compare_negated_bool_with_bool_equal();
+
+            Assert.Equal(
+                @"SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE [e].[BoolA] <> [e].[BoolB]
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE ([e].[BoolA] <> [e].[NullableBoolB]) AND [e].[NullableBoolB] IS NOT NULL
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE ([e].[NullableBoolA] <> [e].[BoolB]) AND [e].[NullableBoolA] IS NOT NULL
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE (([e].[NullableBoolA] <> [e].[NullableBoolB]) AND [e].[NullableBoolA] IS NOT NULL AND [e].[NullableBoolB] IS NOT NULL) OR ([e].[NullableBoolA] IS NULL AND [e].[NullableBoolB] IS NULL)",
+                Sql);
+        }
+
+        public override void Compare_bool_with_negated_bool_equal()
+        {
+            base.Compare_bool_with_negated_bool_equal();
+
+            Assert.Equal(
+                @"SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE [e].[BoolA] <> [e].[BoolB]
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE ([e].[BoolA] <> [e].[NullableBoolB]) AND [e].[NullableBoolB] IS NOT NULL
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE ([e].[NullableBoolA] <> [e].[BoolB]) AND [e].[NullableBoolA] IS NOT NULL
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE (([e].[NullableBoolA] <> [e].[NullableBoolB]) AND [e].[NullableBoolA] IS NOT NULL AND [e].[NullableBoolB] IS NOT NULL) OR ([e].[NullableBoolA] IS NULL AND [e].[NullableBoolB] IS NULL)",
+                Sql);
+        }
+
+        public override void Compare_negated_bool_with_negated_bool_equal()
+        {
+            base.Compare_negated_bool_with_negated_bool_equal();
+
+            Assert.Equal(
+                @"SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE [e].[BoolA] = [e].[BoolB]
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE ([e].[BoolA] = [e].[NullableBoolB]) AND [e].[NullableBoolB] IS NOT NULL
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE ([e].[NullableBoolA] = [e].[BoolB]) AND [e].[NullableBoolA] IS NOT NULL
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE (([e].[NullableBoolA] = [e].[NullableBoolB]) AND [e].[NullableBoolA] IS NOT NULL AND [e].[NullableBoolB] IS NOT NULL) OR ([e].[NullableBoolA] IS NULL AND [e].[NullableBoolB] IS NULL)",
+                Sql);
+        }
+
+        public override void Compare_bool_with_bool_equal_negated()
+        {
+            base.Compare_bool_with_bool_equal_negated();
+
+            Assert.Equal(
+                @"SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE [e].[BoolA] <> [e].[BoolB]
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE ([e].[BoolA] <> [e].[NullableBoolB]) OR [e].[NullableBoolB] IS NULL
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE ([e].[NullableBoolA] <> [e].[BoolB]) OR [e].[NullableBoolA] IS NULL
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE (([e].[NullableBoolA] <> [e].[NullableBoolB]) OR [e].[NullableBoolA] IS NULL OR [e].[NullableBoolB] IS NULL) AND ([e].[NullableBoolA] IS NOT NULL OR [e].[NullableBoolB] IS NOT NULL)",
+                Sql);
+        }
+
+        public override void Compare_negated_bool_with_bool_equal_negated()
+        {
+            base.Compare_negated_bool_with_bool_equal_negated();
+
+            Assert.Equal(
+                @"SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE [e].[BoolA] = [e].[BoolB]
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE ([e].[BoolA] = [e].[NullableBoolB]) OR [e].[NullableBoolB] IS NULL
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE ([e].[NullableBoolA] = [e].[BoolB]) OR [e].[NullableBoolA] IS NULL
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE (([e].[NullableBoolA] = [e].[NullableBoolB]) OR [e].[NullableBoolA] IS NULL OR [e].[NullableBoolB] IS NULL) AND ([e].[NullableBoolA] IS NOT NULL OR [e].[NullableBoolB] IS NOT NULL)",
+                Sql);
+        }
+
+        public override void Compare_bool_with_negated_bool_equal_negated()
+        {
+            base.Compare_bool_with_negated_bool_equal_negated();
+
+            Assert.Equal(
+                @"SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE [e].[BoolA] = [e].[BoolB]
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE ([e].[BoolA] = [e].[NullableBoolB]) OR [e].[NullableBoolB] IS NULL
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE ([e].[NullableBoolA] = [e].[BoolB]) OR [e].[NullableBoolA] IS NULL
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE (([e].[NullableBoolA] = [e].[NullableBoolB]) OR [e].[NullableBoolA] IS NULL OR [e].[NullableBoolB] IS NULL) AND ([e].[NullableBoolA] IS NOT NULL OR [e].[NullableBoolB] IS NOT NULL)",
+                Sql);
+        }
+
+        public override void Compare_negated_bool_with_negated_bool_equal_negated()
+        {
+            base.Compare_negated_bool_with_negated_bool_equal_negated();
+
+            Assert.Equal(
+                @"SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE [e].[BoolA] <> [e].[BoolB]
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE ([e].[BoolA] <> [e].[NullableBoolB]) OR [e].[NullableBoolB] IS NULL
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE ([e].[NullableBoolA] <> [e].[BoolB]) OR [e].[NullableBoolA] IS NULL
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE (([e].[NullableBoolA] <> [e].[NullableBoolB]) OR [e].[NullableBoolA] IS NULL OR [e].[NullableBoolB] IS NULL) AND ([e].[NullableBoolA] IS NOT NULL OR [e].[NullableBoolB] IS NOT NULL)",
+                Sql);
+        }
+
+        public override void Compare_bool_with_bool_not_equal()
+        {
+            base.Compare_bool_with_bool_not_equal();
+
+            Assert.Equal(
+                @"SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE [e].[BoolA] <> [e].[BoolB]
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE ([e].[BoolA] <> [e].[NullableBoolB]) OR [e].[NullableBoolB] IS NULL
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE ([e].[NullableBoolA] <> [e].[BoolB]) OR [e].[NullableBoolA] IS NULL
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE (([e].[NullableBoolA] <> [e].[NullableBoolB]) OR [e].[NullableBoolA] IS NULL OR [e].[NullableBoolB] IS NULL) AND ([e].[NullableBoolA] IS NOT NULL OR [e].[NullableBoolB] IS NOT NULL)",
+                Sql);
+        }
+
+        public override void Compare_negated_bool_with_bool_not_equal()
+        {
+            base.Compare_negated_bool_with_bool_not_equal();
+
+            Assert.Equal(
+                @"SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE [e].[BoolA] = [e].[BoolB]
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE ([e].[BoolA] = [e].[NullableBoolB]) OR [e].[NullableBoolB] IS NULL
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE ([e].[NullableBoolA] = [e].[BoolB]) OR [e].[NullableBoolA] IS NULL
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE (([e].[NullableBoolA] = [e].[NullableBoolB]) OR [e].[NullableBoolA] IS NULL OR [e].[NullableBoolB] IS NULL) AND ([e].[NullableBoolA] IS NOT NULL OR [e].[NullableBoolB] IS NOT NULL)",
+                Sql);
+        }
+
+        public override void Compare_bool_with_negated_bool_not_equal()
+        {
+            base.Compare_bool_with_negated_bool_not_equal();
+
+            Assert.Equal(
+                @"SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE [e].[BoolA] = [e].[BoolB]
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE ([e].[BoolA] = [e].[NullableBoolB]) OR [e].[NullableBoolB] IS NULL
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE ([e].[NullableBoolA] = [e].[BoolB]) OR [e].[NullableBoolA] IS NULL
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE (([e].[NullableBoolA] = [e].[NullableBoolB]) OR [e].[NullableBoolA] IS NULL OR [e].[NullableBoolB] IS NULL) AND ([e].[NullableBoolA] IS NOT NULL OR [e].[NullableBoolB] IS NOT NULL)",
+                Sql);
+        }
+
+        public override void Compare_negated_bool_with_negated_bool_not_equal()
+        {
+            base.Compare_negated_bool_with_negated_bool_not_equal();
+
+            Assert.Equal(
+                @"SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE [e].[BoolA] <> [e].[BoolB]
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE ([e].[BoolA] <> [e].[NullableBoolB]) OR [e].[NullableBoolB] IS NULL
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE ([e].[NullableBoolA] <> [e].[BoolB]) OR [e].[NullableBoolA] IS NULL
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE (([e].[NullableBoolA] <> [e].[NullableBoolB]) OR [e].[NullableBoolA] IS NULL OR [e].[NullableBoolB] IS NULL) AND ([e].[NullableBoolA] IS NOT NULL OR [e].[NullableBoolB] IS NOT NULL)",
+                Sql);
+        }
+
+        public override void Compare_bool_with_bool_not_equal_negated()
+        {
+            base.Compare_bool_with_bool_not_equal_negated();
+
+            Assert.Equal(
+                @"SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE [e].[BoolA] = [e].[BoolB]
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE [e].[BoolA] = [e].[NullableBoolB]
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE [e].[NullableBoolA] = [e].[BoolB]
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE ([e].[NullableBoolA] = [e].[NullableBoolB]) OR ([e].[NullableBoolA] IS NULL AND [e].[NullableBoolB] IS NULL)",
+                Sql);
+        }
+
+        public override void Compare_negated_bool_with_bool_not_equal_negated()
+        {
+            base.Compare_negated_bool_with_bool_not_equal_negated();
+
+            Assert.Equal(
+                @"SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE [e].[BoolA] <> [e].[BoolB]
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE ([e].[BoolA] <> [e].[NullableBoolB]) AND [e].[NullableBoolB] IS NOT NULL
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE ([e].[NullableBoolA] <> [e].[BoolB]) AND [e].[NullableBoolA] IS NOT NULL
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE (([e].[NullableBoolA] <> [e].[NullableBoolB]) AND [e].[NullableBoolA] IS NOT NULL AND [e].[NullableBoolB] IS NOT NULL) OR ([e].[NullableBoolA] IS NULL AND [e].[NullableBoolB] IS NULL)",
+                Sql);
+        }
+
+        public override void Compare_bool_with_negated_bool_not_equal_negated()
+        {
+            base.Compare_bool_with_negated_bool_not_equal_negated();
+
+            Assert.Equal(
+                @"SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE [e].[BoolA] <> [e].[BoolB]
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE ([e].[BoolA] <> [e].[NullableBoolB]) AND [e].[NullableBoolB] IS NOT NULL
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE ([e].[NullableBoolA] <> [e].[BoolB]) AND [e].[NullableBoolA] IS NOT NULL
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE (([e].[NullableBoolA] <> [e].[NullableBoolB]) AND [e].[NullableBoolA] IS NOT NULL AND [e].[NullableBoolB] IS NOT NULL) OR ([e].[NullableBoolA] IS NULL AND [e].[NullableBoolB] IS NULL)",
+                Sql);
+        }
+
+        public override void Compare_negated_bool_with_negated_bool_not_equal_negated()
+        {
+            base.Compare_negated_bool_with_negated_bool_not_equal_negated();
+
+            Assert.Equal(
+                @"SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE [e].[BoolA] = [e].[BoolB]
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE ([e].[BoolA] = [e].[NullableBoolB]) AND [e].[NullableBoolB] IS NOT NULL
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE ([e].[NullableBoolA] = [e].[BoolB]) AND [e].[NullableBoolA] IS NOT NULL
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE (([e].[NullableBoolA] = [e].[NullableBoolB]) AND [e].[NullableBoolA] IS NOT NULL AND [e].[NullableBoolB] IS NOT NULL) OR ([e].[NullableBoolA] IS NULL AND [e].[NullableBoolB] IS NULL)",
+                Sql);
+        }
+
+        public override void Compare_complex_equal_equal_equal()
+        {
+            base.Compare_complex_equal_equal_equal();
+
+            Assert.Equal(
+                @"SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE CASE WHEN (
+    [e].[BoolA] = [e].[BoolB]) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END = CASE WHEN (
+    [e].[IntA] = [e].[IntB]) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE CASE WHEN (
+    [e].[NullableBoolA] = [e].[BoolB]) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END = CASE WHEN (
+    [e].[IntA] = [e].[NullableIntB]) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE CASE WHEN (
+    ([e].[NullableBoolA] = [e].[NullableBoolB]) OR ([e].[NullableBoolA] IS NULL AND [e].[NullableBoolB] IS NULL)) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END = CASE WHEN (
+    ([e].[NullableIntA] = [e].[NullableIntB]) OR ([e].[NullableIntA] IS NULL AND [e].[NullableIntB] IS NULL)) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END",
+                Sql);
+        }
+
+        public override void Compare_complex_equal_not_equal_equal()
+        {
+            base.Compare_complex_equal_not_equal_equal();
+
+            Assert.Equal(
+                @"SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE CASE WHEN (
+    [e].[BoolA] = [e].[BoolB]) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END <> CASE WHEN (
+    [e].[IntA] = [e].[IntB]) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE CASE WHEN (
+    [e].[NullableBoolA] = [e].[BoolB]) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END <> CASE WHEN (
+    [e].[IntA] = [e].[NullableIntB]) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE CASE WHEN (
+    ([e].[NullableBoolA] = [e].[NullableBoolB]) OR ([e].[NullableBoolA] IS NULL AND [e].[NullableBoolB] IS NULL)) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END <> CASE WHEN (
+    ([e].[NullableIntA] = [e].[NullableIntB]) OR ([e].[NullableIntA] IS NULL AND [e].[NullableIntB] IS NULL)) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END",
+                Sql);
+        }
+
+        public override void Compare_complex_not_equal_equal_equal()
+        {
+            base.Compare_complex_not_equal_equal_equal();
+
+            Assert.Equal(
+                @"SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE CASE WHEN (
+    [e].[BoolA] <> [e].[BoolB]) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END = CASE WHEN (
+    [e].[IntA] = [e].[IntB]) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE CASE WHEN (
+    ([e].[NullableBoolA] <> [e].[BoolB]) OR [e].[NullableBoolA] IS NULL) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END = CASE WHEN (
+    ([e].[IntA] = [e].[NullableIntB]) AND [e].[NullableIntB] IS NOT NULL) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE CASE WHEN (
+    (([e].[NullableBoolA] <> [e].[NullableBoolB]) OR [e].[NullableBoolA] IS NULL OR [e].[NullableBoolB] IS NULL) AND ([e].[NullableBoolA] IS NOT NULL OR [e].[NullableBoolB] IS NOT NULL)) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END = CASE WHEN (
+    (([e].[NullableIntA] = [e].[NullableIntB]) AND [e].[NullableIntA] IS NOT NULL AND [e].[NullableIntB] IS NOT NULL) OR ([e].[NullableIntA] IS NULL AND [e].[NullableIntB] IS NULL)) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END",
+                Sql);
+        }
+
+        public override void Compare_complex_not_equal_not_equal_equal()
+        {
+            base.Compare_complex_not_equal_not_equal_equal();
+
+            Assert.Equal(
+                @"SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE CASE WHEN (
+    [e].[BoolA] <> [e].[BoolB]) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END <> CASE WHEN (
+    [e].[IntA] = [e].[IntB]) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE CASE WHEN (
+    ([e].[NullableBoolA] <> [e].[BoolB]) OR [e].[NullableBoolA] IS NULL) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END <> CASE WHEN (
+    ([e].[IntA] = [e].[NullableIntB]) AND [e].[NullableIntB] IS NOT NULL) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE CASE WHEN (
+    (([e].[NullableBoolA] <> [e].[NullableBoolB]) OR [e].[NullableBoolA] IS NULL OR [e].[NullableBoolB] IS NULL) AND ([e].[NullableBoolA] IS NOT NULL OR [e].[NullableBoolB] IS NOT NULL)) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END <> CASE WHEN (
+    (([e].[NullableIntA] = [e].[NullableIntB]) AND [e].[NullableIntA] IS NOT NULL AND [e].[NullableIntB] IS NOT NULL) OR ([e].[NullableIntA] IS NULL AND [e].[NullableIntB] IS NULL)) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END",
+                Sql);
+        }
+
+        public override void Compare_complex_not_equal_equal_not_equal()
+        {
+            base.Compare_complex_not_equal_equal_not_equal();
+
+            Assert.Equal(
+                @"SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE CASE WHEN (
+    [e].[BoolA] <> [e].[BoolB]) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END = CASE WHEN (
+    [e].[IntA] <> [e].[IntB]) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE CASE WHEN (
+    ([e].[NullableBoolA] <> [e].[BoolB]) OR [e].[NullableBoolA] IS NULL) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END = CASE WHEN (
+    ([e].[IntA] <> [e].[NullableIntB]) OR [e].[NullableIntB] IS NULL) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE CASE WHEN (
+    (([e].[NullableBoolA] <> [e].[NullableBoolB]) OR [e].[NullableBoolA] IS NULL OR [e].[NullableBoolB] IS NULL) AND ([e].[NullableBoolA] IS NOT NULL OR [e].[NullableBoolB] IS NOT NULL)) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END = CASE WHEN (
+    (([e].[NullableIntA] <> [e].[NullableIntB]) OR [e].[NullableIntA] IS NULL OR [e].[NullableIntB] IS NULL) AND ([e].[NullableIntA] IS NOT NULL OR [e].[NullableIntB] IS NOT NULL)) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END",
+                Sql);
+        }
+
+        public override void Compare_complex_not_equal_not_equal_not_equal()
+        {
+            base.Compare_complex_not_equal_not_equal_not_equal();
+
+            Assert.Equal(
+                @"SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE CASE WHEN (
+    [e].[BoolA] <> [e].[BoolB]) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END <> CASE WHEN (
+    [e].[IntA] <> [e].[IntB]) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE CASE WHEN (
+    ([e].[NullableBoolA] <> [e].[BoolB]) OR [e].[NullableBoolA] IS NULL) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END <> CASE WHEN (
+    ([e].[IntA] <> [e].[NullableIntB]) OR [e].[NullableIntB] IS NULL) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE CASE WHEN (
+    (([e].[NullableBoolA] <> [e].[NullableBoolB]) OR [e].[NullableBoolA] IS NULL OR [e].[NullableBoolB] IS NULL) AND ([e].[NullableBoolA] IS NOT NULL OR [e].[NullableBoolB] IS NOT NULL)) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END <> CASE WHEN (
+    (([e].[NullableIntA] <> [e].[NullableIntB]) OR [e].[NullableIntA] IS NULL OR [e].[NullableIntB] IS NULL) AND ([e].[NullableIntA] IS NOT NULL OR [e].[NullableIntB] IS NOT NULL)) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END",
+                Sql);
+        }
+
+        public override void Compare_nullable_with_null_parameter_equal()
+        {
+            base.Compare_nullable_with_null_parameter_equal();
+
+            Assert.Equal(
+                @"SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE [e].[NullableStringA] IS NULL",
+                Sql);
+        }
+
+        public override void Compare_nullable_with_non_null_parameter_not_equal()
+        {
+            base.Compare_nullable_with_non_null_parameter_not_equal();
+
+            Assert.Equal(
+                @"__prm_0: Foo
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE [e].[NullableStringA] = @__prm_0",
+                Sql);
+        }
+
+        public override void Join_uses_database_semantics()
+        {
+            base.Join_uses_database_semantics();
+
+            Assert.Equal(
+                @"SELECT [e1].[Id], [e2].[Id], [e1].[NullableIntA], [e2].[NullableIntB]
+FROM [NullSemanticsEntity1] AS [e1]
+INNER JOIN [NullSemanticsEntity2] AS [e2] ON [e1].[NullableIntA] = [e2].[NullableIntB]",
                 Sql);
         }
 

--- a/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -349,7 +349,7 @@ WHERE [o].[CustomerID] = 'ALFKI'",
             Assert.Equal(
                 @"SELECT COUNT(*)
 FROM [Orders] AS [o]
-WHERE ([o].[OrderID] > 10) AND ([o].[CustomerID] <> 'ALFKI')",
+WHERE ([o].[OrderID] > 10) AND (([o].[CustomerID] <> 'ALFKI') OR [o].[CustomerID] IS NULL)",
                 Sql);
         }
 
@@ -437,7 +437,7 @@ WHERE @__ClientEvalPredicateStateless_1 = 1",
             Assert.Equal(
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[CustomerID] <> 'ALFKI'",
+WHERE ([o].[CustomerID] <> 'ALFKI') OR [o].[CustomerID] IS NULL",
                 Sql);
         }
 
@@ -741,33 +741,6 @@ FROM [Orders] AS [o]",
                 Sql);
         }
 
-        //public override void All_client()
-        //{
-        //    base.All_client();
-
-        //    Assert.Equal(
-        //        @"",
-        //        Sql);
-        //}
-
-        //public override void All_client_and_server_top_level()
-        //{
-        //    base.All_client_and_server_top_level();
-
-        //    Assert.Equal(
-        //        @"",
-        //        Sql);
-        //}
-
-        //public override void All_client_or_server_top_level()
-        //{
-        //    base.All_client_or_server_top_level();
-
-        //    Assert.Equal(
-        //        @"",
-        //        Sql);
-        //}
-
         public override void Select_scalar()
         {
             base.Select_scalar();
@@ -882,7 +855,7 @@ FROM [Customers] AS [c]",
             Assert.Equal(
     @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] <> 'AROUT'",
+WHERE ([c].[CustomerID] <> 'AROUT') OR [c].[CustomerID] IS NULL",
     Sql);
         }
 
@@ -913,7 +886,7 @@ FROM [Customers] AS [c]",
             Assert.Equal(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[CustomerID] <> 'ALFKI'",
+WHERE ([c].[CustomerID] <> 'ALFKI') OR [c].[CustomerID] IS NULL",
                 Sql);
         }
 
@@ -1125,7 +1098,7 @@ WHERE 'London' = [c].[City]",
             Assert.Equal(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE [c].[City] = [c].[City]",
+WHERE ([c].[City] = [c].[City]) OR ([c].[City] IS NULL AND [c].[City] IS NULL)",
                 Sql);
         }
 
@@ -1212,7 +1185,7 @@ WHERE [c].[City] IN ('London', 'Berlin') OR ([c].[CustomerID] = 'ALFKI') OR ([c]
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Customers] AS [c]
 CROSS JOIN [Employees] AS [e]
-WHERE ([c].[City] <> 'London') AND ([e].[City] <> 'London')",
+WHERE (([c].[City] <> 'London') OR [c].[City] IS NULL) AND (([e].[City] <> 'London') OR [e].[City] IS NULL)",
                 Sql);
         }
 
@@ -1528,7 +1501,7 @@ FROM [Orders] AS [o]",
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [e].[City]
 FROM [Customers] AS [c]
 CROSS JOIN [Employees] AS [e]
-WHERE [c].[City] = [e].[City]
+WHERE ([c].[City] = [e].[City]) OR ([c].[City] IS NULL AND [e].[City] IS NULL)
 ORDER BY [e].[City], [c].[CustomerID] DESC",
                 Sql);
         }
@@ -1805,7 +1778,9 @@ WHERE (([p].[ProductID] > 100) AND [p].[Discontinued] = 1) OR ([p].[Discontinued
             Assert.Equal(
                 @"SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitsInStock]
 FROM [Products] AS [p]
-WHERE ([p].[Discontinued] = 1 AND ([p].[ProductID] > 50)) OR ([p].[Discontinued] = 0 AND ([p].[ProductID] <= 50))",
+WHERE CASE WHEN (
+    [p].[Discontinued] = 1) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END = CASE WHEN (
+    [p].[ProductID] > 50) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END",
                 Sql);
         }
 
@@ -1816,7 +1791,9 @@ WHERE ([p].[Discontinued] = 1 AND ([p].[ProductID] > 50)) OR ([p].[Discontinued]
             Assert.Equal(
                 @"SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitsInStock]
 FROM [Products] AS [p]
-WHERE ([p].[Discontinued] = 0 AND ([p].[ProductID] > 50)) OR ([p].[Discontinued] = 1 AND ([p].[ProductID] <= 50))",
+WHERE CASE WHEN (
+    [p].[Discontinued] = 1) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END <> CASE WHEN (
+    [p].[ProductID] > 50) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END",
                 Sql);
         }
 
@@ -1827,7 +1804,7 @@ WHERE ([p].[Discontinued] = 0 AND ([p].[ProductID] > 50)) OR ([p].[Discontinued]
             Assert.Equal(
                 @"SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitsInStock]
 FROM [Products] AS [p]
-WHERE ([p].[Discontinued] = 0 AND [p].[Discontinued] = 0) OR ([p].[Discontinued] = 1 AND [p].[Discontinued] = 1)",
+WHERE [p].[Discontinued] = [p].[Discontinued]",
                 Sql);
         }
 
@@ -1838,7 +1815,9 @@ WHERE ([p].[Discontinued] = 0 AND [p].[Discontinued] = 0) OR ([p].[Discontinued]
             Assert.Equal(
                 @"SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitsInStock]
 FROM [Products] AS [p]
-WHERE (([p].[ProductID] <= 50) AND ([p].[ProductID] <= 20)) OR (([p].[ProductID] > 50) AND ([p].[ProductID] > 20))",
+WHERE CASE WHEN (
+    [p].[ProductID] > 50) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END = CASE WHEN (
+    [p].[ProductID] > 20) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END",
                 Sql);
         }
 
@@ -1851,7 +1830,9 @@ WHERE (([p].[ProductID] <= 50) AND ([p].[ProductID] <= 20)) OR (([p].[ProductID]
 
 SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitsInStock]
 FROM [Products] AS [p]
-WHERE (([p].[ProductID] > 50) AND @__prm_0 = 0) OR (([p].[ProductID] <= 50) AND @__prm_0 = 1)",
+WHERE CASE WHEN (
+    [p].[ProductID] > 50) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END <> CASE WHEN (
+    @__prm_0 = 1) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END",
                 Sql);
         }
 
@@ -1864,7 +1845,11 @@ WHERE (([p].[ProductID] > 50) AND @__prm_0 = 0) OR (([p].[ProductID] <= 50) AND 
 
 SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitsInStock]
 FROM [Products] AS [p]
-WHERE ([p].[Discontinued] = 1 AND ((([p].[ProductID] > 50) AND @__prm_0 = 0) OR (([p].[ProductID] <= 50) AND @__prm_0 = 1))) OR ([p].[Discontinued] = 0 AND (([p].[ProductID] <= 50) OR @__prm_0 = 1) AND (([p].[ProductID] > 50) OR @__prm_0 = 0))",
+WHERE CASE WHEN (
+    [p].[Discontinued] = 1) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END = CASE WHEN (
+    CASE WHEN (
+        [p].[ProductID] > 50) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END <> CASE WHEN (
+        @__prm_0 = 1) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END",
                 Sql);
         }
 


### PR DESCRIPTION
Problem is that database semantics for null equality are different from c#, resulting in unexpected results for some queries (involving null value comparisons)

Fix is to compensate this by introducing additional terms in the predicate, effectively converting 3-valued logic into 2-valued logic.

a == b -> [(a == b) && (a != null && b != null)] || (a == null && b == null))
a != b -> [(a != b) || (a == null || b == null)] && (a != null || b != null)]

also added transformations for cases when one of the operands is negated

!a == b -> [(a != b) && (a != null && b != null)] || (a == null && b == null)
!a != b -> [(a == b) || (a == null || b == null)] && (a != null || b != null)

Some terms can be removed if one of the terms is not nullable, e.g:

nullableA == nonNullableB -> (nullableA == nonNullableB) && (nullableA != null)

We do additional optimization for simple predicate of a == b where a and b are nullable:
a == b -> (a == b) || (a == null && b == null)

This is still 3-valued result, true being returned when 'a' and 'b' are in c# terms, and either false or NULL when they are not equal.
This optimization can only be applied if the predicate does not contain any NotEqual or Not operations.