### PR TITLE
Fix to #2026 - consider different expansion for complex equality predicates (e.g. (a == b) == c) for some cases.

### DIFF
--- a/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/EqualityPredicateExpandingVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/EqualityPredicateExpandingVisitor.cs
@@ -32,15 +32,12 @@ namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
 
                 if (complexLeft || complexRight)
                 {
-                    {
-                        return expression.NodeType == ExpressionType.Equal 
-                            ? Expression.Equal(
-                                new CaseExpression(left),
-                                new CaseExpression(right))
-                            : Expression.NotEqual(
-                                new CaseExpression(left),
-                                new CaseExpression(right));
-                    }
+                    var leftOperand = complexLeft ? new CaseExpression(left) : left;
+                    var rightOperand = complexRight ? new CaseExpression(right) : right;
+
+                    return expression.NodeType == ExpressionType.Equal
+                        ? Expression.Equal(leftOperand, rightOperand)
+                        : Expression.NotEqual(leftOperand, rightOperand);
                 }
             }
 

--- a/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -1778,8 +1778,7 @@ WHERE (([p].[ProductID] > 100) AND [p].[Discontinued] = 1) OR ([p].[Discontinued
             Assert.Equal(
                 @"SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitsInStock]
 FROM [Products] AS [p]
-WHERE CASE WHEN (
-    [p].[Discontinued] = 1) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END = CASE WHEN (
+WHERE [p].[Discontinued] = CASE WHEN (
     [p].[ProductID] > 50) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END",
                 Sql);
         }
@@ -1791,8 +1790,7 @@ WHERE CASE WHEN (
             Assert.Equal(
                 @"SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitsInStock]
 FROM [Products] AS [p]
-WHERE CASE WHEN (
-    [p].[Discontinued] = 1) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END <> CASE WHEN (
+WHERE [p].[Discontinued] <> CASE WHEN (
     [p].[ProductID] > 50) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END",
                 Sql);
         }
@@ -1831,8 +1829,7 @@ WHERE CASE WHEN (
 SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitsInStock]
 FROM [Products] AS [p]
 WHERE CASE WHEN (
-    [p].[ProductID] > 50) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END <> CASE WHEN (
-    @__prm_0 = 1) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END",
+    [p].[ProductID] > 50) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END <> @__prm_0",
                 Sql);
         }
 
@@ -1845,11 +1842,9 @@ WHERE CASE WHEN (
 
 SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitsInStock]
 FROM [Products] AS [p]
-WHERE CASE WHEN (
-    [p].[Discontinued] = 1) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END = CASE WHEN (
+WHERE [p].[Discontinued] = CASE WHEN (
     CASE WHEN (
-        [p].[ProductID] > 50) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END <> CASE WHEN (
-        @__prm_0 = 1) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END",
+        [p].[ProductID] > 50) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END <> @__prm_0) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END",
                 Sql);
         }
 


### PR DESCRIPTION
This is a performance/sqlgen improvement.
Currently expressions like (a == b) == (c) are rewritten into case statements:
(CASE WHEN a == b then 1 ELSE 0) == (CASE WHEN c == 1 then 1 ELSE 0)

This is not necessary as we only need to expand the part that is complex (a==b) and we can leave the simple part (c) intact.