### PR TITLE
Short param names for common override methods

### DIFF
--- a/src/EntityFramework.Core/DbContext.cs
+++ b/src/EntityFramework.Core/DbContext.cs
@@ -253,11 +253,11 @@ namespace Microsoft.Data.Entity
         ///     affecting other context instances that are constructed with the same <see cref="DbContextOptions" />
         ///     instance.
         /// </remarks>
-        /// <param name="optionsBuilder">
+        /// <param name="options">
         ///     A builder used to create or modify options for this context. Data stores (and other extensions)
         ///     typically define extension methods on this object that allow you to configure the context.
         /// </param>
-        protected internal virtual void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        protected internal virtual void OnConfiguring(DbContextOptionsBuilder options)
         {
         }
 
@@ -266,12 +266,12 @@ namespace Microsoft.Data.Entity
         ///     exposed in <see cref="DbSet{TEntity}" /> properties on your derived context. The resulting model may be cached
         ///     and re-used for subsequent instances of your derived context.
         /// </summary>
-        /// <param name="modelBuilder">
+        /// <param name="model">
         ///     The builder being used to construct the model for this context. Data stores (and other extensions) typically
         ///     define extension methods on this object that allow you to configure aspects of the model that are specific
         ///     to a given data store.
         /// </param>
-        protected internal virtual void OnModelCreating(ModelBuilder modelBuilder)
+        protected internal virtual void OnModelCreating(ModelBuilder model)
         {
         }
 

--- a/src/EntityFramework.SqlServer.Design/ReverseEngineering/Templates/SqlServerDbContextTemplate.cshtml
+++ b/src/EntityFramework.SqlServer.Design/ReverseEngineering/Templates/SqlServerDbContextTemplate.cshtml
@@ -54,7 +54,7 @@ var className = Model.ClassName ?? Model.Helper.ClassName(Model.ConnectionString
             options.UseSqlServer(@Model.Helper.VerbatimStringLiteral(@Model.ConnectionString));
         }
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        protected override void OnModelCreating(ModelBuilder model)
         {
 @{
 var firstEntity = true;
@@ -65,7 +65,7 @@ var firstEntity = true;
 @:
     }
     firstEntity = false;
-@:            modelBuilder.Entity<@entityConfig.EntityType.DisplayName()>(entity =>
+@:            model.Entity<@entityConfig.EntityType.DisplayName()>(entity =>
 @:            {
     var firstEntityFacet = true;
     @foreach (var entityFacet in @entityConfig.FacetConfigurations)

--- a/test/EntityFramework.Commands.FunctionalTests/ExecutorTest.cs
+++ b/test/EntityFramework.Commands.FunctionalTests/ExecutorTest.cs
@@ -88,9 +88,9 @@ namespace Microsoft.Data.Entity.Commands
                             {
                                 internal class SimpleContext : DbContext
                                 {
-                                    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                                    protected override void OnConfiguring(DbContextOptionsBuilder options)
                                     {
-                                        optionsBuilder.UseSqlServer(""Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=SimpleProject.SimpleContext;Integrated Security=True"");
+                                        options.UseSqlServer(""Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=SimpleProject.SimpleContext;Integrated Security=True"");
                                     }
                                 }
 
@@ -177,9 +177,9 @@ namespace Microsoft.Data.Entity.Commands
                         {
                             internal class Context1 : DbContext
                             {
-                                protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                                protected override void OnConfiguring(DbContextOptionsBuilder options)
                                 {
-                                    optionsBuilder.UseSqlServer(""Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=SimpleProject.SimpleContext;Integrated Security=True"");
+                                    options.UseSqlServer(""Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=SimpleProject.SimpleContext;Integrated Security=True"");
                                 }
                             }
 

--- a/test/EntityFramework.Core.FunctionalTests/BuiltInDataTypesFixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/BuiltInDataTypesFixtureBase.cs
@@ -12,10 +12,10 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
         public abstract DbContext CreateContext(TTestStore testStore);
 
-        public virtual void OnModelCreating(ModelBuilder modelBuilder)
+        public virtual void OnModelCreating(ModelBuilder model)
         {
-            modelBuilder.Entity<BuiltInNonNullableDataTypes>();
-            modelBuilder.Entity<BuiltInNullableDataTypes>();
+            model.Entity<BuiltInNonNullableDataTypes>();
+            model.Entity<BuiltInNullableDataTypes>();
         }
 
         public virtual void Cleanup(DbContext context)

--- a/test/EntityFramework.Core.FunctionalTests/ComplexNavigationsQueryFixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/ComplexNavigationsQueryFixtureBase.cs
@@ -12,53 +12,53 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
         public abstract ComplexNavigationsContext CreateContext(TTestStore testStore);
 
-        protected virtual void OnModelCreating(ModelBuilder modelBuilder)
+        protected virtual void OnModelCreating(ModelBuilder model)
         {
-            modelBuilder.Entity<Level1>().Key(e => e.Id);
-            modelBuilder.Entity<Level2>().Key(e => e.Id);
-            modelBuilder.Entity<Level3>().Key(e => e.Id);
-            modelBuilder.Entity<Level4>().Key(e => e.Id);
+            model.Entity<Level1>().Key(e => e.Id);
+            model.Entity<Level2>().Key(e => e.Id);
+            model.Entity<Level3>().Key(e => e.Id);
+            model.Entity<Level4>().Key(e => e.Id);
 
-            modelBuilder.Entity<Level1>().Reference(e => e.OneToOne_Required_PK).InverseReference(e => e.OneToOne_Required_PK_Inverse).PrincipalKey<Level1>(e => e.Id).Required(true);
-            modelBuilder.Entity<Level1>().Reference(e => e.OneToOne_Optional_PK).InverseReference(e => e.OneToOne_Optional_PK_Inverse).PrincipalKey<Level1>(e => e.Id).Required(false);
-            modelBuilder.Entity<Level1>().Reference(e => e.OneToOne_Required_FK).InverseReference(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level2>(e => e.Level1_Required_Id).Required(true);
-            modelBuilder.Entity<Level1>().Reference(e => e.OneToOne_Optional_FK).InverseReference(e => e.OneToOne_Optional_FK_Inverse).ForeignKey<Level2>(e => e.Level1_Optional_Id).Required(false);
-            modelBuilder.Entity<Level1>().Collection(e => e.OneToMany_Required).InverseReference(e => e.OneToMany_Required_Inverse).Required(true);
-            modelBuilder.Entity<Level1>().Collection(e => e.OneToMany_Optional).InverseReference(e => e.OneToMany_Optional_Inverse).Required(false);
-            modelBuilder.Entity<Level1>().Collection(e => e.OneToMany_Required_Self).InverseReference(e => e.OneToMany_Required_Self_Inverse).Required(true);
-            modelBuilder.Entity<Level1>().Collection(e => e.OneToMany_Optional_Self).InverseReference(e => e.OneToMany_Optional_Self_Inverse).Required(false);
+            model.Entity<Level1>().Reference(e => e.OneToOne_Required_PK).InverseReference(e => e.OneToOne_Required_PK_Inverse).PrincipalKey<Level1>(e => e.Id).Required(true);
+            model.Entity<Level1>().Reference(e => e.OneToOne_Optional_PK).InverseReference(e => e.OneToOne_Optional_PK_Inverse).PrincipalKey<Level1>(e => e.Id).Required(false);
+            model.Entity<Level1>().Reference(e => e.OneToOne_Required_FK).InverseReference(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level2>(e => e.Level1_Required_Id).Required(true);
+            model.Entity<Level1>().Reference(e => e.OneToOne_Optional_FK).InverseReference(e => e.OneToOne_Optional_FK_Inverse).ForeignKey<Level2>(e => e.Level1_Optional_Id).Required(false);
+            model.Entity<Level1>().Collection(e => e.OneToMany_Required).InverseReference(e => e.OneToMany_Required_Inverse).Required(true);
+            model.Entity<Level1>().Collection(e => e.OneToMany_Optional).InverseReference(e => e.OneToMany_Optional_Inverse).Required(false);
+            model.Entity<Level1>().Collection(e => e.OneToMany_Required_Self).InverseReference(e => e.OneToMany_Required_Self_Inverse).Required(true);
+            model.Entity<Level1>().Collection(e => e.OneToMany_Optional_Self).InverseReference(e => e.OneToMany_Optional_Self_Inverse).Required(false);
 
             // issue #1417
             //modelBuilder.Entity<Level1>().Reference(e => e.OneToOne_Optional_Self).InverseReference(); 
 
-            modelBuilder.Entity<Level2>().Reference(e => e.OneToOne_Required_PK).InverseReference(e => e.OneToOne_Required_PK_Inverse).PrincipalKey<Level2>(e => e.Id).Required(true);
-            modelBuilder.Entity<Level2>().Reference(e => e.OneToOne_Optional_PK).InverseReference(e => e.OneToOne_Optional_PK_Inverse).PrincipalKey<Level2>(e => e.Id).Required(false);
-            modelBuilder.Entity<Level2>().Reference(e => e.OneToOne_Required_FK).InverseReference(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level3>(e => e.Level2_Required_Id).Required(true);
-            modelBuilder.Entity<Level2>().Reference(e => e.OneToOne_Optional_FK).InverseReference(e => e.OneToOne_Optional_FK_Inverse).ForeignKey<Level3>(e => e.Level2_Optional_Id).Required(false);
-            modelBuilder.Entity<Level2>().Reference(e => e.OneToOne_Required_FK).InverseReference(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level3>(e => e.Level2_Required_Id).Required(true);
-            modelBuilder.Entity<Level2>().Reference(e => e.OneToOne_Optional_FK).InverseReference(e => e.OneToOne_Optional_FK_Inverse).ForeignKey<Level3>(e => e.Level2_Optional_Id).Required(false);
-            modelBuilder.Entity<Level2>().Collection(e => e.OneToMany_Required).InverseReference(e => e.OneToMany_Required_Inverse).Required(true);
-            modelBuilder.Entity<Level2>().Collection(e => e.OneToMany_Optional).InverseReference(e => e.OneToMany_Optional_Inverse).Required(false);
-            modelBuilder.Entity<Level2>().Collection(e => e.OneToMany_Required_Self).InverseReference(e => e.OneToMany_Required_Self_Inverse).Required(true);
-            modelBuilder.Entity<Level2>().Collection(e => e.OneToMany_Optional_Self).InverseReference(e => e.OneToMany_Optional_Self_Inverse).Required(false);
+            model.Entity<Level2>().Reference(e => e.OneToOne_Required_PK).InverseReference(e => e.OneToOne_Required_PK_Inverse).PrincipalKey<Level2>(e => e.Id).Required(true);
+            model.Entity<Level2>().Reference(e => e.OneToOne_Optional_PK).InverseReference(e => e.OneToOne_Optional_PK_Inverse).PrincipalKey<Level2>(e => e.Id).Required(false);
+            model.Entity<Level2>().Reference(e => e.OneToOne_Required_FK).InverseReference(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level3>(e => e.Level2_Required_Id).Required(true);
+            model.Entity<Level2>().Reference(e => e.OneToOne_Optional_FK).InverseReference(e => e.OneToOne_Optional_FK_Inverse).ForeignKey<Level3>(e => e.Level2_Optional_Id).Required(false);
+            model.Entity<Level2>().Reference(e => e.OneToOne_Required_FK).InverseReference(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level3>(e => e.Level2_Required_Id).Required(true);
+            model.Entity<Level2>().Reference(e => e.OneToOne_Optional_FK).InverseReference(e => e.OneToOne_Optional_FK_Inverse).ForeignKey<Level3>(e => e.Level2_Optional_Id).Required(false);
+            model.Entity<Level2>().Collection(e => e.OneToMany_Required).InverseReference(e => e.OneToMany_Required_Inverse).Required(true);
+            model.Entity<Level2>().Collection(e => e.OneToMany_Optional).InverseReference(e => e.OneToMany_Optional_Inverse).Required(false);
+            model.Entity<Level2>().Collection(e => e.OneToMany_Required_Self).InverseReference(e => e.OneToMany_Required_Self_Inverse).Required(true);
+            model.Entity<Level2>().Collection(e => e.OneToMany_Optional_Self).InverseReference(e => e.OneToMany_Optional_Self_Inverse).Required(false);
 
             // issue #1417
             //modelBuilder.Entity<Level2>().Reference(e => e.OneToOne_Optional_Self).InverseReference(); 
 
-            modelBuilder.Entity<Level3>().Reference(e => e.OneToOne_Required_PK).InverseReference(e => e.OneToOne_Required_PK_Inverse).PrincipalKey<Level3>(e => e.Id).Required(true);
-            modelBuilder.Entity<Level3>().Reference(e => e.OneToOne_Optional_PK).InverseReference(e => e.OneToOne_Optional_PK_Inverse).PrincipalKey<Level3>(e => e.Id).Required(false);
-            modelBuilder.Entity<Level3>().Reference(e => e.OneToOne_Required_FK).InverseReference(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level4>(e => e.Level3_Required_Id).Required(true);
-            modelBuilder.Entity<Level3>().Reference(e => e.OneToOne_Optional_FK).InverseReference(e => e.OneToOne_Optional_FK_Inverse).ForeignKey<Level4>(e => e.Level3_Optional_Id).Required(false);
-            modelBuilder.Entity<Level3>().Collection(e => e.OneToMany_Required).InverseReference(e => e.OneToMany_Required_Inverse).Required(true);
-            modelBuilder.Entity<Level3>().Collection(e => e.OneToMany_Optional).InverseReference(e => e.OneToMany_Optional_Inverse).Required(false);
-            modelBuilder.Entity<Level3>().Collection(e => e.OneToMany_Required_Self).InverseReference(e => e.OneToMany_Required_Self_Inverse).Required(true);
-            modelBuilder.Entity<Level3>().Collection(e => e.OneToMany_Optional_Self).InverseReference(e => e.OneToMany_Optional_Self_Inverse).Required(false);
+            model.Entity<Level3>().Reference(e => e.OneToOne_Required_PK).InverseReference(e => e.OneToOne_Required_PK_Inverse).PrincipalKey<Level3>(e => e.Id).Required(true);
+            model.Entity<Level3>().Reference(e => e.OneToOne_Optional_PK).InverseReference(e => e.OneToOne_Optional_PK_Inverse).PrincipalKey<Level3>(e => e.Id).Required(false);
+            model.Entity<Level3>().Reference(e => e.OneToOne_Required_FK).InverseReference(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level4>(e => e.Level3_Required_Id).Required(true);
+            model.Entity<Level3>().Reference(e => e.OneToOne_Optional_FK).InverseReference(e => e.OneToOne_Optional_FK_Inverse).ForeignKey<Level4>(e => e.Level3_Optional_Id).Required(false);
+            model.Entity<Level3>().Collection(e => e.OneToMany_Required).InverseReference(e => e.OneToMany_Required_Inverse).Required(true);
+            model.Entity<Level3>().Collection(e => e.OneToMany_Optional).InverseReference(e => e.OneToMany_Optional_Inverse).Required(false);
+            model.Entity<Level3>().Collection(e => e.OneToMany_Required_Self).InverseReference(e => e.OneToMany_Required_Self_Inverse).Required(true);
+            model.Entity<Level3>().Collection(e => e.OneToMany_Optional_Self).InverseReference(e => e.OneToMany_Optional_Self_Inverse).Required(false);
 
             // issue #1417
             //modelBuilder.Entity<Level3>().Reference(e => e.OneToOne_Optional_Self).InverseReference();
 
-            modelBuilder.Entity<Level4>().Collection(e => e.OneToMany_Required_Self).InverseReference(e => e.OneToMany_Required_Self_Inverse).Required(true);
-            modelBuilder.Entity<Level4>().Collection(e => e.OneToMany_Optional_Self).InverseReference(e => e.OneToMany_Optional_Self_Inverse).Required(false);
+            model.Entity<Level4>().Collection(e => e.OneToMany_Required_Self).InverseReference(e => e.OneToMany_Required_Self_Inverse).Required(true);
+            model.Entity<Level4>().Collection(e => e.OneToMany_Optional_Self).InverseReference(e => e.OneToMany_Optional_Self_Inverse).Required(false);
         }
     }
 }

--- a/test/EntityFramework.Core.FunctionalTests/DataStoreErrorLogStateTest.cs
+++ b/test/EntityFramework.Core.FunctionalTests/DataStoreErrorLogStateTest.cs
@@ -174,9 +174,9 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 public string Name { get; set; }
             }
 
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            protected override void OnModelCreating(ModelBuilder model)
             {
-                modelBuilder.Entity<Blog>().Key(b => b.Url);
+                model.Entity<Blog>().Key(b => b.Url);
             }
         }
 

--- a/test/EntityFramework.Core.FunctionalTests/F1FixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/F1FixtureBase.cs
@@ -13,11 +13,11 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
         public abstract F1Context CreateContext(TTestStore testStore);
 
-        protected virtual void OnModelCreating(ModelBuilder modelBuilder)
+        protected virtual void OnModelCreating(ModelBuilder model)
         {
             // TODO: Uncomment when complex types are supported
             //builder.ComplexType<Location>();
-            modelBuilder.Entity<Chassis>(b =>
+            model.Entity<Chassis>(b =>
                 {
                     b.Key(c => c.TeamId);
                     b.Property(e => e.Version)
@@ -25,14 +25,14 @@ namespace Microsoft.Data.Entity.FunctionalTests
                         .ConcurrencyToken();
                 });
 
-            modelBuilder.Entity<Driver>(b =>
+            model.Entity<Driver>(b =>
                 {
                     b.Property(e => e.Version)
                         .StoreGeneratedPattern(StoreGeneratedPattern.Computed)
                         .ConcurrencyToken();
                 });
 
-            modelBuilder.Entity<Engine>(b =>
+            model.Entity<Engine>(b =>
                 {
                     b.Property(e => e.EngineSupplierId).ConcurrencyToken();
                     b.Property(e => e.Name).ConcurrencyToken();
@@ -40,11 +40,11 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
             // TODO: Complex type
             // .Property(c => c.StorageLocation);
-            modelBuilder.Ignore<Location>();
+            model.Ignore<Location>();
 
-            modelBuilder.Entity<EngineSupplier>();
+            model.Entity<EngineSupplier>();
 
-            modelBuilder.Entity<Gearbox>();
+            model.Entity<Gearbox>();
 
             // TODO: Complex type
             //builder
@@ -57,7 +57,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             //            ps.Property<double>("Longitude", concurrencyToken: true);
             //        });
 
-            modelBuilder.Entity<Sponsor>(b =>
+            model.Entity<Sponsor>(b =>
                 {
                     b.Property(e => e.Version)
                         .StoreGeneratedPattern(StoreGeneratedPattern.Computed)
@@ -72,9 +72,9 @@ namespace Microsoft.Data.Entity.FunctionalTests
             //            ps.Property(s => s.Days);
             //            ps.Property(s => s.Space);
             //        });
-            modelBuilder.Ignore<SponsorDetails>();
+            model.Ignore<SponsorDetails>();
 
-            modelBuilder.Entity<Team>(b =>
+            model.Entity<Team>(b =>
                 {
                     b.Property(t => t.Version)
                         .StoreGeneratedPattern(StoreGeneratedPattern.Computed)
@@ -84,9 +84,9 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     b.Reference(e => e.Chassis).InverseReference(e => e.Team).ForeignKey<Chassis>(e => e.TeamId);
                 });
 
-            modelBuilder.Entity<TestDriver>();
+            model.Entity<TestDriver>();
 
-            modelBuilder.Entity<TitleSponsor>();
+            model.Entity<TitleSponsor>();
             // TODO: Complex type
             // .Property(t => t.Details);
 

--- a/test/EntityFramework.Core.FunctionalTests/FixupTest.cs
+++ b/test/EntityFramework.Core.FunctionalTests/FixupTest.cs
@@ -243,22 +243,22 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
         private class FixupContext : DbContext
         {
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            protected override void OnModelCreating(ModelBuilder model)
             {
-                modelBuilder.Entity<Product>(b =>
+                model.Entity<Product>(b =>
                     {
                         b.Collection(e => e.SpecialOffers).InverseReference(e => e.Product);
                     });
 
-                modelBuilder.Entity<Category>(b =>
+                model.Entity<Category>(b =>
                     {
                         b.Collection(e => e.Products).InverseReference(e => e.Category);
                     });
             }
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            protected override void OnConfiguring(DbContextOptionsBuilder options)
             {
-                optionsBuilder.UseInMemoryStore(persist: false);
+                options.UseInMemoryStore(persist: false);
             }
         }
 

--- a/test/EntityFramework.Core.FunctionalTests/GearsOfWarQueryFixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/GearsOfWarQueryFixtureBase.cs
@@ -12,11 +12,11 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
         public abstract GearsOfWarContext CreateContext(TTestStore testStore);
 
-        protected virtual void OnModelCreating(ModelBuilder modelBuilder)
+        protected virtual void OnModelCreating(ModelBuilder model)
         {
-            modelBuilder.Entity<City>().Key(c => c.Name);
+            model.Entity<City>().Key(c => c.Name);
 
-            modelBuilder.Entity<Gear>(b =>
+            model.Entity<Gear>(b =>
                 {
                     b.Key(g => new { g.Nickname, g.SquadId });
 
@@ -26,18 +26,18 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     b.Reference(g => g.AssignedCity).InverseCollection(c => c.StationedGears).Required(false);
                 });
 
-            modelBuilder.Entity<CogTag>(b =>
+            model.Entity<CogTag>(b =>
                 {
                     b.Key(t => t.Id);
                 });
 
-            modelBuilder.Entity<Squad>(b =>
+            model.Entity<Squad>(b =>
                 {
                     b.Key(s => s.Id);
                     b.Collection(s => s.Members).InverseReference(g => g.Squad).ForeignKey(g => g.SquadId);
                 });
 
-            modelBuilder.Entity<Weapon>(b =>
+            model.Entity<Weapon>(b =>
                 {
                     b.Reference(w => w.SynergyWith).InverseReference().ForeignKey<Weapon>(w => w.SynergyWithId);
                     b.Reference(w => w.Owner).InverseCollection(g => g.Weapons).ForeignKey(w => new { w.OwnerNickname, w.OwnerSquadId });

--- a/test/EntityFramework.Core.FunctionalTests/GraphUpdatesTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/GraphUpdatesTestBase.cs
@@ -2194,9 +2194,9 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
             public abstract DbContext CreateContext(TTestStore testStore);
 
-            protected virtual void OnModelCreating(ModelBuilder modelBuilder)
+            protected virtual void OnModelCreating(ModelBuilder model)
             {
-                modelBuilder.Entity<Root>(b =>
+                model.Entity<Root>(b =>
                     {
                         b.Collection(e => e.RequiredChildren)
                             .InverseReference(e => e.Parent)
@@ -2244,56 +2244,56 @@ namespace Microsoft.Data.Entity.FunctionalTests
                             .ForeignKey<RequiredNonPkSingleAk1>(e => e.RootId);
                     });
 
-                modelBuilder.Entity<Required1>()
+                model.Entity<Required1>()
                     .Collection(e => e.Children)
                     .InverseReference(e => e.Parent)
                     .ForeignKey(e => e.ParentId);
 
-                modelBuilder.Entity<Optional1>()
+                model.Entity<Optional1>()
                     .Collection(e => e.Children)
                     .InverseReference(e => e.Parent)
                     .ForeignKey(e => e.ParentId);
 
-                modelBuilder.Entity<RequiredSingle1>()
+                model.Entity<RequiredSingle1>()
                     .Reference(e => e.Single)
                     .InverseReference(e => e.Back)
                     .ForeignKey<RequiredSingle2>(e => e.Id);
 
-                modelBuilder.Entity<OptionalSingle1>()
+                model.Entity<OptionalSingle1>()
                     .Reference(e => e.Single)
                     .InverseReference(e => e.Back)
                     .ForeignKey<OptionalSingle2>(e => e.BackId);
 
-                modelBuilder.Entity<RequiredNonPkSingle1>()
+                model.Entity<RequiredNonPkSingle1>()
                     .Reference(e => e.Single)
                     .InverseReference(e => e.Back)
                     .ForeignKey<RequiredNonPkSingle2>(e => e.BackId);
 
-                modelBuilder.Entity<RequiredAk1>()
+                model.Entity<RequiredAk1>()
                     .Collection(e => e.Children)
                     .InverseReference(e => e.Parent)
                     .PrincipalKey(e => e.AlternateId)
                     .ForeignKey(e => e.ParentId);
 
-                modelBuilder.Entity<OptionalAk1>()
+                model.Entity<OptionalAk1>()
                     .Collection(e => e.Children)
                     .InverseReference(e => e.Parent)
                     .PrincipalKey(e => e.AlternateId)
                     .ForeignKey(e => e.ParentId);
 
-                modelBuilder.Entity<RequiredSingleAk1>()
+                model.Entity<RequiredSingleAk1>()
                     .Reference(e => e.Single)
                     .InverseReference(e => e.Back)
                     .ForeignKey<RequiredSingleAk2>(e => e.AlternateId)
                     .PrincipalKey<RequiredSingleAk1>(e => e.AlternateId);
 
-                modelBuilder.Entity<OptionalSingleAk1>()
+                model.Entity<OptionalSingleAk1>()
                     .Reference(e => e.Single)
                     .InverseReference(e => e.Back)
                     .ForeignKey<OptionalSingleAk2>(e => e.BackId)
                     .PrincipalKey<OptionalSingleAk1>(e => e.AlternateId);
 
-                modelBuilder.Entity<RequiredNonPkSingleAk1>()
+                model.Entity<RequiredNonPkSingleAk1>()
                     .Reference(e => e.Single)
                     .InverseReference(e => e.Back)
                     .ForeignKey<RequiredNonPkSingleAk2>(e => e.BackId)

--- a/test/EntityFramework.Core.FunctionalTests/ModelSourceTest.cs
+++ b/test/EntityFramework.Core.FunctionalTests/ModelSourceTest.cs
@@ -62,9 +62,9 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
             public DbSet<Peak> Peaks { get; set; }
 
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            protected override void OnModelCreating(ModelBuilder model)
             {
-                modelBuilder.Entity<Base>().Annotation("AllYourBaseAreBelongTo", "Us!");
+                model.Entity<Base>().Annotation("AllYourBaseAreBelongTo", "Us!");
             }
         }
 

--- a/test/EntityFramework.Core.FunctionalTests/NorthwindQueryFixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/NorthwindQueryFixtureBase.cs
@@ -7,11 +7,11 @@ namespace Microsoft.Data.Entity.FunctionalTests
 {
     public abstract class NorthwindQueryFixtureBase
     {
-        public virtual void OnModelCreating(ModelBuilder modelBuilder)
+        public virtual void OnModelCreating(ModelBuilder model)
         {
-            modelBuilder.Entity<Customer>();
+            model.Entity<Customer>();
 
-            modelBuilder.Entity<Employee>(e =>
+            model.Entity<Employee>(e =>
                 {
                     e.Ignore(em => em.Address);
                     e.Ignore(em => em.BirthDate);
@@ -27,7 +27,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     e.Ignore(em => em.TitleOfCourtesy);
                 });
 
-            modelBuilder.Entity<Product>(e =>
+            model.Entity<Product>(e =>
                 {
                     e.Ignore(p => p.CategoryID);
                     e.Ignore(p => p.QuantityPerUnit);
@@ -36,7 +36,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     e.Ignore(p => p.UnitsOnOrder);
                 });
 
-            modelBuilder.Entity<Order>(e =>
+            model.Entity<Order>(e =>
                 {
                     e.Ignore(o => o.Freight);
                     e.Ignore(o => o.RequiredDate);
@@ -50,7 +50,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     e.Ignore(o => o.ShippedDate);
                 });
 
-            modelBuilder.Entity<OrderDetail>(e => { e.Key(od => new { od.OrderID, od.ProductID }); });
+            model.Entity<OrderDetail>(e => { e.Key(od => new { od.OrderID, od.ProductID }); });
         }
 
         public abstract NorthwindContext CreateContext();

--- a/test/EntityFramework.Core.FunctionalTests/NullKeysTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/NullKeysTestBase.cs
@@ -181,23 +181,23 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             public abstract DbContext CreateContext();
 
-            public virtual void OnModelCreating(ModelBuilder modelBuilder)
+            public virtual void OnModelCreating(ModelBuilder model)
             {
-                modelBuilder.Entity<WithStringKey>()
+                model.Entity<WithStringKey>()
                     .Collection(e => e.Dependents).InverseReference(e => e.Principal)
                     .ForeignKey(e => e.Fk);
 
-                modelBuilder.Entity<WithStringFk>()
+                model.Entity<WithStringFk>()
                     .Reference<WithStringFk>()
                     .InverseReference(e => e.Self)
                     .ForeignKey<WithStringFk>(e => e.SelfFk);
 
-                modelBuilder.Entity<WithIntKey>()
+                model.Entity<WithIntKey>()
                     .Collection(e => e.Dependents)
                     .InverseReference(e => e.Principal)
                     .ForeignKey(e => e.Fk);
 
-                modelBuilder.Entity<WithNullableIntKey>()
+                model.Entity<WithNullableIntKey>()
                     .Collection(e => e.Dependents)
                     .InverseReference(e => e.Principal)
                     .ForeignKey(e => e.Fk);

--- a/test/EntityFramework.Core.FunctionalTests/OneToOneQueryFixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/OneToOneQueryFixtureBase.cs
@@ -5,15 +5,15 @@ namespace Microsoft.Data.Entity.FunctionalTests
 {
     public abstract class OneToOneQueryFixtureBase
     {
-        protected virtual void OnModelCreating(ModelBuilder modelBuilder)
+        protected virtual void OnModelCreating(ModelBuilder model)
         {
-            modelBuilder
+            model
                 .Entity<Address>(e => e.Reference(a => a.Resident).InverseReference(p => p.Address)
                     .PrincipalKey<Person>(person => person.Id));
 
-            modelBuilder.Entity<Address2>().Property<int>("PersonId");
+            model.Entity<Address2>().Property<int>("PersonId");
 
-            modelBuilder
+            model
                 .Entity<Person2>(
                     e => e.Reference(p => p.Address).InverseReference(a => a.Resident)
                         .ForeignKey(typeof(Address2), "PersonId"));

--- a/test/EntityFramework.Core.FunctionalTests/StoreGeneratedTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/StoreGeneratedTestBase.cs
@@ -426,9 +426,9 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
             public abstract DbContext CreateContext(TTestStore testStore);
 
-            protected virtual void OnModelCreating(ModelBuilder modelBuilder)
+            protected virtual void OnModelCreating(ModelBuilder model)
             {
-                modelBuilder.Entity<Gumball>(b =>
+                model.Entity<Gumball>(b =>
                     {
                         var property = b.Property(e => e.Id)
                             .StoreGeneratedPattern(StoreGeneratedPattern.Identity)

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/MonsterContext`.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/MonsterContext`.cs
@@ -208,31 +208,31 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
             get { return Set<TLicense>(); }
         }
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        protected override void OnModelCreating(ModelBuilder model)
         {
             // TODO: Complex types
-            modelBuilder.Ignore<AuditInfo>();
-            modelBuilder.Ignore<ConcurrencyInfo>();
-            modelBuilder.Ignore<ContactDetails>();
-            modelBuilder.Ignore<Dimensions>();
+            model.Ignore<AuditInfo>();
+            model.Ignore<ConcurrencyInfo>();
+            model.Ignore<ContactDetails>();
+            model.Ignore<Dimensions>();
 
-            modelBuilder.Entity<TBarcodeDetail>().Key(e => e.Code);
+            model.Entity<TBarcodeDetail>().Key(e => e.Code);
 
-            modelBuilder.Entity<TSuspiciousActivity>();
-            modelBuilder.Entity<TLastLogin>().Key(e => e.Username);
-            modelBuilder.Entity<TMessage>().Key(e => new { e.MessageId, e.FromUsername });
+            model.Entity<TSuspiciousActivity>();
+            model.Entity<TLastLogin>().Key(e => e.Username);
+            model.Entity<TMessage>().Key(e => new { e.MessageId, e.FromUsername });
 
-            modelBuilder.Entity<TOrderNote>().Key(e => e.NoteId);
+            model.Entity<TOrderNote>().Key(e => e.NoteId);
 
-            modelBuilder.Entity<TProductDetail>().Key(e => e.ProductId);
+            model.Entity<TProductDetail>().Key(e => e.ProductId);
 
-            modelBuilder.Entity<TProductWebFeature>().Key(e => e.FeatureId);
+            model.Entity<TProductWebFeature>().Key(e => e.FeatureId);
 
-            modelBuilder.Entity<TSupplierLogo>().Key(e => e.SupplierId);
+            model.Entity<TSupplierLogo>().Key(e => e.SupplierId);
 
-            modelBuilder.Entity<TLicense>().Key(e => e.Name);
+            model.Entity<TLicense>().Key(e => e.Name);
 
-            modelBuilder.Entity<TAnOrder>(b =>
+            model.Entity<TAnOrder>(b =>
                 {
                     b.Collection(e => (IEnumerable<TOrderLine>)e.OrderLines).InverseReference(e => (TAnOrder)e.Order)
                         .ForeignKey(e => e.OrderId);
@@ -241,7 +241,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
                         .PrincipalKey(e => e.AlternateId);
                 });
 
-            modelBuilder.Entity<TOrderQualityCheck>(b =>
+            model.Entity<TOrderQualityCheck>(b =>
                 {
                     b.Key(e => e.OrderId);
 
@@ -250,7 +250,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
                         .PrincipalKey<TAnOrder>(e => e.AlternateId);
                 });
 
-            modelBuilder.Entity<TProduct>(b =>
+            model.Entity<TProduct>(b =>
                 {
                     b.Collection(e => (IEnumerable<TProductReview>)e.Reviews).InverseReference(e => (TProduct)e.Product);
                     b.Collection(e => (IEnumerable<TBarcode>)e.Barcodes).InverseReference(e => (TProduct)e.Product);
@@ -259,16 +259,16 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
                         .ForeignKey<TProductDetail>(e => e.ProductId);
                 });
 
-            modelBuilder.Entity<TOrderLine>(b =>
+            model.Entity<TOrderLine>(b =>
                 {
                     b.Key(e => new { e.OrderId, e.ProductId });
 
                     b.Reference(e => (TProduct)e.Product).InverseCollection().ForeignKey(e => e.ProductId);
                 });
 
-            modelBuilder.Entity<TSupplier>().Reference(e => (TSupplierLogo)e.Logo).InverseReference().ForeignKey<TSupplierLogo>(e => e.SupplierId);
+            model.Entity<TSupplier>().Reference(e => (TSupplierLogo)e.Logo).InverseReference().ForeignKey<TSupplierLogo>(e => e.SupplierId);
 
-            modelBuilder.Entity<TCustomer>(b =>
+            model.Entity<TCustomer>(b =>
                 {
                     b.Collection(e => (IEnumerable<TAnOrder>)e.Orders).InverseReference(e => (TCustomer)e.Customer);
                     b.Collection(e => (IEnumerable<TLogin>)e.Logins).InverseReference(e => (TCustomer)e.Customer);
@@ -278,7 +278,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
                         .ForeignKey<TCustomer>(e => e.HusbandId);
                 });
 
-            modelBuilder.Entity<TComplaint>(b =>
+            model.Entity<TComplaint>(b =>
                 {
                     b.Reference(e => (TCustomer)e.Customer)
                         .InverseCollection()
@@ -288,7 +288,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
                         .PrincipalKey<TComplaint>(e => e.AlternateId);
                 });
 
-            modelBuilder.Entity<TProductPhoto>(b =>
+            model.Entity<TProductPhoto>(b =>
                 {
                     b.Key(e => new { e.PhotoId, e.ProductId });
 
@@ -297,7 +297,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
                         .PrincipalKey(e => new { e.PhotoId, e.ProductId });
                 });
 
-            modelBuilder.Entity<TProductReview>(b =>
+            model.Entity<TProductReview>(b =>
                 {
                     b.Key(e => new { e.ReviewId, e.ProductId });
 
@@ -305,7 +305,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
                         .ForeignKey(e => new { e.ReviewId, e.ProductId });
                 });
 
-            modelBuilder.Entity<TLogin>(b =>
+            model.Entity<TLogin>(b =>
                 {
                     var key = b.Key(e => e.Username);
 
@@ -326,7 +326,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
                         .ForeignKey<TLastLogin>(e => e.Username);
                 });
 
-            modelBuilder.Entity<TPasswordReset>(b =>
+            model.Entity<TPasswordReset>(b =>
                 {
                     b.Key(e => new { e.ResetNo, e.Username });
 
@@ -335,10 +335,10 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
                         .PrincipalKey(e => e.AlternateUsername);
                 });
 
-            modelBuilder.Entity<TPageView>().Reference(e => (TLogin)e.Login).InverseCollection()
+            model.Entity<TPageView>().Reference(e => (TLogin)e.Login).InverseCollection()
                 .ForeignKey(e => e.Username);
 
-            modelBuilder.Entity<TBarcode>(b =>
+            model.Entity<TBarcode>(b =>
                 {
                     b.Key(e => e.Code);
 
@@ -349,22 +349,22 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
                         .ForeignKey<TBarcodeDetail>(e => e.Code);
                 });
 
-            modelBuilder.Entity<TIncorrectScan>().Reference(e => (TBarcode)e.ActualBarcode).InverseCollection()
+            model.Entity<TIncorrectScan>().Reference(e => (TBarcode)e.ActualBarcode).InverseCollection()
                 .ForeignKey(e => e.ActualCode);
 
-            modelBuilder.Entity<TSupplierInfo>().Reference(e => (TSupplier)e.Supplier).InverseCollection();
+            model.Entity<TSupplierInfo>().Reference(e => (TSupplier)e.Supplier).InverseCollection();
 
-            modelBuilder.Entity<TComputer>().Reference(e => (TComputerDetail)e.ComputerDetail).InverseReference(e => (TComputer)e.Computer)
+            model.Entity<TComputer>().Reference(e => (TComputerDetail)e.ComputerDetail).InverseReference(e => (TComputer)e.Computer)
                 .ForeignKey<TComputerDetail>(e => e.ComputerDetailId);
 
-            modelBuilder.Entity<TDriver>(b =>
+            model.Entity<TDriver>(b =>
                 {
                     b.Key(e => e.Name);
                     b.Reference(e => (TLicense)e.License).InverseReference(e => (TDriver)e.Driver)
                         .PrincipalKey<TDriver>(e => e.Name);
                 });
 
-            modelBuilder.Entity<TSmartCard>(b =>
+            model.Entity<TSmartCard>(b =>
                 {
                     b.Key(e => e.Username);
 
@@ -375,7 +375,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
                         .ForeignKey<TLastLogin>(e => e.SmartcardUsername);
                 });
 
-            modelBuilder.Entity<TRsaToken>(b =>
+            model.Entity<TRsaToken>(b =>
                 {
                     b.Key(e => e.Serial);
                     b.Reference(e => (TLogin)e.Login).InverseReference()
@@ -392,7 +392,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
 
             if (_onModelCreating != null)
             {
-                _onModelCreating(modelBuilder);
+                _onModelCreating(model);
             }
         }
 

--- a/test/EntityFramework.Core.Tests/ChangeTracking/ChangeTrackerTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/ChangeTrackerTest.cs
@@ -1038,24 +1038,24 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             {
             }
 
-            protected internal override void OnModelCreating(ModelBuilder modelBuilder)
+            protected internal override void OnModelCreating(ModelBuilder model)
             {
-                modelBuilder
+                model
                     .Entity<Category>().Collection(e => e.Products).InverseReference(e => e.Category);
 
-                modelBuilder
+                model
                     .Entity<ProductDetailsTag>().Reference(e => e.TagDetails).InverseReference(e => e.Tag)
                     .ForeignKey<ProductDetailsTagDetails>(e => e.Id);
 
-                modelBuilder
+                model
                     .Entity<ProductDetails>().Reference(e => e.Tag).InverseReference(e => e.Details)
                     .ForeignKey<ProductDetailsTag>(e => e.Id);
 
-                modelBuilder
+                model
                     .Entity<Product>().Reference(e => e.Details).InverseReference(e => e.Product)
                     .ForeignKey<ProductDetails>(e => e.Id);
 
-                modelBuilder.Entity<OrderDetails>(b =>
+                model.Entity<OrderDetails>(b =>
                     {
                         b.Key(e => new { e.OrderId, e.ProductId });
                         b.Reference(e => e.Order).InverseCollection(e => e.OrderDetails).ForeignKey(e => e.OrderId);

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/KeyValueEntityTrackerTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/KeyValueEntityTrackerTest.cs
@@ -130,12 +130,12 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             {
             }
 
-            protected internal override void OnModelCreating(ModelBuilder modelBuilder)
+            protected internal override void OnModelCreating(ModelBuilder model)
             {
-                modelBuilder.Entity<Stoat>();
-                modelBuilder.Entity<StoatInACoat>();
+                model.Entity<Stoat>();
+                model.Entity<StoatInACoat>();
 
-                modelBuilder.Entity<CompositeStoat>().Key(e => new { e.Id1, e.Id2 });
+                model.Entity<CompositeStoat>().Key(e => new { e.Id1, e.Id2 });
             }
         }
     }

--- a/test/EntityFramework.Core.Tests/ContextConfigurationTest.cs
+++ b/test/EntityFramework.Core.Tests/ContextConfigurationTest.cs
@@ -107,9 +107,9 @@ namespace Microsoft.Data.Entity.Tests
 
         private class GiddyupContext : DbContext
         {
-            protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            protected internal override void OnConfiguring(DbContextOptionsBuilder options)
             {
-                optionsBuilder.UseInMemoryStore();
+                options.UseInMemoryStore();
             }
         }
     }

--- a/test/EntityFramework.Core.Tests/DbContextTest.cs
+++ b/test/EntityFramework.Core.Tests/DbContextTest.cs
@@ -1892,14 +1892,14 @@ namespace Microsoft.Data.Entity.Tests
             public DbSet<Category> Categories { get; set; }
             public DbSet<TheGu> Gus { get; set; }
 
-            protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            protected internal override void OnConfiguring(DbContextOptionsBuilder options)
             {
-                optionsBuilder.UseInMemoryStore(persist: false);
+                options.UseInMemoryStore(persist: false);
             }
 
-            protected internal override void OnModelCreating(ModelBuilder modelBuilder)
+            protected internal override void OnModelCreating(ModelBuilder model)
             {
-                modelBuilder
+                model
                     .Entity<Category>().Collection(e => e.Products).InverseReference(e => e.Category);
             }
         }
@@ -1965,8 +1965,8 @@ namespace Microsoft.Data.Entity.Tests
             services
                 .AddSingleton<FakeService>()
                 .AddEntityFramework()
-                .AddDbContext<ContextWithDefaults>(optionsBuilder
-                    => ((IOptionsBuilderExtender)optionsBuilder).AddOrUpdateExtension(contextOptionsExtension));
+                .AddDbContext<ContextWithDefaults>(options
+                    => ((IOptionsBuilderExtender)options).AddOrUpdateExtension(contextOptionsExtension));
 
             var serviceProvider = services.BuildServiceProvider();
 
@@ -1990,8 +1990,8 @@ namespace Microsoft.Data.Entity.Tests
             services
                 .AddSingleton<FakeService>()
                 .AddEntityFramework()
-                .AddDbContext<ContextWithServiceProvider>(optionsBuilder
-                    => ((IOptionsBuilderExtender)optionsBuilder).AddOrUpdateExtension(contextOptionsExtension));
+                .AddDbContext<ContextWithServiceProvider>(options
+                    => ((IOptionsBuilderExtender)options).AddOrUpdateExtension(contextOptionsExtension));
 
             var serviceProvider = services.BuildServiceProvider();
 
@@ -2015,8 +2015,8 @@ namespace Microsoft.Data.Entity.Tests
             services
                 .AddSingleton<FakeService>()
                 .AddEntityFramework()
-                .AddDbContext<ContextWithOptions>(optionsBuilder
-                    => ((IOptionsBuilderExtender)optionsBuilder).AddOrUpdateExtension(contextOptionsExtension));
+                .AddDbContext<ContextWithOptions>(options
+                    => ((IOptionsBuilderExtender)options).AddOrUpdateExtension(contextOptionsExtension));
 
             var serviceProvider = services.BuildServiceProvider();
 
@@ -2094,7 +2094,7 @@ namespace Microsoft.Data.Entity.Tests
 
             public DbSet<Product> Products { get; set; }
 
-            protected internal override void OnModelCreating(ModelBuilder modelBuilder)
+            protected internal override void OnModelCreating(ModelBuilder model)
             {
                 var _ = Model;
             }
@@ -2127,7 +2127,7 @@ namespace Microsoft.Data.Entity.Tests
 
             public DbSet<Product> Products { get; set; }
 
-            protected internal override void OnModelCreating(ModelBuilder modelBuilder)
+            protected internal override void OnModelCreating(ModelBuilder model)
             {
                 Products.ToList();
             }
@@ -2160,11 +2160,11 @@ namespace Microsoft.Data.Entity.Tests
 
             public DbSet<Product> Products { get; set; }
 
-            protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            protected internal override void OnConfiguring(DbContextOptionsBuilder options)
             {
                 Products.ToList();
 
-                base.OnConfiguring(optionsBuilder);
+                base.OnConfiguring(options);
             }
         }
 
@@ -2240,9 +2240,9 @@ namespace Microsoft.Data.Entity.Tests
 
             public DbSet<Product> Products { get; set; }
 
-            protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            protected internal override void OnConfiguring(DbContextOptionsBuilder options)
             {
-                optionsBuilder.UseInMemoryStore(persist: true);
+                options.UseInMemoryStore(persist: true);
             }
         }
 

--- a/test/EntityFramework.Core.Tests/DbSetTest.cs
+++ b/test/EntityFramework.Core.Tests/DbSetTest.cs
@@ -379,9 +379,9 @@ namespace Microsoft.Data.Entity.Tests
             public DbSet<Category> Categories { get; set; }
             public DbSet<TheGu> Gus { get; set; }
 
-            protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            protected internal override void OnConfiguring(DbContextOptionsBuilder options)
             {
-                optionsBuilder.UseInMemoryStore(persist: false);
+                options.UseInMemoryStore(persist: false);
             }
         }
     }

--- a/test/EntityFramework.CrossStore.FunctionalTests/TestModels/CrossStoreContext.cs
+++ b/test/EntityFramework.CrossStore.FunctionalTests/TestModels/CrossStoreContext.cs
@@ -17,11 +17,11 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
 
         public virtual DbSet<SimpleEntity> SimpleEntities { get; set; }
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        protected override void OnModelCreating(ModelBuilder model)
         {
-            base.OnModelCreating(modelBuilder);
+            base.OnModelCreating(model);
 
-            modelBuilder
+            model
                 .Entity<SimpleEntity>(eb =>
                     {
                         eb.Property(typeof(string), SimpleEntity.ShadowPartitionIdName);

--- a/test/EntityFramework.InMemory.FunctionalTests/CompositeKeyEndToEndTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/CompositeKeyEndToEndTest.cs
@@ -182,13 +182,13 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
             public DbSet<Unicorn> Unicorns { get; set; }
             public DbSet<EarthPony> EarthPonies { get; set; }
 
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            protected override void OnModelCreating(ModelBuilder model)
             {
-                modelBuilder.Entity<Pegasus>().Key(e => new { e.Id1, e.Id2 });
+                model.Entity<Pegasus>().Key(e => new { e.Id1, e.Id2 });
 
-                modelBuilder.Entity<Unicorn>().Key(e => new { e.Id1, e.Id2, e.Id3 });
+                model.Entity<Unicorn>().Key(e => new { e.Id1, e.Id2, e.Id3 });
 
-                modelBuilder.Entity<EarthPony>().Key(e => new { e.Id1, e.Id2 });
+                model.Entity<EarthPony>().Key(e => new { e.Id1, e.Id2 });
             }
         }
 

--- a/test/EntityFramework.InMemory.FunctionalTests/ConfigPatternsInMemoryTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/ConfigPatternsInMemoryTest.cs
@@ -39,9 +39,9 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
         {
             public DbSet<Blog> Blogs { get; set; }
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            protected override void OnConfiguring(DbContextOptionsBuilder options)
             {
-                optionsBuilder.UseInMemoryStore();
+                options.UseInMemoryStore();
             }
         }
 
@@ -117,9 +117,9 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
 
             public DbSet<Blog> Blogs { get; set; }
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            protected override void OnConfiguring(DbContextOptionsBuilder options)
             {
-                optionsBuilder.UseInMemoryStore();
+                options.UseInMemoryStore();
             }
         }
 
@@ -248,9 +248,9 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
 
             public DbSet<Blog> Blogs { get; set; }
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            protected override void OnConfiguring(DbContextOptionsBuilder options)
             {
-                optionsBuilder.UseInMemoryStore();
+                options.UseInMemoryStore();
             }
         }
 

--- a/test/EntityFramework.InMemory.FunctionalTests/DataStoreInMemoryTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/DataStoreInMemoryTest.cs
@@ -135,14 +135,14 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
         {
             public DbSet<Artist> Artists { get; set; }
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            protected override void OnConfiguring(DbContextOptionsBuilder options)
             {
-                optionsBuilder.UseInMemoryStore();
+                options.UseInMemoryStore();
             }
 
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            protected override void OnModelCreating(ModelBuilder model)
             {
-                modelBuilder.Entity<Artist>().Key(a => a.ArtistId);
+                model.Entity<Artist>().Key(a => a.ArtistId);
             }
 
             public class Artist : ArtistBase<string>

--- a/test/EntityFramework.InMemory.FunctionalTests/SentinelGraphUpdatesInMemoryTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/SentinelGraphUpdatesInMemoryTest.cs
@@ -14,11 +14,11 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
         {
             public override int IntSentinel => -1;
 
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            protected override void OnModelCreating(ModelBuilder model)
             {
-                base.OnModelCreating(modelBuilder);
+                base.OnModelCreating(model);
 
-                SetSentinelValues(modelBuilder);
+                SetSentinelValues(model);
             }
         }
     }

--- a/test/EntityFramework.InMemory.FunctionalTests/StoreGeneratedInMemoryTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/StoreGeneratedInMemoryTest.cs
@@ -123,11 +123,11 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
                 return context;
             }
 
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            protected override void OnModelCreating(ModelBuilder model)
             {
-                base.OnModelCreating(modelBuilder);
+                base.OnModelCreating(model);
 
-                modelBuilder.Entity<Gumball>(b =>
+                model.Entity<Gumball>(b =>
                     {
                         // In-memory store does not support store generation of keys
                         b.Property(e => e.Id).Metadata.IsReadOnlyBeforeSave = false;

--- a/test/EntityFramework.InMemory.Tests/InMemoryDataStoreCreatorTest.cs
+++ b/test/EntityFramework.InMemory.Tests/InMemoryDataStoreCreatorTest.cs
@@ -145,9 +145,9 @@ namespace Microsoft.Data.Entity.InMemory.Tests
         {
             public DbSet<Fraggle> Fraggles { get; set; }
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            protected override void OnConfiguring(DbContextOptionsBuilder options)
             {
-                optionsBuilder.UseInMemoryStore();
+                options.UseInMemoryStore();
             }
         }
 

--- a/test/EntityFramework.Microbenchmarks/Models/Orders/OrdersContext.cs
+++ b/test/EntityFramework.Microbenchmarks/Models/Orders/OrdersContext.cs
@@ -22,9 +22,9 @@ namespace EntityFramework.Microbenchmarks.Models.Orders
         public DbSet<OrderLine> OrderLines { get; set; }
         public DbSet<Product> Products { get; set; }
 
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        protected override void OnConfiguring(DbContextOptionsBuilder options)
         {
-            var sqlBuilder = optionsBuilder.UseSqlServer(_connectionString);
+            var sqlBuilder = options.UseSqlServer(_connectionString);
 
             if (_disableBatching)
             {
@@ -32,15 +32,15 @@ namespace EntityFramework.Microbenchmarks.Models.Orders
             }
         }
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        protected override void OnModelCreating(ModelBuilder model)
         {
-            modelBuilder.Entity<Customer>().Collection(c => c.Orders).InverseReference(o => o.Customer)
+            model.Entity<Customer>().Collection(c => c.Orders).InverseReference(o => o.Customer)
                 .ForeignKey(o => o.CustomerId);
 
-            modelBuilder.Entity<Order>().Collection(o => o.OrderLines).InverseReference(ol => ol.Order)
+            model.Entity<Order>().Collection(o => o.OrderLines).InverseReference(ol => ol.Order)
                 .ForeignKey(ol => ol.OrderId);
 
-            modelBuilder.Entity<Product>().Collection(p => p.OrderLines).InverseReference(ol => ol.Product)
+            model.Entity<Product>().Collection(p => p.OrderLines).InverseReference(ol => ol.Product)
                 .ForeignKey(ol => ol.ProductId);
         }
     }

--- a/test/EntityFramework.Relational.FunctionalTests/F1RelationalFixture.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/F1RelationalFixture.cs
@@ -9,19 +9,19 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
     public abstract class F1RelationalFixture<TTestStore> : F1FixtureBase<TTestStore>
         where TTestStore : TestStore
     {
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        protected override void OnModelCreating(ModelBuilder model)
         {
-            base.OnModelCreating(modelBuilder);
+            base.OnModelCreating(model);
 
-            modelBuilder.Entity<Chassis>().Table("Chassis");
-            modelBuilder.Entity<Team>().Table("Teams");
-            modelBuilder.Entity<Driver>().Table("Drivers");
-            modelBuilder.Entity<Engine>().Table("Engines");
-            modelBuilder.Entity<EngineSupplier>().Table("EngineSuppliers");
-            modelBuilder.Entity<Gearbox>().Table("Gearboxes");
-            modelBuilder.Entity<Sponsor>().Table("Sponsors");
-            modelBuilder.Entity<TestDriver>().Table("TestDrivers");
-            modelBuilder.Entity<TitleSponsor>().Table("TitleSponsors");
+            model.Entity<Chassis>().Table("Chassis");
+            model.Entity<Team>().Table("Teams");
+            model.Entity<Driver>().Table("Drivers");
+            model.Entity<Engine>().Table("Engines");
+            model.Entity<EngineSupplier>().Table("EngineSuppliers");
+            model.Entity<Gearbox>().Table("Gearboxes");
+            model.Entity<Sponsor>().Table("Sponsors");
+            model.Entity<TestDriver>().Table("TestDrivers");
+            model.Entity<TitleSponsor>().Table("TitleSponsors");
         }
     }
 }

--- a/test/EntityFramework.Relational.FunctionalTests/MappingQueryFixtureBase.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/MappingQueryFixtureBase.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
             return modelBuilder.Model;
         }
 
-        protected virtual void OnModelCreating(ModelBuilder modelBuilder)
+        protected virtual void OnModelCreating(ModelBuilder model)
         {
         }
     }

--- a/test/EntityFramework.Relational.FunctionalTests/NorthwindQueryRelationalFixture.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/NorthwindQueryRelationalFixture.cs
@@ -8,16 +8,16 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
 {
     public abstract class NorthwindQueryRelationalFixture : NorthwindQueryFixtureBase
     {
-        public override void OnModelCreating(ModelBuilder modelBuilder)
+        public override void OnModelCreating(ModelBuilder model)
         {
-            base.OnModelCreating(modelBuilder);
+            base.OnModelCreating(model);
 
-            modelBuilder.Entity<Customer>().Table("Customers");
-            modelBuilder.Entity<Employee>().Table("Employees");
-            modelBuilder.Entity<Product>().Table("Products");
-            modelBuilder.Entity<Product>().Ignore(p => p.SupplierID);
-            modelBuilder.Entity<Order>().Table("Orders");
-            modelBuilder.Entity<OrderDetail>().Table("Order Details");
+            model.Entity<Customer>().Table("Customers");
+            model.Entity<Employee>().Table("Employees");
+            model.Entity<Product>().Table("Products");
+            model.Entity<Product>().Ignore(p => p.SupplierID);
+            model.Entity<Order>().Table("Orders");
+            model.Entity<OrderDetail>().Table("Order Details");
         }
     }
 }

--- a/test/EntityFramework.Relational.FunctionalTests/NorthwindSprocQueryRelationalFixture.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/NorthwindSprocQueryRelationalFixture.cs
@@ -8,12 +8,12 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
 {
     public abstract class NorthwindSprocQueryRelationalFixture : NorthwindQueryFixtureBase
     {
-        public override void OnModelCreating(ModelBuilder modelBuilder)
+        public override void OnModelCreating(ModelBuilder model)
         {
-            base.OnModelCreating(modelBuilder);
+            base.OnModelCreating(model);
 
-            modelBuilder.Entity<CustomerOrderHistory>().Key(coh => coh.ProductName);
-            modelBuilder.Entity<MostExpensiveProduct>().Key(mep => mep.TenMostExpensiveProducts);
+            model.Entity<CustomerOrderHistory>().Key(coh => coh.ProductName);
+            model.Entity<MostExpensiveProduct>().Key(mep => mep.TenMostExpensiveProducts);
         }
     }
 }

--- a/test/EntityFramework.Relational.FunctionalTests/NullSemanticsQueryRelationalFixture.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/NullSemanticsQueryRelationalFixture.cs
@@ -13,21 +13,21 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
 
         public abstract NullSemanticsContext CreateContext(TTestStore testStore);
 
-        protected virtual void OnModelCreating(ModelBuilder modelBuilder)
+        protected virtual void OnModelCreating(ModelBuilder model)
         {
-            modelBuilder.Entity<NullSemanticsEntity1>().Key(e => e.Id);
-            modelBuilder.Entity<NullSemanticsEntity1>().Property(e => e.Id).GenerateValueOnAdd(false);
+            model.Entity<NullSemanticsEntity1>().Key(e => e.Id);
+            model.Entity<NullSemanticsEntity1>().Property(e => e.Id).GenerateValueOnAdd(false);
 
-            modelBuilder.Entity<NullSemanticsEntity1>().Property(e => e.StringA).Required(true);
-            modelBuilder.Entity<NullSemanticsEntity1>().Property(e => e.StringB).Required(true);
-            modelBuilder.Entity<NullSemanticsEntity1>().Property(e => e.StringC).Required(true);
+            model.Entity<NullSemanticsEntity1>().Property(e => e.StringA).Required(true);
+            model.Entity<NullSemanticsEntity1>().Property(e => e.StringB).Required(true);
+            model.Entity<NullSemanticsEntity1>().Property(e => e.StringC).Required(true);
 
-            modelBuilder.Entity<NullSemanticsEntity2>().Key(e => e.Id);
-            modelBuilder.Entity<NullSemanticsEntity2>().Property(e => e.Id).GenerateValueOnAdd(false);
+            model.Entity<NullSemanticsEntity2>().Key(e => e.Id);
+            model.Entity<NullSemanticsEntity2>().Property(e => e.Id).GenerateValueOnAdd(false);
 
-            modelBuilder.Entity<NullSemanticsEntity2>().Property(e => e.StringA).Required(true);
-            modelBuilder.Entity<NullSemanticsEntity2>().Property(e => e.StringB).Required(true);
-            modelBuilder.Entity<NullSemanticsEntity2>().Property(e => e.StringC).Required(true);
+            model.Entity<NullSemanticsEntity2>().Property(e => e.StringA).Required(true);
+            model.Entity<NullSemanticsEntity2>().Property(e => e.StringB).Required(true);
+            model.Entity<NullSemanticsEntity2>().Property(e => e.StringC).Required(true);
         }
     }
 }

--- a/test/EntityFramework.Relational.FunctionalTests/TransactionFixtureBase.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/TransactionFixtureBase.cs
@@ -16,9 +16,9 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
 
         public abstract DbContext CreateContext(DbConnection connection);
 
-        public virtual void OnModelCreating(ModelBuilder modelBuilder)
+        public virtual void OnModelCreating(ModelBuilder model)
         {
-            modelBuilder.Entity<TransactionCustomer>(ps =>
+            model.Entity<TransactionCustomer>(ps =>
                 {
                     ps.Property(c => c.Id).GenerateValueOnAdd(generateValue: false);
                     ps.Table("Customers");

--- a/test/EntityFramework.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerFixture.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerFixture.cs
@@ -39,11 +39,11 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             return context;
         }
 
-        public override void OnModelCreating(ModelBuilder modelBuilder)
+        public override void OnModelCreating(ModelBuilder model)
         {
-            base.OnModelCreating(modelBuilder);
+            base.OnModelCreating(model);
 
-            modelBuilder.Entity<BuiltInNonNullableDataTypes>(b =>
+            model.Entity<BuiltInNonNullableDataTypes>(b =>
                 {
                     b.Ignore(dt => dt.TestUnsignedInt16);
                     b.Ignore(dt => dt.TestUnsignedInt32);
@@ -52,7 +52,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                     b.Ignore(dt => dt.TestSignedByte);
                 });
 
-            modelBuilder.Entity<BuiltInNullableDataTypes>(b =>
+            model.Entity<BuiltInNullableDataTypes>(b =>
                 {
                     b.Ignore(dt => dt.TestNullableUnsignedInt16);
                     b.Ignore(dt => dt.TestNullableUnsignedInt32);

--- a/test/EntityFramework.SqlServer.FunctionalTests/CommandConfigurationTests.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/CommandConfigurationTests.cs
@@ -372,9 +372,9 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
             public DbSet<KettleChips> Chips { get; set; }
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            protected override void OnConfiguring(DbContextOptionsBuilder options)
             {
-                optionsBuilder.UseSqlServer(SqlServerTestStore.CreateConnectionString(_databaseName));
+                options.UseSqlServer(SqlServerTestStore.CreateConnectionString(_databaseName));
             }
         }
 
@@ -392,11 +392,11 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             {
             }
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            protected override void OnConfiguring(DbContextOptionsBuilder options)
             {
-                optionsBuilder.UseSqlServer("Database=Crunchie").CommandTimeout(77);
+                options.UseSqlServer("Database=Crunchie").CommandTimeout(77);
 
-                base.OnConfiguring(optionsBuilder);
+                base.OnConfiguring(options);
             }
         }
 

--- a/test/EntityFramework.SqlServer.FunctionalTests/CompositeKeyEndToEndTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/CompositeKeyEndToEndTest.cs
@@ -194,22 +194,22 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             public DbSet<Unicorn> Unicorns { get; set; }
             public DbSet<EarthPony> EarthPonies { get; set; }
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            protected override void OnConfiguring(DbContextOptionsBuilder options)
             {
-                optionsBuilder.UseSqlServer(SqlServerTestStore.CreateConnectionString(_databaseName));
+                options.UseSqlServer(SqlServerTestStore.CreateConnectionString(_databaseName));
             }
 
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            protected override void OnModelCreating(ModelBuilder model)
             {
-                modelBuilder.Entity<Pegasus>().Key(e => new { e.Id1, e.Id2 });
+                model.Entity<Pegasus>().Key(e => new { e.Id1, e.Id2 });
 
-                modelBuilder.Entity<Unicorn>(b =>
+                model.Entity<Unicorn>(b =>
                     {
                         b.Key(e => new { e.Id1, e.Id2, e.Id3 });
                         b.Property(e => e.Id1).ForSqlServer().UseIdentity();
                     });
 
-                modelBuilder.Entity<EarthPony>(b =>
+                model.Entity<EarthPony>(b =>
                 {
                     b.Key(e => new { e.Id1, e.Id2});
                     b.Property(e => e.Id1).ForSqlServer().UseIdentity();

--- a/test/EntityFramework.SqlServer.FunctionalTests/ComputedColumnTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/ComputedColumnTest.cs
@@ -69,19 +69,19 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
             public DbSet<Entity> Entities { get; set; }
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            protected override void OnConfiguring(DbContextOptionsBuilder options)
             {
-                optionsBuilder.UseSqlServer(SqlServerTestStore.CreateConnectionString(_databaseName));
+                options.UseSqlServer(SqlServerTestStore.CreateConnectionString(_databaseName));
             }
 
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            protected override void OnModelCreating(ModelBuilder model)
             {
-                modelBuilder.Entity<Entity>()
+                model.Entity<Entity>()
                     .Property(e => e.P4)
                     .StoreGeneratedPattern(StoreGeneratedPattern.Computed)
                     .ForSqlServer().ComputedExpression("P1 + P2");
 
-                modelBuilder.Entity<Entity>()
+                model.Entity<Entity>()
                     .Property(e => e.P5)
                     .StoreGeneratedPattern(StoreGeneratedPattern.Computed)
                     .ForSqlServer().ComputedExpression("P1 + P3");
@@ -126,14 +126,14 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
             public DbSet<EnumItem> EnumItems { get; set; }
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            protected override void OnConfiguring(DbContextOptionsBuilder options)
             {
-                optionsBuilder.UseSqlServer(SqlServerTestStore.CreateConnectionString(_databaseName));
+                options.UseSqlServer(SqlServerTestStore.CreateConnectionString(_databaseName));
             }
 
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            protected override void OnModelCreating(ModelBuilder model)
             {
-                modelBuilder.Entity<EnumItem>()
+                model.Entity<EnumItem>()
                     .Property(entity => entity.CalculatedFlagEnum)
                     .StoreGeneratedPattern(StoreGeneratedPattern.Computed)
                     .ForSqlServer().ComputedExpression("FlagEnum | OptionalFlagEnum");

--- a/test/EntityFramework.SqlServer.FunctionalTests/ConnectionSpecificationTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/ConnectionSpecificationTest.cs
@@ -48,9 +48,9 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
         private class StringInOnConfiguringContext : NorthwindContextBase
         {
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            protected override void OnConfiguring(DbContextOptionsBuilder options)
             {
-                optionsBuilder.UseSqlServer(SqlServerNorthwindContext.ConnectionString);
+                options.UseSqlServer(SqlServerNorthwindContext.ConnectionString);
             }
         }
 
@@ -96,9 +96,9 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 _connection = connection;
             }
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            protected override void OnConfiguring(DbContextOptionsBuilder options)
             {
-                optionsBuilder.UseSqlServer(_connection);
+                options.UseSqlServer(_connection);
             }
 
             public override void Dispose()
@@ -110,9 +110,9 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
         private class StringInConfigContext : NorthwindContextBase
         {
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            protected override void OnConfiguring(DbContextOptionsBuilder options)
             {
-                optionsBuilder.UseSqlServer("Database=Crunchie");
+                options.UseSqlServer("Database=Crunchie");
             }
         }
 
@@ -240,15 +240,15 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         {
             public bool UseSqlServer { get; set; }
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            protected override void OnConfiguring(DbContextOptionsBuilder options)
             {
                 if (UseSqlServer)
                 {
-                    optionsBuilder.UseSqlServer(SqlServerNorthwindContext.ConnectionString);
+                    options.UseSqlServer(SqlServerNorthwindContext.ConnectionString);
                 }
                 else
                 {
-                    optionsBuilder.UseInMemoryStore();
+                    options.UseInMemoryStore();
                 }
             }
         }
@@ -310,13 +310,13 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 _connection = connection;
             }
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            protected override void OnConfiguring(DbContextOptionsBuilder options)
             {
-                Assert.Same(_options, optionsBuilder.Options);
+                Assert.Same(_options, options.Options);
 
-                optionsBuilder.UseSqlServer(_connection);
+                options.UseSqlServer(_connection);
 
-                Assert.NotSame(_options, optionsBuilder.Options);
+                Assert.NotSame(_options, options.Options);
             }
 
             public override void Dispose()
@@ -380,13 +380,13 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 _options = options;
             }
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            protected override void OnConfiguring(DbContextOptionsBuilder options)
             {
-                Assert.Same(_options, optionsBuilder.Options);
+                Assert.Same(_options, options.Options);
 
-                optionsBuilder.UseSqlServer(SqlServerNorthwindContext.ConnectionString);
+                options.UseSqlServer(SqlServerNorthwindContext.ConnectionString);
 
-                Assert.NotSame(_options, optionsBuilder.Options);
+                Assert.NotSame(_options, options.Options);
             }
         }
 
@@ -400,13 +400,13 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 _options = options;
             }
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            protected override void OnConfiguring(DbContextOptionsBuilder options)
             {
-                Assert.Same(_options, optionsBuilder.Options);
+                Assert.Same(_options, options.Options);
 
-                optionsBuilder.UseInMemoryStore();
+                options.UseInMemoryStore();
 
-                Assert.NotSame(_options, optionsBuilder.Options);
+                Assert.NotSame(_options, options.Options);
             }
         }
 
@@ -453,13 +453,13 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 _options = options;
             }
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            protected override void OnConfiguring(DbContextOptionsBuilder options)
             {
-                Assert.Same(_options, optionsBuilder.Options);
+                Assert.Same(_options, options.Options);
 
-                optionsBuilder.UseSqlServer(SqlServerNorthwindContext.ConnectionString);
+                options.UseSqlServer(SqlServerNorthwindContext.ConnectionString);
 
-                Assert.NotSame(_options, optionsBuilder.Options);
+                Assert.NotSame(_options, options.Options);
             }
         }
 
@@ -476,9 +476,9 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
             public DbSet<Customer> Customers { get; set; }
 
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            protected override void OnModelCreating(ModelBuilder model)
             {
-                modelBuilder.Entity<Customer>(b =>
+                model.Entity<Customer>(b =>
                     {
                         b.Key(c => c.CustomerID);
                         b.ForSqlServer().Table("Customers");

--- a/test/EntityFramework.SqlServer.FunctionalTests/DefaultValuesTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/DefaultValuesTest.cs
@@ -62,14 +62,14 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
             public DbSet<KettleChips> Chips { get; set; }
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            protected override void OnConfiguring(DbContextOptionsBuilder options)
             {
-                optionsBuilder.UseSqlServer(SqlServerTestStore.CreateConnectionString(_databaseName));
+                options.UseSqlServer(SqlServerTestStore.CreateConnectionString(_databaseName));
             }
 
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            protected override void OnModelCreating(ModelBuilder model)
             {
-                modelBuilder.Entity<KettleChips>()
+                model.Entity<KettleChips>()
                     .Property(e => e.BestBuyDate)
                     .StoreGeneratedPattern(StoreGeneratedPattern.Identity)
                     .DefaultValue(new DateTime(2035, 9, 25));

--- a/test/EntityFramework.SqlServer.FunctionalTests/ExistingConnectionTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/ExistingConnectionTest.cs
@@ -99,14 +99,14 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
             public DbSet<Customer> Customers { get; set; }
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            protected override void OnConfiguring(DbContextOptionsBuilder options)
             {
-                optionsBuilder.UseSqlServer(_connection);
+                options.UseSqlServer(_connection);
             }
 
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            protected override void OnModelCreating(ModelBuilder model)
             {
-                modelBuilder.Entity<Customer>(b =>
+                model.Entity<Customer>(b =>
                     {
                         b.Key(c => c.CustomerID);
                         b.ForSqlServer().Table("Customers");

--- a/test/EntityFramework.SqlServer.FunctionalTests/InheritanceSqlServerFixture.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/InheritanceSqlServerFixture.cs
@@ -63,13 +63,13 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             return new AnimalContext(_serviceProvider, _options);
         }
 
-        public override void OnModelCreating(ModelBuilder modelBuilder)
+        public override void OnModelCreating(ModelBuilder model)
         {
-            base.OnModelCreating(modelBuilder);
+            base.OnModelCreating(model);
 
             // TODO: Code First this
 
-            var animal = modelBuilder.Entity<Animal>().Metadata;
+            var animal = model.Entity<Animal>().Metadata;
 
             var discriminatorProperty
                 = animal.AddProperty("Discriminator", typeof(string), shadowProperty: true);

--- a/test/EntityFramework.SqlServer.FunctionalTests/MappingQuerySqlServerFixture.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/MappingQuerySqlServerFixture.cs
@@ -43,9 +43,9 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             _testDatabase.Dispose();
         }
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        protected override void OnModelCreating(ModelBuilder model)
         {
-            modelBuilder.Entity<MappingQueryTestBase.MappedCustomer>(e =>
+            model.Entity<MappingQueryTestBase.MappedCustomer>(e =>
                 {
                     e.Property(c => c.CompanyName2).Metadata.SqlServer().Column = "CompanyName";
                     e.Metadata.SqlServer().Table = "Customers";

--- a/test/EntityFramework.SqlServer.FunctionalTests/NavigationTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/NavigationTest.cs
@@ -86,14 +86,14 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         public DbSet<Person> People { get; set; }
         public Func<ModelBuilder, int> ConfigAction { get; set; }
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        protected override void OnModelCreating(ModelBuilder model)
         {
-            ConfigAction.Invoke(modelBuilder);
+            ConfigAction.Invoke(model);
         }
 
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        protected override void OnConfiguring(DbContextOptionsBuilder options)
         {
-            optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=StateManagerBug;Trusted_Connection=True;MultipleActiveResultSets=true");
+            options.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=StateManagerBug;Trusted_Connection=True;MultipleActiveResultSets=true");
         }
     }
 }

--- a/test/EntityFramework.SqlServer.FunctionalTests/NorthwindQuerySqlServerFixture.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/NorthwindQuerySqlServerFixture.cs
@@ -47,11 +47,11 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             return context;
         }
 
-        public override void OnModelCreating(ModelBuilder modelBuilder)
+        public override void OnModelCreating(ModelBuilder model)
         {
-            base.OnModelCreating(modelBuilder);
+            base.OnModelCreating(model);
 
-            modelBuilder.ForSqlServer().UseIdentity();
+            model.ForSqlServer().UseIdentity();
         }
 
         public void Dispose()

--- a/test/EntityFramework.SqlServer.FunctionalTests/QueryBugsTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/QueryBugsTest.cs
@@ -96,9 +96,9 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
             public DbSet<Product> Products { get; set; }
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            protected override void OnConfiguring(DbContextOptionsBuilder options)
             {
-                optionsBuilder.UseSqlServer(SqlServerTestStore.CreateConnectionString("Repro603"));
+                options.UseSqlServer(SqlServerTestStore.CreateConnectionString("Repro603"));
             }
         }
 
@@ -222,14 +222,14 @@ LEFT JOIN [Customer] AS [c] ON ([o].[CustomerFirstName] = [c].[FirstName] AND [o
             public DbSet<Customer> Customers { get; set; }
             public DbSet<Order> Orders { get; set; }
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            protected override void OnConfiguring(DbContextOptionsBuilder options)
             {
-                optionsBuilder.UseSqlServer(SqlServerTestStore.CreateConnectionString("Repro925"));
+                options.UseSqlServer(SqlServerTestStore.CreateConnectionString("Repro925"));
             }
 
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            protected override void OnModelCreating(ModelBuilder model)
             {
-                modelBuilder.Entity<Customer>(m =>
+                model.Entity<Customer>(m =>
                     {
                         m.Key(c => new { c.FirstName, c.LastName });
                         m.Collection(c => c.Orders).InverseReference(o => o.Customer);
@@ -360,14 +360,14 @@ Queen of the Andals and the Rhoynar and the First Men, Khaleesi of the Great Gra
             public DbSet<Details> Details { get; set; }
             public DbSet<Dragon> Dragons { get; set; }
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            protected override void OnConfiguring(DbContextOptionsBuilder options)
             {
-                optionsBuilder.UseSqlServer(SqlServerTestStore.CreateConnectionString("Repro963"));
+                options.UseSqlServer(SqlServerTestStore.CreateConnectionString("Repro963"));
             }
 
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            protected override void OnModelCreating(ModelBuilder model)
             {
-                modelBuilder.Entity<Targaryen>(m =>
+                model.Entity<Targaryen>(m =>
                     {
                         m.Key(t => t.Id);
                         m.Collection(t => t.Dragons).InverseReference(d => d.Mother).ForeignKey(d => d.MotherId);

--- a/test/EntityFramework.SqlServer.FunctionalTests/SentinelGraphUpdatesSqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SentinelGraphUpdatesSqlServerTest.cs
@@ -16,14 +16,14 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
             public override int IntSentinel => -1;
 
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            protected override void OnModelCreating(ModelBuilder model)
             {
-                base.OnModelCreating(modelBuilder);
+                base.OnModelCreating(model);
 
-                modelBuilder.Sequence("StartAtZeroSequence").Start(0);
-                modelBuilder.ForSqlServer().UseSequence("StartAtZeroSequence");
+                model.Sequence("StartAtZeroSequence").Start(0);
+                model.ForSqlServer().UseSequence("StartAtZeroSequence");
 
-                SetSentinelValues(modelBuilder);
+                SetSentinelValues(model);
             }
         }
     }

--- a/test/EntityFramework.SqlServer.FunctionalTests/SequenceEndToEndTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SequenceEndToEndTest.cs
@@ -234,14 +234,14 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
             public DbSet<Pegasus> Pegasuses { get; set; }
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            protected override void OnConfiguring(DbContextOptionsBuilder options)
             {
-                optionsBuilder.UseSqlServer(SqlServerTestStore.CreateConnectionString(_databaseName));
+                options.UseSqlServer(SqlServerTestStore.CreateConnectionString(_databaseName));
             }
 
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            protected override void OnModelCreating(ModelBuilder model)
             {
-                modelBuilder.Entity<Pegasus>(b =>
+                model.Entity<Pegasus>(b =>
                     {
                         b.Key(e => e.Identifier);
                         b.Property(e => e.Identifier).ForSqlServer().UseSequence();
@@ -345,14 +345,14 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
             public DbSet<Unicon> Unicons { get; set; }
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            protected override void OnConfiguring(DbContextOptionsBuilder options)
             {
-                optionsBuilder.UseSqlServer(SqlServerTestStore.CreateConnectionString(_databaseName));
+                options.UseSqlServer(SqlServerTestStore.CreateConnectionString(_databaseName));
             }
 
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            protected override void OnModelCreating(ModelBuilder model)
             {
-                modelBuilder.Entity<Unicon>(b =>
+                model.Entity<Unicon>(b =>
                     {
                         b.Key(e => e.Identifier);
                         if (_useSequence)

--- a/test/EntityFramework.SqlServer.FunctionalTests/SequentialGuidEndToEndTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SequentialGuidEndToEndTest.cs
@@ -94,9 +94,9 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
             public DbSet<Pegasus> Pegasuses { get; set; }
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            protected override void OnConfiguring(DbContextOptionsBuilder options)
             {
-                optionsBuilder.UseSqlServer(SqlServerTestStore.CreateConnectionString(_databaseName));
+                options.UseSqlServer(SqlServerTestStore.CreateConnectionString(_databaseName));
             }
         }
 

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerConfigPatternsTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerConfigPatternsTest.cs
@@ -32,14 +32,14 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             {
                 public DbSet<Customer> Customers { get; set; }
 
-                protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                protected override void OnConfiguring(DbContextOptionsBuilder options)
                 {
-                    optionsBuilder.UseSqlServer(SqlServerNorthwindContext.ConnectionString);
+                    options.UseSqlServer(SqlServerNorthwindContext.ConnectionString);
                 }
 
-                protected override void OnModelCreating(ModelBuilder modelBuilder)
+                protected override void OnModelCreating(ModelBuilder model)
                 {
-                    ConfigureModel(modelBuilder);
+                    ConfigureModel(model);
                 }
             }
         }
@@ -70,9 +70,9 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
                 public DbSet<Customer> Customers { get; set; }
 
-                protected override void OnModelCreating(ModelBuilder modelBuilder)
+                protected override void OnModelCreating(ModelBuilder model)
                 {
-                    ConfigureModel(modelBuilder);
+                    ConfigureModel(model);
                 }
             }
         }
@@ -107,14 +107,14 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
                 public DbSet<Customer> Customers { get; set; }
 
-                protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                protected override void OnConfiguring(DbContextOptionsBuilder options)
                 {
-                    optionsBuilder.UseSqlServer(SqlServerNorthwindContext.ConnectionString);
+                    options.UseSqlServer(SqlServerNorthwindContext.ConnectionString);
                 }
 
-                protected override void OnModelCreating(ModelBuilder modelBuilder)
+                protected override void OnModelCreating(ModelBuilder model)
                 {
-                    ConfigureModel(modelBuilder);
+                    ConfigureModel(model);
                 }
             }
         }
@@ -152,9 +152,9 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
                 public DbSet<Customer> Customers { get; set; }
 
-                protected override void OnModelCreating(ModelBuilder modelBuilder)
+                protected override void OnModelCreating(ModelBuilder model)
                 {
-                    ConfigureModel(modelBuilder);
+                    ConfigureModel(model);
                 }
             }
         }
@@ -194,9 +194,9 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
                 public DbSet<Customer> Customers { get; set; }
 
-                protected override void OnModelCreating(ModelBuilder modelBuilder)
+                protected override void OnModelCreating(ModelBuilder model)
                 {
-                    ConfigureModel(modelBuilder);
+                    ConfigureModel(model);
                 }
             }
         }
@@ -224,9 +224,9 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             {
                 public DbSet<Customer> Customers { get; set; }
 
-                protected override void OnModelCreating(ModelBuilder modelBuilder)
+                protected override void OnModelCreating(ModelBuilder model)
                 {
-                    ConfigureModel(modelBuilder);
+                    ConfigureModel(model);
                 }
             }
         }
@@ -265,14 +265,14 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
                 public DbSet<Customer> Customers { get; set; }
 
-                protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                protected override void OnConfiguring(DbContextOptionsBuilder options)
                 {
-                    optionsBuilder.UseSqlServer(SqlServerNorthwindContext.ConnectionString);
+                    options.UseSqlServer(SqlServerNorthwindContext.ConnectionString);
                 }
 
-                protected override void OnModelCreating(ModelBuilder modelBuilder)
+                protected override void OnModelCreating(ModelBuilder model)
                 {
-                    ConfigureModel(modelBuilder);
+                    ConfigureModel(model);
                 }
             }
         }
@@ -325,14 +325,14 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
                 public DbSet<Customer> Customers { get; set; }
 
-                protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                protected override void OnConfiguring(DbContextOptionsBuilder options)
                 {
-                    optionsBuilder.UseSqlServer(SqlServerNorthwindContext.ConnectionString);
+                    options.UseSqlServer(SqlServerNorthwindContext.ConnectionString);
                 }
 
-                protected override void OnModelCreating(ModelBuilder modelBuilder)
+                protected override void OnModelCreating(ModelBuilder model)
                 {
-                    ConfigureModel(modelBuilder);
+                    ConfigureModel(model);
                 }
             }
         }
@@ -390,9 +390,9 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
                 public DbSet<Customer> Customers { get; set; }
 
-                protected override void OnModelCreating(ModelBuilder modelBuilder)
+                protected override void OnModelCreating(ModelBuilder model)
                 {
-                    ConfigureModel(modelBuilder);
+                    ConfigureModel(model);
                 }
             }
         }
@@ -452,9 +452,9 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
                 public DbSet<Customer> Customers { get; set; }
 
-                protected override void OnModelCreating(ModelBuilder modelBuilder)
+                protected override void OnModelCreating(ModelBuilder model)
                 {
-                    ConfigureModel(modelBuilder);
+                    ConfigureModel(model);
                 }
             }
         }
@@ -485,9 +485,9 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
                 public DbSet<Customer> Customers { get; set; }
 
-                protected override void OnModelCreating(ModelBuilder modelBuilder)
+                protected override void OnModelCreating(ModelBuilder model)
                 {
-                    ConfigureModel(modelBuilder);
+                    ConfigureModel(model);
                 }
             }
         }
@@ -517,14 +517,14 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
                 public DbSet<Customer> Customers { get; set; }
 
-                protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                protected override void OnConfiguring(DbContextOptionsBuilder options)
                 {
-                    optionsBuilder.UseSqlServer(_connectionString);
+                    options.UseSqlServer(_connectionString);
                 }
 
-                protected override void OnModelCreating(ModelBuilder modelBuilder)
+                protected override void OnModelCreating(ModelBuilder model)
                 {
-                    ConfigureModel(modelBuilder);
+                    ConfigureModel(model);
                 }
             }
         }
@@ -573,14 +573,14 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
                 public DbSet<Customer> Customers { get; set; }
 
-                protected override void OnModelCreating(ModelBuilder modelBuilder)
+                protected override void OnModelCreating(ModelBuilder model)
                 {
-                    ConfigureModel(modelBuilder);
+                    ConfigureModel(model);
                 }
 
-                protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                protected override void OnConfiguring(DbContextOptionsBuilder options)
                 {
-                    optionsBuilder.UseSqlServer(SqlServerNorthwindContext.ConnectionString);
+                    options.UseSqlServer(SqlServerNorthwindContext.ConnectionString);
                 }
             }
         }
@@ -660,9 +660,9 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
                 public DbSet<Blog> Blogs { get; set; }
 
-                protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                protected override void OnConfiguring(DbContextOptionsBuilder options)
                 {
-                    optionsBuilder.UseInMemoryStore();
+                    options.UseInMemoryStore();
                 }
             }
 
@@ -679,14 +679,14 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
                 public DbSet<Customer> Customers { get; set; }
 
-                protected override void OnModelCreating(ModelBuilder modelBuilder)
+                protected override void OnModelCreating(ModelBuilder model)
                 {
-                    ConfigureModel(modelBuilder);
+                    ConfigureModel(model);
                 }
 
-                protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                protected override void OnConfiguring(DbContextOptionsBuilder options)
                 {
-                    optionsBuilder.UseSqlServer(SqlServerNorthwindContext.ConnectionString);
+                    options.UseSqlServer(SqlServerNorthwindContext.ConnectionString);
                 }
             }
         }

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerDatabaseCreationTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerDatabaseCreationTest.cs
@@ -306,14 +306,14 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 _testStore = testStore;
             }
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            protected override void OnConfiguring(DbContextOptionsBuilder options)
             {
-                optionsBuilder.UseSqlServer(_testStore.Connection.ConnectionString);
+                options.UseSqlServer(_testStore.Connection.ConnectionString);
             }
 
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            protected override void OnModelCreating(ModelBuilder model)
             {
-                modelBuilder.Entity<Blog>(b =>
+                model.Entity<Blog>(b =>
                     {
                         b.Key(e => new { e.Key1, e.Key2 });
                         b.Property(e => e.AndRow).ConcurrencyToken();

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
@@ -329,19 +329,19 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             public DbSet<Jack> Jacks { get; set; }
             public DbSet<Black> Blacks { get; set; }
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            protected override void OnConfiguring(DbContextOptionsBuilder options)
             {
-                optionsBuilder.UseSqlServer(Connection);
+                options.UseSqlServer(Connection);
             }
 
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            protected override void OnModelCreating(ModelBuilder model)
             {
-                modelBuilder
+                model
                     .Entity<Jack>()
                     .Table("Jack", "Apple")
                     .Key(e => e.MyKey);
 
-                modelBuilder
+                model
                     .Entity<Black>()
                     .ForSqlServer(b => b.Table("Black", "Apple"))
                     .Key(e => e.MyKey);
@@ -514,14 +514,14 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
             public DbSet<Customer> Customers { get; set; }
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            protected override void OnConfiguring(DbContextOptionsBuilder options)
             {
-                optionsBuilder.UseSqlServer(SqlServerNorthwindContext.ConnectionString);
+                options.UseSqlServer(SqlServerNorthwindContext.ConnectionString);
             }
 
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            protected override void OnModelCreating(ModelBuilder model)
             {
-                modelBuilder.Entity<Customer>(b =>
+                model.Entity<Customer>(b =>
                     {
                         b.Key(c => c.CustomerID);
                         b.ForSqlServer().Table("Customers");
@@ -572,9 +572,9 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             {
             }
 
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            protected override void OnModelCreating(ModelBuilder model)
             {
-                modelBuilder.Entity<TBlog>().Table("Blog", "dbo");
+                model.Entity<TBlog>().Table("Blog", "dbo");
             }
 
             public DbSet<TBlog> Blogs { get; set; }

--- a/test/EntityFramework.SqlServer.FunctionalTests/StoreGeneratedSqlServerTestBase.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/StoreGeneratedSqlServerTestBase.cs
@@ -57,11 +57,11 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 return context;
             }
 
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            protected override void OnModelCreating(ModelBuilder model)
             {
-                base.OnModelCreating(modelBuilder);
+                base.OnModelCreating(model);
 
-                modelBuilder.Entity<Gumball>(b =>
+                model.Entity<Gumball>(b =>
                     {
                         b.Property(e => e.Id)
                             .ForSqlServer()

--- a/test/EntityFramework.SqlServer.Tests/CommandConfigurationTests.cs
+++ b/test/EntityFramework.SqlServer.Tests/CommandConfigurationTests.cs
@@ -57,10 +57,10 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                     Database.AsRelational().Connection.CommandTimeout = commandTimeout;
                 }
 
-                protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                protected internal override void OnConfiguring(DbContextOptionsBuilder options)
                 {
                     var connectionMock = new Mock<DbConnection>();
-                    optionsBuilder.UseSqlServer(connectionMock.Object);
+                    options.UseSqlServer(connectionMock.Object);
                 }
             }
         }


### PR DESCRIPTION
Use shorter parameter names for OnModelCreating and OnConfiguring since
they are used repetitively within the user code in those methods.