### PR TITLE
Move ValueReaderFactory to query compilation context

### DIFF
--- a/src/EntityFramework.Relational/Query/AsyncQueryMethodProvider.cs
+++ b/src/EntityFramework.Relational/Query/AsyncQueryMethodProvider.cs
@@ -128,27 +128,32 @@ namespace Microsoft.Data.Entity.Relational.Query
         [UsedImplicitly]
         private static IAsyncIncludeRelatedValuesStrategy _CreateReferenceIncludeStrategy(
             RelationalQueryContext relationalQueryContext,
+            IRelationalValueReaderFactory valueReaderFactory,
             int readerIndex,
             int readerOffset,
             Func<IValueReader, object> materializer)
         {
-            return new ReferenceIncludeRelatedValuesStrategy(relationalQueryContext, readerIndex, readerOffset, materializer);
+            return new ReferenceIncludeRelatedValuesStrategy(
+                relationalQueryContext, valueReaderFactory, readerIndex, readerOffset, materializer);
         }
 
         private class ReferenceIncludeRelatedValuesStrategy : IAsyncIncludeRelatedValuesStrategy
         {
             private readonly RelationalQueryContext _queryContext;
+            private readonly IRelationalValueReaderFactory _valueReaderFactory;
             private readonly int _readerIndex;
             private readonly int _readerOffset;
             private readonly Func<IValueReader, object> _materializer;
 
             public ReferenceIncludeRelatedValuesStrategy(
                 RelationalQueryContext queryContext,
+                IRelationalValueReaderFactory valueReaderFactory,
                 int readerIndex,
                 int readerOffset,
                 Func<IValueReader, object> materializer)
             {
                 _queryContext = queryContext;
+                _valueReaderFactory = valueReaderFactory;
                 _readerIndex = readerIndex;
                 _readerOffset = readerOffset;
                 _materializer = materializer;
@@ -159,7 +164,7 @@ namespace Microsoft.Data.Entity.Relational.Query
                 return new AsyncEnumerableAdapter<EntityLoadInfo>(
                     new EntityLoadInfo(
                         new OffsetValueReaderDecorator(
-                            _queryContext.CreateValueReader(_readerIndex),
+                            _valueReaderFactory.CreateValueReader(_queryContext.GetDataReader(_readerIndex)),
                             _readerOffset),
                         _materializer));
             }

--- a/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/QueryFlatteningExpressionTreeVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/QueryFlatteningExpressionTreeVisitor.cs
@@ -87,10 +87,10 @@ namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
 
                     if (newArguments.Count == RelationalQueryModelVisitor.CreateEntityMethodInfo.GetParameters().Length)
                     {
-                        newArguments[4]
+                        newArguments[5]
                             = Expression.Constant(
                                 _readerOffset
-                                + (int)((ConstantExpression)newArguments[4]).Value);
+                                + (int)((ConstantExpression)newArguments[5]).Value);
                     }
 
                     newExpression

--- a/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/RelationalEntityQueryableExpressionTreeVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/RelationalEntityQueryableExpressionTreeVisitor.cs
@@ -130,6 +130,7 @@ namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
                         Expression.Constant(QuerySource),
                         EntityQueryModelVisitor.QueryContextParameter,
                         EntityQueryModelVisitor.QuerySourceScopeParameter,
+                        Expression.Constant(QueryModelVisitor.QueryCompilationContext.ValueReaderFactory),
                         _readerParameter
                     };
 

--- a/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/ResultTransformingExpressionTreeVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/ResultTransformingExpressionTreeVisitor.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
                  || ReferenceEquals(methodCallExpression.Method, RelationalQueryModelVisitor.CreateValueReaderMethodInfo))
                 && ((ConstantExpression)methodCallExpression.Arguments[0]).Value == _outerQuerySource)
             {
-                return methodCallExpression.Arguments[3];
+                return methodCallExpression.Arguments[4];
             }
 
             if (newArguments != methodCallExpression.Arguments)

--- a/src/EntityFramework.Relational/Query/QueryMethodProvider.cs
+++ b/src/EntityFramework.Relational/Query/QueryMethodProvider.cs
@@ -119,27 +119,32 @@ namespace Microsoft.Data.Entity.Relational.Query
         [UsedImplicitly]
         private static IIncludeRelatedValuesStrategy _CreateReferenceIncludeStrategy(
             RelationalQueryContext relationalQueryContext,
+            IRelationalValueReaderFactory valueReaderFactory,
             int readerIndex,
             int readerOffset,
             Func<IValueReader, object> materializer)
         {
-            return new ReferenceIncludeRelatedValuesStrategy(relationalQueryContext, readerIndex, readerOffset, materializer);
+            return new ReferenceIncludeRelatedValuesStrategy(
+                relationalQueryContext, valueReaderFactory, readerIndex, readerOffset, materializer);
         }
 
         private class ReferenceIncludeRelatedValuesStrategy : IIncludeRelatedValuesStrategy
         {
             private readonly RelationalQueryContext _queryContext;
+            private readonly IRelationalValueReaderFactory _valueReaderFactory;
             private readonly int _readerIndex;
             private readonly int _readerOffset;
             private readonly Func<IValueReader, object> _materializer;
 
             public ReferenceIncludeRelatedValuesStrategy(
                 RelationalQueryContext queryContext,
+                IRelationalValueReaderFactory valueReaderFactory,
                 int readerIndex,
                 int readerOffset,
                 Func<IValueReader, object> materializer)
             {
                 _queryContext = queryContext;
+                _valueReaderFactory = valueReaderFactory;
                 _readerIndex = readerIndex;
                 _readerOffset = readerOffset;
                 _materializer = materializer;
@@ -150,7 +155,7 @@ namespace Microsoft.Data.Entity.Relational.Query
                 yield return
                     new EntityLoadInfo(
                         new OffsetValueReaderDecorator(
-                            _queryContext.CreateValueReader(_readerIndex),
+                            _valueReaderFactory.CreateValueReader(_queryContext.GetDataReader(_readerIndex)),
                             _readerOffset),
                         _materializer);
             }

--- a/src/EntityFramework.Relational/Query/RelationalQueryCompilationContext.cs
+++ b/src/EntityFramework.Relational/Query/RelationalQueryCompilationContext.cs
@@ -30,7 +30,8 @@ namespace Microsoft.Data.Entity.Relational.Query
             [NotNull] IEntityMaterializerSource entityMaterializerSource,
             [NotNull] IEntityKeyFactorySource entityKeyFactorySource,
             [NotNull] IQueryMethodProvider queryMethodProvider,
-            [NotNull] IMethodCallTranslator methodCallTranslator)
+            [NotNull] IMethodCallTranslator methodCallTranslator,
+            [NotNull] IRelationalValueReaderFactory valueReaderFactory)
             : base(
                 Check.NotNull(model, nameof(model)),
                 Check.NotNull(logger, nameof(logger)),
@@ -41,9 +42,11 @@ namespace Microsoft.Data.Entity.Relational.Query
         {
             Check.NotNull(queryMethodProvider, nameof(queryMethodProvider));
             Check.NotNull(methodCallTranslator, nameof(methodCallTranslator));
+            Check.NotNull(valueReaderFactory, nameof(valueReaderFactory));
 
             QueryMethodProvider = queryMethodProvider;
             MethodCallTranslator = methodCallTranslator;
+            ValueReaderFactory = valueReaderFactory;
         }
 
         public override EntityQueryModelVisitor CreateQueryModelVisitor(
@@ -73,6 +76,8 @@ namespace Microsoft.Data.Entity.Relational.Query
         public virtual IQueryMethodProvider QueryMethodProvider { get; }
 
         public virtual IMethodCallTranslator MethodCallTranslator { get; }
+
+        public virtual IRelationalValueReaderFactory ValueReaderFactory { get; }
 
         public virtual ISqlQueryGenerator CreateSqlQueryGenerator([NotNull] SelectExpression selectExpression)
         {

--- a/src/EntityFramework.Relational/Query/RelationalQueryContext.cs
+++ b/src/EntityFramework.Relational/Query/RelationalQueryContext.cs
@@ -6,7 +6,6 @@ using System.Data.Common;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Query;
-using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 
@@ -22,22 +21,16 @@ namespace Microsoft.Data.Entity.Relational.Query
             [NotNull] ILogger logger,
             [NotNull] IQueryBuffer queryBuffer,
             [NotNull] IStateManager stateManager,
-            [NotNull] IRelationalConnection connection,
-            [NotNull] IRelationalValueReaderFactory valueReaderFactory)
+            [NotNull] IRelationalConnection connection)
             : base(
                 Check.NotNull(logger, nameof(logger)),
                 Check.NotNull(queryBuffer, nameof(queryBuffer)),
                 Check.NotNull(stateManager, nameof(stateManager)))
         {
             Check.NotNull(connection, nameof(connection));
-            Check.NotNull(valueReaderFactory, nameof(valueReaderFactory));
 
             Connection = connection;
-            ValueReaderFactory = valueReaderFactory;
         }
-
-        // TODO: Move this to compilation context
-        public virtual IRelationalValueReaderFactory ValueReaderFactory { get; }
 
         public virtual IRelationalConnection Connection { get; }
 
@@ -48,8 +41,7 @@ namespace Microsoft.Data.Entity.Relational.Query
             _activeDataReaders.Add(dataReader);
         }
 
-        public virtual IValueReader CreateValueReader(int readerIndex)
-            => ValueReaderFactory.CreateValueReader(_activeDataReaders[_activeReaderOffset + readerIndex]);
+        public virtual DbDataReader GetDataReader(int readerIndex) => _activeDataReaders[_activeReaderOffset + readerIndex];
 
         public virtual void BeginIncludeScope() => _activeReaderOffset = _activeDataReaders.Count;
 

--- a/src/EntityFramework.Relational/Query/RelationalQueryContextFactory.cs
+++ b/src/EntityFramework.Relational/Query/RelationalQueryContextFactory.cs
@@ -12,7 +12,6 @@ namespace Microsoft.Data.Entity.Relational.Query
 {
     public class RelationalQueryContextFactory : QueryContextFactory, IRelationalQueryContextFactory
     {
-        private readonly IRelationalValueReaderFactory _valueReaderFactory;
         private readonly IRelationalConnection _connection;
 
         public RelationalQueryContextFactory(
@@ -20,19 +19,16 @@ namespace Microsoft.Data.Entity.Relational.Query
             [NotNull] IEntityKeyFactorySource entityKeyFactorySource,
             [NotNull] IClrCollectionAccessorSource collectionAccessorSource,
             [NotNull] IClrAccessorSource<IClrPropertySetter> propertySetterSource,
-            [NotNull] IRelationalValueReaderFactory valueReaderFactory,
             [NotNull] IRelationalConnection connection,
             [NotNull] ILoggerFactory loggerFactory)
             : base(stateManager, entityKeyFactorySource, collectionAccessorSource, propertySetterSource, loggerFactory)
         {
             Check.NotNull(connection, nameof(connection));
-            Check.NotNull(valueReaderFactory, nameof(valueReaderFactory));
 
-            _valueReaderFactory = valueReaderFactory;
             _connection = connection;
         }
 
         public override QueryContext CreateQueryContext()
-            => new RelationalQueryContext(Logger, CreateQueryBuffer(), StateManager, _connection, _valueReaderFactory);
+            => new RelationalQueryContext(Logger, CreateQueryBuffer(), StateManager, _connection);
     }
 }

--- a/src/EntityFramework.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EntityFramework.Relational/Query/RelationalQueryModelVisitor.cs
@@ -438,11 +438,12 @@ namespace Microsoft.Data.Entity.Relational.Query
             IQuerySource querySource,
             QueryContext queryContext,
             QuerySourceScope parentQuerySourceScope,
+            IRelationalValueReaderFactory valueReaderFactory,
             DbDataReader dataReader)
         {
             return new QuerySourceScope<IValueReader>(
                 querySource,
-                ((RelationalQueryContext)queryContext).ValueReaderFactory.CreateValueReader(dataReader),
+                valueReaderFactory.CreateValueReader(dataReader),
                 parentQuerySourceScope,
                 null);
         }
@@ -456,6 +457,7 @@ namespace Microsoft.Data.Entity.Relational.Query
             IQuerySource querySource,
             QueryContext queryContext,
             QuerySourceScope parentQuerySourceScope,
+            IRelationalValueReaderFactory valueReaderFactory,
             DbDataReader dataReader,
             int readerOffset,
             IEntityType entityType,
@@ -465,9 +467,7 @@ namespace Microsoft.Data.Entity.Relational.Query
             Func<IValueReader, object> materializer)
             where TEntity : class
         {
-            var valueReader
-                = ((RelationalQueryContext)queryContext).ValueReaderFactory
-                    .CreateValueReader(dataReader);
+            var valueReader = valueReaderFactory.CreateValueReader(dataReader);
 
             if (readerOffset > 0)
             {

--- a/src/EntityFramework.Relational/RelationalDataStore.cs
+++ b/src/EntityFramework.Relational/RelationalDataStore.cs
@@ -36,23 +36,29 @@ namespace Microsoft.Data.Entity.Relational
             [NotNull] ICommandBatchPreparer batchPreparer,
             [NotNull] IBatchExecutor batchExecutor,
             [NotNull] IDbContextOptions options,
-            [NotNull] ILoggerFactory loggerFactory)
+            [NotNull] ILoggerFactory loggerFactory,
+            [NotNull] IRelationalValueReaderFactory valueReaderFactory)
             : base(
                 Check.NotNull(model, nameof(model)),
                 Check.NotNull(entityKeyFactorySource, nameof(entityKeyFactorySource)),
                 Check.NotNull(entityMaterializerSource, nameof(entityMaterializerSource)),
                 Check.NotNull(loggerFactory, nameof(loggerFactory)))
         {
+            ValueReaderFactory = valueReaderFactory;
             Check.NotNull(connection, nameof(connection));
             Check.NotNull(batchPreparer, nameof(batchPreparer));
             Check.NotNull(batchExecutor, nameof(batchExecutor));
             Check.NotNull(options, nameof(options));
+            Check.NotNull(options, nameof(options));
+            Check.NotNull(valueReaderFactory, nameof(valueReaderFactory));
 
             _batchPreparer = batchPreparer;
             _batchExecutor = batchExecutor;
             _connection = connection;
             _options = options;
         }
+
+        public virtual IRelationalValueReaderFactory ValueReaderFactory { get; }
 
         public virtual IDbContextOptions DbContextOptions => _options;
 
@@ -126,7 +132,8 @@ namespace Microsoft.Data.Entity.Relational
                 EntityMaterializerSource,
                 EntityKeyFactorySource,
                 queryMethodProvider,
-                methodCallTranslator);
+                methodCallTranslator,
+                ValueReaderFactory);
         }
     }
 }

--- a/src/EntityFramework.SqlServer/Query/SqlServerQueryCompilationContext.cs
+++ b/src/EntityFramework.SqlServer/Query/SqlServerQueryCompilationContext.cs
@@ -25,7 +25,8 @@ namespace Microsoft.Data.Entity.SqlServer.Query
             [NotNull] IEntityMaterializerSource entityMaterializerSource,
             [NotNull] IEntityKeyFactorySource entityKeyFactorySource,
             [NotNull] IQueryMethodProvider queryMethodProvider,
-            [NotNull] IMethodCallTranslator methodCallTranslator)
+            [NotNull] IMethodCallTranslator methodCallTranslator,
+            [NotNull] ISqlServerValueReaderFactory valueReaderFactory)
             : base(
                 Check.NotNull(model, nameof(model)),
                 Check.NotNull(logger, nameof(logger)),
@@ -34,11 +35,12 @@ namespace Microsoft.Data.Entity.SqlServer.Query
                 Check.NotNull(entityMaterializerSource, nameof(entityMaterializerSource)),
                 Check.NotNull(entityKeyFactorySource, nameof(entityKeyFactorySource)),
                 Check.NotNull(queryMethodProvider, nameof(queryMethodProvider)),
-                Check.NotNull(methodCallTranslator, nameof(methodCallTranslator)))
+                Check.NotNull(methodCallTranslator, nameof(methodCallTranslator)),
+                Check.NotNull(valueReaderFactory, nameof(valueReaderFactory)))
         {
         }
 
-        public override ISqlQueryGenerator CreateSqlQueryGenerator([NotNull] SelectExpression selectExpression)
+        public override ISqlQueryGenerator CreateSqlQueryGenerator(SelectExpression selectExpression)
         {
             Check.NotNull(selectExpression, nameof(selectExpression));
 

--- a/src/EntityFramework.SqlServer/Query/SqlServerQueryContextFactory.cs
+++ b/src/EntityFramework.SqlServer/Query/SqlServerQueryContextFactory.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Data.Entity.SqlServer.Query
             [NotNull] IEntityKeyFactorySource entityKeyFactorySource,
             [NotNull] IClrCollectionAccessorSource collectionAccessorSource,
             [NotNull] IClrAccessorSource<IClrPropertySetter> propertySetterSource,
-            [NotNull] ISqlServerValueReaderFactory valueReaderFactory,
             [NotNull] ISqlServerConnection connection,
             [NotNull] ILoggerFactory loggerFactory)
             : base(
@@ -24,7 +23,6 @@ namespace Microsoft.Data.Entity.SqlServer.Query
                   entityKeyFactorySource, 
                   collectionAccessorSource, 
                   propertySetterSource, 
-                  valueReaderFactory, 
                   connection, 
                   loggerFactory)
         {

--- a/src/EntityFramework.SqlServer/SqlServerDataStore.cs
+++ b/src/EntityFramework.SqlServer/SqlServerDataStore.cs
@@ -27,7 +27,8 @@ namespace Microsoft.Data.Entity.SqlServer
             [NotNull] ISqlServerCommandBatchPreparer batchPreparer,
             [NotNull] ISqlServerBatchExecutor batchExecutor,
             [NotNull] IDbContextOptions options,
-            [NotNull] ILoggerFactory loggerFactory)
+            [NotNull] ILoggerFactory loggerFactory,
+            [NotNull] ISqlServerValueReaderFactory valueReaderFactory)
             : base(
                 Check.NotNull(model, nameof(model)),
                 Check.NotNull(entityKeyFactorySource, nameof(entityKeyFactorySource)),
@@ -36,7 +37,8 @@ namespace Microsoft.Data.Entity.SqlServer
                 Check.NotNull(batchPreparer, nameof(batchPreparer)),
                 Check.NotNull(batchExecutor, nameof(batchExecutor)),
                 Check.NotNull(options, nameof(options)),
-                Check.NotNull(loggerFactory, nameof(loggerFactory)))
+                Check.NotNull(loggerFactory, nameof(loggerFactory)),
+                Check.NotNull(valueReaderFactory, nameof(valueReaderFactory)))
         {
         }
 
@@ -59,7 +61,8 @@ namespace Microsoft.Data.Entity.SqlServer
                 EntityMaterializerSource,
                 EntityKeyFactorySource,
                 enumerableMethodProvider,
-                methodCallTranslator);
+                methodCallTranslator,
+                (ISqlServerValueReaderFactory)ValueReaderFactory);
         }
     }
 }

--- a/test/EntityFramework.Relational.Tests/RelationalDataStoreTest.cs
+++ b/test/EntityFramework.Relational.Tests/RelationalDataStoreTest.cs
@@ -24,11 +24,13 @@ namespace Microsoft.Data.Entity.Relational.Tests
             var relationalConnectionMock = new Mock<IRelationalConnection>();
             var commandBatchPreparerMock = new Mock<ICommandBatchPreparer>();
             var batchExecutorMock = new Mock<IBatchExecutor>();
+            var valueReaderMock = new Mock<IRelationalValueReaderFactory>();
 
             var customServices = new ServiceCollection()
                 .AddInstance(relationalConnectionMock.Object)
                 .AddInstance(commandBatchPreparerMock.Object)
                 .AddInstance(batchExecutorMock.Object)
+                .AddInstance(valueReaderMock.Object)
                 .AddScoped<FakeRelationalDataStore>();
 
             var contextServices = RelationalTestHelpers.Instance.CreateContextServices(customServices);
@@ -50,11 +52,13 @@ namespace Microsoft.Data.Entity.Relational.Tests
             var relationalConnectionMock = new Mock<IRelationalConnection>();
             var commandBatchPreparerMock = new Mock<ICommandBatchPreparer>();
             var batchExecutorMock = new Mock<IBatchExecutor>();
+            var valueReaderMock = new Mock<IRelationalValueReaderFactory>();
 
             var customServices = new ServiceCollection()
                 .AddInstance(relationalConnectionMock.Object)
                 .AddInstance(commandBatchPreparerMock.Object)
                 .AddInstance(batchExecutorMock.Object)
+                .AddInstance(valueReaderMock.Object)
                 .AddScoped<FakeRelationalDataStore>();
 
             var contextServices = RelationalTestHelpers.Instance.CreateContextServices(customServices);
@@ -79,8 +83,18 @@ namespace Microsoft.Data.Entity.Relational.Tests
                 ICommandBatchPreparer batchPreparer,
                 IBatchExecutor batchExecutor,
                 IDbContextOptions options,
-                ILoggerFactory loggerFactory)
-                : base(model, entityKeyFactorySource, entityMaterializerSource, connection, batchPreparer, batchExecutor, options, loggerFactory)
+                ILoggerFactory loggerFactory,
+                IRelationalValueReaderFactory valueReaderFactory)
+                : base(
+                      model, 
+                      entityKeyFactorySource, 
+                      entityMaterializerSource, 
+                      connection, 
+                      batchPreparer, 
+                      batchExecutor, 
+                      options, 
+                      loggerFactory,
+                      valueReaderFactory)
             {
             }
         }


### PR DESCRIPTION
First step to allowing the typed factory to be created at query compilation time.