### PR TITLE
Target net45 and net45+win

### DIFF
--- a/src/EntityFramework.Commands/EntityFramework.Commands.csproj
+++ b/src/EntityFramework.Commands/EntityFramework.Commands.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Data.Entity.Commands</RootNamespace>
     <AssemblyName>EntityFramework.Commands</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -18,7 +18,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NET451;VSBUILD</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET45;VSBUILD</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -27,7 +27,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE;NET451;VSBUILD</DefineConstants>
+    <DefineConstants>TRACE;NET45;VSBUILD</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/EntityFramework.Commands/Executor.cs
+++ b/src/EntityFramework.Commands/Executor.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NET451
+#if NET45
 
 using System;
 using System.Collections;

--- a/src/EntityFramework.Commands/Utilities/ForwardingProxy.cs
+++ b/src/EntityFramework.Commands/Utilities/ForwardingProxy.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NET451
+#if NET45
 
 using System;
 using System.Runtime.Remoting;

--- a/src/EntityFramework.Commands/project.json
+++ b/src/EntityFramework.Commands/project.json
@@ -17,7 +17,7 @@
         "EntityFramework.Commands.Strings": "Properties/Strings.resx"
     },
     "frameworks": {
-        "net451": { },
+        "net45": { },
         "dnx451": {
             "dependencies": {
                 "Microsoft.AspNet.Hosting": "1.0.0-*",

--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -14,8 +14,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile7</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/EntityFramework.Core/project.json
+++ b/src/EntityFramework.Core/project.json
@@ -11,7 +11,7 @@
         "Microsoft.Framework.Logging": "1.0.0-*",
         "Microsoft.Framework.OptionsModel": "1.0.0-*",
         "Remotion.Linq": "2.0.0-alpha-002",
-        "System.Collections.Immutable": "1.1.33-beta"
+        "System.Collections.Immutable": "1.1.34-rc"
     },
     "compile": "..\\Shared\\*.cs",
     "namedResource": {
@@ -64,7 +64,7 @@
                 "System.Reflection.Extensions": "4.0.0-beta-*"
             }
         },
-        "netcore451": {
+        ".NETPortable,Version=v4.5,Profile=Profile7": {
             "frameworkAssemblies": {
                 "System.Diagnostics.Contracts": "",
                 "System.IO": "",

--- a/src/EntityFramework.InMemory/EntityFramework.InMemory.csproj
+++ b/src/EntityFramework.InMemory/EntityFramework.InMemory.csproj
@@ -14,8 +14,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile7</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/EntityFramework.InMemory/project.json
+++ b/src/EntityFramework.InMemory/project.json
@@ -15,6 +15,6 @@
         "net45": { },
         "dnx451": { },
         "dnxcore50": { },
-        "netcore451": { }
+        ".NETPortable,Version=v4.5,Profile=Profile7": { }
     }
 }

--- a/src/EntityFramework.Relational.Design/EntityFramework.Relational.Design.csproj
+++ b/src/EntityFramework.Relational.Design/EntityFramework.Relational.Design.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Data.Entity.Relational.Design</RootNamespace>
     <AssemblyName>EntityFramework.Relational.Design</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/EntityFramework.Relational.Design/project.json
+++ b/src/EntityFramework.Relational.Design/project.json
@@ -13,7 +13,7 @@
         "EntityFramework.Relational.Design.Strings": "Properties/Strings.resx"
     },
     "frameworks": {
-        "net451": {
+        "net45": {
             "frameworkAssemblies": {
                 "System.Data": ""
             }

--- a/src/EntityFramework.Relational/EntityFramework.Relational.csproj
+++ b/src/EntityFramework.Relational/EntityFramework.Relational.csproj
@@ -14,8 +14,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile151</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile7</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/IncludeExpressionTreeVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/IncludeExpressionTreeVisitor.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
             {
                 var targetEntityType = navigation.GetTargetType();
                 var targetTableName = _queryCompilationContext.GetTableName(targetEntityType);
-                var targetTableAlias = targetTableName.First().ToString().ToLower();
+                var targetTableAlias = targetTableName[0].ToString().ToLower();
 
                 if (!navigation.IsCollection())
                 {

--- a/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/RelationalEntityQueryableExpressionTreeVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/RelationalEntityQueryableExpressionTreeVisitor.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
             var tableName = QueryModelVisitor.QueryCompilationContext.GetTableName(entityType);
 
             var alias = _querySource.ItemName.StartsWith("<generated>_")
-                ? tableName.First().ToString().ToLower()
+                ? tableName[0].ToString().ToLower()
                 : _querySource.ItemName;
 
             var fromSqlAnnotation = QueryModelVisitor.QueryCompilationContext.QueryAnnotations

--- a/src/EntityFramework.Relational/RelationalConnection.cs
+++ b/src/EntityFramework.Relational/RelationalConnection.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Data.Entity.Relational
         private int _openedCount;
         private int? _commandTimeout;
         private readonly LazyRef<ILogger> _logger;
-#if NET451
+#if NET45
         private bool _throwOnAmbientTransaction;
 #endif
 
@@ -58,7 +58,7 @@ namespace Microsoft.Data.Entity.Relational
                 throw new InvalidOperationException(Strings.NoConnectionOrConnectionString);
             }
 
-#if NET451
+#if NET45
             _throwOnAmbientTransaction = storeConfig.ThrowOnAmbientTransaction ?? true;
 #endif
         }
@@ -160,43 +160,32 @@ namespace Microsoft.Data.Entity.Relational
 
         public virtual void Open()
         {
-#if NET451
+#if NET45
             CheckForAmbientTransactions();
 
-            using (new System.Transactions.TransactionScope(System.Transactions.TransactionScopeOption.Suppress))
-            {
 #endif
             if (_openedCount == 0)
             {
                 _connection.Value.Open();
             }
 
-#if NET451
-            }
-#endif
             _openedCount++;
         }
 
         public virtual async Task OpenAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-#if NET451
+#if NET45
             CheckForAmbientTransactions();
-
-            using (new System.Transactions.TransactionScope(
-                System.Transactions.TransactionScopeOption.Suppress, System.Transactions.TransactionScopeAsyncFlowOption.Enabled))
-            {
+            
 #endif
             if (_openedCount == 0)
             {
                 await _connection.Value.OpenAsync(cancellationToken).WithCurrentCulture();
             }
-#if NET451
-            }
-#endif
             _openedCount++;
         }
 
-#if NET451
+#if NET45
         private void CheckForAmbientTransactions()
         {
             if (_throwOnAmbientTransaction

--- a/src/EntityFramework.Relational/RelationalDecimalTypeMapping.cs
+++ b/src/EntityFramework.Relational/RelationalDecimalTypeMapping.cs
@@ -28,8 +28,13 @@ namespace Microsoft.Data.Entity.Relational
             // Note: Precision/scale should not be set for input parameters because this will cause truncation
             if (parameter.Direction == ParameterDirection.Output)
             {
+#if NET45
+                ((IDbDataParameter)parameter).Scale = _scale;
+                ((IDbDataParameter)parameter).Precision = _precision;
+#else
                 parameter.Scale = _scale;
                 parameter.Precision = _precision;
+#endif
             }
 
             base.ConfigureParameter(parameter, columnModification);

--- a/src/EntityFramework.Relational/project.json
+++ b/src/EntityFramework.Relational/project.json
@@ -12,7 +12,7 @@
         "EntityFramework.Relational.Strings": "Properties/Strings.resx"
     },
     "frameworks": {
-        "net451": {
+        "net45": {
             "frameworkAssemblies": {
                 "System.Data": "",
                 "System.Transactions": ""
@@ -30,7 +30,7 @@
                 "System.Text.RegularExpressions": "4.0.10-beta-*"
             }
         },
-        "netcore451": {
+        ".NETPortable,Version=v4.5,Profile=Profile7": {
             "dependencies": {
                 "System.Data.Common": "4.0.0-beta-*"
             },

--- a/src/EntityFramework.SqlServer.Design/EntityFramework.SqlServer.Design.csproj
+++ b/src/EntityFramework.SqlServer.Design/EntityFramework.SqlServer.Design.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Data.Entity.SqlServer.Design</RootNamespace>
     <AssemblyName>EntityFramework.SqlServer.Design</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -18,7 +18,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NET451;VSBUILD</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET45;VSBUILD</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -27,7 +27,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE;NET451;VSBUILD</DefineConstants>
+    <DefineConstants>TRACE;NET45;VSBUILD</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/EntityFramework.SqlServer.Design/project.json
+++ b/src/EntityFramework.SqlServer.Design/project.json
@@ -13,7 +13,7 @@
         "EntityFramework.SqlServer.Design.Strings": "Properties/Strings.resx"
     },
     "frameworks": {
-        "net451": { },
+        "net45": { },
         "dnx451": { },
         "dnxcore50": {
             "dependencies": {

--- a/src/EntityFramework.SqlServer/EntityFramework.SqlServer.csproj
+++ b/src/EntityFramework.SqlServer/EntityFramework.SqlServer.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>Microsoft.Data.Entity.SqlServer</RootNamespace>
     <AssemblyName>EntityFramework.SqlServer</AssemblyName>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/EntityFramework.SqlServer/project.json
+++ b/src/EntityFramework.SqlServer/project.json
@@ -12,7 +12,7 @@
         "EntityFramework.SqlServer.Strings": "Properties/Strings.resx"
     },
     "frameworks": {
-        "net451": { },
+        "net45": { },
         "dnx451": { },
         "dnxcore50": {
             "dependencies": {

--- a/test/EntityFramework.Commands.FunctionalTests/EntityFramework.Commands.FunctionalTests.csproj
+++ b/test/EntityFramework.Commands.FunctionalTests/EntityFramework.Commands.FunctionalTests.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Data.Entity.Commands</RootNamespace>
     <AssemblyName>EntityFramework.Commands.FunctionalTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>199587f0</NuGetPackageImportStamp>
   </PropertyGroup>
@@ -20,7 +20,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NET451</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET45</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -28,7 +28,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE;NET451</DefineConstants>
+    <DefineConstants>TRACE;NET45</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/test/EntityFramework.Commands.FunctionalTests/ExecutorTest.cs
+++ b/test/EntityFramework.Commands.FunctionalTests/ExecutorTest.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NET451
+#if NET45
 
 using System;
 using System.Linq;

--- a/test/EntityFramework.Commands.FunctionalTests/TestUtilities/ExecutorWrapper.cs
+++ b/test/EntityFramework.Commands.FunctionalTests/TestUtilities/ExecutorWrapper.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NET451
+#if NET45
 
 using System;
 using System.Collections;

--- a/test/EntityFramework.Commands.FunctionalTests/packages.config
+++ b/test/EntityFramework.Commands.FunctionalTests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.abstractions" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.assert" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.core" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.extensibility.core" version="2.0.0-rc3-build2880" targetFramework="net451" />
+  <package id="xunit" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.assert" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.core" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.0.0-rc3-build2880" targetFramework="net45" />
 </packages>

--- a/test/EntityFramework.Commands.Tests/EntityFramework.Commands.Tests.csproj
+++ b/test/EntityFramework.Commands.Tests/EntityFramework.Commands.Tests.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Data.Entity.Commands.Tests</RootNamespace>
     <AssemblyName>EntityFramework.Commands.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>3453667e</NuGetPackageImportStamp>
   </PropertyGroup>
@@ -20,7 +20,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE;VSBUILD;NET451</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;VSBUILD;NET45</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -28,7 +28,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE;VSBUILD;NET451</DefineConstants>
+    <DefineConstants>TRACE;VSBUILD;NET45</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/test/EntityFramework.Commands.Tests/ExecutorTest.cs
+++ b/test/EntityFramework.Commands.Tests/ExecutorTest.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 
-#if NET451
+#if NET45
 
 using System;
 using System.Collections.Generic;

--- a/test/EntityFramework.Commands.Tests/packages.config
+++ b/test/EntityFramework.Commands.Tests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.abstractions" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.assert" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.core" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.extensibility.core" version="2.0.0-rc3-build2880" targetFramework="net451" />
+  <package id="xunit" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.assert" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.core" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.0.0-rc3-build2880" targetFramework="net45" />
 </packages>

--- a/test/EntityFramework.Core.FunctionalTests/EntityFramework.Core.FunctionalTests.csproj
+++ b/test/EntityFramework.Core.FunctionalTests/EntityFramework.Core.FunctionalTests.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Data.Entity.FunctionalTests</RootNamespace>
     <AssemblyName>EntityFramework.Core.FunctionalTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>275c64a3</NuGetPackageImportStamp>
   </PropertyGroup>

--- a/test/EntityFramework.Core.FunctionalTests/packages.config
+++ b/test/EntityFramework.Core.FunctionalTests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.abstractions" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.assert" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.core" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.extensibility.core" version="2.0.0-rc3-build2880" targetFramework="net451" />
+  <package id="xunit" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.assert" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.core" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.0.0-rc3-build2880" targetFramework="net45" />
 </packages>

--- a/test/EntityFramework.Core.Tests/EntityFramework.Core.Tests.csproj
+++ b/test/EntityFramework.Core.Tests/EntityFramework.Core.Tests.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Data.Entity.Tests</RootNamespace>
     <AssemblyName>EntityFramework.Core.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>0337bf42</NuGetPackageImportStamp>
   </PropertyGroup>

--- a/test/EntityFramework.Core.Tests/packages.config
+++ b/test/EntityFramework.Core.Tests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.abstractions" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.assert" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.core" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.extensibility.core" version="2.0.0-rc3-build2880" targetFramework="net451" />
+  <package id="xunit" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.assert" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.core" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.0.0-rc3-build2880" targetFramework="net45" />
 </packages>

--- a/test/EntityFramework.CrossStore.FunctionalTests/EntityFramework.CrossStore.FunctionalTests.csproj
+++ b/test/EntityFramework.CrossStore.FunctionalTests/EntityFramework.CrossStore.FunctionalTests.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Data.Entity.FunctionalTests</RootNamespace>
     <AssemblyName>EntityFramework.CrossStore.FunctionalTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>fd74b8fa</NuGetPackageImportStamp>
   </PropertyGroup>

--- a/test/EntityFramework.CrossStore.FunctionalTests/packages.config
+++ b/test/EntityFramework.CrossStore.FunctionalTests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.abstractions" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.assert" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.core" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.extensibility.core" version="2.0.0-rc3-build2880" targetFramework="net451" />
+  <package id="xunit" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.assert" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.core" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.0.0-rc3-build2880" targetFramework="net45" />
 </packages>

--- a/test/EntityFramework.InMemory.FunctionalTests/EntityFramework.InMemory.FunctionalTests.csproj
+++ b/test/EntityFramework.InMemory.FunctionalTests/EntityFramework.InMemory.FunctionalTests.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Data.Entity.InMemory.FunctionalTests</RootNamespace>
     <AssemblyName>EntityFramework.InMemory.FunctionalTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>6edf0372</NuGetPackageImportStamp>
   </PropertyGroup>

--- a/test/EntityFramework.InMemory.FunctionalTests/packages.config
+++ b/test/EntityFramework.InMemory.FunctionalTests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.abstractions" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.assert" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.core" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.extensibility.core" version="2.0.0-rc3-build2880" targetFramework="net451" />
+  <package id="xunit" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.assert" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.core" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.0.0-rc3-build2880" targetFramework="net45" />
 </packages>

--- a/test/EntityFramework.InMemory.Tests/EntityFramework.InMemory.Tests.csproj
+++ b/test/EntityFramework.InMemory.Tests/EntityFramework.InMemory.Tests.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Data.Entity.InMemory.Tests</RootNamespace>
     <AssemblyName>EntityFramework.InMemory.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>ded15bf9</NuGetPackageImportStamp>
   </PropertyGroup>

--- a/test/EntityFramework.InMemory.Tests/packages.config
+++ b/test/EntityFramework.InMemory.Tests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.abstractions" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.assert" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.core" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.extensibility.core" version="2.0.0-rc3-build2880" targetFramework="net451" />
+  <package id="xunit" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.assert" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.core" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.0.0-rc3-build2880" targetFramework="net45" />
 </packages>

--- a/test/EntityFramework.Microbenchmarks.Core/EntityFramework.Microbenchmarks.Core.csproj
+++ b/test/EntityFramework.Microbenchmarks.Core/EntityFramework.Microbenchmarks.Core.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>EntityFramework.Microbenchmarks.Core</RootNamespace>
     <AssemblyName>EntityFramework.Microbenchmarks.Core</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>c783c500</NuGetPackageImportStamp>
   </PropertyGroup>

--- a/test/EntityFramework.Microbenchmarks.Core/packages.config
+++ b/test/EntityFramework.Microbenchmarks.Core/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.0.0-rc3-build2880" targetFramework="net451" userInstalled="true" />
-  <package id="xunit.abstractions" version="2.0.0-rc3-build2880" targetFramework="net451" userInstalled="true" />
-  <package id="xunit.assert" version="2.0.0-rc3-build2880" targetFramework="net451" userInstalled="true" />
-  <package id="xunit.core" version="2.0.0-rc3-build2880" targetFramework="net451" userInstalled="true" />
-  <package id="xunit.extensibility.core" version="2.0.0-rc3-build2880" targetFramework="net451" userInstalled="true" />
-  <package id="xunit.extensibility.execution" version="2.0.0-rc3-build2880" targetFramework="net451" userInstalled="true" />
+  <package id="xunit" version="2.0.0-rc3-build2880" targetFramework="net45" userInstalled="true" />
+  <package id="xunit.abstractions" version="2.0.0-rc3-build2880" targetFramework="net45" userInstalled="true" />
+  <package id="xunit.assert" version="2.0.0-rc3-build2880" targetFramework="net45" userInstalled="true" />
+  <package id="xunit.core" version="2.0.0-rc3-build2880" targetFramework="net45" userInstalled="true" />
+  <package id="xunit.extensibility.core" version="2.0.0-rc3-build2880" targetFramework="net45" userInstalled="true" />
+  <package id="xunit.extensibility.execution" version="2.0.0-rc3-build2880" targetFramework="net45" userInstalled="true" />
 </packages>

--- a/test/EntityFramework.Microbenchmarks.EF6/EntityFramework.Microbenchmarks.EF6.csproj
+++ b/test/EntityFramework.Microbenchmarks.EF6/EntityFramework.Microbenchmarks.EF6.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>EntityFramework.Microbenchmarks.EF6</RootNamespace>
     <AssemblyName>EntityFramework.Microbenchmarks.EF6</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>e69ad63a</NuGetPackageImportStamp>
   </PropertyGroup>

--- a/test/EntityFramework.Microbenchmarks.EF6/packages.config
+++ b/test/EntityFramework.Microbenchmarks.EF6/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EntityFramework" version="6.1.2" targetFramework="net451" />
-  <package id="xunit" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.abstractions" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.assert" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.core" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.extensibility.core" version="2.0.0-rc3-build2880" targetFramework="net451" />
+  <package id="EntityFramework" version="6.1.2" targetFramework="net45" />
+  <package id="xunit" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.assert" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.core" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.0.0-rc3-build2880" targetFramework="net45" />
 </packages>

--- a/test/EntityFramework.Microbenchmarks/EntityFramework.Microbenchmarks.csproj
+++ b/test/EntityFramework.Microbenchmarks/EntityFramework.Microbenchmarks.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>EntityFramework.Microbenchmarks</RootNamespace>
     <AssemblyName>EntityFramework.Microbenchmarks</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>ff20b591</NuGetPackageImportStamp>
   </PropertyGroup>

--- a/test/EntityFramework.Microbenchmarks/packages.config
+++ b/test/EntityFramework.Microbenchmarks/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.abstractions" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.assert" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.core" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.extensibility.core" version="2.0.0-rc3-build2880" targetFramework="net451" />
+  <package id="xunit" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.assert" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.core" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.0.0-rc3-build2880" targetFramework="net45" />
 </packages>

--- a/test/EntityFramework.Relational.Design.Tests/EntityFramework.Relational.Design.Tests.csproj
+++ b/test/EntityFramework.Relational.Design.Tests/EntityFramework.Relational.Design.Tests.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Data.Entity.Relational.Design.Tests</RootNamespace>
     <AssemblyName>EntityFramework.Relational.Design.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/test/EntityFramework.Relational.Design.Tests/packages.config
+++ b/test/EntityFramework.Relational.Design.Tests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.abstractions" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.assert" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.core" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.extensibility.core" version="2.0.0-rc3-build2880" targetFramework="net451" />
+  <package id="xunit" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.assert" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.core" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.0.0-rc3-build2880" targetFramework="net45" />
 </packages>

--- a/test/EntityFramework.Relational.FunctionalTests/EntityFramework.Relational.FunctionalTests.csproj
+++ b/test/EntityFramework.Relational.FunctionalTests/EntityFramework.Relational.FunctionalTests.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Data.Entity.Relational.FunctionalTests</RootNamespace>
     <AssemblyName>EntityFramework.Relational.FunctionalTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>7c6125aa</NuGetPackageImportStamp>
   </PropertyGroup>

--- a/test/EntityFramework.Relational.FunctionalTests/packages.config
+++ b/test/EntityFramework.Relational.FunctionalTests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.abstractions" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.assert" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.core" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.extensibility.core" version="2.0.0-rc3-build2880" targetFramework="net451" />
+  <package id="xunit" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.assert" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.core" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.0.0-rc3-build2880" targetFramework="net45" />
 </packages>

--- a/test/EntityFramework.Relational.Tests/EntityFramework.Relational.Tests.csproj
+++ b/test/EntityFramework.Relational.Tests/EntityFramework.Relational.Tests.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Data.Entity.Relational.Tests</RootNamespace>
     <AssemblyName>EntityFramework.Relational.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>f94b196b</NuGetPackageImportStamp>
   </PropertyGroup>

--- a/test/EntityFramework.Relational.Tests/packages.config
+++ b/test/EntityFramework.Relational.Tests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.abstractions" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.assert" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.core" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.extensibility.core" version="2.0.0-rc3-build2880" targetFramework="net451" />
+  <package id="xunit" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.assert" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.core" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.0.0-rc3-build2880" targetFramework="net45" />
 </packages>

--- a/test/EntityFramework.SqlServer.Design.Tests/EntityFramework.SqlServer.Design.Tests.csproj
+++ b/test/EntityFramework.SqlServer.Design.Tests/EntityFramework.SqlServer.Design.Tests.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Data.Entity.SqlServer.Design.Tests</RootNamespace>
     <AssemblyName>EntityFramework.SqlServer.Design.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/test/EntityFramework.SqlServer.Design.Tests/packages.config
+++ b/test/EntityFramework.SqlServer.Design.Tests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.abstractions" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.assert" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.core" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.extensibility.core" version="2.0.0-rc3-build2880" targetFramework="net451" />
+  <package id="xunit" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.assert" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.core" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.0.0-rc3-build2880" targetFramework="net45" />
 </packages>

--- a/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
+++ b/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\packages\xunit.core.2.0.0-rc3-build2880\build\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.0.0-rc3-build2880\build\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Data.Entity.SqlServer.FunctionalTests</RootNamespace>
     <AssemblyName>EntityFramework.SqlServer.FunctionalTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>04bdbbf8</NuGetPackageImportStamp>
   </PropertyGroup>

--- a/test/EntityFramework.SqlServer.FunctionalTests/packages.config
+++ b/test/EntityFramework.SqlServer.FunctionalTests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.abstractions" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.assert" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.core" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.extensibility.core" version="2.0.0-rc3-build2880" targetFramework="net451" />
+  <package id="xunit" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.assert" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.core" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.0.0-rc3-build2880" targetFramework="net45" />
 </packages>

--- a/test/EntityFramework.SqlServer.Tests/EntityFramework.SqlServer.Tests.csproj
+++ b/test/EntityFramework.SqlServer.Tests/EntityFramework.SqlServer.Tests.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Data.Entity.SqlServer.Tests</RootNamespace>
     <AssemblyName>EntityFramework.SqlServer.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>7a22f5fc</NuGetPackageImportStamp>
   </PropertyGroup>

--- a/test/EntityFramework.SqlServer.Tests/packages.config
+++ b/test/EntityFramework.SqlServer.Tests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.abstractions" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.assert" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.core" version="2.0.0-rc3-build2880" targetFramework="net451" />
-  <package id="xunit.extensibility.core" version="2.0.0-rc3-build2880" targetFramework="net451" />
+  <package id="xunit" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.assert" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.core" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.0.0-rc3-build2880" targetFramework="net45" />
 </packages>

--- a/tools/EntityFramework.targets
+++ b/tools/EntityFramework.targets
@@ -7,7 +7,7 @@
   <ItemDefinitionGroup>
     <PackageReference>
       <Visible>False</Visible>
-      <TargetFramework>portable-net451+win81+wpa81</TargetFramework>
+      <TargetFramework>portable-net45+win</TargetFramework>
       <Assemblies />
     </PackageReference>
   </ItemDefinitionGroup>


### PR DESCRIPTION
This may (or may not) enable Mono/Xamarin.

This resolves #1965

@AndriySvyryd Will the removal of `TransactionScopeAsyncFlowOption` be a problem? If so, we'll have to cross-compile `EntityFramework.Relational` to both `net45` and `net451`.

This depends on the following.
- aspnet/Configuration#180
- aspnet/DependencyInjection#223
- aspnet/Logging#174
- aspnet/Options#57