### PR TITLE
Allow providers to override the truth literal

### DIFF
--- a/src/EntityFramework.Relational/Query/Sql/DefaultSqlQueryGenerator.cs
+++ b/src/EntityFramework.Relational/Query/Sql/DefaultSqlQueryGenerator.cs
@@ -45,6 +45,8 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
 
         protected virtual string ParameterPrefix => "@";
 
+        protected virtual string TruthLiteral => "1";
+
         public virtual Expression VisitSelectExpression(SelectExpression selectExpression)
         {
             Check.NotNull(selectExpression, nameof(selectExpression));
@@ -111,7 +113,8 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
                     if (selectExpression.Predicate is ColumnExpression
                         || selectExpression.Predicate is ParameterExpression)
                     {
-                        _sql.Append(" = 1");
+                        _sql.Append(" = ");
+                        _sql.Append(TruthLiteral);
                     }
                 }
             }
@@ -494,7 +497,8 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
                 && (binaryExpression.Left is ColumnExpression
                     || binaryExpression.Left is ParameterExpression))
             {
-                _sql.Append(" = 1");
+                _sql.Append(" = ");
+                _sql.Append(TruthLiteral);
             }
 
             if (needClosingParen)
@@ -566,7 +570,8 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
                 && (binaryExpression.Right is ColumnExpression
                     || binaryExpression.Right is ParameterExpression))
             {
-                _sql.Append(" = 1");
+                _sql.Append(" = ");
+                _sql.Append(TruthLiteral);
             }
 
             if (needClosingParen)

--- a/src/EntityFramework.Relational/Query/Sql/DefaultSqlQueryGenerator.cs
+++ b/src/EntityFramework.Relational/Query/Sql/DefaultSqlQueryGenerator.cs
@@ -45,7 +45,9 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
 
         protected virtual string ParameterPrefix => "@";
 
-        protected virtual string TruthLiteral => "1";
+        protected virtual string TrueLiteral => "1";
+
+        protected virtual string FalseLiteral => "0";
 
         public virtual Expression VisitSelectExpression(SelectExpression selectExpression)
         {
@@ -114,7 +116,7 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
                         || selectExpression.Predicate is ParameterExpression)
                     {
                         _sql.Append(" = ");
-                        _sql.Append(TruthLiteral);
+                        _sql.Append(TrueLiteral);
                     }
                 }
             }
@@ -498,7 +500,7 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
                     || binaryExpression.Left is ParameterExpression))
             {
                 _sql.Append(" = ");
-                _sql.Append(TruthLiteral);
+                _sql.Append(TrueLiteral);
             }
 
             if (needClosingParen)
@@ -571,7 +573,7 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
                     || binaryExpression.Right is ParameterExpression))
             {
                 _sql.Append(" = ");
-                _sql.Append(TruthLiteral);
+                _sql.Append(TrueLiteral);
             }
 
             if (needClosingParen)
@@ -700,7 +702,8 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
                 else
                 {
                     VisitExpression(unaryExpression.Operand);
-                    _sql.Append(" = 0");
+                    _sql.Append(" = ");
+                    _sql.Append(FalseLiteral);
                 }
 
                 return unaryExpression;
@@ -756,7 +759,7 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
 
         protected virtual string GenerateLiteral(bool value)
         {
-            return value ? "1" : "0";
+            return value ? TrueLiteral : FalseLiteral;
         }
 
         protected virtual string GenerateLiteral([NotNull] string value)


### PR DESCRIPTION
DefaultQueryGenerator currently imposes "= 1" as the check for true boolean columns / parameters, for PostgreSQL this isn't a valid value.

Refactored 1 out as an overridable string.