### PR TITLE
Only read values from data reader that will be used

### DIFF
--- a/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/IncludeExpressionTreeVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/IncludeExpressionTreeVisitor.cs
@@ -150,6 +150,8 @@ namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
 
                     targetTableExpression = joinedTableExpression;
 
+                    selectExpression.RegisterReaderOffset(readerOffset);
+
                     yield return
                         Expression.Lambda(
                             Expression.Call(
@@ -160,7 +162,7 @@ namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
                                     typeof(RelationalQueryContext)),
                                 Expression.Constant(
                                     _queryCompilationContext.ValueReaderFactoryFactory.CreateValueReaderFactory(
-                                        selectExpression.GetProjectionTypes().Skip(readerOffset),
+                                        selectExpression.GetProjectionTypes(readerOffset),
                                         readerOffset)),
                                 Expression.Constant(readerIndex),
                                 materializer));
@@ -255,7 +257,7 @@ namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
                                         Expression.Call(
                                             Expression.Constant(
                                                 _queryCompilationContext.ValueReaderFactoryFactory.CreateValueReaderFactory(
-                                                    selectExpression.GetProjectionTypes(), 
+                                                    selectExpression.GetProjectionTypes(0), 
                                                     0)),
                                             _createValueReaderMethod,
                                             readerParameter),

--- a/src/EntityFramework.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EntityFramework.Relational/Query/RelationalQueryModelVisitor.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Data.Entity.Relational.Query
         public virtual IEnumerable<Type> GetProjectionTypes([NotNull] IQuerySource querySource)
             => (TryGetQuery(Check.NotNull(querySource, nameof(querySource)))
                 ?? _queriesBySource.First().Value)
-                .GetProjectionTypes();
+                .GetProjectionTypes(0);
 
         protected override ExpressionTreeVisitor CreateQueryingExpressionTreeVisitor(IQuerySource querySource)
         {


### PR DESCRIPTION
Multiple value readers can be used against the same DbDataReader using different offsets into that data reader. This change ensures that only the section of the data reader actually used is read and the buffer is no bigger than it needs to be.