### PR TITLE
Fixes for 5 Small Reverse Engineering issues

### DIFF
--- a/src/EntityFramework.Relational.Design/ReverseEngineering/Configuration/EntityConfiguration.cs
+++ b/src/EntityFramework.Relational.Design/ReverseEngineering/Configuration/EntityConfiguration.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering.Configuration
+{
+    public class EntityConfiguration
+    {
+        public EntityConfiguration([NotNull]IEntityType entityType)
+        {
+            Check.NotNull(entityType, nameof(entityType));
+
+            EntityType = entityType;
+        }
+
+        public virtual IEntityType EntityType { get;[param: NotNull]private set; }
+        public virtual List<FacetConfiguration> FacetConfigurations { get; } = new List<FacetConfiguration>();
+        public virtual List<PropertyConfiguration> PropertyConfigurations { get; } = new List<PropertyConfiguration>();
+        public virtual List<NavigationConfiguration> NavigationConfigurations { get; } = new List<NavigationConfiguration>();
+    }
+}

--- a/src/EntityFramework.Relational.Design/ReverseEngineering/Configuration/FacetConfiguration.cs
+++ b/src/EntityFramework.Relational.Design/ReverseEngineering/Configuration/FacetConfiguration.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering.Configuration
+{
+    public class FacetConfiguration
+    {
+        public FacetConfiguration([NotNull]string methodBody)
+        {
+            Check.NotNull(methodBody, nameof(methodBody));
+
+            MethodBody = methodBody;
+        }
+
+        public FacetConfiguration([NotNull]string @for, [NotNull]string methodBody)
+        {
+            Check.NotNull(@for, nameof(@for));
+            Check.NotNull(methodBody, nameof(methodBody));
+
+            For = @for;
+            MethodBody = methodBody;
+        }
+
+        public virtual string For { get;[param: NotNull]private set; }
+        public virtual string MethodBody { get;[param: NotNull]private set; }
+
+        public override string ToString()
+        {
+            return (For == null ? MethodBody : For + "." + MethodBody);
+        }
+    }
+}

--- a/src/EntityFramework.Relational.Design/ReverseEngineering/Configuration/NavigationConfiguration.cs
+++ b/src/EntityFramework.Relational.Design/ReverseEngineering/Configuration/NavigationConfiguration.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering.Configuration
+{
+    public class NavigationConfiguration
+    {
+        public NavigationConfiguration([NotNull]EntityConfiguration entityConfiguration,
+            [NotNull]IForeignKey foreignKey, [NotNull]string dependentEndNavigationPropertyName,
+            [CanBeNull]string principalEndNavigationPropertyName)
+        {
+            Check.NotNull(entityConfiguration, nameof(entityConfiguration));
+            Check.NotNull(foreignKey, nameof(foreignKey));
+            Check.NotEmpty(dependentEndNavigationPropertyName, nameof(dependentEndNavigationPropertyName));
+
+            EntityConfiguration = entityConfiguration;
+            ForeignKey = foreignKey;
+            DependentEndNavigationPropertyName = dependentEndNavigationPropertyName;
+            PrincipalEndNavigationPropertyName = principalEndNavigationPropertyName;
+        }
+
+        public virtual EntityConfiguration EntityConfiguration { get;[param: NotNull]private set; }
+        public virtual IForeignKey ForeignKey { get;[param: NotNull]private set; }
+        public virtual string DependentEndNavigationPropertyName { get;[param: NotNull]private set; }
+        public virtual string PrincipalEndNavigationPropertyName { get;[param: NotNull]private set; }
+    }
+}

--- a/src/EntityFramework.Relational.Design/ReverseEngineering/Configuration/NavigationConfiguration.cs
+++ b/src/EntityFramework.Relational.Design/ReverseEngineering/Configuration/NavigationConfiguration.cs
@@ -11,11 +11,12 @@ namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering.Configurati
     {
         public NavigationConfiguration([NotNull]EntityConfiguration entityConfiguration,
             [NotNull]IForeignKey foreignKey, [NotNull]string dependentEndNavigationPropertyName,
-            [CanBeNull]string principalEndNavigationPropertyName)
+            [NotNull]string principalEndNavigationPropertyName)
         {
             Check.NotNull(entityConfiguration, nameof(entityConfiguration));
             Check.NotNull(foreignKey, nameof(foreignKey));
             Check.NotEmpty(dependentEndNavigationPropertyName, nameof(dependentEndNavigationPropertyName));
+            Check.NotEmpty(principalEndNavigationPropertyName, nameof(principalEndNavigationPropertyName));
 
             EntityConfiguration = entityConfiguration;
             ForeignKey = foreignKey;

--- a/src/EntityFramework.Relational.Design/ReverseEngineering/Configuration/PropertyConfiguration.cs
+++ b/src/EntityFramework.Relational.Design/ReverseEngineering/Configuration/PropertyConfiguration.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering.Configuration
+{
+    public class PropertyConfiguration
+    {
+        public PropertyConfiguration(
+            [NotNull]EntityConfiguration entityConfiguration, [NotNull]IProperty property)
+        {
+            Check.NotNull(entityConfiguration, nameof(entityConfiguration));
+            Check.NotNull(property, nameof(property));
+
+            EntityConfiguration = entityConfiguration;
+            Property = property;
+        }
+
+        public virtual EntityConfiguration EntityConfiguration { get;[param: NotNull]private set; }
+        public virtual IProperty Property { get;[param: NotNull]private set; }
+        public virtual Dictionary<string, List<string>> FacetConfigurations { get; } = new Dictionary<string, List<string>>();
+
+        public virtual void AddFacetConfiguration([NotNull]FacetConfiguration facetConfiguration)
+        {
+            Check.NotNull(facetConfiguration, nameof(facetConfiguration));
+
+            var @for = facetConfiguration.For ?? string.Empty;
+            List<string> listOfFacetMethodBodies;
+            if (!FacetConfigurations.TryGetValue(@for, out listOfFacetMethodBodies))
+            {
+                listOfFacetMethodBodies = new List<string>();
+                FacetConfigurations.Add(@for, listOfFacetMethodBodies);
+            }
+            listOfFacetMethodBodies.Add(facetConfiguration.MethodBody);
+        }
+    }
+
+}

--- a/src/EntityFramework.Relational.Design/ReverseEngineering/DbContextCodeGeneratorHelper.cs
+++ b/src/EntityFramework.Relational.Design/ReverseEngineering/DbContextCodeGeneratorHelper.cs
@@ -185,12 +185,32 @@ namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering
         {
             Check.NotNull(propertyConfiguration, nameof(propertyConfiguration));
 
+            AddRequiredFacetConfiguration(propertyConfiguration);
             AddMaxLengthFacetConfiguration(propertyConfiguration);
             AddStoreGeneratedPatternFacetConfiguration(propertyConfiguration);
             AddColumnNameFacetConfiguration(propertyConfiguration);
             AddColumnTypeFacetConfiguration(propertyConfiguration);
             AddDefaultValueFacetConfiguration(propertyConfiguration);
             AddDefaultExpressionFacetConfiguration(propertyConfiguration);
+        }
+
+        public virtual void AddRequiredFacetConfiguration(
+            [NotNull]PropertyConfiguration propertyConfiguration)
+        {
+            Check.NotNull(propertyConfiguration, nameof(propertyConfiguration));
+
+            if (!propertyConfiguration.Property.IsNullable)
+            {
+                var entityKeyProperties =
+                    ((EntityType)propertyConfiguration.EntityConfiguration.EntityType)
+                        .FindPrimaryKey()?.Properties
+                    ?? Enumerable.Empty<Property>();
+                if (!entityKeyProperties.Contains(propertyConfiguration.Property))
+                {
+                    propertyConfiguration.AddFacetConfiguration(
+                        new FacetConfiguration("Required()"));
+                }
+            }
         }
 
         public virtual void AddMaxLengthFacetConfiguration(

--- a/src/EntityFramework.SqlServer.Design/ReverseEngineering/Configuration/SqlServerNavigationProperty.cs
+++ b/src/EntityFramework.SqlServer.Design/ReverseEngineering/Configuration/SqlServerNavigationProperty.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering.Configuration
+{
+    public class SqlServerNavigationProperty
+    {
+        public SqlServerNavigationProperty([NotNull]string errorAnnotation)
+        {
+            Check.NotEmpty(errorAnnotation, nameof(errorAnnotation));
+
+            ErrorAnnotation = errorAnnotation;
+        }
+
+        public SqlServerNavigationProperty([NotNull]string type, [NotNull]string name)
+        {
+            Check.NotNull(type, nameof(type));
+            Check.NotEmpty(name, nameof(name));
+
+            Type = type;
+            Name = name;
+        }
+
+        public virtual string ErrorAnnotation { get;[param: NotNull]private set; }
+        public virtual string Type { get;[param: NotNull]private set; }
+        public virtual string Name { get;[param: NotNull]private set; }
+    }
+}

--- a/src/EntityFramework.SqlServer.Design/ReverseEngineering/Configuration/SqlServerNavigationPropertyInitializer.cs
+++ b/src/EntityFramework.SqlServer.Design/ReverseEngineering/Configuration/SqlServerNavigationPropertyInitializer.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering.Configuration
+{
+    public class SqlServerNavigationPropertyInitializer
+    {
+        public SqlServerNavigationPropertyInitializer([NotNull]string navPropName, [NotNull]string principalEntityTypeName)
+        {
+            Check.NotEmpty(navPropName, nameof(navPropName));
+            Check.NotEmpty(principalEntityTypeName, nameof(principalEntityTypeName));
+
+            NavigationPropertyName = navPropName;
+            PrincipalEntityTypeName = principalEntityTypeName;
+        }
+
+        public virtual string NavigationPropertyName { get;[param: NotNull]private set; }
+        public virtual string PrincipalEntityTypeName { get;[param: NotNull]private set; }
+    }
+}

--- a/src/EntityFramework.SqlServer.Design/ReverseEngineering/SqlServerDbContextCodeGeneratorHelper.cs
+++ b/src/EntityFramework.SqlServer.Design/ReverseEngineering/SqlServerDbContextCodeGeneratorHelper.cs
@@ -61,9 +61,7 @@ namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering
 
                 var sb = new StringBuilder();
                 sb.Append("Reference");
-                sb.Append("<");
-                sb.Append(foreignKey.PrincipalEntityType.Name);
-                sb.Append(">(d => d.");
+                sb.Append("(d => d.");
                 sb.Append(dependentEndNavigationPropertyName);
                 sb.Append(")");
 

--- a/src/EntityFramework.SqlServer.Design/ReverseEngineering/SqlServerEntityTypeCodeGeneratorHelper.cs
+++ b/src/EntityFramework.SqlServer.Design/ReverseEngineering/SqlServerEntityTypeCodeGeneratorHelper.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Relational.Design.ReverseEngineering;
-using Microsoft.Data.Entity.Utilities;
+using Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering.Configuration;
 
 namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering
 {
@@ -27,11 +27,11 @@ namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering
             }
         }
 
-        public virtual IEnumerable<SqlServerNavPropInitializer> NavPropInitializers
+        public virtual IEnumerable<SqlServerNavigationPropertyInitializer> NavPropInitializers
         {
             get
             {
-                var navPropInitializers = new List<SqlServerNavPropInitializer>();
+                var navPropInitializers = new List<SqlServerNavigationPropertyInitializer>();
 
                 foreach (var otherEntityType in GeneratorModel.EntityType.Model
                     .EntityTypes.Where(et => et != GeneratorModel.EntityType))
@@ -48,7 +48,8 @@ namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering
                             if (!foreignKey.IsUnique)
                             {
                                 navPropInitializers.Add(
-                                    new SqlServerNavPropInitializer(navigationPropertyName, otherEntityType.Name));
+                                    new SqlServerNavigationPropertyInitializer(
+                                        navigationPropertyName, otherEntityType.Name));
                             }
                         }
                     }
@@ -108,43 +109,5 @@ namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering
                 return navProps;
             }
         }
-    }
-
-    public class SqlServerNavigationProperty
-    {
-        public SqlServerNavigationProperty([NotNull]string errorAnnotation)
-        {
-            Check.NotEmpty(errorAnnotation, nameof(errorAnnotation));
-
-            ErrorAnnotation = errorAnnotation;
-        }
-
-        public SqlServerNavigationProperty([NotNull]string type, [NotNull]string name)
-        {
-            Check.NotNull(type, nameof(type));
-            Check.NotEmpty(name, nameof(name));
-
-            Type = type;
-            Name = name;
-        }
-
-        public virtual string ErrorAnnotation { get;[param: NotNull]private set; }
-        public virtual string Type { get;[param: NotNull]private set; }
-        public virtual string Name { get;[param: NotNull]private set; }
-    }
-
-    public class SqlServerNavPropInitializer
-    {
-        public SqlServerNavPropInitializer([NotNull]string navPropName, [NotNull]string principalEntityTypeName)
-        {
-            Check.NotEmpty(navPropName, nameof(navPropName));
-            Check.NotEmpty(principalEntityTypeName, nameof(principalEntityTypeName));
-
-            NavigationPropertyName = navPropName;
-            PrincipalEntityTypeName = principalEntityTypeName;
-        }
-
-        public virtual string NavigationPropertyName { get;[param: NotNull]private set; }
-        public virtual string PrincipalEntityTypeName { get;[param: NotNull]private set; }
     }
 }

--- a/src/EntityFramework.SqlServer.Design/ReverseEngineering/SqlServerMetadataModelProvider.cs
+++ b/src/EntityFramework.SqlServer.Design/ReverseEngineering/SqlServerMetadataModelProvider.cs
@@ -548,6 +548,8 @@ namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering
             Check.NotNull(property, nameof(property));
             Check.NotNull(tableColumn, nameof(tableColumn));
 
+            property.IsNullable = tableColumn.IsNullable;
+
             if (property.Name != tableColumn.ColumnName)
             {
                 property.Relational().Column = tableColumn.ColumnName;

--- a/src/EntityFramework.SqlServer.Design/ReverseEngineering/Templates/SqlServerDbContextTemplate.cshtml
+++ b/src/EntityFramework.SqlServer.Design/ReverseEngineering/Templates/SqlServerDbContextTemplate.cshtml
@@ -34,7 +34,7 @@ var firstEntity = true;
 @:
         }
         firstConfig = false;
-@:                entity@(entityFacet.ToString());
+@:                entity.@(entityFacet.ToString());
     }                        
     var firstFacet = true;
     @foreach(var propertyConfig in @entityConfig.PropertyConfigurations)
@@ -61,31 +61,16 @@ var firstEntity = true;
             }
         }
     }
-@:            });
-}
-
-@{
-var firstNavigation = true;
-}
-@foreach(var navigationConfig in Model.Helper.NavigationConfigurations)
-{
-    var firstConfig = true;
-    @if(!firstNavigation)
+    var firstNavigation = true;
+    @foreach (var navigationConfig in @entityConfig.NavigationConfigurations)
     {
-@:
-    }
-    firstNavigation = false;
-@:            modelBuilder.Entity<@navigationConfig.EntityType.DisplayName()>(entity =>
-@:            {
-    @foreach(var navigationFacet in @navigationConfig.FacetConfigurations)
-    {
-        @if(!firstConfig)
+        @if (!firstConfig || !firstNavigation)
         {
 @:
         }
-        firstConfig = false;
-@:                entity@(navigationFacet.ToString());
-    }                        
+        firstNavigation = false;
+@:                entity.@Model.Generator.ModelUtilities.ConstructNavigationConfiguration(navigationConfig);
+    }
 @:            });
 }
         }@* End of OnModelCreating() *@

--- a/src/EntityFramework.SqlServer.Design/ReverseEngineering/Templates/SqlServerDbContextTemplate.cshtml
+++ b/src/EntityFramework.SqlServer.Design/ReverseEngineering/Templates/SqlServerDbContextTemplate.cshtml
@@ -1,7 +1,4 @@
 @inherits Microsoft.Data.Entity.Relational.Design.Templating.RazorReverseEngineeringBase
-// Generated using Provider Assembly: @Model.ProviderAssembly
-// And Database Connection String: @Model.ConnectionString
-
 using Microsoft.Data.Entity;
 using Microsoft.Data.Entity.Metadata;
 

--- a/src/EntityFramework.SqlServer.Design/ReverseEngineering/Templates/SqlServerEntityTypeTemplate.cshtml
+++ b/src/EntityFramework.SqlServer.Design/ReverseEngineering/Templates/SqlServerEntityTypeTemplate.cshtml
@@ -1,12 +1,8 @@
 @inherits Microsoft.Data.Entity.Relational.Design.Templating.RazorReverseEngineeringBase
 @using Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering
-//
-// Generated code
-//
 @{
 string errorMessageAnnotation = Model.Helper.ErrorMessageAnnotation;
 }@if(errorMessageAnnotation != null) {
-@:
 @:// @errorMessageAnnotation
 }
 else {
@@ -19,21 +15,21 @@ else {
 @:{
 @:    public class @Model.EntityType.Name
 @:    {
+    @if(Model.Helper.NavPropInitializers.Count > 0) {
 @:        public @(Model.EntityType.Name)()
 @:        {
-    @foreach(var navPropInitializer in Model.Helper.NavPropInitializers)
-    {
+        @foreach(var navPropInitializer in Model.Helper.NavPropInitializers)
+        {
 @:            @navPropInitializer.NavigationPropertyName = new HashSet<@navPropInitializer.PrincipalEntityTypeName>();
-    }
+        }
 @:        }
 @:
-@:        // Properties
+    }
     @foreach(var property in Model.Helper.OrderedEntityProperties)
     {
 @:        public @Model.Generator.CSharpCodeGeneratorHelper.GetTypeName(@property.ClrType) @property.Name { get; set; }
     }
 @:
-@:        // Navigation Properties
     @foreach(var navProp in Model.Helper.NavigationProperties)
     {
         @if(navProp.ErrorAnnotation != null) {


### PR DESCRIPTION
Fixes for #1932 (remove unnecessary explicit generics), #1933 (combine relationship config with other config), #1935 (generated Required() on properties as needed), #1936 (fully specify self-referencing relationships), #1939 (minor improvements to generated code).

This includes the changes to pull the XYZConfiguration classes out into their own .cs files.
