### PR TITLE
Allow providers to override the truth literal

### DIFF
--- a/src/EntityFramework.Relational/Query/Sql/DefaultSqlQueryGenerator.cs
+++ b/src/EntityFramework.Relational/Query/Sql/DefaultSqlQueryGenerator.cs
@@ -53,6 +53,8 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
 
         protected virtual string ParameterPrefix => "@";
 
+        protected virtual string TruthLiteral => "1";
+
         public virtual Expression VisitSelectExpression(SelectExpression selectExpression)
         {
             Check.NotNull(selectExpression, nameof(selectExpression));
@@ -138,7 +140,8 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
                     if (selectExpression.Predicate is ParameterExpression
                         || selectExpression.Predicate.IsAliasWithColumnExpression())
                     {
-                        _sql.Append(" = 1");
+                        _sql.Append(" = ");
+                        _sql.Append(TruthValue);
                     }
                 }
             }
@@ -535,7 +538,8 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
                         || caseExpression.When is ParameterExpression
                         || caseExpression.When.IsAliasWithColumnExpression())
                     {
-                        _sql.Append(" = 1");
+                        _sql.Append(" = ");
+                        _sql.Append(TruthValue);
                     }
                 }
 
@@ -591,7 +595,8 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
                         || binaryExpression.Left is ParameterExpression
                         || binaryExpression.Left.IsAliasWithColumnExpression()))
                 {
-                    _sql.Append(" = 1");
+                    _sql.Append(" = ");
+                    _sql.Append(TruthValue);
                 }
 
                 string op;
@@ -647,7 +652,8 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
                         || binaryExpression.Right is ParameterExpression
                         || binaryExpression.Right.IsAliasWithColumnExpression()))
                 {
-                    _sql.Append(" = 1");
+                    _sql.Append(" = ");
+                    _sql.Append(TruthValue);
                 }
 
                 if (needParentheses)

--- a/src/EntityFramework.Relational/Query/Sql/DefaultSqlQueryGenerator.cs
+++ b/src/EntityFramework.Relational/Query/Sql/DefaultSqlQueryGenerator.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
 
         protected virtual string TrueLiteral => "1";
 
-        protected virtual string FalseLiteral => "1";
+        protected virtual string FalseLiteral => "0";
 
         public virtual Expression VisitSelectExpression(SelectExpression selectExpression)
         {

--- a/src/EntityFramework.Relational/Query/Sql/DefaultSqlQueryGenerator.cs
+++ b/src/EntityFramework.Relational/Query/Sql/DefaultSqlQueryGenerator.cs
@@ -53,7 +53,9 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
 
         protected virtual string ParameterPrefix => "@";
 
-        protected virtual string TruthLiteral => "1";
+        protected virtual string TrueLiteral => "1";
+
+        protected virtual string FalseLiteral => "1";
 
         public virtual Expression VisitSelectExpression(SelectExpression selectExpression)
         {
@@ -141,7 +143,7 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
                         || selectExpression.Predicate.IsAliasWithColumnExpression())
                     {
                         _sql.Append(" = ");
-                        _sql.Append(TruthValue);
+                        _sql.Append(TrueLiteral);
                     }
                 }
             }
@@ -539,7 +541,7 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
                         || caseExpression.When.IsAliasWithColumnExpression())
                     {
                         _sql.Append(" = ");
-                        _sql.Append(TruthValue);
+                        _sql.Append(TrueLiteral);
                     }
                 }
 
@@ -596,7 +598,7 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
                         || binaryExpression.Left.IsAliasWithColumnExpression()))
                 {
                     _sql.Append(" = ");
-                    _sql.Append(TruthValue);
+                    _sql.Append(TrueLiteral);
                 }
 
                 string op;
@@ -653,7 +655,7 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
                         || binaryExpression.Right.IsAliasWithColumnExpression()))
                 {
                     _sql.Append(" = ");
-                    _sql.Append(TruthValue);
+                    _sql.Append(TrueLiteral);
                 }
 
                 if (needParentheses)
@@ -786,7 +788,8 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
                 else
                 {
                     VisitExpression(unaryExpression.Operand);
-                    _sql.Append(" = 0");
+                    _sql.Append(" = ");
+                    _sql.Append(FalseLiteral);
                 }
 
                 return unaryExpression;
@@ -842,7 +845,7 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
 
         protected virtual string GenerateLiteral(bool value)
         {
-            return value ? "1" : "0";
+            return value ? TrueLiteral : FalseLiteral;
         }
 
         protected virtual string GenerateLiteral([NotNull] string value)


### PR DESCRIPTION
DefaultQueryGenerator currently imposes "= 1" as the check for true boolean columns / parameters, for PostgreSQL this isn't a valid value.

Refactored 1 out as an overridable string.