### PR TITLE
Fixed concurrency issue in CommandConfigurationTest

### DIFF
--- a/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
+++ b/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
@@ -70,7 +70,7 @@
   <ItemGroup>
     <Compile Include="AsyncFromSqlQuerySqlServerTest.cs" />
     <Compile Include="AsyncFromSqlSprocQuerySqlServerTest.cs" />
-    <Compile Include="CommandConfigurationTests.cs" />
+    <Compile Include="CommandConfigurationTest.cs" />
     <Compile Include="ComputedColumnTest.cs" />
     <Compile Include="FromSqlSprocQuerySqlServerTest.cs" />
     <Compile Include="NorthwindSprocQuerySqlServerFixture.cs" />


### PR DESCRIPTION
The test was calling EnsureCreated multiple times in a non-thread safe manner. Switched to use a fixture instead. Also changed the database name since the same name was being used for a different database in different tests.