### PR TITLE
Ignore user override for culture parsing dates

### DIFF
--- a/test/EntityFramework.Core.FunctionalTests/TestModels/Northwind/NorthwindData.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/Northwind/NorthwindData.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.Northwind
 
         private static DateTime ParseDate(string date)
         {
-            return DateTime.Parse(date, new CultureInfo("en-US"));
+            return DateTime.Parse(date, new CultureInfo("en-US", false));
         }
 
         #region Customers


### PR DESCRIPTION
In the tests' Northwind data, ignore the user override for the en-US culture while parsing date strings. Otherwise tests fail because of an external user preference.