### PR TITLE
 Fix Sequence contains more than one element Error

### DIFF
--- a/src/EntityFramework.Core/Query/EntityQueryModelVisitor.cs
+++ b/src/EntityFramework.Core/Query/EntityQueryModelVisitor.cs
@@ -944,7 +944,7 @@ namespace Microsoft.Data.Entity.Query
             return BindMemberExpressionCore(memberExpression, querySource,
                 (ps, qs) =>
                     {
-                        var property = ps.Single() as IProperty;
+                        var property = ps.OfType<IProperty>().SingleOrDefault();
 
                         return property != null
                             ? memberBinder(property, qs)


### PR DESCRIPTION
When a model has a child property-class with the same named property as the parent you get a sequence contains more than one element Error when using AutoMapper

Such as:

``` CSharp
public class Person
{
	public int Id { get; set; }

	public string Name { get; set; }

	public Country Country
	{
		get;
		set;
	}
}

public class Country
{
	public string Id { get; set; }

	public string Name { get; set; }
}
```