### PR TITLE
Fix for issue #2188 - allow tests to pass on Azure SQL Database V12

### DIFF
--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerDataStoreCreatorTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerDataStoreCreatorTest.cs
@@ -249,11 +249,11 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                         await testDatabase.Connection.OpenAsync();
                     }
 
-                    var tables = await testDatabase.QueryAsync<string>("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES");
+                    var tables = await testDatabase.QueryAsync<string>("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = 'BASE TABLE'");
                     Assert.Equal(1, tables.Count());
                     Assert.Equal("Blog", tables.Single());
 
-                    var columns = await testDatabase.QueryAsync<string>("SELECT TABLE_NAME + '.' + COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS");
+                    var columns = await testDatabase.QueryAsync<string>("SELECT TABLE_NAME + '.' + COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'Blog'");
                     Assert.Equal(2, columns.Count());
                     Assert.True(columns.Any(c => c == "Blog.Id"));
                     Assert.True(columns.Any(c => c == "Blog.Name"));
@@ -329,7 +329,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                     await testDatabase.Connection.OpenAsync();
                 }
 
-                Assert.Equal(0, (await testDatabase.QueryAsync<string>("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES")).Count());
+                Assert.Equal(0, (await testDatabase.QueryAsync<string>("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = 'BASE TABLE'")).Count());
 
                 Assert.True(await testDatabase.ExecuteScalarAsync<bool>(
                     string.Concat(

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerDatabaseCreationTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerDatabaseCreationTest.cs
@@ -217,12 +217,12 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                     await testStore.Connection.OpenAsync();
                 }
 
-                var tables = await testStore.QueryAsync<string>("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES");
+                var tables = await testStore.QueryAsync<string>("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = 'BASE TABLE'");
                 Assert.Equal(1, tables.Count());
                 Assert.Equal("Blog", tables.Single());
 
                 var columns = (await testStore.QueryAsync<string>(
-                    "SELECT TABLE_NAME + '.' + COLUMN_NAME + ' (' + DATA_TYPE + ')' FROM INFORMATION_SCHEMA.COLUMNS ORDER BY TABLE_NAME, COLUMN_NAME")).ToArray();
+                    "SELECT TABLE_NAME + '.' + COLUMN_NAME + ' (' + DATA_TYPE + ')' FROM INFORMATION_SCHEMA.COLUMNS  WHERE TABLE_NAME = 'Blog' ORDER BY TABLE_NAME, COLUMN_NAME")).ToArray();
                 Assert.Equal(19, columns.Length);
 
                 Assert.Equal(


### PR DESCRIPTION
Executing just

    SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES

will return rows on Azure SQL Database V12 even with no user created tables present, see #2179 

This fix limits the rows returned by only returning user created tables (as done already elsewhere in the product code) 