### PR TITLE
[SMALL] Fix to #1861 - contains -> IN transformation should handle nulls correctly

### DIFF
--- a/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/EqualityPredicateInExpressionOptimizer.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/EqualityPredicateInExpressionOptimizer.cs
@@ -170,7 +170,7 @@ namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
             {
                 values = inExpression.Values;
 
-                return inExpression.Alias;
+                return inExpression.Operand;
             }
 
             return null;

--- a/src/EntityFramework.Relational/Query/Expressions/InExpression.cs
+++ b/src/EntityFramework.Relational/Query/Expressions/InExpression.cs
@@ -14,18 +14,18 @@ namespace Microsoft.Data.Entity.Relational.Query.Expressions
     public class InExpression : ExtensionExpression
     {
         public InExpression(
-            [NotNull] AliasExpression alias,
+            [NotNull] AliasExpression operand,
             [NotNull] IReadOnlyList<Expression> values)
             : base(typeof(bool))
         {
-            Check.NotNull(alias, nameof(alias));
+            Check.NotNull(operand, nameof(operand));
             Check.NotNull(values, nameof(values));
 
-            Alias = alias;
+            Operand = operand;
             Values = values;
         }
 
-        public virtual AliasExpression Alias { get; }
+        public virtual AliasExpression Operand { get; }
         public virtual IReadOnlyList<Expression> Values { get; }
 
         public override Expression Accept([NotNull] ExpressionTreeVisitor visitor)
@@ -46,7 +46,7 @@ namespace Microsoft.Data.Entity.Relational.Query.Expressions
 
         public override string ToString()
         {
-            return Alias.Expression + " IN (" + string.Join(", ", Values) + ")";
+            return Operand.Expression + " IN (" + string.Join(", ", Values) + ")";
         }
     }
 }

--- a/test/EntityFramework.Core.FunctionalTests/NullSemanticsQueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/NullSemanticsQueryTestBase.cs
@@ -258,6 +258,71 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
+        [Fact]
+        public virtual void Contains_with_local_array_closure_with_null()
+        {
+            string[] ids = { "Foo", null };
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => ids.Contains(e.NullableStringA)));
+        }
+
+        [Fact]
+        public virtual void Contains_with_local_array_closure_with_multiple_nulls()
+        {
+            string[] ids = { null, "Foo", null, null };
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => ids.Contains(e.NullableStringA)));
+        }
+
+        [Fact]
+        public virtual void Contains_with_local_array_closure_false_with_null()
+        {
+            string[] ids = { "Foo", null };
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !ids.Contains(e.NullableStringA)));
+        }
+
+        [Fact]
+        public virtual void Where_select_many_or_with_null()
+        {
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => e.NullableStringA == "Foo" || e.NullableStringA == "Blah" || e.NullableStringA == null));
+        }
+
+        [Fact]
+        public virtual void Where_select_many_and_with_null()
+        {
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => e.NullableStringA != "Foo" && e.NullableStringA != "Blah" && e.NullableStringA != null));
+        }
+
+        [Fact]
+        public virtual void Where_select_many_or_with_nullable_parameter()
+        {
+            string prm = null;
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => e.NullableStringA == "Foo" || e.NullableStringA == prm));
+        }
+
+        [Fact]
+        public virtual void Where_select_many_and_with_nullable_parameter_and_constant()
+        {
+
+
+            string prm1 = null;
+            string prm2 = null;
+            string prm3 = "Blah";
+
+            // wrong results!
+            //AssertQuery<NullSemanticsEntity1>(es => es.Where(e => 
+            //    e.NullableStringB != null 
+            //    && e.NullableStringA != "Foo" 
+            //    && e.NullableStringA != prm1 
+            //    && e.NullableStringA != prm2 
+            //    && e.NullableStringA != prm3));
+
+
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e =>
+                e.NullableStringA != "Foo"
+                && e.NullableStringA != prm1
+                && e.NullableStringA != prm2
+                && e.NullableStringA != prm3));
+        }
+
         protected void AssertQuery<TItem>(Func<IQueryable<TItem>, IQueryable<TItem>> query)
             where TItem : NullSemanticsEntityBase
         {

--- a/test/EntityFramework.SqlServer.FunctionalTests/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/NullSemanticsQuerySqlServerTest.cs
@@ -567,6 +567,85 @@ INNER JOIN [NullSemanticsEntity2] AS [e2] ON [e1].[NullableIntA] = [e2].[Nullabl
                 Sql);
         }
 
+        public override void Contains_with_local_array_closure_with_null()
+        {
+            base.Contains_with_local_array_closure_with_null();
+
+            Assert.Equal(
+                @"SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE [e].[NullableStringA] IN ('Foo') OR [e].[NullableStringA] IS NULL",
+                Sql);
+        }
+
+        public override void Contains_with_local_array_closure_false_with_null()
+        {
+            base.Contains_with_local_array_closure_false_with_null();
+
+            Assert.Equal(
+                @"SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE [e].[NullableStringA] NOT IN ('Foo') AND [e].[NullableStringA] IS NOT NULL",
+                Sql);
+        }
+
+        public override void Contains_with_local_array_closure_with_multiple_nulls()
+        {
+            base.Contains_with_local_array_closure_with_multiple_nulls();
+
+            Assert.Equal(
+                @"SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE [e].[NullableStringA] IN ('Foo') OR [e].[NullableStringA] IS NULL",
+                Sql);
+        }
+
+        public override void Where_select_many_or_with_null()
+        {
+            base.Where_select_many_or_with_null();
+
+            Assert.Equal(
+                @"SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE [e].[NullableStringA] IN ('Foo', 'Blah') OR [e].[NullableStringA] IS NULL",
+                Sql);
+        }
+
+        public override void Where_select_many_and_with_null()
+        {
+            base.Where_select_many_and_with_null();
+
+            Assert.Equal(
+                @"SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE [e].[NullableStringA] NOT IN ('Foo', 'Blah') AND [e].[NullableStringA] IS NOT NULL",
+                Sql);
+        }
+
+        public override void Where_select_many_or_with_nullable_parameter()
+        {
+            base.Where_select_many_or_with_nullable_parameter();
+
+            Assert.Equal(
+                @"SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE [e].[NullableStringA] IN ('Foo') OR [e].[NullableStringA] IS NULL",
+                Sql);
+        }
+
+        public override void Where_select_many_and_with_nullable_parameter_and_constant()
+        {
+            base.Where_select_many_and_with_nullable_parameter_and_constant();
+
+            Assert.Equal(
+                @"__prm3_2: Blah
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE [e].[NullableStringA] NOT IN ('Foo', @__prm3_2) AND [e].[NullableStringA] IS NOT NULL",
+                Sql);
+        }
+
         private static string Sql
         {
             get { return TestSqlLoggerFactory.Sql; }


### PR DESCRIPTION
Queries translated to IN expression were not handling nulls correctly, e.g.:

from c in customers
where c.Name == "Foo" || c.Name == "Bar" || c.Name == null
select c.Id

would translate to

SELECT c.Id
FROM Customers as c
WHERE c.Name IN ('Foo', 'Bar', NULL)

This would not return customers with Name == null, because it would apply database null semantics for this comparison (null == null -> null)

Fix is to add additional term that will handle the case.

Above query will get translated to:

SELECT c.Id
FROM Customers as c
WHERE c.Name IN ('Foo', 'Bar') || c.Name IS NULL