### PR TITLE
Adding batch separator to CREATE SCHEMA (fixes issue #2112)

### DIFF
--- a/src/EntityFramework.Relational/Migrations/Sql/MigrationSqlGenerator.cs
+++ b/src/EntityFramework.Relational/Migrations/Sql/MigrationSqlGenerator.cs
@@ -180,7 +180,9 @@ namespace Microsoft.Data.Entity.Relational.Migrations.Sql
 
             builder
                 .Append("CREATE SCHEMA ")
-                .Append(_sql.DelimitIdentifier(operation.Name));
+                .Append(_sql.DelimitIdentifier(operation.Name))
+                .AppendLine()
+                .Append(_sql.BatchSeparator);
         }
 
         public virtual void Generate(


### PR DESCRIPTION
This fix adds the mandatory GO after CREATE SCHEMA