### PR TITLE
Remove travis and appveyor CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: csharp
-sudo: false
-script:
-  - ./build.sh --quiet verify

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 Entity Framework
 ===
-AppVeyor: [![AppVeyor](https://ci.appveyor.com/api/projects/status/seadcah8q68tykgw/branch/dev?svg=true)](https://ci.appveyor.com/project/aspnetci/EntityFramework/branch/dev)
-
-Travis:   [![Travis](https://travis-ci.org/aspnet/EntityFramework.svg?branch=dev)](https://travis-ci.org/aspnet/EntityFramework)
-
 Entity Framework is Microsoft's recommended data access technology for new applications in .NET. 
 
 Entity Framework 7 (EF7) provides a familiar developer experience to previous versions of EF, including LINQ, POCO, and Code First support. EF7 also enables access to data across relational and non-relational stores. EF7 is much more lightweight than previous versions and is built from the ground up to work great in the cloud (using ASP.NET 5) on devices (i.e. in universal Windows apps) as well as in traditional .NET scenarios.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,0 @@
-init:
-  - git config --global core.autocrlf true
-build_script:
-  - build.cmd --quiet verify
-clone_depth: 1
-test: off
-deploy: off


### PR DESCRIPTION
We'll add these back when we get the agents setup correctly to build and run tests.