### PR TITLE
Remove design-time facades from net45 framework assemblies in packages

### DIFF
--- a/src/EntityFramework.Core/project.json
+++ b/src/EntityFramework.Core/project.json
@@ -20,6 +20,24 @@
   "frameworks": {
     "net45": {
       "frameworkAssemblies": {
+        "System.Collections": { "version": "4.0.0.0", "type": "build" },
+        "System.Diagnostics.Debug": { "version": "4.0.0.0", "type": "build" },
+        "System.Diagnostics.Tools": { "version": "4.0.0.0", "type": "build" },
+        "System.Globalization": { "version": "4.0.0.0", "type": "build" },
+        "System.Linq": { "version": "4.0.0.0", "type": "build" },
+        "System.Linq.Expressions": { "version": "4.0.0.0", "type": "build" },
+        "System.Linq.Queryable": { "version": "4.0.0.0", "type": "build" },
+        "System.ObjectModel": { "version": "4.0.0.0", "type": "build" },
+        "System.Reflection": { "version": "4.0.0.0", "type": "build" },
+        "System.Reflection.Extensions": { "version": "4.0.0.0", "type": "build" },
+        "System.Resources.ResourceManager": { "version": "4.0.0.0", "type": "build" },
+        "System.Runtime": { "version": "4.0.0.0", "type": "build" },
+        "System.Runtime.Extensions": { "version": "4.0.0.0", "type": "build" },
+        "System.Threading": { "version": "4.0.0.0", "type": "build" }
+      }
+    },
+    "dnx451": {
+      "frameworkAssemblies": {
         "System.Collections": "4.0.0.0",
         "System.Diagnostics.Debug": "4.0.0.0",
         "System.Diagnostics.Tools": "4.0.0.0",

--- a/src/EntityFramework.Relational.Design/project.json
+++ b/src/EntityFramework.Relational.Design/project.json
@@ -16,9 +16,9 @@
   "frameworks": {
     "net45": {
       "frameworkAssemblies": {
-        "System.IO": "4.0.0.0",
-        "System.Text.Encoding": "4.0.0.0",
-        "System.Threading.Tasks": "4.0.0.0"
+        "System.IO": { "version": "4.0.0.0", "type": "build" },
+        "System.Text.Encoding": { "version": "4.0.0.0", "type": "build" },
+        "System.Threading.Tasks": { "version": "4.0.0.0", "type": "build" }
       }
     },
     "dnx451": {

--- a/src/EntityFramework.Sqlite/project.json
+++ b/src/EntityFramework.Sqlite/project.json
@@ -10,7 +10,7 @@
   },
   "compile": "..\\Shared\\*.cs",
   "frameworks": {
-    "net451": { },
+    "net45": { },
     "dnxcore50": { },
     ".NETPortable,Version=v4.5,Profile=Profile7": { }
   }


### PR DESCRIPTION
Resolves #2152

/cc @davidfowl Having these in the nuspec blocks installation into net45 projects. Without them, dnx451 won't work.