### PR TITLE
ValueGeneratorSelectors unwrapping nullable types

### DIFF
--- a/src/EntityFramework.Core/ValueGeneration/ValueGeneratorSelector.cs
+++ b/src/EntityFramework.Core/ValueGeneration/ValueGeneratorSelector.cs
@@ -29,8 +29,7 @@ namespace Microsoft.Data.Entity.ValueGeneration
         {
             Check.NotNull(property, nameof(property));
 
-            var propertyType = property.ClrType;
-
+            var propertyType = property.ClrType.UnwrapNullableType();
             if (propertyType == typeof(Guid))
             {
                 return _guidFactory.Create(property);

--- a/test/EntityFramework.Core.Tests/ValueGeneration/ValueGeneratorSelectorTest.cs
+++ b/test/EntityFramework.Core.Tests/ValueGeneration/ValueGeneratorSelectorTest.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Data.Entity.Tests.ValueGeneration
             Assert.IsType<TemporaryIntegerValueGenerator<sbyte>>(selector.Select(entityType.GetProperty("NullableSByte")));
             Assert.IsType<TemporaryStringValueGenerator>(selector.Select(entityType.GetProperty("String")));
             Assert.IsType<GuidValueGenerator>(selector.Select(entityType.GetProperty("Guid")));
+            Assert.IsType<GuidValueGenerator>(selector.Select(entityType.GetProperty("NullableGuid")));
             Assert.IsType<TemporaryBinaryValueGenerator>(selector.Select(entityType.GetProperty("Binary")));
         }
 
@@ -89,6 +90,7 @@ namespace Microsoft.Data.Entity.Tests.ValueGeneration
             public sbyte? NullableSByte { get; set; }
             public string String { get; set; }
             public Guid Guid { get; set; }
+            public Guid? NullableGuid { get; set; }
             public byte[] Binary { get; set; }
             public float Float { get; set; }
         }


### PR DESCRIPTION
Unwrapping nullable types, before passing them into their selector. Updated tests to check for nullable Guid's.

Not 100% sure on the workings of the selectors, so this might be the wrong approach. It should also fix #478.