### PR TITLE
Fix #1705: Update: Enables inheritance in update pipeline.

### DIFF
--- a/EntityFramework.sln
+++ b/EntityFramework.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.22311.0
+VisualStudioVersion = 14.0.22821.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{35BED7DE-CA6F-41EA-91E3-25CA7295C7B9}"
 EndProject

--- a/src/EntityFramework.Core/ChangeTracking/Internal/IValueGenerationManager.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/IValueGenerationManager.cs
@@ -9,6 +9,6 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
     public interface IValueGenerationManager
     {
         void Generate([NotNull] InternalEntityEntry entry);
-        bool MayGetTemporaryValue([NotNull] IProperty property);
+        bool MayGetTemporaryValue([NotNull] IProperty property, [NotNull] IEntityType entityType);
     }
 }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -412,14 +412,14 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
         private IReadOnlyList<IProperty> MayGetStoreValue()
         {
-            var properties = EntityType.GetProperties().Where(MayGetStoreValue).ToList();
+            var properties = EntityType.GetProperties().Where(p => MayGetStoreValue(p, EntityType)).ToList();
 
             foreach (var foreignKey in EntityType.GetForeignKeys())
             {
                 foreach (var property in foreignKey.Properties)
                 {
                     if (!properties.Contains(property)
-                        && MayGetStoreValue(property.GetGenerationProperty()))
+                        && MayGetStoreValue(property.GetGenerationProperty(), EntityType))
                     {
                         properties.Add(property);
                     }
@@ -428,10 +428,10 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
             return properties;
         }
 
-        private bool MayGetStoreValue([CanBeNull] IProperty property)
+        private bool MayGetStoreValue([CanBeNull] IProperty property, IEntityType entityType)
             => property != null
                && (property.StoreGeneratedPattern != StoreGeneratedPattern.None
-                   || StateManager.ValueGeneration.MayGetTemporaryValue(property));
+                   || StateManager.ValueGeneration.MayGetTemporaryValue(property, entityType));
 
         public virtual void AutoRollbackSidecars()
         {

--- a/src/EntityFramework.Core/ChangeTracking/Internal/KeyPropagator.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/KeyPropagator.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
             if (generationProperty != null)
             {
-                return _valueGeneratorSelector.Select(generationProperty);
+                return _valueGeneratorSelector.Select(generationProperty, generationProperty.EntityType);
             }
 
             return null;

--- a/src/EntityFramework.Core/ChangeTracking/Internal/ValueGenerationManager.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/ValueGenerationManager.cs
@@ -36,7 +36,8 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
                     }
                     else
                     {
-                        var valueGenerator = _valueGeneratorSelector.Select(property);
+                        var valueGenerator = _valueGeneratorSelector.Select(property, entry.EntityType);
+
                         Debug.Assert(valueGenerator != null);
 
                         var generatedValue = valueGenerator.Next();
@@ -46,9 +47,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
             }
         }
 
-        public virtual bool MayGetTemporaryValue(IProperty property)
+        public virtual bool MayGetTemporaryValue(IProperty property, IEntityType entityType)
             => property.IsValueGeneratedOnAdd
-               && _valueGeneratorSelector.Select(property).GeneratesTemporaryValues;
+               && _valueGeneratorSelector.Select(property, entityType).GeneratesTemporaryValues;
 
         private static void SetGeneratedValue(InternalEntityEntry entry, IProperty property, object generatedValue, bool isTemporary)
         {

--- a/src/EntityFramework.Core/Metadata/ForeignKey.cs
+++ b/src/EntityFramework.Core/Metadata/ForeignKey.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Data.Entity.Metadata
 
             Property.EnsureCompatible(principalProperties, dependentProperties);
 
-            if (principalEntityType?.Keys.Contains(principalKey) == false)
+            if (principalEntityType?.GetKeys().Contains(principalKey) == false)
             {
                 throw new ArgumentException(
                     Strings.ForeignKeyReferencedEntityKeyMismatch(

--- a/src/EntityFramework.Core/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
         private void ReplaceConventionShadowKeys(Key newKey)
         {
-            foreach (var key in Metadata.Keys.ToList())
+            foreach (var key in Metadata.GetKeys().ToList())
             {
                 if (key != newKey
                     && _keyBuilders.GetConfigurationSource(key) == ConfigurationSource.Convention
@@ -390,12 +390,12 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             }
 
             var detachedRelationships = new List<RelationshipSnapshot>();
-            foreach (var foreignKey in Metadata.ForeignKeys.Where(i => i.Properties.Contains(property)).ToList())
+            foreach (var foreignKey in Metadata.GetForeignKeys().Where(i => i.Properties.Contains(property)).ToList())
             {
                 detachedRelationships.Add(DetachRelationship(foreignKey, configurationSource));
             }
 
-            foreach (var key in Metadata.Keys.Where(i => i.Properties.Contains(property)).ToList())
+            foreach (var key in Metadata.GetKeys().Where(i => i.Properties.Contains(property)).ToList())
             {
                 foreach (var foreignKey in ModelBuilder.Metadata.GetReferencingForeignKeys(key))
                 {
@@ -566,12 +566,12 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 return;
             }
 
-            if (Metadata.ForeignKeys.Any(i => i.Properties.Contains(property)))
+            if (Metadata.GetForeignKeys().Any(i => i.Properties.Contains(property)))
             {
                 return;
             }
 
-            if (Metadata.Keys.Any(i => i.Properties.Contains(property)))
+            if (Metadata.GetKeys().Any(i => i.Properties.Contains(property)))
             {
                 return;
             }

--- a/src/EntityFramework.Core/Metadata/Internal/InternalModelBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/InternalModelBuilder.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 return false;
             }
 
-            foreach (var foreignKey in entityType.ForeignKeys.ToList())
+            foreach (var foreignKey in entityType.GetForeignKeys().ToList())
             {
                 var removed = entityTypeBuilder.RemoveRelationship(foreignKey, configurationSource);
                 Debug.Assert(removed.HasValue);

--- a/src/EntityFramework.Core/Metadata/Internal/InternalRelationshipBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/InternalRelationshipBuilder.cs
@@ -473,7 +473,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
         public virtual InternalRelationshipBuilder Attach(ConfigurationSource configurationSource)
         {
-            if (Metadata.EntityType.ForeignKeys.Contains(Metadata))
+            if (Metadata.EntityType.GetForeignKeys().Contains(Metadata))
             {
                 return ModelBuilder.Entity(Metadata.EntityType.Name, configurationSource)
                     .Relationship(Metadata, existingForeignKey: true, configurationSource: configurationSource);

--- a/src/EntityFramework.Core/Metadata/Model.cs
+++ b/src/EntityFramework.Core/Metadata/Model.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Data.Entity.Metadata
 
             // TODO: Perf: Add additional indexes so that this isn't a linear lookup
             // Issue #1179
-            return EntityTypes.SelectMany(et => et.ForeignKeys).Where(fk => fk.PrincipalEntityType == entityType).ToList();
+            return EntityTypes.SelectMany(et => et.GetForeignKeys()).Where(fk => fk.PrincipalEntityType == entityType).ToList();
         }
 
         public virtual IReadOnlyList<ForeignKey> GetReferencingForeignKeys([NotNull] IKey key)
@@ -136,7 +136,7 @@ namespace Microsoft.Data.Entity.Metadata
 
             // TODO: Perf: Add additional indexes so that this isn't a linear lookup
             // Issue #1179
-            return EntityTypes.SelectMany(e => e.ForeignKeys).Where(fk => fk.PrincipalKey == key).ToList();
+            return EntityTypes.SelectMany(e => e.GetForeignKeys()).Where(fk => fk.PrincipalKey == key).ToList();
         }
 
         public virtual IReadOnlyList<ForeignKey> GetReferencingForeignKeys([NotNull] IProperty property)
@@ -146,7 +146,7 @@ namespace Microsoft.Data.Entity.Metadata
             // TODO: Perf: Add additional indexes so that this isn't a linear lookup
             // Issue #1179
             return EntityTypes
-                .SelectMany(e => e.ForeignKeys
+                .SelectMany(e => e.GetForeignKeys()
                     .Where(f => f.PrincipalKey.Properties.Contains(property)))
                 .ToList();
         }

--- a/src/EntityFramework.Core/Metadata/ModelConventions/KeyConvention.cs
+++ b/src/EntityFramework.Core/Metadata/ModelConventions/KeyConvention.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
             Check.NotNull(properties, nameof(properties));
 
             foreach (var property in properties.Where(
-                property => !entityTypeBuilder.Metadata.ForeignKeys.SelectMany(fk => fk.Properties).Contains(property)))
+                property => !entityTypeBuilder.Metadata.GetForeignKeys().SelectMany(fk => fk.Properties).Contains(property)))
             {
                 entityTypeBuilder.Property(property.ClrType, property.Name, ConfigurationSource.Convention)
                     ?.GenerateValueOnAdd(true, ConfigurationSource.Convention);

--- a/src/EntityFramework.Core/Utilities/ModelForeignKeyUndirectedGraphAdapter.cs
+++ b/src/EntityFramework.Core/Utilities/ModelForeignKeyUndirectedGraphAdapter.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Data.Entity.Utilities
         public override IEnumerable<EntityType> Vertices => _model.EntityTypes;
 
         public override IEnumerable<EntityType> GetOutgoingNeighbours(EntityType from)
-            => @from.ForeignKeys.Select(fk => fk.PrincipalEntityType)
+            => @from.GetForeignKeys().Select(fk => fk.PrincipalEntityType)
                 .Union(_model.GetReferencingForeignKeys(@from).Select(fk => fk.EntityType));
 
         public override IEnumerable<EntityType> GetIncomingNeighbours(EntityType to)

--- a/src/EntityFramework.Core/Utilities/ModelNavigationsGraphAdapter.cs
+++ b/src/EntityFramework.Core/Utilities/ModelNavigationsGraphAdapter.cs
@@ -22,11 +22,11 @@ namespace Microsoft.Data.Entity.Utilities
         public override IEnumerable<EntityType> Vertices => _model.EntityTypes;
 
         public override IEnumerable<EntityType> GetOutgoingNeighbours(EntityType from)
-            => @from.ForeignKeys.Where(fk => fk.DependentToPrincipal != null).Select(fk => fk.PrincipalEntityType)
+            => @from.GetForeignKeys().Where(fk => fk.DependentToPrincipal != null).Select(fk => fk.PrincipalEntityType)
                 .Union(_model.GetReferencingForeignKeys(@from).Where(fk => fk.PrincipalToDependent != null).Select(fk => fk.EntityType));
 
         public override IEnumerable<EntityType> GetIncomingNeighbours(EntityType to)
-            => to.ForeignKeys.Where(fk => fk.PrincipalToDependent != null).Select(fk => fk.PrincipalEntityType)
+            => to.GetForeignKeys().Where(fk => fk.PrincipalToDependent != null).Select(fk => fk.PrincipalEntityType)
                 .Union(_model.GetReferencingForeignKeys(to).Where(fk => fk.DependentToPrincipal != null).Select(fk => fk.EntityType));
     }
 }

--- a/src/EntityFramework.Core/ValueGeneration/IValueGeneratorCache.cs
+++ b/src/EntityFramework.Core/ValueGeneration/IValueGeneratorCache.cs
@@ -9,6 +9,9 @@ namespace Microsoft.Data.Entity.ValueGeneration
 {
     public interface IValueGeneratorCache
     {
-        ValueGenerator GetOrAdd([NotNull] IProperty property, [NotNull] Func<IProperty, ValueGenerator> factory);
+        ValueGenerator GetOrAdd(
+            [NotNull] IProperty property,
+            [NotNull] IEntityType entityType,
+            [NotNull] Func<IProperty, IEntityType, ValueGenerator> factory);
     }
 }

--- a/src/EntityFramework.Core/ValueGeneration/IValueGeneratorSelector.cs
+++ b/src/EntityFramework.Core/ValueGeneration/IValueGeneratorSelector.cs
@@ -8,6 +8,6 @@ namespace Microsoft.Data.Entity.ValueGeneration
 {
     public interface IValueGeneratorSelector
     {
-        ValueGenerator Select([NotNull] IProperty property);
+        ValueGenerator Select([NotNull] IProperty property, [NotNull] IEntityType entityType);
     }
 }

--- a/src/EntityFramework.Core/ValueGeneration/ValueGeneratorSelector.cs
+++ b/src/EntityFramework.Core/ValueGeneration/ValueGeneratorSelector.cs
@@ -38,16 +38,18 @@ namespace Microsoft.Data.Entity.ValueGeneration
             Cache = cache;
         }
 
-        public virtual ValueGenerator Select(IProperty property)
+        public virtual ValueGenerator Select(IProperty property, IEntityType entityType)
         {
             Check.NotNull(property, nameof(property));
+            Check.NotNull(entityType, nameof(entityType));
 
-            return Cache.GetOrAdd(property, Create);
+            return Cache.GetOrAdd(property, entityType, Create);
         }
 
-        public virtual ValueGenerator Create([NotNull] IProperty property)
+        public virtual ValueGenerator Create([NotNull] IProperty property, [NotNull] IEntityType entityType)
         {
             Check.NotNull(property, nameof(property));
+            Check.NotNull(entityType, nameof(entityType));
 
             var propertyType = property.ClrType.UnwrapNullableType();
 

--- a/src/EntityFramework.InMemory/InMemoryValueGeneratorSelector.cs
+++ b/src/EntityFramework.InMemory/InMemoryValueGeneratorSelector.cs
@@ -18,13 +18,14 @@ namespace Microsoft.Data.Entity.InMemory
         {
         }
 
-        public override ValueGenerator Create(IProperty property)
+        public override ValueGenerator Create(IProperty property, IEntityType entityType)
         {
             Check.NotNull(property, nameof(property));
+            Check.NotNull(entityType, nameof(entityType));
 
             return property.ClrType.IsInteger()
                 ? _inMemoryFactory.Create(property)
-                : base.Create(property);
+                : base.Create(property, entityType);
         }
     }
 }

--- a/src/EntityFramework.Relational/EntityFramework.Relational.csproj
+++ b/src/EntityFramework.Relational/EntityFramework.Relational.csproj
@@ -272,6 +272,8 @@
     <Compile Include="Utilities\EnumerableExtensions.cs" />
     <Compile Include="Utilities\ExpressionExtensions.cs" />
     <Compile Include="Utilities\MethodInfoExtensions.cs" />
+    <Compile Include="ValueGeneration\DiscriminatorValueGenerator.cs" />
+    <Compile Include="ValueGeneration\RelationalValueGeneratorSelector.cs" />
     <EmbeddedResource Include="Properties\Strings.resx">
       <LogicalName>EntityFramework.Relational.Strings.resources</LogicalName>
       <SubType>Designer</SubType>

--- a/src/EntityFramework.Relational/Metadata/ReadOnlyRelationalEntityTypeExtensions.cs
+++ b/src/EntityFramework.Relational/Metadata/ReadOnlyRelationalEntityTypeExtensions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Data.Entity.Relational.Metadata
     {
         protected const string RelationalTableAnnotation = RelationalAnnotationNames.Prefix + RelationalAnnotationNames.TableName;
         protected const string RelationalSchemaAnnotation = RelationalAnnotationNames.Prefix + RelationalAnnotationNames.Schema;
-        protected const string DiscriminatorPropertyAnnotation = RelationalAnnotationNames.Prefix + RelationalAnnotationNames.DiscriminatorProperty;
+        protected internal const string DiscriminatorPropertyAnnotation = RelationalAnnotationNames.Prefix + RelationalAnnotationNames.DiscriminatorProperty;
         protected const string DiscriminatorValueAnnotation = RelationalAnnotationNames.Prefix + RelationalAnnotationNames.DiscriminatorValue;
 
         private readonly IEntityType _entityType;

--- a/src/EntityFramework.Relational/RelationalDataStoreServices.cs
+++ b/src/EntityFramework.Relational/RelationalDataStoreServices.cs
@@ -11,6 +11,7 @@ using Microsoft.Data.Entity.Relational.Migrations.Infrastructure;
 using Microsoft.Data.Entity.Relational.Migrations.Sql;
 using Microsoft.Data.Entity.Relational.Query;
 using Microsoft.Data.Entity.Relational.Update;
+using Microsoft.Data.Entity.Relational.ValueGeneration;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.ValueGeneration;
 using Microsoft.Framework.DependencyInjection;
@@ -27,7 +28,7 @@ namespace Microsoft.Data.Entity.Relational
         public override IDatabaseFactory DatabaseFactory => Services.GetRequiredService<RelationalDatabaseFactory>();
         public override IModelBuilderFactory ModelBuilderFactory => Services.GetRequiredService<ModelBuilderFactory>();
         public override IQueryContextFactory QueryContextFactory => Services.GetRequiredService<RelationalQueryContextFactory>();
-        public override IValueGeneratorSelector ValueGeneratorSelector => Services.GetRequiredService<ValueGeneratorSelector>();
+        public override IValueGeneratorSelector ValueGeneratorSelector => Services.GetRequiredService<RelationalValueGeneratorSelector>();
 
         public virtual IRelationalTypeMapper TypeMapper => Services.GetRequiredService<RelationalTypeMapper>();
         public virtual IModelDiffer ModelDiffer => Services.GetRequiredService<ModelDiffer>();

--- a/src/EntityFramework.Relational/RelationalEntityServicesBuilderExtensions.cs
+++ b/src/EntityFramework.Relational/RelationalEntityServicesBuilderExtensions.cs
@@ -10,6 +10,7 @@ using Microsoft.Data.Entity.Relational.Migrations;
 using Microsoft.Data.Entity.Relational.Migrations.Infrastructure;
 using Microsoft.Data.Entity.Relational.Query;
 using Microsoft.Data.Entity.Relational.Update;
+using Microsoft.Data.Entity.Relational.ValueGeneration;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.DependencyInjection;
 
@@ -37,6 +38,7 @@ namespace Microsoft.Data.Entity.Relational
                 .AddScoped<BatchExecutor>()
                 .AddScoped<ModelDiffer>()
                 .AddScoped<RelationalDatabaseFactory>()
+                .AddScoped<RelationalValueGeneratorSelector>()
                 .AddScoped(p => GetStoreServices(p).ModelDiffer)
                 .AddScoped(p => GetStoreServices(p).HistoryRepository)
                 .AddScoped(p => GetStoreServices(p).MigrationSqlGenerator)

--- a/src/EntityFramework.Relational/Update/CommandBatchPreparer.cs
+++ b/src/EntityFramework.Relational/Update/CommandBatchPreparer.cs
@@ -100,7 +100,8 @@ namespace Microsoft.Data.Entity.Relational.Update
             var predecessorsMap = CreateKeyValuePredecessorMap(modificationCommandGraph);
             AddForeignKeyEdges(modificationCommandGraph, predecessorsMap);
 
-            var sortedCommands = modificationCommandGraph.BatchingTopologicalSort(data => { return string.Join(", ", data.Select(d => d.Item3.First())); });
+            var sortedCommands 
+                = modificationCommandGraph.BatchingTopologicalSort(data => { return string.Join(", ", data.Select(d => d.Item3.First())); });
 
             return sortedCommands;
         }

--- a/src/EntityFramework.Relational/ValueGeneration/DiscriminatorValueGenerator.cs
+++ b/src/EntityFramework.Relational/ValueGeneration/DiscriminatorValueGenerator.cs
@@ -1,0 +1,25 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Utilities;
+using Microsoft.Data.Entity.ValueGeneration;
+
+namespace Microsoft.Data.Entity.Relational.ValueGeneration
+{
+    public class DiscriminatorValueGenerator : ValueGenerator
+    {
+        private readonly object _discriminator;
+
+        public DiscriminatorValueGenerator([NotNull] object discriminator)
+        {
+            Check.NotNull(discriminator, nameof(discriminator));
+
+            _discriminator = discriminator;
+        }
+
+        protected override object NextValue() => _discriminator;
+
+        public override bool GeneratesTemporaryValues => false;
+    }
+}

--- a/src/EntityFramework.Relational/ValueGeneration/RelationalValueGeneratorSelector.cs
+++ b/src/EntityFramework.Relational/ValueGeneration/RelationalValueGeneratorSelector.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Relational.Metadata;
+using Microsoft.Data.Entity.Utilities;
+using Microsoft.Data.Entity.ValueGeneration;
+
+namespace Microsoft.Data.Entity.Relational.ValueGeneration
+{
+    public class RelationalValueGeneratorSelector : ValueGeneratorSelector
+    {
+        public RelationalValueGeneratorSelector([NotNull] IValueGeneratorCache cache)
+            : base(cache)
+        {
+        }
+
+        public override ValueGenerator Create(IProperty property, IEntityType entityType)
+        {
+            Check.NotNull(property, nameof(property));
+            Check.NotNull(entityType, nameof(entityType));
+
+            if (property.EntityType.BaseType == null)
+            {
+                var discriminatorPropertyName
+                    = property.EntityType[ReadOnlyRelationalEntityTypeExtensions.DiscriminatorPropertyAnnotation]
+                        as string;
+
+                if (discriminatorPropertyName != null
+                    && string.Equals(discriminatorPropertyName, property.Name, StringComparison.Ordinal))
+                {
+                    return new DiscriminatorValueGenerator(entityType.Relational().DiscriminatorValue);
+                }
+            }
+
+            return base.Create(property, entityType);
+        }
+    }
+}

--- a/src/EntityFramework.SqlServer/EntityFramework.SqlServer.csproj
+++ b/src/EntityFramework.SqlServer/EntityFramework.SqlServer.csproj
@@ -61,9 +61,7 @@
     </Compile>
     <Compile Include="Extensions\SqlServerDbContextOptions.cs" />
     <Compile Include="ISqlServerConnection.cs" />
-    <Compile Include="ISqlServerSequenceValueGeneratorFactory.cs" />
     <Compile Include="ISqlServerSqlGenerator.cs" />
-    <Compile Include="ISqlServerValueGeneratorCache.cs" />
     <Compile Include="Metadata\ISqlServerEntityTypeExtensions.cs" />
     <Compile Include="Metadata\ISqlServerForeignKeyExtensions.cs" />
     <Compile Include="Metadata\ISqlServerIndexExtensions.cs" />
@@ -104,7 +102,6 @@
     <Compile Include="SqlServerModelBuilderFactory.cs" />
     <Compile Include="Migrations\SqlServerModelDiffer.cs" />
     <Compile Include="SqlServerModelSource.cs" />
-    <Compile Include="SqlServerSequenceValueGeneratorState.cs" />
     <Compile Include="SqlServerDataStoreServices.cs" />
     <Compile Include="Update\SqlServerCommandBatchPreparer.cs" />
     <Compile Include="Update\SqlServerModificationCommandBatchFactory.cs" />
@@ -114,8 +111,6 @@
     <Compile Include="SqlServerDataStoreCreator.cs" />
     <Compile Include="SqlServerDataStoreSource.cs" />
     <Compile Include="Migrations\SqlServerMigrationSqlGenerator.cs" />
-    <Compile Include="SqlServerSequenceValueGenerator.cs" />
-    <Compile Include="SqlServerSequenceValueGeneratorFactory.cs" />
     <Compile Include="SqlServerSqlGenerator.cs" />
     <Compile Include="SqlServerTypeMapper.cs" />
     <Compile Include="Extensions\SqlServerDbContextOptionsExtensions.cs" />
@@ -125,8 +120,6 @@
     <Compile Include="Properties\Strings.Designer.cs">
       <DependentUpon>Strings.resx</DependentUpon>
     </Compile>
-    <Compile Include="SqlServerValueGeneratorCache.cs" />
-    <Compile Include="SqlServerValueGeneratorSelector.cs" />
     <Compile Include="Update\SqlServerModificationCommandBatch.cs" />
     <Compile Include="Utilities\EnumerableExtensions.cs" />
     <Compile Include="..\Shared\CodeAnnotations.cs" />
@@ -135,6 +128,13 @@
     </Compile>
     <Compile Include="..\Shared\StringBuilderExtensions.cs" />
     <Compile Include="..\Shared\SharedTypeExtensions.cs" />
+    <Compile Include="ValueGeneration\ISqlServerSequenceValueGeneratorFactory.cs" />
+    <Compile Include="ValueGeneration\ISqlServerValueGeneratorCache.cs" />
+    <Compile Include="ValueGeneration\SqlServerSequenceValueGenerator.cs" />
+    <Compile Include="ValueGeneration\SqlServerSequenceValueGeneratorFactory.cs" />
+    <Compile Include="ValueGeneration\SqlServerSequenceValueGeneratorState.cs" />
+    <Compile Include="ValueGeneration\SqlServerValueGeneratorCache.cs" />
+    <Compile Include="ValueGeneration\SqlServerValueGeneratorSelector.cs" />
     <EmbeddedResource Include="Properties\Strings.resx">
       <LogicalName>EntityFramework.SqlServer.Strings.resources</LogicalName>
       <SubType>Designer</SubType>

--- a/src/EntityFramework.SqlServer/Extensions/SqlServerEntityServicesBuilderExtensions.cs
+++ b/src/EntityFramework.SqlServer/Extensions/SqlServerEntityServicesBuilderExtensions.cs
@@ -7,6 +7,7 @@ using Microsoft.Data.Entity.Relational;
 using Microsoft.Data.Entity.SqlServer;
 using Microsoft.Data.Entity.SqlServer.Migrations;
 using Microsoft.Data.Entity.SqlServer.Update;
+using Microsoft.Data.Entity.SqlServer.ValueGeneration;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Utilities;
 

--- a/src/EntityFramework.SqlServer/SqlServerDataStoreServices.cs
+++ b/src/EntityFramework.SqlServer/SqlServerDataStoreServices.cs
@@ -12,6 +12,7 @@ using Microsoft.Data.Entity.Relational.Migrations.Sql;
 using Microsoft.Data.Entity.Relational.Update;
 using Microsoft.Data.Entity.SqlServer.Migrations;
 using Microsoft.Data.Entity.SqlServer.Update;
+using Microsoft.Data.Entity.SqlServer.ValueGeneration;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.ValueGeneration;
 using Microsoft.Framework.DependencyInjection;

--- a/src/EntityFramework.SqlServer/ValueGeneration/ISqlServerSequenceValueGeneratorFactory.cs
+++ b/src/EntityFramework.SqlServer/ValueGeneration/ISqlServerSequenceValueGeneratorFactory.cs
@@ -5,7 +5,7 @@ using JetBrains.Annotations;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.ValueGeneration;
 
-namespace Microsoft.Data.Entity.SqlServer
+namespace Microsoft.Data.Entity.SqlServer.ValueGeneration
 {
     public interface ISqlServerSequenceValueGeneratorFactory
     {

--- a/src/EntityFramework.SqlServer/ValueGeneration/ISqlServerValueGeneratorCache.cs
+++ b/src/EntityFramework.SqlServer/ValueGeneration/ISqlServerValueGeneratorCache.cs
@@ -5,7 +5,7 @@ using JetBrains.Annotations;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.ValueGeneration;
 
-namespace Microsoft.Data.Entity.SqlServer
+namespace Microsoft.Data.Entity.SqlServer.ValueGeneration
 {
     public interface ISqlServerValueGeneratorCache : IValueGeneratorCache
     {

--- a/src/EntityFramework.SqlServer/ValueGeneration/SqlServerSequenceValueGenerator.cs
+++ b/src/EntityFramework.SqlServer/ValueGeneration/SqlServerSequenceValueGenerator.cs
@@ -8,7 +8,7 @@ using Microsoft.Data.Entity.Relational;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Data.Entity.ValueGeneration;
 
-namespace Microsoft.Data.Entity.SqlServer
+namespace Microsoft.Data.Entity.SqlServer.ValueGeneration
 {
     public class SqlServerSequenceValueGenerator<TValue> : HiLoValueGenerator<TValue>
     {

--- a/src/EntityFramework.SqlServer/ValueGeneration/SqlServerSequenceValueGeneratorFactory.cs
+++ b/src/EntityFramework.SqlServer/ValueGeneration/SqlServerSequenceValueGeneratorFactory.cs
@@ -8,7 +8,7 @@ using Microsoft.Data.Entity.Relational;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Data.Entity.ValueGeneration;
 
-namespace Microsoft.Data.Entity.SqlServer
+namespace Microsoft.Data.Entity.SqlServer.ValueGeneration
 {
     public class SqlServerSequenceValueGeneratorFactory : ISqlServerSequenceValueGeneratorFactory
     {

--- a/src/EntityFramework.SqlServer/ValueGeneration/SqlServerSequenceValueGeneratorState.cs
+++ b/src/EntityFramework.SqlServer/ValueGeneration/SqlServerSequenceValueGeneratorState.cs
@@ -5,7 +5,7 @@ using JetBrains.Annotations;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Data.Entity.ValueGeneration;
 
-namespace Microsoft.Data.Entity.SqlServer
+namespace Microsoft.Data.Entity.SqlServer.ValueGeneration
 {
     public class SqlServerSequenceValueGeneratorState : HiLoValueGeneratorState
     {

--- a/src/EntityFramework.SqlServer/ValueGeneration/SqlServerValueGeneratorCache.cs
+++ b/src/EntityFramework.SqlServer/ValueGeneration/SqlServerValueGeneratorCache.cs
@@ -7,7 +7,7 @@ using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Data.Entity.ValueGeneration;
 
-namespace Microsoft.Data.Entity.SqlServer
+namespace Microsoft.Data.Entity.SqlServer.ValueGeneration
 {
     public class SqlServerValueGeneratorCache : ValueGeneratorCache, ISqlServerValueGeneratorCache
     {

--- a/test/EntityFramework.Core.FunctionalTests/InheritanceFixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/InheritanceFixtureBase.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             var kiwi = new Kiwi
                 {
-                    Species = "Apteryx owenii",
+                    Species = "Apteryx haastii",
                     Name = "Great spotted kiwi",
                     IsFlightless = true,
                     FoundOn = Island.South

--- a/test/EntityFramework.Core.FunctionalTests/InheritanceTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/InheritanceTestBase.cs
@@ -149,6 +149,54 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
+        [Fact]
+        public virtual void Can_insert_update_delete()
+        {
+            using (var context = CreateContext())
+            {
+                var kiwi = new Kiwi
+                {
+                    Species = "Apteryx owenii",
+                    Name = "Little spotted kiwi",
+                    IsFlightless = true,
+                    FoundOn = Island.North
+                };
+
+                var nz = context.Set<Country>().Single(c => c.Id == 1);
+
+                nz.Animals.Add(kiwi);
+
+                context.SaveChanges();
+            }
+
+            using (var context = CreateContext())
+            {
+                var kiwi = context.Set<Kiwi>().Single(k => k.Species.EndsWith("owenii"));
+
+                kiwi.EagleId = "Aquila chrysaetos canadensis";
+                
+                context.SaveChanges();
+            }
+
+            using (var context = CreateContext())
+            {
+                var kiwi = context.Set<Kiwi>().Single(k => k.Species.EndsWith("owenii"));
+
+                Assert.Equal("Aquila chrysaetos canadensis", kiwi.EagleId);
+
+                context.Set<Bird>().Remove(kiwi);
+
+                context.SaveChanges();
+            }
+
+            using (var context = CreateContext())
+            {
+                var count = context.Set<Kiwi>().Count(k => k.Species.EndsWith("owenii"));
+
+                Assert.Equal(0, count);
+            }
+        }
+
         protected AnimalContext CreateContext()
         {
             return Fixture.CreateContext();

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntityEntryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntityEntryTest.cs
@@ -504,7 +504,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             entry[fkProperty] = 77;
             entry.RelationshipsSnapshot[fkProperty] = 78;
 
-            var keyValue = entry.GetDependentKeyValue(entityType.ForeignKeys.Single());
+            var keyValue = entry.GetDependentKeyValue(entityType.GetForeignKeys().Single());
             Assert.IsType<SimpleEntityKey<int>>(keyValue);
             Assert.Equal(77, keyValue.Value);
         }
@@ -521,7 +521,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             entry[fkProperty] = 77;
             entry.RelationshipsSnapshot[fkProperty] = 78;
 
-            var keyValue = entry.GetDependentKeySnapshot(entityType.ForeignKeys.Single());
+            var keyValue = entry.GetDependentKeySnapshot(entityType.GetForeignKeys().Single());
             Assert.IsType<SimpleEntityKey<int>>(keyValue);
             Assert.Equal(78, keyValue.Value);
         }
@@ -537,7 +537,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var entry = CreateInternalEntry(configuration, entityType, new SomeDependentEntity());
             entry[fkProperty] = 77;
 
-            var keyValue = entry.GetDependentKeySnapshot(entityType.ForeignKeys.Single());
+            var keyValue = entry.GetDependentKeySnapshot(entityType.GetForeignKeys().Single());
             Assert.IsType<SimpleEntityKey<int>>(keyValue);
             Assert.Equal(77, keyValue.Value);
         }
@@ -556,7 +556,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             entry[fkProperty] = 79;
 
-            var keyValue = entry.GetDependentKeySnapshot(entityType.ForeignKeys.Single());
+            var keyValue = entry.GetDependentKeySnapshot(entityType.GetForeignKeys().Single());
             Assert.IsType<SimpleEntityKey<int>>(keyValue);
             Assert.Equal(79, keyValue.Value);
         }
@@ -575,7 +575,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             entry[fkProperty] = 77;
 
-            var keyValue = entry.GetDependentKeySnapshot(entityType.ForeignKeys.Single());
+            var keyValue = entry.GetDependentKeySnapshot(entityType.GetForeignKeys().Single());
             Assert.IsType<SimpleEntityKey<int>>(keyValue);
             Assert.Equal(78, keyValue.Value);
         }
@@ -592,7 +592,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var entry = CreateInternalEntry(configuration, principalType, new SomeEntity());
             entry[key] = 77;
 
-            var keyValue = entry.GetPrincipalKeyValue(dependentType.ForeignKeys.Single());
+            var keyValue = entry.GetPrincipalKeyValue(dependentType.GetForeignKeys().Single());
             Assert.IsType<SimpleEntityKey<int>>(keyValue);
             Assert.Equal(77, keyValue.Value);
         }
@@ -609,7 +609,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             entry[fkProperties[0]] = 77;
             entry[fkProperties[1]] = "CheeseAndOnion";
 
-            var keyValue = (CompositeEntityKey)entry.GetDependentKeyValue(entityType.ForeignKeys.Single());
+            var keyValue = (CompositeEntityKey)entry.GetDependentKeyValue(entityType.GetForeignKeys().Single());
             Assert.Equal(77, keyValue.Value[0]);
             Assert.Equal("CheeseAndOnion", keyValue.Value[1]);
         }
@@ -627,7 +627,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             entry[keyProperties[0]] = 77;
             entry[keyProperties[1]] = "PrawnCocktail";
 
-            var keyValue = (CompositeEntityKey)entry.GetPrincipalKeyValue(dependentType.ForeignKeys.Single());
+            var keyValue = (CompositeEntityKey)entry.GetPrincipalKeyValue(dependentType.GetForeignKeys().Single());
             Assert.Equal(77, keyValue.Value[0]);
             Assert.Equal("PrawnCocktail", keyValue.Value[1]);
         }
@@ -645,7 +645,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             entry[keyProperties[0]] = 77;
             entry[keyProperties[1]] = null;
 
-            Assert.Same(EntityKey.InvalidEntityKey, entry.GetPrincipalKeyValue(dependentType.ForeignKeys.Single()));
+            Assert.Same(EntityKey.InvalidEntityKey, entry.GetPrincipalKeyValue(dependentType.GetForeignKeys().Single()));
         }
 
         [Fact]
@@ -1452,11 +1452,11 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             {
             }
 
-            public override ValueGenerator Create(IProperty property)
+            public override ValueGenerator Create(IProperty property, IEntityType entityType)
             {
                 return property.ClrType == typeof(int)
                     ? _inMemoryFactory.Create(property)
-                    : base.Create(property);
+                    : base.Create(property, entityType);
             }
         }
 

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/RelationshipsSnapshotTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/RelationshipsSnapshotTest.cs
@@ -337,7 +337,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
         private ForeignKey ForeignKey
         {
-            get { return _model.GetEntityType(typeof(Banana)).ForeignKeys.Single(); }
+            get { return _model.GetEntityType(typeof(Banana)).GetForeignKeys().Single(); }
         }
 
         protected class Banana : INotifyPropertyChanged, INotifyPropertyChanging

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/SidecarTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/SidecarTest.cs
@@ -297,7 +297,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         public virtual void Can_create_foreign_key_value_based_on_dependent_values()
         {
             var entityType = _model.GetEntityType(typeof(Banana).FullName);
-            var foreignKey = entityType.ForeignKeys.Single();
+            var foreignKey = entityType.GetForeignKeys().Single();
 
             var entry = CreateInternalEntry();
             var sidecar = CreateSidecar(entry);
@@ -312,7 +312,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         public virtual void Can_create_foreign_key_value_based_on_principal_end_values()
         {
             var entityType = _model.GetEntityType(typeof(Banana).FullName);
-            var foreignKey = entityType.ForeignKeys.Single();
+            var foreignKey = entityType.GetForeignKeys().Single();
 
             var entry = CreateInternalEntry();
             var sidecar = CreateSidecar(entry);
@@ -339,7 +339,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         public virtual void Can_create_composite_foreign_key_value_based_on_dependent_values()
         {
             var entityType = _model.GetEntityType(typeof(SomeMoreDependentEntity).FullName);
-            var foreignKey = entityType.ForeignKeys.Single();
+            var foreignKey = entityType.GetForeignKeys().Single();
 
             var entry = TestHelpers.Instance.CreateInternalEntry<SomeMoreDependentEntity>(_model);
             var sidecar = CreateSidecar(entry);
@@ -355,7 +355,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         public virtual void Can_create_composite_foreign_key_value_based_on_principal_end_values()
         {
             var dependentType = _model.GetEntityType(typeof(SomeMoreDependentEntity).FullName);
-            var foreignKey = dependentType.ForeignKeys.Single();
+            var foreignKey = dependentType.GetForeignKeys().Single();
 
             var entry = TestHelpers.Instance.CreateInternalEntry<SomeDependentEntity>(_model);
             var sidecar = CreateSidecar(entry);
@@ -474,11 +474,11 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             {
             }
 
-            public override ValueGenerator Create(IProperty property)
+            public override ValueGenerator Create(IProperty property, IEntityType entityType)
             {
                 return property.ClrType == typeof(int)
                     ? _inMemoryFactory.Create(property)
-                    : base.Create(property);
+                    : base.Create(property, entityType);
             }
         }
     }

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/StateManagerTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/StateManagerTest.cs
@@ -562,7 +562,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var productEntry4 = stateManager.StartTracking(stateManager.GetOrCreateEntry(new Product { Id = Guid.NewGuid(), DependentId = 78 }));
             var productEntry5 = stateManager.StartTracking(stateManager.GetOrCreateEntry(new Product { Id = Guid.NewGuid(), DependentId = null }));
 
-            var fk = model.GetEntityType(typeof(Product)).ForeignKeys.Single();
+            var fk = model.GetEntityType(typeof(Product)).GetForeignKeys().Single();
 
             Assert.Equal(
                 new[] { productEntry1, productEntry2 },

--- a/test/EntityFramework.Core.Tests/DbContextTest.cs
+++ b/test/EntityFramework.Core.Tests/DbContextTest.cs
@@ -1534,7 +1534,7 @@ namespace Microsoft.Data.Entity.Tests
                 .Returns(3);
 
             var valueGenMock = new Mock<IValueGeneratorSelector>();
-            valueGenMock.Setup(m => m.Select(It.IsAny<IProperty>())).Returns(Mock.Of<ValueGenerator>());
+            valueGenMock.Setup(m => m.Select(It.IsAny<IProperty>(), It.IsAny<IEntityType>())).Returns(Mock.Of<ValueGenerator>());
 
             var servicesMock = new Mock<IDataStoreServices>();
             servicesMock.Setup(m => m.Store).Returns(store.Object);
@@ -1580,7 +1580,7 @@ namespace Microsoft.Data.Entity.Tests
                 .Returns(Task.FromResult(3));
 
             var valueGenMock = new Mock<IValueGeneratorSelector>();
-            valueGenMock.Setup(m => m.Select(It.IsAny<IProperty>())).Returns(Mock.Of<ValueGenerator>());
+            valueGenMock.Setup(m => m.Select(It.IsAny<IProperty>(), It.IsAny<IEntityType>())).Returns(Mock.Of<ValueGenerator>());
 
             var servicesMock = new Mock<IDataStoreServices>();
             servicesMock.Setup(m => m.Store).Returns(store.Object);

--- a/test/EntityFramework.Core.Tests/Metadata/BasicModelBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/BasicModelBuilderTest.cs
@@ -648,7 +648,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var entityType = model.GetEntityType(typeof(Order));
 
-            Assert.Equal(1, entityType.ForeignKeys.Count());
+            Assert.Equal(1, entityType.GetForeignKeys().Count());
         }
 
         [Fact]
@@ -669,7 +669,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var entityType = model.GetEntityType(typeof(Order));
 
-            Assert.Equal(1, entityType.ForeignKeys.Count());
+            Assert.Equal(1, entityType.GetForeignKeys().Count());
         }
 
         [Fact]
@@ -690,7 +690,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var entityType = model.GetEntityType(typeof(Order));
 
-            Assert.Equal(1, entityType.ForeignKeys.Count());
+            Assert.Equal(1, entityType.GetForeignKeys().Count());
         }
 
         [Fact]
@@ -713,7 +713,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var entityType = model.GetEntityType(typeof(Order));
 
-            Assert.Equal(1, entityType.ForeignKeys.Count());
+            Assert.Equal(1, entityType.GetForeignKeys().Count());
         }
 
         [Fact]

--- a/test/EntityFramework.Core.Tests/Metadata/EntityTypeTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/EntityTypeTest.cs
@@ -357,14 +357,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(key1, entityType.GetPrimaryKey());
 
             Assert.Same(key1, entityType.FindPrimaryKey());
-            Assert.Same(key1, entityType.Keys.Single());
+            Assert.Same(key1, entityType.GetKeys().Single());
 
             var key2 = entityType.SetPrimaryKey(idProperty);
 
             Assert.NotNull(key2);
             Assert.Same(key2, entityType.GetPrimaryKey());
             Assert.Same(key2, entityType.FindPrimaryKey());
-            Assert.Equal(2, entityType.Keys.Count);
+            Assert.Equal(2, entityType.GetKeys().Count());
 
             Assert.Same(key1, entityType.GetKey(key1.Properties));
             Assert.Same(key2, entityType.GetKey(key2.Properties));
@@ -372,12 +372,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Null(entityType.SetPrimaryKey((Property)null));
 
             Assert.Null(entityType.FindPrimaryKey());
-            Assert.Equal(2, entityType.Keys.Count);
+            Assert.Equal(2, entityType.GetKeys().Count());
 
             Assert.Null(entityType.SetPrimaryKey(new Property[0]));
 
             Assert.Null(entityType.FindPrimaryKey());
-            Assert.Equal(2, entityType.Keys.Count);
+            Assert.Equal(2, entityType.GetKeys().Count());
 
             Assert.Equal(
                 Strings.EntityRequiresKey(typeof(Customer).FullName),
@@ -410,7 +410,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(key1, entityType.GetPrimaryKey());
 
             Assert.Same(key1, entityType.FindPrimaryKey());
-            Assert.Same(key1, entityType.Keys.Single());
+            Assert.Same(key1, entityType.GetKeys().Single());
 
             var key2 = entityType.GetOrSetPrimaryKey(idProperty);
 
@@ -419,19 +419,19 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(key2, entityType.GetOrSetPrimaryKey(idProperty));
             Assert.Same(key2, entityType.GetPrimaryKey());
             Assert.Same(key2, entityType.FindPrimaryKey());
-            Assert.Equal(2, entityType.Keys.Count);
+            Assert.Equal(2, entityType.GetKeys().Count());
             Assert.Same(key1, entityType.GetKey(key1.Properties));
             Assert.Same(key2, entityType.GetKey(key2.Properties));
 
             Assert.Null(entityType.GetOrSetPrimaryKey((Property)null));
 
             Assert.Null(entityType.FindPrimaryKey());
-            Assert.Equal(2, entityType.Keys.Count);
+            Assert.Equal(2, entityType.GetKeys().Count());
 
             Assert.Null(entityType.GetOrSetPrimaryKey(new Property[0]));
 
             Assert.Null(entityType.FindPrimaryKey());
-            Assert.Equal(2, entityType.Keys.Count);
+            Assert.Equal(2, entityType.GetKeys().Count());
             Assert.Equal(
                 Strings.EntityRequiresKey(typeof(Customer).FullName),
                 Assert.Throws<ModelItemNotFoundException>(() => entityType.GetPrimaryKey()).Message);
@@ -450,7 +450,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             entityType.SetPrimaryKey((Property)null);
 
-            Assert.Equal(1, entityType.Keys.Count);
+            Assert.Equal(1, entityType.GetKeys().Count());
             Assert.Same(customerPk, entityType.FindKey(idProperty));
             Assert.Null(entityType.FindPrimaryKey());
             Assert.Same(customerPk, fk.PrincipalKey);
@@ -469,7 +469,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             entityType.SetPrimaryKey(entityType.GetOrAddProperty(Customer.NameProperty));
 
-            Assert.Equal(2, entityType.Keys.Count);
+            Assert.Equal(2, entityType.GetKeys().Count());
             Assert.Same(customerPk, entityType.FindKey(idProperty));
             Assert.NotSame(customerPk, entityType.GetPrimaryKey());
             Assert.Same(customerPk, fk.PrincipalKey);
@@ -486,15 +486,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             Assert.NotNull(key1);
             Assert.Same(key1, entityType.GetOrAddKey(new[] { idProperty, nameProperty }));
-            Assert.Same(key1, entityType.Keys.Single());
+            Assert.Same(key1, entityType.GetKeys().Single());
 
             var key2 = entityType.GetOrAddKey(idProperty);
 
             Assert.NotNull(key2);
             Assert.Same(key2, entityType.GetKey(idProperty));
-            Assert.Equal(2, entityType.Keys.Count());
-            Assert.Contains(key1, entityType.Keys);
-            Assert.Contains(key2, entityType.Keys);
+            Assert.Equal(2, entityType.GetKeys().Count());
+            Assert.Contains(key1, entityType.GetKeys());
+            Assert.Contains(key2, entityType.GetKeys());
         }
 
         [Fact]
@@ -550,7 +550,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var key1 = entityType.GetOrSetPrimaryKey(new[] { idProperty, nameProperty });
             var key2 = entityType.GetOrAddKey(idProperty);
 
-            Assert.Equal(new[] { key2, key1 }, entityType.Keys.ToArray());
+            Assert.Equal(new[] { key2, key1 }, entityType.GetKeys().ToArray());
 
             Assert.Same(key1, entityType.RemoveKey(key1));
             Assert.Null(entityType.RemoveKey(key1));
@@ -559,11 +559,11 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 Strings.KeyNotFound("{'" + idProperty.Name + "', '" + nameProperty.Name + "'}", typeof(Customer).FullName),
                 Assert.Throws<ModelItemNotFoundException>(() => entityType.GetKey(new[] { idProperty, nameProperty })).Message);
 
-            Assert.Equal(new[] { key2 }, entityType.Keys.ToArray());
+            Assert.Equal(new[] { key2 }, entityType.GetKeys().ToArray());
 
             Assert.Same(key2, entityType.RemoveKey(new Key(new[] { idProperty })));
 
-            Assert.Empty(entityType.Keys);
+            Assert.Empty(entityType.GetKeys());
         }
 
         [Fact]
@@ -596,7 +596,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var k3 = customerType.GetOrAddKey(new[] { idProperty, nameProperty });
             var k1 = customerType.GetOrAddKey(idProperty);
 
-            Assert.True(new[] { k1, k2, k3, k4 }.SequenceEqual(customerType.Keys));
+            Assert.True(new[] { k1, k2, k3, k4 }.SequenceEqual(customerType.GetKeys()));
         }
 
         [Fact]
@@ -673,13 +673,13 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk1, orderType.GetForeignKey(customerFk1));
             Assert.Same(fk1, orderType.FindForeignKey(customerFk1));
             Assert.Same(fk1, orderType.GetOrAddForeignKey(customerFk1, new Key(new[] { idProperty })));
-            Assert.Same(fk1, orderType.ForeignKeys.Single());
+            Assert.Same(fk1, orderType.GetForeignKeys().Single());
 
             var fk2 = orderType.AddForeignKey(customerFk2, customerKey);
             Assert.Same(fk2, orderType.GetForeignKey(customerFk2));
             Assert.Same(fk2, orderType.FindForeignKey(customerFk2));
             Assert.Same(fk2, orderType.GetOrAddForeignKey(customerFk2, new Key(new[] { idProperty })));
-            Assert.Equal(new[] { fk1, fk2 }, orderType.ForeignKeys.ToArray());
+            Assert.Equal(new[] { fk1, fk2 }, orderType.GetForeignKeys().ToArray());
         }
 
         [Fact]
@@ -725,9 +725,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.NotEqual(fk1, fk2);
             Assert.Same(fk2, orderType.GetForeignKey(customerFk2));
             Assert.Same(fk2, orderType.FindForeignKey(customerFk2));
-            Assert.Equal(new[] { fk1, fk2 }, orderType.ForeignKeys.ToArray());
+            Assert.Equal(new[] { fk1, fk2 }, orderType.GetForeignKeys().ToArray());
             Assert.Same(fk2, orderType.GetOrAddForeignKey(customerFk2, customerKey));
-            Assert.Equal(new[] { fk1, fk2 }, orderType.ForeignKeys.ToArray());
+            Assert.Equal(new[] { fk1, fk2 }, orderType.GetForeignKeys().ToArray());
         }
 
         [Fact]
@@ -962,7 +962,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var fk1 = orderType.AddForeignKey(customerFk1, customerKey);
             var fk2 = orderType.AddForeignKey(customerFk2, customerKey);
 
-            Assert.Equal(new[] { fk1, fk2 }, orderType.ForeignKeys.ToArray());
+            Assert.Equal(new[] { fk1, fk2 }, orderType.GetForeignKeys().ToArray());
 
             Assert.Same(fk1, orderType.RemoveForeignKey(fk1));
             Assert.Null(orderType.RemoveForeignKey(fk1));
@@ -970,11 +970,11 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Equal(
                 Strings.ForeignKeyNotFound("{'" + Order.CustomerIdProperty.Name + "'}", typeof(Order).FullName),
                 Assert.Throws<ModelItemNotFoundException>(() => orderType.GetForeignKey(customerFk1)).Message);
-            Assert.Equal(new[] { fk2 }, orderType.ForeignKeys.ToArray());
+            Assert.Equal(new[] { fk2 }, orderType.GetForeignKeys().ToArray());
 
             Assert.Same(fk2, orderType.RemoveForeignKey(new ForeignKey(new[] { customerFk2 }, customerKey)));
 
-            Assert.Empty(orderType.ForeignKeys);
+            Assert.Empty(orderType.GetForeignKeys());
         }
 
         [Fact]
@@ -1023,7 +1023,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var fk3 = orderType.AddForeignKey(new[] { customerFk3A, customerFk3B }, otherCustomerKey);
             var fk1 = orderType.AddForeignKey(customerFk1, customerKey);
 
-            Assert.True(new[] { fk1, fk2, fk3, fk4 }.SequenceEqual(orderType.ForeignKeys));
+            Assert.True(new[] { fk1, fk2, fk3, fk4 }.SequenceEqual(orderType.GetForeignKeys()));
         }
 
         [Fact]

--- a/test/EntityFramework.Core.Tests/Metadata/Internal/InternalEntityBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/Internal/InternalEntityBuilderTest.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             Assert.Equal(
                 new[] { Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name },
                 dependentEntityBuilder.Metadata.Properties.Select(p => p.Name));
-            Assert.Empty(dependentEntityBuilder.Metadata.ForeignKeys);
+            Assert.Empty(dependentEntityBuilder.Metadata.GetForeignKeys());
         }
 
         [Fact]
@@ -169,7 +169,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             Assert.Equal(ConfigurationSource.Convention, dependentEntityBuilder.RemoveRelationship(relationshipBuilder.Metadata, ConfigurationSource.DataAnnotation));
 
             Assert.Same(Order.CustomerIdProperty.Name, dependentEntityBuilder.Metadata.Properties.Single().Name);
-            Assert.Empty(dependentEntityBuilder.Metadata.ForeignKeys);
+            Assert.Empty(dependentEntityBuilder.Metadata.GetForeignKeys());
         }
 
         [Fact]
@@ -217,7 +217,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             Assert.Equal(ConfigurationSource.Convention, dependentEntityBuilder.RemoveRelationship(relationshipBuilder.Metadata, ConfigurationSource.DataAnnotation));
 
             Assert.Equal(1, dependentEntityBuilder.Metadata.Properties.Count(p => p.Name == shadowProperty.Metadata.Name));
-            Assert.Empty(dependentEntityBuilder.Metadata.ForeignKeys.Where(foreignKey => foreignKey.Properties.SequenceEqual(relationshipBuilder.Metadata.Properties)));
+            Assert.Empty(dependentEntityBuilder.Metadata.GetForeignKeys().Where(foreignKey => foreignKey.Properties.SequenceEqual(relationshipBuilder.Metadata.Properties)));
         }
 
         [Fact]
@@ -403,7 +403,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
             Assert.NotNull(entityBuilder.Key(new[] { Order.CustomerIdProperty.Name }, ConfigurationSource.Convention));
 
-            Assert.Equal(Order.CustomerIdProperty.Name, entityBuilder.Metadata.Keys.Single().Properties.Single().Name);
+            Assert.Equal(Order.CustomerIdProperty.Name, entityBuilder.Metadata.GetKeys().Single().Properties.Single().Name);
         }
 
         [Fact]
@@ -439,7 +439,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             Assert.Equal(ConfigurationSource.DataAnnotation, entityBuilder.RemoveKey(key.Metadata, ConfigurationSource.DataAnnotation));
 
             Assert.Equal(Order.CustomerIdProperty.Name, entityBuilder.Metadata.Properties.Single().Name);
-            Assert.Empty(entityBuilder.Metadata.Keys);
+            Assert.Empty(entityBuilder.Metadata.GetKeys());
         }
 
         [Fact]
@@ -455,7 +455,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             Assert.Equal(ConfigurationSource.Convention, entityBuilder.RemoveKey(key.Metadata, ConfigurationSource.DataAnnotation));
 
             Assert.Equal(Order.CustomerIdProperty.Name, entityBuilder.Metadata.Properties.Single().Name);
-            Assert.Empty(entityBuilder.Metadata.Keys);
+            Assert.Empty(entityBuilder.Metadata.GetKeys());
         }
 
         [Fact]
@@ -498,7 +498,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             Assert.Equal(ConfigurationSource.Convention, entityBuilder.RemoveKey(key.Metadata, ConfigurationSource.DataAnnotation));
 
             Assert.Equal(1, entityBuilder.Metadata.Properties.Count(p => p.Name == shadowProperty.Metadata.Name));
-            Assert.Empty(entityBuilder.Metadata.Keys.Where(foreignKey => foreignKey.Properties.SequenceEqual(key.Metadata.Properties)));
+            Assert.Empty(entityBuilder.Metadata.GetKeys().Where(foreignKey => foreignKey.Properties.SequenceEqual(key.Metadata.Properties)));
         }
 
         [Fact]
@@ -539,8 +539,8 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             Assert.Equal(
                 new[] { Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name },
                 dependentEntityBuilder.Metadata.Properties.Select(p => p.Name));
-            Assert.Empty(dependentEntityBuilder.Metadata.ForeignKeys);
-            Assert.Empty(principalEntityBuilder.Metadata.Keys);
+            Assert.Empty(dependentEntityBuilder.Metadata.GetForeignKeys());
+            Assert.Empty(principalEntityBuilder.Metadata.GetKeys());
         }
 
         [Fact]
@@ -813,7 +813,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             Assert.True(dependentEntityBuilder.Ignore(Order.CustomerIdProperty.Name, ConfigurationSource.DataAnnotation));
 
             Assert.Empty(dependentEntityBuilder.Metadata.Properties.Where(p => p.Name == Order.CustomerIdProperty.Name));
-            var newFk = dependentEntityBuilder.Metadata.ForeignKeys.Single();
+            var newFk = dependentEntityBuilder.Metadata.GetForeignKeys().Single();
             Assert.Same(fk.EntityType, newFk.EntityType);
             Assert.Same(fk.PrincipalEntityType, newFk.PrincipalEntityType);
             Assert.NotEqual(fk.Properties, newFk.EntityType.Properties);
@@ -846,7 +846,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             Assert.False(dependentEntityBuilder.Ignore(Order.CustomerIdProperty.Name, ConfigurationSource.DataAnnotation));
 
             Assert.NotEmpty(dependentEntityBuilder.Metadata.Properties.Where(p => p.Name == Order.CustomerIdProperty.Name));
-            Assert.NotEmpty(dependentEntityBuilder.Metadata.ForeignKeys);
+            Assert.NotEmpty(dependentEntityBuilder.Metadata.GetForeignKeys());
         }
 
         [Fact]
@@ -889,7 +889,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             Assert.True(entityBuilder.Ignore(Order.CustomerIdProperty.Name, ConfigurationSource.Explicit));
 
             Assert.Empty(entityBuilder.Metadata.Properties.Where(p => p.Name == Order.CustomerIdProperty.Name));
-            Assert.Empty(entityBuilder.Metadata.Keys);
+            Assert.Empty(entityBuilder.Metadata.GetKeys());
         }
 
         [Fact]
@@ -916,7 +916,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             Assert.True(principalEntityBuilder.Ignore(Customer.UniqueProperty.Name, ConfigurationSource.DataAnnotation));
 
             Assert.Empty(principalEntityBuilder.Metadata.Properties.Where(p => p.Name == Customer.UniqueProperty.Name));
-            var newFk = dependentEntityBuilder.Metadata.ForeignKeys.Single();
+            var newFk = dependentEntityBuilder.Metadata.GetForeignKeys().Single();
             Assert.Same(fk.EntityType, newFk.EntityType);
             Assert.Same(fk.PrincipalEntityType, newFk.PrincipalEntityType);
             Assert.Equal(fk.Properties, newFk.EntityType.Properties);
@@ -936,7 +936,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             Assert.False(entityBuilder.Ignore(Order.CustomerIdProperty.Name, ConfigurationSource.DataAnnotation));
 
             Assert.NotEmpty(entityBuilder.Metadata.Properties.Where(p => p.Name == Order.CustomerIdProperty.Name));
-            Assert.NotEmpty(entityBuilder.Metadata.Keys);
+            Assert.NotEmpty(entityBuilder.Metadata.GetKeys());
         }
 
         [Fact]
@@ -986,7 +986,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
             Assert.Same(foreignKeyBuilder.Metadata, dependentEntityBuilder.Metadata.FindNavigation(Order.CustomerProperty.Name).ForeignKey);
             Assert.Same(foreignKeyBuilder.Metadata, principalEntityBuilder.Metadata.FindNavigation(Customer.OrdersProperty.Name).ForeignKey);
-            Assert.Same(foreignKeyBuilder.Metadata, dependentEntityBuilder.Metadata.ForeignKeys.Single());
+            Assert.Same(foreignKeyBuilder.Metadata, dependentEntityBuilder.Metadata.GetForeignKeys().Single());
         }
 
         [Fact]
@@ -1007,7 +1007,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             Assert.Null(principalEntityBuilder.Metadata.FindNavigation(Customer.OrdersProperty.Name));
             Assert.True(dependentEntityBuilder.Ignore(Order.CustomerProperty.Name, ConfigurationSource.Convention));
             Assert.True(principalEntityBuilder.Ignore(Customer.OrdersProperty.Name, ConfigurationSource.Convention));
-            Assert.Empty(dependentEntityBuilder.Metadata.ForeignKeys);
+            Assert.Empty(dependentEntityBuilder.Metadata.GetForeignKeys());
 
             foreignKeyBuilder = dependentEntityBuilder.ForeignKey(typeof(Customer).FullName, new[] { Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name }, ConfigurationSource.DataAnnotation);
             Assert.False(dependentEntityBuilder.Navigation(Order.CustomerProperty.Name, foreignKeyBuilder.Metadata, pointsToPrincipal: true, configurationSource: ConfigurationSource.DataAnnotation));
@@ -1227,8 +1227,8 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
             Assert.True(principalEntityBuilder.Ignore(Customer.OrdersProperty.Name, ConfigurationSource.Explicit));
 
-            Assert.Empty(dependentEntityBuilder.Metadata.ForeignKeys);
-            Assert.Empty(principalEntityBuilder.Metadata.ForeignKeys);
+            Assert.Empty(dependentEntityBuilder.Metadata.GetForeignKeys());
+            Assert.Empty(principalEntityBuilder.Metadata.GetForeignKeys());
             Assert.True(principalEntityBuilder.Ignore(Customer.OrdersProperty.Name, ConfigurationSource.Convention));
             Assert.Null(dependentEntityBuilder.Relationship(typeof(Customer), typeof(Order), null, Customer.OrdersProperty.Name, ConfigurationSource.Convention, false));
             Assert.Equal(Strings.NavigationIgnoredExplicitly(Customer.OrdersProperty.Name, typeof(Customer).FullName),
@@ -1248,8 +1248,8 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
             Assert.True(dependentEntityBuilder.Ignore(Order.CustomerProperty.Name, ConfigurationSource.Explicit));
 
-            Assert.Empty(dependentEntityBuilder.Metadata.ForeignKeys);
-            Assert.Empty(principalEntityBuilder.Metadata.ForeignKeys);
+            Assert.Empty(dependentEntityBuilder.Metadata.GetForeignKeys());
+            Assert.Empty(principalEntityBuilder.Metadata.GetForeignKeys());
             Assert.True(dependentEntityBuilder.Ignore(Order.CustomerProperty.Name, ConfigurationSource.Convention));
             Assert.Null(dependentEntityBuilder.Relationship(typeof(Customer), typeof(Order), Order.CustomerProperty.Name, null, ConfigurationSource.Convention, false));
             Assert.Equal(Strings.NavigationIgnoredExplicitly(Order.CustomerProperty.Name, typeof(Order).FullName),
@@ -1268,8 +1268,8 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
             Assert.Null(dependentEntityBuilder.Relationship(typeof(Customer), typeof(Order), Order.CustomerProperty.Name, Customer.OrdersProperty.Name, ConfigurationSource.Convention, false, true));
 
-            Assert.Empty(principalEntityBuilder.Metadata.ForeignKeys);
-            var fk = dependentEntityBuilder.Metadata.ForeignKeys.Single();
+            Assert.Empty(principalEntityBuilder.Metadata.GetForeignKeys());
+            var fk = dependentEntityBuilder.Metadata.GetForeignKeys().Single();
             Assert.Null(fk.DependentToPrincipal);
             Assert.Equal(Customer.OrdersProperty.Name, fk.PrincipalToDependent.Name);
         }
@@ -1285,8 +1285,8 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
             Assert.Null(dependentEntityBuilder.Relationship(typeof(Customer), typeof(Order), Order.CustomerProperty.Name, Customer.OrdersProperty.Name, ConfigurationSource.Convention, false, true));
 
-            Assert.Empty(principalEntityBuilder.Metadata.ForeignKeys);
-            var fk = dependentEntityBuilder.Metadata.ForeignKeys.Single();
+            Assert.Empty(principalEntityBuilder.Metadata.GetForeignKeys());
+            var fk = dependentEntityBuilder.Metadata.GetForeignKeys().Single();
             Assert.Null(fk.PrincipalToDependent);
             Assert.Equal(Order.CustomerProperty.Name, fk.DependentToPrincipal.Name);
         }

--- a/test/EntityFramework.Core.Tests/Metadata/Internal/InternalModelBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/Internal/InternalModelBuilderTest.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             Assert.True(modelBuilder.Ignore(typeof(Customer), ConfigurationSource.Explicit));
 
             Assert.Equal(typeof(Order), modelBuilder.Metadata.EntityTypes.Single().ClrType);
-            Assert.Empty(orderEntityTypeBuilder.Metadata.ForeignKeys);
+            Assert.Empty(orderEntityTypeBuilder.Metadata.GetForeignKeys());
         }
 
         [Fact]
@@ -170,7 +170,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             Assert.False(modelBuilder.Ignore(typeof(Customer), ConfigurationSource.DataAnnotation));
 
             Assert.Equal(2, modelBuilder.Metadata.EntityTypes.Count);
-            Assert.Equal(1, orderEntityTypeBuilder.Metadata.ForeignKeys.Count);
+            Assert.Equal(1, orderEntityTypeBuilder.Metadata.GetForeignKeys().Count());
         }
 
         [Fact]
@@ -211,7 +211,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             Assert.True(modelBuilder.Ignore(typeof(Customer), ConfigurationSource.DataAnnotation));
 
             Assert.Equal(new[] { typeof(Order), typeof(Product) }, modelBuilder.Metadata.EntityTypes.Select(et => et.ClrType));
-            Assert.Equal(typeof(Product), orderEntityTypeBuilder.Metadata.ForeignKeys.Single().PrincipalEntityType.ClrType);
+            Assert.Equal(typeof(Product), orderEntityTypeBuilder.Metadata.GetForeignKeys().Single().PrincipalEntityType.ClrType);
         }
 
         [Fact]
@@ -232,7 +232,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             Assert.True(modelBuilder.Ignore(typeof(Customer), ConfigurationSource.DataAnnotation));
 
             Assert.Equal(new[] { typeof(Order), typeof(Product) }, modelBuilder.Metadata.EntityTypes.Select(et => et.ClrType));
-            Assert.Equal(typeof(Product), orderEntityTypeBuilder.Metadata.ForeignKeys.Single().PrincipalEntityType.ClrType);
+            Assert.Equal(typeof(Product), orderEntityTypeBuilder.Metadata.GetForeignKeys().Single().PrincipalEntityType.ClrType);
         }
 
         protected virtual InternalModelBuilder CreateModelBuilder(Model model = null)

--- a/test/EntityFramework.Core.Tests/Metadata/Internal/InternalRelationshipBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/Internal/InternalRelationshipBuilderTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Metadata.Internal;
@@ -47,7 +48,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Internal
                 relationshipBuilder.PrincipalKey(typeof(Order), new[] { Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name }, ConfigurationSource.DataAnnotation));
             Assert.Null(relationshipBuilder.PrincipalKey(typeof(Order), new[] { Order.CustomerIdProperty }, ConfigurationSource.Convention));
 
-            Assert.Equal(1, customerEntityBuilder.Metadata.ForeignKeys.Count);
+            Assert.Equal(1, customerEntityBuilder.Metadata.GetForeignKeys().Count());
         }
 
         [Fact]

--- a/test/EntityFramework.Core.Tests/Metadata/MetadataBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/MetadataBuilderTest.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.IsType<ReferenceCollectionBuilder<Gunter, Gate>>(returnedBuilder);
 
             var model = builder.Model;
-            var foreignKey = model.GetEntityType(typeof(Gate)).ForeignKeys.Single();
+            var foreignKey = model.GetEntityType(typeof(Gate)).GetForeignKeys().Single();
 
             Assert.Equal("V2.Annotation", foreignKey["Annotation"]);
             Assert.Equal("V2.Metadata", foreignKey["Metadata"]);
@@ -186,7 +186,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.IsType<CollectionReferenceBuilder<Gate, Gunter>>(returnedBuilder);
 
             var model = builder.Model;
-            var foreignKey = model.GetEntityType(typeof(Gate)).ForeignKeys.Single();
+            var foreignKey = model.GetEntityType(typeof(Gate)).GetForeignKeys().Single();
 
             Assert.Equal("V2.Annotation", foreignKey["Annotation"]);
             Assert.Equal("V2.Metadata", foreignKey["Metadata"]);
@@ -207,7 +207,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.IsType<ReferenceReferenceBuilder<Avatar, Gunter>>(returnedBuilder);
 
             var model = builder.Model;
-            var foreignKey = model.GetEntityType(typeof(Avatar)).ForeignKeys.Single();
+            var foreignKey = model.GetEntityType(typeof(Avatar)).GetForeignKeys().Single();
 
             Assert.Equal("V2.Annotation", foreignKey["Annotation"]);
             Assert.Equal("V2.Metadata", foreignKey["Metadata"]);
@@ -368,7 +368,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.IsType<ReferenceCollectionBuilder<Gunter, Gate>>(returnedBuilder);
 
             var model = builder.Model;
-            var foreignKey = model.GetEntityType(typeof(Gate)).ForeignKeys.Single();
+            var foreignKey = model.GetEntityType(typeof(Gate)).GetForeignKeys().Single();
 
             Assert.Equal("V2.Annotation", foreignKey["Annotation"]);
             Assert.Equal("V2.Metadata", foreignKey["Metadata"]);
@@ -388,7 +388,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.IsType<CollectionReferenceBuilder<Gate, Gunter>>(returnedBuilder);
 
             var model = builder.Model;
-            var foreignKey = model.GetEntityType(typeof(Gate)).ForeignKeys.Single();
+            var foreignKey = model.GetEntityType(typeof(Gate)).GetForeignKeys().Single();
 
             Assert.Equal("V2.Annotation", foreignKey["Annotation"]);
             Assert.Equal("V2.Metadata", foreignKey["Metadata"]);
@@ -409,7 +409,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.IsType<ReferenceReferenceBuilder<Avatar, Gunter>>(returnedBuilder);
 
             var model = builder.Model;
-            var foreignKey = model.GetEntityType(typeof(Avatar)).ForeignKeys.Single();
+            var foreignKey = model.GetEntityType(typeof(Avatar)).GetForeignKeys().Single();
 
             Assert.Equal("V2.Annotation", foreignKey["Annotation"]);
             Assert.Equal("V2.Metadata", foreignKey["Metadata"]);

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/ForeignKeyPropertyDiscoveryConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/ForeignKeyPropertyDiscoveryConventionTest.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             Assert.Same(relationshipBuilder, new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder));
 
             var fk = (IForeignKey)relationshipBuilder.Metadata;
-            Assert.Same(fk, DependentType.Metadata.ForeignKeys.Single());
+            Assert.Same(fk, DependentType.Metadata.GetForeignKeys().Single());
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(PrimaryKey, fk.PrincipalKey.Properties.Single());
             Assert.False(fk.IsUnique);
@@ -70,7 +70,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             Assert.Same(relationshipBuilder, new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder));
 
             var fk = (IForeignKey)relationshipBuilder.Metadata;
-            Assert.Same(fk, DependentTypeWithCompositeKey.Metadata.ForeignKeys.Single());
+            Assert.Same(fk, DependentTypeWithCompositeKey.Metadata.GetForeignKeys().Single());
             Assert.Same(fkProperty1.Metadata, fk.Properties[0]);
             Assert.Same(fkProperty2.Metadata, fk.Properties[1]);
             Assert.Same(CompositePrimaryKey[0], fk.PrincipalKey.Properties[0]);
@@ -95,7 +95,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             Assert.Same(relationshipBuilder, new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder));
 
             var fk = (IForeignKey)relationshipBuilder.Metadata;
-            Assert.Same(fk, DependentType.Metadata.ForeignKeys.Single());
+            Assert.Same(fk, DependentType.Metadata.GetForeignKeys().Single());
             Assert.Equal("SomeNav" + PrimaryKey.Name, fk.Properties.Single().Name);
             Assert.False(fk.IsUnique);
             Assert.False(fk.IsRequired);
@@ -124,7 +124,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             var newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder);
             Assert.NotSame(relationshipBuilder, newRelationshipBuilder);
 
-            var fk = (IForeignKey)DependentType.Metadata.ForeignKeys.Single();
+            var fk = (IForeignKey)DependentType.Metadata.GetForeignKeys().Single();
             Assert.Same(fk, newRelationshipBuilder.Metadata);
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(PrimaryKey, fk.PrincipalKey.Properties.Single());
@@ -157,7 +157,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             var newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder);
             Assert.NotSame(relationshipBuilder, newRelationshipBuilder);
 
-            var fk = (IForeignKey)DependentTypeWithCompositeKey.Metadata.ForeignKeys.Single();
+            var fk = (IForeignKey)DependentTypeWithCompositeKey.Metadata.GetForeignKeys().Single();
             Assert.Same(fk, newRelationshipBuilder.Metadata);
             Assert.Same(fkProperty1.Metadata, fk.Properties[0]);
             Assert.Same(fkProperty2.Metadata, fk.Properties[1]);
@@ -189,7 +189,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             var newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder);
             Assert.NotSame(relationshipBuilder, newRelationshipBuilder);
 
-            var fk = (IForeignKey)DependentType.Metadata.ForeignKeys.Single();
+            var fk = (IForeignKey)DependentType.Metadata.GetForeignKeys().Single();
             Assert.Same(fk, newRelationshipBuilder.Metadata);
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(PrimaryKey, fk.PrincipalKey.Properties.Single());
@@ -217,7 +217,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             var newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder);
             Assert.NotSame(relationshipBuilder, newRelationshipBuilder);
 
-            var fk = (IForeignKey)DependentType.Metadata.ForeignKeys.Single();
+            var fk = (IForeignKey)DependentType.Metadata.GetForeignKeys().Single();
             Assert.Same(fk, newRelationshipBuilder.Metadata);
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(PrimaryKey, fk.PrincipalKey.Properties.Single());
@@ -244,7 +244,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             var newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder);
             Assert.NotSame(relationshipBuilder, newRelationshipBuilder);
 
-            var fk = (IForeignKey)DependentType.Metadata.ForeignKeys.Single();
+            var fk = (IForeignKey)DependentType.Metadata.GetForeignKeys().Single();
             Assert.Same(fk, newRelationshipBuilder.Metadata);
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(PrimaryKey, fk.PrincipalKey.Properties.Single());
@@ -274,7 +274,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             var newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder);
             Assert.NotSame(relationshipBuilder, newRelationshipBuilder);
 
-            var fk = (IForeignKey)DependentTypeWithCompositeKey.Metadata.ForeignKeys.Single();
+            var fk = (IForeignKey)DependentTypeWithCompositeKey.Metadata.GetForeignKeys().Single();
             Assert.Same(fk, newRelationshipBuilder.Metadata);
             Assert.Same(fkProperty1.Metadata, fk.Properties[0]);
             Assert.Same(fkProperty2.Metadata, fk.Properties[1]);
@@ -303,7 +303,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             var newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder);
             Assert.NotSame(relationshipBuilder, newRelationshipBuilder);
 
-            var fk = (IForeignKey)DependentType.Metadata.ForeignKeys.Single();
+            var fk = (IForeignKey)DependentType.Metadata.GetForeignKeys().Single();
             Assert.Same(fk, newRelationshipBuilder.Metadata);
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(PrimaryKey, fk.PrincipalKey.Properties.Single());
@@ -329,7 +329,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             var newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder);
             Assert.NotSame(relationshipBuilder, newRelationshipBuilder);
 
-            var fk = (IForeignKey)DependentType.Metadata.ForeignKeys.Single();
+            var fk = (IForeignKey)DependentType.Metadata.GetForeignKeys().Single();
             Assert.Same(fk, newRelationshipBuilder.Metadata);
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(PrimaryKey, fk.PrincipalKey.Properties.Single());
@@ -357,7 +357,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             var newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder);
             Assert.NotSame(relationshipBuilder, newRelationshipBuilder);
 
-            var fk = (IForeignKey)DependentTypeWithCompositeKey.Metadata.ForeignKeys.Single();
+            var fk = (IForeignKey)DependentTypeWithCompositeKey.Metadata.GetForeignKeys().Single();
             Assert.Same(fk, newRelationshipBuilder.Metadata);
             Assert.Same(fkProperty1.Metadata, fk.Properties[0]);
             Assert.Same(fkProperty2.Metadata, fk.Properties[1]);
@@ -385,7 +385,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             var newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder);
             Assert.NotSame(relationshipBuilder, newRelationshipBuilder);
 
-            var fk = (IForeignKey)DependentType.Metadata.ForeignKeys.Single();
+            var fk = (IForeignKey)DependentType.Metadata.GetForeignKeys().Single();
             Assert.Same(fk, newRelationshipBuilder.Metadata);
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(PrimaryKey, fk.PrincipalKey.Properties.Single());
@@ -411,7 +411,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             Assert.Same(relationshipBuilder, new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder));
 
             var fk = (IForeignKey)relationshipBuilder.Metadata;
-            Assert.Same(fk, DependentType.Metadata.ForeignKeys.Single());
+            Assert.Same(fk, DependentType.Metadata.GetForeignKeys().Single());
             Assert.Equal(PrincipalType.Metadata.DisplayName() + PrimaryKey.Name, fk.Properties.Single().Name);
             Assert.False(fk.IsUnique);
             Assert.False(fk.IsRequired);
@@ -459,7 +459,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             Assert.Same(relationshipBuilder, new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder));
 
             var fk = (IForeignKey)relationshipBuilder.Metadata;
-            Assert.Same(fk, PrincipalType.Metadata.ForeignKeys.Single());
+            Assert.Same(fk, PrincipalType.Metadata.GetForeignKeys().Single());
             Assert.Equal(PrincipalType.Metadata.DisplayName() + PrimaryKey.Name, fk.Properties.Single().Name);
             Assert.True(fk.IsUnique);
             Assert.False(fk.IsRequired);
@@ -484,7 +484,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             var newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder);
             Assert.NotSame(relationshipBuilder, newRelationshipBuilder);
 
-            var fk = (IForeignKey)DependentTypeWithCompositeKey.Metadata.ForeignKeys.Single();
+            var fk = (IForeignKey)DependentTypeWithCompositeKey.Metadata.GetForeignKeys().Single();
             Assert.Same(fk, newRelationshipBuilder.Metadata);
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
@@ -513,7 +513,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             Assert.Same(relationshipBuilder, new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder));
 
             var fk = (IForeignKey)relationshipBuilder.Metadata;
-            Assert.Same(fk, DependentTypeWithCompositeKey.Metadata.ForeignKeys.Single());
+            Assert.Same(fk, DependentTypeWithCompositeKey.Metadata.GetForeignKeys().Single());
             Assert.Equal("NavProp" + CompositePrimaryKey[0].Name + "1", fk.Properties[0].Name);
             Assert.Equal("NavProp" + CompositePrimaryKey[1].Name + "1", fk.Properties[1].Name);
             Assert.Same(CompositePrimaryKey[0], fk.PrincipalKey.Properties[0]);
@@ -541,7 +541,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             Assert.Same(relationshipBuilder, new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder));
 
             var fk = (IForeignKey)relationshipBuilder.Metadata;
-            Assert.Same(fk, DependentTypeWithCompositeKey.Metadata.ForeignKeys.Single());
+            Assert.Same(fk, DependentTypeWithCompositeKey.Metadata.GetForeignKeys().Single());
             Assert.Equal("NavProp" + CompositePrimaryKey[0].Name, fk.Properties[0].Name);
             Assert.Equal("NavProp" + CompositePrimaryKey[1].Name, fk.Properties[1].Name);
             Assert.Same(CompositePrimaryKey[0], fk.PrincipalKey.Properties[0]);
@@ -569,7 +569,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             Assert.Same(relationshipBuilder, new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder));
 
             var fk = (IForeignKey)relationshipBuilder.Metadata;
-            Assert.Same(fk, DependentTypeWithCompositeKey.Metadata.ForeignKeys.Single());
+            Assert.Same(fk, DependentTypeWithCompositeKey.Metadata.GetForeignKeys().Single());
             Assert.Equal(2, fk.Properties.Count);
             Assert.NotSame(fkProperty1, fk.Properties[0]);
             Assert.NotSame(fkProperty1, fk.Properties[1]);
@@ -599,7 +599,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             Assert.Same(relationshipBuilder, new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder));
 
             var fk = (IForeignKey)relationshipBuilder.Metadata;
-            Assert.Same(fk, DependentTypeWithCompositeKey.Metadata.ForeignKeys.Single());
+            Assert.Same(fk, DependentTypeWithCompositeKey.Metadata.GetForeignKeys().Single());
             Assert.Equal(2, fk.Properties.Count);
             Assert.NotSame(fkProperty1, fk.Properties[0]);
             Assert.NotSame(fkProperty2, fk.Properties[1]);
@@ -631,7 +631,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             Assert.Same(relationshipBuilder, new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder));
 
             var fk = (IForeignKey)relationshipBuilder.Metadata;
-            Assert.Same(fk, DependentTypeWithCompositeKey.Metadata.ForeignKeys.Single());
+            Assert.Same(fk, DependentTypeWithCompositeKey.Metadata.GetForeignKeys().Single());
             Assert.Same(CompositePrimaryKey[0], fk.PrincipalKey.Properties[0]);
             Assert.Same(CompositePrimaryKey[1], fk.PrincipalKey.Properties[1]);
             Assert.False(fk.IsUnique);
@@ -674,7 +674,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             Assert.Same(relationshipBuilder, new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder));
 
             var newFk = (IForeignKey)relationshipBuilder.Metadata;
-            Assert.Equal(2, DependentType.Metadata.ForeignKeys.Count);
+            Assert.Equal(2, DependentType.Metadata.GetForeignKeys().Count());
             Assert.NotEqual(fkProperty.Name, newFk.Properties.Single().Name);
             Assert.False(newFk.IsUnique);
             Assert.False(newFk.IsRequired);
@@ -701,7 +701,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
 
             newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(newRelationshipBuilder);
 
-            var fk = (IForeignKey)DependentType.Metadata.ForeignKeys.Single();
+            var fk = (IForeignKey)DependentType.Metadata.GetForeignKeys().Single();
             Assert.Same(fk, newRelationshipBuilder.Metadata);
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(PrimaryKey, fk.PrincipalKey.Properties.Single());
@@ -730,7 +730,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
 
             newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(newRelationshipBuilder);
 
-            var fk = (IForeignKey)DependentType.Metadata.ForeignKeys.Single();
+            var fk = (IForeignKey)DependentType.Metadata.GetForeignKeys().Single();
             Assert.Same(fk, newRelationshipBuilder.Metadata);
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(PrimaryKey, fk.PrincipalKey.Properties.Single());
@@ -789,13 +789,13 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
 
             newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(newRelationshipBuilder);
 
-            var fk = (IForeignKey)PrincipalType.Metadata.ForeignKeys.Single();
+            var fk = (IForeignKey)PrincipalType.Metadata.GetForeignKeys().Single();
             Assert.Same(fk, newRelationshipBuilder.Metadata);
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(DependentType.Metadata.GetPrimaryKey(), fk.PrincipalKey);
             Assert.True(fk.IsUnique);
             Assert.False(fk.IsRequired);
-            Assert.Empty(DependentType.Metadata.ForeignKeys);
+            Assert.Empty(DependentType.Metadata.GetForeignKeys());
         }
 
         [Fact]
@@ -817,12 +817,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
 
             newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(newRelationshipBuilder);
 
-            var fk = (IForeignKey)DependentType.Metadata.ForeignKeys.Single();
+            var fk = (IForeignKey)DependentType.Metadata.GetForeignKeys().Single();
             Assert.Same(fk, newRelationshipBuilder.Metadata);
             Assert.Same(PrimaryKey, fk.PrincipalKey.Properties.Single());
             Assert.True(fk.IsUnique);
             Assert.True(fk.IsRequired);
-            Assert.Empty(PrincipalType.Metadata.ForeignKeys);
+            Assert.Empty(PrincipalType.Metadata.GetForeignKeys());
         }
 
         [Fact]
@@ -844,12 +844,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
 
             newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(newRelationshipBuilder);
 
-            var fk = (IForeignKey)DependentType.Metadata.ForeignKeys.Single();
+            var fk = (IForeignKey)DependentType.Metadata.GetForeignKeys().Single();
             Assert.Same(fk, newRelationshipBuilder.Metadata);
             Assert.Same(PrimaryKey, fk.PrincipalKey.Properties.Single());
             Assert.True(fk.IsUnique);
             Assert.True(fk.IsRequired);
-            Assert.Empty(PrincipalType.Metadata.ForeignKeys);
+            Assert.Empty(PrincipalType.Metadata.GetForeignKeys());
         }
 
         [Fact]
@@ -871,12 +871,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
 
             newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(newRelationshipBuilder);
 
-            var fk = (IForeignKey)PrincipalType.Metadata.ForeignKeys.Single();
+            var fk = (IForeignKey)PrincipalType.Metadata.GetForeignKeys().Single();
             Assert.Same(fk, newRelationshipBuilder.Metadata);
             Assert.Same(DependentType.Metadata.GetPrimaryKey(), fk.PrincipalKey);
             Assert.True(fk.IsUnique);
             Assert.True(fk.IsRequired);
-            Assert.Empty(DependentType.Metadata.ForeignKeys);
+            Assert.Empty(DependentType.Metadata.GetForeignKeys());
         }
 
         [Fact]
@@ -905,7 +905,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             Assert.Same(PrimaryKey, fk.PrincipalKey.Properties.Single());
             Assert.True(fk.IsUnique);
             Assert.True(fk.IsRequired);
-            Assert.Empty(PrincipalType.Metadata.ForeignKeys);
+            Assert.Empty(PrincipalType.Metadata.GetForeignKeys());
         }
 
         [Fact]

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/RelationshipDiscoveryConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/RelationshipDiscoveryConventionTest.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
 
             Assert.Empty(entityBuilder.Metadata.Properties);
-            Assert.Empty(entityBuilder.Metadata.ForeignKeys);
+            Assert.Empty(entityBuilder.Metadata.GetForeignKeys());
             Assert.Empty(entityBuilder.Metadata.Navigations);
             Assert.Equal(entityBuilder.Metadata.ClrType, entityBuilder.Metadata.Model.EntityTypes.Single().ClrType);
         }
@@ -57,7 +57,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
 
             Assert.Empty(entityBuilder.Metadata.Properties);
-            Assert.Empty(entityBuilder.Metadata.ForeignKeys);
+            Assert.Empty(entityBuilder.Metadata.GetForeignKeys());
             Assert.Empty(entityBuilder.Metadata.Navigations);
             Assert.Equal(entityBuilder.Metadata.ClrType, entityBuilder.Metadata.Model.EntityTypes.Single().ClrType);
         }
@@ -96,7 +96,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
 
             Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
             var entityType = entityBuilder.Metadata;
-            var fk = entityType.ForeignKeys.Single();
+            var fk = entityType.GetForeignKeys().Single();
             Assert.Null(fk.IsRequired);
             Assert.False(((IForeignKey)fk).IsUnique);
 
@@ -105,7 +105,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
 
             Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
 
-            var newFk = (IForeignKey)entityType.ForeignKeys.Single();
+            var newFk = (IForeignKey)entityType.GetForeignKeys().Single();
             Assert.True(newFk.IsRequired);
             Assert.True(newFk.IsUnique);
         }
@@ -117,7 +117,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
 
             Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
 
-            Assert.Empty(entityBuilder.Metadata.ForeignKeys);
+            Assert.Empty(entityBuilder.Metadata.GetForeignKeys());
             Assert.Empty(entityBuilder.Metadata.Navigations);
             Assert.Empty(entityBuilder.Metadata.Properties);
         }
@@ -150,7 +150,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
 
             Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
 
-            Assert.Empty(entityBuilder.Metadata.ForeignKeys);
+            Assert.Empty(entityBuilder.Metadata.GetForeignKeys());
             Assert.Empty(entityBuilder.Metadata.Navigations);
             // TODO: remove discovered entity types if no relationship discovered
             Assert.Equal(2, entityBuilder.Metadata.Model.EntityTypes.Count);
@@ -164,7 +164,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
 
             Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
             
-            Assert.Empty(entityBuilder.Metadata.ForeignKeys);
+            Assert.Empty(entityBuilder.Metadata.GetForeignKeys());
             Assert.Empty(entityBuilder.Metadata.Navigations);
             // TODO: remove discovered entity types if no relationship discovered
             Assert.Equal(2, entityBuilder.Metadata.Model.EntityTypes.Count);
@@ -178,7 +178,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
 
             Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
             
-            Assert.Empty(entityBuilder.Metadata.ForeignKeys);
+            Assert.Empty(entityBuilder.Metadata.GetForeignKeys());
             Assert.Empty(entityBuilder.Metadata.Navigations);
             // TODO: remove discovered entity types if no relationship discovered
             Assert.Equal(2, entityBuilder.Metadata.Model.EntityTypes.Count);
@@ -221,7 +221,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
 
             Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
 
-            Assert.Empty(entityBuilder.Metadata.ForeignKeys);
+            Assert.Empty(entityBuilder.Metadata.GetForeignKeys());
             Assert.Empty(entityBuilder.Metadata.Navigations);
             Assert.Empty(entityBuilder.Metadata.Properties);
         }

--- a/test/EntityFramework.Core.Tests/Metadata/NonGenericRelationshipBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/NonGenericRelationshipBuilderTest.cs
@@ -28,28 +28,28 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = model.GetEntityType(typeof(Order));
             var principalType = model.GetEntityType(typeof(Customer));
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
 
             var navToPrincipal = dependentType.AddNavigation("Customer", fk, true);
             var navToDependent = principalType.AddNavigation("Orders", fk, false);
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity(typeof(Customer)).Collection(typeof(Order), "Orders").InverseReference("Customer");
 
-            Assert.Same(fk, dependentType.ForeignKeys.Single());
+            Assert.Same(fk, dependentType.GetForeignKeys().Single());
             Assert.Same(navToPrincipal, dependentType.Navigations.Single());
             Assert.Same(navToDependent, principalType.Navigations.Single());
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -66,27 +66,27 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = model.GetEntityType(typeof(Order));
             var principalType = model.GetEntityType(typeof(Customer));
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
 
             var navigation = dependentType.AddNavigation("Customer", fk, true);
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity(typeof(Customer)).Collection(typeof(Order), "Orders").InverseReference("Customer");
 
-            Assert.Same(fk, dependentType.ForeignKeys.Single());
+            Assert.Same(fk, dependentType.GetForeignKeys().Single());
             Assert.Same(navigation, dependentType.Navigations.Single());
             Assert.Equal("Orders", principalType.Navigations.Single().Name);
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -103,27 +103,27 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = model.GetEntityType(typeof(Order));
             var principalType = model.GetEntityType(typeof(Customer));
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
 
             var navigation = principalType.AddNavigation("Orders", fk, false);
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity(typeof(Customer)).Collection(typeof(Order), "Orders").InverseReference("Customer");
 
-            Assert.Same(fk, dependentType.ForeignKeys.Single());
+            Assert.Same(fk, dependentType.GetForeignKeys().Single());
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
             Assert.Same(navigation, principalType.Navigations.Single());
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -140,25 +140,25 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = model.GetEntityType(typeof(Order));
             var principalType = model.GetEntityType(typeof(Customer));
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity(typeof(Customer)).Collection(typeof(Order), "Orders").InverseReference("Customer");
 
-            Assert.Same(fk, dependentType.ForeignKeys.Single());
+            Assert.Same(fk, dependentType.GetForeignKeys().Single());
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
             Assert.Equal("Orders", principalType.Navigations.Single().Name);
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -178,12 +178,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity(typeof(Customer)).Collection(typeof(Order), "Orders").InverseReference("Customer");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -192,9 +192,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -214,12 +214,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity(typeof(Customer)).Collection(typeof(Order), "Orders").InverseReference(null);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Empty(dependentType.Navigations);
@@ -227,9 +227,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -249,13 +249,13 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             // Passing null as the first arg is not super-compelling, but it is consistent
             modelBuilder.Entity(typeof(Customer)).Collection(typeof(Order), null).InverseReference("Customer");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -263,9 +263,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -285,21 +285,21 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity(typeof(Customer)).Collection(typeof(Order), null).InverseReference(null);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Empty(dependentType.Navigations);
             Assert.Empty(principalType.Navigations);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -319,14 +319,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Customer)).Collection(typeof(Order), "Orders").InverseReference("Customer")
                 .ForeignKey("CustomerId");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -335,9 +335,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -354,27 +354,27 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = model.GetEntityType(typeof(Pickle));
             var principalType = model.GetEntityType(typeof(BigMak));
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(BigMak)).Collection(typeof(Pickle), "Pickles").InverseReference("BigMak")
                 .ForeignKey("BurgerId");
 
-            Assert.Same(fk, dependentType.ForeignKeys.Single());
+            Assert.Same(fk, dependentType.GetForeignKeys().Single());
             Assert.Equal("BigMak", dependentType.Navigations.Single().Name);
             Assert.Equal("Pickles", principalType.Navigations.Single().Name);
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -394,14 +394,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(BigMak)).Collection(typeof(Pickle), "Pickles").InverseReference("BigMak")
                 .ForeignKey("BurgerId");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("BigMak", dependentType.Navigations.Single().Name);
@@ -410,9 +410,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -432,14 +432,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(BigMak)).Collection(typeof(Pickle), "Pickles").InverseReference(null)
                 .ForeignKey("BurgerId");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Empty(dependentType.Navigations);
@@ -447,9 +447,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -469,14 +469,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(BigMak)).Collection(typeof(Pickle), null).InverseReference("BigMak")
                 .ForeignKey("BurgerId");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("BigMak", dependentType.Navigations.Single().Name);
@@ -484,9 +484,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -506,23 +506,23 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(BigMak)).Collection(typeof(Pickle), null).InverseReference(null)
                 .ForeignKey("BurgerId");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Empty(dependentType.Navigations);
             Assert.Empty(principalType.Navigations);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -540,12 +540,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity(typeof(BigMak)).Collection(typeof(Pickle), "Pickles").InverseReference("BigMak");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             var fkProperty = fk.Properties.Single();
 
             Assert.Equal("BigMakId", fkProperty.Name);
@@ -559,9 +559,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount + 1, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -579,12 +579,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity(typeof(BigMak)).Collection(typeof(Pickle), "Pickles").InverseReference(null);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             var fkProperty = fk.Properties.Single();
 
             Assert.Equal("BigMakId", fkProperty.Name);
@@ -597,9 +597,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount + 1, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -617,12 +617,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity(typeof(BigMak)).Collection(typeof(Pickle), null).InverseReference("BigMak");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             var fkProperty = fk.Properties.Single();
 
             Assert.Equal("BigMakId", fkProperty.Name);
@@ -635,9 +635,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount + 1, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -655,12 +655,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity(typeof(BigMak)).Collection(typeof(Pickle), null).InverseReference(null);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             var fkProperty = fk.Properties.Single();
 
             Assert.Equal("BigMakId", fkProperty.Name);
@@ -672,9 +672,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Empty(principalType.Navigations);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount + 1, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -692,14 +692,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             var fkProperty = dependentType.GetProperty("BigMakId");
 
             modelBuilder.Entity(typeof(BigMak)).Collection(typeof(Pickle), "Pickles").InverseReference("BigMak");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("BigMak", dependentType.Navigations.Single().Name);
@@ -708,9 +708,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -731,7 +731,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.GetProperties().Count();
-            var principalKey = principalType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
             var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
@@ -750,8 +750,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(newFk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount + 1, dependentType.GetProperties().Count());
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
             Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
@@ -773,14 +773,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Customer)).Collection(typeof(Order), "Orders").InverseReference("Customer")
                 .PrincipalKey("Id");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(principalProperty, fk.PrincipalKey.Properties.Single());
 
@@ -790,9 +790,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -817,14 +817,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Customer)).Collection(typeof(Order), "Orders").InverseReference("Customer")
                 .PrincipalKey("AlternateKey");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(principalProperty, fk.PrincipalKey.Properties.Single());
 
@@ -834,14 +834,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.Contains(principalKey, principalType.Keys);
-            Assert.Contains(fk.PrincipalKey, principalType.Keys);
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.Contains(principalKey, principalType.GetKeys());
+            Assert.Contains(fk.PrincipalKey, principalType.GetKeys());
             Assert.NotSame(principalKey, fk.PrincipalKey);
 
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -866,15 +866,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Customer)).Collection(typeof(Order), "Orders").InverseReference("Customer")
                 .ForeignKey("CustomerId")
                 .PrincipalKey("Id");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(principalProperty, fk.PrincipalKey.Properties.Single());
 
@@ -884,9 +884,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -911,15 +911,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Customer)).Collection(typeof(Order), "Orders").InverseReference("Customer")
                 .PrincipalKey("Id")
                 .ForeignKey("CustomerId");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(principalProperty, fk.PrincipalKey.Properties.Single());
 
@@ -929,9 +929,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -956,15 +956,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Customer)).Collection(typeof(Order), "Orders").InverseReference("Customer")
                 .ForeignKey("CustomerId")
                 .PrincipalKey("AlternateKey");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(principalProperty, fk.PrincipalKey.Properties.Single());
 
@@ -974,14 +974,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.Contains(principalKey, principalType.Keys);
-            Assert.Contains(fk.PrincipalKey, principalType.Keys);
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.Contains(principalKey, principalType.GetKeys());
+            Assert.Contains(fk.PrincipalKey, principalType.GetKeys());
             Assert.NotSame(principalKey, fk.PrincipalKey);
 
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1006,15 +1006,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Customer)).Collection(typeof(Order), "Orders").InverseReference("Customer")
                 .PrincipalKey("AlternateKey")
                 .ForeignKey("CustomerId");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(principalProperty, fk.PrincipalKey.Properties.Single());
 
@@ -1024,14 +1024,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.Contains(principalKey, principalType.Keys);
-            Assert.Contains(fk.PrincipalKey, principalType.Keys);
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.Contains(principalKey, principalType.GetKeys());
+            Assert.Contains(fk.PrincipalKey, principalType.GetKeys());
             Assert.NotSame(principalKey, fk.PrincipalKey);
 
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1056,15 +1056,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(BigMak)).Collection(typeof(Pickle), "Pickles").InverseReference("BigMak")
                 .ForeignKey("BurgerId")
                 .PrincipalKey("AlternateKey");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(principalProperty, fk.PrincipalKey.Properties.Single());
 
@@ -1074,14 +1074,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.Contains(principalKey, principalType.Keys);
-            Assert.Contains(fk.PrincipalKey, principalType.Keys);
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.Contains(principalKey, principalType.GetKeys());
+            Assert.Contains(fk.PrincipalKey, principalType.GetKeys());
             Assert.NotSame(principalKey, fk.PrincipalKey);
 
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1106,15 +1106,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(BigMak)).Collection(typeof(Pickle), "Pickles").InverseReference("BigMak")
                 .PrincipalKey("AlternateKey")
                 .ForeignKey("BurgerId");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(principalProperty, fk.PrincipalKey.Properties.Single());
 
@@ -1124,14 +1124,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.Contains(principalKey, principalType.Keys);
-            Assert.Contains(fk.PrincipalKey, principalType.Keys);
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.Contains(principalKey, principalType.GetKeys());
+            Assert.Contains(fk.PrincipalKey, principalType.GetKeys());
             Assert.NotSame(principalKey, fk.PrincipalKey);
 
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1148,28 +1148,28 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = model.GetEntityType(typeof(Order));
             var principalType = model.GetEntityType(typeof(Customer));
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
 
             var navToPrincipal = dependentType.AddNavigation("Customer", fk, true);
             var navToDependent = principalType.AddNavigation("Orders", fk, false);
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity(typeof(Order)).Reference(typeof(Customer), "Customer").InverseCollection("Orders");
 
-            Assert.Same(fk, dependentType.ForeignKeys.Single());
+            Assert.Same(fk, dependentType.GetForeignKeys().Single());
             Assert.Same(navToPrincipal, dependentType.Navigations.Single());
             Assert.Same(navToDependent, principalType.Navigations.Single());
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1186,27 +1186,27 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = model.GetEntityType(typeof(Order));
             var principalType = model.GetEntityType(typeof(Customer));
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
 
             var navigation = dependentType.AddNavigation("Customer", fk, true);
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity(typeof(Order)).Reference(typeof(Customer), "Customer").InverseCollection("Orders");
 
-            Assert.Same(fk, dependentType.ForeignKeys.Single());
+            Assert.Same(fk, dependentType.GetForeignKeys().Single());
             Assert.Same(navigation, dependentType.Navigations.Single());
             Assert.Equal("Orders", principalType.Navigations.Single().Name);
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1223,27 +1223,27 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = model.GetEntityType(typeof(Order));
             var principalType = model.GetEntityType(typeof(Customer));
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
 
             var navigation = principalType.AddNavigation("Orders", fk, false);
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity(typeof(Order)).Reference(typeof(Customer), "Customer").InverseCollection("Orders");
 
-            Assert.Same(fk, dependentType.ForeignKeys.Single());
+            Assert.Same(fk, dependentType.GetForeignKeys().Single());
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
             Assert.Same(navigation, principalType.Navigations.Single());
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1260,25 +1260,25 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = model.GetEntityType(typeof(Order));
             var principalType = model.GetEntityType(typeof(Customer));
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity(typeof(Order)).Reference(typeof(Customer), "Customer").InverseCollection("Orders");
 
-            Assert.Same(fk, dependentType.ForeignKeys.Single());
+            Assert.Same(fk, dependentType.GetForeignKeys().Single());
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
             Assert.Equal("Orders", principalType.Navigations.Single().Name);
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1298,12 +1298,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity(typeof(Order)).Reference(typeof(Customer), "Customer").InverseCollection("Orders");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -1312,9 +1312,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1334,13 +1334,13 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             // Passing null as the first arg is not super-compelling, but it is consistent
             modelBuilder.Entity(typeof(Order)).Reference(typeof(Customer), null).InverseCollection("Orders");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Empty(dependentType.Navigations);
@@ -1348,9 +1348,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1370,12 +1370,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity(typeof(Order)).Reference(typeof(Customer), "Customer").InverseCollection(null);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -1383,9 +1383,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1405,21 +1405,21 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity(typeof(Order)).Reference(typeof(Customer), null).InverseCollection(null);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Empty(dependentType.Navigations);
             Assert.Empty(principalType.Navigations);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1439,14 +1439,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Order)).Reference(typeof(Customer), "Customer").InverseCollection("Orders")
                 .ForeignKey("CustomerId");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -1455,9 +1455,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1474,27 +1474,27 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = model.GetEntityType(typeof(Pickle));
             var principalType = model.GetEntityType(typeof(BigMak));
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Pickle)).Reference(typeof(BigMak), "BigMak").InverseCollection("Pickles")
                 .ForeignKey("BurgerId");
 
-            Assert.Same(fk, dependentType.ForeignKeys.Single());
+            Assert.Same(fk, dependentType.GetForeignKeys().Single());
             Assert.Equal("BigMak", dependentType.Navigations.Single().Name);
             Assert.Equal("Pickles", principalType.Navigations.Single().Name);
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1514,14 +1514,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Pickle)).Reference(typeof(BigMak), "BigMak").InverseCollection("Pickles")
                 .ForeignKey("BurgerId");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("BigMak", dependentType.Navigations.Single().Name);
@@ -1530,9 +1530,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1552,14 +1552,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Pickle)).Reference(typeof(BigMak), null).InverseCollection("Pickles")
                 .ForeignKey("BurgerId");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Empty(dependentType.Navigations);
@@ -1567,9 +1567,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1589,14 +1589,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Pickle)).Reference(typeof(BigMak), "BigMak").InverseCollection(null)
                 .ForeignKey("BurgerId");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("BigMak", dependentType.Navigations.Single().Name);
@@ -1604,9 +1604,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1626,23 +1626,23 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Pickle)).Reference(typeof(BigMak), null).InverseCollection(null)
                 .ForeignKey("BurgerId");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Empty(dependentType.Navigations);
             Assert.Empty(principalType.Navigations);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1660,12 +1660,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity(typeof(Pickle)).Reference(typeof(BigMak), "BigMak").InverseCollection("Pickles");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             var fkProperty = fk.Properties.Single();
 
             Assert.Equal("BigMakId", fkProperty.Name);
@@ -1679,9 +1679,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount + 1, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1699,12 +1699,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity(typeof(Pickle)).Reference(typeof(BigMak), null).InverseCollection("Pickles");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             var fkProperty = fk.Properties.Single();
 
             Assert.Equal("BigMakId", fkProperty.Name);
@@ -1717,9 +1717,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount + 1, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1737,12 +1737,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity(typeof(Pickle)).Reference(typeof(BigMak), "BigMak").InverseCollection(null);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             var fkProperty = fk.Properties.Single();
 
             Assert.Equal("BigMakId", fkProperty.Name);
@@ -1755,9 +1755,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount + 1, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1775,12 +1775,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity(typeof(Pickle)).Reference(typeof(BigMak), null).InverseCollection(null);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             var fkProperty = fk.Properties.Single();
 
             Assert.Equal("BigMakId", fkProperty.Name);
@@ -1792,9 +1792,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Empty(principalType.Navigations);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount + 1, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1812,14 +1812,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             var fkProperty = dependentType.GetProperty("BigMakId");
 
             modelBuilder.Entity(typeof(Pickle)).Reference(typeof(BigMak), "BigMak").InverseCollection("Pickles");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("BigMak", dependentType.Navigations.Single().Name);
@@ -1828,9 +1828,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1851,7 +1851,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.GetProperties().Count();
-            var principalKey = principalType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
             var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
@@ -1870,8 +1870,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(newFk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount + 1, dependentType.GetProperties().Count());
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
             Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
@@ -1893,14 +1893,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Order)).Reference(typeof(Customer), "Customer").InverseCollection("Orders")
                 .PrincipalKey("Id");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(principalProperty, fk.PrincipalKey.Properties.Single());
 
@@ -1910,9 +1910,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1937,14 +1937,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Order)).Reference(typeof(Customer), "Customer").InverseCollection("Orders")
                 .PrincipalKey("AlternateKey");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(principalProperty, fk.PrincipalKey.Properties.Single());
 
@@ -1954,14 +1954,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.Contains(principalKey, principalType.Keys);
-            Assert.Contains(fk.PrincipalKey, principalType.Keys);
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.Contains(principalKey, principalType.GetKeys());
+            Assert.Contains(fk.PrincipalKey, principalType.GetKeys());
             Assert.NotSame(principalKey, fk.PrincipalKey);
 
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1986,15 +1986,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Order)).Reference(typeof(Customer), "Customer").InverseCollection("Orders")
                 .ForeignKey("CustomerId")
                 .PrincipalKey("Id");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(principalProperty, fk.PrincipalKey.Properties.Single());
 
@@ -2004,9 +2004,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2031,15 +2031,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Order)).Reference(typeof(Customer), "Customer").InverseCollection("Orders")
                 .PrincipalKey("Id")
                 .ForeignKey("CustomerId");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(principalProperty, fk.PrincipalKey.Properties.Single());
 
@@ -2049,9 +2049,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2076,15 +2076,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Order)).Reference(typeof(Customer), "Customer").InverseCollection("Orders")
                 .ForeignKey("CustomerId")
                 .PrincipalKey("AlternateKey");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(principalProperty, fk.PrincipalKey.Properties.Single());
 
@@ -2094,14 +2094,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.Contains(principalKey, principalType.Keys);
-            Assert.Contains(fk.PrincipalKey, principalType.Keys);
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.Contains(principalKey, principalType.GetKeys());
+            Assert.Contains(fk.PrincipalKey, principalType.GetKeys());
             Assert.NotSame(principalKey, fk.PrincipalKey);
 
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2126,15 +2126,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Order)).Reference(typeof(Customer), "Customer").InverseCollection("Orders")
                 .PrincipalKey("AlternateKey")
                 .ForeignKey("CustomerId");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(principalProperty, fk.PrincipalKey.Properties.Single());
 
@@ -2144,14 +2144,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.Contains(principalKey, principalType.Keys);
-            Assert.Contains(fk.PrincipalKey, principalType.Keys);
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.Contains(principalKey, principalType.GetKeys());
+            Assert.Contains(fk.PrincipalKey, principalType.GetKeys());
             Assert.NotSame(principalKey, fk.PrincipalKey);
 
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2176,15 +2176,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Pickle)).Reference(typeof(BigMak), "BigMak").InverseCollection("Pickles")
                 .ForeignKey("BurgerId")
                 .PrincipalKey("AlternateKey");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(principalProperty, fk.PrincipalKey.Properties.Single());
 
@@ -2194,14 +2194,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.Contains(principalKey, principalType.Keys);
-            Assert.Contains(fk.PrincipalKey, principalType.Keys);
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.Contains(principalKey, principalType.GetKeys());
+            Assert.Contains(fk.PrincipalKey, principalType.GetKeys());
             Assert.NotSame(principalKey, fk.PrincipalKey);
 
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2226,15 +2226,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Pickle)).Reference(typeof(BigMak), "BigMak").InverseCollection("Pickles")
                 .PrincipalKey("AlternateKey")
                 .ForeignKey("BurgerId");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(principalProperty, fk.PrincipalKey.Properties.Single());
 
@@ -2244,14 +2244,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.Contains(principalKey, principalType.Keys);
-            Assert.Contains(fk.PrincipalKey, principalType.Keys);
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.Contains(principalKey, principalType.GetKeys());
+            Assert.Contains(fk.PrincipalKey, principalType.GetKeys());
             Assert.NotSame(principalKey, fk.PrincipalKey);
 
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2268,7 +2268,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = model.GetEntityType(typeof(CustomerDetails));
             var principalType = model.GetEntityType(typeof(Customer));
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             fk.IsUnique = true;
 
             var navToPrincipal = dependentType.AddNavigation("Customer", fk, true);
@@ -2276,21 +2276,21 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity(typeof(Customer)).Reference(typeof(CustomerDetails), "Details").InverseReference("Customer");
 
-            Assert.Same(fk, dependentType.ForeignKeys.Single());
+            Assert.Same(fk, dependentType.GetForeignKeys().Single());
             Assert.Same(navToPrincipal, dependentType.Navigations.Single());
             Assert.Same(navToDependent, principalType.Navigations.Single());
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2307,28 +2307,28 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = model.GetEntityType(typeof(CustomerDetails));
             var principalType = model.GetEntityType(typeof(Customer));
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             fk.IsUnique = true;
 
             var navigation = dependentType.AddNavigation("Customer", fk, true);
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity(typeof(Customer)).Reference(typeof(CustomerDetails), "Details").InverseReference("Customer");
 
-            Assert.Same(fk, dependentType.ForeignKeys.Single());
+            Assert.Same(fk, dependentType.GetForeignKeys().Single());
             Assert.Same(navigation, dependentType.Navigations.Single());
             Assert.Equal("Details", principalType.Navigations.Single().Name);
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2345,28 +2345,28 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = model.GetEntityType(typeof(CustomerDetails));
             var principalType = model.GetEntityType(typeof(Customer));
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             fk.IsUnique = true;
 
             var navigation = principalType.AddNavigation("Details", fk, false);
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity(typeof(Customer)).Reference(typeof(CustomerDetails), "Details").InverseReference("Customer");
 
-            Assert.Same(fk, dependentType.ForeignKeys.Single());
+            Assert.Same(fk, dependentType.GetForeignKeys().Single());
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
             Assert.Same(navigation, principalType.Navigations.Single());
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2384,26 +2384,26 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = model.GetEntityType(typeof(CustomerDetails));
             var principalType = model.GetEntityType(typeof(Customer));
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             fk.IsUnique = true;
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity(typeof(Customer)).Reference(typeof(CustomerDetails), "Details").InverseReference("Customer");
 
-            Assert.Same(fk, dependentType.ForeignKeys.Single());
+            Assert.Same(fk, dependentType.GetForeignKeys().Single());
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
             Assert.Equal("Details", principalType.Navigations.Single().Name);
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2423,12 +2423,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity(typeof(Customer)).Reference(typeof(CustomerDetails), "Details").InverseReference("Customer");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -2437,9 +2437,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2457,26 +2457,26 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = model.GetEntityType(typeof(OrderDetails));
             var principalType = model.GetEntityType(typeof(Order));
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             fk.IsUnique = true;
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity(typeof(Order)).Reference(typeof(OrderDetails), "Details").InverseReference("Order");
 
-            Assert.Same(fk, dependentType.ForeignKeys.Single());
+            Assert.Same(fk, dependentType.GetForeignKeys().Single());
             Assert.Equal("Order", dependentType.Navigations.Single().Name);
             Assert.Equal("Details", principalType.Navigations.Single().Name);
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2500,12 +2500,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity(typeof(Order)).Reference(typeof(OrderDetails), "Details").InverseReference("Order");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("Order", dependentType.Navigations.Single().Name);
@@ -2514,9 +2514,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2536,12 +2536,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity(typeof(Customer)).Reference(typeof(CustomerDetails), "Details").InverseReference(null);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Empty(dependentType.Navigations);
@@ -2549,9 +2549,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2571,13 +2571,13 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             // Passing null as the first arg is not super-compelling, but it is consistent
             modelBuilder.Entity(typeof(Customer)).Reference(typeof(CustomerDetails), null).InverseReference("Customer");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -2585,9 +2585,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2607,21 +2607,21 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity(typeof(Customer)).Reference(typeof(CustomerDetails), null).InverseReference(null);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Empty(dependentType.Navigations);
             Assert.Empty(principalType.Navigations);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2645,14 +2645,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Order)).Reference(typeof(OrderDetails), "Details").InverseReference("Order")
                 .ForeignKey(typeof(OrderDetails), "OrderId");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("Order", dependentType.Navigations.Single().Name);
@@ -2661,9 +2661,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2683,14 +2683,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Customer)).Reference(typeof(CustomerDetails), "Details").InverseReference("Customer")
                 .ForeignKey(typeof(CustomerDetails), "Id");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -2699,9 +2699,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2718,28 +2718,28 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = model.GetEntityType(typeof(Bun));
             var principalType = model.GetEntityType(typeof(BigMak));
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             fk.IsUnique = true;
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(BigMak)).Reference(typeof(Bun), "Bun").InverseReference("BigMak")
                 .ForeignKey(typeof(Bun), "BurgerId");
 
-            Assert.Same(fk, dependentType.ForeignKeys.Single());
+            Assert.Same(fk, dependentType.GetForeignKeys().Single());
             Assert.Equal("BigMak", dependentType.Navigations.Single().Name);
             Assert.Equal("Bun", principalType.Navigations.Single().Name);
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2759,14 +2759,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(BigMak)).Reference(typeof(Bun), "Bun").InverseReference("BigMak")
                 .ForeignKey(typeof(Bun), "BurgerId");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("BigMak", dependentType.Navigations.Single().Name);
@@ -2775,9 +2775,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2797,14 +2797,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(BigMak)).Reference(typeof(Bun), "Bun").InverseReference(null)
                 .ForeignKey(typeof(Bun), "BurgerId");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Empty(dependentType.Navigations);
@@ -2812,9 +2812,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2834,14 +2834,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(BigMak)).Reference(typeof(Bun), null).InverseReference("BigMak")
                 .ForeignKey(typeof(Bun), "BurgerId");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("BigMak", dependentType.Navigations.Single().Name);
@@ -2849,9 +2849,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2871,23 +2871,23 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(BigMak)).Reference(typeof(Bun), null).InverseReference(null)
                 .ForeignKey(typeof(Bun), "BurgerId");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Empty(dependentType.Navigations);
             Assert.Empty(principalType.Navigations);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2908,7 +2908,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.GetProperties().Count();
-            var principalKey = principalType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
             var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
@@ -2927,8 +2927,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(newFk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount + 1, dependentType.GetProperties().Count());
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
             Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
@@ -2947,28 +2947,28 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = model.GetEntityType(typeof(OrderDetails));
             var principalType = model.GetEntityType(typeof(Order));
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             fk.IsUnique = true;
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(OrderDetails)).Reference(typeof(Order), "Order").InverseReference("Details")
                 .ForeignKey(typeof(OrderDetails), "Id");
 
-            Assert.Same(fk, dependentType.ForeignKeys.Single());
+            Assert.Same(fk, dependentType.GetForeignKeys().Single());
             Assert.Equal("Order", dependentType.Navigations.Single().Name);
             Assert.Equal("Details", principalType.Navigations.Single().Name);
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2992,14 +2992,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(OrderDetails)).Reference(typeof(Order), "Order").InverseReference("Details")
                 .ForeignKey(typeof(OrderDetails), "OrderId");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("Order", dependentType.Navigations.Single().Name);
@@ -3008,9 +3008,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3030,14 +3030,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<CustomerDetails>().Reference(typeof(Customer), "Customer").InverseReference(null)
                 .ForeignKey(typeof(CustomerDetails), "Id");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -3045,9 +3045,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3067,14 +3067,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<CustomerDetails>().Reference(typeof(Customer), null).InverseReference("Details")
                 .ForeignKey(typeof(CustomerDetails), "Id");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Empty(dependentType.Navigations);
@@ -3082,9 +3082,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3104,23 +3104,23 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<CustomerDetails>().Reference(typeof(Customer), null).InverseReference(null)
                 .ForeignKey(typeof(CustomerDetails), "Id");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Empty(dependentType.Navigations);
             Assert.Empty(principalType.Navigations);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3140,14 +3140,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<CustomerDetails>().Reference(typeof(Customer), "Customer").InverseReference("Details")
                 .ForeignKey(typeof(CustomerDetails), "Id");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -3156,9 +3156,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3179,14 +3179,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Customer)).Reference(typeof(CustomerDetails), "Details").InverseReference("Customer")
                 .PrincipalKey(typeof(Customer), "Id");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(principalProperty, fk.PrincipalKey.Properties.Single());
 
@@ -3196,9 +3196,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3223,14 +3223,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Customer)).Reference(typeof(CustomerDetails), "Details").InverseReference("Customer")
                 .PrincipalKey(typeof(Customer), "AlternateKey");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(principalProperty, fk.PrincipalKey.Properties.Single());
 
@@ -3240,14 +3240,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.Contains(principalKey, principalType.Keys);
-            Assert.Contains(fk.PrincipalKey, principalType.Keys);
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.Contains(principalKey, principalType.GetKeys());
+            Assert.Contains(fk.PrincipalKey, principalType.GetKeys());
             Assert.NotSame(principalKey, fk.PrincipalKey);
 
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3272,15 +3272,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Order)).Reference(typeof(OrderDetails), "Details").InverseReference("Order")
                 .ForeignKey(typeof(OrderDetails), "OrderId")
                 .PrincipalKey(typeof(Order), "OrderId");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(principalProperty, fk.PrincipalKey.Properties.Single());
 
@@ -3290,9 +3290,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3317,15 +3317,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Order)).Reference(typeof(OrderDetails), "Details").InverseReference("Order")
                 .PrincipalKey(typeof(Order), "OrderId")
                 .ForeignKey(typeof(OrderDetails), "OrderId");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(principalProperty, fk.PrincipalKey.Properties.Single());
 
@@ -3335,9 +3335,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3362,15 +3362,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(BigMak)).Reference(typeof(Bun), "Bun").InverseReference("BigMak")
                 .ForeignKey(typeof(Bun), "BurgerId")
                 .PrincipalKey(typeof(BigMak), "AlternateKey");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(principalProperty, fk.PrincipalKey.Properties.Single());
 
@@ -3380,14 +3380,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.Contains(principalKey, principalType.Keys);
-            Assert.Contains(fk.PrincipalKey, principalType.Keys);
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.Contains(principalKey, principalType.GetKeys());
+            Assert.Contains(fk.PrincipalKey, principalType.GetKeys());
             Assert.NotSame(principalKey, fk.PrincipalKey);
 
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3412,15 +3412,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(BigMak)).Reference(typeof(Bun), "Bun").InverseReference("BigMak")
                 .PrincipalKey(typeof(BigMak), "AlternateKey")
                 .ForeignKey(typeof(Bun), "BurgerId");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(principalProperty, fk.PrincipalKey.Properties.Single());
 
@@ -3430,14 +3430,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.Contains(principalKey, principalType.Keys);
-            Assert.Contains(fk.PrincipalKey, principalType.Keys);
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.Contains(principalKey, principalType.GetKeys());
+            Assert.Contains(fk.PrincipalKey, principalType.GetKeys());
             Assert.NotSame(principalKey, fk.PrincipalKey);
 
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3455,28 +3455,28 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = model.GetEntityType(typeof(OrderDetails));
             var principalType = model.GetEntityType(typeof(Order));
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             fk.IsUnique = true;
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(OrderDetails)).Reference(typeof(Order), "Order").InverseReference("Details")
                 .PrincipalKey(typeof(Order), "OrderId");
 
-            Assert.Same(fk, dependentType.ForeignKeys.Single());
+            Assert.Same(fk, dependentType.GetForeignKeys().Single());
             Assert.Equal("Order", dependentType.Navigations.Single().Name);
             Assert.Equal("Details", principalType.Navigations.Single().Name);
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3500,14 +3500,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(OrderDetails)).Reference(typeof(Order), "Order").InverseReference("Details")
                 .PrincipalKey(typeof(Order), "OrderId");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("Order", dependentType.Navigations.Single().Name);
@@ -3516,9 +3516,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3542,15 +3542,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(OrderDetails)).Reference(typeof(Order), "Order").InverseReference("Details")
                 .ForeignKey(typeof(OrderDetails), "OrderId")
                 .PrincipalKey(typeof(Order), "OrderId");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("Order", dependentType.Navigations.Single().Name);
@@ -3559,9 +3559,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3585,15 +3585,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(OrderDetails)).Reference(typeof(Order), "Order").InverseReference("Details")
                 .PrincipalKey(typeof(Order), "OrderId")
                 .ForeignKey(typeof(OrderDetails), "OrderId");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("Order", dependentType.Navigations.Single().Name);
@@ -3602,9 +3602,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3624,14 +3624,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<CustomerDetails>().Reference(typeof(Customer), "Customer").InverseReference(null)
                 .PrincipalKey(typeof(Customer), "Id");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -3639,9 +3639,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3661,14 +3661,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<CustomerDetails>().Reference(typeof(Customer), null).InverseReference("Details")
                 .PrincipalKey(typeof(Customer), "Id");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Empty(dependentType.Navigations);
@@ -3676,9 +3676,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3698,23 +3698,23 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<CustomerDetails>().Reference(typeof(Customer), null).InverseReference(null)
                 .PrincipalKey(typeof(Customer), "Id");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Empty(dependentType.Navigations);
             Assert.Empty(principalType.Navigations);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3758,27 +3758,27 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = model.GetEntityType(typeof(Tomato));
             var principalType = model.GetEntityType(typeof(Whoopper));
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Whoopper)).Collection(typeof(Tomato), "Tomatoes").InverseReference("Whoopper")
                 .ForeignKey("BurgerId1", "BurgerId2");
 
-            Assert.Same(fk, dependentType.ForeignKeys.Single());
+            Assert.Same(fk, dependentType.GetForeignKeys().Single());
             Assert.Equal("Whoopper", dependentType.Navigations.Single().Name);
             Assert.Equal("Tomatoes", principalType.Navigations.Single().Name);
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3803,14 +3803,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Whoopper)).Collection(typeof(Tomato), "Tomatoes").InverseReference("Whoopper")
                 .ForeignKey("BurgerId1", "BurgerId2");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
 
@@ -3820,9 +3820,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3854,15 +3854,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Whoopper)).Collection(typeof(Tomato), "Tomatoes").InverseReference("Whoopper")
                 .ForeignKey("BurgerId1", "BurgerId2")
                 .PrincipalKey("AlternateKey1", "AlternateKey2");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
             Assert.Same(principalProperty1, fk.PrincipalKey.Properties[0]);
@@ -3874,14 +3874,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.Contains(principalKey, principalType.Keys);
-            Assert.Contains(fk.PrincipalKey, principalType.Keys);
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.Contains(principalKey, principalType.GetKeys());
+            Assert.Contains(fk.PrincipalKey, principalType.GetKeys());
             Assert.NotSame(principalKey, fk.PrincipalKey);
 
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3913,15 +3913,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Whoopper)).Collection(typeof(Tomato), "Tomatoes").InverseReference("Whoopper")
                 .PrincipalKey("AlternateKey1", "AlternateKey2")
                 .ForeignKey("BurgerId1", "BurgerId2");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
             Assert.Same(principalProperty1, fk.PrincipalKey.Properties[0]);
@@ -3933,14 +3933,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.Contains(principalKey, principalType.Keys);
-            Assert.Contains(fk.PrincipalKey, principalType.Keys);
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.Contains(principalKey, principalType.GetKeys());
+            Assert.Contains(fk.PrincipalKey, principalType.GetKeys());
             Assert.NotSame(principalKey, fk.PrincipalKey);
 
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3965,14 +3965,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Whoopper)).Collection(typeof(Tomato), "Tomatoes").InverseReference(null)
                 .ForeignKey("BurgerId1", "BurgerId2");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
 
@@ -3981,9 +3981,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4008,14 +4008,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Whoopper)).Collection(typeof(Tomato), null).InverseReference("Whoopper")
                 .ForeignKey("BurgerId1", "BurgerId2");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
 
@@ -4024,9 +4024,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4051,14 +4051,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Whoopper)).Collection(typeof(Tomato), null).InverseReference(null)
                 .ForeignKey("BurgerId1", "BurgerId2");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
 
@@ -4066,9 +4066,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Empty(principalType.Navigations);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4086,27 +4086,27 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = tomatoType;
             var principalType = model.GetEntityType(typeof(Whoopper));
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Tomato)).Reference(typeof(Whoopper), "Whoopper").InverseCollection("Tomatoes")
                 .ForeignKey("BurgerId1", "BurgerId2");
 
-            Assert.Same(fk, dependentType.ForeignKeys.Single());
+            Assert.Same(fk, dependentType.GetForeignKeys().Single());
             Assert.Equal("Whoopper", dependentType.Navigations.Single().Name);
             Assert.Equal("Tomatoes", principalType.Navigations.Single().Name);
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4131,14 +4131,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Tomato)).Reference(typeof(Whoopper), "Whoopper").InverseCollection("Tomatoes")
                 .ForeignKey("BurgerId1", "BurgerId2");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
 
@@ -4148,9 +4148,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4182,15 +4182,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Tomato)).Reference(typeof(Whoopper), "Whoopper").InverseCollection("Tomatoes")
                 .ForeignKey("BurgerId1", "BurgerId2")
                 .PrincipalKey("AlternateKey1", "AlternateKey2");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
             Assert.Same(principalProperty1, fk.PrincipalKey.Properties[0]);
@@ -4202,14 +4202,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.Contains(principalKey, principalType.Keys);
-            Assert.Contains(fk.PrincipalKey, principalType.Keys);
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.Contains(principalKey, principalType.GetKeys());
+            Assert.Contains(fk.PrincipalKey, principalType.GetKeys());
             Assert.NotSame(principalKey, fk.PrincipalKey);
 
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4241,15 +4241,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Tomato)).Reference(typeof(Whoopper), "Whoopper").InverseCollection("Tomatoes")
                 .PrincipalKey("AlternateKey1", "AlternateKey2")
                 .ForeignKey("BurgerId1", "BurgerId2");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
             Assert.Same(principalProperty1, fk.PrincipalKey.Properties[0]);
@@ -4261,14 +4261,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.Contains(principalKey, principalType.Keys);
-            Assert.Contains(fk.PrincipalKey, principalType.Keys);
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.Contains(principalKey, principalType.GetKeys());
+            Assert.Contains(fk.PrincipalKey, principalType.GetKeys());
             Assert.NotSame(principalKey, fk.PrincipalKey);
 
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4293,14 +4293,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Tomato)).Reference(typeof(Whoopper), null).InverseCollection("Tomatoes")
                 .ForeignKey("BurgerId1", "BurgerId2");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
 
@@ -4309,9 +4309,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4336,14 +4336,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Tomato)).Reference(typeof(Whoopper), "Whoopper").InverseCollection(null)
                 .ForeignKey("BurgerId1", "BurgerId2");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
 
@@ -4352,9 +4352,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4379,14 +4379,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Tomato)).Reference(typeof(Whoopper), null).InverseCollection(null)
                 .ForeignKey("BurgerId1", "BurgerId2");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
 
@@ -4394,9 +4394,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Empty(principalType.Navigations);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4414,28 +4414,28 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = model.GetEntityType(typeof(ToastedBun));
             var principalType = model.GetEntityType(typeof(Whoopper));
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             fk.IsUnique = true;
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Whoopper)).Reference(typeof(ToastedBun), "ToastedBun").InverseReference("Whoopper")
                 .ForeignKey(typeof(ToastedBun), "BurgerId1", "BurgerId2");
 
-            Assert.Same(fk, dependentType.ForeignKeys.Single());
+            Assert.Same(fk, dependentType.GetForeignKeys().Single());
             Assert.Equal("Whoopper", dependentType.Navigations.Single().Name);
             Assert.Equal("ToastedBun", principalType.Navigations.Single().Name);
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4460,14 +4460,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Whoopper)).Reference(typeof(ToastedBun), "ToastedBun").InverseReference("Whoopper")
                 .ForeignKey(typeof(ToastedBun), "BurgerId1", "BurgerId2");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
 
@@ -4477,9 +4477,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4511,15 +4511,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Whoopper)).Reference(typeof(ToastedBun), "ToastedBun").InverseReference("Whoopper")
                 .ForeignKey(typeof(ToastedBun), "BurgerId1", "BurgerId2")
                 .PrincipalKey(typeof(Whoopper), "AlternateKey1", "AlternateKey2");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
             Assert.Same(principalProperty1, fk.PrincipalKey.Properties[0]);
@@ -4531,14 +4531,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.Contains(principalKey, principalType.Keys);
-            Assert.Contains(fk.PrincipalKey, principalType.Keys);
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.Contains(principalKey, principalType.GetKeys());
+            Assert.Contains(fk.PrincipalKey, principalType.GetKeys());
             Assert.NotSame(principalKey, fk.PrincipalKey);
 
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4570,15 +4570,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Whoopper)).Reference(typeof(ToastedBun), "ToastedBun").InverseReference("Whoopper")
                 .PrincipalKey(typeof(Whoopper), "AlternateKey1", "AlternateKey2")
                 .ForeignKey(typeof(ToastedBun), "BurgerId1", "BurgerId2");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
             Assert.Same(principalProperty1, fk.PrincipalKey.Properties[0]);
@@ -4590,14 +4590,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.Contains(principalKey, principalType.Keys);
-            Assert.Contains(fk.PrincipalKey, principalType.Keys);
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.Contains(principalKey, principalType.GetKeys());
+            Assert.Contains(fk.PrincipalKey, principalType.GetKeys());
             Assert.NotSame(principalKey, fk.PrincipalKey);
 
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4618,13 +4618,13 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Whoopper)).Reference(typeof(Moostard), "Moostard").InverseReference("Whoopper");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
 
@@ -4634,9 +4634,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4657,14 +4657,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Moostard)).Reference(typeof(Whoopper), "Whoopper").InverseReference("Moostard")
                 .ForeignKey(typeof(Moostard), "Id1", "Id2");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
 
@@ -4674,9 +4674,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4697,14 +4697,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Moostard)).Reference(typeof(Whoopper), "Whoopper").InverseReference("Moostard")
                 .PrincipalKey(typeof(Whoopper), "Id1", "Id2");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
 
@@ -4714,9 +4714,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4741,14 +4741,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Whoopper)).Reference(typeof(ToastedBun), "ToastedBun").InverseReference(null)
                 .ForeignKey(typeof(ToastedBun), "BurgerId1", "BurgerId2");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
 
@@ -4757,9 +4757,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4784,14 +4784,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Whoopper)).Reference(typeof(ToastedBun), null).InverseReference("Whoopper")
                 .ForeignKey(typeof(ToastedBun), "BurgerId1", "BurgerId2");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
 
@@ -4800,9 +4800,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4827,14 +4827,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity(typeof(Whoopper)).Reference(typeof(ToastedBun), null).InverseReference(null)
                 .ForeignKey(typeof(ToastedBun), "BurgerId1", "BurgerId2");
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
 
@@ -4842,9 +4842,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Empty(principalType.Navigations);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest.cs
@@ -273,7 +273,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             modelBuilder.Entity<Customer>().Key(b => b.Name);
 
-            Assert.Same(key, entity.Keys.Single());
+            Assert.Same(key, entity.GetKeys().Single());
             Assert.Equal(Customer.NameProperty.Name, entity.GetPrimaryKey().Properties.Single().Name);
         }
 
@@ -454,8 +454,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             modelBuilder.Entity<CustomerDetails>(b => { b.Ignore(c => c.Customer); });
 
             Assert.Equal(2, model.EntityTypes.Count);
-            Assert.Equal(0, model.EntityTypes[0].ForeignKeys.Count);
-            Assert.Equal(0, model.EntityTypes[1].ForeignKeys.Count);
+            Assert.Equal(0, model.EntityTypes[0].GetForeignKeys().Count());
+            Assert.Equal(0, model.EntityTypes[1].GetForeignKeys().Count());
         }
 
         [Fact]
@@ -742,26 +742,26 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = model.GetEntityType(typeof(Order));
             var principalType = model.GetEntityType(typeof(Customer));
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
 
             var navToPrincipal = dependentType.GetNavigation("Customer");
             var navToDependent = principalType.GetNavigation("Orders");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity<Customer>().Collection(e => e.Orders).InverseReference(e => e.Customer);
 
-            Assert.Same(fk, dependentType.ForeignKeys.Single());
+            Assert.Same(fk, dependentType.GetForeignKeys().Single());
             Assert.Equal(navToPrincipal.Name, dependentType.Navigations.Single().Name);
             Assert.Same(navToDependent, principalType.Navigations.Single());
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name, Customer.NameProperty.Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { "AnotherCustomerId", fk.Properties.Single().Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -780,23 +780,23 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = model.GetEntityType(typeof(Order));
             var principalType = model.GetEntityType(typeof(Customer));
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
 
             var navigation = dependentType.GetNavigation("Customer");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity<Customer>().Collection(e => e.Orders).InverseReference(e => e.Customer);
 
-            Assert.Equal(1, dependentType.ForeignKeys.Count());
+            Assert.Equal(1, dependentType.GetForeignKeys().Count());
             Assert.Equal("Orders", principalType.Navigations.Single().Name);
             Assert.Same(fk.PrincipalKey, principalType.Navigations.Single().ForeignKey.PrincipalKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name, Customer.NameProperty.Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { "AnotherCustomerId", fk.Properties.Single().Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -815,25 +815,25 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = model.GetEntityType(typeof(Order));
             var principalType = model.GetEntityType(typeof(Customer));
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
 
             var navigation = principalType.GetOrAddNavigation("Orders", fk, pointsToPrincipal: false);
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity<Customer>().Collection(e => e.Orders).InverseReference(e => e.Customer);
 
-            Assert.Same(fk, dependentType.ForeignKeys.Single());
+            Assert.Same(fk, dependentType.GetForeignKeys().Single());
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
             Assert.Same(navigation, principalType.Navigations.Single());
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name, Customer.NameProperty.Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { "AnotherCustomerId", fk.Properties.Single().Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -852,23 +852,23 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = model.GetEntityType(typeof(Order));
             var principalType = model.GetEntityType(typeof(Customer));
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity<Customer>().Collection(e => e.Orders).InverseReference(e => e.Customer);
 
-            Assert.Same(fk, dependentType.ForeignKeys.Single());
+            Assert.Same(fk, dependentType.GetForeignKeys().Single());
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
             Assert.Equal("Orders", principalType.Navigations.Single().Name);
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name, Customer.NameProperty.Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { "AnotherCustomerId", fk.Properties.Single().Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -888,12 +888,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty = dependentType.GetProperty("CustomerId");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity<Customer>().Collection(e => e.Orders).InverseReference(e => e.Customer);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -902,9 +902,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name, Customer.NameProperty.Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { "AnotherCustomerId", fk.Properties.Single().Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -924,12 +924,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty = dependentType.GetProperty("CustomerId");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity<Customer>().Collection(e => e.Orders).InverseReference();
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Empty(dependentType.Navigations);
@@ -937,9 +937,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name, Customer.NameProperty.Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { "AnotherCustomerId", fk.Properties.Single().Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -959,13 +959,13 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty = dependentType.GetProperty("CustomerId");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             // Passing null as the first arg is not super-compelling, but it is consistent
             modelBuilder.Entity<Customer>().Collection<Order>().InverseReference(e => e.Customer);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -973,9 +973,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name, Customer.NameProperty.Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { "AnotherCustomerId", fk.Properties.Single().Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -994,15 +994,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalType = model.GetEntityType(typeof(Customer));
 
             var fkProperty = dependentType.GetProperty("CustomerId");
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity<Customer>().Collection<Order>().InverseReference();
 
-            var newFk = dependentType.ForeignKeys.Single(foreignKey => foreignKey != fk);
+            var newFk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey != fk);
 
             Assert.Equal(fk.PrincipalKey.Properties, newFk.PrincipalKey.Properties);
             Assert.Empty(dependentType.Navigations.Where(nav => nav.ForeignKey == newFk));
@@ -1010,9 +1010,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name, Customer.NameProperty.Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { "AnotherCustomerId", fk.Properties.Single().Name, newFk.Properties.Single().Name, dependentKey.Properties.Single().Name },
                 dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1032,14 +1032,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty = dependentType.GetProperty("CustomerId");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Customer>().Collection(e => e.Orders).InverseReference(e => e.Customer)
                 .ForeignKey(e => e.CustomerId);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -1048,9 +1048,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name, Customer.NameProperty.Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { "AnotherCustomerId", fk.Properties.Single().Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1068,26 +1068,26 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = model.GetEntityType(typeof(Pickle));
             var principalType = model.GetEntityType(typeof(BigMak));
-            var fk = dependentType.ForeignKeys.Single(foreignKey => foreignKey.Properties.Single().Name == "BurgerId");
+            var fk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey.Properties.Single().Name == "BurgerId");
             dependentType.RemoveNavigation(fk.DependentToPrincipal);
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<BigMak>().Collection(e => e.Pickles).InverseReference(e => e.BigMak)
                 .ForeignKey(e => e.BurgerId);
 
-            Assert.Same(fk, dependentType.ForeignKeys.Single());
+            Assert.Same(fk, dependentType.GetForeignKeys().Single());
             Assert.Equal("BigMak", dependentType.Navigations.Single().Name);
             Assert.Equal("Pickles", principalType.Navigations.Single().Name);
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fk.Properties.Single().Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1106,14 +1106,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty = dependentType.GetProperty("BurgerId");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<BigMak>().Collection(e => e.Pickles).InverseReference(e => e.BigMak)
                 .ForeignKey(e => e.BurgerId);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("BigMak", dependentType.Navigations.Single().Name);
@@ -1122,9 +1122,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fk.Properties.Single().Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1143,14 +1143,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty = dependentType.GetProperty("BurgerId");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<BigMak>().Collection(e => e.Pickles).InverseReference()
                 .ForeignKey(e => e.BurgerId);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Empty(dependentType.Navigations);
@@ -1158,9 +1158,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fk.Properties.Single().Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1179,14 +1179,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty = dependentType.GetProperty("BurgerId");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<BigMak>().Collection<Pickle>().InverseReference(e => e.BigMak)
                 .ForeignKey(e => e.BurgerId);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("BigMak", dependentType.Navigations.Single().Name);
@@ -1194,9 +1194,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fk.Properties.Single().Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1214,25 +1214,25 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalType = model.GetEntityType(typeof(BigMak));
 
             var fkProperty = dependentType.GetProperty("BurgerId");
-            var fk = dependentType.ForeignKeys.SingleOrDefault();
+            var fk = dependentType.GetForeignKeys().SingleOrDefault();
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<BigMak>().Collection<Pickle>().InverseReference()
                 .ForeignKey(e => e.BurgerId);
 
-            var newFk = dependentType.ForeignKeys.Single(foreignKey => foreignKey != fk);
+            var newFk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey != fk);
             Assert.Same(fkProperty, newFk.Properties.Single());
 
             Assert.Empty(dependentType.Navigations.Where(nav => nav.ForeignKey != fk));
             Assert.Empty(principalType.Navigations.Where(nav => nav.ForeignKey != fk));
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fk.Properties.Single().Name, fkProperty.Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1249,12 +1249,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentType = model.GetEntityType(typeof(Pickle));
             var principalType = model.GetEntityType(typeof(BigMak));
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity<BigMak>().Collection(e => e.Pickles).InverseReference(e => e.BigMak);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             var fkProperty = fk.Properties.Single();
 
             Assert.Equal("BigMakId", fkProperty.Name);
@@ -1268,9 +1268,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fk.Properties.Single().Name, "BurgerId", dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1287,12 +1287,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentType = model.GetEntityType(typeof(Pickle));
             var principalType = model.GetEntityType(typeof(BigMak));
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity<BigMak>().Collection(e => e.Pickles).InverseReference();
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             var fkProperty = fk.Properties.Single();
 
             Assert.Equal("BigMakId", fkProperty.Name);
@@ -1305,9 +1305,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fk.Properties.Single().Name, "BurgerId", dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1324,12 +1324,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentType = model.GetEntityType(typeof(Pickle));
             var principalType = model.GetEntityType(typeof(BigMak));
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity<BigMak>().Collection<Pickle>().InverseReference(e => e.BigMak);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             var fkProperty = fk.Properties.Single();
 
             Assert.Equal("BigMakId", fkProperty.Name);
@@ -1342,9 +1342,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fk.Properties.Single().Name, "BurgerId", dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1361,13 +1361,13 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentType = model.GetEntityType(typeof(Pickle));
             var principalType = model.GetEntityType(typeof(BigMak));
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
-            var existingFk = dependentType.ForeignKeys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
+            var existingFk = dependentType.GetForeignKeys().Single();
 
             modelBuilder.Entity<BigMak>().Collection<Pickle>().InverseReference();
 
-            var foreignKey = dependentType.ForeignKeys.Single(fk => fk != existingFk);
+            var foreignKey = dependentType.GetForeignKeys().Single(fk => fk != existingFk);
             var fkProperty = foreignKey.Properties.Single();
 
             Assert.Equal("BigMakId1", fkProperty.Name);
@@ -1380,9 +1380,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { existingFk.Properties.Single().Name, fkProperty.Name, "BurgerId", dependentKey.Properties.Single().Name },
                 dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1399,14 +1399,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentType = model.GetEntityType(typeof(Pickle));
             var principalType = model.GetEntityType(typeof(BigMak));
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             var fkProperty = dependentType.GetProperty("BigMakId");
 
             modelBuilder.Entity<BigMak>().Collection(e => e.Pickles).InverseReference(e => e.BigMak);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("BigMak", dependentType.Navigations.Single().Name);
@@ -1416,9 +1416,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fkProperty.Name, "BurgerId", dependentKey.Properties.Single().Name },
                 dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1435,8 +1435,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentType = model.GetEntityType(typeof(Pickle));
             var principalType = model.GetEntityType(typeof(BigMak));
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             var fk = dependentType.AddForeignKey(dependentType.GetOrAddProperty("BurgerId", typeof(int)), principalKey);
             fk.IsUnique = true;
@@ -1445,8 +1445,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .Entity<BigMak>().Collection(e => e.Pickles).InverseReference(e => e.BigMak)
                 .ForeignKey(e => e.BurgerId);
 
-            Assert.Equal(1, dependentType.ForeignKeys.Count);
-            var newFk = (IForeignKey)dependentType.ForeignKeys.Single(k => k != fk);
+            Assert.Equal(1, dependentType.GetForeignKeys().Count());
+            var newFk = (IForeignKey)dependentType.GetForeignKeys().Single(k => k != fk);
 
             Assert.False(newFk.IsUnique);
 
@@ -1458,9 +1458,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { newFk.Properties.Single().Name, dependentKey.Properties.Single().Name },
                 dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1481,14 +1481,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var fkProperty = dependentType.GetProperty("CustomerId");
             var principalProperty = principalType.GetProperty(Customer.IdProperty.Name);
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Customer>().Collection(e => e.Orders).InverseReference(e => e.Customer)
                 .PrincipalKey(e => e.Id);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(principalProperty, fk.PrincipalKey.Properties.Single());
 
@@ -1498,9 +1498,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name, Customer.NameProperty.Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { "AnotherCustomerId", fk.Properties.Single().Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1519,28 +1519,28 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalType = model.GetEntityType(typeof(Customer));
             var expectedPrincipalProperties = principalType.Properties.ToList();
             var expectedDependentProperties = dependentType.Properties.ToList();
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Customer>().Collection(e => e.Orders).InverseReference(e => e.Customer)
                 .PrincipalKey(e => e.AlternateKey);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Equal("AlternateKey", fk.PrincipalKey.Properties.Single().Name);
 
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
             Assert.Equal("Orders", principalType.Navigations.Single().Name);
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.Contains(principalKey, principalType.Keys);
-            Assert.Contains(fk.PrincipalKey, principalType.Keys);
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.Contains(principalKey, principalType.GetKeys());
+            Assert.Contains(fk.PrincipalKey, principalType.GetKeys());
             Assert.NotSame(principalKey, fk.PrincipalKey);
 
-            Assert.Equal(1, dependentType.Keys.Count);
+            Assert.Equal(1, dependentType.GetKeys().Count());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
 
@@ -1566,15 +1566,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var fkProperty = dependentType.GetProperty("CustomerId");
             var principalProperty = principalType.GetProperty(Customer.IdProperty.Name);
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Customer>().Collection(e => e.Orders).InverseReference(e => e.Customer)
                 .ForeignKey(e => e.CustomerId)
                 .PrincipalKey(e => e.Id);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(principalProperty, fk.PrincipalKey.Properties.Single());
 
@@ -1584,9 +1584,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name, Customer.NameProperty.Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { "AnotherCustomerId", fk.Properties.Single().Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1607,15 +1607,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var fkProperty = dependentType.GetProperty("CustomerId");
             var principalProperty = principalType.GetProperty(Customer.IdProperty.Name);
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Customer>().Collection(e => e.Orders).InverseReference(e => e.Customer)
                 .PrincipalKey(e => e.Id)
                 .ForeignKey(e => e.CustomerId);
 
-            var foreignKey = dependentType.ForeignKeys.Single();
+            var foreignKey = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, foreignKey.Properties.Single());
             Assert.Same(principalProperty, foreignKey.PrincipalKey.Properties.Single());
 
@@ -1625,9 +1625,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(foreignKey, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name, Customer.NameProperty.Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { "AnotherCustomerId", fkProperty.Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1646,15 +1646,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalType = model.GetEntityType(typeof(Customer));
             var expectedPrincipalProperties = principalType.Properties.ToList();
             var expectedDependentProperties = dependentType.Properties.ToList();
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Customer>().Collection(e => e.Orders).InverseReference(e => e.Customer)
                 .ForeignKey(e => e.AnotherCustomerId)
                 .PrincipalKey(e => e.AlternateKey);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Equal("AnotherCustomerId", fk.Properties.Single().Name);
             Assert.Equal("AlternateKey", fk.PrincipalKey.Properties.Single().Name);
 
@@ -1662,14 +1662,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Equal("Orders", principalType.Navigations.Single().Name);
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.Contains(principalKey, principalType.Keys);
-            Assert.Contains(fk.PrincipalKey, principalType.Keys);
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.Contains(principalKey, principalType.GetKeys());
+            Assert.Contains(fk.PrincipalKey, principalType.GetKeys());
             Assert.NotSame(principalKey, fk.PrincipalKey);
 
-            Assert.Equal(1, dependentType.Keys.Count);
+            Assert.Equal(1, dependentType.GetKeys().Count());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
 
@@ -1693,15 +1693,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalType = model.GetEntityType(typeof(Customer));
             var expectedPrincipalProperties = principalType.Properties.ToList();
             var expectedDependentProperties = dependentType.Properties.ToList();
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Customer>().Collection(e => e.Orders).InverseReference(e => e.Customer)
                 .PrincipalKey(e => e.AlternateKey)
                 .ForeignKey(e => e.AnotherCustomerId);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Equal("AnotherCustomerId", fk.Properties.Single().Name);
             Assert.Equal("AlternateKey", fk.PrincipalKey.Properties.Single().Name);
 
@@ -1709,14 +1709,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Equal("Orders", principalType.Navigations.Single().Name);
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.Contains(principalKey, principalType.Keys);
-            Assert.Contains(fk.PrincipalKey, principalType.Keys);
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.Contains(principalKey, principalType.GetKeys());
+            Assert.Contains(fk.PrincipalKey, principalType.GetKeys());
             Assert.NotSame(principalKey, fk.PrincipalKey);
 
-            Assert.Equal(1, dependentType.Keys.Count);
+            Assert.Equal(1, dependentType.GetKeys().Count());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
 
@@ -1741,15 +1741,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var fkProperty = dependentType.GetProperty("BurgerId");
             var principalProperty = principalType.GetProperty("AlternateKey");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<BigMak>().Collection(e => e.Pickles).InverseReference(e => e.BigMak)
                 .ForeignKey(e => e.BurgerId)
                 .PrincipalKey(e => e.AlternateKey);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(principalProperty, fk.PrincipalKey.Properties.Single());
 
@@ -1759,14 +1759,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fk.Properties.Single().Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.Contains(principalKey, principalType.Keys);
-            Assert.Contains(fk.PrincipalKey, principalType.Keys);
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.Contains(principalKey, principalType.GetKeys());
+            Assert.Contains(fk.PrincipalKey, principalType.GetKeys());
             Assert.NotSame(principalKey, fk.PrincipalKey);
 
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1786,15 +1786,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var fkProperty = dependentType.GetProperty("BurgerId");
             var principalProperty = principalType.GetProperty("AlternateKey");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<BigMak>().Collection(e => e.Pickles).InverseReference(e => e.BigMak)
                 .PrincipalKey(e => e.AlternateKey)
                 .ForeignKey(e => e.BurgerId);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(principalProperty, fk.PrincipalKey.Properties.Single());
 
@@ -1804,14 +1804,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fk.Properties.Single().Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.Contains(principalKey, principalType.Keys);
-            Assert.Contains(fk.PrincipalKey, principalType.Keys);
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.Contains(principalKey, principalType.GetKeys());
+            Assert.Contains(fk.PrincipalKey, principalType.GetKeys());
             Assert.NotSame(principalKey, fk.PrincipalKey);
 
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1832,14 +1832,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var fkProperty = dependentType.GetOrAddProperty("BurgerId", typeof(int));
             var principalProperty = principalType.GetOrAddProperty("AlternateKey", typeof(int));
 
-            var dependentKey = dependentType.Keys.SingleOrDefault();
+            var dependentKey = dependentType.GetKeys().SingleOrDefault();
 
             var expectedPrincipalProperties = principalType.Properties.ToList();
             var expectedDependentProperties = dependentType.Properties.ToList();
 
             modelBuilder.Entity<BigMak>().Key(e => e.AlternateKey);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("BigMak", dependentType.Navigations.Single().Name);
@@ -1848,13 +1848,13 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(expectedPrincipalProperties, principalType.Properties);
             AssertEqual(expectedDependentProperties, dependentType.Properties);
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
-            var principalKey = principalType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
             Assert.Same(principalProperty, principalKey.Properties.Single());
             Assert.Same(principalKey, fk.PrincipalKey);
 
-            Assert.Same(dependentKey, dependentType.Keys.SingleOrDefault());
+            Assert.Same(dependentKey, dependentType.GetKeys().SingleOrDefault());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
         }
@@ -1872,17 +1872,17 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentType = model.GetEntityType(typeof(Pickle));
             var principalType = model.GetEntityType(typeof(BigMak));
 
-            var nonPrimaryPrincipalKey = principalType.Keys.Single(k => !k.IsPrimaryKey());
+            var nonPrimaryPrincipalKey = principalType.GetKeys().Single(k => !k.IsPrimaryKey());
             var principalProperty = principalType.GetOrAddProperty("AlternateKey", typeof(int));
 
-            var dependentKey = dependentType.Keys.SingleOrDefault();
+            var dependentKey = dependentType.GetKeys().SingleOrDefault();
 
             var expectedPrincipalProperties = principalType.Properties.ToList();
             var expectedDependentProperties = dependentType.Properties.ToList();
 
             modelBuilder.Entity<BigMak>().Key(e => e.AlternateKey);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Equal(2, fk.Properties.Count);
             Assert.Same(nonPrimaryPrincipalKey, fk.PrincipalKey);
 
@@ -1892,14 +1892,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(expectedPrincipalProperties, principalType.Properties);
             AssertEqual(expectedDependentProperties, dependentType.Properties);
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
             var primaryPrincipalKey = principalType.GetPrimaryKey();
             Assert.Same(principalProperty, primaryPrincipalKey.Properties.Single());
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.True(principalType.Keys.Contains(nonPrimaryPrincipalKey));
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.True(principalType.GetKeys().Contains(nonPrimaryPrincipalKey));
 
-            Assert.Same(dependentKey, dependentType.Keys.SingleOrDefault());
+            Assert.Same(dependentKey, dependentType.GetKeys().SingleOrDefault());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
         }
 
@@ -1916,17 +1916,17 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentType = model.GetEntityType(typeof(Pickle));
             var principalType = model.GetEntityType(typeof(BigMak));
 
-            var nonPrimaryPrincipalKey = principalType.Keys.Single();
+            var nonPrimaryPrincipalKey = principalType.GetKeys().Single();
             var principalProperty = principalType.GetOrAddProperty("AlternateKey", typeof(int));
 
-            var dependentKey = dependentType.Keys.SingleOrDefault();
+            var dependentKey = dependentType.GetKeys().SingleOrDefault();
 
             var expectedPrincipalProperties = principalType.Properties.ToList();
             var expectedDependentProperties = dependentType.Properties.ToList();
 
             modelBuilder.Entity<BigMak>().Key(e => e.AlternateKey);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(nonPrimaryPrincipalKey, fk.PrincipalKey);
 
             Assert.Equal("BigMak", dependentType.Navigations.Single().Name);
@@ -1935,13 +1935,13 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(expectedPrincipalProperties, principalType.Properties);
             AssertEqual(expectedDependentProperties, dependentType.Properties);
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
             var primaryPrincipalKey = principalType.GetPrimaryKey();
             Assert.Same(principalProperty, primaryPrincipalKey.Properties.Single());
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.True(principalType.Keys.Contains(nonPrimaryPrincipalKey));
-            Assert.Same(dependentKey, dependentType.Keys.SingleOrDefault());
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.True(principalType.GetKeys().Contains(nonPrimaryPrincipalKey));
+            Assert.Same(dependentKey, dependentType.GetKeys().SingleOrDefault());
             Assert.Same(dependentKey, dependentType.FindPrimaryKey());
         }
 
@@ -1959,26 +1959,26 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = model.GetEntityType(typeof(Order));
             var principalType = model.GetEntityType(typeof(Customer));
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
 
             var navToPrincipal = dependentType.GetOrAddNavigation("Customer", fk, pointsToPrincipal: true);
             var navToDependent = principalType.GetOrAddNavigation("Orders", fk, pointsToPrincipal: false);
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity<Order>().Reference(e => e.Customer).InverseCollection(e => e.Orders);
 
-            Assert.Same(fk, dependentType.ForeignKeys.Single());
+            Assert.Same(fk, dependentType.GetForeignKeys().Single());
             Assert.Same(navToPrincipal, dependentType.Navigations.Single());
             Assert.Same(navToDependent, principalType.Navigations.Single());
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name, Customer.NameProperty.Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { "AnotherCustomerId", fk.Properties.Single().Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -1997,23 +1997,23 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = model.GetEntityType(typeof(Order));
             var principalType = model.GetEntityType(typeof(Customer));
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
 
             var navigation = dependentType.GetNavigation("Customer");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity<Order>().Reference(e => e.Customer).InverseCollection(e => e.Orders);
 
-            Assert.Equal(1, dependentType.ForeignKeys.Count());
+            Assert.Equal(1, dependentType.GetForeignKeys().Count());
             Assert.Equal("Orders", principalType.Navigations.Single().Name);
             Assert.Same(fk.PrincipalKey, principalType.Navigations.Single().ForeignKey.PrincipalKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name, Customer.NameProperty.Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { "AnotherCustomerId", fk.Properties.Single().Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2032,24 +2032,24 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = model.GetEntityType(typeof(Order));
             var principalType = model.GetEntityType(typeof(Customer));
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             var navigation = fk.PrincipalToDependent;
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity<Order>().Reference(e => e.Customer).InverseCollection(e => e.Orders);
 
-            Assert.Same(fk, dependentType.ForeignKeys.Single());
+            Assert.Same(fk, dependentType.GetForeignKeys().Single());
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
             Assert.Same(navigation, principalType.Navigations.Single());
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name, Customer.NameProperty.Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { "AnotherCustomerId", fk.Properties.Single().Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2066,13 +2066,13 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = model.GetEntityType(typeof(Order));
             var principalType = model.GetEntityType(typeof(Customer));
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity<Order>().Reference(e => e.Customer).InverseCollection(e => e.Orders);
-            var newFk = dependentType.ForeignKeys.Single(foreignKey => foreignKey != fk);
+            var newFk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey != fk);
 
             Assert.NotSame(fk, newFk);
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -2081,9 +2081,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(newFk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name, Customer.NameProperty.Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { "AnotherCustomerId", fk.Properties.Single().Name, newFk.Properties.Single().Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2103,12 +2103,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty = dependentType.GetProperty("CustomerId");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity<Order>().Reference(e => e.Customer).InverseCollection(e => e.Orders);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -2117,9 +2117,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name, Customer.NameProperty.Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { "AnotherCustomerId", fk.Properties.Single().Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2139,12 +2139,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty = dependentType.GetProperty("CustomerId");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity<Order>().Reference(e => e.Customer).InverseCollection();
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -2152,9 +2152,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name, Customer.NameProperty.Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { "AnotherCustomerId", fk.Properties.Single().Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2174,12 +2174,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty = dependentType.GetProperty("CustomerId");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity<Order>().Reference<Customer>().InverseCollection(e => e.Orders);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Empty(dependentType.Navigations);
@@ -2187,9 +2187,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name, Customer.NameProperty.Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { "AnotherCustomerId", fk.Properties.Single().Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2208,24 +2208,24 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalType = model.GetEntityType(typeof(Customer));
 
             var fkProperty = dependentType.GetProperty("CustomerId");
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity<Order>().Reference<Customer>().InverseCollection();
 
-            var newFk = dependentType.ForeignKeys.Single(foreignKey => foreignKey != fk);
+            var newFk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey != fk);
 
             Assert.Empty(dependentType.Navigations.Where(nav => nav.ForeignKey != fk));
             Assert.Empty(principalType.Navigations.Where(nav => nav.ForeignKey != fk));
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name, Customer.NameProperty.Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { "AnotherCustomerId", fk.Properties.Single().Name, newFk.Properties.Single().Name, dependentKey.Properties.Single().Name },
                 dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2245,14 +2245,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty = dependentType.GetProperty("CustomerId");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Order>().Reference(e => e.Customer).InverseCollection(e => e.Orders)
                 .ForeignKey(e => e.CustomerId);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -2261,9 +2261,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name, Customer.NameProperty.Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { "AnotherCustomerId", fk.Properties.Single().Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2280,8 +2280,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentType = model.GetEntityType(typeof(Pickle));
             var principalType = model.GetEntityType(typeof(BigMak));
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             var fk = dependentType.AddForeignKey(dependentType.GetOrAddProperty("BurgerId", typeof(int)), principalKey);
             fk.IsUnique = false;
@@ -2290,16 +2290,16 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .Entity<Pickle>().Reference(e => e.BigMak).InverseCollection(e => e.Pickles)
                 .ForeignKey(e => e.BurgerId);
 
-            Assert.Same(fk, dependentType.ForeignKeys.Single());
+            Assert.Same(fk, dependentType.GetForeignKeys().Single());
             Assert.Equal("BigMak", dependentType.Navigations.Single().Name);
             Assert.Equal("Pickles", principalType.Navigations.Single().Name);
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fk.Properties.Single().Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2318,14 +2318,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty = dependentType.GetProperty("BurgerId");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Pickle>().Reference(e => e.BigMak).InverseCollection(e => e.Pickles)
                 .ForeignKey(e => e.BurgerId);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("BigMak", dependentType.Navigations.Single().Name);
@@ -2334,9 +2334,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fkProperty.Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2355,14 +2355,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty = dependentType.GetProperty("BurgerId");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Pickle>().Reference(e => e.BigMak).InverseCollection()
                 .ForeignKey(e => e.BurgerId);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("BigMak", dependentType.Navigations.Single().Name);
@@ -2370,9 +2370,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fkProperty.Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2391,14 +2391,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty = dependentType.GetProperty("BurgerId");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Pickle>().Reference<BigMak>().InverseCollection(e => e.Pickles)
                 .ForeignKey(e => e.BurgerId);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Empty(dependentType.Navigations);
@@ -2406,9 +2406,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fkProperty.Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2426,25 +2426,25 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalType = model.GetEntityType(typeof(BigMak));
 
             var fkProperty = dependentType.GetProperty("BurgerId");
-            var fk = dependentType.ForeignKeys.SingleOrDefault();
+            var fk = dependentType.GetForeignKeys().SingleOrDefault();
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Pickle>().Reference<BigMak>().InverseCollection()
                 .ForeignKey(e => e.BurgerId);
 
-            var newFk = dependentType.ForeignKeys.Single(foreignKey => foreignKey != fk);
+            var newFk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey != fk);
             Assert.Same(fkProperty, newFk.Properties.Single());
 
             Assert.Empty(dependentType.Navigations.Where(nav => nav.ForeignKey != fk));
             Assert.Empty(principalType.Navigations.Where(nav => nav.ForeignKey != fk));
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fk.Properties.Single().Name, fkProperty.Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2461,12 +2461,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentType = model.GetEntityType(typeof(Pickle));
             var principalType = model.GetEntityType(typeof(BigMak));
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity<Pickle>().Reference(e => e.BigMak).InverseCollection(e => e.Pickles);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             var fkProperty = fk.Properties.Single();
 
             Assert.Equal("BigMakId", fkProperty.Name);
@@ -2480,9 +2480,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fkProperty.Name, "BurgerId", dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2499,12 +2499,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentType = model.GetEntityType(typeof(Pickle));
             var principalType = model.GetEntityType(typeof(BigMak));
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity<Pickle>().Reference(e => e.BigMak).InverseCollection();
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             var fkProperty = fk.Properties.Single();
 
             Assert.Equal("BigMakId", fkProperty.Name);
@@ -2517,9 +2517,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fkProperty.Name, "BurgerId", dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2536,12 +2536,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentType = model.GetEntityType(typeof(Pickle));
             var principalType = model.GetEntityType(typeof(BigMak));
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity<Pickle>().Reference<BigMak>().InverseCollection(e => e.Pickles);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             var fkProperty = fk.Properties.Single();
 
             Assert.Equal("BigMakId", fkProperty.Name);
@@ -2554,9 +2554,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fkProperty.Name, "BurgerId", dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2573,14 +2573,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentType = model.GetEntityType(typeof(Pickle));
             var principalType = model.GetEntityType(typeof(BigMak));
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
-            var fk = dependentType.ForeignKeys.SingleOrDefault();
+            var fk = dependentType.GetForeignKeys().SingleOrDefault();
 
             modelBuilder.Entity<Pickle>().Reference<BigMak>().InverseCollection();
 
-            var newFk = dependentType.ForeignKeys.Single(foreignKey => foreignKey != fk);
+            var newFk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey != fk);
             var fkProperty = newFk.Properties.Single();
 
             Assert.True(fkProperty.IsShadowProperty);
@@ -2591,9 +2591,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Empty(principalType.Navigations.Where(nav => nav.ForeignKey != fk));
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fk.Properties.Single().Name, fkProperty.Name, "BurgerId", dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2610,14 +2610,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentType = model.GetEntityType(typeof(Pickle));
             var principalType = model.GetEntityType(typeof(BigMak));
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             var fkProperty = dependentType.GetProperty("BigMakId");
 
             modelBuilder.Entity<Pickle>().Reference(e => e.BigMak).InverseCollection(e => e.Pickles);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("BigMak", dependentType.Navigations.Single().Name);
@@ -2626,9 +2626,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fkProperty.Name, "BurgerId", dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2645,19 +2645,19 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = model.GetEntityType(typeof(Pickle));
             var principalType = model.GetEntityType(typeof(BigMak));
-            var fk = dependentType.ForeignKeys.Single(foreignKey => foreignKey.Properties.Single().Name == "BurgerId");
+            var fk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey.Properties.Single().Name == "BurgerId");
             Assert.True(((IForeignKey)fk).IsUnique);
             dependentType.RemoveNavigation(fk.DependentToPrincipal);
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Pickle>().Reference(e => e.BigMak).InverseCollection(e => e.Pickles)
                 .ForeignKey(e => e.BurgerId);
 
-            Assert.Equal(1, dependentType.ForeignKeys.Count);
-            var newFk = (IForeignKey)dependentType.ForeignKeys.Single();
+            Assert.Equal(1, dependentType.GetForeignKeys().Count());
+            var newFk = (IForeignKey)dependentType.GetForeignKeys().Single();
 
             Assert.False(newFk.IsUnique);
             Assert.NotSame(fk, newFk);
@@ -2668,9 +2668,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(newFk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { newFk.Properties.Single().Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2691,14 +2691,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var fkProperty = dependentType.GetProperty("CustomerId");
             var principalProperty = principalType.GetProperty(Customer.IdProperty.Name);
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Order>().Reference(e => e.Customer).InverseCollection(e => e.Orders)
                 .PrincipalKey(e => e.Id);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(principalProperty, fk.PrincipalKey.Properties.Single());
 
@@ -2708,9 +2708,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name, Customer.NameProperty.Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { "AnotherCustomerId", fkProperty.Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2733,14 +2733,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var expectedPrincipalProperties = principalType.Properties.ToList();
             var expectedDependentProperties = dependentType.Properties.ToList();
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Order>().Reference(e => e.Customer).InverseCollection(e => e.Orders)
                 .PrincipalKey(e => e.AlternateKey);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(principalProperty, fk.PrincipalKey.Properties.Single());
 
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -2748,13 +2748,13 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
 
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.Contains(principalKey, principalType.Keys);
-            Assert.Contains(fk.PrincipalKey, principalType.Keys);
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.Contains(principalKey, principalType.GetKeys());
+            Assert.Contains(fk.PrincipalKey, principalType.GetKeys());
             Assert.NotSame(principalKey, fk.PrincipalKey);
 
-            Assert.Equal(1, dependentType.Keys.Count);
+            Assert.Equal(1, dependentType.GetKeys().Count());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
 
@@ -2780,15 +2780,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var fkProperty = dependentType.GetProperty("CustomerId");
             var principalProperty = principalType.GetProperty(Customer.IdProperty.Name);
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Order>().Reference(e => e.Customer).InverseCollection(e => e.Orders)
                 .ForeignKey(e => e.CustomerId)
                 .PrincipalKey(e => e.Id);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(principalProperty, fk.PrincipalKey.Properties.Single());
 
@@ -2798,9 +2798,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name, Customer.NameProperty.Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { "AnotherCustomerId", fkProperty.Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2821,15 +2821,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var fkProperty = dependentType.GetProperty("CustomerId");
             var principalProperty = principalType.GetProperty(Customer.IdProperty.Name);
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Order>().Reference(e => e.Customer).InverseCollection(e => e.Orders)
                 .PrincipalKey(e => e.Id)
                 .ForeignKey(e => e.CustomerId);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(principalProperty, fk.PrincipalKey.Properties.Single());
 
@@ -2839,9 +2839,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name, Customer.NameProperty.Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { "AnotherCustomerId", fkProperty.Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -2860,15 +2860,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalType = model.GetEntityType(typeof(Customer));
             var expectedPrincipalProperties = principalType.Properties.ToList();
             var expectedDependentProperties = dependentType.Properties.ToList();
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Order>().Reference(e => e.Customer).InverseCollection(e => e.Orders)
                 .ForeignKey(e => e.AnotherCustomerId)
                 .PrincipalKey(e => e.AlternateKey);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Equal("AnotherCustomerId", fk.Properties.Single().Name);
             Assert.Equal("AlternateKey", fk.PrincipalKey.Properties.Single().Name);
 
@@ -2876,14 +2876,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Equal("Orders", principalType.Navigations.Single().Name);
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.Contains(principalKey, principalType.Keys);
-            Assert.Contains(fk.PrincipalKey, principalType.Keys);
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.Contains(principalKey, principalType.GetKeys());
+            Assert.Contains(fk.PrincipalKey, principalType.GetKeys());
             Assert.NotSame(principalKey, fk.PrincipalKey);
 
-            Assert.Equal(1, dependentType.Keys.Count);
+            Assert.Equal(1, dependentType.GetKeys().Count());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
 
@@ -2907,15 +2907,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalType = model.GetEntityType(typeof(Customer));
             var expectedPrincipalProperties = principalType.Properties.ToList();
             var expectedDependentProperties = dependentType.Properties.ToList();
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Order>().Reference(e => e.Customer).InverseCollection(e => e.Orders)
                 .PrincipalKey(e => e.AlternateKey)
                 .ForeignKey(e => e.AnotherCustomerId);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Equal("AnotherCustomerId", fk.Properties.Single().Name);
             Assert.Equal("AlternateKey", fk.PrincipalKey.Properties.Single().Name);
 
@@ -2923,14 +2923,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Equal("Orders", principalType.Navigations.Single().Name);
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.Contains(principalKey, principalType.Keys);
-            Assert.Contains(fk.PrincipalKey, principalType.Keys);
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.Contains(principalKey, principalType.GetKeys());
+            Assert.Contains(fk.PrincipalKey, principalType.GetKeys());
             Assert.NotSame(principalKey, fk.PrincipalKey);
 
-            Assert.Equal(1, dependentType.Keys.Count);
+            Assert.Equal(1, dependentType.GetKeys().Count());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
 
@@ -2955,15 +2955,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var fkProperty = dependentType.GetProperty("BurgerId");
             var principalProperty = principalType.GetProperty("AlternateKey");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Pickle>().Reference(e => e.BigMak).InverseCollection(e => e.Pickles)
                 .ForeignKey(e => e.BurgerId)
                 .PrincipalKey(e => e.AlternateKey);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(principalProperty, fk.PrincipalKey.Properties.Single());
 
@@ -2973,14 +2973,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fkProperty.Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.Contains(principalKey, principalType.Keys);
-            Assert.Contains(fk.PrincipalKey, principalType.Keys);
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.Contains(principalKey, principalType.GetKeys());
+            Assert.Contains(fk.PrincipalKey, principalType.GetKeys());
             Assert.NotSame(principalKey, fk.PrincipalKey);
 
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3000,15 +3000,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var fkProperty = dependentType.GetProperty("BurgerId");
             var principalProperty = principalType.GetProperty("AlternateKey");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Pickle>().Reference(e => e.BigMak).InverseCollection(e => e.Pickles)
                 .PrincipalKey(e => e.AlternateKey)
                 .ForeignKey(e => e.BurgerId);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(principalProperty, fk.PrincipalKey.Properties.Single());
 
@@ -3018,14 +3018,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fkProperty.Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.Contains(principalKey, principalType.Keys);
-            Assert.Contains(fk.PrincipalKey, principalType.Keys);
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.Contains(principalKey, principalType.GetKeys());
+            Assert.Contains(fk.PrincipalKey, principalType.GetKeys());
             Assert.NotSame(principalKey, fk.PrincipalKey);
 
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3043,25 +3043,25 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = model.GetEntityType(typeof(CustomerDetails));
             var principalType = model.GetEntityType(typeof(Customer));
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
 
             var navToPrincipal = dependentType.GetNavigation("Customer");
             var navToDependent = principalType.GetNavigation("Details");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity<Customer>().Reference(e => e.Details).InverseReference(e => e.Customer);
 
-            Assert.Equal(1, dependentType.ForeignKeys.Count());
+            Assert.Equal(1, dependentType.GetForeignKeys().Count());
             Assert.Same(navToPrincipal, dependentType.Navigations.Single());
             Assert.Same(navToDependent, principalType.Navigations.Single());
             Assert.Same(fk.PrincipalKey, principalType.Navigations.Single().ForeignKey.PrincipalKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name, Customer.NameProperty.Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3079,19 +3079,19 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var expectedPrincipalProperties = principalType.Properties.ToList();
             var expectedDependentProperties = dependentType.Properties.ToList();
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity<Customer>().Reference(e => e.Details).InverseReference(e => e.Customer);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fk.DependentToPrincipal, dependentType.Navigations.Single());
             Assert.Same(fk.PrincipalToDependent, principalType.Navigations.Single());
             AssertEqual(expectedPrincipalProperties, principalType.Properties);
             AssertEqual(expectedDependentProperties, dependentType.Properties);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3108,23 +3108,23 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = model.GetEntityType(typeof(CustomerDetails));
             var principalType = model.GetEntityType(typeof(Customer));
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
 
             var navigation = principalType.GetNavigation("Details");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity<Customer>().Reference(e => e.Details).InverseReference(e => e.Customer);
 
-            Assert.Equal(1, dependentType.ForeignKeys.Count);
+            Assert.Equal(1, dependentType.GetForeignKeys().Count());
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
             Assert.Same(fk.PrincipalKey, principalType.Navigations.Single().ForeignKey.PrincipalKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name, Customer.NameProperty.Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3143,16 +3143,16 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = model.GetEntityType(typeof(CustomerDetails));
             var principalType = model.GetEntityType(typeof(Customer));
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
             var expectedPrincipalProperties = principalType.Properties.ToList();
             var expectedDependentProperties = dependentType.Properties.ToList();
 
             modelBuilder.Entity<CustomerDetails>().Reference(e => e.Customer).InverseReference(e => e.Details)
                 .PrincipalKey<Customer>(e => e.Id);
-            var newFk = dependentType.ForeignKeys.Single(foreignKey => foreignKey != fk);
+            var newFk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey != fk);
 
             Assert.NotSame(fk.Properties.Single(), newFk.Properties.Single());
             Assert.Same(newFk.DependentToPrincipal, dependentType.Navigations.Single());
@@ -3160,9 +3160,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             AssertEqual(expectedPrincipalProperties, principalType.Properties);
             expectedDependentProperties.Add(newFk.Properties.Single());
             AssertEqual(expectedDependentProperties, dependentType.Properties);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3179,14 +3179,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentType = model.GetEntityType(typeof(CustomerDetails));
             var principalType = model.GetEntityType(typeof(Customer));
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
             var expectedPrincipalProperties = principalType.Properties.ToList();
             var expectedDependentProperties = dependentType.Properties.ToList();
 
             modelBuilder.Entity<CustomerDetails>().Reference(e => e.Customer).InverseReference(e => e.Details);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
 
             Assert.Same(fk.DependentToPrincipal, dependentType.Navigations.Single());
             Assert.Same(fk.PrincipalToDependent, principalType.Navigations.Single());
@@ -3194,9 +3194,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(expectedPrincipalProperties, principalType.Properties);
             Assert.Equal(expectedDependentProperties, dependentType.Properties);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3217,25 +3217,25 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = model.GetEntityType(typeof(OrderDetails));
             var principalType = model.GetEntityType(typeof(Order));
-            var existingFk = dependentType.ForeignKeys.Single();
+            var existingFk = dependentType.GetForeignKeys().Single();
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
             var expectedPrincipalProperties = principalType.Properties.ToList();
             var expectedDependentProperties = dependentType.Properties.ToList();
 
             modelBuilder.Entity<OrderDetails>().Reference(e => e.Order).InverseReference(e => e.Details);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.NotSame(existingFk, fk);
 
             Assert.Same(fk.DependentToPrincipal, dependentType.Navigations.Single());
             Assert.Same(fk.PrincipalToDependent, principalType.Navigations.Single());
             Assert.Equal(expectedPrincipalProperties, principalType.Properties);
             Assert.Equal(expectedDependentProperties, dependentType.Properties);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3254,12 +3254,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty = dependentType.GetProperty("OrderId");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity<OrderDetails>().Reference(e => e.Order).InverseReference(e => e.Details);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("Order", dependentType.Navigations.Single().Name);
@@ -3268,9 +3268,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AnotherCustomerId", "CustomerId", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { dependentKey.Properties.Single().Name, fkProperty.Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3289,26 +3289,26 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var expectedPrincipalProperties = principalType.Properties.ToList();
             var expectedDependentProperties = dependentType.Properties.ToList();
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder.Entity<Customer>().Reference(e => e.Details).InverseReference();
 
             var fk = dependentType.Navigations.Single().ForeignKey;
             if (fk.EntityType == dependentType)
             {
-                Assert.Empty(principalType.ForeignKeys);
+                Assert.Empty(principalType.GetForeignKeys());
             }
             else
             {
-                Assert.Empty(dependentType.ForeignKeys);
+                Assert.Empty(dependentType.GetForeignKeys());
             }
 
             Assert.Empty(principalType.Navigations);
             Assert.Equal(expectedPrincipalProperties, principalType.Properties);
             Assert.Equal(expectedDependentProperties, dependentType.Properties);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3335,8 +3335,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 foreignKey.EntityType.RemoveForeignKey(foreignKey);
             }
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
             var expectedPrincipalProperties = principalType.Properties.ToList();
             var expectedDependentProperties = dependentType.Properties.ToList();
 
@@ -3348,9 +3348,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             AssertEqual(expectedPrincipalProperties, principalType.Properties);
             expectedDependentProperties.Add(fk.Properties.Single());
             AssertEqual(expectedDependentProperties, dependentType.Properties);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3367,21 +3367,21 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentType = model.GetEntityType(typeof(CustomerDetails));
             var principalType = model.GetEntityType(typeof(Customer));
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
             var expectedPrincipalProperties = principalType.Properties.ToList();
             var expectedDependentProperties = dependentType.Properties.ToList();
 
             modelBuilder.Entity<CustomerDetails>().Reference<Customer>().InverseReference();
 
-            var fk = dependentType.ForeignKeys.Single(foreignKey => foreignKey.PrincipalToDependent == null);
+            var fk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey.PrincipalToDependent == null);
 
             Assert.Empty(dependentType.Navigations.Where(nav => nav.ForeignKey == fk));
             Assert.Equal(expectedPrincipalProperties, principalType.Properties);
             expectedDependentProperties.Add(fk.Properties.Single());
             AssertEqual(expectedDependentProperties, dependentType.Properties);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3400,14 +3400,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty = dependentType.GetProperty("OrderId");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Order>().Reference(e => e.Details).InverseReference(e => e.Order)
                 .ForeignKey<OrderDetails>(e => e.OrderId);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("Order", dependentType.Navigations.Single().Name);
@@ -3416,9 +3416,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AnotherCustomerId", "CustomerId", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { dependentKey.Properties.Single().Name, fkProperty.Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3437,14 +3437,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty = dependentType.GetProperty(Customer.IdProperty.Name);
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Customer>().Reference(e => e.Details).InverseReference(e => e.Customer)
                 .ForeignKey<CustomerDetails>(e => e.Id);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -3453,9 +3453,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name, "Name" }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3473,26 +3473,26 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = model.GetEntityType(typeof(Bun));
             var principalType = model.GetEntityType(typeof(BigMak));
-            var fk = dependentType.ForeignKeys.Single(foreignKey => foreignKey.Properties.All(p => p.Name == "BurgerId"));
+            var fk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey.Properties.All(p => p.Name == "BurgerId"));
             fk.IsUnique = true;
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<BigMak>().Reference(e => e.Bun).InverseReference(e => e.BigMak)
                 .ForeignKey<Bun>(e => e.BurgerId);
 
-            Assert.Same(fk, dependentType.ForeignKeys.Single());
+            Assert.Same(fk, dependentType.GetForeignKeys().Single());
             Assert.Equal("BigMak", dependentType.Navigations.Single().Name);
             Assert.Equal("Bun", principalType.Navigations.Single().Name);
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fk.Properties.Single().Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3511,14 +3511,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty = dependentType.GetProperty("BurgerId");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<BigMak>().Reference(e => e.Bun).InverseReference(e => e.BigMak)
                 .ForeignKey<Bun>(e => e.BurgerId);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("BigMak", dependentType.Navigations.Single().Name);
@@ -3527,9 +3527,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fk.Properties.Single().Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3548,14 +3548,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty = dependentType.GetProperty("BurgerId");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<BigMak>().Reference(e => e.Bun).InverseReference()
                 .ForeignKey<Bun>(e => e.BurgerId);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Empty(dependentType.Navigations);
@@ -3563,9 +3563,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fk.Properties.Single().Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3584,14 +3584,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty = dependentType.GetProperty("BurgerId");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<BigMak>().Reference<Bun>().InverseReference(e => e.BigMak)
                 .ForeignKey<Bun>(e => e.BurgerId);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("BigMak", dependentType.Navigations.Single().Name);
@@ -3599,9 +3599,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fk.Properties.Single().Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3618,8 +3618,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentType = model.GetEntityType(typeof(Bun));
             var principalType = model.GetEntityType(typeof(BigMak));
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
             var expectedPrincipalProperties = principalType.Properties.ToList();
             var expectedDependentProperties = dependentType.Properties.ToList();
 
@@ -3627,14 +3627,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .Entity<BigMak>().Reference<Bun>().InverseReference()
                 .ForeignKey<Bun>(e => e.BurgerId);
 
-            var newFk = dependentType.ForeignKeys.Single(foreignKey => foreignKey.Properties.All(p => p.Name == "BurgerId"));
+            var newFk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey.Properties.All(p => p.Name == "BurgerId"));
 
             Assert.Empty(dependentType.Navigations.Where(nav => nav.ForeignKey == newFk));
             Assert.Empty(principalType.Navigations.Where(nav => nav.ForeignKey == newFk));
             Assert.Equal(expectedPrincipalProperties, principalType.Properties);
             Assert.Equal(expectedDependentProperties, dependentType.Properties);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3654,7 +3654,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalType = model.GetEntityType(typeof(BigMak));
             var fk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey.Properties.All(p => p.Name == "BurgerId"));
 
-            var principalKey = principalType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
             var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
@@ -3674,8 +3674,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(newFk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { newFk.Properties.Single().Name, dependentKey.Properties.Single().Name }, dependentType.GetProperties().Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
             Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
@@ -3695,16 +3695,16 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = model.GetEntityType(typeof(OrderDetails));
             var principalType = model.GetEntityType(typeof(Order));
-            var existingFk = dependentType.ForeignKeys.Single(fk => fk.Properties.All(p => p.Name == "Id"));
+            var existingFk = dependentType.GetForeignKeys().Single(fk => fk.Properties.All(p => p.Name == "Id"));
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<OrderDetails>().Reference(e => e.Order).InverseReference(e => e.Details)
                 .ForeignKey<OrderDetails>(e => e.Id);
 
-            var newFk = dependentType.ForeignKeys.Single();
+            var newFk = dependentType.GetForeignKeys().Single();
             Assert.Equal(existingFk.Properties, newFk.Properties);
             Assert.Equal(existingFk.PrincipalKey.Properties, newFk.PrincipalKey.Properties);
             Assert.Equal("Order", dependentType.Navigations.Single().Name);
@@ -3713,9 +3713,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(newFk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AnotherCustomerId", "CustomerId", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { existingFk.Properties.Single().Name, "OrderId" }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3734,8 +3734,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty = dependentType.GetProperty("OrderId");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
             var expectedPrincipalProperties = principalType.Properties.ToList();
             var expectedDependentProperties = dependentType.Properties.ToList();
 
@@ -3743,7 +3743,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .Entity<OrderDetails>().Reference(e => e.Order).InverseReference(e => e.Details)
                 .ForeignKey<OrderDetails>(e => e.OrderId);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Same(fk.DependentToPrincipal, dependentType.Navigations.Single());
@@ -3752,9 +3752,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(expectedPrincipalProperties, principalType.Properties);
             Assert.Equal(expectedDependentProperties, dependentType.Properties);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3773,8 +3773,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty = dependentType.GetProperty("OrderId");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
             var expectedPrincipalProperties = principalType.Properties.ToList();
             var expectedDependentProperties = dependentType.Properties.ToList();
 
@@ -3782,7 +3782,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .Entity<OrderDetails>().Reference(e => e.Order).InverseReference(e => e.Details)
                 .ForeignKey<Order>(e => e.OrderId);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Same(fk.DependentToPrincipal, dependentType.Navigations.Single());
@@ -3791,9 +3791,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(expectedPrincipalProperties, principalType.Properties);
             Assert.Equal(expectedDependentProperties, dependentType.Properties);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3812,8 +3812,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty = dependentType.GetProperty(Customer.IdProperty.Name);
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
             var expectedPrincipalProperties = principalType.Properties.Where(p => !p.IsShadowProperty).ToList();
             var expectedDependentProperties = dependentType.Properties.ToList();
 
@@ -3821,16 +3821,16 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .Entity<CustomerDetails>().Reference(e => e.Customer).InverseReference()
                 .ForeignKey<Customer>(e => e.Id);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Empty(dependentType.Navigations);
             Assert.Same(fk.PrincipalToDependent, principalType.Navigations.Single());
             Assert.Equal(expectedPrincipalProperties, principalType.Properties);
             Assert.Equal(expectedDependentProperties, dependentType.Properties);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3849,8 +3849,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty = dependentType.GetProperty(Customer.IdProperty.Name);
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
             var expectedPrincipalProperties = principalType.Properties.ToList();
             var expectedDependentProperties = dependentType.Properties.Where(p => !p.IsShadowProperty).ToList();
 
@@ -3858,16 +3858,16 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .Entity<CustomerDetails>().Reference(e => e.Customer).InverseReference()
                 .ForeignKey<CustomerDetails>(e => e.Id);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Same(fk.DependentToPrincipal, dependentType.Navigations.Single());
             Assert.Empty(principalType.Navigations);
             Assert.Equal(expectedPrincipalProperties, principalType.Properties);
             Assert.Equal(expectedDependentProperties, dependentType.Properties);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3886,8 +3886,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty = dependentType.GetProperty(Customer.IdProperty.Name);
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
             var expectedPrincipalProperties = principalType.Properties.Where(p => !p.IsShadowProperty).ToList();
             var expectedDependentProperties = dependentType.Properties.ToList();
 
@@ -3895,16 +3895,16 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .Entity<CustomerDetails>().Reference<Customer>().InverseReference(e => e.Details)
                 .ForeignKey<Customer>(e => e.Id);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Same(fk.DependentToPrincipal, dependentType.Navigations.Single());
             Assert.Empty(principalType.Navigations);
             Assert.Equal(expectedPrincipalProperties, principalType.Properties);
             Assert.Equal(expectedDependentProperties, dependentType.Properties);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3923,8 +3923,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty = dependentType.GetProperty(Customer.IdProperty.Name);
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
             var expectedPrincipalProperties = principalType.Properties.ToList();
             var expectedDependentProperties = dependentType.Properties.Where(p => !p.IsShadowProperty).ToList();
 
@@ -3932,16 +3932,16 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .Entity<CustomerDetails>().Reference<Customer>().InverseReference(e => e.Details)
                 .ForeignKey<CustomerDetails>(e => e.Id);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Empty(dependentType.Navigations);
             Assert.Same(fk.PrincipalToDependent, principalType.Navigations.Single());
             Assert.Equal(expectedPrincipalProperties, principalType.Properties);
             Assert.Equal(expectedDependentProperties, dependentType.Properties);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -3960,11 +3960,11 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty = dependentType.GetProperty(Customer.IdProperty.Name);
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
-            var principalFk = principalType.ForeignKeys.SingleOrDefault();
-            var existingFk = dependentType.ForeignKeys.SingleOrDefault();
+            var principalFk = principalType.GetForeignKeys().SingleOrDefault();
+            var existingFk = dependentType.GetForeignKeys().SingleOrDefault();
             var expectedPrincipalProperties = principalType.Properties.ToList();
             var expectedDependentProperties = dependentType.Properties.ToList();
 
@@ -3972,16 +3972,16 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .Entity<CustomerDetails>().Reference<Customer>().InverseReference()
                 .ForeignKey<CustomerDetails>(e => e.Id);
 
-            var newForeignKey = dependentType.ForeignKeys.Single(fk => fk != existingFk);
+            var newForeignKey = dependentType.GetForeignKeys().Single(fk => fk != existingFk);
             Assert.Same(fkProperty, newForeignKey.Properties.Single());
 
             Assert.Empty(dependentType.Navigations.Where(nav => nav.ForeignKey == newForeignKey));
             Assert.Empty(principalType.Navigations.Where(nav => nav.ForeignKey == newForeignKey));
             Assert.Equal(expectedPrincipalProperties, principalType.Properties);
             Assert.Equal(expectedDependentProperties, dependentType.Properties);
-            Assert.Same(principalFk, principalType.ForeignKeys.SingleOrDefault());
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Same(principalFk, principalType.GetForeignKeys().SingleOrDefault());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4000,11 +4000,11 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty = dependentType.GetProperty(Customer.IdProperty.Name);
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
-            var principalFk = principalType.ForeignKeys.SingleOrDefault();
-            var existingFk = dependentType.ForeignKeys.SingleOrDefault();
+            var principalFk = principalType.GetForeignKeys().SingleOrDefault();
+            var existingFk = dependentType.GetForeignKeys().SingleOrDefault();
             var expectedPrincipalProperties = principalType.Properties.ToList();
             var expectedDependentProperties = dependentType.Properties.ToList();
 
@@ -4012,16 +4012,16 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .Entity<CustomerDetails>().Reference<Customer>().InverseReference()
                 .ForeignKey<Customer>(e => e.Id);
 
-            var newForeignKey = dependentType.ForeignKeys.Single(fk => fk != existingFk);
+            var newForeignKey = dependentType.GetForeignKeys().Single(fk => fk != existingFk);
             Assert.Same(fkProperty, newForeignKey.Properties.Single());
 
             Assert.Empty(dependentType.Navigations.Where(nav => nav.ForeignKey == newForeignKey));
             Assert.Empty(principalType.Navigations.Where(nav => nav.ForeignKey == newForeignKey));
             Assert.Equal(expectedPrincipalProperties, principalType.Properties);
             Assert.Equal(expectedDependentProperties, dependentType.Properties);
-            Assert.Same(principalFk, principalType.ForeignKeys.SingleOrDefault());
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Same(principalFk, principalType.GetForeignKeys().SingleOrDefault());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4040,14 +4040,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty = dependentType.GetProperty(Customer.IdProperty.Name);
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<CustomerDetails>().Reference(e => e.Customer).InverseReference(e => e.Details)
                 .ForeignKey<CustomerDetails>(e => e.Id);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -4056,9 +4056,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name, "Name" }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4077,8 +4077,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalProperty = principalType.GetProperty(Customer.IdProperty.Name);
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
             var expectedPrincipalProperties = principalType.Properties.ToList();
             var expectedDependentProperties = dependentType.Properties.ToList();
 
@@ -4086,7 +4086,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .Entity<Customer>().Reference(e => e.Details).InverseReference(e => e.Customer)
                 .PrincipalKey<Customer>(e => e.Id);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(principalProperty, fk.PrincipalKey.Properties.Single());
 
             Assert.Same(fk.DependentToPrincipal, dependentType.Navigations.Single());
@@ -4095,9 +4095,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(expectedPrincipalProperties, principalType.Properties);
             Assert.Equal(expectedDependentProperties, dependentType.Properties);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4116,28 +4116,28 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalProperty = principalType.GetProperty("AlternateKey");
             var expectedPrincipalProperties = principalType.Properties.ToList();
             var expectedDependentProperties = dependentType.Properties.Where(p => !p.IsShadowProperty).ToList();
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Customer>().Reference(e => e.Details).InverseReference(e => e.Customer)
                 .PrincipalKey<Customer>(e => e.AlternateKey);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(principalProperty, fk.PrincipalKey.Properties.Single());
 
             Assert.Same(fk.DependentToPrincipal, dependentType.Navigations.Single());
             Assert.Same(fk.PrincipalToDependent, principalType.Navigations.Single());
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.Contains(principalKey, principalType.Keys);
-            Assert.Contains(fk.PrincipalKey, principalType.Keys);
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.Contains(principalKey, principalType.GetKeys());
+            Assert.Contains(fk.PrincipalKey, principalType.GetKeys());
             Assert.NotSame(principalKey, fk.PrincipalKey);
 
-            Assert.Equal(1, dependentType.Keys.Count);
+            Assert.Equal(1, dependentType.GetKeys().Count());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
 
@@ -4164,15 +4164,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Order>().Reference(e => e.Details).InverseReference(e => e.Order)
                 .ForeignKey<OrderDetails>(e => e.OrderId)
                 .PrincipalKey<Order>(e => e.OrderId);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(principalProperty, fk.PrincipalKey.Properties.Single());
 
@@ -4182,9 +4182,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4206,15 +4206,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var principalPropertyCount = principalType.PropertyCount;
             var dependentPropertyCount = dependentType.PropertyCount;
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Order>().Reference(e => e.Details).InverseReference(e => e.Order)
                 .PrincipalKey<Order>(e => e.OrderId)
                 .ForeignKey<OrderDetails>(e => e.OrderId);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(principalProperty, fk.PrincipalKey.Properties.Single());
 
@@ -4224,9 +4224,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.PropertyCount);
             Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4246,15 +4246,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var fkProperty = dependentType.GetProperty("BurgerId");
             var principalProperty = principalType.GetProperty("AlternateKey");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<BigMak>().Reference(e => e.Bun).InverseReference(e => e.BigMak)
                 .ForeignKey<Bun>(e => e.BurgerId)
                 .PrincipalKey<BigMak>(e => e.AlternateKey);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(principalProperty, fk.PrincipalKey.Properties.Single());
 
@@ -4264,14 +4264,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { principalProperty.Name, principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fkProperty.Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.Contains(principalKey, principalType.Keys);
-            Assert.Contains(fk.PrincipalKey, principalType.Keys);
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.Contains(principalKey, principalType.GetKeys());
+            Assert.Contains(fk.PrincipalKey, principalType.GetKeys());
             Assert.NotSame(principalKey, fk.PrincipalKey);
 
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4291,15 +4291,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var fkProperty = dependentType.GetProperty("BurgerId");
             var principalProperty = principalType.GetProperty("AlternateKey");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<BigMak>().Reference(e => e.Bun).InverseReference(e => e.BigMak)
                 .PrincipalKey<BigMak>(e => e.AlternateKey)
                 .ForeignKey<Bun>(e => e.BurgerId);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(principalProperty, fk.PrincipalKey.Properties.Single());
 
@@ -4309,14 +4309,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fkProperty.Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.Contains(principalKey, principalType.Keys);
-            Assert.Contains(fk.PrincipalKey, principalType.Keys);
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.Contains(principalKey, principalType.GetKeys());
+            Assert.Contains(fk.PrincipalKey, principalType.GetKeys());
             Assert.NotSame(principalKey, fk.PrincipalKey);
 
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4335,10 +4335,10 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = model.GetEntityType(typeof(OrderDetails));
             var principalType = model.GetEntityType(typeof(Order));
-            var existingFk = dependentType.ForeignKeys.Single(fk => fk.Properties.All(p => p.Name == "Id"));
+            var existingFk = dependentType.GetForeignKeys().Single(fk => fk.Properties.All(p => p.Name == "Id"));
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
             var expectedPrincipalProperties = principalType.Properties.ToList();
             var expectedDependentProperties = dependentType.Properties.ToList();
 
@@ -4346,7 +4346,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .Entity<OrderDetails>().Reference(e => e.Order).InverseReference(e => e.Details)
                 .PrincipalKey<Order>(e => e.OrderId);
 
-            var newFk = dependentType.ForeignKeys.Single(fk => fk != existingFk);
+            var newFk = dependentType.GetForeignKeys().Single(fk => fk != existingFk);
             Assert.NotEqual(existingFk.Properties, newFk.Properties);
             Assert.Equal("Order", dependentType.Navigations.Single().Name);
             Assert.Equal("Details", principalType.Navigations.Single().Name);
@@ -4354,9 +4354,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(newFk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(expectedPrincipalProperties, principalType.Properties);
             Assert.Equal(expectedDependentProperties, dependentType.Properties);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4376,8 +4376,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var keyProperty = principalType.GetProperty("OrderId");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
             var expectedPrincipalProperties = principalType.Properties.ToList();
             var expectedDependentProperties = dependentType.Properties.ToList();
 
@@ -4385,7 +4385,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .Entity<OrderDetails>().Reference(e => e.Order).InverseReference(e => e.Details)
                 .PrincipalKey<Order>(e => e.OrderId);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(keyProperty, fk.PrincipalKey.Properties.Single());
 
             Assert.Same(fk.DependentToPrincipal, dependentType.Navigations.Single());
@@ -4394,9 +4394,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(expectedPrincipalProperties, principalType.Properties);
             Assert.Equal(expectedDependentProperties, dependentType.Properties);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4416,8 +4416,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var keyProperty = principalType.GetProperty("OrderId");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
             var expectedPrincipalProperties = principalType.Properties.ToList();
             var expectedDependentProperties = dependentType.Properties.ToList();
 
@@ -4425,7 +4425,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .Entity<OrderDetails>().Reference(e => e.Order).InverseReference(e => e.Details)
                 .PrincipalKey<OrderDetails>(e => e.OrderId);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(keyProperty, fk.PrincipalKey.Properties.Single());
 
             Assert.Same(fk.DependentToPrincipal, dependentType.Navigations.Single());
@@ -4435,9 +4435,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Equal(expectedPrincipalProperties, principalType.Properties);
             expectedDependentProperties.Add(fk.Properties.Single());
             AssertEqual(expectedDependentProperties, dependentType.Properties);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(fk.PrincipalKey, principalType.Keys.Single(k => k != principalKey));
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(fk.PrincipalKey, principalType.GetKeys().Single(k => k != principalKey));
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4457,8 +4457,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty = dependentType.GetProperty("OrderId");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
             var expectedPrincipalProperties = principalType.Properties.ToList();
             var expectedDependentProperties = dependentType.Properties.ToList();
 
@@ -4467,7 +4467,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .ForeignKey<OrderDetails>(e => e.OrderId)
                 .PrincipalKey<Order>(e => e.OrderId);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Same(fk.DependentToPrincipal, dependentType.Navigations.Single());
@@ -4476,9 +4476,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(expectedPrincipalProperties, principalType.Properties);
             Assert.Equal(expectedDependentProperties, dependentType.Properties);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4498,8 +4498,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty = dependentType.GetProperty("OrderId");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
             var expectedPrincipalProperties = principalType.Properties.ToList();
             var expectedDependentProperties = dependentType.Properties.ToList();
 
@@ -4508,7 +4508,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .PrincipalKey<Order>(e => e.OrderId)
                 .ForeignKey<OrderDetails>(e => e.OrderId);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Same(fk.DependentToPrincipal, dependentType.Navigations.Single());
@@ -4517,9 +4517,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(expectedPrincipalProperties, principalType.Properties);
             Assert.Equal(expectedDependentProperties, dependentType.Properties);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4539,8 +4539,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty = dependentType.GetProperty("OrderId");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
             var expectedPrincipalProperties = principalType.Properties.ToList();
             var expectedDependentProperties = dependentType.Properties.ToList();
 
@@ -4549,7 +4549,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .ForeignKey<Order>(e => e.OrderId)
                 .PrincipalKey<OrderDetails>(e => e.OrderId);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty, fk.Properties.Single());
 
             Assert.Same(fk.DependentToPrincipal, dependentType.Navigations.Single());
@@ -4558,9 +4558,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(expectedPrincipalProperties, principalType.Properties);
             Assert.Equal(expectedDependentProperties, dependentType.Properties);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(fk.PrincipalKey, principalType.Keys.Single(k => k != principalKey));
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(fk.PrincipalKey, principalType.GetKeys().Single(k => k != principalKey));
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4615,8 +4615,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentType = model.GetEntityType(typeof(CustomerDetails));
             var principalType = model.GetEntityType(typeof(Customer));
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
             var expectedPrincipalProperties = principalType.Properties.ToList();
             var expectedDependentProperties = dependentType.Properties.ToList();
 
@@ -4624,16 +4624,16 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .Entity<Customer>().Reference(e => e.Details).InverseReference()
                 .PrincipalKey<Customer>(e => e.Id);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(principalKey.Properties.Single(), fk.PrincipalKey.Properties.Single());
 
             Assert.Empty(dependentType.Navigations);
             Assert.Same(fk.PrincipalToDependent, principalType.Navigations.Single());
             Assert.Equal(expectedPrincipalProperties, principalType.Properties);
             Assert.Equal(expectedDependentProperties, dependentType.Properties);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4650,8 +4650,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentType = model.GetEntityType(typeof(CustomerDetails));
             var principalType = model.GetEntityType(typeof(Customer));
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
             var expectedPrincipalProperties = principalType.Properties.ToList();
             var expectedDependentProperties = dependentType.Properties.ToList();
 
@@ -4659,16 +4659,16 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .Entity<CustomerDetails>().Reference(e => e.Customer).InverseReference()
                 .PrincipalKey<Customer>(e => e.Id);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(principalKey.Properties.Single(), fk.PrincipalKey.Properties.Single());
 
             Assert.Same(fk.DependentToPrincipal, dependentType.Navigations.Single());
             Assert.Empty(principalType.Navigations);
             Assert.Equal(expectedPrincipalProperties, principalType.Properties);
             Assert.Equal(expectedDependentProperties, dependentType.Properties);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4685,8 +4685,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentType = model.GetEntityType(typeof(CustomerDetails));
             var principalType = model.GetEntityType(typeof(Customer));
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
             var expectedPrincipalProperties = principalType.Properties.ToList();
             var expectedDependentProperties = dependentType.Properties.ToList();
 
@@ -4694,16 +4694,16 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .Entity<Customer>().Reference<CustomerDetails>().InverseReference(e => e.Customer)
                 .PrincipalKey<Customer>(e => e.Id);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(principalKey.Properties.Single(), fk.PrincipalKey.Properties.Single());
 
             Assert.Same(fk.DependentToPrincipal, dependentType.Navigations.Single());
             Assert.Empty(principalType.Navigations);
             Assert.Equal(expectedPrincipalProperties, principalType.Properties);
             Assert.Equal(expectedDependentProperties, dependentType.Properties);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4720,8 +4720,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentType = model.GetEntityType(typeof(CustomerDetails));
             var principalType = model.GetEntityType(typeof(Customer));
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
             var expectedPrincipalProperties = principalType.Properties.ToList();
             var expectedDependentProperties = dependentType.Properties.ToList();
 
@@ -4729,16 +4729,16 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .Entity<CustomerDetails>().Reference<Customer>().InverseReference(e => e.Details)
                 .PrincipalKey<Customer>(e => e.Id);
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(principalKey.Properties.Single(), fk.PrincipalKey.Properties.Single());
 
             Assert.Empty(dependentType.Navigations);
             Assert.Same(fk.PrincipalToDependent, principalType.Navigations.Single());
             Assert.Equal(expectedPrincipalProperties, principalType.Properties);
             Assert.Equal(expectedDependentProperties, dependentType.Properties);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4755,9 +4755,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentType = model.GetEntityType(typeof(CustomerDetails));
             var principalType = model.GetEntityType(typeof(Customer));
 
-            var existingFk = dependentType.ForeignKeys.SingleOrDefault();
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var existingFk = dependentType.GetForeignKeys().SingleOrDefault();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
             var expectedPrincipalProperties = principalType.Properties.ToList();
             var expectedDependentProperties = dependentType.Properties.ToList();
 
@@ -4765,7 +4765,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .Entity<Customer>().Reference<CustomerDetails>().InverseReference()
                 .PrincipalKey<Customer>(e => e.Id);
 
-            var fk = dependentType.ForeignKeys.Single(foreignKey => foreignKey != existingFk);
+            var fk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey != existingFk);
             Assert.Same(principalKey.Properties.Single(), fk.PrincipalKey.Properties.Single());
 
             Assert.Empty(dependentType.Navigations.Where(nav => nav.ForeignKey == fk));
@@ -4773,9 +4773,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Equal(expectedPrincipalProperties, principalType.Properties);
             expectedDependentProperties.Add(fk.Properties.Single());
             AssertEqual(expectedDependentProperties, dependentType.Properties);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4792,9 +4792,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentType = model.GetEntityType(typeof(CustomerDetails));
             var principalType = model.GetEntityType(typeof(Customer));
 
-            var existingFk = dependentType.ForeignKeys.SingleOrDefault();
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var existingFk = dependentType.GetForeignKeys().SingleOrDefault();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
             var expectedPrincipalProperties = principalType.Properties.ToList();
             var expectedDependentProperties = dependentType.Properties.ToList();
 
@@ -4802,7 +4802,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .Entity<CustomerDetails>().Reference<Customer>().InverseReference()
                 .PrincipalKey<Customer>(e => e.Id);
 
-            var fk = dependentType.ForeignKeys.Single(foreignKey => foreignKey != existingFk);
+            var fk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey != existingFk);
             Assert.Same(principalKey.Properties.Single(), fk.PrincipalKey.Properties.Single());
 
             Assert.Empty(dependentType.Navigations.Where(nav => nav.ForeignKey == fk));
@@ -4810,9 +4810,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Equal(expectedPrincipalProperties, principalType.Properties);
             expectedDependentProperties.Add(fk.Properties.Single());
             AssertEqual(expectedDependentProperties, dependentType.Properties);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4857,24 +4857,24 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = model.GetEntityType(typeof(Tomato));
             var principalType = model.GetEntityType(typeof(Whoopper));
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Whoopper>().Collection(e => e.Tomatoes).InverseReference(e => e.Whoopper)
                 .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
 
-            Assert.Equal(1, dependentType.ForeignKeys.Count());
+            Assert.Equal(1, dependentType.GetForeignKeys().Count());
             Assert.Equal("Whoopper", dependentType.Navigations.Single().Name);
             Assert.Equal("Tomatoes", principalType.Navigations.Single().Name);
             Assert.Same(fk.PrincipalKey, principalType.Navigations.Single().ForeignKey.PrincipalKey);
             AssertEqual(new[] { "AlternateKey1", "AlternateKey2", principalKey.Properties[0].Name, principalKey.Properties[1].Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fk.Properties[0].Name, fk.Properties[1].Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4896,13 +4896,13 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var fkProperty2 = dependentType.GetProperty("BurgerId2");
 
             var principalKey = principalType.GetPrimaryKey();
-            var dependentKey = dependentType.Keys.Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Whoopper>().Collection(e => e.Tomatoes).InverseReference(e => e.Whoopper)
                 .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
 
@@ -4912,9 +4912,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey1", "AlternateKey2", principalKey.Properties[0].Name, principalKey.Properties[1].Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fk.Properties[0].Name, fk.Properties[1].Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4938,14 +4938,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalProperty2 = principalType.GetProperty("AlternateKey2");
 
             var principalKey = principalType.GetPrimaryKey();
-            var dependentKey = dependentType.Keys.Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Whoopper>().Collection(e => e.Tomatoes).InverseReference(e => e.Whoopper)
                 .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 })
                 .PrincipalKey(e => new { e.AlternateKey1, e.AlternateKey2 });
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
             Assert.Same(principalProperty1, fk.PrincipalKey.Properties[0]);
@@ -4957,14 +4957,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey1", "AlternateKey2", principalKey.Properties[0].Name, principalKey.Properties[1].Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fk.Properties[0].Name, fk.Properties[1].Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.Contains(principalKey, principalType.Keys);
-            Assert.Contains(fk.PrincipalKey, principalType.Keys);
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.Contains(principalKey, principalType.GetKeys());
+            Assert.Contains(fk.PrincipalKey, principalType.GetKeys());
             Assert.NotSame(principalKey, fk.PrincipalKey);
 
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -4988,14 +4988,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalProperty2 = principalType.GetProperty("AlternateKey2");
 
             var principalKey = principalType.GetPrimaryKey();
-            var dependentKey = dependentType.Keys.Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Whoopper>().Collection(e => e.Tomatoes).InverseReference(e => e.Whoopper)
                 .PrincipalKey(e => new { e.AlternateKey1, e.AlternateKey2 })
                 .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
             Assert.Same(principalProperty1, fk.PrincipalKey.Properties[0]);
@@ -5007,14 +5007,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey1", "AlternateKey2", principalKey.Properties[0].Name, principalKey.Properties[1].Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fk.Properties[0].Name, fk.Properties[1].Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.Contains(principalKey, principalType.Keys);
-            Assert.Contains(fk.PrincipalKey, principalType.Keys);
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.Contains(principalKey, principalType.GetKeys());
+            Assert.Contains(fk.PrincipalKey, principalType.GetKeys());
             Assert.NotSame(principalKey, fk.PrincipalKey);
 
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -5040,13 +5040,13 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var fkProperty2 = dependentType.GetProperty("BurgerId2");
 
             var principalKey = principalType.GetPrimaryKey();
-            var dependentKey = dependentType.Keys.Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Whoopper>().Collection(e => e.Tomatoes).InverseReference()
                 .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
 
@@ -5055,9 +5055,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey1", "AlternateKey2", principalKey.Properties[0].Name, principalKey.Properties[1].Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fk.Properties[0].Name, fk.Properties[1].Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -5079,13 +5079,13 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var fkProperty2 = dependentType.GetProperty("BurgerId2");
 
             var principalKey = principalType.GetPrimaryKey();
-            var dependentKey = dependentType.Keys.Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Whoopper>().Collection<Tomato>().InverseReference(e => e.Whoopper)
                 .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
 
@@ -5094,9 +5094,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey1", "AlternateKey2", principalKey.Properties[0].Name, principalKey.Properties[1].Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fk.Properties[0].Name, fk.Properties[1].Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -5115,7 +5115,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var dependentType = model.GetEntityType(typeof(Tomato));
             var principalType = model.GetEntityType(typeof(Whoopper));
 
-            var fk = dependentType.ForeignKeys.SingleOrDefault();
+            var fk = dependentType.GetForeignKeys().SingleOrDefault();
             var fkProperty1 = dependentType.GetProperty("BurgerId1");
             var fkProperty2 = dependentType.GetProperty("BurgerId2");
 
@@ -5126,7 +5126,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .Entity<Whoopper>().Collection<Tomato>().InverseReference()
                 .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
 
-            var newFk = dependentType.ForeignKeys.Single(foreignKey => foreignKey != fk);
+            var newFk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey != fk);
             Assert.Same(fkProperty1, newFk.Properties[0]);
             Assert.Same(fkProperty2, newFk.Properties[1]);
 
@@ -5135,8 +5135,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             AssertEqual(new[] { "AlternateKey1", "AlternateKey2", principalKey.Properties[0].Name, principalKey.Properties[1].Name },
                 principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fkProperty1.Name, fkProperty2.Name, dependentKey.Properties.Single().Name, fk.Properties[0].Name, fk.Properties[1].Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -5155,26 +5155,26 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var dependentType = model.GetEntityType(typeof(Tomato));
             var principalType = model.GetEntityType(typeof(Whoopper));
-            var fk = dependentType.ForeignKeys.Single(foreignKey => foreignKey.Properties.First().Name == "BurgerId1");
+            var fk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey.Properties.First().Name == "BurgerId1");
             dependentType.RemoveNavigation(fk.DependentToPrincipal);
 
             var principalKey = principalType.GetPrimaryKey();
-            var dependentKey = dependentType.Keys.Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Tomato>().Reference(e => e.Whoopper).InverseCollection(e => e.Tomatoes)
                 .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
 
-            Assert.Same(fk, dependentType.ForeignKeys.Single());
+            Assert.Same(fk, dependentType.GetForeignKeys().Single());
             Assert.Equal("Whoopper", dependentType.Navigations.Single().Name);
             Assert.Equal("Tomatoes", principalType.Navigations.Single().Name);
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey1", "AlternateKey2", principalKey.Properties[0].Name, principalKey.Properties[1].Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fk.Properties[0].Name, fk.Properties[1].Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -5202,7 +5202,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .Entity<Tomato>().Reference(e => e.Whoopper).InverseCollection(e => e.Tomatoes)
                 .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
 
@@ -5212,9 +5212,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey1", "AlternateKey2", principalKey.Properties[0].Name, principalKey.Properties[1].Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fk.Properties[0].Name, fk.Properties[1].Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -5238,14 +5238,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var principalProperty2 = principalType.GetProperty("AlternateKey2");
 
             var principalKey = principalType.GetPrimaryKey();
-            var dependentKey = dependentType.Keys.Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Tomato>().Reference(e => e.Whoopper).InverseCollection(e => e.Tomatoes)
                 .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 })
                 .PrincipalKey(e => new { e.AlternateKey1, e.AlternateKey2 });
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
             Assert.Same(principalProperty1, fk.PrincipalKey.Properties[0]);
@@ -5257,14 +5257,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey1", "AlternateKey2", principalKey.Properties[0].Name, principalKey.Properties[1].Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fk.Properties[0].Name, fk.Properties[1].Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.Contains(principalKey, principalType.Keys);
-            Assert.Contains(fk.PrincipalKey, principalType.Keys);
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.Contains(principalKey, principalType.GetKeys());
+            Assert.Contains(fk.PrincipalKey, principalType.GetKeys());
             Assert.NotSame(principalKey, fk.PrincipalKey);
 
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -5295,7 +5295,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .PrincipalKey(e => new { e.AlternateKey1, e.AlternateKey2 })
                 .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
             Assert.Same(principalProperty1, fk.PrincipalKey.Properties[0]);
@@ -5307,14 +5307,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey1", "AlternateKey2", principalKey.Properties[0].Name, principalKey.Properties[1].Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fk.Properties[0].Name, fk.Properties[1].Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.Contains(principalKey, principalType.Keys);
-            Assert.Contains(fk.PrincipalKey, principalType.Keys);
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.Contains(principalKey, principalType.GetKeys());
+            Assert.Contains(fk.PrincipalKey, principalType.GetKeys());
             Assert.NotSame(principalKey, fk.PrincipalKey);
 
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -5336,13 +5336,13 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var fkProperty2 = dependentType.GetProperty("BurgerId2");
 
             var principalKey = principalType.GetPrimaryKey();
-            var dependentKey = dependentType.Keys.Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Tomato>().Reference(e => e.Whoopper).InverseCollection()
                 .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
 
@@ -5351,9 +5351,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey1", "AlternateKey2", principalKey.Properties[0].Name, principalKey.Properties[1].Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fk.Properties[0].Name, fk.Properties[1].Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -5375,13 +5375,13 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var fkProperty2 = dependentType.GetProperty("BurgerId2");
 
             var principalKey = principalType.GetPrimaryKey();
-            var dependentKey = dependentType.Keys.Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Tomato>().Reference<Whoopper>().InverseCollection(e => e.Tomatoes)
                 .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
 
@@ -5390,9 +5390,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey1", "AlternateKey2", principalKey.Properties[0].Name, principalKey.Properties[1].Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fk.Properties[0].Name, fk.Properties[1].Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -5413,19 +5413,19 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var fkProperty1 = dependentType.GetOrAddProperty("BurgerId1", typeof(int));
             var fkProperty2 = dependentType.GetOrAddProperty("BurgerId2", typeof(int));
-            var navigationForeignKey = dependentType.ForeignKeys.SingleOrDefault();
+            var navigationForeignKey = dependentType.GetForeignKeys().SingleOrDefault();
 
             var expectedPrincipalProperties = principalType.Properties.ToList();
             var expectedDependentProperties = dependentType.Properties.ToList();
 
             var principalKey = principalType.GetPrimaryKey();
-            var dependentKey = dependentType.Keys.Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Tomato>().Reference<Whoopper>().InverseCollection()
                 .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
 
-            var newFk = dependentType.ForeignKeys.Single(foreignKey => foreignKey != navigationForeignKey);
+            var newFk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey != navigationForeignKey);
             Assert.Same(fkProperty1, newFk.Properties[0]);
             Assert.Same(fkProperty2, newFk.Properties[1]);
 
@@ -5433,9 +5433,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Empty(principalType.Navigations.Where(nav => nav.ForeignKey != navigationForeignKey));
             AssertEqual(expectedPrincipalProperties, principalType.Properties);
             AssertEqual(expectedDependentProperties, dependentType.Properties);
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Equal(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Equal(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -5454,7 +5454,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             modelBuilder.Ignore<Moostard>();
 
             var principalType = model.GetEntityType(typeof(Whoopper));
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             fk.IsUnique = true;
 
             var principalKey = principalType.GetPrimaryKey();
@@ -5464,16 +5464,16 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .Entity<Whoopper>().Reference(e => e.ToastedBun).InverseReference(e => e.Whoopper)
                 .ForeignKey<ToastedBun>(e => new { e.BurgerId1, e.BurgerId2 });
 
-            Assert.Same(fk, dependentType.ForeignKeys.Single());
+            Assert.Same(fk, dependentType.GetForeignKeys().Single());
             Assert.Equal("Whoopper", dependentType.Navigations.Single().Name);
             Assert.Equal("ToastedBun", principalType.Navigations.Single().Name);
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey1", "AlternateKey2", principalKey.Properties[0].Name, principalKey.Properties[1].Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fk.Properties[0].Name, fk.Properties[1].Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -5495,13 +5495,13 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var fkProperty2 = dependentType.GetProperty("BurgerId2");
 
             var principalKey = principalType.GetPrimaryKey();
-            var dependentKey = dependentType.Keys.Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Whoopper>().Reference(e => e.ToastedBun).InverseReference(e => e.Whoopper)
                 .ForeignKey<ToastedBun>(e => new { e.BurgerId1, e.BurgerId2 });
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
 
@@ -5511,9 +5511,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey1", "AlternateKey2", principalKey.Properties[0].Name, principalKey.Properties[1].Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fkProperty1.Name, fkProperty2.Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -5536,15 +5536,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var fkProperty1 = dependentType.GetProperty("BurgerId1");
             var fkProperty2 = dependentType.GetProperty("BurgerId2");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Whoopper>().Reference(e => e.ToastedBun).InverseReference(e => e.Whoopper)
                 .ForeignKey<ToastedBun>(e => new { e.BurgerId1, e.BurgerId2 })
                 .PrincipalKey<Whoopper>(e => new { e.AlternateKey1, e.AlternateKey2 });
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
             Assert.Same(principalProperty1, fk.PrincipalKey.Properties[0]);
@@ -5556,14 +5556,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey1", "AlternateKey2", principalKey.Properties[0].Name, principalKey.Properties[1].Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fkProperty1.Name, fkProperty2.Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.Contains(principalKey, principalType.Keys);
-            Assert.Contains(fk.PrincipalKey, principalType.Keys);
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.Contains(principalKey, principalType.GetKeys());
+            Assert.Contains(fk.PrincipalKey, principalType.GetKeys());
             Assert.NotSame(principalKey, fk.PrincipalKey);
 
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -5586,15 +5586,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var fkProperty1 = dependentType.GetProperty("BurgerId1");
             var fkProperty2 = dependentType.GetProperty("BurgerId2");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Whoopper>().Reference(e => e.ToastedBun).InverseReference(e => e.Whoopper)
                 .PrincipalKey<Whoopper>(e => new { e.AlternateKey1, e.AlternateKey2 })
                 .ForeignKey<ToastedBun>(e => new { e.BurgerId1, e.BurgerId2 });
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
             Assert.Same(principalProperty1, fk.PrincipalKey.Properties[0]);
@@ -5606,14 +5606,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey1", "AlternateKey2", principalKey.Properties[0].Name, principalKey.Properties[1].Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fkProperty1.Name, fkProperty2.Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
+            Assert.Empty(principalType.GetForeignKeys());
 
-            Assert.Equal(2, principalType.Keys.Count);
-            Assert.Contains(principalKey, principalType.Keys);
-            Assert.Contains(fk.PrincipalKey, principalType.Keys);
+            Assert.Equal(2, principalType.GetKeys().Count());
+            Assert.Contains(principalKey, principalType.GetKeys());
+            Assert.Contains(fk.PrincipalKey, principalType.GetKeys());
             Assert.NotSame(principalKey, fk.PrincipalKey);
 
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -5634,14 +5634,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var fkProperty1 = dependentType.GetProperty("Id1");
             var fkProperty2 = dependentType.GetProperty("Id2");
 
-            var principalKey = principalType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
             var dependentKey = dependentType.GetPrimaryKey();
 
             modelBuilder
                 .Entity<Moostard>().Reference(e => e.Whoopper).InverseReference(e => e.Moostard)
                 .ForeignKey<Moostard>(e => new { e.Id1, e.Id2 });
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
 
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
@@ -5652,9 +5652,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey1", "AlternateKey2", principalKey.Properties[0].Name, principalKey.Properties[1].Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { dependentKey.Properties[0].Name, dependentKey.Properties[1].Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -5682,7 +5682,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .Entity<Moostard>().Reference(e => e.Whoopper).InverseReference(e => e.Moostard)
                 .ForeignKey<Moostard>(e => new { e.Id1, e.Id2 });
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
 
@@ -5692,9 +5692,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey1", "AlternateKey2", principalKey.Properties[0].Name, principalKey.Properties[1].Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { dependentKey.Properties[0].Name, dependentKey.Properties[1].Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -5715,7 +5715,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var fkProperty1 = dependentType.GetProperty("Id1");
             var fkProperty2 = dependentType.GetProperty("Id2");
 
-            var principalKey = principalType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
             var dependentKey = dependentType.GetPrimaryKey();
 
             modelBuilder
@@ -5723,7 +5723,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .PrincipalKey<Whoopper>(e => new { e.Id1, e.Id2 })
                 .Required();
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
 
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
@@ -5734,8 +5734,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey1", "AlternateKey2", principalKey.Properties[0].Name, principalKey.Properties[1].Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { dependentKey.Properties[0].Name, dependentKey.Properties[1].Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -5756,14 +5756,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var fkProperty1 = dependentType.GetProperty("BurgerId1");
             var fkProperty2 = dependentType.GetProperty("BurgerId2");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Whoopper>().Reference(e => e.ToastedBun).InverseReference()
                 .ForeignKey<ToastedBun>(e => new { e.BurgerId1, e.BurgerId2 });
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
 
@@ -5772,9 +5772,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey1", "AlternateKey2", principalKey.Properties[0].Name, principalKey.Properties[1].Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fkProperty1.Name, fkProperty2.Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -5795,14 +5795,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var fkProperty1 = dependentType.GetProperty("BurgerId1");
             var fkProperty2 = dependentType.GetProperty("BurgerId2");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Whoopper>().Reference<ToastedBun>().InverseReference(e => e.Whoopper)
                 .ForeignKey<ToastedBun>(e => new { e.BurgerId1, e.BurgerId2 });
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
 
@@ -5811,9 +5811,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
             AssertEqual(new[] { "AlternateKey1", "AlternateKey2", principalKey.Properties[0].Name, principalKey.Properties[1].Name }, principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fkProperty1.Name, fkProperty2.Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Empty(principalType.ForeignKeys);
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Empty(principalType.GetForeignKeys());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -5834,24 +5834,24 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var fkProperty1 = dependentType.GetProperty("BurgerId1");
             var fkProperty2 = dependentType.GetProperty("BurgerId2");
 
-            var principalKey = principalType.Keys.Single();
-            var dependentKey = dependentType.Keys.Single();
+            var principalKey = principalType.GetKeys().Single();
+            var dependentKey = dependentType.GetKeys().Single();
 
             modelBuilder
                 .Entity<Whoopper>().Reference<ToastedBun>().InverseReference()
                 .ForeignKey<ToastedBun>(e => new { e.BurgerId1, e.BurgerId2 });
 
-            var fk = dependentType.ForeignKeys.Single();
+            var fk = dependentType.GetForeignKeys().Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
 
             Assert.Empty(dependentType.Navigations.Where(nav => nav.ForeignKey == fk));
             Assert.Empty(principalType.Navigations.Where(nav => nav.ForeignKey == fk));
-            AssertEqual(new[] { "AlternateKey1", "AlternateKey2", principalKey.Properties[0].Name, principalKey.Properties[1].Name, principalType.ForeignKeys.Single().Properties.Single().Name },
+            AssertEqual(new[] { "AlternateKey1", "AlternateKey2", principalKey.Properties[0].Name, principalKey.Properties[1].Name, principalType.GetForeignKeys().Single().Properties.Single().Name },
                 principalType.Properties.Select(p => p.Name));
             AssertEqual(new[] { fkProperty1.Name, fkProperty2.Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-            Assert.Same(principalKey, principalType.Keys.Single());
-            Assert.Same(dependentKey, dependentType.Keys.Single());
+            Assert.Same(principalKey, principalType.GetKeys().Single());
+            Assert.Same(dependentKey, dependentType.GetKeys().Single());
             Assert.Same(principalKey, principalType.GetPrimaryKey());
             Assert.Same(dependentKey, dependentType.GetPrimaryKey());
         }
@@ -6398,7 +6398,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .Annotation("X", "Y"));
 
             var entityType = modelBuilder.Model.GetEntityType(typeof(Order));
-            Assert.Equal("Y", entityType.ForeignKeys.Single()["X"]);
+            Assert.Equal("Y", entityType.GetForeignKeys().Single()["X"]);
         }
 
         [Fact]
@@ -6412,7 +6412,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .ForeignKey("AnotherCustomerId"));
 
             var entityType = modelBuilder.Model.GetEntityType(typeof(Order));
-            Assert.Equal("AnotherCustomerId", entityType.ForeignKeys.Single().Properties.Single().Name);
+            Assert.Equal("AnotherCustomerId", entityType.GetForeignKeys().Single().Properties.Single().Name);
         }
 
         [Fact]
@@ -6426,7 +6426,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .PrincipalKey("AlternateKey"));
 
             var entityType = modelBuilder.Model.GetEntityType(typeof(Order));
-            Assert.Equal("AlternateKey", entityType.ForeignKeys.Single().PrincipalKey.Properties.Single().Name);
+            Assert.Equal("AlternateKey", entityType.GetForeignKeys().Single().PrincipalKey.Properties.Single().Name);
         }
 
         [Fact]
@@ -6459,7 +6459,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .Annotation("X", "Y"));
 
             var entityType = modelBuilder.Model.GetEntityType(typeof(Order));
-            Assert.Equal("Y", entityType.ForeignKeys.Single()["X"]);
+            Assert.Equal("Y", entityType.GetForeignKeys().Single()["X"]);
         }
 
         [Fact]
@@ -6473,7 +6473,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .ForeignKey("AnotherCustomerId"));
 
             var entityType = modelBuilder.Model.GetEntityType(typeof(Order));
-            Assert.Equal("AnotherCustomerId", entityType.ForeignKeys.Single().Properties.Single().Name);
+            Assert.Equal("AnotherCustomerId", entityType.GetForeignKeys().Single().Properties.Single().Name);
         }
 
         [Fact]
@@ -6487,7 +6487,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .PrincipalKey("AlternateKey"));
 
             var entityType = modelBuilder.Model.GetEntityType(typeof(Order));
-            Assert.Equal("AlternateKey", entityType.ForeignKeys.Single().PrincipalKey.Properties.Single().Name);
+            Assert.Equal("AlternateKey", entityType.GetForeignKeys().Single().PrincipalKey.Properties.Single().Name);
         }
 
         [Fact]
@@ -6516,7 +6516,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .Entity<SelfRef>().Reference(e => e.SelfRef1).InverseReference(e => e.SelfRef2);
 
             var entityType = modelBuilder.Model.GetEntityType(typeof(SelfRef));
-            var fk = entityType.ForeignKeys.Single();
+            var fk = entityType.GetForeignKeys().Single();
 
             var navigationToPrincipal = fk.DependentToPrincipal;
             var navigationToDependent = fk.PrincipalToDependent;
@@ -6524,7 +6524,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             modelBuilder
                 .Entity<SelfRef>().Reference(e => e.SelfRef1).InverseReference(e => e.SelfRef2);
 
-            Assert.Same(fk, entityType.ForeignKeys.Single());
+            Assert.Same(fk, entityType.GetForeignKeys().Single());
             Assert.Equal(navigationToDependent.Name, fk.PrincipalToDependent.Name);
             Assert.Equal(navigationToPrincipal.Name, fk.DependentToPrincipal.Name);
             Assert.True(((IForeignKey)fk).IsRequired);
@@ -6532,7 +6532,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             modelBuilder
                 .Entity<SelfRef>().Reference(e => e.SelfRef2).InverseReference(e => e.SelfRef1);
 
-            var newFk = entityType.ForeignKeys.Single();
+            var newFk = entityType.GetForeignKeys().Single();
 
             Assert.Equal(fk.Properties, newFk.Properties);
             Assert.Equal(fk.PrincipalKey, newFk.PrincipalKey);
@@ -6556,7 +6556,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             modelBuilder.Entity<SelfRef>().Reference(e => e.SelfRef1).InverseReference();
 
-            var fk = entityType.ForeignKeys.Single();
+            var fk = entityType.GetForeignKeys().Single();
             var navigationToPrincipal = fk.DependentToPrincipal;
             var navigationToDependent = fk.PrincipalToDependent;
 
@@ -6584,7 +6584,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             modelBuilder.Entity<SelfRef>().Reference<SelfRef>().InverseReference(e => e.SelfRef1);
 
-            var fk = entityType.ForeignKeys.Single();
+            var fk = entityType.GetForeignKeys().Single();
             var navigationToPrincipal = fk.DependentToPrincipal;
             var navigationToDependent = fk.PrincipalToDependent;
 

--- a/test/EntityFramework.Core.Tests/Utilities/MultigraphTest.cs
+++ b/test/EntityFramework.Core.Tests/Utilities/MultigraphTest.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Data.Entity.Tests.Utilities
 
                 foreach (var entityType in entityTypes)
                 {
-                    foreach (var foreignKey in entityType.ForeignKeys)
+                    foreach (var foreignKey in entityType.GetForeignKeys())
                     {
                         AddEdge(foreignKey.PrincipalEntityType, foreignKey.EntityType, foreignKey);
                     }

--- a/test/EntityFramework.Core.Tests/ValueGeneration/ValueGeneratorCacheTest.cs
+++ b/test/EntityFramework.Core.Tests/ValueGeneration/ValueGeneratorCacheTest.cs
@@ -16,17 +16,18 @@ namespace Microsoft.Data.Entity.Tests.ValueGeneration
         public void Uses_single_generator_per_property()
         {
             var model = CreateModel();
-            var property1 = GetProperty1(model);
-            var property2 = GetProperty2(model);
+            var entityType = model.GetEntityType("Led");
+            var property1 = entityType.GetProperty("Zeppelin");
+            var property2 = entityType.GetProperty("Stairway");
             var cache = TestHelpers.Instance.CreateContextServices(model).GetRequiredService<IValueGeneratorCache>();
 
-            var generator1 = cache.GetOrAdd(property1, p => new GuidValueGenerator());
+            var generator1 = cache.GetOrAdd(property1, entityType, (p, et) => new GuidValueGenerator());
             Assert.NotNull(generator1);
-            Assert.Same(generator1, cache.GetOrAdd(property1, p => new GuidValueGenerator()));
+            Assert.Same(generator1, cache.GetOrAdd(property1, entityType, (p, et) => new GuidValueGenerator()));
 
-            var generator2 = cache.GetOrAdd(property2, p => new GuidValueGenerator());
+            var generator2 = cache.GetOrAdd(property2, entityType, (p, et) => new GuidValueGenerator());
             Assert.NotNull(generator2);
-            Assert.Same(generator2, cache.GetOrAdd(property2, p => new GuidValueGenerator()));
+            Assert.Same(generator2, cache.GetOrAdd(property2, entityType, (p, et) => new GuidValueGenerator()));
             Assert.NotSame(generator1, generator2);
         }
 

--- a/test/EntityFramework.Core.Tests/ValueGeneration/ValueGeneratorSelectorTest.cs
+++ b/test/EntityFramework.Core.Tests/ValueGeneration/ValueGeneratorSelectorTest.cs
@@ -21,47 +21,47 @@ namespace Microsoft.Data.Entity.Tests.ValueGeneration
             var contextServices = TestHelpers.Instance.CreateContextServices(model);
             var selector = contextServices.GetRequiredService<ValueGeneratorSelector>();
 
-            Assert.IsType<TemporaryNumberValueGenerator<int>>(selector.Select(entityType.GetProperty("Id")));
-            Assert.IsType<TemporaryNumberValueGenerator<long>>(selector.Select(entityType.GetProperty("Long")));
-            Assert.IsType<TemporaryNumberValueGenerator<short>>(selector.Select(entityType.GetProperty("Short")));
-            Assert.IsType<TemporaryNumberValueGenerator<byte>>(selector.Select(entityType.GetProperty("Byte")));
+            Assert.IsType<TemporaryNumberValueGenerator<int>>(selector.Select(entityType.GetProperty("Id"), entityType));
+            Assert.IsType<TemporaryNumberValueGenerator<long>>(selector.Select(entityType.GetProperty("Long"), entityType));
+            Assert.IsType<TemporaryNumberValueGenerator<short>>(selector.Select(entityType.GetProperty("Short"), entityType));
+            Assert.IsType<TemporaryNumberValueGenerator<byte>>(selector.Select(entityType.GetProperty("Byte"), entityType));
 
-            Assert.IsType<TemporaryNumberValueGenerator<int>>(selector.Select(entityType.GetProperty("NullableInt")));
-            Assert.IsType<TemporaryNumberValueGenerator<long>>(selector.Select(entityType.GetProperty("NullableLong")));
-            Assert.IsType<TemporaryNumberValueGenerator<short>>(selector.Select(entityType.GetProperty("NullableShort")));
-            Assert.IsType<TemporaryNumberValueGenerator<byte>>(selector.Select(entityType.GetProperty("NullableByte")));
+            Assert.IsType<TemporaryNumberValueGenerator<int>>(selector.Select(entityType.GetProperty("NullableInt"), entityType));
+            Assert.IsType<TemporaryNumberValueGenerator<long>>(selector.Select(entityType.GetProperty("NullableLong"), entityType));
+            Assert.IsType<TemporaryNumberValueGenerator<short>>(selector.Select(entityType.GetProperty("NullableShort"), entityType));
+            Assert.IsType<TemporaryNumberValueGenerator<byte>>(selector.Select(entityType.GetProperty("NullableByte"), entityType));
 
-            Assert.IsType<TemporaryNumberValueGenerator<uint>>(selector.Select(entityType.GetProperty("UInt")));
-            Assert.IsType<TemporaryNumberValueGenerator<ulong>>(selector.Select(entityType.GetProperty("ULong")));
-            Assert.IsType<TemporaryNumberValueGenerator<ushort>>(selector.Select(entityType.GetProperty("UShort")));
-            Assert.IsType<TemporaryNumberValueGenerator<sbyte>>(selector.Select(entityType.GetProperty("SByte")));
+            Assert.IsType<TemporaryNumberValueGenerator<uint>>(selector.Select(entityType.GetProperty("UInt"), entityType));
+            Assert.IsType<TemporaryNumberValueGenerator<ulong>>(selector.Select(entityType.GetProperty("ULong"), entityType));
+            Assert.IsType<TemporaryNumberValueGenerator<ushort>>(selector.Select(entityType.GetProperty("UShort"), entityType));
+            Assert.IsType<TemporaryNumberValueGenerator<sbyte>>(selector.Select(entityType.GetProperty("SByte"), entityType));
 
-            Assert.IsType<TemporaryNumberValueGenerator<uint>>(selector.Select(entityType.GetProperty("NullableUInt")));
-            Assert.IsType<TemporaryNumberValueGenerator<ulong>>(selector.Select(entityType.GetProperty("NullableULong")));
-            Assert.IsType<TemporaryNumberValueGenerator<ushort>>(selector.Select(entityType.GetProperty("NullableUShort")));
-            Assert.IsType<TemporaryNumberValueGenerator<sbyte>>(selector.Select(entityType.GetProperty("NullableSByte")));
+            Assert.IsType<TemporaryNumberValueGenerator<uint>>(selector.Select(entityType.GetProperty("NullableUInt"), entityType));
+            Assert.IsType<TemporaryNumberValueGenerator<ulong>>(selector.Select(entityType.GetProperty("NullableULong"), entityType));
+            Assert.IsType<TemporaryNumberValueGenerator<ushort>>(selector.Select(entityType.GetProperty("NullableUShort"), entityType));
+            Assert.IsType<TemporaryNumberValueGenerator<sbyte>>(selector.Select(entityType.GetProperty("NullableSByte"), entityType));
 
-            Assert.IsType<TemporaryNumberValueGenerator<decimal>>(selector.Select(entityType.GetProperty("Decimal")));
-            Assert.IsType<TemporaryNumberValueGenerator<decimal>>(selector.Select(entityType.GetProperty("NullableDecimal")));
+            Assert.IsType<TemporaryNumberValueGenerator<decimal>>(selector.Select(entityType.GetProperty("Decimal"), entityType));
+            Assert.IsType<TemporaryNumberValueGenerator<decimal>>(selector.Select(entityType.GetProperty("NullableDecimal"), entityType));
 
-            Assert.IsType<TemporaryNumberValueGenerator<float>>(selector.Select(entityType.GetProperty("Float")));
-            Assert.IsType<TemporaryNumberValueGenerator<float>>(selector.Select(entityType.GetProperty("NullableFloat")));
+            Assert.IsType<TemporaryNumberValueGenerator<float>>(selector.Select(entityType.GetProperty("Float"), entityType));
+            Assert.IsType<TemporaryNumberValueGenerator<float>>(selector.Select(entityType.GetProperty("NullableFloat"), entityType));
 
-            Assert.IsType<TemporaryNumberValueGenerator<double>>(selector.Select(entityType.GetProperty("Double")));
-            Assert.IsType<TemporaryNumberValueGenerator<double>>(selector.Select(entityType.GetProperty("NullableDouble")));
+            Assert.IsType<TemporaryNumberValueGenerator<double>>(selector.Select(entityType.GetProperty("Double"), entityType));
+            Assert.IsType<TemporaryNumberValueGenerator<double>>(selector.Select(entityType.GetProperty("NullableDouble"), entityType));
 
-            Assert.IsType<TemporaryDateTimeValueGenerator>(selector.Select(entityType.GetProperty("DateTime")));
-            Assert.IsType<TemporaryDateTimeValueGenerator>(selector.Select(entityType.GetProperty("NullableDateTime")));
+            Assert.IsType<TemporaryDateTimeValueGenerator>(selector.Select(entityType.GetProperty("DateTime"), entityType));
+            Assert.IsType<TemporaryDateTimeValueGenerator>(selector.Select(entityType.GetProperty("NullableDateTime"), entityType));
 
-            Assert.IsType<TemporaryDateTimeOffsetValueGenerator>(selector.Select(entityType.GetProperty("DateTimeOffset")));
-            Assert.IsType<TemporaryDateTimeOffsetValueGenerator>(selector.Select(entityType.GetProperty("NullableDateTimeOffset")));
+            Assert.IsType<TemporaryDateTimeOffsetValueGenerator>(selector.Select(entityType.GetProperty("DateTimeOffset"), entityType));
+            Assert.IsType<TemporaryDateTimeOffsetValueGenerator>(selector.Select(entityType.GetProperty("NullableDateTimeOffset"), entityType));
 
-            Assert.IsType<TemporaryStringValueGenerator>(selector.Select(entityType.GetProperty("String")));
+            Assert.IsType<TemporaryStringValueGenerator>(selector.Select(entityType.GetProperty("String"), entityType));
 
-            Assert.IsType<GuidValueGenerator>(selector.Select(entityType.GetProperty("Guid")));
-            Assert.IsType<GuidValueGenerator>(selector.Select(entityType.GetProperty("NullableGuid")));
+            Assert.IsType<GuidValueGenerator>(selector.Select(entityType.GetProperty("Guid"), entityType));
+            Assert.IsType<GuidValueGenerator>(selector.Select(entityType.GetProperty("NullableGuid"), entityType));
 
-            Assert.IsType<TemporaryBinaryValueGenerator>(selector.Select(entityType.GetProperty("Binary")));
+            Assert.IsType<TemporaryBinaryValueGenerator>(selector.Select(entityType.GetProperty("Binary"), entityType));
         }
 
         [Fact]
@@ -76,7 +76,7 @@ namespace Microsoft.Data.Entity.Tests.ValueGeneration
 
             Assert.Equal(
                 Strings.NoValueGenerator("Random", "AnEntity", typeof(Random).Name),
-                Assert.Throws<NotSupportedException>(() => selector.Select(entityType.GetProperty("Random"))).Message);
+                Assert.Throws<NotSupportedException>(() => selector.Select(entityType.GetProperty("Random"), entityType)).Message);
         }
 
         private static Model BuildModel(bool generateValues = true)

--- a/test/EntityFramework.InMemory.Tests/InMemoryValueGeneratorSelectorTest.cs
+++ b/test/EntityFramework.InMemory.Tests/InMemoryValueGeneratorSelectorTest.cs
@@ -21,25 +21,25 @@ namespace Microsoft.Data.Entity.InMemory.Tests
 
             var selector = InMemoryTestHelpers.Instance.CreateContextServices(model).GetRequiredService<IValueGeneratorSelector>();
 
-            Assert.IsType<InMemoryIntegerValueGenerator<int>>(selector.Select(entityType.GetProperty("Id")));
-            Assert.IsType<InMemoryIntegerValueGenerator<long>>(selector.Select(entityType.GetProperty("Long")));
-            Assert.IsType<InMemoryIntegerValueGenerator<short>>(selector.Select(entityType.GetProperty("Short")));
-            Assert.IsType<InMemoryIntegerValueGenerator<byte>>(selector.Select(entityType.GetProperty("Byte")));
-            Assert.IsType<InMemoryIntegerValueGenerator<int>>(selector.Select(entityType.GetProperty("NullableInt")));
-            Assert.IsType<InMemoryIntegerValueGenerator<long>>(selector.Select(entityType.GetProperty("NullableLong")));
-            Assert.IsType<InMemoryIntegerValueGenerator<short>>(selector.Select(entityType.GetProperty("NullableShort")));
-            Assert.IsType<InMemoryIntegerValueGenerator<byte>>(selector.Select(entityType.GetProperty("NullableByte")));
-            Assert.IsType<InMemoryIntegerValueGenerator<uint>>(selector.Select(entityType.GetProperty("UInt")));
-            Assert.IsType<InMemoryIntegerValueGenerator<ulong>>(selector.Select(entityType.GetProperty("ULong")));
-            Assert.IsType<InMemoryIntegerValueGenerator<ushort>>(selector.Select(entityType.GetProperty("UShort")));
-            Assert.IsType<InMemoryIntegerValueGenerator<sbyte>>(selector.Select(entityType.GetProperty("SByte")));
-            Assert.IsType<InMemoryIntegerValueGenerator<uint>>(selector.Select(entityType.GetProperty("NullableUInt")));
-            Assert.IsType<InMemoryIntegerValueGenerator<ulong>>(selector.Select(entityType.GetProperty("NullableULong")));
-            Assert.IsType<InMemoryIntegerValueGenerator<ushort>>(selector.Select(entityType.GetProperty("NullableUShort")));
-            Assert.IsType<InMemoryIntegerValueGenerator<sbyte>>(selector.Select(entityType.GetProperty("NullableSByte")));
-            Assert.IsType<TemporaryStringValueGenerator>(selector.Select(entityType.GetProperty("String")));
-            Assert.IsType<GuidValueGenerator>(selector.Select(entityType.GetProperty("Guid")));
-            Assert.IsType<TemporaryBinaryValueGenerator>(selector.Select(entityType.GetProperty("Binary")));
+            Assert.IsType<InMemoryIntegerValueGenerator<int>>(selector.Select(entityType.GetProperty("Id"), entityType));
+            Assert.IsType<InMemoryIntegerValueGenerator<long>>(selector.Select(entityType.GetProperty("Long"), entityType));
+            Assert.IsType<InMemoryIntegerValueGenerator<short>>(selector.Select(entityType.GetProperty("Short"), entityType));
+            Assert.IsType<InMemoryIntegerValueGenerator<byte>>(selector.Select(entityType.GetProperty("Byte"), entityType));
+            Assert.IsType<InMemoryIntegerValueGenerator<int>>(selector.Select(entityType.GetProperty("NullableInt"), entityType));
+            Assert.IsType<InMemoryIntegerValueGenerator<long>>(selector.Select(entityType.GetProperty("NullableLong"), entityType));
+            Assert.IsType<InMemoryIntegerValueGenerator<short>>(selector.Select(entityType.GetProperty("NullableShort"), entityType));
+            Assert.IsType<InMemoryIntegerValueGenerator<byte>>(selector.Select(entityType.GetProperty("NullableByte"), entityType));
+            Assert.IsType<InMemoryIntegerValueGenerator<uint>>(selector.Select(entityType.GetProperty("UInt"), entityType));
+            Assert.IsType<InMemoryIntegerValueGenerator<ulong>>(selector.Select(entityType.GetProperty("ULong"), entityType));
+            Assert.IsType<InMemoryIntegerValueGenerator<ushort>>(selector.Select(entityType.GetProperty("UShort"), entityType));
+            Assert.IsType<InMemoryIntegerValueGenerator<sbyte>>(selector.Select(entityType.GetProperty("SByte"), entityType));
+            Assert.IsType<InMemoryIntegerValueGenerator<uint>>(selector.Select(entityType.GetProperty("NullableUInt"), entityType));
+            Assert.IsType<InMemoryIntegerValueGenerator<ulong>>(selector.Select(entityType.GetProperty("NullableULong"), entityType));
+            Assert.IsType<InMemoryIntegerValueGenerator<ushort>>(selector.Select(entityType.GetProperty("NullableUShort"), entityType));
+            Assert.IsType<InMemoryIntegerValueGenerator<sbyte>>(selector.Select(entityType.GetProperty("NullableSByte"), entityType));
+            Assert.IsType<TemporaryStringValueGenerator>(selector.Select(entityType.GetProperty("String"), entityType));
+            Assert.IsType<GuidValueGenerator>(selector.Select(entityType.GetProperty("Guid"), entityType));
+            Assert.IsType<TemporaryBinaryValueGenerator>(selector.Select(entityType.GetProperty("Binary"), entityType));
         }
 
         [Fact]
@@ -52,7 +52,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
 
             Assert.Equal(
                 CoreStrings.NoValueGenerator("Random", "AnEntity", typeof(Random).Name),
-                Assert.Throws<NotSupportedException>(() => selector.Select(entityType.GetProperty("Random"))).Message);
+                Assert.Throws<NotSupportedException>(() => selector.Select(entityType.GetProperty("Random"), entityType)).Message);
         }
 
         private static Model BuildModel(bool generateValues = true)

--- a/test/EntityFramework.Relational.Tests/Metadata/RelationalBuilderExtensionsTest.cs
+++ b/test/EntityFramework.Relational.Tests/Metadata/RelationalBuilderExtensionsTest.cs
@@ -175,7 +175,7 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
                 .Entity<Customer>().Collection(e => e.Orders).InverseReference(e => e.Customer)
                 .Name("LemonSupreme");
 
-            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).ForeignKeys.Single(fk => fk.PrincipalEntityType.ClrType == typeof(Customer));
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).GetForeignKeys().Single(fk => fk.PrincipalEntityType.ClrType == typeof(Customer));
 
             Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
 
@@ -196,7 +196,7 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
                 .ForeignKey(e => e.CustomerId)
                 .Name("LemonSupreme");
 
-            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).ForeignKeys.Single(fk => fk.PrincipalEntityType.ClrType == typeof(Customer));
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).GetForeignKeys().Single(fk => fk.PrincipalEntityType.ClrType == typeof(Customer));
 
             Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
         }
@@ -210,7 +210,7 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
                 .Entity<Customer>().Collection(e => e.Orders).InverseReference(e => e.Customer)
                 .Name("LemonSupreme");
 
-            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).ForeignKeys.Single(fk => fk.PrincipalEntityType.ClrType == typeof(Customer));
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).GetForeignKeys().Single(fk => fk.PrincipalEntityType.ClrType == typeof(Customer));
 
             Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
         }
@@ -225,7 +225,7 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
                 .ForeignKey(e => e.CustomerId)
                 .Name("LemonSupreme");
 
-            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).ForeignKeys.Single(fk => fk.PrincipalEntityType.ClrType == typeof(Customer));
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).GetForeignKeys().Single(fk => fk.PrincipalEntityType.ClrType == typeof(Customer));
 
             Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
         }
@@ -239,7 +239,7 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
                 .Entity<Order>().Reference(e => e.Customer).InverseCollection(e => e.Orders)
                 .Name("LemonSupreme");
 
-            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).ForeignKeys.Single(fk => fk.PrincipalEntityType.ClrType == typeof(Customer));
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).GetForeignKeys().Single(fk => fk.PrincipalEntityType.ClrType == typeof(Customer));
 
             Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
 
@@ -260,7 +260,7 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
                 .ForeignKey(e => e.CustomerId)
                 .Name("LemonSupreme");
 
-            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).ForeignKeys.Single(fk => fk.PrincipalEntityType.ClrType == typeof(Customer));
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).GetForeignKeys().Single(fk => fk.PrincipalEntityType.ClrType == typeof(Customer));
 
             Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
         }
@@ -274,7 +274,7 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
                 .Entity<Order>().Reference(e => e.Customer).InverseCollection(e => e.Orders)
                 .Name("LemonSupreme");
 
-            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).ForeignKeys.Single(fk => fk.PrincipalEntityType.ClrType == typeof(Customer));
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).GetForeignKeys().Single(fk => fk.PrincipalEntityType.ClrType == typeof(Customer));
 
             Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
         }
@@ -289,7 +289,7 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
                 .ForeignKey(e => e.CustomerId)
                 .Name("LemonSupreme");
 
-            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).ForeignKeys.Single(fk => fk.PrincipalEntityType.ClrType == typeof(Customer));
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).GetForeignKeys().Single(fk => fk.PrincipalEntityType.ClrType == typeof(Customer));
 
             Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
         }
@@ -304,7 +304,7 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
                 .PrincipalKey<Order>(e => e.OrderId)
                 .Name("LemonSupreme");
 
-            var foreignKey = modelBuilder.Model.GetEntityType(typeof(OrderDetails)).ForeignKeys.Single();
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(OrderDetails)).GetForeignKeys().Single();
 
             Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
 
@@ -325,7 +325,7 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
                 .ForeignKey<OrderDetails>(e => e.Id)
                 .Name("LemonSupreme");
 
-            var foreignKey = modelBuilder.Model.GetEntityType(typeof(OrderDetails)).ForeignKeys.Single();
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(OrderDetails)).GetForeignKeys().Single();
 
             Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
         }
@@ -340,7 +340,7 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
                 .PrincipalKey<Order>(e => e.OrderId)
                 .Name("LemonSupreme");
 
-            var foreignKey = modelBuilder.Model.GetEntityType(typeof(OrderDetails)).ForeignKeys.Single();
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(OrderDetails)).GetForeignKeys().Single();
 
             Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
         }
@@ -355,7 +355,7 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
                 .ForeignKey<OrderDetails>(e => e.Id)
                 .Name("LemonSupreme");
 
-            var foreignKey = modelBuilder.Model.GetEntityType(typeof(OrderDetails)).ForeignKeys.Single();
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(OrderDetails)).GetForeignKeys().Single();
 
             Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
         }

--- a/test/EntityFramework.SqlServer.FunctionalTests/InheritanceSqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/InheritanceSqlServerTest.cs
@@ -33,6 +33,18 @@ ORDER BY [a].[Species]",
                 Sql);
         }
 
+        public override void Can_use_of_type_bird_first()
+        {
+            base.Can_use_of_type_bird_first();
+
+            Assert.Equal(
+                @"SELECT TOP(1) [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
+FROM [Animal] AS [a]
+WHERE [a].[Discriminator] IN ('Kiwi', 'Eagle')
+ORDER BY [a].[Species]",
+                Sql);
+        }
+
         public override void Can_use_of_type_kiwi()
         {
             base.Can_use_of_type_kiwi();
@@ -133,9 +145,61 @@ ORDER BY [c].[Name], [c].[Id]",
                 Sql);
         }
 
+        public override void Can_insert_update_delete()
+        {
+            base.Can_insert_update_delete();
+
+            Assert.Equal(
+                @"SELECT TOP(2) [c].[Id], [c].[Name]
+FROM [Country] AS [c]
+WHERE [c].[Id] = 1
+
+@p0: Apteryx owenii
+@p1: 1
+@p2: Kiwi
+@p3: Little spotted kiwi
+@p4: 
+@p5: True
+@p6: North
+
+SET NOCOUNT OFF;
+INSERT INTO [Animal] ([Species], [CountryId], [Discriminator], [Name], [EagleId], [IsFlightless], [FoundOn])
+VALUES (@p0, @p1, @p2, @p3, @p4, @p5, @p6);
+SELECT @@ROWCOUNT;
+
+SELECT TOP(2) [k].[Species], [k].[CountryId], [k].[Discriminator], [k].[Name], [k].[EagleId], [k].[IsFlightless], [k].[FoundOn]
+FROM [Animal] AS [k]
+WHERE ([k].[Discriminator] = 'Kiwi' AND [k].[Species] LIKE '%' + 'owenii')
+
+@p0: Apteryx owenii
+@p1: Aquila chrysaetos canadensis
+
+SET NOCOUNT OFF;
+UPDATE [Animal] SET [EagleId] = @p1
+WHERE [Species] = @p0;
+SELECT @@ROWCOUNT;
+
+SELECT TOP(2) [k].[Species], [k].[CountryId], [k].[Discriminator], [k].[Name], [k].[EagleId], [k].[IsFlightless], [k].[FoundOn]
+FROM [Animal] AS [k]
+WHERE ([k].[Discriminator] = 'Kiwi' AND [k].[Species] LIKE '%' + 'owenii')
+
+@p0: Apteryx owenii
+
+SET NOCOUNT OFF;
+DELETE FROM [Animal]
+WHERE [Species] = @p0;
+SELECT @@ROWCOUNT;
+
+SELECT COUNT(*)
+FROM [Animal] AS [k]
+WHERE ([k].[Discriminator] = 'Kiwi' AND [k].[Species] LIKE '%' + 'owenii')",
+                Sql);
+        }
+
         public InheritanceSqlServerTest(InheritanceSqlServerFixture fixture)
             : base(fixture)
         {
+            TestSqlLoggerFactory.Reset();
         }
 
         private static string Sql => TestSqlLoggerFactory.Sql;

--- a/test/EntityFramework.SqlServer.Tests/Metadata/SqlServerBuilderExtensionsTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/Metadata/SqlServerBuilderExtensionsTest.cs
@@ -226,7 +226,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
                 .ForSqlServer()
                 .Name("ChocolateLimes");
 
-            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).ForeignKeys.Single(fk => fk.PrincipalEntityType.ClrType == typeof(Customer));
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).GetForeignKeys().Single(fk => fk.PrincipalEntityType.ClrType == typeof(Customer));
 
             Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
             Assert.Equal("ChocolateLimes", foreignKey.SqlServer().Name);
@@ -256,7 +256,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
                 .ForSqlServer()
                 .Name("ChocolateLimes");
 
-            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).ForeignKeys.Single(fk => fk.PrincipalEntityType.ClrType == typeof(Customer));
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).GetForeignKeys().Single(fk => fk.PrincipalEntityType.ClrType == typeof(Customer));
 
             Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
             Assert.Equal("ChocolateLimes", foreignKey.SqlServer().Name);
@@ -272,7 +272,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
                 .Name("LemonSupreme")
                 .ForSqlServer(b => { b.Name("ChocolateLimes"); });
 
-            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).ForeignKeys.Single(fk => fk.PrincipalEntityType.ClrType == typeof(Customer));
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).GetForeignKeys().Single(fk => fk.PrincipalEntityType.ClrType == typeof(Customer));
 
             Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
             Assert.Equal("ChocolateLimes", foreignKey.SqlServer().Name);
@@ -289,7 +289,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
                 .Name("LemonSupreme")
                 .ForSqlServer(b => { b.Name("ChocolateLimes"); });
 
-            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).ForeignKeys.Single(fk => fk.PrincipalEntityType.ClrType == typeof(Customer));
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).GetForeignKeys().Single(fk => fk.PrincipalEntityType.ClrType == typeof(Customer));
 
             Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
             Assert.Equal("ChocolateLimes", foreignKey.SqlServer().Name);
@@ -309,7 +309,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
                 .ForSqlServer()
                 .Name("ChocolateLimes");
 
-            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).ForeignKeys.Single(fk => fk.PrincipalEntityType.ClrType == typeof(Customer));
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).GetForeignKeys().Single(fk => fk.PrincipalEntityType.ClrType == typeof(Customer));
 
             Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
             Assert.Equal("ChocolateLimes", foreignKey.SqlServer().Name);
@@ -339,7 +339,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
                 .ForSqlServer()
                 .Name("ChocolateLimes");
 
-            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).ForeignKeys.Single(fk => fk.PrincipalEntityType.ClrType == typeof(Customer));
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).GetForeignKeys().Single(fk => fk.PrincipalEntityType.ClrType == typeof(Customer));
 
             Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
             Assert.Equal("ChocolateLimes", foreignKey.SqlServer().Name);
@@ -355,7 +355,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
                 .Name("LemonSupreme")
                 .ForSqlServer(b => { b.Name("ChocolateLimes"); });
 
-            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).ForeignKeys.Single(fk => fk.PrincipalEntityType.ClrType == typeof(Customer));
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).GetForeignKeys().Single(fk => fk.PrincipalEntityType.ClrType == typeof(Customer));
 
             Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
             Assert.Equal("ChocolateLimes", foreignKey.SqlServer().Name);
@@ -372,7 +372,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
                 .Name("LemonSupreme")
                 .ForSqlServer(b => { b.Name("ChocolateLimes"); });
 
-            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).ForeignKeys.Single(fk => fk.PrincipalEntityType.ClrType == typeof(Customer));
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).GetForeignKeys().Single(fk => fk.PrincipalEntityType.ClrType == typeof(Customer));
 
             Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
             Assert.Equal("ChocolateLimes", foreignKey.SqlServer().Name);
@@ -393,7 +393,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
                 .ForSqlServer()
                 .Name("ChocolateLimes");
 
-            var foreignKey = modelBuilder.Model.GetEntityType(typeof(OrderDetails)).ForeignKeys.Single();
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(OrderDetails)).GetForeignKeys().Single();
 
             Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
             Assert.Equal("ChocolateLimes", foreignKey.SqlServer().Name);
@@ -423,7 +423,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
                 .ForSqlServer()
                 .Name("ChocolateLimes");
 
-            var foreignKey = modelBuilder.Model.GetEntityType(typeof(OrderDetails)).ForeignKeys.Single();
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(OrderDetails)).GetForeignKeys().Single();
 
             Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
             Assert.Equal("ChocolateLimes", foreignKey.SqlServer().Name);
@@ -440,7 +440,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
                 .Name("LemonSupreme")
                 .ForSqlServer(b => { b.Name("ChocolateLimes"); });
 
-            var foreignKey = modelBuilder.Model.GetEntityType(typeof(OrderDetails)).ForeignKeys.Single();
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(OrderDetails)).GetForeignKeys().Single();
 
             Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
             Assert.Equal("ChocolateLimes", foreignKey.SqlServer().Name);
@@ -457,7 +457,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
                 .Name("LemonSupreme")
                 .ForSqlServer(b => { b.Name("ChocolateLimes"); });
 
-            var foreignKey = modelBuilder.Model.GetEntityType(typeof(OrderDetails)).ForeignKeys.Single();
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(OrderDetails)).GetForeignKeys().Single();
 
             Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
             Assert.Equal("ChocolateLimes", foreignKey.SqlServer().Name);

--- a/test/EntityFramework.SqlServer.Tests/SqlServerEntityFrameworkServicesBuilderExtensionsTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerEntityFrameworkServicesBuilderExtensionsTest.cs
@@ -12,6 +12,7 @@ using Microsoft.Data.Entity.Relational.Migrations.Sql;
 using Microsoft.Data.Entity.Relational.Update;
 using Microsoft.Data.Entity.SqlServer.Migrations;
 using Microsoft.Data.Entity.SqlServer.Update;
+using Microsoft.Data.Entity.SqlServer.ValueGeneration;
 using Microsoft.Data.Entity.Tests;
 using Microsoft.Framework.DependencyInjection;
 using Xunit;

--- a/test/EntityFramework.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.Entity.Relational;
+using Microsoft.Data.Entity.SqlServer.ValueGeneration;
 using Microsoft.Data.Entity.Tests;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.Logging;

--- a/test/EntityFramework.SqlServer.Tests/SqlServerValueGeneratorCacheTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerValueGeneratorCacheTest.cs
@@ -4,6 +4,7 @@
 using System;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.SqlServer.Metadata;
+using Microsoft.Data.Entity.SqlServer.ValueGeneration;
 using Microsoft.Data.Entity.Tests;
 using Microsoft.Data.Entity.ValueGeneration;
 using Microsoft.Framework.DependencyInjection;
@@ -17,17 +18,18 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         public void Uses_single_generator_per_property()
         {
             var model = CreateModel();
+            var entityType = model.GetEntityType(typeof(Led));
             var property1 = GetProperty1(model);
             var property2 = GetProperty2(model);
             var cache = SqlServerTestHelpers.Instance.CreateContextServices(model).GetRequiredService<ISqlServerValueGeneratorCache>();
 
-            var generator1 = cache.GetOrAdd(property1, p => new TemporaryNumberValueGenerator<int>());
+            var generator1 = cache.GetOrAdd(property1, entityType, (p, et) => new TemporaryNumberValueGenerator<int>());
             Assert.NotNull(generator1);
-            Assert.Same(generator1, cache.GetOrAdd(property1, p => new TemporaryNumberValueGenerator<int>()));
+            Assert.Same(generator1, cache.GetOrAdd(property1, entityType, (p, et) => new TemporaryNumberValueGenerator<int>()));
 
-            var generator2 = cache.GetOrAdd(property2, p => new TemporaryNumberValueGenerator<int>());
+            var generator2 = cache.GetOrAdd(property2, entityType, (p, et) => new TemporaryNumberValueGenerator<int>());
             Assert.NotNull(generator2);
-            Assert.Same(generator2, cache.GetOrAdd(property2, p => new TemporaryNumberValueGenerator<int>()));
+            Assert.Same(generator2, cache.GetOrAdd(property2, entityType, (p, et) => new TemporaryNumberValueGenerator<int>()));
             Assert.NotSame(generator1, generator2);
         }
 

--- a/test/EntityFramework.SqlServer.Tests/SqlServerValueGeneratorSelectorTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerValueGeneratorSelectorTest.cs
@@ -4,6 +4,7 @@
 using System;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.SqlServer.Metadata;
+using Microsoft.Data.Entity.SqlServer.ValueGeneration;
 using Microsoft.Data.Entity.Tests;
 using Microsoft.Data.Entity.ValueGeneration;
 using Microsoft.Framework.DependencyInjection;
@@ -22,27 +23,27 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
 
             var selector = SqlServerTestHelpers.Instance.CreateContextServices(model).GetRequiredService<IValueGeneratorSelector>();
 
-            Assert.IsType<TemporaryNumberValueGenerator<int>>(selector.Select(entityType.GetProperty("Id")));
-            Assert.IsType<TemporaryNumberValueGenerator<long>>(selector.Select(entityType.GetProperty("Long")));
-            Assert.IsType<TemporaryNumberValueGenerator<short>>(selector.Select(entityType.GetProperty("Short")));
-            Assert.IsType<TemporaryNumberValueGenerator<byte>>(selector.Select(entityType.GetProperty("Byte")));
-            Assert.IsType<TemporaryNumberValueGenerator<int>>(selector.Select(entityType.GetProperty("NullableInt")));
-            Assert.IsType<TemporaryNumberValueGenerator<long>>(selector.Select(entityType.GetProperty("NullableLong")));
-            Assert.IsType<TemporaryNumberValueGenerator<short>>(selector.Select(entityType.GetProperty("NullableShort")));
-            Assert.IsType<TemporaryNumberValueGenerator<byte>>(selector.Select(entityType.GetProperty("NullableByte")));
-            Assert.IsType<TemporaryNumberValueGenerator<uint>>(selector.Select(entityType.GetProperty("UInt")));
-            Assert.IsType<TemporaryNumberValueGenerator<ulong>>(selector.Select(entityType.GetProperty("ULong")));
-            Assert.IsType<TemporaryNumberValueGenerator<ushort>>(selector.Select(entityType.GetProperty("UShort")));
-            Assert.IsType<TemporaryNumberValueGenerator<sbyte>>(selector.Select(entityType.GetProperty("SByte")));
-            Assert.IsType<TemporaryNumberValueGenerator<uint>>(selector.Select(entityType.GetProperty("NullableUInt")));
-            Assert.IsType<TemporaryNumberValueGenerator<ulong>>(selector.Select(entityType.GetProperty("NullableULong")));
-            Assert.IsType<TemporaryNumberValueGenerator<ushort>>(selector.Select(entityType.GetProperty("NullableUShort")));
-            Assert.IsType<TemporaryNumberValueGenerator<sbyte>>(selector.Select(entityType.GetProperty("NullableSByte")));
-            Assert.IsType<TemporaryStringValueGenerator>(selector.Select(entityType.GetProperty("String")));
-            Assert.IsType<SequentialGuidValueGenerator>(selector.Select(entityType.GetProperty("Guid")));
-            Assert.IsType<TemporaryBinaryValueGenerator>(selector.Select(entityType.GetProperty("Binary")));
-            Assert.IsType<TemporaryNumberValueGenerator<int>>(selector.Select(entityType.GetProperty("AlwaysIdentity")));
-            Assert.IsType<SqlServerSequenceValueGenerator<int>>(selector.Select(entityType.GetProperty("AlwaysSequence")));
+            Assert.IsType<TemporaryNumberValueGenerator<int>>(selector.Select(entityType.GetProperty("Id"), entityType));
+            Assert.IsType<TemporaryNumberValueGenerator<long>>(selector.Select(entityType.GetProperty("Long"), entityType));
+            Assert.IsType<TemporaryNumberValueGenerator<short>>(selector.Select(entityType.GetProperty("Short"), entityType));
+            Assert.IsType<TemporaryNumberValueGenerator<byte>>(selector.Select(entityType.GetProperty("Byte"), entityType));
+            Assert.IsType<TemporaryNumberValueGenerator<int>>(selector.Select(entityType.GetProperty("NullableInt"), entityType));
+            Assert.IsType<TemporaryNumberValueGenerator<long>>(selector.Select(entityType.GetProperty("NullableLong"), entityType));
+            Assert.IsType<TemporaryNumberValueGenerator<short>>(selector.Select(entityType.GetProperty("NullableShort"), entityType));
+            Assert.IsType<TemporaryNumberValueGenerator<byte>>(selector.Select(entityType.GetProperty("NullableByte"), entityType));
+            Assert.IsType<TemporaryNumberValueGenerator<uint>>(selector.Select(entityType.GetProperty("UInt"), entityType));
+            Assert.IsType<TemporaryNumberValueGenerator<ulong>>(selector.Select(entityType.GetProperty("ULong"), entityType));
+            Assert.IsType<TemporaryNumberValueGenerator<ushort>>(selector.Select(entityType.GetProperty("UShort"), entityType));
+            Assert.IsType<TemporaryNumberValueGenerator<sbyte>>(selector.Select(entityType.GetProperty("SByte"), entityType));
+            Assert.IsType<TemporaryNumberValueGenerator<uint>>(selector.Select(entityType.GetProperty("NullableUInt"), entityType));
+            Assert.IsType<TemporaryNumberValueGenerator<ulong>>(selector.Select(entityType.GetProperty("NullableULong"), entityType));
+            Assert.IsType<TemporaryNumberValueGenerator<ushort>>(selector.Select(entityType.GetProperty("NullableUShort"), entityType));
+            Assert.IsType<TemporaryNumberValueGenerator<sbyte>>(selector.Select(entityType.GetProperty("NullableSByte"), entityType));
+            Assert.IsType<TemporaryStringValueGenerator>(selector.Select(entityType.GetProperty("String"), entityType));
+            Assert.IsType<SequentialGuidValueGenerator>(selector.Select(entityType.GetProperty("Guid"), entityType));
+            Assert.IsType<TemporaryBinaryValueGenerator>(selector.Select(entityType.GetProperty("Binary"), entityType));
+            Assert.IsType<TemporaryNumberValueGenerator<int>>(selector.Select(entityType.GetProperty("AlwaysIdentity"), entityType));
+            Assert.IsType<SqlServerSequenceValueGenerator<int>>(selector.Select(entityType.GetProperty("AlwaysSequence"), entityType));
         }
 
         [Fact]
@@ -54,27 +55,27 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
 
             var selector = SqlServerTestHelpers.Instance.CreateContextServices(model).GetRequiredService<IValueGeneratorSelector>();
 
-            Assert.IsType<SqlServerSequenceValueGenerator<int>>(selector.Select(entityType.GetProperty("Id")));
-            Assert.IsType<SqlServerSequenceValueGenerator<long>>(selector.Select(entityType.GetProperty("Long")));
-            Assert.IsType<SqlServerSequenceValueGenerator<short>>(selector.Select(entityType.GetProperty("Short")));
-            Assert.IsType<SqlServerSequenceValueGenerator<byte>>(selector.Select(entityType.GetProperty("Byte")));
-            Assert.IsType<SqlServerSequenceValueGenerator<int>>(selector.Select(entityType.GetProperty("NullableInt")));
-            Assert.IsType<SqlServerSequenceValueGenerator<long>>(selector.Select(entityType.GetProperty("NullableLong")));
-            Assert.IsType<SqlServerSequenceValueGenerator<short>>(selector.Select(entityType.GetProperty("NullableShort")));
-            Assert.IsType<SqlServerSequenceValueGenerator<byte>>(selector.Select(entityType.GetProperty("NullableByte")));
-            Assert.IsType<SqlServerSequenceValueGenerator<uint>>(selector.Select(entityType.GetProperty("UInt")));
-            Assert.IsType<SqlServerSequenceValueGenerator<ulong>>(selector.Select(entityType.GetProperty("ULong")));
-            Assert.IsType<SqlServerSequenceValueGenerator<ushort>>(selector.Select(entityType.GetProperty("UShort")));
-            Assert.IsType<SqlServerSequenceValueGenerator<sbyte>>(selector.Select(entityType.GetProperty("SByte")));
-            Assert.IsType<SqlServerSequenceValueGenerator<uint>>(selector.Select(entityType.GetProperty("NullableUInt")));
-            Assert.IsType<SqlServerSequenceValueGenerator<ulong>>(selector.Select(entityType.GetProperty("NullableULong")));
-            Assert.IsType<SqlServerSequenceValueGenerator<ushort>>(selector.Select(entityType.GetProperty("NullableUShort")));
-            Assert.IsType<SqlServerSequenceValueGenerator<sbyte>>(selector.Select(entityType.GetProperty("NullableSByte")));
-            Assert.IsType<TemporaryStringValueGenerator>(selector.Select(entityType.GetProperty("String")));
-            Assert.IsType<SequentialGuidValueGenerator>(selector.Select(entityType.GetProperty("Guid")));
-            Assert.IsType<TemporaryBinaryValueGenerator>(selector.Select(entityType.GetProperty("Binary")));
-            Assert.IsType<TemporaryNumberValueGenerator<int>>(selector.Select(entityType.GetProperty("AlwaysIdentity")));
-            Assert.IsType<SqlServerSequenceValueGenerator<int>>(selector.Select(entityType.GetProperty("AlwaysSequence")));
+            Assert.IsType<SqlServerSequenceValueGenerator<int>>(selector.Select(entityType.GetProperty("Id"), entityType));
+            Assert.IsType<SqlServerSequenceValueGenerator<long>>(selector.Select(entityType.GetProperty("Long"), entityType));
+            Assert.IsType<SqlServerSequenceValueGenerator<short>>(selector.Select(entityType.GetProperty("Short"), entityType));
+            Assert.IsType<SqlServerSequenceValueGenerator<byte>>(selector.Select(entityType.GetProperty("Byte"), entityType));
+            Assert.IsType<SqlServerSequenceValueGenerator<int>>(selector.Select(entityType.GetProperty("NullableInt"), entityType));
+            Assert.IsType<SqlServerSequenceValueGenerator<long>>(selector.Select(entityType.GetProperty("NullableLong"), entityType));
+            Assert.IsType<SqlServerSequenceValueGenerator<short>>(selector.Select(entityType.GetProperty("NullableShort"), entityType));
+            Assert.IsType<SqlServerSequenceValueGenerator<byte>>(selector.Select(entityType.GetProperty("NullableByte"), entityType));
+            Assert.IsType<SqlServerSequenceValueGenerator<uint>>(selector.Select(entityType.GetProperty("UInt"), entityType));
+            Assert.IsType<SqlServerSequenceValueGenerator<ulong>>(selector.Select(entityType.GetProperty("ULong"), entityType));
+            Assert.IsType<SqlServerSequenceValueGenerator<ushort>>(selector.Select(entityType.GetProperty("UShort"), entityType));
+            Assert.IsType<SqlServerSequenceValueGenerator<sbyte>>(selector.Select(entityType.GetProperty("SByte"), entityType));
+            Assert.IsType<SqlServerSequenceValueGenerator<uint>>(selector.Select(entityType.GetProperty("NullableUInt"), entityType));
+            Assert.IsType<SqlServerSequenceValueGenerator<ulong>>(selector.Select(entityType.GetProperty("NullableULong"), entityType));
+            Assert.IsType<SqlServerSequenceValueGenerator<ushort>>(selector.Select(entityType.GetProperty("NullableUShort"), entityType));
+            Assert.IsType<SqlServerSequenceValueGenerator<sbyte>>(selector.Select(entityType.GetProperty("NullableSByte"), entityType));
+            Assert.IsType<TemporaryStringValueGenerator>(selector.Select(entityType.GetProperty("String"), entityType));
+            Assert.IsType<SequentialGuidValueGenerator>(selector.Select(entityType.GetProperty("Guid"), entityType));
+            Assert.IsType<TemporaryBinaryValueGenerator>(selector.Select(entityType.GetProperty("Binary"), entityType));
+            Assert.IsType<TemporaryNumberValueGenerator<int>>(selector.Select(entityType.GetProperty("AlwaysIdentity"), entityType));
+            Assert.IsType<SqlServerSequenceValueGenerator<int>>(selector.Select(entityType.GetProperty("AlwaysSequence"), entityType));
         }
 
         [Fact]
@@ -87,7 +88,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
 
             Assert.Equal(
                 CoreStrings.NoValueGenerator("Random", "AnEntity", typeof(Random).Name),
-                Assert.Throws<NotSupportedException>(() => selector.Select(entityType.GetProperty("Random"))).Message);
+                Assert.Throws<NotSupportedException>(() => selector.Select(entityType.GetProperty("Random"), entityType)).Message);
         }
 
         [Fact]
@@ -99,7 +100,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
 
             var selector = SqlServerTestHelpers.Instance.CreateContextServices(model).GetRequiredService<IValueGeneratorSelector>();
 
-            Assert.IsType<SqlServerSequenceValueGenerator<int>>(selector.Select(entityType.GetProperty("Id")));
+            Assert.IsType<SqlServerSequenceValueGenerator<int>>(selector.Select(entityType.GetProperty("Id"), entityType));
         }
 
         [Fact]
@@ -113,7 +114,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
 
             var selector = SqlServerTestHelpers.Instance.CreateContextServices(model).GetRequiredService<IValueGeneratorSelector>();
 
-            Assert.IsType<TemporaryNumberValueGenerator<int>>(selector.Select(property));
+            Assert.IsType<TemporaryNumberValueGenerator<int>>(selector.Select(property, entityType));
         }
 
         private static Model BuildModel(bool generateValues = true)


### PR DESCRIPTION
- Flow property "reflected" entity type to value generator selector. Incorporate it into the value generator cache key.
- IEntityType.Keys and IEntityType.ForeignKeys to GetX methods to match GetProperties.
- Introduced RelationalValueGeneratorSelector which does discriminator value generation.