### PR TITLE
#2145 Fix ArgumentException in TemporaryDateTimeOffsetValueGenerator …

### DIFF
--- a/src/EntityFramework.Core/ValueGeneration/TemporaryDateTimeOffsetValueGenerator.cs
+++ b/src/EntityFramework.Core/ValueGeneration/TemporaryDateTimeOffsetValueGenerator.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Data.Entity.ValueGeneration
         private long _current;
 
         public override DateTimeOffset Next()
-            => new DateTimeOffset(new DateTime(Interlocked.Increment(ref _current)));
+            => new DateTimeOffset(Interlocked.Increment(ref _current), TimeSpan.Zero);
 
         public override bool GeneratesTemporaryValues => true;
     }

--- a/test/EntityFramework.Core.Tests/ValueGeneration/TemporaryDateTimeOffsetValueGeneratorTest.cs
+++ b/test/EntityFramework.Core.Tests/ValueGeneration/TemporaryDateTimeOffsetValueGeneratorTest.cs
@@ -13,9 +13,8 @@ namespace Microsoft.Data.Entity.Tests.ValueGeneration
         public void Can_create_values_for_DateTime_types()
         {
             var generator = new TemporaryDateTimeOffsetValueGenerator();
-
-            Assert.Equal(new DateTimeOffset(new DateTime(1)), generator.Next());
-            Assert.Equal(new DateTimeOffset(new DateTime(2)), generator.Next());
+            Assert.Equal(new DateTimeOffset(1, TimeSpan.Zero), generator.Next());
+            Assert.Equal(new DateTimeOffset(2, TimeSpan.Zero), generator.Next());
         }
 
         [Fact]


### PR DESCRIPTION
…for time zones with a positive UTC offset

DateTimeOffset will fail with an ArgumentException when attempting to initialize with a DateTime that results in a negative offset. This can happen when the actual DateTime value used has a positive UTC offset, e.g. the local time in Europe.

I propose switching the DateTimeOffset to always use a UTC offset = 0 and increment from there.