### PR TITLE
#2203 Switch test projects to .NET 4.6…

### DIFF
--- a/test/EntityFramework.Commands.FunctionalTests/EntityFramework.Commands.FunctionalTests.csproj
+++ b/test/EntityFramework.Commands.FunctionalTests/EntityFramework.Commands.FunctionalTests.csproj
@@ -11,9 +11,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Data.Entity.Commands</RootNamespace>
     <AssemblyName>EntityFramework.Commands.FunctionalTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>199587f0</NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/test/EntityFramework.Commands.FunctionalTests/project.json
+++ b/test/EntityFramework.Commands.FunctionalTests/project.json
@@ -10,6 +10,6 @@
         "test": "xunit.runner.aspnet"
     },
     "frameworks": {
-        "dnx451": { }
+        "dnx46": { }
     }
 }

--- a/test/EntityFramework.Commands.Tests/EntityFramework.Commands.Tests.csproj
+++ b/test/EntityFramework.Commands.Tests/EntityFramework.Commands.Tests.csproj
@@ -11,9 +11,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Data.Entity.Commands.Tests</RootNamespace>
     <AssemblyName>EntityFramework.Commands.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>3453667e</NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/test/EntityFramework.Commands.Tests/project.json
+++ b/test/EntityFramework.Commands.Tests/project.json
@@ -9,6 +9,6 @@
         "test": "xunit.runner.aspnet"
     },
     "frameworks": {
-        "dnx451": { }
+        "dnx46": { }
     }
 }

--- a/test/EntityFramework.Core.FunctionalTests/EntityFramework.Core.FunctionalTests.csproj
+++ b/test/EntityFramework.Core.FunctionalTests/EntityFramework.Core.FunctionalTests.csproj
@@ -11,9 +11,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Data.Entity.FunctionalTests</RootNamespace>
     <AssemblyName>EntityFramework.Core.FunctionalTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>275c64a3</NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/test/EntityFramework.Core.FunctionalTests/project.json
+++ b/test/EntityFramework.Core.FunctionalTests/project.json
@@ -7,7 +7,7 @@
     "test": "xunit.runner.aspnet"
   },
   "frameworks": {
-    "dnx451": {
+    "dnx46": {
       "frameworkAssemblies": {
         "WindowsBase": "4.0.0.0"
       }

--- a/test/EntityFramework.Core.Tests/EntityFramework.Core.Tests.csproj
+++ b/test/EntityFramework.Core.Tests/EntityFramework.Core.Tests.csproj
@@ -11,9 +11,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Data.Entity.Tests</RootNamespace>
     <AssemblyName>EntityFramework.Core.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>0337bf42</NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/test/EntityFramework.Core.Tests/project.json
+++ b/test/EntityFramework.Core.Tests/project.json
@@ -9,6 +9,6 @@
         "test": "xunit.runner.aspnet"
     },
     "frameworks": {
-        "dnx451": { }
+        "dnx46": { }
     }
 }

--- a/test/EntityFramework.CrossStore.FunctionalTests/EntityFramework.CrossStore.FunctionalTests.csproj
+++ b/test/EntityFramework.CrossStore.FunctionalTests/EntityFramework.CrossStore.FunctionalTests.csproj
@@ -11,9 +11,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Data.Entity.FunctionalTests</RootNamespace>
     <AssemblyName>EntityFramework.CrossStore.FunctionalTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>fd74b8fa</NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/test/EntityFramework.CrossStore.FunctionalTests/project.json
+++ b/test/EntityFramework.CrossStore.FunctionalTests/project.json
@@ -8,6 +8,6 @@
         "test": "xunit.runner.aspnet"
     },
     "frameworks": {
-        "dnx451": { }
+        "dnx46": { }
     }
 }

--- a/test/EntityFramework.InMemory.FunctionalTests/EntityFramework.InMemory.FunctionalTests.csproj
+++ b/test/EntityFramework.InMemory.FunctionalTests/EntityFramework.InMemory.FunctionalTests.csproj
@@ -11,9 +11,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Data.Entity.InMemory.FunctionalTests</RootNamespace>
     <AssemblyName>EntityFramework.InMemory.FunctionalTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>6edf0372</NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/test/EntityFramework.InMemory.FunctionalTests/project.json
+++ b/test/EntityFramework.InMemory.FunctionalTests/project.json
@@ -6,7 +6,7 @@
         "test": "xunit.runner.aspnet"
     },
     "frameworks": {
-        "dnx451": { },
+        "dnx46": { },
         "dnxcore50": { }
     }
 }

--- a/test/EntityFramework.InMemory.Tests/EntityFramework.InMemory.Tests.csproj
+++ b/test/EntityFramework.InMemory.Tests/EntityFramework.InMemory.Tests.csproj
@@ -11,9 +11,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Data.Entity.InMemory.Tests</RootNamespace>
     <AssemblyName>EntityFramework.InMemory.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>ded15bf9</NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/test/EntityFramework.InMemory.Tests/project.json
+++ b/test/EntityFramework.InMemory.Tests/project.json
@@ -6,6 +6,6 @@
         "test": "xunit.runner.aspnet"
     },
     "frameworks": {
-        "dnx451": { }
+        "dnx46": { }
     }
 }

--- a/test/EntityFramework.Microbenchmarks.Core/EntityFramework.Microbenchmarks.Core.csproj
+++ b/test/EntityFramework.Microbenchmarks.Core/EntityFramework.Microbenchmarks.Core.csproj
@@ -12,9 +12,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>EntityFramework.Microbenchmarks.Core</RootNamespace>
     <AssemblyName>EntityFramework.Microbenchmarks.Core</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>c783c500</NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/test/EntityFramework.Microbenchmarks.Core/project.json
+++ b/test/EntityFramework.Microbenchmarks.Core/project.json
@@ -13,7 +13,7 @@
                 "System.Net.NetworkInformation":  "4.0.10-beta-*"
             }
         },
-        "dnx451": {
+        "dnx46": {
             "frameworkAssemblies": {
                 "System.ComponentModel.DataAnnotations": ""
             }

--- a/test/EntityFramework.Microbenchmarks.EF6/App.config
+++ b/test/EntityFramework.Microbenchmarks.EF6/App.config
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <configSections>
         <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
@@ -11,4 +10,7 @@
             <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
         </providers>
     </entityFramework>
+    <startup>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
+    </startup>
 </configuration>

--- a/test/EntityFramework.Microbenchmarks.EF6/EntityFramework.Microbenchmarks.EF6.csproj
+++ b/test/EntityFramework.Microbenchmarks.EF6/EntityFramework.Microbenchmarks.EF6.csproj
@@ -11,9 +11,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>EntityFramework.Microbenchmarks.EF6</RootNamespace>
     <AssemblyName>EntityFramework.Microbenchmarks.EF6</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>e69ad63a</NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/test/EntityFramework.Microbenchmarks.EF6/project.json
+++ b/test/EntityFramework.Microbenchmarks.EF6/project.json
@@ -10,7 +10,7 @@
         "test": "xunit.runner.aspnet"
     },
     "frameworks": {
-        "dnx451": {
+        "dnx46": {
             "frameworkAssemblies": {
                 "System.ComponentModel.DataAnnotations": ""
             }

--- a/test/EntityFramework.Microbenchmarks/EntityFramework.Microbenchmarks.csproj
+++ b/test/EntityFramework.Microbenchmarks/EntityFramework.Microbenchmarks.csproj
@@ -11,9 +11,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>EntityFramework.Microbenchmarks</RootNamespace>
     <AssemblyName>EntityFramework.Microbenchmarks</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>ff20b591</NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/test/EntityFramework.Microbenchmarks/project.json
+++ b/test/EntityFramework.Microbenchmarks/project.json
@@ -16,7 +16,7 @@
                 "System.Net.NetworkInformation":  "4.0.10-beta-*"
             }
         },
-        "dnx451": {
+        "dnx46": {
             "frameworkAssemblies": {
                 "System.ComponentModel.DataAnnotations": ""
             }

--- a/test/EntityFramework.Relational.Design.Tests/EntityFramework.Relational.Design.Tests.csproj
+++ b/test/EntityFramework.Relational.Design.Tests/EntityFramework.Relational.Design.Tests.csproj
@@ -11,8 +11,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Data.Entity.Relational.Design.Tests</RootNamespace>
     <AssemblyName>EntityFramework.Relational.Design.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/test/EntityFramework.Relational.Design.Tests/project.json
+++ b/test/EntityFramework.Relational.Design.Tests/project.json
@@ -7,6 +7,6 @@
         "test": "xunit.runner.aspnet"
     },
     "frameworks": {
-        "dnx451": { }
+        "dnx46": { }
     }
 }

--- a/test/EntityFramework.Relational.FunctionalTests/EntityFramework.Relational.FunctionalTests.csproj
+++ b/test/EntityFramework.Relational.FunctionalTests/EntityFramework.Relational.FunctionalTests.csproj
@@ -11,9 +11,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Data.Entity.Relational.FunctionalTests</RootNamespace>
     <AssemblyName>EntityFramework.Relational.FunctionalTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>7c6125aa</NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/test/EntityFramework.Relational.FunctionalTests/project.json
+++ b/test/EntityFramework.Relational.FunctionalTests/project.json
@@ -4,7 +4,7 @@
         "EntityFramework.Relational": "7.0.0-*"
     },
     "frameworks": {
-        "dnx451": { },
+        "dnx46": { },
         "dnxcore50": {
             "dependencies": {
                 "System.Threading": "4.0.10-beta-*"

--- a/test/EntityFramework.Relational.Tests/EntityFramework.Relational.Tests.csproj
+++ b/test/EntityFramework.Relational.Tests/EntityFramework.Relational.Tests.csproj
@@ -11,9 +11,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Data.Entity.Relational.Tests</RootNamespace>
     <AssemblyName>EntityFramework.Relational.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>f94b196b</NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/test/EntityFramework.Relational.Tests/project.json
+++ b/test/EntityFramework.Relational.Tests/project.json
@@ -7,6 +7,6 @@
         "test": "xunit.runner.aspnet"
     },
     "frameworks": {
-        "dnx451": { }
+        "dnx46": { }
     }
 }

--- a/test/EntityFramework.SqlServer.Design.Tests/EntityFramework.SqlServer.Design.Tests.csproj
+++ b/test/EntityFramework.SqlServer.Design.Tests/EntityFramework.SqlServer.Design.Tests.csproj
@@ -11,8 +11,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Data.Entity.SqlServer.Design.Tests</RootNamespace>
     <AssemblyName>EntityFramework.SqlServer.Design.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/test/EntityFramework.SqlServer.Design.Tests/project.json
+++ b/test/EntityFramework.SqlServer.Design.Tests/project.json
@@ -7,6 +7,6 @@
         "test": "xunit.runner.aspnet"
     },
     "frameworks": {
-        "dnx451": { }
+        "dnx46": { }
     }
 }

--- a/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
+++ b/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
@@ -11,9 +11,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Data.Entity.SqlServer.FunctionalTests</RootNamespace>
     <AssemblyName>EntityFramework.SqlServer.FunctionalTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>04bdbbf8</NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/test/EntityFramework.SqlServer.FunctionalTests/project.json
+++ b/test/EntityFramework.SqlServer.FunctionalTests/project.json
@@ -7,7 +7,7 @@
         "test": "xunit.runner.aspnet"
     },
     "frameworks": {
-        "dnx451": { },
+        "dnx46": { },
         "dnxcore50": { }
     }
 }

--- a/test/EntityFramework.SqlServer.Tests/EntityFramework.SqlServer.Tests.csproj
+++ b/test/EntityFramework.SqlServer.Tests/EntityFramework.SqlServer.Tests.csproj
@@ -11,9 +11,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Data.Entity.SqlServer.Tests</RootNamespace>
     <AssemblyName>EntityFramework.SqlServer.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>7a22f5fc</NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/test/EntityFramework.SqlServer.Tests/project.json
+++ b/test/EntityFramework.SqlServer.Tests/project.json
@@ -7,6 +7,6 @@
         "test": "xunit.runner.aspnet"
     },
     "frameworks": {
-        "dnx451": { }
+        "dnx46": { }
     }
 }

--- a/test/EntityFramework.Sqlite.FunctionalTests/EntityFramework.Sqlite.FunctionalTests.csproj
+++ b/test/EntityFramework.Sqlite.FunctionalTests/EntityFramework.Sqlite.FunctionalTests.csproj
@@ -11,9 +11,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Data.Entity.Sqlite.FunctionalTests</RootNamespace>
     <AssemblyName>EntityFramework.Sqlite.FunctionalTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>04bdbbf8</NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/test/EntityFramework.Sqlite.FunctionalTests/project.json
+++ b/test/EntityFramework.Sqlite.FunctionalTests/project.json
@@ -7,7 +7,7 @@
         "test": "xunit.runner.aspnet"
     },
     "frameworks": {
-        "dnx451": { },
+        "dnx46": { },
         "dnxcore50": { }
     }
 }

--- a/test/EntityFramework.Sqlite.Tests/EntityFramework.Sqlite.Tests.csproj
+++ b/test/EntityFramework.Sqlite.Tests/EntityFramework.Sqlite.Tests.csproj
@@ -11,9 +11,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Data.Entity.Sqlite</RootNamespace>
     <AssemblyName>EntityFramework.Sqlite.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>7ce5139e</NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/test/EntityFramework.Sqlite.Tests/project.json
+++ b/test/EntityFramework.Sqlite.Tests/project.json
@@ -7,6 +7,6 @@
         "test": "xunit.runner.aspnet"
     },
     "frameworks": {
-        "dnx451": { }
+        "dnx46": { }
     }
 }


### PR DESCRIPTION
… to enable use of features such as settable CultureInfo.CurrentCulture/CurrentUICulture properties.

This is in response to @divega and @bricelam suggesting the switch in #2160.