### PR TITLE
Query: Foundational work on stateless query pipeline. The main change he...

### DIFF
--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -196,6 +196,7 @@
     <Compile Include="Query\Annotations\AsNoTrackingQueryAnnotation.cs" />
     <Compile Include="Query\Annotations\IncludeQueryAnnotation.cs" />
     <Compile Include="Query\EntityLoadInfo.cs" />
+    <Compile Include="Query\EntityTrackingInfo.cs" />
     <Compile Include="Query\ExpressionTreeVisitors\ExpressionStringBuilder.cs" />
     <Compile Include="Query\ExpressionTreeVisitors\ExpressionTreeVisitorBase.cs" />
     <Compile Include="Query\IEntityQueryProvider.cs" />

--- a/src/EntityFramework.Core/Query/EntityTrackingInfo.cs
+++ b/src/EntityFramework.Core/Query/EntityTrackingInfo.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Utilities;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.Expressions;
+
+namespace Microsoft.Data.Entity.Query
+{
+    public class EntityTrackingInfo
+    {
+        public EntityTrackingInfo(
+            [NotNull] QuerySourceReferenceExpression querySourceReferenceExpression,
+            [NotNull] IEntityType entityType)
+        {
+            Check.NotNull(querySourceReferenceExpression, nameof(querySourceReferenceExpression));
+            Check.NotNull(entityType, nameof(entityType));
+
+            QuerySourceReferenceExpression = querySourceReferenceExpression;
+            EntityType = entityType;
+        }
+
+        public virtual QuerySourceReferenceExpression QuerySourceReferenceExpression { get; }
+        public virtual IEntityType EntityType { get; }
+
+        public virtual IQuerySource QuerySource => QuerySourceReferenceExpression.ReferencedQuerySource;
+    }
+}

--- a/src/EntityFramework.Core/Query/ExpressionTreeVisitors/DefaultQueryExpressionTreeVisitor.cs
+++ b/src/EntityFramework.Core/Query/ExpressionTreeVisitors/DefaultQueryExpressionTreeVisitor.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
-using Microsoft.Data.Entity.Query.ResultOperators;
 using Microsoft.Data.Entity.Utilities;
 using Remotion.Linq.Clauses;
 using Remotion.Linq.Clauses.Expressions;
@@ -16,15 +15,72 @@ namespace Microsoft.Data.Entity.Query.ExpressionTreeVisitors
     public class DefaultQueryExpressionTreeVisitor : ExpressionTreeVisitorBase
     {
         private readonly EntityQueryModelVisitor _entityQueryModelVisitor;
+        private readonly IQuerySource _querySource;
 
-        public DefaultQueryExpressionTreeVisitor([NotNull] EntityQueryModelVisitor entityQueryModelVisitor)
+        public DefaultQueryExpressionTreeVisitor(
+            [NotNull] EntityQueryModelVisitor entityQueryModelVisitor,
+            [NotNull] IQuerySource querySource)
         {
             Check.NotNull(entityQueryModelVisitor, nameof(entityQueryModelVisitor));
+            Check.NotNull(querySource, nameof(querySource));
 
             _entityQueryModelVisitor = entityQueryModelVisitor;
+            _querySource = querySource;
         }
 
         public virtual EntityQueryModelVisitor QueryModelVisitor => _entityQueryModelVisitor;
+
+        public virtual IQuerySource QuerySource => _querySource;
+
+        protected override Expression VisitMemberExpression(MemberExpression memberExpression)
+        {
+            var newExpression = VisitExpression(memberExpression.Expression);
+
+            if (newExpression != memberExpression.Expression)
+            {
+                var newExpressionTypeInfo = newExpression.Type.GetTypeInfo();
+
+                if (newExpressionTypeInfo.IsGenericType
+                    && newExpressionTypeInfo.GetGenericTypeDefinition() == typeof(QuerySourceScope<>))
+                {
+                    newExpression
+                        = Expression.Convert(newExpression, memberExpression.Expression.Type);
+                }
+
+                return Expression.MakeMemberAccess(newExpression, memberExpression.Member);
+            }
+
+            return memberExpression;
+        }
+
+        protected override Expression VisitMethodCallExpression(MethodCallExpression methodCallExpression)
+        {
+            var newObject = VisitExpression(methodCallExpression.Object);
+            IList<Expression> newArguments = VisitAndConvert(methodCallExpression.Arguments, "VisitMethodCallExpression");
+
+            if (newObject != methodCallExpression.Object
+                || !ReferenceEquals(newArguments, methodCallExpression.Arguments))
+            {
+                if (newArguments.Any()
+                    && newArguments[0] != methodCallExpression.Arguments[0])
+                {
+                    var newArgumentTypeInfo = newArguments[0].Type.GetTypeInfo();
+
+                    if (newArgumentTypeInfo.IsGenericType
+                        && newArgumentTypeInfo.GetGenericTypeDefinition() == typeof(QuerySourceScope<>))
+                    {
+                        newArguments = new List<Expression>(newArguments);
+
+                        newArguments[0]
+                            = Expression.Convert(newArguments[0], methodCallExpression.Arguments[0].Type);
+                    }
+                }
+
+                return Expression.Call(newObject, methodCallExpression.Method, newArguments);
+            }
+
+            return methodCallExpression;
+        }
 
         protected override Expression VisitSubQueryExpression(SubQueryExpression subQueryExpression)
         {
@@ -34,12 +90,52 @@ namespace Microsoft.Data.Entity.Query.ExpressionTreeVisitors
 
             queryModelVisitor.VisitQueryModel(subQueryExpression.QueryModel);
 
+            var resultItemTypeInfo
+                = (queryModelVisitor.StreamedSequenceInfo?.ResultItemType
+                   ?? queryModelVisitor.Expression.Type)
+                    .GetTypeInfo();
+
+            if (resultItemTypeInfo.IsGenericType
+                && resultItemTypeInfo.GetGenericTypeDefinition() == typeof(QuerySourceScope<>))
+            {
+                return
+                    Expression.Call(
+                        (queryModelVisitor.StreamedSequenceInfo != null
+                            ? QueryModelVisitor.QueryCompilationContext.LinqOperatorProvider
+                                .RewrapQueryResults
+                            : _rewrapSingleResult)
+                            .MakeGenericMethod(resultItemTypeInfo.GenericTypeArguments[0]),
+                        queryModelVisitor.Expression,
+                        Expression.Constant(_querySource));
+            }
+
             return queryModelVisitor.Expression;
         }
 
-        protected EntityQueryModelVisitor CreateQueryModelVisitor() 
-            => QueryModelVisitor.QueryCompilationContext
-            .CreateQueryModelVisitor(_entityQueryModelVisitor);
+        private static readonly MethodInfo _rewrapSingleResult
+            = typeof(DefaultQueryExpressionTreeVisitor)
+                .GetTypeInfo().GetDeclaredMethod("RewrapSingleResult");
+
+        [UsedImplicitly]
+        private static QuerySourceScope<TResult> RewrapSingleResult<TResult>(
+            QuerySourceScope<TResult> querySourceScope,
+            IQuerySource querySource)
+            where TResult : class
+        {
+            return
+                new QuerySourceScope<TResult>(
+                    querySource,
+                    // ReSharper disable once MergeConditionalExpression
+                    querySourceScope != null ? querySourceScope.Result : default(TResult),
+                    querySourceScope,
+                    null);
+        }
+
+        protected EntityQueryModelVisitor CreateQueryModelVisitor()
+        {
+            return QueryModelVisitor.QueryCompilationContext
+                .CreateQueryModelVisitor(_entityQueryModelVisitor);
+        }
 
         protected override Expression VisitParameterExpression(ParameterExpression parameterExpression)
         {
@@ -61,7 +157,9 @@ namespace Microsoft.Data.Entity.Query.ExpressionTreeVisitors
                 .GetTypeInfo().GetDeclaredMethod("GetParameterValue");
 
         [UsedImplicitly]
-        private static T GetParameterValue<T>(QueryContext queryContext, string parameterName) 
-            => (T)queryContext.ParameterValues[parameterName];
+        private static T GetParameterValue<T>(QueryContext queryContext, string parameterName)
+        {
+            return (T)queryContext.ParameterValues[parameterName];
+        }
     }
 }

--- a/src/EntityFramework.Core/Query/ExpressionTreeVisitors/EntityResultFindingExpressionTreeVisitor.cs
+++ b/src/EntityFramework.Core/Query/ExpressionTreeVisitors/EntityResultFindingExpressionTreeVisitor.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Data.Entity.Query.ExpressionTreeVisitors
     {
         private readonly IModel _model;
 
-        private List<QuerySourceReferenceExpression> _querySourceReferenceExpressions;
+        private List<EntityTrackingInfo> _entityTrackingInfos;
 
         public EntityResultFindingExpressionTreeVisitor([NotNull] IModel model)
         {
@@ -23,43 +23,70 @@ namespace Microsoft.Data.Entity.Query.ExpressionTreeVisitors
             _model = model;
         }
 
-        public virtual IEnumerable<QuerySourceReferenceExpression> FindEntitiesInResult([NotNull] Expression expression)
+        public virtual IEnumerable<EntityTrackingInfo> FindEntitiesInResult([NotNull] Expression expression)
         {
             Check.NotNull(expression, nameof(expression));
 
-            _querySourceReferenceExpressions = new List<QuerySourceReferenceExpression>();
+            _entityTrackingInfos = new List<EntityTrackingInfo>();
 
             VisitExpression(expression);
 
-            return _querySourceReferenceExpressions;
+            return _entityTrackingInfos;
         }
 
-        protected override Expression VisitQuerySourceReferenceExpression(QuerySourceReferenceExpression expression)
+        protected override Expression VisitQuerySourceReferenceExpression(
+            QuerySourceReferenceExpression querySourceReferenceExpression)
         {
-            if (_model.FindEntityType(expression.Type) != null)
+            var entityType = _model.FindEntityType(querySourceReferenceExpression.Type);
+
+            if (entityType != null)
             {
-                _querySourceReferenceExpressions.Add(expression);
+                _entityTrackingInfos.Add(new EntityTrackingInfo(querySourceReferenceExpression, entityType));
             }
 
-            return expression;
+            return querySourceReferenceExpression;
         }
 
         // Prune these nodes...
 
-        protected override Expression VisitSubQueryExpression(SubQueryExpression expression) => expression;
+        protected override Expression VisitSubQueryExpression(SubQueryExpression expression)
+        {
+            return expression;
+        }
 
-        protected override Expression VisitMemberExpression(MemberExpression expression) => expression;
+        protected override Expression VisitMemberExpression(MemberExpression expression)
+        {
+            return expression;
+        }
 
-        protected override Expression VisitMethodCallExpression(MethodCallExpression expression) => expression;
+        protected override Expression VisitMethodCallExpression(MethodCallExpression expression)
+        {
+            return expression;
+        }
 
-        protected override Expression VisitConditionalExpression(ConditionalExpression expression) => expression;
+        protected override Expression VisitConditionalExpression(ConditionalExpression expression)
+        {
+            return expression;
+        }
 
-        protected override Expression VisitBinaryExpression(BinaryExpression expression) => expression;
+        protected override Expression VisitBinaryExpression(BinaryExpression expression)
+        {
+            return expression;
+        }
 
-        protected override Expression VisitTypeBinaryExpression(TypeBinaryExpression expression) => expression;
+        protected override Expression VisitTypeBinaryExpression(TypeBinaryExpression expression)
+        {
+            return expression;
+        }
 
-        protected override Expression VisitLambdaExpression(LambdaExpression expression) => expression;
+        protected override Expression VisitLambdaExpression(LambdaExpression expression)
+        {
+            return expression;
+        }
 
-        protected override Expression VisitInvocationExpression(InvocationExpression expression) => expression;
+        protected override Expression VisitInvocationExpression(InvocationExpression expression)
+        {
+            return expression;
+        }
     }
 }

--- a/src/EntityFramework.Core/Query/ExpressionTreeVisitors/MemberAccessBindingExpressionTreeVisitor.cs
+++ b/src/EntityFramework.Core/Query/ExpressionTreeVisitors/MemberAccessBindingExpressionTreeVisitor.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -9,17 +10,21 @@ using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Utilities;
 using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.Expressions;
 using Remotion.Linq.Clauses.ExpressionTreeVisitors;
+using Remotion.Linq.Parsing;
 
 namespace Microsoft.Data.Entity.Query.ExpressionTreeVisitors
 {
     public class MemberAccessBindingExpressionTreeVisitor : ReferenceReplacingExpressionTreeVisitor
     {
         private readonly EntityQueryModelVisitor _queryModelVisitor;
+        private readonly bool _inProjection;
 
         public MemberAccessBindingExpressionTreeVisitor(
             [NotNull] QuerySourceMapping querySourceMapping,
-            [NotNull] EntityQueryModelVisitor queryModelVisitor)
+            [NotNull] EntityQueryModelVisitor queryModelVisitor,
+            bool inProjection)
             : base(
                 Check.NotNull(querySourceMapping, nameof(querySourceMapping)),
                 throwOnUnmappedReferences: false)
@@ -27,9 +32,75 @@ namespace Microsoft.Data.Entity.Query.ExpressionTreeVisitors
             Check.NotNull(queryModelVisitor, nameof(queryModelVisitor));
 
             _queryModelVisitor = queryModelVisitor;
+            _inProjection = inProjection;
         }
 
-        protected override Expression VisitMemberExpression(MemberExpression memberExpression)
+        protected override Expression VisitSubQueryExpression(SubQueryExpression subQueryExpression)
+        {
+            subQueryExpression.QueryModel.TransformExpressions(VisitExpression);
+
+            return subQueryExpression;
+        }
+
+        protected override Expression VisitQuerySourceReferenceExpression(QuerySourceReferenceExpression expression)
+        {
+            var newExpression
+                = QuerySourceMapping.ContainsMapping(expression.ReferencedQuerySource)
+                    ? QuerySourceMapping.GetExpression(expression.ReferencedQuerySource)
+                    : base.VisitQuerySourceReferenceExpression(expression);
+
+            if (_inProjection
+                && newExpression.Type.IsConstructedGenericType)
+            {
+                var genericTypeDefinition = newExpression.Type.GetGenericTypeDefinition();
+
+                if (genericTypeDefinition == typeof(IOrderedAsyncEnumerable<>))
+                {
+                    newExpression = TryUnwrap(newExpression);
+
+                    newExpression
+                        = Expression.Call(
+                            _queryModelVisitor.LinqOperatorProvider.ToOrdered
+                                .MakeGenericMethod(newExpression.Type.GenericTypeArguments[0]),
+                            newExpression);
+                }
+                else if (genericTypeDefinition == typeof(IAsyncEnumerable<>))
+                {
+                    newExpression = TryUnwrap(newExpression);
+
+                    newExpression
+                        = Expression.Call(
+                            _queryModelVisitor.LinqOperatorProvider.ToEnumerable
+                                .MakeGenericMethod(newExpression.Type.GenericTypeArguments[0]),
+                            newExpression);
+                }
+                else if (genericTypeDefinition == typeof(IEnumerable<>))
+                {
+                    newExpression = TryUnwrap(newExpression);
+                }
+            }
+
+            return newExpression;
+        }
+
+        private Expression TryUnwrap(Expression expression)
+        {
+            var sequenceType = expression.Type.GenericTypeArguments[0];
+
+            if (sequenceType.IsConstructedGenericType
+                && sequenceType.GetGenericTypeDefinition() == typeof(QuerySourceScope<>))
+            {
+                expression
+                    = Expression.Call(
+                        _queryModelVisitor.LinqOperatorProvider.UnwrapQueryResults
+                            .MakeGenericMethod(sequenceType.GenericTypeArguments[0]),
+                        expression);
+            }
+
+            return expression;
+        }
+
+        protected override Expression VisitMemberExpression([NotNull] MemberExpression memberExpression)
         {
             var newExpression = VisitExpression(memberExpression.Expression);
 
@@ -37,16 +108,44 @@ namespace Microsoft.Data.Entity.Query.ExpressionTreeVisitors
             {
                 if (newExpression.Type == typeof(IValueReader))
                 {
-                    return _queryModelVisitor.BindMemberToValueReader(memberExpression, newExpression);
+                    return _queryModelVisitor.BindMemberToValueReader(memberExpression, newExpression)
+                           ?? memberExpression;
                 }
 
                 var member = memberExpression.Member;
                 var typeInfo = newExpression.Type.GetTypeInfo();
 
-                if (typeInfo.IsGenericType
-                    && typeInfo.GetGenericTypeDefinition() == typeof(IAsyncGrouping<,>))
+                if (typeInfo.IsGenericType)
                 {
-                    member = typeInfo.GetDeclaredProperty("Key");
+                    var genericTypeDefinition = typeInfo.GetGenericTypeDefinition();
+                    var asyncGrouping = genericTypeDefinition == typeof(IAsyncGrouping<,>);
+
+                    if (genericTypeDefinition == typeof(IGrouping<,>)
+                        || asyncGrouping)
+                    {
+                        newExpression
+                            = Expression.Call(
+                                _queryModelVisitor.LinqOperatorProvider
+                                    .UnwrapGrouping
+                                    .MakeGenericMethod(
+                                        typeInfo.GenericTypeArguments[0],
+                                        typeInfo.GenericTypeArguments[1]
+                                            .GetTypeInfo()
+                                            .GenericTypeArguments[0]),
+                                newExpression);
+
+                        if (asyncGrouping)
+                        {
+                            member = newExpression.Type.GetTypeInfo().GetDeclaredProperty("Key");
+                        }
+                    }
+                    else if (genericTypeDefinition == typeof(QuerySourceScope<>))
+                    {
+                        newExpression
+                            = Expression.Convert(
+                                newExpression,
+                                typeInfo.GenericTypeArguments[0]);
+                    }
                 }
 
                 return Expression.MakeMemberAccess(newExpression, member);
@@ -55,7 +154,7 @@ namespace Microsoft.Data.Entity.Query.ExpressionTreeVisitors
             return memberExpression;
         }
 
-        protected override Expression VisitMethodCallExpression(MethodCallExpression methodCallExpression)
+        protected override Expression VisitMethodCallExpression([NotNull] MethodCallExpression methodCallExpression)
         {
             var newExpression
                 = (MethodCallExpression)base.VisitMethodCallExpression(methodCallExpression);
@@ -73,12 +172,54 @@ namespace Microsoft.Data.Entity.Query.ExpressionTreeVisitors
             return _queryModelVisitor
                 .BindMethodCallExpression(
                     methodCallExpression,
-                    (property, _) => Expression.Call(
-                        _getValueMethodInfo.MakeGenericMethod(newExpression.Method.GetGenericArguments()[0]),
-                        EntityQueryModelVisitor.QueryContextParameter,
-                        newExpression.Arguments[0],
-                        Expression.Constant(property)))
+                    (property, _) =>
+                        {
+                            var querySourceScopeExpression
+                                = new QuerySourceScopeFindingExpressionTreeVisitor()
+                                    .Find(newExpression.Arguments[0]);
+
+                            return Expression.Call(
+                                _getValueMethodInfo.MakeGenericMethod(newExpression.Method.GetGenericArguments()[0]),
+                                EntityQueryModelVisitor.QueryContextParameter,
+                                newExpression.Arguments[0],
+                                querySourceScopeExpression,
+                                Expression.Constant(property));
+                        })
                    ?? newExpression;
+        }
+
+        private class QuerySourceScopeFindingExpressionTreeVisitor : ExpressionTreeVisitor
+        {
+            private Expression _result;
+
+            public Expression Find(Expression expression)
+            {
+                _result = null;
+
+                VisitExpression(expression);
+
+                return _result;
+            }
+
+            public override Expression VisitExpression(Expression expression)
+            {
+                if (_result == null
+                    && expression != null)
+                {
+                    if ((expression.Type.IsConstructedGenericType
+                         && expression.Type.GetGenericTypeDefinition() == typeof(QuerySourceScope<>))
+                        || expression.Type == typeof(QuerySourceScope))
+                    {
+                        _result = expression;
+                    }
+                    else
+                    {
+                        return base.VisitExpression(expression);
+                    }
+                }
+
+                return expression;
+            }
         }
 
         private static readonly MethodInfo _getValueMethodInfo
@@ -86,7 +227,13 @@ namespace Microsoft.Data.Entity.Query.ExpressionTreeVisitors
                 .GetTypeInfo().GetDeclaredMethod(nameof(GetValue));
 
         [UsedImplicitly]
-        private static T GetValue<T>(QueryContext queryContext, object entity, IProperty property) 
-            => (T)queryContext.QueryBuffer.GetPropertyValue(entity, property);
+        private static T GetValue<T>(
+            QueryContext queryContext,
+            object entity,
+            QuerySourceScope querySourceScope,
+            IProperty property)
+        {
+            return (T)queryContext.GetPropertyValue(entity, querySourceScope, property);
+        }
     }
 }

--- a/src/EntityFramework.Core/Query/ILinqOperatorProvider.cs
+++ b/src/EntityFramework.Core/Query/ILinqOperatorProvider.cs
@@ -10,6 +10,10 @@ namespace Microsoft.Data.Entity.Query
 {
     public interface ILinqOperatorProvider
     {
+        MethodInfo TrackEntities { get; }
+        MethodInfo TrackGroupedEntities { get; }
+        MethodInfo InterceptExceptions { get; }
+
         MethodInfo SelectMany { get; }
         MethodInfo Join { get; }
         MethodInfo GroupJoin { get; }
@@ -17,10 +21,10 @@ namespace Microsoft.Data.Entity.Query
         MethodInfo OrderBy { get; }
         MethodInfo ThenBy { get; }
         MethodInfo Where { get; }
-        MethodInfo ToSequence { get; }
         MethodInfo Any { get; }
         MethodInfo All { get; }
         MethodInfo Cast { get; }
+        MethodInfo CastWrappedResult { get; }
         MethodInfo Count { get; }
         MethodInfo Contains { get; }
         MethodInfo DefaultIfEmpty { get; }
@@ -36,12 +40,20 @@ namespace Microsoft.Data.Entity.Query
         MethodInfo SingleOrDefault { get; }
         MethodInfo Skip { get; }
         MethodInfo Take { get; }
-        MethodInfo AsQueryable { get; }
-        MethodInfo TrackEntities { get; }
-        MethodInfo InterceptExceptions { get; }
         MethodInfo OfType { get; }
+        MethodInfo OfTypeWrappedResult { get; }
+
+        MethodInfo UnwrapQueryResults { get; }
+        MethodInfo UnwrapGroupedQueryResults { get; }
+        MethodInfo UnwrapGrouping { get; }
+        MethodInfo RewrapQueryResults { get; }
+
+        MethodInfo ToSequence { get; }
+        MethodInfo ToOrdered { get; }
+        MethodInfo ToEnumerable { get; }
+        MethodInfo ToQueryable { get; }
+        Expression AdjustSequenceType([NotNull] Expression expression);
 
         MethodInfo GetAggregateMethod([NotNull] string methodName, [NotNull] Type elementType);
-        Expression AdjustSequenceType([NotNull] Expression expression);
     }
 }

--- a/src/EntityFramework.Core/Query/IQueryBuffer.cs
+++ b/src/EntityFramework.Core/Query/IQueryBuffer.cs
@@ -26,8 +26,6 @@ namespace Microsoft.Data.Entity.Query
             EntityLoadInfo entityLoadInfo,
             bool queryStateManager);
 
-        object GetPropertyValue([NotNull] object entity, [NotNull] IProperty property);
-
         void StartTracking([NotNull] object entity);
 
         void Include(

--- a/src/EntityFramework.Core/Query/QueryCompilationContext.cs
+++ b/src/EntityFramework.Core/Query/QueryCompilationContext.cs
@@ -8,6 +8,7 @@ using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
+using Remotion.Linq.Clauses;
 
 namespace Microsoft.Data.Entity.Query
 {
@@ -49,6 +50,8 @@ namespace Microsoft.Data.Entity.Query
         public virtual IEntityMaterializerSource EntityMaterializerSource { get; }
 
         public virtual IEntityKeyFactorySource EntityKeyFactorySource { get; }
+
+        public virtual QuerySourceMapping QuerySourceMapping { get; } = new QuerySourceMapping();
 
         public virtual ICollection<QueryAnnotation> QueryAnnotations
         {

--- a/src/EntityFramework.Core/Query/QueryContext.cs
+++ b/src/EntityFramework.Core/Query/QueryContext.cs
@@ -5,6 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.ChangeTracking.Internal;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 
@@ -12,17 +15,22 @@ namespace Microsoft.Data.Entity.Query
 {
     public class QueryContext
     {
+        private readonly IStateManager _stateManager;
+
         private IDictionary<string, object> _parameterValues;
 
         public QueryContext(
             [NotNull] ILogger logger,
-            [NotNull] IQueryBuffer queryBuffer)
+            [NotNull] IQueryBuffer queryBuffer,
+            [NotNull] IStateManager stateManager)
         {
             Check.NotNull(logger, nameof(logger));
             Check.NotNull(queryBuffer, nameof(queryBuffer));
 
             Logger = logger;
             QueryBuffer = queryBuffer;
+
+            _stateManager = stateManager;
         }
 
         // TODO: Move this to compilation context
@@ -33,8 +41,47 @@ namespace Microsoft.Data.Entity.Query
         public virtual CancellationToken CancellationToken { get; set; }
 
         public virtual IDictionary<string, object> ParameterValues
-            => _parameterValues ?? (_parameterValues = new Dictionary<string, object>());
+            => _parameterValues
+               ?? (_parameterValues = new Dictionary<string, object>());
 
         public virtual Type ContextType { get; [param: NotNull] set; }
+
+        public virtual void StartTracking(
+            [NotNull] IEntityType entityType,
+            [NotNull] object instance,
+            [NotNull] IValueReader valueReader)
+        {
+            Check.NotNull(entityType, nameof(entityType));
+            Check.NotNull(instance, nameof(instance));
+            Check.NotNull(valueReader, nameof(valueReader));
+
+            _stateManager.StartTracking(entityType, instance, valueReader);
+
+            // TODO: Remove #2015, #2016
+            QueryBuffer.StartTracking(instance);
+        }
+
+        public virtual object GetPropertyValue(
+            [NotNull] object entity,
+            [NotNull] QuerySourceScope querySourceScope,
+            [NotNull] IProperty property)
+        {
+            Check.NotNull(entity, nameof(entity));
+            Check.NotNull(querySourceScope, nameof(querySourceScope));
+            Check.NotNull(property, nameof(property));
+
+            var entry = _stateManager.TryGetEntry(entity);
+
+            if (entry != null)
+            {
+                return entry[property];
+            }
+
+            var valueReader = querySourceScope.GetValueReader(entity);
+
+            return valueReader.IsNull(property.Index)
+                ? null
+                : valueReader.ReadValue<object>(property.Index);
+        }
     }
 }

--- a/src/EntityFramework.Core/Query/QueryContextFactory.cs
+++ b/src/EntityFramework.Core/Query/QueryContextFactory.cs
@@ -12,7 +12,6 @@ namespace Microsoft.Data.Entity.Query
     public abstract class QueryContextFactory : IQueryContextFactory
     {
         private readonly LazyRef<ILogger> _logger;
-        private readonly IStateManager _stateManager;
         private readonly IClrCollectionAccessorSource _collectionAccessorSource;
         private readonly IClrAccessorSource<IClrPropertySetter> _propertySetterSource;
         private readonly IEntityKeyFactorySource _entityKeyFactorySource;
@@ -30,7 +29,7 @@ namespace Microsoft.Data.Entity.Query
             Check.NotNull(propertySetterSource, nameof(propertySetterSource));
             Check.NotNull(loggerFactory, nameof(loggerFactory));
 
-            _stateManager = stateManager;
+            StateManager = stateManager;
             _entityKeyFactorySource = entityKeyFactorySource;
             _collectionAccessorSource = collectionAccessorSource;
             _propertySetterSource = propertySetterSource;
@@ -41,8 +40,10 @@ namespace Microsoft.Data.Entity.Query
         public virtual ILogger Logger => _logger.Value;
 
         protected virtual IQueryBuffer CreateQueryBuffer()
-            => new QueryBuffer(_stateManager, _entityKeyFactorySource, _collectionAccessorSource, _propertySetterSource);
+            => new QueryBuffer(StateManager, _entityKeyFactorySource, _collectionAccessorSource, _propertySetterSource);
 
         public abstract QueryContext CreateQueryContext();
+
+        public virtual IStateManager StateManager { get; }
     }
 }

--- a/src/EntityFramework.Core/Query/QuerySourceScope.cs
+++ b/src/EntityFramework.Core/Query/QuerySourceScope.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Storage;
 using Remotion.Linq.Clauses;
 
 namespace Microsoft.Data.Entity.Query
@@ -20,50 +21,144 @@ namespace Microsoft.Data.Entity.Query
             = typeof(QuerySourceScope).GetTypeInfo()
                 .GetDeclaredMethods("GetResult").FirstOrDefault(m => !m.IsStatic && !m.IsPublic);
 
+        private static readonly MethodInfo _getFirstResultMethodInfo
+            = typeof(QuerySourceScope).GetTypeInfo()
+                .GetDeclaredMethods("GetFirstResult").FirstOrDefault(m => !m.IsStatic && !m.IsPublic);
+
+        private static readonly MethodInfo _joinMethodInfo
+            = typeof(QuerySourceScope).GetTypeInfo()
+                .GetDeclaredMethods("Join").FirstOrDefault(m => m.IsStatic && !m.IsPublic);
+
+        public static Expression Join(
+            [NotNull] IQuerySource querySource,
+            [NotNull] Expression scope,
+            [NotNull] Expression parentScope)
+        {
+            return Expression.Call(
+                _joinMethodInfo.MakeGenericMethod(
+                    scope.Type.GenericTypeArguments[0]),
+                Expression.Constant(querySource),
+                scope,
+                parentScope);
+        }
+
+        [UsedImplicitly]
+        private static QuerySourceScope<TResult> Join<TResult>(
+            IQuerySource querySource,
+            QuerySourceScope<TResult> scope,
+            QuerySourceScope parentScope)
+        {
+            if (parentScope != null)
+            {
+                Reparent(scope, parentScope);
+            }
+
+            return new QuerySourceScope<TResult>(querySource, scope.Result, scope, null);
+        }
+
+        private static void Reparent(QuerySourceScope scope, QuerySourceScope parentScope)
+        {
+            if (scope.ParentScope == null
+                || scope.ParentScope.QuerySource == parentScope.QuerySource)
+            {
+                scope.ParentScope = parentScope;
+            }
+            else
+            {
+                Reparent(scope.ParentScope, parentScope);
+            }
+        }
+
         public static Expression Create(
             [NotNull] IQuerySource querySource,
             [NotNull] Expression result,
-            [NotNull] Expression parentScope)
-            => Expression.Call(
+            [NotNull] Expression parentScope,
+            [CanBeNull] Expression valueReader = null)
+        {
+            return Expression.Call(
                 _createMethodInfo.MakeGenericMethod(result.Type),
                 Expression.Constant(querySource),
                 result,
-                parentScope);
+                parentScope,
+                valueReader ?? Expression.Constant(null, typeof(IValueReader)));
+        }
 
         public static Expression GetResult(
             [NotNull] Expression querySourceScope,
             [NotNull] IQuerySource querySource,
             [NotNull] Type resultType)
-            => Expression.Call(
+        {
+            return Expression.Call(
                 querySourceScope,
                 _getResultMethodInfo.MakeGenericMethod(resultType),
                 Expression.Constant(querySource));
-
-        private readonly QuerySourceScope _parentScope;
-        private readonly IQuerySource _querySource;
-
-        protected QuerySourceScope(IQuerySource querySource, QuerySourceScope parentScope)
-        {
-            _querySource = querySource;
-            _parentScope = parentScope;
         }
+
+        public static Expression GetResult(
+            [NotNull] Expression querySourceScope,
+            [NotNull] Type resultType)
+        {
+            return Expression.Call(
+                querySourceScope,
+                _getFirstResultMethodInfo.MakeGenericMethod(resultType));
+        }
+
+        private readonly IValueReader _valueReader;
+
+        protected QuerySourceScope(
+            IQuerySource querySource,
+            QuerySourceScope parentScope,
+            IValueReader valueReader)
+        {
+            QuerySource = querySource;
+            ParentScope = parentScope;
+
+            _valueReader = valueReader;
+        }
+
+        public abstract object UntypedResult { get; }
+
+        public virtual IQuerySource QuerySource { get; }
+        public virtual QuerySourceScope ParentScope { get; private set; }
+        public virtual IValueReader ValueReader => _valueReader;
 
         [UsedImplicitly]
         private static QuerySourceScope<TResult> Create<TResult>(
-            IQuerySource querySource, TResult result, QuerySourceScope parentScope)
-            => new QuerySourceScope<TResult>(querySource, result, parentScope);
+            IQuerySource querySource,
+            TResult result,
+            QuerySourceScope parentScope,
+            IValueReader valueReader)
+        {
+            return new QuerySourceScope<TResult>(querySource, result, parentScope, valueReader);
+        }
 
         [UsedImplicitly]
         private TResult GetResult<TResult>(IQuerySource querySource)
-            => _querySource == querySource
+        {
+            return QuerySource == querySource
                 ? ((QuerySourceScope<TResult>)this).Result
-                : _parentScope.GetResult<TResult>(querySource);
+                : ParentScope.GetResult<TResult>(querySource);
+        }
+
+        [UsedImplicitly]
+        private TResult GetFirstResult<TResult>()
+        {
+            return ((QuerySourceScope<TResult>)this).Result;
+        }
 
         public virtual object GetResult([NotNull] IQuerySource querySource)
-            => _querySource == querySource
+        {
+            return QuerySource == querySource
                 ? UntypedResult
-                : _parentScope.GetResult(querySource);
+                : ParentScope.GetResult(querySource);
+        }
 
-        public abstract object UntypedResult { get; }
+        public virtual IValueReader GetValueReader([NotNull] object result)
+        {
+            return UntypedResult == result
+                   && _valueReader != null
+                ? _valueReader
+                : ParentScope?.GetValueReader(result);
+        }
     }
 }

--- a/src/EntityFramework.Core/Query/QuerySourceScope`.cs
+++ b/src/EntityFramework.Core/Query/QuerySourceScope`.cs
@@ -1,24 +1,63 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Diagnostics;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Storage;
 using Remotion.Linq.Clauses;
 
 namespace Microsoft.Data.Entity.Query
 {
-    public class QuerySourceScope<TResult> : QuerySourceScope
+    public class QuerySourceScope<TResult>
+        : QuerySourceScope, IEquatable<QuerySourceScope<TResult>>, IComparable<QuerySourceScope<TResult>>
     {
+        public static implicit operator TResult([NotNull] QuerySourceScope<TResult> querySourceScope)
+        {
+            return querySourceScope.Result;
+        }
+
         public readonly TResult Result;
 
         public QuerySourceScope(
             [NotNull] IQuerySource querySource,
-            [NotNull] TResult result,
-            [CanBeNull] QuerySourceScope parentScope)
-            : base(querySource, parentScope)
+            [CanBeNull] TResult result,
+            [CanBeNull] QuerySourceScope parentScope,
+            [CanBeNull] IValueReader valueReader)
+            : base(querySource, parentScope, valueReader)
         {
             Result = result;
         }
 
         public override object UntypedResult => Result;
+
+        public virtual bool Equals([NotNull] QuerySourceScope<TResult> other)
+        {
+            Debug.Assert(other != null);
+
+            return Equals(Result, other.Result);
+        }
+
+        public virtual int CompareTo(QuerySourceScope<TResult> other)
+        {
+            return ((IComparable<TResult>)Result).CompareTo(other.Result);
+        }
+
+        public override bool Equals([NotNull] object obj)
+        {
+            Debug.Assert(obj != null);
+
+            return Equals(Result, ((QuerySourceScope<TResult>)obj).Result);
+        }
+
+        public override int GetHashCode()
+        {
+            return Result?.GetHashCode() ?? 0;
+        }
+
+        public override string ToString()
+        {
+            return Result?.ToString() ?? "(null)";
+        }
     }
 }

--- a/src/EntityFramework.Core/Query/ResultOperatorHandler.cs
+++ b/src/EntityFramework.Core/Query/ResultOperatorHandler.cs
@@ -8,7 +8,6 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading;
 using JetBrains.Annotations;
-using Microsoft.Data.Entity.Query.ResultOperators;
 using Microsoft.Data.Entity.Utilities;
 using Remotion.Linq;
 using Remotion.Linq.Clauses;
@@ -26,7 +25,7 @@ namespace Microsoft.Data.Entity.Query
                     { typeof(AllResultOperator), (v, r, q) => HandleAll(v, (AllResultOperator)r, q) },
                     { typeof(AnyResultOperator), (v, _, __) => HandleAny(v) },
                     { typeof(AverageResultOperator), (v, _, __) => HandleAverage(v) },
-                    { typeof(CastResultOperator), (v, r, __) => HandleCast(v, (CastResultOperator)r) },
+                    { typeof(CastResultOperator), (v, r, _) => HandleCast(v, (CastResultOperator)r) },
                     { typeof(CountResultOperator), (v, _, __) => HandleCount(v) },
                     { typeof(ContainsResultOperator), (v, r, q) => HandleContains(v, (ContainsResultOperator)r, q) },
                     { typeof(DefaultIfEmptyResultOperator), (v, r, q) => HandleDefaultIfEmpty(v, (DefaultIfEmptyResultOperator)r, q) },
@@ -37,7 +36,7 @@ namespace Microsoft.Data.Entity.Query
                     { typeof(LongCountResultOperator), (v, _, __) => HandleLongCount(v) },
                     { typeof(MinResultOperator), (v, _, __) => HandleMin(v) },
                     { typeof(MaxResultOperator), (v, _, __) => HandleMax(v) },
-                    { typeof(OfTypeResultOperator), (v, r, q) => HandleOfType(v, (OfTypeResultOperator)r) },
+                    { typeof(OfTypeResultOperator), (v, r, q) => HandleOfType(v, (OfTypeResultOperator)r, q) },
                     { typeof(SingleResultOperator), (v, r, __) => HandleSingle(v, (ChoiceResultOperatorBase)r) },
                     { typeof(SkipResultOperator), (v, r, __) => HandleSkip(v, (SkipResultOperator)r) },
                     { typeof(SumResultOperator), (v, _, __) => HandleSum(v) },
@@ -84,36 +83,63 @@ namespace Microsoft.Data.Entity.Query
         }
 
         private static Expression HandleAny(EntityQueryModelVisitor entityQueryModelVisitor)
-            => CallWithPossibleCancellationToken(
+        {
+            return CallWithPossibleCancellationToken(
                 entityQueryModelVisitor.LinqOperatorProvider.Any
                     .MakeGenericMethod(entityQueryModelVisitor.StreamedSequenceInfo.ResultItemType),
                 entityQueryModelVisitor.Expression);
+        }
 
         private static Expression HandleAverage(EntityQueryModelVisitor entityQueryModelVisitor)
-            => HandleAggregate(entityQueryModelVisitor, "Average");
+        {
+            return HandleAggregate(entityQueryModelVisitor, "Average");
+        }
 
         private static Expression HandleCast(
-            EntityQueryModelVisitor entityQueryModelVisitor, CastResultOperator castResultOperator)
-            => Expression.Call(
+            EntityQueryModelVisitor entityQueryModelVisitor,
+            CastResultOperator castResultOperator)
+        {
+            var resultItemTypeInfo
+                = entityQueryModelVisitor.Expression.Type.GetSequenceType().GetTypeInfo();
+
+            if (castResultOperator.CastItemType.GetTypeInfo()
+                .IsAssignableFrom(resultItemTypeInfo))
+            {
+                return entityQueryModelVisitor.Expression;
+            }
+
+            if (entityQueryModelVisitor.IsWrappingResults)
+            {
+                return Expression.Call(
+                    entityQueryModelVisitor.LinqOperatorProvider
+                        .CastWrappedResult.MakeGenericMethod(castResultOperator.CastItemType),
+                    entityQueryModelVisitor.Expression);
+            }
+
+            return Expression.Call(
                 entityQueryModelVisitor.LinqOperatorProvider
                     .Cast.MakeGenericMethod(castResultOperator.CastItemType),
                 entityQueryModelVisitor.Expression);
+        }
 
         private static Expression HandleCount(EntityQueryModelVisitor entityQueryModelVisitor)
-            => CallWithPossibleCancellationToken(
+        {
+            return CallWithPossibleCancellationToken(
                 entityQueryModelVisitor.LinqOperatorProvider
                     .Count.MakeGenericMethod(entityQueryModelVisitor.StreamedSequenceInfo.ResultItemType),
                 entityQueryModelVisitor.Expression);
+        }
 
         private static Expression HandleContains(
             EntityQueryModelVisitor entityQueryModelVisitor,
             ContainsResultOperator containsResultOperator,
             QueryModel queryModel)
         {
-            var item = entityQueryModelVisitor
-                .ReplaceClauseReferences(
-                    containsResultOperator.Item,
-                    queryModel.MainFromClause);
+            var item
+                = entityQueryModelVisitor
+                    .ReplaceClauseReferences(
+                        containsResultOperator.Item,
+                        queryModel.MainFromClause);
 
             return CallWithPossibleCancellationToken(
                 entityQueryModelVisitor.LinqOperatorProvider.Contains
@@ -143,28 +169,32 @@ namespace Microsoft.Data.Entity.Query
 
             return Expression.Call(
                 entityQueryModelVisitor.LinqOperatorProvider.DefaultIfEmptyArg
-                    .MakeGenericMethod(typeof(QuerySourceScope)),
-                entityQueryModelVisitor.CreateScope(
-                    entityQueryModelVisitor.Expression,
-                    entityQueryModelVisitor.StreamedSequenceInfo.ResultItemType,
-                    queryModel.MainFromClause),
-                optionalDefaultValue);
+                    .MakeGenericMethod(entityQueryModelVisitor.StreamedSequenceInfo.ResultItemType),
+                entityQueryModelVisitor.Expression,
+                QuerySourceScope.Create(
+                    queryModel.MainFromClause,
+                    optionalDefaultValue,
+                    EntityQueryModelVisitor.QuerySourceScopeParameter));
         }
 
         private static Expression HandleDistinct(EntityQueryModelVisitor entityQueryModelVisitor)
-            => Expression.Call(
+        {
+            return Expression.Call(
                 entityQueryModelVisitor.LinqOperatorProvider.Distinct
                     .MakeGenericMethod(entityQueryModelVisitor.StreamedSequenceInfo.ResultItemType),
                 entityQueryModelVisitor.Expression);
+        }
 
         private static Expression HandleFirst(
             EntityQueryModelVisitor entityQueryModelVisitor, ChoiceResultOperatorBase choiceResultOperator)
-            => CallWithPossibleCancellationToken(
+        {
+            return CallWithPossibleCancellationToken(
                 (choiceResultOperator.ReturnDefaultWhenEmpty
                     ? entityQueryModelVisitor.LinqOperatorProvider.FirstOrDefault
                     : entityQueryModelVisitor.LinqOperatorProvider.First)
                     .MakeGenericMethod(entityQueryModelVisitor.StreamedSequenceInfo.ResultItemType),
                 entityQueryModelVisitor.Expression);
+        }
 
         private static Expression HandleGroup(
             EntityQueryModelVisitor entityQueryModelVisitor,
@@ -178,86 +208,133 @@ namespace Microsoft.Data.Entity.Query
                         queryModel.MainFromClause);
 
             var elementSelector
-                = entityQueryModelVisitor
-                    .ReplaceClauseReferences(
-                        groupResultOperator.ElementSelector,
-                        queryModel.MainFromClause);
+                = QuerySourceScope.Create(
+                    queryModel.MainFromClause,
+                    entityQueryModelVisitor
+                        .ReplaceClauseReferences(
+                            groupResultOperator.ElementSelector,
+                            queryModel.MainFromClause),
+                    EntityQueryModelVisitor.QuerySourceScopeParameter);
 
             return Expression.Call(
                 entityQueryModelVisitor.LinqOperatorProvider.GroupBy
                     .MakeGenericMethod(
-                        typeof(QuerySourceScope),
+                        entityQueryModelVisitor.StreamedSequenceInfo.ResultItemType,
                         groupResultOperator.KeySelector.Type,
-                        groupResultOperator.ElementSelector.Type),
-                entityQueryModelVisitor.CreateScope(
-                    entityQueryModelVisitor.Expression,
-                    entityQueryModelVisitor.StreamedSequenceInfo.ResultItemType,
-                    queryModel.MainFromClause),
+                        elementSelector.Type),
+                entityQueryModelVisitor.Expression,
                 Expression.Lambda(keySelector, EntityQueryModelVisitor.QuerySourceScopeParameter),
                 Expression.Lambda(elementSelector, EntityQueryModelVisitor.QuerySourceScopeParameter));
         }
 
         private static Expression HandleLast(
             EntityQueryModelVisitor entityQueryModelVisitor, ChoiceResultOperatorBase choiceResultOperator)
-            => CallWithPossibleCancellationToken(
+        {
+            return CallWithPossibleCancellationToken(
                 (choiceResultOperator.ReturnDefaultWhenEmpty
                     ? entityQueryModelVisitor.LinqOperatorProvider.LastOrDefault
                     : entityQueryModelVisitor.LinqOperatorProvider.Last)
                     .MakeGenericMethod(entityQueryModelVisitor.StreamedSequenceInfo.ResultItemType),
                 entityQueryModelVisitor.Expression);
+        }
 
         private static Expression HandleLongCount(EntityQueryModelVisitor entityQueryModelVisitor)
-            => CallWithPossibleCancellationToken(
+        {
+            return CallWithPossibleCancellationToken(
                 entityQueryModelVisitor.LinqOperatorProvider.LongCount
                     .MakeGenericMethod(entityQueryModelVisitor.StreamedSequenceInfo.ResultItemType),
                 entityQueryModelVisitor.Expression);
+        }
 
         private static Expression HandleMin(EntityQueryModelVisitor entityQueryModelVisitor)
-            => HandleAggregate(entityQueryModelVisitor, "Min");
+        {
+            return HandleAggregate(entityQueryModelVisitor, "Min");
+        }
 
         private static Expression HandleMax(EntityQueryModelVisitor entityQueryModelVisitor)
-            => HandleAggregate(entityQueryModelVisitor, "Max");
+        {
+            return HandleAggregate(entityQueryModelVisitor, "Max");
+        }
 
         private static Expression HandleOfType(
             EntityQueryModelVisitor entityQueryModelVisitor,
-            OfTypeResultOperator ofTypeResultOperator)
-            => Expression.Call(
+            OfTypeResultOperator ofTypeResultOperator,
+            QueryModel queryModel)
+        {
+            if (entityQueryModelVisitor.IsWrappingResults)
+            {
+                return Expression.Call(
+                    entityQueryModelVisitor.LinqOperatorProvider.OfTypeWrappedResult
+                        .MakeGenericMethod(
+                            queryModel.SelectClause.Selector.Type,
+                            ofTypeResultOperator.SearchedItemType),
+                    entityQueryModelVisitor.Expression);
+            }
+
+            return Expression.Call(
                 entityQueryModelVisitor.LinqOperatorProvider.OfType
                     .MakeGenericMethod(ofTypeResultOperator.SearchedItemType),
                 entityQueryModelVisitor.Expression);
+        }
 
         private static Expression HandleSingle(
             EntityQueryModelVisitor entityQueryModelVisitor, ChoiceResultOperatorBase choiceResultOperator)
-            => CallWithPossibleCancellationToken(
+        {
+            return CallWithPossibleCancellationToken(
                 (choiceResultOperator.ReturnDefaultWhenEmpty
                     ? entityQueryModelVisitor.LinqOperatorProvider.SingleOrDefault
                     : entityQueryModelVisitor.LinqOperatorProvider.Single)
                     .MakeGenericMethod(entityQueryModelVisitor.StreamedSequenceInfo.ResultItemType),
                 entityQueryModelVisitor.Expression);
+        }
 
         private static Expression HandleSkip(
             EntityQueryModelVisitor entityQueryModelVisitor, SkipResultOperator skipResultOperator)
-            => Expression.Call(
+        {
+            return Expression.Call(
                 entityQueryModelVisitor.LinqOperatorProvider.Skip
                     .MakeGenericMethod(entityQueryModelVisitor.StreamedSequenceInfo.ResultItemType),
                 entityQueryModelVisitor.Expression, skipResultOperator.Count);
+        }
 
         private static Expression HandleSum(EntityQueryModelVisitor entityQueryModelVisitor)
-            => HandleAggregate(entityQueryModelVisitor, "Sum");
+        {
+            return HandleAggregate(entityQueryModelVisitor, "Sum");
+        }
 
         private static Expression HandleTake(
             EntityQueryModelVisitor entityQueryModelVisitor, TakeResultOperator takeResultOperator)
-            => Expression.Call(
+        {
+            return Expression.Call(
                 entityQueryModelVisitor.LinqOperatorProvider.Take
                     .MakeGenericMethod(entityQueryModelVisitor.StreamedSequenceInfo.ResultItemType),
                 entityQueryModelVisitor.Expression, takeResultOperator.Count);
+        }
 
         private static Expression HandleAggregate(EntityQueryModelVisitor entityQueryModelVisitor, string methodName)
-            => CallWithPossibleCancellationToken(
-                entityQueryModelVisitor.LinqOperatorProvider.GetAggregateMethod(
-                    methodName,
-                    entityQueryModelVisitor.StreamedSequenceInfo.ResultItemType),
-                entityQueryModelVisitor.Expression);
+        {
+            var expression = entityQueryModelVisitor.Expression;
+            var resultItemType = entityQueryModelVisitor.StreamedSequenceInfo.ResultItemType;
+            var resultItemTypeInfo = resultItemType.GetTypeInfo();
+
+            if (resultItemTypeInfo.IsGenericType
+                && resultItemTypeInfo.GetGenericTypeDefinition() == typeof(QuerySourceScope<>))
+            {
+                resultItemType = resultItemTypeInfo.GenericTypeArguments[0];
+
+                expression
+                    = Expression.Call(
+                        entityQueryModelVisitor.LinqOperatorProvider
+                            .UnwrapQueryResults
+                            .MakeGenericMethod(resultItemType),
+                        expression);
+            }
+
+            return CallWithPossibleCancellationToken(
+                entityQueryModelVisitor.LinqOperatorProvider
+                    .GetAggregateMethod(methodName, resultItemType),
+                expression);
+        }
 
         private static readonly PropertyInfo _cancellationTokenProperty
             = typeof(QueryContext).GetTypeInfo()

--- a/src/EntityFramework.InMemory/Query/InMemoryQueryContext.cs
+++ b/src/EntityFramework.InMemory/Query/InMemoryQueryContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Query;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
@@ -13,10 +14,12 @@ namespace Microsoft.Data.Entity.InMemory.Query
         public InMemoryQueryContext(
             [NotNull] ILogger logger,
             [NotNull] IQueryBuffer queryBuffer,
+            [NotNull] IStateManager stateManager,
             [NotNull] IInMemoryDatabase database)
             : base(
                 Check.NotNull(logger, nameof(logger)),
-                Check.NotNull(queryBuffer, nameof(queryBuffer)))
+                Check.NotNull(queryBuffer, nameof(queryBuffer)),
+                Check.NotNull(stateManager, nameof(stateManager)))
         {
             Database = database;
         }

--- a/src/EntityFramework.InMemory/Query/InMemoryQueryContextFactory.cs
+++ b/src/EntityFramework.InMemory/Query/InMemoryQueryContextFactory.cs
@@ -3,7 +3,6 @@
 
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
-using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Query;
 using Microsoft.Data.Entity.Utilities;
@@ -29,6 +28,7 @@ namespace Microsoft.Data.Entity.InMemory.Query
             _dataStore = dataStore;
         }
 
-        public override QueryContext CreateQueryContext() => new InMemoryQueryContext(Logger, CreateQueryBuffer(), _dataStore.Database);
+        public override QueryContext CreateQueryContext()
+            => new InMemoryQueryContext(Logger, CreateQueryBuffer(), StateManager, _dataStore.Database);
     }
 }

--- a/src/EntityFramework.Relational/Query/AsyncQueryingEnumerable.cs
+++ b/src/EntityFramework.Relational/Query/AsyncQueryingEnumerable.cs
@@ -97,13 +97,13 @@ namespace Microsoft.Data.Entity.Relational.Query
             {
                 if (!_disposed)
                 {
+                    _disposed = true;
+
                     if (_reader != null)
                     {
                         _reader.Dispose();
                         _enumerable._relationalQueryContext.Connection?.Close();
                     }
-
-                    _disposed = true;
                 }
             }
         }

--- a/src/EntityFramework.Relational/Query/RelationalQueryContext.cs
+++ b/src/EntityFramework.Relational/Query/RelationalQueryContext.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Data.Common;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Query;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Utilities;
@@ -20,11 +21,13 @@ namespace Microsoft.Data.Entity.Relational.Query
         public RelationalQueryContext(
             [NotNull] ILogger logger,
             [NotNull] IQueryBuffer queryBuffer,
+            [NotNull] IStateManager stateManager,
             [NotNull] IRelationalConnection connection,
             [NotNull] IRelationalValueReaderFactory valueReaderFactory)
             : base(
                 Check.NotNull(logger, nameof(logger)),
-                Check.NotNull(queryBuffer, nameof(queryBuffer)))
+                Check.NotNull(queryBuffer, nameof(queryBuffer)),
+                Check.NotNull(stateManager, nameof(stateManager)))
         {
             Check.NotNull(connection, nameof(connection));
             Check.NotNull(valueReaderFactory, nameof(valueReaderFactory));
@@ -45,7 +48,7 @@ namespace Microsoft.Data.Entity.Relational.Query
             _activeDataReaders.Add(dataReader);
         }
 
-        public virtual IValueReader CreateValueReader(int readerIndex) 
+        public virtual IValueReader CreateValueReader(int readerIndex)
             => ValueReaderFactory.CreateValueReader(_activeDataReaders[_activeReaderOffset + readerIndex]);
 
         public virtual void BeginIncludeScope() => _activeReaderOffset = _activeDataReaders.Count;

--- a/src/EntityFramework.Relational/Query/RelationalQueryContextFactory.cs
+++ b/src/EntityFramework.Relational/Query/RelationalQueryContextFactory.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Data.Entity.Relational.Query
             _connection = connection;
         }
 
-        public override QueryContext CreateQueryContext() => new RelationalQueryContext(Logger, CreateQueryBuffer(), _connection, _valueReaderFactory);
+        public override QueryContext CreateQueryContext()
+            => new RelationalQueryContext(Logger, CreateQueryBuffer(), StateManager, _connection, _valueReaderFactory);
     }
 }

--- a/test/EntityFramework.Core.FunctionalTests/AsyncQueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/AsyncQueryTestBase.cs
@@ -16,6 +16,12 @@ namespace Microsoft.Data.Entity.FunctionalTests
     public abstract class AsyncQueryTestBase<TFixture> : IClassFixture<TFixture>
         where TFixture : NorthwindQueryFixtureBase, new()
     {
+        public virtual async Task Single_Predicate_Cancellation(CancellationToken cancellationToken)
+        {
+            await AssertQuery<Customer>(
+                cs => cs.SingleAsync(c => c.CustomerID == "ALFKI", cancellationToken));
+        }
+
         [Fact]
         public virtual async Task Mixed_sync_async_in_query_cache()
         {
@@ -29,163 +35,263 @@ namespace Microsoft.Data.Entity.FunctionalTests
         [Fact]
         public virtual async Task Queryable_simple()
         {
-            Assert.Equal(91,
-                await AssertQuery<Customer>(cs => cs));
+            await AssertQuery<Customer>(
+                cs => cs,
+                entryCount: 91);
         }
 
         [Fact]
         public virtual async Task Queryable_simple_anonymous()
         {
-            Assert.Equal(91,
-                await AssertQuery<Customer>(cs => cs.Select(c => new { c })));
+            await AssertQuery<Customer>(
+                cs => cs.Select(c => new { c }),
+                entryCount: 91);
         }
 
         [Fact]
         public virtual async Task Queryable_nested_simple()
         {
-            Assert.Equal(91,
-                await AssertQuery<Customer>(cs =>
-                    from c1 in (from c2 in (from c3 in cs select c3) select c2) select c1));
+            await AssertQuery<Customer>(
+                cs =>
+                    from c1 in (from c2 in (from c3 in cs select c3) select c2) select c1,
+                entryCount: 91);
         }
 
         [Fact]
         public virtual async Task Take_simple()
         {
-            Assert.Equal(10,
-                await AssertQuery<Customer>(cs => cs.OrderBy(c => c.CustomerID).Take(10), assertOrder: true));
+            await AssertQuery<Customer>(
+                cs => cs.OrderBy(c => c.CustomerID).Take(10),
+                assertOrder: true,
+                entryCount: 10);
         }
 
         [Fact]
         public virtual async Task Take_simple_projection()
         {
-            Assert.Equal(10,
-                await AssertQuery<Customer>(cs => cs.OrderBy(c => c.CustomerID).Select(c => c.City).Take(10), assertOrder: true));
+            await AssertQuery<Customer>(
+                cs => cs.OrderBy(c => c.CustomerID).Select(c => c.City).Take(10),
+                assertOrder: true);
         }
 
         [Fact]
         public virtual async Task Skip()
         {
-            await AssertQuery<Customer>(cs => cs.OrderBy(c => c.CustomerID).Skip(5), assertOrder: true);
+            await AssertQuery<Customer>(
+                cs => cs.OrderBy(c => c.CustomerID).Skip(5),
+                assertOrder: true,
+                entryCount: 86);
         }
 
         [Fact]
         public virtual async Task Take_Skip()
         {
-            await AssertQuery<Customer>(cs => cs.OrderBy(c => c.ContactName).Take(10).Skip(5), assertOrder: true);
+            await AssertQuery<Customer>(
+                cs => cs.OrderBy(c => c.ContactName).Take(10).Skip(5),
+                assertOrder: true,
+                entryCount: 5);
         }
 
         [Fact]
         public virtual async Task Distinct_Skip()
         {
-            await AssertQuery<Customer>(cs =>
-                cs.Distinct().OrderBy(c => c.ContactName).Skip(5), assertOrder: true);
+            await AssertQuery<Customer>(
+                cs => cs.Distinct().OrderBy(c => c.ContactName).Skip(5),
+                assertOrder: true,
+                entryCount: 86);
         }
 
         [Fact]
         public virtual async Task Skip_Take()
         {
-            await AssertQuery<Customer>(cs =>
-                cs.OrderBy(c => c.ContactName).Skip(5).Take(10), assertOrder: true);
+            await AssertQuery<Customer>(
+                cs => cs.OrderBy(c => c.ContactName).Skip(5).Take(10),
+                assertOrder: true,
+                entryCount: 10);
         }
 
         [Fact]
         public virtual async Task Distinct_Skip_Take()
         {
-            await AssertQuery<Customer>(cs =>
-                cs.Distinct().OrderBy(c => c.ContactName).Skip(5).Take(10), assertOrder: true);
+            await AssertQuery<Customer>(
+                cs => cs.Distinct().OrderBy(c => c.ContactName).Skip(5).Take(10),
+                assertOrder: true,
+                entryCount: 10);
         }
 
         [Fact]
         public virtual async Task Skip_Distinct()
         {
-            await AssertQuery<Customer>(cs =>
-                cs.OrderBy(c => c.ContactName).Skip(5).Distinct());
+            await AssertQuery<Customer>(
+                cs => cs.OrderBy(c => c.ContactName).Skip(5).Distinct(),
+                entryCount: 86);
         }
 
         [Fact]
         public virtual async Task Skip_Take_Distinct()
         {
-            await AssertQuery<Customer>(cs =>
-                cs.OrderBy(c => c.ContactName).Skip(5).Take(10).Distinct());
+            await AssertQuery<Customer>(
+                cs => cs.OrderBy(c => c.ContactName).Skip(5).Take(10).Distinct(),
+                entryCount: 10);
         }
 
         [Fact]
         public virtual async Task Take_Skip_Distinct()
         {
-            await AssertQuery<Customer>(cs =>
-                cs.OrderBy(c => c.ContactName).Take(10).Skip(5).Distinct());
+            await AssertQuery<Customer>(
+                cs => cs.OrderBy(c => c.ContactName).Take(10).Skip(5).Distinct(),
+                entryCount: 5);
         }
 
         [Fact]
         public virtual async Task Take_Distinct()
         {
-            await AssertQuery<Order>(os => os.OrderBy(o => o.OrderID).Take(5).Distinct());
+            await AssertQuery<Order>(
+                os => os.OrderBy(o => o.OrderID).Take(5).Distinct(),
+                entryCount: 5);
         }
 
         [Fact]
         public virtual async Task Distinct_Take()
         {
-            await AssertQuery<Order>(os => os.Distinct().OrderBy(o => o.OrderID).Take(5), assertOrder: true);
+            await AssertQuery<Order>(
+                os => os.Distinct().OrderBy(o => o.OrderID).Take(5),
+                assertOrder: true,
+                entryCount: 5);
         }
 
         [Fact]
         public virtual async Task Distinct_Take_Count()
         {
-            await AssertQuery<Order>(os => os.Distinct().Take(5).CountAsync());
+            await AssertQuery<Order>(
+                os => os.Distinct().Take(5).CountAsync());
         }
 
         [Fact]
         public virtual async Task Take_Distinct_Count()
         {
-            await AssertQuery<Order>(os => os.Take(5).Distinct().CountAsync());
+            await AssertQuery<Order>(
+                os => os.Take(5).Distinct().CountAsync());
         }
 
         [Fact]
         public virtual async Task Any_simple()
         {
-            await AssertQuery<Customer>(cs => cs.AnyAsync());
+            await AssertQuery<Customer>(
+                cs => cs.AnyAsync());
+        }
+
+        [Fact]
+        public virtual async Task OrderBy_Take_Count()
+        {
+            await AssertQuery<Order>(
+                os => os.OrderBy(o => o.OrderID).Take(5).CountAsync());
+        }
+
+        [Fact]
+        public virtual async Task Take_OrderBy_Count()
+        {
+            await AssertQuery<Order>(
+                os => os.Take(5).OrderBy(o => o.OrderID).CountAsync());
         }
 
         [Fact]
         public virtual async Task Any_predicate()
         {
-            await AssertQuery<Customer>(cs => cs.AnyAsync(c => c.ContactName.StartsWith("A")));
+            await AssertQuery<Customer>(
+                cs => cs.AnyAsync(c => c.ContactName.StartsWith("A")));
         }
 
         [Fact]
         public virtual async Task All_top_level()
         {
-            await AssertQuery<Customer>(cs => cs.AllAsync(c => c.ContactName.StartsWith("A")));
+            await AssertQuery<Customer>(
+                cs => cs.AllAsync(c => c.ContactName.StartsWith("A")));
         }
 
         [Fact]
         public virtual async Task All_top_level_subquery()
         {
             // ReSharper disable once PossibleUnintendedReferenceComparison
-            await AssertQuery<Customer>(cs => cs.AllAsync(c1 => cs.Any(c2 => cs.Any(c3 => c1 == c3))));
+            await AssertQuery<Customer>(
+                cs => cs.AllAsync(c1 => cs.Any(c2 => cs.Any(c3 => c1 == c3))));
         }
 
         [Fact]
         public virtual async Task Select_into()
         {
-            await AssertQuery<Customer>(cs =>
-                from c in cs
-                select c.CustomerID
-                into id
-                where id == "ALFKI"
-                select id);
+            await AssertQuery<Customer>(
+                cs =>
+                    from c in cs
+                    select c.CustomerID
+                    into id
+                    where id == "ALFKI"
+                    select id);
+        }
+
+        [Fact]
+        public virtual async Task Projection_when_arithmetic_expressions()
+        {
+            await AssertQuery<Order>(
+                os => os.Select(o => new
+                {
+                    o.OrderID,
+                    Double = o.OrderID * 2,
+                    Add = o.OrderID + 23,
+                    Sub = 100000 - o.OrderID,
+                    Divide = o.OrderID / (o.OrderID / 2),
+                    Literal = 42,
+                    o
+                }),
+                entryCount: 830);
+        }
+
+        [Fact]
+        public virtual async Task Projection_when_arithmetic_mixed()
+        {
+            await AssertQuery<Order, Employee>((os, es) =>
+                from o in os
+                from e in es
+                select new
+                {
+                    Add = e.EmployeeID + o.OrderID,
+                    o.OrderID,
+                    o,
+                    Literal = 42,
+                    e.EmployeeID,
+                    e
+                });
+        }
+
+        [Fact]
+        public virtual async Task Projection_when_arithmetic_mixed_subqueries()
+        {
+            await AssertQuery<Order, Employee>((os, es) =>
+                from o in os.Select(o2 => new { o2, Mod = o2.OrderID % 2 })
+                from e in es.Select(e2 => new { e2, Square = e2.EmployeeID ^ 2 })
+                select new
+                {
+                    Add = e.e2.EmployeeID + o.o2.OrderID,
+                    e.Square,
+                    e.e2,
+                    Literal = 42,
+                    o.o2,
+                    o.Mod
+                });
         }
 
         [Fact]
         public virtual async Task Projection_when_null_value()
         {
-            await AssertQuery<Customer>(cs => cs.Select(c => c.Region));
+            await AssertQuery<Customer>(
+                cs => cs.Select(c => c.Region));
         }
 
         [Fact]
         public virtual async Task Take_with_single()
         {
-            await AssertQuery<Customer>(cs => cs.OrderBy(c => c.CustomerID).Take(1).SingleAsync());
+            await AssertQuery<Customer>(
+                cs => cs.OrderBy(c => c.CustomerID).Take(1).SingleAsync());
         }
 
         [Fact]
@@ -193,24 +299,327 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             await AssertQuery<Customer, Order>((cs, os) =>
                 (from c in cs
-                    from o in os
-                    orderby c.CustomerID, o.OrderID
-                    select new { c, o })
+                 from o in os
+                 orderby c.CustomerID, o.OrderID
+                 select new { c, o })
                     .Take(1)
                     .Cast<object>()
                     .SingleAsync());
         }
 
         [Fact]
+        public virtual async Task Cast_results_to_object()
+        {
+            await AssertQuery<Customer>(cs => from c in cs.Cast<object>() select c, entryCount: 91);
+        }
+
+        [Fact]
         public virtual async Task Where_simple()
         {
-            await AssertQuery<Customer>(cs => cs.Where(c => c.City == "London"));
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.City == "London"),
+                entryCount: 6);
+        }
+
+        [Fact]
+        public virtual async Task Where_simple_closure()
+        {
+            // ReSharper disable once ConvertToConstant.Local
+            var city = "London";
+
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.City == city),
+                entryCount: 6);
+        }
+
+        [Fact]
+        public virtual async Task Where_simple_closure_constant()
+        {
+            // ReSharper disable once ConvertToConstant.Local
+            var predicate = true;
+
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => predicate),
+                entryCount: 91);
+        }
+
+        [Fact]
+        public virtual async Task Where_simple_closure_via_query_cache()
+        {
+            var city = "London";
+
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.City == city),
+                entryCount: 6);
+
+            city = "Seattle";
+
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.City == city),
+                entryCount: 1);
+        }
+
+        private class City
+        {
+            // ReSharper disable once StaticMemberInGenericType
+            public static string StaticFieldValue;
+
+            // ReSharper disable once StaticMemberInGenericType
+            public static string StaticPropertyValue { get; set; }
+
+            public string InstanceFieldValue;
+            public string InstancePropertyValue { get; set; }
+
+            public int Int { get; set; }
+            public int? NullableInt { get; set; }
+
+            public City Nested;
+
+            public City Throw()
+            {
+                throw new NotImplementedException();
+            }
+
+            public string GetCity()
+            {
+                return InstanceFieldValue;
+            }
+        }
+
+        [Fact]
+        public virtual async Task Where_method_call_nullable_type_closure_via_query_cache()
+        {
+            var city = new City { Int = 2 };
+
+            await AssertQuery<Employee>(
+                es => es.Where(e => e.ReportsTo == city.Int),
+                entryCount: 5);
+
+            city.Int = 5;
+
+            await AssertQuery<Employee>(
+                es => es.Where(e => e.ReportsTo == city.Int),
+                entryCount: 3);
+        }
+
+        [Fact]
+        public virtual async Task Where_method_call_nullable_type_reverse_closure_via_query_cache()
+        {
+            var city = new City { NullableInt = 1 };
+
+            await AssertQuery<Employee>(
+                es => es.Where(e => e.EmployeeID > city.NullableInt),
+                entryCount: 8);
+
+            city.NullableInt = 5;
+
+            await AssertQuery<Employee>(
+                es => es.Where(e => e.EmployeeID > city.NullableInt),
+                entryCount: 4);
+        }
+
+        [Fact]
+        public virtual async Task Where_method_call_closure_via_query_cache()
+        {
+            var city = new City { InstanceFieldValue = "London" };
+
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.City == city.GetCity()),
+                entryCount: 6);
+
+            city.InstanceFieldValue = "Seattle";
+
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.City == city.GetCity()),
+                entryCount: 1);
+        }
+
+        [Fact]
+        public virtual async Task Where_field_access_closure_via_query_cache()
+        {
+            var city = new City { InstanceFieldValue = "London" };
+
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.City == city.InstanceFieldValue),
+                entryCount: 6);
+
+            city.InstanceFieldValue = "Seattle";
+
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.City == city.InstanceFieldValue),
+                entryCount: 1);
+        }
+
+        [Fact]
+        public virtual async Task Where_property_access_closure_via_query_cache()
+        {
+            var city = new City { InstancePropertyValue = "London" };
+
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.City == city.InstancePropertyValue),
+                entryCount: 6);
+
+            city.InstancePropertyValue = "Seattle";
+
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.City == city.InstancePropertyValue),
+                entryCount: 1);
+        }
+
+        [Fact]
+        public virtual async Task Where_static_field_access_closure_via_query_cache()
+        {
+            City.StaticFieldValue = "London";
+
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.City == City.StaticFieldValue),
+                entryCount: 6);
+
+            City.StaticFieldValue = "Seattle";
+
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.City == City.StaticFieldValue),
+                entryCount: 1);
+        }
+
+        [Fact]
+        public virtual async Task Where_static_property_access_closure_via_query_cache()
+        {
+            City.StaticPropertyValue = "London";
+
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.City == City.StaticPropertyValue),
+                entryCount: 6);
+
+            City.StaticPropertyValue = "Seattle";
+
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.City == City.StaticPropertyValue),
+                entryCount: 1);
+        }
+
+        [Fact]
+        public virtual async Task Where_nested_field_access_closure_via_query_cache()
+        {
+            var city = new City { Nested = new City { InstanceFieldValue = "London" } };
+
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.City == city.Nested.InstanceFieldValue),
+                entryCount: 6);
+
+            city.Nested.InstanceFieldValue = "Seattle";
+
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.City == city.Nested.InstanceFieldValue),
+                entryCount: 1);
+        }
+
+        [Fact]
+        public virtual async Task Where_nested_property_access_closure_via_query_cache()
+        {
+            var city = new City { Nested = new City { InstancePropertyValue = "London" } };
+
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.City == city.Nested.InstancePropertyValue),
+                entryCount: 6);
+
+            city.Nested.InstancePropertyValue = "Seattle";
+
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.City == city.Nested.InstancePropertyValue),
+                entryCount: 1);
+        }
+
+        [Fact]
+        public virtual async Task Where_nested_field_access_closure_via_query_cache_error_null()
+        {
+            var city = new City();
+
+            using (var context = CreateContext())
+            {
+                await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                    await context.Set<Customer>()
+                        .Where(c => c.City == city.Nested.InstanceFieldValue)
+                        .ToListAsync());
+            }
+        }
+
+        [Fact]
+        public virtual async Task Where_nested_field_access_closure_via_query_cache_error_method_null()
+        {
+            var city = new City();
+
+            using (var context = CreateContext())
+            {
+                await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                    await context.Set<Customer>()
+                        .Where(c => c.City == city.Throw().InstanceFieldValue)
+                        .ToListAsync());
+            }
+        }
+
+        [Fact]
+        public virtual async Task Where_new_instance_field_access_closure_via_query_cache()
+        {
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.City == new City { InstanceFieldValue = "London" }.InstanceFieldValue),
+                entryCount: 6);
+
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.City == new City { InstanceFieldValue = "Seattle" }.InstanceFieldValue),
+                entryCount: 1);
+        }
+
+        [Fact]
+        public virtual async Task Where_simple_closure_via_query_cache_nullable_type()
+        {
+            int? reportsTo = 2;
+
+            await AssertQuery<Employee>(
+                es => es.Where(e => e.ReportsTo == reportsTo),
+                entryCount: 5);
+
+            reportsTo = 5;
+
+            await AssertQuery<Employee>(
+                es => es.Where(e => e.ReportsTo == reportsTo),
+                entryCount: 3);
+
+            reportsTo = null;
+
+            await AssertQuery<Employee>(
+                es => es.Where(e => e.ReportsTo == reportsTo),
+                entryCount: 1);
+        }
+
+        [Fact]
+        public virtual async Task Where_simple_closure_via_query_cache_nullable_type_reverse()
+        {
+            int? reportsTo = null;
+
+            await AssertQuery<Employee>(
+                es => es.Where(e => e.ReportsTo == reportsTo),
+                entryCount: 1);
+
+            reportsTo = 5;
+
+            await AssertQuery<Employee>(
+                es => es.Where(e => e.ReportsTo == reportsTo),
+                entryCount: 3);
+
+            reportsTo = 2;
+
+            await AssertQuery<Employee>(
+                es => es.Where(e => e.ReportsTo == reportsTo),
+                entryCount: 5);
         }
 
         [Fact]
         public virtual async Task Where_simple_shadow()
         {
-            await AssertQuery<Employee>(es => es.Where(e => e.Property<string>("Title") == "Sales Representative"));
+            await AssertQuery<Employee>(
+                es => es.Where(e => e.Property<string>("Title") == "Sales Representative"),
+                entryCount: 6);
         }
 
         [Fact]
@@ -221,97 +630,152 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     .Select(e => e.Property<string>("Title")));
         }
 
+        public virtual async Task Where_simple_shadow_projection_mixed()
+        {
+            await AssertQuery<Employee>(
+                es => es.Where(e => e.Property<string>("Title") == "Sales Representative")
+                    .Select(e => new { e, Title = e.Property<string>("Title") }),
+                entryCount: 6);
+        }
+
+        [Fact]
+        public virtual async Task Where_simple_shadow_subquery()
+        {
+            await AssertQuery<Employee>(
+                es => from e in es.OrderBy(e => e.EmployeeID).Take(5)
+                      where e.Property<string>("Title") == "Sales Representative"
+                      select e,
+                entryCount: 3);
+        }
+
+        [Fact]
+        public virtual async Task Where_shadow_subquery_first()
+        {
+            await AssertQuery<Employee>(es =>
+                from e in es
+                where e.Property<string>("Title")
+                      == es.OrderBy(e2 => e2.Property<string>("Title")).First().Property<string>("Title")
+                select e,
+                entryCount: 1);
+        }
+
         [Fact]
         public virtual async Task Where_client()
         {
-            await AssertQuery<Customer>(cs => cs.Where(c => c.IsLondon));
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.IsLondon),
+                entryCount: 6);
         }
 
         [Fact]
         public virtual async Task First_client_predicate()
         {
-            await AssertQuery<Customer>(cs => cs.OrderBy(c => c.CustomerID).FirstAsync(c => c.IsLondon));
+            await AssertQuery<Customer>(
+                cs => cs.OrderBy(c => c.CustomerID).FirstAsync(c => c.IsLondon));
         }
 
         [Fact]
         public virtual async Task Where_equals_method_string()
         {
-            await AssertQuery<Customer>(cs => cs.Where(c => c.City.Equals("London")));
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.City.Equals("London")),
+                entryCount: 6);
         }
 
         [Fact]
         public virtual async Task Where_equals_method_int()
         {
-            await AssertQuery<Employee>(es => es.Where(e => e.EmployeeID.Equals(1)));
+            await AssertQuery<Employee>(
+                es => es.Where(e => e.EmployeeID.Equals(1)),
+                entryCount: 1);
         }
 
         [Fact]
         public virtual async Task Where_comparison_nullable_type_not_null()
         {
-            await AssertQuery<Employee>(es => es.Where(e => e.ReportsTo == 2));
+            await AssertQuery<Employee>(
+                es => es.Where(e => e.ReportsTo == 2),
+                entryCount: 5);
         }
 
         [Fact]
         public virtual async Task Where_comparison_nullable_type_null()
         {
-            await AssertQuery<Employee>(es => es.Where(e => e.ReportsTo == null));
+            await AssertQuery<Employee>(
+                es => es.Where(e => e.ReportsTo == null),
+                entryCount: 1);
         }
 
         [Fact]
         public virtual async Task Where_string_length()
         {
-            await AssertQuery<Customer>(cs => cs.Where(c => c.City.Length == 6));
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.City.Length == 6),
+                entryCount: 20);
         }
 
         [Fact]
         public virtual async Task Where_simple_reversed()
         {
-            await AssertQuery<Customer>(cs => cs.Where(c => "London" == c.City));
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => "London" == c.City),
+                entryCount: 6);
         }
 
         [Fact]
         public virtual async Task Where_is_null()
         {
-            await AssertQuery<Customer>(cs => cs.Where(c => c.City == null));
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.City == null));
         }
 
         [Fact]
         public virtual async Task Where_null_is_null()
         {
             // ReSharper disable once EqualExpressionComparison
-            await AssertQuery<Customer>(cs => cs.Where(c => null == null));
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => null == null),
+                entryCount: 91);
         }
 
         [Fact]
         public virtual async Task Where_constant_is_null()
         {
-            await AssertQuery<Customer>(cs => cs.Where(c => "foo" == null));
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => "foo" == null));
         }
 
         [Fact]
         public virtual async Task Where_is_not_null()
         {
-            await AssertQuery<Customer>(cs => cs.Where(c => c.City != null));
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.City != null),
+                entryCount: 91);
         }
 
         [Fact]
         public virtual async Task Where_null_is_not_null()
         {
             // ReSharper disable once EqualExpressionComparison
-            await AssertQuery<Customer>(cs => cs.Where(c => null != null));
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => null != null));
         }
 
         [Fact]
         public virtual async Task Where_constant_is_not_null()
         {
-            await AssertQuery<Customer>(cs => cs.Where(c => "foo" != null));
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => "foo" != null),
+                entryCount: 91);
         }
 
         [Fact]
         public virtual async Task Where_identity_comparison()
         {
             // ReSharper disable once EqualExpressionComparison
-            await AssertQuery<Customer>(cs => cs.Where(c => c.City == c.City));
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.City == c.City),
+                entryCount: 91);
         }
 
         [Fact]
@@ -337,6 +801,107 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
+        public virtual async Task Where_select_many_or3()
+        {
+            await AssertQuery<Customer, Employee>((cs, es) =>
+                from c in cs
+                from e in es
+                where c.City == "London"
+                      || c.City == "Berlin"
+                      || c.City == "Seattle"
+                select new { c, e });
+        }
+
+        [Fact]
+        public virtual async Task Where_select_many_or4()
+        {
+            await AssertQuery<Customer, Employee>((cs, es) =>
+                from c in cs
+                from e in es
+                where c.City == "London"
+                      || c.City == "Berlin"
+                      || c.City == "Seattle"
+                      || c.City == "Lisboa"
+                select new { c, e });
+        }
+
+        [Fact]
+        public virtual async Task Where_select_many_or_with_parameter()
+        {
+            var london = "London";
+            var lisboa = "Lisboa";
+
+            await AssertQuery<Customer, Employee>((cs, es) =>
+                from c in cs
+                from e in es
+                where c.City == london
+                      || c.City == "Berlin"
+                      || c.City == "Seattle"
+                      || c.City == lisboa
+                select new { c, e });
+        }
+
+        [Fact]
+        public virtual async Task Where_in_optimization_multiple()
+        {
+            await AssertQuery<Customer, Employee>((cs, es) =>
+                from c in cs
+                from e in es
+                where c.City == "London"
+                      || c.City == "Berlin"
+                      || c.CustomerID == "ALFKI"
+                      || c.CustomerID == "ABCDE"
+                select new { c, e });
+        }
+
+        [Fact]
+        public virtual async Task Where_not_in_optimization1()
+        {
+            await AssertQuery<Customer, Employee>((cs, es) =>
+                from c in cs
+                from e in es
+                where c.City != "London"
+                      && e.City != "London"
+                select new { c, e });
+        }
+
+        [Fact]
+        public virtual async Task Where_not_in_optimization2()
+        {
+            await AssertQuery<Customer, Employee>((cs, es) =>
+                from c in cs
+                from e in es
+                where c.City != "London"
+                      && c.City != "Berlin"
+                select new { c, e });
+        }
+
+        [Fact]
+        public virtual async Task Where_not_in_optimization3()
+        {
+            await AssertQuery<Customer, Employee>((cs, es) =>
+                from c in cs
+                from e in es
+                where c.City != "London"
+                      && c.City != "Berlin"
+                      && c.City != "Seattle"
+                select new { c, e });
+        }
+
+        [Fact]
+        public virtual async Task Where_not_in_optimization4()
+        {
+            await AssertQuery<Customer, Employee>((cs, es) =>
+                from c in cs
+                from e in es
+                where c.City != "London"
+                      && c.City != "Berlin"
+                      && c.City != "Seattle"
+                      && c.City != "Lisboa"
+                select new { c, e });
+        }
+
+        [Fact]
         public virtual async Task Where_select_many_and()
         {
             await AssertQuery<Customer, Employee>((cs, es) =>
@@ -350,151 +915,333 @@ namespace Microsoft.Data.Entity.FunctionalTests
         [Fact]
         public virtual async Task Where_primitive()
         {
-            await AssertQuery<Employee>(es =>
-                es.Select(e => e.EmployeeID).Take(9).Where(i => i == 5));
+            await AssertQuery<Employee>(
+                es => es.Select(e => e.EmployeeID).Take(9).Where(i => i == 5));
+        }
+
+        [Fact]
+        public virtual async Task Where_primitive_tracked()
+        {
+            await AssertQuery<Employee>(
+                es => es.Take(9).Where(e => e.EmployeeID == 5),
+                entryCount: 1);
+        }
+
+        [Fact]
+        public virtual async Task Where_primitive_tracked2()
+        {
+            await AssertQuery<Employee>(
+                es => es.Take(9).Select(e => new { e }).Where(e => e.e.EmployeeID == 5),
+                entryCount: 1);
+        }
+
+        [Fact]
+        public virtual async Task Where_subquery_anon()
+        {
+            await AssertQuery<Employee, Order>((es, os) =>
+                from e in es.Take(9).Select(e => new { e })
+                from o in os.Take(1000).Select(o => new { o })
+                where e.e.EmployeeID == o.o.EmployeeID
+                select new { e, o });
+        }
+
+        [Fact]
+        public virtual async Task Where_bool_member()
+        {
+            await AssertQuery<Product>(ps => ps.Where(p => p.Discontinued), entryCount: 8);
+        }
+
+        [Fact]
+        public virtual async Task Where_bool_member_false()
+        {
+            await AssertQuery<Product>(ps => ps.Where(p => !p.Discontinued), entryCount: 69);
+        }
+
+        [Fact]
+        public virtual async Task Where_bool_member_negated_twice()
+        {
+            await AssertQuery<Product>(ps => ps.Where(p => !!p.Discontinued), entryCount: 8);
+        }
+
+        [Fact]
+        public virtual async Task Where_bool_member_shadow()
+        {
+            await AssertQuery<Product>(ps => ps.Where(p => p.Property<bool>("Discontinued")), entryCount: 8);
+        }
+
+        [Fact]
+        public virtual async Task Where_bool_member_false_shadow()
+        {
+            await AssertQuery<Product>(ps => ps.Where(p => !p.Property<bool>("Discontinued")), entryCount: 69);
+        }
+
+        [Fact]
+        public virtual async Task Where_bool_member_equals_constant()
+        {
+            await AssertQuery<Product>(ps => ps.Where(p => p.Discontinued.Equals(true)), entryCount: 8);
+        }
+
+        [Fact]
+        public virtual async Task Where_bool_member_in_complex_predicate()
+        {
+            // ReSharper disable once RedundantBoolCompare
+            await AssertQuery<Product>(ps => ps.Where(p => p.ProductID > 100 && p.Discontinued || (p.Discontinued == true)), entryCount: 8);
+        }
+
+        [Fact]
+        public virtual async Task Where_bool_member_compared_to_binary_expression()
+        {
+            await AssertQuery<Product>(ps => ps.Where(p => p.Discontinued == (p.ProductID > 50)), entryCount: 44);
+        }
+
+        [Fact]
+        public virtual async Task Where_not_bool_member_compared_to_not_bool_member()
+        {
+            await AssertQuery<Product>(ps => ps.Where(p => !p.Discontinued == !p.Discontinued), entryCount: 77);
+        }
+
+        [Fact]
+        public virtual async Task Where_negated_boolean_expression_compared_to_another_negated_boolean_expression()
+        {
+            await AssertQuery<Product>(ps => ps.Where(p => !(p.ProductID > 50) == !(p.ProductID > 20)), entryCount: 47);
+        }
+
+        [Fact]
+        public virtual async Task Where_not_bool_member_compared_to_binary_expression()
+        {
+            await AssertQuery<Product>(ps => ps.Where(p => !p.Discontinued == (p.ProductID > 50)), entryCount: 33);
+        }
+
+        [Fact]
+        public virtual async Task Where_bool_parameter_compared_to_binary_expression()
+        {
+            var prm = true;
+            await AssertQuery<Product>(ps => ps.Where(p => (p.ProductID > 50) != prm), entryCount: 50);
+        }
+
+        [Fact]
+        public virtual async Task Where_bool_member_and_parameter_compared_to_binary_expression_nested()
+        {
+            var prm = true;
+            await AssertQuery<Product>(ps => ps.Where(p => p.Discontinued == ((p.ProductID > 50) != prm)), entryCount: 33);
+        }
+
+        [Fact]
+        public virtual async Task Where_de_morgan_or_optimizated()
+        {
+            await AssertQuery<Product>(ps => ps.Where(p => !(p.Discontinued || (p.ProductID < 20))), entryCount: 53);
+        }
+
+        [Fact]
+        public virtual async Task Where_de_morgan_and_optimizated()
+        {
+            await AssertQuery<Product>(ps => ps.Where(p => !(p.Discontinued && (p.ProductID < 20))), entryCount: 74);
+        }
+
+        [Fact]
+        public virtual async Task Where_complex_negated_expression_optimized()
+        {
+            await AssertQuery<Product>(ps => ps.Where(p => !(!(!p.Discontinued && (p.ProductID < 60)) || !(p.ProductID > 30))), entryCount: 27);
+        }
+
+        [Fact]
+        public virtual async Task Where_short_member_comparison()
+        {
+            await AssertQuery<Product>(ps => ps.Where(p => p.UnitsInStock > 10), entryCount: 63);
         }
 
         [Fact]
         public virtual async Task Where_true()
         {
-            Assert.Equal(91,
-                await AssertQuery<Customer>(cs => cs.Where(c => true)));
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => true),
+                entryCount: 91);
         }
 
         [Fact]
         public virtual async Task Where_false()
         {
-            Assert.Equal(0,
-                await AssertQuery<Customer>(cs => cs.Where(c => false)));
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => false));
         }
 
-        //        TODO: Re-write entity ref equality to identity equality.
+        [Fact]
+        public virtual async Task Where_bool_closure()
+        {
+            var boolean = false;
+
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.CustomerID == "ALFKI" && boolean));
+
+            boolean = true;
+
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.CustomerID == "ALFKI" && boolean),
+                entryCount: 1);
+        }
+
+        [Fact]
+        public virtual async Task Select_bool_closure()
+        {
+            var boolean = false;
+
+            await AssertQuery<Customer>(
+                cs => cs.Select(c => new { f = boolean }));
+
+            boolean = true;
+
+            await AssertQuery<Customer>(
+                cs => cs.Select(c => new { f = boolean }));
+        }
+
+        // TODO: Re-write entity ref equality to identity equality.
         //
-        //        [Fact]
-        //        public virtual async Task Where_compare_entity_equal()
-        //        {
-        //            var alfki = NorthwindData.Customers.Single(c => c.CustomerID == "ALFKI");
+        // [Fact]
+        // public virtual async Task Where_compare_entity_equal()
+        // {
+        //     var alfki = NorthwindData.Customers.SingleAsync(c => c.CustomerID == "ALFKI");
         //
-        //            Assert.Equal(1,
-        //                // ReSharper disable once PossibleUnintendedReferenceComparison
-        //                await AssertQuery<Customer>(cs => cs.Where(c => c == alfki)));
-        //        }
+        //     Assert.Equal(1,
+        //         // ReSharper disable once PossibleUnintendedReferenceComparison
+        //         AssertQuery<Customer>(cs => cs.Where(c => c == alfki)));
+        // }
         //
-        //        [Fact]
-        //        public virtual async Task Where_compare_entity_not_equal()
-        //        {
-        //            var alfki = new Customer { CustomerID = "ALFKI" };
+        // [Fact]
+        // public virtual async Task Where_compare_entity_not_equal()
+        // {
+        //     var alfki = new Customer { CustomerID = "ALFKI" };
         //
-        //            Assert.Equal(90,
-        //                // ReSharper disable once PossibleUnintendedReferenceComparison
-        //                await AssertQuery<Customer>(cs => cs.Where(c => c != alfki)));
+        //     Assert.Equal(90,
+        //         // ReSharper disable once PossibleUnintendedReferenceComparison
+        //         AssertQuery<Customer>(cs => cs.Where(c => c != alfki)));
         //
-        //        [Fact]
-        //        public virtual async Task Project_compare_entity_equal()
-        //        {
-        //            var alfki = NorthwindData.Customers.Single(c => c.CustomerID == "ALFKI");
+        // [Fact]
+        // public virtual async Task Project_compare_entity_equal()
+        // {
+        //     var alfki = NorthwindData.Customers.SingleAsync(c => c.CustomerID == "ALFKI");
         //
-        //            Assert.Equal(1,
-        //                // ReSharper disable once PossibleUnintendedReferenceComparison
-        //                await AssertQuery<Customer>(cs => cs.Select(c => c == alfki)));
-        //        }
+        //     Assert.Equal(1,
+        //         // ReSharper disable once PossibleUnintendedReferenceComparison
+        //         AssertQuery<Customer>(cs => cs.Select(c => c == alfki)));
+        // }
         //
-        //        [Fact]
-        //        public virtual async Task Project_compare_entity_not_equal()
-        //        {
-        //            var alfki = new Customer { CustomerID = "ALFKI" };
+        // [Fact]
+        // public virtual async Task Project_compare_entity_not_equal()
+        // {
+        //     var alfki = new Customer { CustomerID = "ALFKI" };
         //
-        //            Assert.Equal(90,
-        //                // ReSharper disable once PossibleUnintendedReferenceComparison
-        //                await AssertQuery<Customer>(cs => cs.Select(c => c != alfki)));
-        //        }
+        //     Assert.Equal(90,
+        //         // ReSharper disable once PossibleUnintendedReferenceComparison
+        //         AssertQuery<Customer>(cs => cs.Select(c => c != alfki)));
+        // }
 
         [Fact]
         public virtual async Task Where_compare_constructed_equal()
         {
-            await AssertQuery<Customer>(cs =>
-                cs.Where(c => new { x = c.City } == new { x = "London" }));
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => new { x = c.City } == new { x = "London" }));
         }
 
         [Fact]
         public virtual async Task Where_compare_constructed_multi_value_equal()
         {
-            await AssertQuery<Customer>(cs =>
-                cs.Where(c => new { x = c.City, y = c.Country } == new { x = "London", y = "UK" }));
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => new { x = c.City, y = c.Country } == new { x = "London", y = "UK" }));
         }
 
         [Fact]
         public virtual async Task Where_compare_constructed_multi_value_not_equal()
         {
-            await AssertQuery<Customer>(cs =>
-                cs.Where(c => new { x = c.City, y = c.Country } != new { x = "London", y = "UK" }));
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => new { x = c.City, y = c.Country } != new { x = "London", y = "UK" }),
+                entryCount: 91);
         }
 
         [Fact]
         public virtual async Task Where_compare_constructed()
         {
-            await AssertQuery<Customer>(cs =>
-                cs.Where(c => new { x = c.City } == new { x = "London" }));
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => new { x = c.City } == new { x = "London" }));
+        }
+
+        [Fact]
+        public virtual async Task Where_compare_null()
+        {
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.City == null && c.Country == "UK"));
         }
 
         [Fact]
         public virtual async Task Where_projection()
         {
-            await AssertQuery<Customer>(cs => cs.Where(c => c.City == "London").Select(c => c.CompanyName));
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.City == "London").Select(c => c.CompanyName));
         }
 
         [Fact]
         public virtual async Task Select_scalar()
         {
-            await AssertQuery<Customer>(cs => cs.Select(c => c.City));
+            await AssertQuery<Customer>(
+                cs => cs.Select(c => c.City));
         }
 
         [Fact]
         public virtual async Task Select_anonymous_one()
         {
-            await AssertQuery<Customer>(cs => cs.Select(c => new { c.City }));
+            await AssertQuery<Customer>(
+                cs => cs.Select(c => new { c.City }));
         }
 
         [Fact]
         public virtual async Task Select_anonymous_two()
         {
-            await AssertQuery<Customer>(cs => cs.Select(c => new { c.City, c.Phone }));
+            await AssertQuery<Customer>(
+                cs => cs.Select(c => new { c.City, c.Phone }));
         }
 
         [Fact]
         public virtual async Task Select_anonymous_three()
         {
-            await AssertQuery<Customer>(cs => cs.Select(c => new { c.City, c.Phone, c.Country }));
+            await AssertQuery<Customer>(
+                cs => cs.Select(c => new { c.City, c.Phone, c.Country }));
         }
 
         [Fact]
         public virtual async Task Select_customer_table()
         {
-            await AssertQuery<Customer>(cs => cs);
+            await AssertQuery<Customer>(
+                cs => cs,
+                entryCount: 91);
         }
 
         [Fact]
         public virtual async Task Select_customer_identity()
         {
-            await AssertQuery<Customer>(cs => cs.Select(c => c));
+            await AssertQuery<Customer>(
+                cs => cs.Select(c => c),
+                entryCount: 91);
         }
 
         [Fact]
         public virtual async Task Select_anonymous_with_object()
         {
-            await AssertQuery<Customer>(cs => cs.Select(c => new { c.City, c }));
+            await AssertQuery<Customer>(
+                cs => cs.Select(c => new { c.City, c }),
+                entryCount: 91);
         }
 
         [Fact]
         public virtual async Task Select_anonymous_nested()
         {
-            await AssertQuery<Customer>(cs => cs.Select(c => new { c.City, Country = new { c.Country } }));
+            await AssertQuery<Customer>(
+                cs => cs.Select(c => new { c.City, Country = new { c.Country } }));
         }
 
         [Fact]
         public virtual async Task Select_anonymous_empty()
         {
-            await AssertQuery<Customer>(cs => cs.Select(c => new { }));
+            await AssertQuery<Customer>(
+                cs => cs.Select(c => new { }));
         }
 
         [Fact]
@@ -527,33 +1274,35 @@ namespace Microsoft.Data.Entity.FunctionalTests
         [Fact]
         public virtual async Task Select_scalar_primitive()
         {
-            Assert.Equal(9,
-                await AssertQuery<Employee>(es => es.Select(e => e.EmployeeID)));
+            await AssertQuery<Employee>(
+                es => es.Select(e => e.EmployeeID));
         }
 
         [Fact]
         public virtual async Task Select_scalar_primitive_after_take()
         {
-            Assert.Equal(9,
-                await AssertQuery<Employee>(es => es.Take(9).Select(e => e.EmployeeID)));
+            await AssertQuery<Employee>(
+                es => es.Take(9).Select(e => e.EmployeeID));
         }
 
         [Fact]
         public virtual async Task Select_project_filter()
         {
-            await AssertQuery<Customer>(cs =>
-                from c in cs
-                where c.City == "London"
-                select c.CompanyName);
+            await AssertQuery<Customer>(
+                cs =>
+                    from c in cs
+                    where c.City == "London"
+                    select c.CompanyName);
         }
 
         [Fact]
         public virtual async Task Select_project_filter2()
         {
-            await AssertQuery<Customer>(cs =>
-                from c in cs
-                where c.City == "London"
-                select c.City);
+            await AssertQuery<Customer>(
+                cs =>
+                    from c in cs
+                    where c.City == "London"
+                    select c.City);
         }
 
         [Fact]
@@ -570,17 +1319,17 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     .OrderBy(o => o),
                 asserter:
                     (l2oResults, efResults) =>
-                        {
-                            var l2oObjects
-                                = l2oResults
-                                    .SelectMany(q1 => ((IEnumerable<int>)q1));
+                    {
+                        var l2oObjects
+                            = l2oResults
+                                .SelectMany(q1 => ((IEnumerable<int>)q1));
 
-                            var efObjects
-                                = efResults
-                                    .SelectMany(q1 => ((IEnumerable<int>)q1));
+                        var efObjects
+                            = efResults
+                                .SelectMany(q1 => ((IEnumerable<int>)q1));
 
-                            Assert.Equal(l2oObjects, efObjects);
-                        });
+                        Assert.Equal(l2oObjects, efObjects);
+                    });
         }
 
         [Fact]
@@ -592,19 +1341,19 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     .Where(o => o.CustomerID == c.CustomerID),
                 asserter:
                     (l2oResults, efResults) =>
-                        {
-                            var l2oObjects
-                                = l2oResults
-                                    .SelectMany(q1 => ((IEnumerable<Order>)q1))
-                                    .OrderBy(o => o.OrderID);
+                    {
+                        var l2oObjects
+                            = l2oResults
+                                .SelectMany(q1 => ((IEnumerable<Order>)q1))
+                                .OrderBy(o => o.OrderID);
 
-                            var efObjects
-                                = efResults
-                                    .SelectMany(q1 => ((IEnumerable<Order>)q1))
-                                    .OrderBy(o => o.OrderID);
+                        var efObjects
+                            = efResults
+                                .SelectMany(q1 => ((IEnumerable<Order>)q1))
+                                .OrderBy(o => o.OrderID);
 
-                            Assert.Equal(l2oObjects, efObjects);
-                        });
+                        Assert.Equal(l2oObjects, efObjects);
+                    });
         }
 
         [Fact]
@@ -616,26 +1365,26 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     .OrderBy(o => c.CustomerID),
                 asserter:
                     (l2oResults, efResults) =>
-                        {
-                            var l2oObjects
-                                = l2oResults
-                                    .SelectMany(q1 => ((IEnumerable<Order>)q1))
-                                    .OrderBy(o => o.OrderID);
+                    {
+                        var l2oObjects
+                            = l2oResults
+                                .SelectMany(q1 => ((IEnumerable<Order>)q1))
+                                .OrderBy(o => o.OrderID);
 
-                            var efObjects
-                                = efResults
-                                    .SelectMany(q1 => ((IEnumerable<Order>)q1))
-                                    .OrderBy(o => o.OrderID);
+                        var efObjects
+                            = efResults
+                                .SelectMany(q1 => ((IEnumerable<Order>)q1))
+                                .OrderBy(o => o.OrderID);
 
-                            Assert.Equal(l2oObjects, efObjects);
-                        });
+                        Assert.Equal(l2oObjects, efObjects);
+                    });
         }
 
         // TODO: Re-linq parser
         // [Fact]
         // public virtual async Task Select_nested_ordered_enumerable_collection()
         // {
-        //     await AssertQuery<Customer>(cs =>
+        //     AssertQuery<Customer>(cs =>
         //         cs.Select(c => cs.AsEnumerable().OrderBy(c2 => c2.CustomerID)),
         //         assertOrder: true);
         // }
@@ -647,51 +1396,52 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 from c in cs
                 where c.CustomerID == "ALFKI"
                 select new
-                    {
-                        CustomerId = c.CustomerID,
-                        OrderIds
+                {
+                    CustomerId = c.CustomerID,
+                    OrderIds
                             = os.Where(o => o.CustomerID == c.CustomerID
                                             && o.OrderDate.Value.Year == 1997)
                                 .Select(o => o.OrderID)
                                 .OrderBy(o => o),
-                        Customer = c
-                    },
+                    Customer = c
+                },
                 asserter:
                     (l2oResults, efResults) =>
-                        {
-                            dynamic l2oResult = l2oResults.Single();
-                            dynamic efResult = efResults.Single();
+                    {
+                        dynamic l2oResult = l2oResults.Single();
+                        dynamic efResult = efResults.Single();
 
-                            Assert.Equal(l2oResult.CustomerId, efResult.CustomerId);
-                            Assert.Equal((IEnumerable<int>)l2oResult.OrderIds, (IEnumerable<int>)efResult.OrderIds);
-                            Assert.Equal(l2oResult.Customer, efResult.Customer);
-                        });
+                        Assert.Equal(l2oResult.CustomerId, efResult.CustomerId);
+                        Assert.Equal((IEnumerable<int>)l2oResult.OrderIds, (IEnumerable<int>)efResult.OrderIds);
+                        Assert.Equal(l2oResult.Customer, efResult.Customer);
+                    });
         }
 
         [Fact]
         public virtual async Task Select_subquery_recursive_trivial()
         {
-            await AssertQuery<Employee>(es =>
-                from e1 in es
-                select (from e2 in es
-                    select (from e3 in es
-                        orderby e3.EmployeeID
-                        select e3)),
+            await AssertQuery<Employee>(
+                es =>
+                    from e1 in es
+                    select (from e2 in es
+                            select (from e3 in es
+                                    orderby e3.EmployeeID
+                                    select e3)),
                 asserter:
                     (l2oResults, efResults) =>
-                        {
-                            var l2oObjects
-                                = l2oResults
-                                    .SelectMany(q1 => ((IEnumerable<object>)q1)
-                                        .SelectMany(q2 => (IEnumerable<object>)q2));
+                    {
+                        var l2oObjects
+                            = l2oResults
+                                .SelectMany(q1 => ((IEnumerable<object>)q1)
+                                    .SelectMany(q2 => (IEnumerable<object>)q2));
 
-                            var efObjects
-                                = efResults
-                                    .SelectMany(q1 => ((IEnumerable<object>)q1)
-                                        .SelectMany(q2 => (IEnumerable<object>)q2));
+                        var efObjects
+                            = efResults
+                                .SelectMany(q1 => ((IEnumerable<object>)q1)
+                                    .SelectMany(q2 => (IEnumerable<object>)q2));
 
-                            Assert.Equal(l2oObjects, efObjects);
-                        });
+                        Assert.Equal(l2oObjects, efObjects);
+                    });
         }
 
         // TODO: [Fact] See #153
@@ -706,25 +1456,29 @@ namespace Microsoft.Data.Entity.FunctionalTests
         [Fact]
         public virtual async Task Where_query_composition()
         {
-            await AssertQuery<Employee>(es =>
-                from e1 in es
-                where e1.FirstName == es.OrderBy(e => e.EmployeeID).First().FirstName
-                select e1);
+            await AssertQuery<Employee>(
+                es =>
+                    from e1 in es
+                    where e1.FirstName == es.OrderBy(e => e.EmployeeID).First().FirstName
+                    select e1,
+                entryCount: 1);
         }
 
         [Fact]
         public virtual async Task Where_subquery_recursive_trivial()
         {
-            await AssertQuery<Employee>(es =>
-                from e1 in es
-                where (from e2 in es
-                    where (from e3 in es
-                        orderby e3.EmployeeID
-                        select e3).Any()
-                    select e2).Any()
-                orderby e1.EmployeeID
-                select e1,
-                assertOrder: true);
+            await AssertQuery<Employee>(
+                es =>
+                    from e1 in es
+                    where (from e2 in es
+                           where (from e3 in es
+                                  orderby e3.EmployeeID
+                                  select e3).Any()
+                           select e2).Any()
+                    orderby e1.EmployeeID
+                    select e1,
+                assertOrder: true,
+                entryCount: 9);
         }
 
         [Fact]
@@ -735,35 +1489,36 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 where c.City == "London"
                 orderby c.CustomerID
                 select (from o1 in os
-                    where o1.CustomerID == c.CustomerID
-                          && o1.OrderDate.Value.Year == 1997
-                    orderby o1.OrderID
-                    select (from o2 in os
                         where o1.CustomerID == c.CustomerID
-                        orderby o2.OrderID
-                        select o1.OrderID)),
+                              && o1.OrderDate.Value.Year == 1997
+                        orderby o1.OrderID
+                        select (from o2 in os
+                                where o1.CustomerID == c.CustomerID
+                                orderby o2.OrderID
+                                select o1.OrderID)),
                 asserter:
                     (l2oResults, efResults) =>
-                        {
-                            var l2oObjects
-                                = l2oResults
-                                    .SelectMany(q1 => ((IEnumerable<object>)q1)
-                                        .SelectMany(q2 => (IEnumerable<int>)q2));
+                    {
+                        var l2oObjects
+                            = l2oResults
+                                .SelectMany(q1 => ((IEnumerable<object>)q1)
+                                    .SelectMany(q2 => (IEnumerable<int>)q2));
 
-                            var efObjects
-                                = efResults
-                                    .SelectMany(q1 => ((IEnumerable<object>)q1)
-                                        .SelectMany(q2 => (IEnumerable<int>)q2));
+                        var efObjects
+                            = efResults
+                                .SelectMany(q1 => ((IEnumerable<object>)q1)
+                                    .SelectMany(q2 => (IEnumerable<int>)q2));
 
-                            Assert.Equal(l2oObjects, efObjects);
-                        });
+                        Assert.Equal(l2oObjects, efObjects);
+                    });
         }
 
         [Fact]
         public virtual async Task OrderBy_scalar_primitive()
         {
-            await AssertQuery<Employee>(es =>
-                es.Select(e => e.EmployeeID).OrderBy(i => i),
+            await AssertQuery<Employee>(
+                es =>
+                    es.Select(e => e.EmployeeID).OrderBy(i => i),
                 assertOrder: true);
         }
 
@@ -772,9 +1527,9 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             await AssertQuery<Employee, Customer>(
                 (es, cs) => from e1 in es
-                    from s in new[] { "a", "b" }
-                    from c in cs
-                    select new { e1, s, c });
+                            from s in new[] { "a", "b" }
+                            from c in cs
+                            select new { e1, s, c });
         }
 
         [Fact]
@@ -782,19 +1537,18 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             await AssertQuery<Employee, Customer>(
                 (es, cs) => from e in es
-                    from c in cs
-                    select new { c, e });
+                            from c in cs
+                            select new { c, e });
         }
 
         [Fact]
         public virtual async Task SelectMany_simple2()
         {
             await AssertQuery<Employee, Customer>(
-                (es, cs) =>
-                    from e1 in es
-                    from c in cs
-                    from e2 in es
-                    select new { e1, c, e2.FirstName });
+                (es, cs) => from e1 in es
+                            from c in cs
+                            from e2 in es
+                            select new { e1, c, e2.FirstName });
         }
 
         [Fact]
@@ -805,7 +1559,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     from e1 in es
                     from e2 in es
                     from e3 in es
-                    select new { e2, e3, e1 });
+                    select new { e2, e3, e1 },
+                entryCount: 9);
         }
 
         [Fact]
@@ -813,8 +1568,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             await AssertQuery<Employee>(
                 es => from e1 in es
-                    from e2 in es
-                    select new { e1.City, e2.Country });
+                      from e2 in es
+                      select new { e1.City, e2.Country });
         }
 
         [Fact]
@@ -822,21 +1577,23 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             await AssertQuery<Employee>(
                 es => from e1 in es
-                    from e2 in es
-                    from e3 in es
-                    select new { e1.City, e2.Country, e3.FirstName });
+                      from e2 in es
+                      from e3 in es
+                      select new { e1.City, e2.Country, e3.FirstName });
         }
 
         [Fact]
         public virtual async Task SelectMany_nested_simple()
         {
-            await AssertQuery<Customer>(cs =>
-                from c in cs
-                from c1 in
-                    (from c2 in (from c3 in cs select c3) select c2)
-                orderby c1.CustomerID
-                select c1,
-                assertOrder: true);
+            await AssertQuery<Customer>(
+                cs =>
+                    from c in cs
+                    from c1 in
+                        (from c2 in (from c3 in cs select c3) select c2)
+                    orderby c1.CustomerID
+                    select c1,
+                assertOrder: true,
+                entryCount: 91);
         }
 
         [Fact]
@@ -961,6 +1718,28 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
+        public virtual async Task Join_customers_orders_with_subquery_anonymous_property_method()
+        {
+            await AssertQuery<Customer, Order>((cs, os) =>
+                from c in cs
+                join o1 in
+                    (from o2 in os orderby o2.OrderID select new { o2 }) on c.CustomerID equals o1.o2.CustomerID
+                where o1.o2.Property<string>("CustomerID") == "ALFKI"
+                select new { o1, o1.o2, Shadow = o1.o2.Property<DateTime?>("OrderDate") });
+        }
+
+        [Fact]
+        public virtual async Task Join_customers_orders_with_subquery_predicate()
+        {
+            await AssertQuery<Customer, Order>((cs, os) =>
+                from c in cs
+                join o1 in
+                    (from o2 in os where o2.OrderID > 0 orderby o2.OrderID select o2) on c.CustomerID equals o1.CustomerID
+                where o1.CustomerID == "ALFKI"
+                select new { c.ContactName, o1.OrderID });
+        }
+
+        [Fact]
         public virtual async Task Join_composite_key()
         {
             await AssertQuery<Customer, Order>((cs, os) =>
@@ -979,13 +1758,43 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c, o });
         }
 
+        [Fact]
+        public virtual async Task Join_Where_Count()
+        {
+            await AssertQuery<Customer, Order>((cs, os) =>
+                (from c in cs
+                 join o in os on c.CustomerID equals o.CustomerID
+                 where c.CustomerID == "ALFKI"
+                 select c).CountAsync());
+        }
+
+        [Fact]
+        public virtual async Task Multiple_joins_Where_Order_Any()
+        {
+            await AssertQuery<Customer, Order, OrderDetail>((cs, os, ods) =>
+                cs.Join(os, c => c.CustomerID, o => o.CustomerID, (cr, or) => new { cr, or })
+                    .Join(ods, e => e.or.OrderID, od => od.OrderID, (e, od) => new { e.cr, e.or, od })
+                    .Where(r => r.cr.City == "London").OrderBy(r => r.cr.CustomerID)
+                    .AnyAsync());
+        }
+
+        [Fact]
+        public virtual async Task Join_OrderBy_Count()
+        {
+            await AssertQuery<Customer, Order>((cs, os) =>
+                (from c in cs
+                 join o in os on c.CustomerID equals o.CustomerID
+                 orderby c.CustomerID
+                 select c).CountAsync());
+        }
+
         private class Foo
         {
+            // ReSharper disable once UnusedAutoPropertyAccessor.Local
             public string Bar { get; set; }
         }
 
-        //[Fact]
-        // TODO: Convert orders to IEnumerable<T>
+        [Fact]
         public virtual async Task GroupJoin_customers_orders()
         {
             await AssertQuery<Customer, Order>((cs, os) =>
@@ -993,15 +1802,15 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 join o in os.OrderBy(o => o.OrderID) on c.CustomerID equals o.CustomerID into orders
                 select new { customer = c, orders = orders.ToList() },
                 asserter: (l2oItems, efItems) =>
+                {
+                    foreach (var pair in
+                        from dynamic l2oItem in l2oItems
+                        join dynamic efItem in efItems on l2oItem.customer equals efItem.customer
+                        select new { l2oItem, efItem })
                     {
-                        foreach (var pair in
-                            from dynamic l2oItem in l2oItems
-                            join dynamic efItem in efItems on l2oItem.customer equals efItem.customer
-                            select new { l2oItem, efItem })
-                        {
-                            Assert.Equal(pair.l2oItem.orders, pair.efItem.orders);
-                        }
-                    });
+                        Assert.Equal(pair.l2oItem.orders, pair.efItem.orders);
+                    }
+                });
         }
 
         [Fact]
@@ -1014,13 +1823,51 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
-        public virtual async Task GroupJoin_default_if_empty()
+        public virtual async Task Default_if_empty_top_level()
         {
-            await AssertQuery<Customer, Order>((cs, os) =>
-                from c in cs
-                join o in os on c.CustomerID equals o.CustomerID into orders
-                from o1 in orders.DefaultIfEmpty()
-                select new { c, o1 });
+            await AssertQuery<Employee>(cs =>
+                from c in cs.Where(c => c.EmployeeID == -1).DefaultIfEmpty()
+                select c);
+        }
+
+        [Fact]
+        public virtual async Task Default_if_empty_top_level_arg()
+        {
+            await AssertQuery<Employee>(cs =>
+                from c in cs.Where(c => c.EmployeeID == -1).DefaultIfEmpty(new Employee())
+                select c);
+        }
+
+        [Fact]
+        public virtual async Task GroupJoin_customers_employees_shadow()
+        {
+            await AssertQuery<Customer, Employee>((cs, es) =>
+                (from c in cs
+                 join e in es on c.City equals e.City into employees
+                 select employees)
+                    .SelectMany(emps => emps)
+                    .Select(e =>
+                        new
+                        {
+                            Title = e.Property<string>("Title"),
+                            Id = e.EmployeeID
+                        }));
+        }
+
+        [Fact]
+        public virtual async Task GroupJoin_customers_employees_subquery_shadow()
+        {
+            await AssertQuery<Customer, Employee>((cs, es) =>
+                (from c in cs
+                 join e in es.OrderBy(e => e.City) on c.City equals e.City into employees
+                 select employees)
+                    .SelectMany(emps => emps)
+                    .Select(e =>
+                        new
+                        {
+                            Title = e.Property<string>("Title"),
+                            Id = e.EmployeeID
+                        }));
         }
 
         [Fact]
@@ -1033,12 +1880,40 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c.ContactName, o.OrderID });
         }
 
+        [Fact]
+        public virtual async Task SelectMany_Count()
+        {
+            await AssertQuery<Customer, Order>((cs, os) =>
+                (from c in cs
+                 from o in os
+                 select c.CustomerID).CountAsync());
+        }
+
+        [Fact]
+        public virtual async Task SelectMany_LongCount()
+        {
+            await AssertQuery<Customer, Order>((cs, os) =>
+                (from c in cs
+                 from o in os
+                 select c.CustomerID).LongCountAsync());
+        }
+
+        [Fact]
+        public virtual async Task SelectMany_OrderBy_ThenBy_Any()
+        {
+            await AssertQuery<Customer, Order>((cs, os) =>
+                (from c in cs
+                 from o in os
+                 orderby c.CustomerID, c.City
+                 select c).AnyAsync());
+        }
+
         // TODO: Composite keys, slow..
 
         //        [Fact]
         //        public virtual async Task Multiple_joins_with_join_conditions_in_where()
         //        {
-        //            await AssertQuery<Customer, Order, OrderDetail>((cs, os, ods) =>
+        //            AssertQuery<Customer, Order, OrderDetail>((cs, os, ods) =>
         //                from c in cs
         //                from o in os.OrderBy(o1 => o1.OrderID).Take(10)
         //                from od in ods
@@ -1052,7 +1927,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         //
         //        public virtual async Task TestMultipleJoinsWithMissingJoinCondition()
         //        {
-        //            await AssertQuery<Customer, Order, OrderDetail>((cs, os, ods) =>
+        //            AssertQuery<Customer, Order, OrderDetail>((cs, os, ods) =>
         //                from c in cs
         //                from o in os
         //                from od in ods
@@ -1065,17 +1940,19 @@ namespace Microsoft.Data.Entity.FunctionalTests
         [Fact]
         public virtual async Task OrderBy()
         {
-            await AssertQuery<Customer>(cs =>
-                cs.OrderBy(c => c.CustomerID),
-                assertOrder: true);
+            await AssertQuery<Customer>(
+                cs => cs.OrderBy(c => c.CustomerID),
+                assertOrder: true,
+                entryCount: 91);
         }
 
         [Fact]
         public virtual async Task OrderBy_client_mixed()
         {
-            await AssertQuery<Customer>(cs =>
-                cs.OrderBy(c => c.IsLondon).ThenBy(c => c.CompanyName),
-                assertOrder: true);
+            await AssertQuery<Customer>(
+                cs => cs.OrderBy(c => c.IsLondon).ThenBy(c => c.CompanyName),
+                assertOrder: true,
+                entryCount: 91);
         }
 
         [Fact]
@@ -1091,80 +1968,96 @@ namespace Microsoft.Data.Entity.FunctionalTests
         [Fact]
         public virtual async Task OrderBy_shadow()
         {
-            await AssertQuery<Employee>(es =>
-                es.OrderBy(e => e.Property<string>("Title")).ThenBy(e => e.EmployeeID),
-                assertOrder: true);
+            await AssertQuery<Employee>(
+                es => es.OrderBy(e => e.Property<string>("Title")).ThenBy(e => e.EmployeeID),
+                assertOrder: true,
+                entryCount: 9);
         }
 
         [Fact]
         public virtual async Task OrderBy_ThenBy_predicate()
         {
-            await AssertQuery<Customer>(cs =>
-                cs.Where(c => c.City == "London")
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.City == "London")
                     .OrderBy(c => c.City)
                     .ThenBy(c => c.CustomerID),
-                assertOrder: true);
+                assertOrder: true,
+                entryCount: 6);
         }
 
         [Fact]
         public virtual async Task OrderBy_correlated_subquery_lol()
         {
-            await AssertQuery<Customer>(cs =>
-                from c in cs
-                orderby cs.Any(c2 => c2.CustomerID == c.CustomerID)
-                select c);
+            await AssertQuery<Customer>(
+                cs => from c in cs
+                      orderby cs.Any(c2 => c2.CustomerID == c.CustomerID)
+                      select c,
+                entryCount: 91);
         }
 
         [Fact]
         public virtual async Task OrderBy_Select()
         {
-            await AssertQuery<Customer>(cs =>
-                cs.OrderBy(c => c.CustomerID)
-                    .Select(c => c.ContactName),
+            await AssertQuery<Customer>(
+                cs =>
+                    cs.OrderBy(c => c.CustomerID)
+                        .Select(c => c.ContactName),
                 assertOrder: true);
         }
 
         [Fact]
         public virtual async Task OrderBy_multiple()
         {
-            await AssertQuery<Customer>(cs =>
-                cs.OrderBy(c => c.CustomerID)
-                    // ReSharper disable once MultipleOrderBy
-                    .OrderBy(c => c.Country)
-                    .Select(c => c.City),
+            await AssertQuery<Customer>(
+                cs =>
+                    cs.OrderBy(c => c.CustomerID)
+                        // ReSharper disable once MultipleOrderBy
+                        .OrderBy(c => c.Country)
+                        .Select(c => c.City),
                 assertOrder: true);
         }
 
         [Fact]
         public virtual async Task OrderBy_ThenBy()
         {
-            await AssertQuery<Customer>(cs =>
-                cs.OrderBy(c => c.CustomerID).ThenBy(c => c.Country).Select(c => c.City),
+            await AssertQuery<Customer>(
+                cs =>
+                    cs.OrderBy(c => c.CustomerID).ThenBy(c => c.Country).Select(c => c.City),
                 assertOrder: true);
         }
 
         [Fact]
         public virtual async Task OrderByDescending()
         {
-            await AssertQuery<Customer>(cs =>
-                cs.OrderByDescending(c => c.CustomerID).Select(c => c.City),
+            await AssertQuery<Customer>(
+                cs =>
+                    cs.OrderByDescending(c => c.CustomerID).Select(c => c.City),
                 assertOrder: true);
         }
 
         [Fact]
         public virtual async Task OrderByDescending_ThenBy()
         {
-            await AssertQuery<Customer>(cs =>
-                cs.OrderByDescending(c => c.CustomerID).ThenBy(c => c.Country).Select(c => c.City),
+            await AssertQuery<Customer>(
+                cs =>
+                    cs.OrderByDescending(c => c.CustomerID).ThenBy(c => c.Country).Select(c => c.City),
                 assertOrder: true);
         }
 
         [Fact]
         public virtual async Task OrderByDescending_ThenByDescending()
         {
-            await AssertQuery<Customer>(cs =>
-                cs.OrderByDescending(c => c.CustomerID).ThenByDescending(c => c.Country).Select(c => c.City),
+            await AssertQuery<Customer>(
+                cs =>
+                    cs.OrderByDescending(c => c.CustomerID).ThenByDescending(c => c.Country).Select(c => c.City),
                 assertOrder: true);
+        }
+
+        [Fact]
+        public virtual async Task OrderBy_ThenBy_Any()
+        {
+            await AssertQuery<Customer>(
+                cs => cs.OrderBy(c => c.CustomerID).ThenBy(c => c.ContactName).AnyAsync());
         }
 
         [Fact]
@@ -1191,7 +2084,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         //        [Fact]
         //        public virtual async Task GroupBy_anonymous()
         //        {
-        //            await AssertQuery<Customer>(cs =>
+        //            AssertQuery<Customer>(cs =>
         //                cs.Select(c => new { c.City, c.CustomerID })
         //                    .GroupBy(a => a.City),
         //                assertOrder: true);
@@ -1200,7 +2093,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         //        [Fact]
         //        public virtual async Task GroupBy_anonymous_subquery()
         //        {
-        //            await AssertQuery<Customer>(cs =>
+        //            AssertQuery<Customer>(cs =>
         //                cs.Select(c => new { c.City, c.CustomerID })
         //                    .GroupBy(a => from c2 in cs select c2),
         //                assertOrder: true);
@@ -1209,7 +2102,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         //        [Fact]
         //        public virtual async Task GroupBy_nested_order_by_enumerable()
         //        {
-        //            await AssertQuery<Customer>(cs =>
+        //            AssertQuery<Customer>(cs =>
         //                cs.Select(c => new { c.City, c.CustomerID })
         //                    .OrderBy(a => a.City)
         //                    .GroupBy(a => a.City)
@@ -1220,8 +2113,63 @@ namespace Microsoft.Data.Entity.FunctionalTests
         [Fact]
         public virtual async Task GroupBy_SelectMany()
         {
-            await AssertQuery<Customer>(cs =>
-                cs.GroupBy(c => c.City).SelectMany(g => g));
+            await AssertQuery<Customer>(
+                cs => cs.GroupBy(c => c.City).SelectMany(g => g),
+                entryCount: 91);
+        }
+
+        [Fact]
+        public virtual async Task GroupBy_simple()
+        {
+            await AssertQuery<Order>(
+                os => os.GroupBy(o => o.CustomerID),
+                entryCount: 830,
+                asserter: (l2oResults, efResults) =>
+                {
+                    var efGroupings = efResults.Cast<IGrouping<string, Order>>().ToList();
+
+                    foreach (IGrouping<string, Order> l2oGrouping in l2oResults)
+                    {
+                        var efGrouping = efGroupings.Single(efg => efg.Key == l2oGrouping.Key);
+
+                        Assert.Equal(l2oGrouping.OrderBy(o => o.OrderID), efGrouping.OrderBy(o => o.OrderID));
+                    }
+                });
+        }
+
+        [Fact]
+        public virtual async Task GroupBy_simple2()
+        {
+            await AssertQuery<Order>(
+                os => os.GroupBy(o => o.CustomerID).Select(g => g),
+                entryCount: 830,
+                asserter: (l2oResults, efResults) =>
+                {
+                    var efGroupings = efResults.Cast<IGrouping<string, Order>>().ToList();
+
+                    foreach (IGrouping<string, Order> l2oGrouping in l2oResults)
+                    {
+                        var efGrouping = efGroupings.Single(efg => efg.Key == l2oGrouping.Key);
+
+                        Assert.Equal(l2oGrouping.OrderBy(o => o.OrderID), efGrouping.OrderBy(o => o.OrderID));
+                    }
+                });
+        }
+
+        [Fact]
+        public virtual async Task GroupBy_first()
+        {
+            await AssertQuery<Order>(
+                os => os.Where(o => o.CustomerID == "ALFKI").GroupBy(o => o.CustomerID).Cast<object>().FirstAsync(),
+                asserter: (l2oResult, efResult) =>
+                {
+                    var l2oGrouping = (IGrouping<string, Order>)l2oResult;
+                    var efGrouping = (IGrouping<string, Order>)efResult;
+
+                    Assert.Equal(l2oGrouping.Key, efGrouping.Key);
+                    Assert.Equal(l2oGrouping.OrderBy(o => o.OrderID), efGrouping.OrderBy(o => o.OrderID));
+                },
+                entryCount: 6);
         }
 
         [Fact]
@@ -1246,17 +2194,46 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
+        public virtual async Task GroupBy_Shadow()
+        {
+            await AssertQuery<Employee>(es =>
+                es.Where(e => e.Property<string>("Title") == "Sales Representative"
+                              && e.EmployeeID == 1)
+                    .GroupBy(e => e.Property<string>("Title"))
+                    .Select(g => g.First().Property<string>("Title")));
+        }
+
+        [Fact]
+        public virtual async Task GroupBy_Shadow2()
+        {
+            await AssertQuery<Employee>(es =>
+                es.Where(e => e.Property<string>("Title") == "Sales Representative"
+                              && e.EmployeeID == 1)
+                    .GroupBy(e => e.Property<string>("Title"))
+                    .Select(g => g.First()));
+        }
+
+        [Fact]
+        public virtual async Task GroupBy_Shadow3()
+        {
+            await AssertQuery<Employee>(es =>
+                es.Where(e => e.EmployeeID == 1)
+                    .GroupBy(e => e.EmployeeID)
+                    .Select(g => g.First().Property<string>("Title")));
+        }
+
+        [Fact]
         public virtual async Task GroupBy_Sum_Min_Max_Avg()
         {
             await AssertQuery<Order>(os =>
                 os.GroupBy(o => o.CustomerID).Select(g =>
                     new
-                        {
-                            Sum = g.Sum(o => o.OrderID),
-                            Min = g.Min(o => o.OrderID),
-                            Max = g.Max(o => o.OrderID),
-                            Avg = g.Average(o => o.OrderID)
-                        }));
+                    {
+                        Sum = g.Sum(o => o.OrderID),
+                        Min = g.Min(o => o.OrderID),
+                        Max = g.Max(o => o.OrderID),
+                        Avg = g.Average(o => o.OrderID)
+                    }));
         }
 
         [Fact]
@@ -1265,12 +2242,12 @@ namespace Microsoft.Data.Entity.FunctionalTests
             await AssertQuery<Order>(os =>
                 os.GroupBy(o => o.CustomerID, (k, g) =>
                     new
-                        {
-                            Sum = g.Sum(o => o.OrderID),
-                            Min = g.Min(o => o.OrderID),
-                            Max = g.Max(o => o.OrderID),
-                            Avg = g.Average(o => o.OrderID)
-                        }));
+                    {
+                        Sum = g.Sum(o => o.OrderID),
+                        MinAsync = g.Min(o => o.OrderID),
+                        MaxAsync = g.Max(o => o.OrderID),
+                        Avg = g.Average(o => o.OrderID)
+                    }));
         }
 
         [Fact]
@@ -1289,17 +2266,49 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     .Select(g => g.OrderBy(o => o)),
                 asserter:
                     (l2oResults, efResults) =>
-                        {
-                            var l2oObjects
-                                = l2oResults
-                                    .SelectMany(q1 => ((IEnumerable<int>)q1));
+                    {
+                        var l2oObjects
+                            = l2oResults
+                                .SelectMany(q1 => ((IEnumerable<int>)q1));
 
-                            var efObjects
-                                = efResults
-                                    .SelectMany(q1 => ((IEnumerable<int>)q1));
+                        var efObjects
+                            = efResults
+                                .SelectMany(q1 => ((IEnumerable<int>)q1));
 
-                            Assert.Equal(l2oObjects, efObjects);
-                        });
+                        Assert.Equal(l2oObjects, efObjects);
+                    });
+        }
+
+        [Fact]
+        public virtual async Task GroupBy_with_element_selector2()
+        {
+            await AssertQuery<Order>(os =>
+                os.GroupBy(o => o.CustomerID)
+                    .OrderBy(g => g.Key)
+                    .Select(g => g.OrderBy(o => o.OrderID)),
+                asserter:
+                    (l2oResults, efResults) =>
+                    {
+                        var l2oObjects
+                            = l2oResults
+                                .SelectMany(q1 => ((IEnumerable<Order>)q1));
+
+                        var efObjects
+                            = efResults
+                                .SelectMany(q1 => ((IEnumerable<Order>)q1));
+
+                        Assert.Equal(l2oObjects, efObjects);
+                    });
+        }
+
+        [Fact]
+        public virtual async Task GroupBy_with_element_selector3()
+        {
+            await AssertQuery<Employee>(es =>
+                es.GroupBy(e => e.EmployeeID)
+                    .OrderBy(g => g.Key)
+                    .Select(g => g.Select(e => new { Title = e.Property<string>("Title"), e }).ToList()),
+                assertOrder: true);
         }
 
         [Fact]
@@ -1307,7 +2316,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             await AssertQuery<Order>(os =>
                 os.GroupBy(o => o.CustomerID, o => o.OrderID)
-                    .Select(g => new { Sum = g.Sum(), Max = g.Max() }));
+                    .Select(g => new { Sum = g.Sum(), MaxAsync = g.Max() }));
         }
 
         [Fact]
@@ -1341,7 +2350,18 @@ namespace Microsoft.Data.Entity.FunctionalTests
             await AssertQuery<Order>(os =>
                 os.OrderBy(o => o.OrderID)
                     .GroupBy(o => o.CustomerID)
-                    .SelectMany(g => g));
+                    .SelectMany(g => g),
+                entryCount: 830);
+        }
+
+        [Fact]
+        public virtual async Task OrderBy_GroupBy_SelectMany_shadow()
+        {
+            await AssertQuery<Employee>(es =>
+                es.OrderBy(e => e.EmployeeID)
+                    .GroupBy(e => e.EmployeeID)
+                    .SelectMany(g => g)
+                    .Select(g => g.Property<string>("Title")));
         }
 
         [Fact]
@@ -1351,9 +2371,27 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
+        public virtual async Task Sum_with_binary_expression()
+        {
+            await AssertQuery<Order>(os => os.Select(o => o.OrderID * 2).SumAsync());
+        }
+
+        [Fact]
+        public virtual async Task Sum_with_no_arg_empty()
+        {
+            await AssertQuery<Order>(os => os.Where(o => o.OrderID == 42).Select(o => o.OrderID).SumAsync());
+        }
+
+        [Fact]
         public virtual async Task Sum_with_arg()
         {
             await AssertQuery<Order>(os => os.SumAsync(o => o.OrderID));
+        }
+
+        [Fact]
+        public virtual async Task Sum_with_arg_expression()
+        {
+            await AssertQuery<Order>(os => os.SumAsync(o => o.OrderID + o.OrderID));
         }
 
         [Fact]
@@ -1394,30 +2432,133 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
+        public virtual async Task Count_with_order_by()
+        {
+            await AssertQuery<Order>(os => os.OrderBy(o => o.CustomerID).CountAsync());
+        }
+
+        [Fact]
+        public virtual async Task Where_OrderBy_Count()
+        {
+            await AssertQuery<Order>(os => os.Where(o => o.CustomerID == "ALFKI").OrderBy(o => o.OrderID).CountAsync());
+        }
+
+        [Fact]
+        public virtual async Task OrderBy_Where_Count()
+        {
+            await AssertQuery<Order>(os => os.OrderBy(o => o.OrderID).Where(o => o.CustomerID == "ALFKI").CountAsync());
+        }
+
+        [Fact]
+        public virtual async Task OrderBy_Count_with_predicate()
+        {
+            await AssertQuery<Order>(os => os.OrderBy(o => o.OrderID).CountAsync(o => o.CustomerID == "ALFKI"));
+        }
+
+        [Fact]
+        public virtual async Task OrderBy_Where_Count_with_predicate()
+        {
+            await AssertQuery<Order>(os => os.OrderBy(o => o.OrderID).Where(o => o.OrderID > 10).CountAsync(o => o.CustomerID != "ALFKI"));
+        }
+
+        [Fact]
+        public virtual async Task Where_OrderBy_Count_client_eval()
+        {
+            await AssertQuery<Order>(os => os.Where(o => ClientEvalPredicate(o)).OrderBy(o => ClientEvalSelectorStateless()).CountAsync());
+        }
+
+        [Fact]
+        public virtual async Task Where_OrderBy_Count_client_eval_mixed()
+        {
+            await AssertQuery<Order>(os => os.Where(o => o.OrderID > 10).OrderBy(o => ClientEvalPredicate(o)).CountAsync());
+        }
+
+        [Fact]
+        public virtual async Task OrderBy_Where_Count_client_eval()
+        {
+            await AssertQuery<Order>(os => os.OrderBy(o => ClientEvalSelectorStateless()).Where(o => ClientEvalPredicate(o)).CountAsync());
+        }
+
+        [Fact]
+        public virtual async Task OrderBy_Where_Count_client_eval_mixed()
+        {
+            await AssertQuery<Order>(os => os.OrderBy(o => o.OrderID).Where(o => ClientEvalPredicate(o)).CountAsync());
+        }
+
+        [Fact]
+        public virtual async Task OrderBy_Count_with_predicate_client_eval()
+        {
+            await AssertQuery<Order>(os => os.OrderBy(o => ClientEvalSelectorStateless()).CountAsync(o => ClientEvalPredicate(o)));
+        }
+
+        [Fact]
+        public virtual async Task OrderBy_Count_with_predicate_client_eval_mixed()
+        {
+            await AssertQuery<Order>(os => os.OrderBy(o => o.OrderID).CountAsync(o => ClientEvalPredicateStateless()));
+        }
+
+        [Fact]
+        public virtual async Task OrderBy_Where_Count_with_predicate_client_eval()
+        {
+            await AssertQuery<Order>(os => os.OrderBy(o => ClientEvalSelectorStateless()).Where(o => ClientEvalPredicateStateless()).CountAsync(o => ClientEvalPredicate(o)));
+        }
+
+        [Fact]
+        public virtual async Task OrderBy_Where_Count_with_predicate_client_eval_mixed()
+        {
+            await AssertQuery<Order>(os => os.OrderBy(o => o.OrderID).Where(o => ClientEvalPredicate(o)).CountAsync(o => o.CustomerID != "ALFKI"));
+        }
+
+        public static bool ClientEvalPredicateStateless()
+        {
+            return true;
+        }
+
+        protected static bool ClientEvalPredicate(Order order)
+        {
+            return order.OrderID > 10000;
+        }
+
+        private static int ClientEvalSelectorStateless()
+        {
+            return 42;
+        }
+
+        protected internal int ClientEvalSelector(Order order)
+        {
+            return order.EmployeeID.HasValue ? order.EmployeeID.Value % 10 : 0;
+        }
+
+        [Fact]
         public virtual async Task Distinct()
         {
-            await AssertQuery<Customer>(cs => cs.Distinct());
+            await AssertQuery<Customer>(
+                cs => cs.Distinct(),
+                entryCount: 91);
         }
 
         [Fact]
         public virtual async Task Distinct_Scalar()
         {
-            await AssertQuery<Customer>(cs =>
-                cs.Select(c => c.City).Distinct());
+            await AssertQuery<Customer>(
+                cs =>
+                    cs.Select(c => c.City).Distinct());
         }
 
         [Fact]
         public virtual async Task OrderBy_Distinct()
         {
-            await AssertQuery<Customer>(cs =>
-                cs.OrderBy(c => c.CustomerID).Select(c => c.City).Distinct());
+            await AssertQuery<Customer>(
+                cs =>
+                    cs.OrderBy(c => c.CustomerID).Select(c => c.City).Distinct());
         }
 
         [Fact]
         public virtual async Task Distinct_OrderBy()
         {
-            await AssertQuery<Customer>(cs =>
-                cs.Select(c => c.City).Distinct().OrderBy(c => c),
+            await AssertQuery<Customer>(
+                cs =>
+                    cs.Select(c => c.City).Distinct().OrderBy(c => c),
                 assertOrder: true);
         }
 
@@ -1442,28 +2583,32 @@ namespace Microsoft.Data.Entity.FunctionalTests
         [Fact]
         public virtual async Task Distinct_Count()
         {
-            await AssertQuery<Customer>(cs => cs.Distinct().CountAsync());
+            await AssertQuery<Customer>(
+                cs => cs.Distinct().CountAsync());
         }
 
         [Fact]
         public virtual async Task Select_Distinct_Count()
         {
-            await AssertQuery<Customer>(cs =>
-                cs.Select(c => c.City).Distinct().CountAsync());
+            await AssertQuery<Customer>(
+                cs =>
+                    cs.Select(c => c.City).Distinct().CountAsync());
         }
 
         [Fact]
         public virtual async Task Select_Select_Distinct_Count()
         {
-            await AssertQuery<Customer>(cs =>
-                cs.Select(c => c.City).Select(c => c).Distinct().CountAsync());
+            await AssertQuery<Customer>(
+                cs =>
+                    cs.Select(c => c.City).Select(c => c).Distinct().CountAsync());
         }
 
         [Fact]
         public virtual async Task Single_Throws()
         {
-            await Assert.ThrowsAsync<InvalidOperationException>(() =>
-                AssertQuery<Customer>(cs => cs.SingleAsync()));
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                await AssertQuery<Customer>(
+                    cs => cs.SingleAsync()));
         }
 
         [Fact]
@@ -1471,12 +2616,6 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             await AssertQuery<Customer>(
                 cs => cs.SingleAsync(c => c.CustomerID == "ALFKI"));
-        }
-
-        public virtual async Task Single_Predicate_Cancellation(CancellationToken cancellationToken)
-        {
-            await AssertQuery<Customer>(
-                cs => cs.SingleAsync(c => c.CustomerID == "ALFKI", cancellationToken));
         }
 
         [Fact]
@@ -1490,8 +2629,9 @@ namespace Microsoft.Data.Entity.FunctionalTests
         [Fact]
         public virtual async Task SingleOrDefault_Throws()
         {
-            await Assert.ThrowsAsync<InvalidOperationException>(() =>
-                AssertQuery<Customer>(cs => cs.SingleOrDefaultAsync()));
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                await AssertQuery<Customer>(
+                    cs => cs.SingleOrDefaultAsync()));
         }
 
         [Fact]
@@ -1510,7 +2650,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
-        public virtual async Task First()
+        public virtual async Task FirstAsync()
         {
             await AssertQuery<Customer>(
                 cs => cs.OrderBy(c => c.ContactName).FirstAsync());
@@ -1608,49 +2748,205 @@ namespace Microsoft.Data.Entity.FunctionalTests
         [Fact]
         public virtual async Task String_StartsWith_Literal()
         {
-            await AssertQuery<Customer>(cs => cs.Where(c => c.ContactName.StartsWith("M")));
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.ContactName.StartsWith("M")),
+                entryCount: 12);
         }
 
         [Fact]
         public virtual async Task String_StartsWith_Identity()
         {
-            await AssertQuery<Customer>(cs => cs.Where(c => c.ContactName.StartsWith(c.ContactName)));
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.ContactName.StartsWith(c.ContactName)),
+                entryCount: 91);
         }
 
         [Fact]
         public virtual async Task String_StartsWith_Column()
         {
-            await AssertQuery<Customer>(cs => cs.Where(c => c.ContactName.StartsWith(c.ContactName)));
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.ContactName.StartsWith(c.ContactName)),
+                entryCount: 91);
         }
 
         [Fact]
         public virtual async Task String_StartsWith_MethodCall()
         {
-            await AssertQuery<Customer>(cs => cs.Where(c => c.ContactName.StartsWith(LocalMethod1())));
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.ContactName.StartsWith(LocalMethod1())),
+                entryCount: 12);
         }
 
         [Fact]
         public virtual async Task String_EndsWith_Literal()
         {
-            await AssertQuery<Customer>(cs => cs.Where(c => c.ContactName.EndsWith("b")));
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.ContactName.EndsWith("b")),
+                entryCount: 1);
         }
 
         [Fact]
         public virtual async Task String_EndsWith_Identity()
         {
-            await AssertQuery<Customer>(cs => cs.Where(c => c.ContactName.EndsWith(c.ContactName)));
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.ContactName.EndsWith(c.ContactName)),
+                entryCount: 91);
         }
 
         [Fact]
         public virtual async Task String_EndsWith_Column()
         {
-            await AssertQuery<Customer>(cs => cs.Where(c => c.ContactName.EndsWith(c.ContactName)));
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.ContactName.EndsWith(c.ContactName)),
+                entryCount: 91);
         }
 
         [Fact]
         public virtual async Task String_EndsWith_MethodCall()
         {
-            await AssertQuery<Customer>(cs => cs.Where(c => c.ContactName.EndsWith(LocalMethod2())));
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.ContactName.EndsWith(LocalMethod2())),
+                entryCount: 1);
+        }
+
+        [Fact]
+        public virtual async Task String_Contains_Literal()
+        {
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.ContactName.Contains("M")),
+                entryCount: 19);
+        }
+
+        [Fact]
+        public virtual async Task String_Contains_Identity()
+        {
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.ContactName.Contains(c.ContactName)),
+                entryCount: 91);
+        }
+
+        [Fact]
+        public virtual async Task String_Contains_Column()
+        {
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.ContactName.Contains(c.ContactName)),
+                entryCount: 91);
+        }
+
+        [Fact]
+        public virtual async Task String_Contains_MethodCall()
+        {
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.ContactName.Contains(LocalMethod1())),
+                entryCount: 19);
+        }
+
+        protected static string LocalMethod1()
+        {
+            return "M";
+        }
+
+        protected static string LocalMethod2()
+        {
+            return "m";
+        }
+
+        [Fact]
+        public virtual async Task GroupJoin_simple()
+        {
+            await AssertQuery<Customer, Order>((cs, os) =>
+                from c in cs
+                join o in os on c.CustomerID equals o.CustomerID into orders
+                from o in orders
+                select o);
+        }
+
+        [Fact]
+        public virtual async Task GroupJoin_projection()
+        {
+            await AssertQuery<Customer, Order>((cs, os) =>
+                from c in cs
+                join o in os on c.CustomerID equals o.CustomerID into orders
+                from o in orders
+                select new { c, o });
+        }
+
+        [Fact]
+        public virtual async Task GroupJoin_DefaultIfEmpty()
+        {
+            await AssertQuery<Customer, Order>((cs, os) =>
+                from c in cs
+                join o in os on c.CustomerID equals o.CustomerID into orders
+                from o in orders.DefaultIfEmpty()
+                select new { c, o });
+        }
+
+        [Fact]
+        public virtual async Task GroupJoin_DefaultIfEmpty2()
+        {
+            await AssertQuery<Employee, Order>((es, os) =>
+                from e in es
+                join o in os on e.EmployeeID equals o.EmployeeID into orders
+                from o in orders.DefaultIfEmpty()
+                select new { e, o });
+        }
+
+        [Fact]
+        public virtual async Task GroupJoin_DefaultIfEmpty3()
+        {
+            await AssertQuery<Customer, Order>((cs, os) =>
+                from c in cs //.Take(1)
+                join o in os on c.CustomerID equals o.CustomerID into orders
+                from o in orders.DefaultIfEmpty()
+                select o);
+        }
+
+        [Fact]
+        public virtual async Task SelectMany_Joined()
+        {
+            await AssertQuery<Customer, Order>((cs, os) =>
+                from c in cs
+                from o in os.Where(o => o.CustomerID == c.CustomerID)
+                select new { c.ContactName, o.OrderDate });
+        }
+
+        [Fact]
+        public virtual async Task SelectMany_Joined_DefaultIfEmpty()
+        {
+            await AssertQuery<Customer, Order>((cs, os) =>
+                from c in cs
+                from o in os.Where(o => o.CustomerID == c.CustomerID).DefaultIfEmpty()
+                select new { c.ContactName, o });
+        }
+
+        [Fact]
+        public virtual async Task SelectMany_Joined_DefaultIfEmpty2()
+        {
+            await AssertQuery<Customer, Order>((cs, os) =>
+                from c in cs
+                from o in os.Where(o => o.CustomerID == c.CustomerID).DefaultIfEmpty()
+                select o);
+        }
+
+        [Fact]
+        public virtual async Task Select_many_cross_join_same_collection()
+        {
+            await AssertQuery<Customer, Customer>((cs1, cs2) =>
+                cs1.SelectMany(c => cs2));
+        }
+
+        [Fact]
+        public virtual async Task Join_same_collection_multiple()
+        {
+            await AssertQuery<Customer, Customer, Customer>((cs1, cs2, cs3) =>
+                cs1.Join(cs2, o => o.CustomerID, i => i.CustomerID, (c1, c2) => new { c1, c2 }).Join(cs3, o => o.c1.CustomerID, i => i.CustomerID, (c12, c3) => c3));
+        }
+
+        [Fact]
+        public virtual async Task Join_same_collection_force_alias_uniquefication()
+        {
+            await AssertQuery<Order, Order>((os1, os2) =>
+                os1.Join(os2, o => o.CustomerID, i => i.CustomerID, (_, o) => new { _, o }));
         }
 
         [Fact]
@@ -1661,11 +2957,105 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
-        public virtual async Task Contains_with_local_collection()
+        public virtual async Task Contains_with_local_array_closure()
         {
             string[] ids = { "ABCDE", "ALFKI" };
             await AssertQuery<Customer>(cs =>
+                cs.Where(c => ids.Contains(c.CustomerID)), entryCount: 1);
+        }
+
+        [Fact]
+        public virtual async Task Contains_with_local_array_inline()
+        {
+            await AssertQuery<Customer>(cs =>
+                cs.Where(c => new[] { "ABCDE", "ALFKI" }.Contains(c.CustomerID)), entryCount: 1);
+        }
+
+        [Fact]
+        public virtual async Task Contains_with_local_list_closure()
+        {
+            var ids = new List<string> { "ABCDE", "ALFKI" };
+            await AssertQuery<Customer>(cs =>
+                cs.Where(c => ids.Contains(c.CustomerID)), entryCount: 1);
+        }
+
+        [Fact]
+        public virtual async Task Contains_with_local_list_inline()
+        {
+            await AssertQuery<Customer>(cs =>
+                cs.Where(c => new List<string> { "ABCDE", "ALFKI" }.Contains(c.CustomerID)), entryCount: 1);
+        }
+
+        [Fact]
+        public virtual async Task Contains_with_local_list_inline_closure_mix()
+        {
+            var alfki = "ALFKI";
+            await AssertQuery<Customer>(cs =>
+                cs.Where(c => new List<string> { "ABCDE", alfki }.Contains(c.CustomerID)), entryCount: 1);
+        }
+
+        [Fact]
+        public virtual async Task Contains_with_local_collection_false()
+        {
+            string[] ids = { "ABCDE", "ALFKI" };
+            await AssertQuery<Customer>(cs =>
+                cs.Where(c => !ids.Contains(c.CustomerID)), entryCount: 90);
+        }
+
+        [Fact]
+        public virtual async Task Contains_with_local_collection_complex_predicate_and()
+        {
+            string[] ids = { "ABCDE", "ALFKI" };
+            await AssertQuery<Customer>(cs =>
+                cs.Where(c => (c.CustomerID == "ALFKI" || c.CustomerID == "ABCDE") && ids.Contains(c.CustomerID)), entryCount: 1);
+        }
+
+        [Fact]
+        public virtual async Task Contains_with_local_collection_complex_predicate_or()
+        {
+            string[] ids = { "ABCDE", "ALFKI" };
+            await AssertQuery<Customer>(cs =>
+                cs.Where(c => ids.Contains(c.CustomerID) || (c.CustomerID == "ALFKI" || c.CustomerID == "ABCDE")), entryCount: 1);
+        }
+
+        [Fact]
+        public virtual async Task Contains_with_local_collection_complex_predicate_not_matching_ins1()
+        {
+            string[] ids = { "ABCDE", "ALFKI" };
+            await AssertQuery<Customer>(cs =>
+                cs.Where(c => (c.CustomerID == "ALFKI" || c.CustomerID == "ABCDE") || !ids.Contains(c.CustomerID)), entryCount: 91);
+        }
+
+        [Fact]
+        public virtual async Task Contains_with_local_collection_complex_predicate_not_matching_ins2()
+        {
+            string[] ids = { "ABCDE", "ALFKI" };
+            await AssertQuery<Customer>(cs =>
+                cs.Where(c => ids.Contains(c.CustomerID) && (c.CustomerID != "ALFKI" && c.CustomerID != "ABCDE")));
+        }
+
+        [Fact]
+        public virtual async Task Contains_with_local_collection_sql_injection()
+        {
+            string[] ids = { "ALFKI", "ABC')); GO; DROP TABLE Orders; GO; --" };
+            await AssertQuery<Customer>(cs =>
+                cs.Where(c => ids.Contains(c.CustomerID) || (c.CustomerID == "ALFKI" || c.CustomerID == "ABCDE")), entryCount: 1);
+        }
+
+        [Fact]
+        public virtual async Task Contains_with_local_collection_empty_closure()
+        {
+            var ids = new string[0];
+
+            await AssertQuery<Customer>(cs =>
                 cs.Where(c => ids.Contains(c.CustomerID)));
+        }
+
+        [Fact]
+        public virtual async Task Contains_with_local_collection_empty_inline()
+        {
+            await AssertQuery<Customer>(cs =>
+                cs.Where(c => !(new List<string>().Contains(c.CustomerID))), entryCount: 91);
         }
 
         [Fact]
@@ -1675,14 +3065,12 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs.Select(c => c.CustomerID).ContainsAsync("ALFKI"));
         }
 
-        private static string LocalMethod1()
+        [Fact]
+        public virtual async Task Where_chain()
         {
-            return "M";
-        }
-
-        private static string LocalMethod2()
-        {
-            return "m";
+            await AssertQuery<Order>(order => order
+                .Where(o => o.CustomerID == "QUICK")
+                .Where(o => o.OrderDate > new DateTime(1998, 1, 1)), entryCount: 8);
         }
 
         protected NorthwindContext CreateContext()
@@ -1697,49 +3085,49 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
         protected TFixture Fixture { get; }
 
-        private async Task<int> AssertQuery<TItem>(
+        private async Task AssertQuery<TItem>(
             Func<IQueryable<TItem>, Task<int>> query,
             bool assertOrder = false)
             where TItem : class
         {
             using (var context = CreateContext())
             {
-                return TestHelpers.AssertResults(
+                TestHelpers.AssertResults(
                     new[] { await query(NorthwindData.Set<TItem>()) },
                     new[] { await query(context.Set<TItem>()) },
                     assertOrder);
             }
         }
 
-        private async Task<int> AssertQuery<TItem>(
+        private async Task AssertQuery<TItem>(
             Func<IQueryable<TItem>, Task<bool>> query,
             bool assertOrder = false)
             where TItem : class
         {
             using (var context = CreateContext())
             {
-                return TestHelpers.AssertResults(
+                TestHelpers.AssertResults(
                     new[] { await query(NorthwindData.Set<TItem>()) },
                     new[] { await query(context.Set<TItem>()) },
                     assertOrder);
             }
         }
 
-        private async Task<int> AssertQuery<TItem>(
+        private async Task AssertQuery<TItem>(
             Func<IQueryable<TItem>, Task<TItem>> query,
             bool assertOrder = false)
             where TItem : class
         {
             using (var context = CreateContext())
             {
-                return TestHelpers.AssertResults(
+                TestHelpers.AssertResults(
                     new[] { await query(NorthwindData.Set<TItem>()) },
                     new[] { await query(context.Set<TItem>()) },
                     assertOrder);
             }
         }
 
-        private async Task<int> AssertQuery<TItem1, TItem2>(
+        private async Task AssertQuery<TItem1, TItem2>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, Task<object>> query,
             bool assertOrder = false)
             where TItem1 : class
@@ -1747,14 +3135,75 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             using (var context = CreateContext())
             {
-                return TestHelpers.AssertResults(
+                TestHelpers.AssertResults(
                     new[] { await query(NorthwindData.Set<TItem1>(), NorthwindData.Set<TItem2>()) },
                     new[] { await query(context.Set<TItem1>(), context.Set<TItem2>()) },
                     assertOrder);
             }
         }
 
-        private async Task<int> AssertQuery<TItem>(
+        private async Task AssertQuery<TItem1, TItem2>(
+            Func<IQueryable<TItem1>, IQueryable<TItem2>, Task<bool>> query,
+            bool assertOrder = false)
+            where TItem1 : class
+            where TItem2 : class
+        {
+            using (var context = CreateContext())
+            {
+                TestHelpers.AssertResults(
+                    new[] { await query(NorthwindData.Set<TItem1>(), NorthwindData.Set<TItem2>()) },
+                    new[] { await query(context.Set<TItem1>(), context.Set<TItem2>()) },
+                    assertOrder);
+            }
+        }
+
+        private async Task AssertQuery<TItem1, TItem2>(
+            Func<IQueryable<TItem1>, IQueryable<TItem2>, Task<int>> query,
+            bool assertOrder = false)
+            where TItem1 : class
+            where TItem2 : class
+        {
+            using (var context = CreateContext())
+            {
+                TestHelpers.AssertResults(
+                    new[] { await query(NorthwindData.Set<TItem1>(), NorthwindData.Set<TItem2>()) },
+                    new[] { await query(context.Set<TItem1>(), context.Set<TItem2>()) },
+                    assertOrder);
+            }
+        }
+
+        private async Task AssertQuery<TItem1, TItem2>(
+            Func<IQueryable<TItem1>, IQueryable<TItem2>, Task<long>> query,
+            bool assertOrder = false)
+            where TItem1 : class
+            where TItem2 : class
+        {
+            using (var context = CreateContext())
+            {
+                TestHelpers.AssertResults(
+                    new[] { await query(NorthwindData.Set<TItem1>(), NorthwindData.Set<TItem2>()) },
+                    new[] { await query(context.Set<TItem1>(), context.Set<TItem2>()) },
+                    assertOrder);
+            }
+        }
+
+        private async Task AssertQuery<TItem1, TItem2, TItem3>(
+            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, Task<bool>> query,
+            bool assertOrder = false)
+            where TItem1 : class
+            where TItem2 : class
+            where TItem3 : class
+        {
+            using (var context = CreateContext())
+            {
+                TestHelpers.AssertResults(
+                    new[] { await query(NorthwindData.Set<TItem1>(), NorthwindData.Set<TItem2>(), NorthwindData.Set<TItem3>()) },
+                    new[] { await query(context.Set<TItem1>(), context.Set<TItem2>(), context.Set<TItem3>()) },
+                    assertOrder);
+            }
+        }
+
+        private async Task AssertQuery<TItem>(
             Func<IQueryable<TItem>, IQueryable<IQueryable<object>>> query,
             bool assertOrder = false,
             Action<IList<IQueryable<object>>, IList<IQueryable<object>>> asserter = null)
@@ -1762,7 +3211,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             using (var context = CreateContext())
             {
-                return TestHelpers.AssertResults(
+                TestHelpers.AssertResults(
                     query(NorthwindData.Set<TItem>()).ToArray(),
                     await query(context.Set<TItem>()).ToArrayAsync(),
                     assertOrder,
@@ -1770,23 +3219,36 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        private async Task<int> AssertQuery<TItem>(
+        protected async Task AssertQuery<TItem>(
             Func<IQueryable<TItem>, IQueryable<object>> query,
             bool assertOrder = false,
+            int entryCount = 0,
             Action<IList<object>, IList<object>> asserter = null)
+            where TItem : class
+        {
+            await AssertQuery(query, query, assertOrder, entryCount, asserter);
+        }
+
+        protected async Task AssertQuery<TItem>(
+            Func<IQueryable<TItem>, Task<object>> query,
+            bool assertOrder = false,
+            int entryCount = 0,
+            Action<object, object> asserter = null)
             where TItem : class
         {
             using (var context = CreateContext())
             {
-                return TestHelpers.AssertResults(
-                    query(NorthwindData.Set<TItem>()).ToArray(),
-                    await query(context.Set<TItem>()).ToArrayAsync(),
+                TestHelpers.AssertResults(
+                    new[] { await query(NorthwindData.Set<TItem>()) },
+                    new[] { await query(context.Set<TItem>()) },
                     assertOrder,
-                    asserter);
+                    (l2os, efs) => asserter(l2os.Single(), efs.Single()));
+
+                Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
             }
         }
 
-        private async Task<int> AssertQuery<TItem1, TItem2>(
+        private async Task AssertQuery<TItem1, TItem2>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> query,
             bool assertOrder = false,
             Action<IList<object>, IList<object>> asserter = null)
@@ -1795,7 +3257,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             using (var context = CreateContext())
             {
-                return TestHelpers.AssertResults(
+                TestHelpers.AssertResults(
                     query(NorthwindData.Set<TItem1>(), NorthwindData.Set<TItem2>()).ToArray(),
                     await query(context.Set<TItem1>(), context.Set<TItem2>()).ToArrayAsync(),
                     assertOrder,
@@ -1803,7 +3265,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        private async Task<int> AssertQuery<TItem1, TItem2, TItem3>(
+        private async Task AssertQuery<TItem1, TItem2, TItem3>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, IQueryable<object>> query,
             bool assertOrder = false)
             where TItem1 : class
@@ -1812,46 +3274,70 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             using (var context = CreateContext())
             {
-                return TestHelpers.AssertResults(
+                TestHelpers.AssertResults(
                     query(NorthwindData.Set<TItem1>(), NorthwindData.Set<TItem2>(), NorthwindData.Set<TItem3>()).ToArray(),
                     await query(context.Set<TItem1>(), context.Set<TItem2>(), context.Set<TItem3>()).ToArrayAsync(),
                     assertOrder);
             }
         }
 
-        private async Task<int> AssertQuery<TItem>(
-            Func<IQueryable<TItem>, IQueryable<int>> query, bool assertOrder = false)
+        private async Task AssertQuery<TItem>(
+            Func<IQueryable<TItem>, IQueryable<int>> query,
+            bool assertOrder = false,
+            int entryCount = 0)
             where TItem : class
         {
             using (var context = CreateContext())
             {
-                return TestHelpers.AssertResults(
+                TestHelpers.AssertResults(
                     query(NorthwindData.Set<TItem>()).ToArray(),
                     await query(context.Set<TItem>()).ToArrayAsync(),
                     assertOrder);
+
+                Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
             }
         }
 
-        private async Task<int> AssertQuery<TItem>(
+        private async Task AssertQuery<TItem>(
             Func<IQueryable<TItem>, IQueryable<long>> query, bool assertOrder = false)
             where TItem : class
         {
             using (var context = CreateContext())
             {
-                return TestHelpers.AssertResults(
+                TestHelpers.AssertResults(
                     query(NorthwindData.Set<TItem>()).ToArray(),
                     await query(context.Set<TItem>()).ToArrayAsync(),
                     assertOrder);
             }
         }
 
-        private async Task<int> AssertQuery<TItem>(
+        protected async Task AssertQuery<TItem>(
+            Func<IQueryable<TItem>, IQueryable<object>> efQuery,
+            Func<IQueryable<TItem>, IQueryable<object>> l2oQuery,
+            bool assertOrder = false,
+            int entryCount = 0,
+            Action<IList<object>, IList<object>> asserter = null)
+            where TItem : class
+        {
+            using (var context = CreateContext())
+            {
+                TestHelpers.AssertResults(
+                    l2oQuery(NorthwindData.Set<TItem>()).ToArray(),
+                    await efQuery(context.Set<TItem>()).ToArrayAsync(),
+                    assertOrder,
+                    asserter);
+
+                Assert.Equal(entryCount, context.ChangeTracker.Entries().Count());
+            }
+        }
+
+        private async Task AssertQuery<TItem>(
             Func<IQueryable<TItem>, IQueryable<bool>> query, bool assertOrder = false)
             where TItem : class
         {
             using (var context = CreateContext())
             {
-                return TestHelpers.AssertResults(
+                TestHelpers.AssertResults(
                     query(NorthwindData.Set<TItem>()).ToArray(),
                     await query(context.Set<TItem>()).ToArrayAsync(),
                     assertOrder);

--- a/test/EntityFramework.Core.FunctionalTests/InheritanceTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/InheritanceTestBase.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 Assert.Equal(2, animals.Count);
                 Assert.IsType<Kiwi>(animals[0]);
                 Assert.IsType<Eagle>(animals[1]);
+                Assert.Equal(2, context.ChangeTracker.Entries().Count());
             }
         }
 
@@ -33,6 +34,20 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 Assert.Equal(2, animals.Count);
                 Assert.IsType<Kiwi>(animals[0]);
                 Assert.IsType<Eagle>(animals[1]);
+                Assert.Equal(2, context.ChangeTracker.Entries().Count());
+            }
+        }
+
+        [Fact]
+        public virtual void Can_use_of_type_bird_first()
+        {
+            using (var context = CreateContext())
+            {
+                var bird = context.Set<Animal>().OfType<Bird>().OrderBy(a => a.Species).First();
+
+                Assert.NotNull(bird);
+                Assert.IsType<Kiwi>(bird);
+                Assert.Equal(1, context.ChangeTracker.Entries().Count());
             }
         }
 
@@ -45,6 +60,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
                 Assert.Equal(1, animals.Count);
                 Assert.IsType<Kiwi>(animals[0]);
+                Assert.Equal(1, context.ChangeTracker.Entries().Count());
             }
         }
 

--- a/test/EntityFramework.Core.FunctionalTests/NorthwindQueryFixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/NorthwindQueryFixtureBase.cs
@@ -38,7 +38,6 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
             modelBuilder.Entity<Order>(e =>
                 {
-                    e.Ignore(o => o.EmployeeID);
                     e.Ignore(o => o.Freight);
                     e.Ignore(o => o.RequiredDate);
                     e.Ignore(o => o.ShipAddress);

--- a/test/EntityFramework.InMemory.FunctionalTests/NorthwindQueryInMemoryFixture.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/NorthwindQueryInMemoryFixture.cs
@@ -36,7 +36,11 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
 
         public override NorthwindContext CreateContext()
         {
-            return new NorthwindContext(_serviceProvider, _options);
+            var context = new NorthwindContext(_serviceProvider, _options);
+
+            context.ChangeTracker.AutoDetectChangesEnabled = false;
+
+            return context;
         }
     }
 }

--- a/test/EntityFramework.SqlServer.FunctionalTests/AsyncQuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/AsyncQuerySqlServerTest.cs
@@ -1,20 +1,63 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Data.Entity.FunctionalTests.TestModels.Northwind;
 using Microsoft.Data.Entity.Relational.FunctionalTests;
+using Microsoft.Data.Entity.Storage;
 using Xunit;
+
+#pragma warning disable 1998
 
 namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 {
     public class AsyncQuerySqlServerTest : AsyncQueryTestBase<NorthwindQuerySqlServerFixture>
     {
+        // TODO: Complex projection translation.
+
+        public override async Task Projection_when_arithmetic_expressions()
+        {
+            //base.Projection_when_arithmetic_expressions();
+        }
+
+        public override async Task Projection_when_arithmetic_mixed()
+        {
+            //base.Projection_when_arithmetic_mixed();
+        }
+
+        public override async Task Projection_when_arithmetic_mixed_subqueries()
+        {
+            //base.Projection_when_arithmetic_mixed_subqueries();
+        }
+
+        public override async Task String_Contains_Literal()
+        {
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.ContactName.Contains("M")), // case-insensitive
+                cs => cs.Where(c => c.ContactName.Contains("M") || c.ContactName.Contains("m")), // case-sensitive
+                entryCount: 34);
+        }
+
+        public override async Task String_Contains_MethodCall()
+        {
+            await AssertQuery<Customer>(
+                cs => cs.Where(c => c.ContactName.Contains(LocalMethod1())), // case-insensitive
+                cs => cs.Where(c => c.ContactName.Contains(LocalMethod1()) || c.ContactName.Contains(LocalMethod2())), // case-sensitive
+                entryCount: 34);
+        }
+
+        public async Task Skip_when_no_order_by()
+        {
+            await Assert.ThrowsAsync<DataStoreException>(async () => await AssertQuery<Customer>(cs => cs.Skip(5).Take(10)));
+        }
+
         [Fact]
         public async Task Single_Predicate_Cancellation()
         {
-            await Assert.ThrowsAsync<TaskCanceledException>(() =>
-                Single_Predicate_Cancellation(TestSqlLoggerFactory.CancelQuery()));
+            await Assert.ThrowsAsync<TaskCanceledException>(async () =>
+                await Single_Predicate_Cancellation(TestSqlLoggerFactory.CancelQuery()));
         }
 
         public AsyncQuerySqlServerTest(NorthwindQuerySqlServerFixture fixture)

--- a/test/EntityFramework.SqlServer.FunctionalTests/FromSqlQuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/FromSqlQuerySqlServerTest.cs
@@ -136,7 +136,7 @@ SELECT * FROM Customers WHERE City = @p0 AND ContactTitle = @p1",
             Assert.Equal(
                 @"SELECT * FROM Customers
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 INNER JOIN (
     SELECT DISTINCT [c].[CustomerID]
@@ -160,7 +160,7 @@ FROM (
 WHERE [c].[City] = 'London'
 ORDER BY [c].[CustomerID]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 INNER JOIN (
     SELECT DISTINCT [c].[CustomerID]

--- a/test/EntityFramework.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 INNER JOIN (
     SELECT DISTINCT [c].[CustomerID]
@@ -33,7 +33,7 @@ ORDER BY [c].[CustomerID]",
             base.Include_reference_and_collection();
 
             Assert.Equal(
-                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 ORDER BY [o].[OrderID]
@@ -53,7 +53,7 @@ ORDER BY [o0].[OrderID]",
             base.Include_references_multi_level();
 
             Assert.Equal(
-                @"SELECT [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice], [o].[OrderID], [o].[CustomerID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+                @"SELECT [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Order Details] AS [od]
 INNER JOIN [Orders] AS [o] ON [od].[OrderID] = [o].[OrderID]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]",
@@ -65,7 +65,7 @@ LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]",
             base.Include_multiple_references_multi_level();
 
             Assert.Equal(
-                @"SELECT [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice], [o].[OrderID], [o].[CustomerID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitsInStock]
+                @"SELECT [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitsInStock]
 FROM [Order Details] AS [od]
 INNER JOIN [Orders] AS [o] ON [od].[OrderID] = [o].[OrderID]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
@@ -78,7 +78,7 @@ INNER JOIN [Products] AS [p] ON [od].[ProductID] = [p].[ProductID]",
             base.Include_multiple_references_multi_level_reverse();
 
             Assert.Equal(
-                @"SELECT [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice], [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitsInStock], [o].[OrderID], [o].[CustomerID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+                @"SELECT [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice], [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitsInStock], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Order Details] AS [od]
 INNER JOIN [Products] AS [p] ON [od].[ProductID] = [p].[ProductID]
 INNER JOIN [Orders] AS [o] ON [od].[OrderID] = [o].[OrderID]
@@ -91,13 +91,13 @@ LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]",
             base.Include_references_and_collection_multi_level();
 
             Assert.Equal(
-                @"SELECT [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice], [o].[OrderID], [o].[CustomerID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+                @"SELECT [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Order Details] AS [od]
 INNER JOIN [Orders] AS [o] ON [od].[OrderID] = [o].[OrderID]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 ORDER BY [c].[CustomerID]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 INNER JOIN (
     SELECT DISTINCT [c].[CustomerID]
@@ -114,13 +114,13 @@ ORDER BY [c].[CustomerID]",
             base.Include_multi_level_reference_and_collection_predicate();
 
             Assert.Equal(
-                @"SELECT TOP(2) [o].[OrderID], [o].[CustomerID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+                @"SELECT TOP(2) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 WHERE [o].[OrderID] = 10248
 ORDER BY [c].[CustomerID]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 INNER JOIN (
     SELECT DISTINCT TOP(2) [c].[CustomerID]
@@ -137,7 +137,7 @@ ORDER BY [c].[CustomerID]",
             base.Include_multi_level_collection_and_then_include_reference_predicate();
 
             Assert.Equal(
-                @"SELECT TOP(2) [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+                @"SELECT TOP(2) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE [o].[OrderID] = 10248
 ORDER BY [o].[OrderID]
@@ -159,7 +159,7 @@ ORDER BY [o0].[OrderID]",
             base.Include_collection_alias_generation();
 
             Assert.Equal(
-                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 ORDER BY [o].[OrderID]
 
@@ -182,7 +182,7 @@ ORDER BY [o0].[OrderID]",
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 INNER JOIN (
     SELECT DISTINCT [c].[CustomerID]
@@ -201,7 +201,7 @@ ORDER BY [c].[CustomerID]",
 FROM [Customers] AS [c]
 ORDER BY [c].[City], [c].[CustomerID]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 INNER JOIN (
     SELECT DISTINCT [c].[City], [c].[CustomerID]
@@ -220,7 +220,7 @@ ORDER BY [c].[City], [c].[CustomerID]",
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 INNER JOIN (
     SELECT DISTINCT [c].[CustomerID]
@@ -244,7 +244,7 @@ FROM [Customers] AS [c]
 WHERE [c].[CustomerID] = 'ALFKI'
 ORDER BY [c].[CustomerID]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 INNER JOIN (
     SELECT DISTINCT TOP(2) [c].[CustomerID]
@@ -269,7 +269,7 @@ FROM [Customers] AS [c]
 WHERE [c].[CustomerID] = 'ALFKI'
 ORDER BY [c].[CustomerID]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 INNER JOIN (
     SELECT DISTINCT TOP(2) [c].[CustomerID]
@@ -290,7 +290,7 @@ FROM [Customers] AS [c]
 WHERE [c].[CustomerID] = 'ALFKI'
 ORDER BY [c].[CustomerID]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 INNER JOIN (
     SELECT DISTINCT [c].[CustomerID]
@@ -311,7 +311,7 @@ FROM [Customers] AS [c]
 WHERE [c].[CustomerID] = 'ALFKI'
 ORDER BY [c].[CustomerID]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 INNER JOIN (
     SELECT DISTINCT [c].[CustomerID]
@@ -331,7 +331,7 @@ ORDER BY [c].[CustomerID]",
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 INNER JOIN (
     SELECT DISTINCT [c].[CustomerID]
@@ -374,7 +374,7 @@ INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 WHERE [c].[CustomerID] = 'ALFKI'
 ORDER BY [c].[CustomerID]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 INNER JOIN (
     SELECT DISTINCT [c].[CustomerID]
@@ -397,7 +397,7 @@ CROSS JOIN [Customers] AS [c]
 WHERE [c].[CustomerID] = 'ALFKI'
 ORDER BY [c].[CustomerID]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 INNER JOIN (
     SELECT DISTINCT [c].[CustomerID]
@@ -422,7 +422,7 @@ SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[Cont
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 INNER JOIN (
     SELECT DISTINCT [c].[CustomerID]
@@ -434,7 +434,7 @@ SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[Cont
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 INNER JOIN (
     SELECT DISTINCT [c].[CustomerID]
@@ -446,7 +446,7 @@ SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[Cont
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 INNER JOIN (
     SELECT DISTINCT [c].[CustomerID]
@@ -458,7 +458,7 @@ SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[Cont
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 INNER JOIN (
     SELECT DISTINCT [c].[CustomerID]
@@ -470,7 +470,7 @@ SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[Cont
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 INNER JOIN (
     SELECT DISTINCT [c].[CustomerID]
@@ -489,7 +489,7 @@ ORDER BY [c].[CustomerID]",
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 INNER JOIN (
     SELECT DISTINCT TOP(2) [c].[CustomerID]
@@ -501,7 +501,7 @@ SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[Cont
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID] OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 INNER JOIN (
     SELECT DISTINCT [t0].*
@@ -517,7 +517,7 @@ SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[Cont
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID] OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 INNER JOIN (
     SELECT DISTINCT [t0].*
@@ -540,7 +540,7 @@ ORDER BY [c].[CustomerID]",
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 INNER JOIN (
     SELECT DISTINCT TOP(2) [c].[CustomerID]
@@ -552,7 +552,7 @@ SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[Cont
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID] OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 INNER JOIN (
     SELECT DISTINCT [t0].*
@@ -577,7 +577,7 @@ INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 WHERE [c].[CustomerID] = 'ALFKI'
 ORDER BY [c].[City], [c].[CustomerID]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 INNER JOIN (
     SELECT DISTINCT [c].[City], [c].[CustomerID]
@@ -624,7 +624,7 @@ FROM [Customers] AS [c]",
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 INNER JOIN (
     SELECT DISTINCT TOP(2) [c].[CustomerID]
@@ -643,7 +643,7 @@ ORDER BY [c].[CustomerID] OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY",
             base.Include_reference();
 
             Assert.Equal(
-                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]",
                 Sql);
@@ -654,7 +654,7 @@ LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]",
             base.Include_multiple_references();
 
             Assert.Equal(
-                @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID], [o0].[CustomerID], [o0].[OrderDate], [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitsInStock]
+                @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate], [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitsInStock]
 FROM [Order Details] AS [o]
 INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
 INNER JOIN [Products] AS [p] ON [o].[ProductID] = [p].[ProductID]",
@@ -666,7 +666,7 @@ INNER JOIN [Products] AS [p] ON [o].[ProductID] = [p].[ProductID]",
             base.Include_reference_alias_generation();
 
             Assert.Equal(
-                @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID], [o0].[CustomerID], [o0].[OrderDate]
+                @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM [Order Details] AS [o]
 INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]",
                 Sql);
@@ -677,17 +677,17 @@ INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]",
             base.Include_duplicate_reference();
 
             Assert.Equal(
-                @"SELECT TOP(2) [o].[OrderID], [o].[CustomerID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+                @"SELECT TOP(2) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 ORDER BY [o].[CustomerID]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 ORDER BY [o].[CustomerID] OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 ORDER BY [o].[CustomerID] OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY",
@@ -699,16 +699,16 @@ ORDER BY [o].[CustomerID] OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY",
             base.Include_duplicate_reference2();
 
             Assert.Equal(
-                @"SELECT TOP(2) [o].[OrderID], [o].[CustomerID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+                @"SELECT TOP(2) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 ORDER BY [o].[OrderID]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 ORDER BY [o].[OrderID] OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 ORDER BY [o].[OrderID] OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY",
                 Sql);
@@ -719,16 +719,16 @@ ORDER BY [o].[OrderID] OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY",
             base.Include_duplicate_reference3();
 
             Assert.Equal(
-                @"SELECT TOP(2) [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+                @"SELECT TOP(2) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 ORDER BY [o].[OrderID]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 ORDER BY [o].[OrderID] OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 ORDER BY [o].[OrderID] OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY",
@@ -750,7 +750,7 @@ FROM [Orders] AS [o]",
             base.Include_reference_with_filter_reordered();
 
             Assert.Equal(
-                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 WHERE [o].[CustomerID] = 'ALFKI'",
@@ -762,7 +762,7 @@ WHERE [o].[CustomerID] = 'ALFKI'",
             base.Include_reference_with_filter();
 
             Assert.Equal(
-                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 WHERE [o].[CustomerID] = 'ALFKI'",
@@ -774,7 +774,7 @@ WHERE [o].[CustomerID] = 'ALFKI'",
             base.Include_collection_dependent_already_tracked_as_no_tracking();
 
             Assert.Equal(
-                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE [o].[CustomerID] = 'ALFKI'
 
@@ -783,7 +783,7 @@ FROM [Customers] AS [c]
 WHERE [c].[CustomerID] = 'ALFKI'
 ORDER BY [c].[CustomerID]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 INNER JOIN (
     SELECT DISTINCT TOP(2) [c].[CustomerID]
@@ -799,7 +799,7 @@ ORDER BY [c].[CustomerID]",
             base.Include_collection_dependent_already_tracked();
 
             Assert.Equal(
-                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE [o].[CustomerID] = 'ALFKI'
 
@@ -808,7 +808,7 @@ FROM [Customers] AS [c]
 WHERE [c].[CustomerID] = 'ALFKI'
 ORDER BY [c].[CustomerID]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 INNER JOIN (
     SELECT DISTINCT TOP(2) [c].[CustomerID]
@@ -824,11 +824,11 @@ ORDER BY [c].[CustomerID]",
             base.Include_reference_dependent_already_tracked();
 
             Assert.Equal(
-                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE [o].[CustomerID] = 'ALFKI'
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]",
                 Sql);
@@ -839,7 +839,7 @@ LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]",
             base.Include_reference_as_no_tracking();
 
             Assert.Equal(
-                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]",
                 Sql);
@@ -854,7 +854,7 @@ LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]",
 FROM [Customers] AS [c]
 ORDER BY [c].[CustomerID]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 INNER JOIN (
     SELECT DISTINCT TOP(5) [c].[CustomerID]

--- a/test/EntityFramework.SqlServer.FunctionalTests/NorthwindQuerySqlServerFixture.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/NorthwindQuerySqlServerFixture.cs
@@ -40,7 +40,11 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
         public override NorthwindContext CreateContext()
         {
-            return new SqlServerNorthwindContext(_serviceProvider, _options);
+            var context = new SqlServerNorthwindContext(_serviceProvider, _options);
+
+            context.ChangeTracker.AutoDetectChangesEnabled = false;
+
+            return context;
         }
 
         public void Dispose()

--- a/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Data.SqlClient;
 using System.Linq;
 using Microsoft.Data.Entity.FunctionalTests;
 using Microsoft.Data.Entity.FunctionalTests.TestModels.Northwind;
@@ -358,7 +357,7 @@ WHERE ([o].[OrderID] > 10 AND ([o].[CustomerID] <> 'ALFKI' OR [o].[CustomerID] I
             base.Where_OrderBy_Count_client_eval();
 
             Assert.Equal(
-                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]",
                 Sql);
         }
@@ -379,7 +378,7 @@ WHERE [o].[OrderID] > 10",
             base.OrderBy_Where_Count_client_eval();
 
             Assert.Equal(
-                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]",
                 Sql);
         }
@@ -389,7 +388,7 @@ FROM [Orders] AS [o]",
             base.OrderBy_Where_Count_client_eval_mixed();
 
             Assert.Equal(
-                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]",
                 Sql);
         }
@@ -399,7 +398,7 @@ FROM [Orders] AS [o]",
             base.OrderBy_Count_with_predicate_client_eval();
 
             Assert.Equal(
-                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]",
                 Sql);
         }
@@ -424,7 +423,7 @@ WHERE @__ClientEvalPredicateStateless_0 = 1",
             Assert.Equal(
                 @"__ClientEvalPredicateStateless_1: True
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE @__ClientEvalPredicateStateless_1 = 1",
                 Sql);
@@ -435,7 +434,7 @@ WHERE @__ClientEvalPredicateStateless_1 = 1",
             base.OrderBy_Where_Count_with_predicate_client_eval_mixed();
 
             Assert.Equal(
-                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE ([o].[CustomerID] <> 'ALFKI' OR [o].[CustomerID] IS NULL)",
                 Sql);
@@ -615,7 +614,7 @@ FROM (
             Assert.Equal(
                 @"SELECT COUNT(*)
 FROM (
-    SELECT DISTINCT TOP(5) [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+    SELECT DISTINCT TOP(5) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
 ) AS [t0]",
                 Sql);
@@ -680,7 +679,7 @@ ORDER BY [c].[CustomerID]",
             Assert.Equal(
                 @"SELECT COUNT(*)
 FROM (
-    SELECT TOP(5) [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+    SELECT TOP(5) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
 ) AS [t0]",
@@ -692,7 +691,7 @@ FROM (
             base.Take_OrderBy_Count();
 
             Assert.Equal(
-                @"SELECT TOP(5) [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+                @"SELECT TOP(5) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]",
                 Sql);
         }
@@ -1491,7 +1490,7 @@ INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]",
             base.Join_customers_orders_entities();
 
             Assert.Equal(
-                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Customers] AS [c]
 INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]",
                 Sql);
@@ -1502,7 +1501,7 @@ INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]",
             base.Join_composite_key();
 
             Assert.Equal(
-                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Customers] AS [c]
 INNER JOIN [Orders] AS [o] ON ([c].[CustomerID] = [o].[CustomerID] AND [c].[CustomerID] = [o].[CustomerID])",
                 Sql);
@@ -1513,7 +1512,7 @@ INNER JOIN [Orders] AS [o] ON ([c].[CustomerID] = [o].[CustomerID] AND [c].[Cust
             base.Join_client_new_expression();
 
             Assert.Equal(
-                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
@@ -1526,7 +1525,7 @@ FROM [Customers] AS [c]",
             base.Join_select_many();
 
             Assert.Equal(
-                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[OrderDate], [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Customers] AS [c]
 INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 CROSS JOIN [Employees] AS [e]",
@@ -1575,7 +1574,7 @@ INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]", Sql);
             base.GroupBy_Distinct();
 
             Assert.Equal(
-                @"SELECT DISTINCT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]",
                 Sql);
         }
@@ -1585,7 +1584,7 @@ FROM [Orders] AS [o]",
             base.GroupBy_Count();
 
             Assert.Equal(
-                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]",
                 Sql);
         }
@@ -1595,7 +1594,7 @@ FROM [Orders] AS [o]",
             base.GroupBy_LongCount();
 
             Assert.Equal(
-                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]",
                 Sql);
         }
@@ -1618,7 +1617,7 @@ ORDER BY [e].[City], [c].[CustomerID] DESC",
             base.GroupJoin_customers_orders_count();
 
             Assert.Equal(
-                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
@@ -1647,7 +1646,7 @@ FROM (
             Assert.Equal(
                 @"SELECT TOP(2) [t0].*
 FROM (
-    SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID] AS [c0], [o].[OrderDate]
+    SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID] AS [c0], [o].[EmployeeID], [o].[OrderDate]
     FROM [Customers] AS [c]
     CROSS JOIN [Orders] AS [o]
     ORDER BY [c].[CustomerID], [o].[OrderID]
@@ -1690,7 +1689,7 @@ FROM [Customers] AS [c]",
             base.OrderBy_multiple_queries();
 
             Assert.Equal(
-                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
@@ -2079,7 +2078,7 @@ WHERE [c].[CustomerID] = 'ALFKI'",
             //            base.Projection_when_arithmetic_expressions();
             //
             //            Assert.Equal(
-            //                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate], [o].[OrderID], [o].[OrderID] * 2, [o].[OrderID] + 23, 100000 - [o].[OrderID], [o].[OrderID] / ([o].[OrderID] / 2)
+            //                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o].[OrderID], [o].[OrderID] * 2, [o].[OrderID] + 23, 100000 - [o].[OrderID], [o].[OrderID] / ([o].[OrderID] / 2)
             //FROM [Orders] AS [o]",
             //                Sql);
         }
@@ -2274,7 +2273,7 @@ ORDER BY [o].[OrderID]
                 @"SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 
 ",
@@ -2289,7 +2288,7 @@ FROM [Orders] AS [o]
                 @"SELECT [c].[CustomerID]
 FROM [Customers] AS [c]
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 
 ",
@@ -2324,7 +2323,7 @@ INNER JOIN [Customers] AS [c3] ON [o].[CustomerID] = [c3].[CustomerID]",
             base.Join_same_collection_force_alias_uniquefication();
 
             Assert.Equal(
-                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate], [o0].[OrderID], [o0].[CustomerID], [o0].[OrderDate]
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
 FROM [Orders] AS [o]
 INNER JOIN [Orders] AS [o0] ON [o].[CustomerID] = [o0].[CustomerID]",
                 Sql);
@@ -2337,7 +2336,7 @@ INNER JOIN [Orders] AS [o0] ON [o].[CustomerID] = [o0].[CustomerID]",
             Assert.Equal(
                 @"__p_0: 1/1/1998 12:00:00 AM
 
-SELECT [o].[OrderID], [o].[CustomerID], [o].[OrderDate]
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE ([o].[CustomerID] = 'QUICK' AND [o].[OrderDate] > @__p_0)",
                 Sql);


### PR DESCRIPTION
...re is to go from buffering value readers in the query buffer to having value readers move through a query as part of the result data flow.

QueryBuffer removal is pending #2016.