### PR TITLE
Fix #2179 - table presence detection not working on SQL Azure DB V12

### DIFF
--- a/src/EntityFramework.SqlServer/SqlServerDataStoreCreator.cs
+++ b/src/EntityFramework.SqlServer/SqlServerDataStoreCreator.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Data.Entity.SqlServer
             => _sqlGenerator.Generate(_modelDiffer.GetDifferences(null, model), model);
 
         private string CreateHasTablesCommand()
-            => "IF EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES) SELECT 1 ELSE SELECT 0";
+            => "IF EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = 'BASE TABLE') SELECT 1 ELSE SELECT 0";
 
         private IEnumerable<SqlBatch> CreateCreateOperations()
             => _sqlGenerator.Generate(new[] { new CreateDatabaseOperation { Name = _connection.DbConnection.Database } });


### PR DESCRIPTION
Fixes issue #2179 by adding a check for the table type in the check for the precense of any user created tables, as the INFORMATION_SCHEMA.TABLES view contains rows on a blank database on Azure SQL DB V12.
Modifeid query verfied against a V12 database (and against localdb by running the tests)