### PR TITLE
#2143 Fix culture sensitive tests

### DIFF
--- a/test/EntityFramework.Commands.Tests/Utilities/CSharpHelperTest.cs
+++ b/test/EntityFramework.Commands.Tests/Utilities/CSharpHelperTest.cs
@@ -2,12 +2,27 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Globalization;
+using System.Threading;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Commands.Utilities
 {
-    public class CSharpHelperTest
+    public class CSharpHelperTest : IDisposable
     {
+        private readonly CultureInfo _backupCultureInfo;
+
+        public CSharpHelperTest()
+        {
+            _backupCultureInfo = Thread.CurrentThread.CurrentCulture;
+            Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
+        }
+
+        void IDisposable.Dispose()
+        {
+            Thread.CurrentThread.CurrentCulture = _backupCultureInfo;
+        }
+
         [Theory]
         [InlineData(
             "single-line string with \"",


### PR DESCRIPTION
CSharpHelperTest uses US-English culture formatting when asserting the text. This fails on machines using other default culture settings. By setting the culture in the setup (and resetting it in tear down), the test can run successfully on non-US systems as well.