### PR TITLE
BuildInDataTypeTests: move EnsureCreated() call into test setup

### DIFF
--- a/test/EntityFramework.Core.FunctionalTests/BuiltInDataTypesFixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/BuiltInDataTypesFixtureBase.cs
@@ -5,12 +5,9 @@ using System;
 
 namespace Microsoft.Data.Entity.FunctionalTests
 {
-    public abstract class BuiltInDataTypesFixtureBase<TTestStore>
-        where TTestStore : TestStore
+    public abstract class BuiltInDataTypesFixtureBase : IDisposable
     {
-        public abstract TTestStore CreateTestStore();
-
-        public abstract DbContext CreateContext(TTestStore testStore);
+        public abstract DbContext CreateContext();
 
         public virtual void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -25,6 +22,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
             context.SaveChanges();
         }
+
+        public abstract void Dispose();
     }
 
     public class BuiltInNonNullableDataTypes

--- a/test/EntityFramework.Core.FunctionalTests/BuiltInDataTypesTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/BuiltInDataTypesTestBase.cs
@@ -7,9 +7,8 @@ using Xunit;
 
 namespace Microsoft.Data.Entity.FunctionalTests
 {
-    public abstract class BuiltInDataTypesTestBase<TTestStore, TFixture> : IClassFixture<TFixture>, IDisposable
-        where TTestStore : TestStore
-        where TFixture : BuiltInDataTypesFixtureBase<TTestStore>, new()
+    public abstract class BuiltInDataTypesTestBase<TFixture> : IClassFixture<TFixture>
+        where TFixture : BuiltInDataTypesFixtureBase, new()
     {
         [Fact]
         public virtual void Can_insert_and_read_back_all_non_nullable_data_types()
@@ -213,22 +212,13 @@ namespace Microsoft.Data.Entity.FunctionalTests
         protected BuiltInDataTypesTestBase(TFixture fixture)
         {
             Fixture = fixture;
-
-            TestStore = Fixture.CreateTestStore();
         }
 
         protected TFixture Fixture { get; }
 
-        protected TTestStore TestStore { get; }
-
-        public void Dispose()
-        {
-            TestStore.Dispose();
-        }
-
         protected DbContext CreateContext()
         {
-            return Fixture.CreateContext(TestStore);
+            return Fixture.CreateContext();
         }
     }
 }

--- a/test/EntityFramework.InMemory.FunctionalTests/BuiltInDataTypesInMemoryFixture.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/BuiltInDataTypesInMemoryFixture.cs
@@ -3,35 +3,36 @@
 
 using System;
 using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Framework.DependencyInjection;
 
 namespace Microsoft.Data.Entity.InMemory.FunctionalTests
 {
-    public class BuiltInDataTypesInMemoryFixture : BuiltInDataTypesFixtureBase<InMemoryTestStore>
+    public class BuiltInDataTypesInMemoryFixture : BuiltInDataTypesFixtureBase
     {
         private readonly IServiceProvider _serviceProvider;
+        private readonly DbContextOptions _options;
+        private readonly InMemoryTestStore _testStore;
 
         public BuiltInDataTypesInMemoryFixture()
         {
+            _testStore = new InMemoryTestStore();
             _serviceProvider = new ServiceCollection()
                 .AddEntityFramework()
                 .AddInMemoryStore()
                 .ServiceCollection()
                 .AddSingleton(TestInMemoryModelSource.GetFactory(OnModelCreating))
                 .BuildServiceProvider();
-        }
 
-        public override InMemoryTestStore CreateTestStore()
-        {
-            return new InMemoryTestStore();
-        }
-
-        public override DbContext CreateContext(InMemoryTestStore testStore)
-        {
             var optionsBuilder = new DbContextOptionsBuilder();
             optionsBuilder.UseInMemoryStore();
-
-            return new DbContext(_serviceProvider, optionsBuilder.Options);
+            _options = optionsBuilder.Options;
+        }
+        
+        public override DbContext CreateContext() => new DbContext(_serviceProvider, _options);
+        public override void Dispose()
+        {
+            _testStore.Dispose();
         }
     }
 }

--- a/test/EntityFramework.InMemory.FunctionalTests/BuiltInDataTypesInMemoryTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/BuiltInDataTypesInMemoryTest.cs
@@ -5,7 +5,7 @@ using Microsoft.Data.Entity.FunctionalTests;
 
 namespace Microsoft.Data.Entity.InMemory.FunctionalTests
 {
-    public class BuiltInDataTypesInMemoryTest : BuiltInDataTypesTestBase<InMemoryTestStore, BuiltInDataTypesInMemoryFixture>
+    public class BuiltInDataTypesInMemoryTest : BuiltInDataTypesTestBase<BuiltInDataTypesInMemoryFixture>
     {
         public BuiltInDataTypesInMemoryTest(BuiltInDataTypesInMemoryFixture fixture)
             : base(fixture)

--- a/test/EntityFramework.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
@@ -5,7 +5,7 @@ using Microsoft.Data.Entity.FunctionalTests;
 
 namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 {
-    public class BuiltInDataTypesSqlServerTest : BuiltInDataTypesTestBase<SqlServerTestStore, BuiltInDataTypesSqlServerFixture>
+    public class BuiltInDataTypesSqlServerTest : BuiltInDataTypesTestBase<BuiltInDataTypesSqlServerFixture>
     {
         public BuiltInDataTypesSqlServerTest(BuiltInDataTypesSqlServerFixture fixture)
             : base(fixture)

--- a/test/EntityFramework.Sqlite.FunctionalTests/BuiltInDataTypesSqliteTest.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/BuiltInDataTypesSqliteTest.cs
@@ -5,7 +5,7 @@ using Microsoft.Data.Entity.FunctionalTests;
 
 namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
 {
-    public class BuiltInDataTypesSqliteTest : BuiltInDataTypesTestBase<SqliteTestStore, BuiltInDataTypesSqliteFixture>
+    public class BuiltInDataTypesSqliteTest : BuiltInDataTypesTestBase<BuiltInDataTypesSqliteFixture>
     {
         public BuiltInDataTypesSqliteTest(BuiltInDataTypesSqliteFixture fixture)
             : base(fixture)

--- a/test/EntityFramework.Sqlite.FunctionalTests/SqliteTestStore.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/SqliteTestStore.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
         public static SqliteTestStore GetOrCreateShared(string name, Action initializeDatabase) =>
             new SqliteTestStore(name).CreateShared(initializeDatabase);
 
-        public static SqliteTestStore CreateScratch() =>
+        public static SqliteTestStore CreateScratch() => 
             new SqliteTestStore("scratch-" + Interlocked.Increment(ref _scratchCount)).CreateTransient();
 
         private SqliteConnection _connection;


### PR DESCRIPTION
Should help fix the race conditions when running tests on DNX Core.