### PR TITLE
fixed to #921 - Add params argument to DbContextActivator.CreateInstance...

### DIFF
--- a/src/EntityFramework.Core/Internal/DbContextActivator.cs
+++ b/src/EntityFramework.Core/Internal/DbContextActivator.cs
@@ -32,5 +32,19 @@ namespace Microsoft.Data.Entity.Internal
                 _serviceProvider = null;
             }
         }
+
+        public static TContext CreateInstance<TContext>([NotNull] IServiceProvider serviceProvider, [NotNull] params object[] parameters)
+        {
+            try
+            {
+                _serviceProvider = serviceProvider;
+
+                return (TContext)ActivatorUtilities.CreateInstance(serviceProvider, typeof(TContext), parameters);
+            }
+            finally
+            {
+                _serviceProvider = null;
+            }
+        }
     }
 }

--- a/test/EntityFramework.Core.Tests/DbContextTest.cs
+++ b/test/EntityFramework.Core.Tests/DbContextTest.cs
@@ -2034,6 +2034,29 @@ namespace Microsoft.Data.Entity.Tests
             }
         }
 
+        [Fact]
+        public void Context_with_parameters_can_be_created_By_dbcontextactivator_createinstance()
+        {
+            var services = new ServiceCollection();
+            var contextOptionsExtension = new FakeEntityOptionsExtension();
+
+            services
+                .AddSingleton<FakeService>()
+                .AddEntityFramework();
+
+            var serviceProvider = services.BuildServiceProvider();
+            var valueOfParamInt = 100;
+            var valueOfParamStr = "Hello DbContext";
+            using (var context = DbContextActivator.CreateInstance<ContextWithParameters>(serviceProvider, valueOfParamInt, valueOfParamStr))
+            {
+                var contextServices = ((IAccessor<IServiceProvider>)context).Service;
+
+                Assert.NotNull(contextServices.GetRequiredService<FakeService>());
+                Assert.Equal(valueOfParamInt, context.ParamInt);
+                Assert.Equal(valueOfParamStr, context.ParamStr);
+            }
+        }
+
         private class FakeService
         {
         }
@@ -2065,6 +2088,20 @@ namespace Microsoft.Data.Entity.Tests
             public ContextWithOptions(DbContextOptions<ContextWithOptions> contextOptions)
                 : base(contextOptions)
             {
+            }
+
+            public DbSet<Product> Products { get; set; }
+        }
+
+        private class ContextWithParameters : DbContext
+        {
+            public int ParamInt { get; set; }
+            public string ParamStr { get; set; }
+
+            public ContextWithParameters(int paramInt, string paramStr)
+            {
+                ParamInt = paramInt;
+                ParamStr = paramStr;
             }
 
             public DbSet<Product> Products { get; set; }


### PR DESCRIPTION
this PR addresses #921. I have to add it as an overload method because of [AddScoped method](https://github.com/aspnet/EntityFramework/blob/dev/src/EntityFramework.Core/Infrastructure/EntityFrameworkServicesBuilder.cs#L74).
In addition, a test seems to require all public api arguments must have `[NotNull]`attribute?