### PR TITLE
:art: Move default constraint naming to relational metadata extensions

### DIFF
--- a/src/EntityFramework.Relational/Metadata/ReadOnlyRelationalForeignKeyExtensions.cs
+++ b/src/EntityFramework.Relational/Metadata/ReadOnlyRelationalForeignKeyExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Utilities;
@@ -20,8 +21,16 @@ namespace Microsoft.Data.Entity.Relational.Metadata
             _foreignKey = foreignKey;
         }
 
-        public virtual string Name => _foreignKey[NameAnnotation] as string;
+        public virtual string Name => _foreignKey[NameAnnotation] as string ?? GetDefaultName();
 
         protected virtual IForeignKey ForeignKey => _foreignKey;
+
+        protected virtual string GetDefaultName()
+            => "FK_" +
+                _foreignKey.EntityType.DisplayName() +
+                "_" +
+                _foreignKey.PrincipalEntityType.DisplayName() +
+                "_" +
+                string.Join("_", _foreignKey.Properties.Select(p => p.Name));
     }
 }

--- a/src/EntityFramework.Relational/Metadata/ReadOnlyRelationalIndexExtensions.cs
+++ b/src/EntityFramework.Relational/Metadata/ReadOnlyRelationalIndexExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Utilities;
@@ -20,8 +21,14 @@ namespace Microsoft.Data.Entity.Relational.Metadata
             _index = index;
         }
 
-        public virtual string Name => _index[NameAnnotation] as string;
+        public virtual string Name => _index[NameAnnotation] as string ?? GetDefaultName();
 
         protected virtual IIndex Index => _index;
+
+        protected virtual string GetDefaultName()
+            => "IX_" +
+                _index.EntityType.DisplayName() +
+                "_" +
+                string.Join("_", _index.Properties.Select(p => p.Name));
     }
 }

--- a/src/EntityFramework.Relational/Metadata/ReadOnlyRelationalKeyExtensions.cs
+++ b/src/EntityFramework.Relational/Metadata/ReadOnlyRelationalKeyExtensions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Text;
+using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Utilities;
@@ -20,8 +22,26 @@ namespace Microsoft.Data.Entity.Relational.Metadata
             _key = key;
         }
 
-        public virtual string Name => _key[NameAnnotation] as string;
+        public virtual string Name => _key[NameAnnotation] as string ?? GetDefaultName();
 
         protected virtual IKey Key => _key;
+
+        protected virtual string GetDefaultName()
+        {
+            var builder = new StringBuilder();
+
+            builder
+                .Append(_key.IsPrimaryKey() ? "PK_" : "AK_")
+                .Append(_key.EntityType.DisplayName());
+
+            if (!_key.IsPrimaryKey())
+            {
+                builder
+                    .Append("_")
+                    .Append(string.Join("_", _key.Properties.Select(p => p.Name)));
+            }
+
+            return builder.ToString();
+        }
     }
 }

--- a/test/EntityFramework.Relational.Tests/Metadata/RelationalBuilderExtensionsTest.cs
+++ b/test/EntityFramework.Relational.Tests/Metadata/RelationalBuilderExtensionsTest.cs
@@ -183,7 +183,7 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
                 .Entity<Customer>().Collection(e => e.Orders).InverseReference(e => e.Customer)
                 .Name(null);
 
-            Assert.Null(foreignKey.Relational().Name);
+            Assert.Equal("FK_Order_Customer_CustomerId", foreignKey.Relational().Name);
         }
 
         [Fact]
@@ -247,7 +247,7 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
                 .Entity<Order>().Reference(e => e.Customer).InverseCollection(e => e.Orders)
                 .Name(null);
 
-            Assert.Null(foreignKey.Relational().Name);
+            Assert.Equal("FK_Order_Customer_CustomerId", foreignKey.Relational().Name);
         }
 
         [Fact]
@@ -312,7 +312,7 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
                 .Entity<Order>().Reference(e => e.Details).InverseReference(e => e.Order)
                 .Name(null);
 
-            Assert.Null(foreignKey.Relational().Name);
+            Assert.Equal("FK_OrderDetails_Order_OrderId", foreignKey.Relational().Name);
         }
 
         [Fact]

--- a/test/EntityFramework.Relational.Tests/Metadata/RelationalMetadataExtensionsTest.cs
+++ b/test/EntityFramework.Relational.Tests/Metadata/RelationalMetadataExtensionsTest.cs
@@ -168,8 +168,8 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
                 .Key(e => e.Id)
                 .Metadata;
 
-            Assert.Null(key.Relational().Name);
-            Assert.Null(((IKey)key).Relational().Name);
+            Assert.Equal("PK_Customer", key.Relational().Name);
+            Assert.Equal("PK_Customer", ((IKey)key).Relational().Name);
 
             key.Relational().Name = "PrimaryKey";
 
@@ -178,8 +178,8 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
 
             key.Relational().Name = null;
 
-            Assert.Null(key.Relational().Name);
-            Assert.Null(((IKey)key).Relational().Name);
+            Assert.Equal("PK_Customer", key.Relational().Name);
+            Assert.Equal("PK_Customer", ((IKey)key).Relational().Name);
         }
 
         [Fact]
@@ -198,8 +198,8 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
                 .ForeignKey<Order>(e => e.CustomerId)
                 .Metadata;
 
-            Assert.Null(foreignKey.Relational().Name);
-            Assert.Null(((IForeignKey)foreignKey).Relational().Name);
+            Assert.Equal("FK_Order_Customer_CustomerId", foreignKey.Relational().Name);
+            Assert.Equal("FK_Order_Customer_CustomerId", ((IForeignKey)foreignKey).Relational().Name);
 
             foreignKey.Relational().Name = "FK";
 
@@ -208,8 +208,8 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
 
             foreignKey.Relational().Name = null;
 
-            Assert.Null(foreignKey.Relational().Name);
-            Assert.Null(((IForeignKey)foreignKey).Relational().Name);
+            Assert.Equal("FK_Order_Customer_CustomerId", foreignKey.Relational().Name);
+            Assert.Equal("FK_Order_Customer_CustomerId", ((IForeignKey)foreignKey).Relational().Name);
         }
 
         [Fact]
@@ -222,8 +222,8 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
                 .Index(e => e.Id)
                 .Metadata;
 
-            Assert.Null(index.Relational().Name);
-            Assert.Null(((IIndex)index).Relational().Name);
+            Assert.Equal("IX_Customer_Id", index.Relational().Name);
+            Assert.Equal("IX_Customer_Id", ((IIndex)index).Relational().Name);
 
             index.Relational().Name = "MyIndex";
 
@@ -232,8 +232,8 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
 
             index.Relational().Name = null;
 
-            Assert.Null(index.Relational().Name);
-            Assert.Null(((IIndex)index).Relational().Name);
+            Assert.Equal("IX_Customer_Id", index.Relational().Name);
+            Assert.Equal("IX_Customer_Id", ((IIndex)index).Relational().Name);
         }
 
         [Fact]

--- a/test/EntityFramework.SqlServer.Tests/Metadata/SqlServerMetadataExtensionsTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/Metadata/SqlServerMetadataExtensionsTest.cs
@@ -251,10 +251,10 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
                 .Key(e => e.Id)
                 .Metadata;
 
-            Assert.Null(key.Relational().Name);
-            Assert.Null(((IKey)key).Relational().Name);
-            Assert.Null(key.SqlServer().Name);
-            Assert.Null(((IKey)key).SqlServer().Name);
+            Assert.Equal("PK_Customer", key.Relational().Name);
+            Assert.Equal("PK_Customer", ((IKey)key).Relational().Name);
+            Assert.Equal("PK_Customer", key.SqlServer().Name);
+            Assert.Equal("PK_Customer", ((IKey)key).SqlServer().Name);
 
             key.Relational().Name = "PrimaryKey";
 
@@ -294,10 +294,10 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
                 .ForeignKey<Order>(e => e.CustomerId)
                 .Metadata;
 
-            Assert.Null(foreignKey.Relational().Name);
-            Assert.Null(((IForeignKey)foreignKey).Relational().Name);
-            Assert.Null(foreignKey.SqlServer().Name);
-            Assert.Null(((IForeignKey)foreignKey).SqlServer().Name);
+            Assert.Equal("FK_Order_Customer_CustomerId", foreignKey.Relational().Name);
+            Assert.Equal("FK_Order_Customer_CustomerId", ((IForeignKey)foreignKey).Relational().Name);
+            Assert.Equal("FK_Order_Customer_CustomerId", foreignKey.SqlServer().Name);
+            Assert.Equal("FK_Order_Customer_CustomerId", ((IForeignKey)foreignKey).SqlServer().Name);
 
             foreignKey.Relational().Name = "FK";
 
@@ -331,10 +331,10 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
                 .Index(e => e.Id)
                 .Metadata;
 
-            Assert.Null(index.Relational().Name);
-            Assert.Null(((IIndex)index).Relational().Name);
-            Assert.Null(index.SqlServer().Name);
-            Assert.Null(((IIndex)index).SqlServer().Name);
+            Assert.Equal("IX_Customer_Id", index.Relational().Name);
+            Assert.Equal("IX_Customer_Id", ((IIndex)index).Relational().Name);
+            Assert.Equal("IX_Customer_Id", index.SqlServer().Name);
+            Assert.Equal("IX_Customer_Id", ((IIndex)index).SqlServer().Name);
 
             index.Relational().Name = "MyIndex";
 

--- a/test/EntityFramework.Sqlite.Tests/Metadata/SqliteMetadataExtensionsTest.cs
+++ b/test/EntityFramework.Sqlite.Tests/Metadata/SqliteMetadataExtensionsTest.cs
@@ -153,8 +153,8 @@ namespace Microsoft.Data.Entity.Sqlite.Metadata
                 .Key(e => e.Id)
                 .Metadata;
 
-            Assert.Null(key.Sqlite().Name);
-            Assert.Null(((IKey)key).Sqlite().Name);
+            Assert.Equal("PK_Customer", key.Sqlite().Name);
+            Assert.Equal("PK_Customer", ((IKey)key).Sqlite().Name);
 
             key.Relational().Name = "PrimaryKey";
 
@@ -188,8 +188,8 @@ namespace Microsoft.Data.Entity.Sqlite.Metadata
                 .ForeignKey<Order>(e => e.CustomerId)
                 .Metadata;
 
-            Assert.Null(foreignKey.Sqlite().Name);
-            Assert.Null(((IForeignKey)foreignKey).Sqlite().Name);
+            Assert.Equal("FK_Order_Customer_CustomerId", foreignKey.Sqlite().Name);
+            Assert.Equal("FK_Order_Customer_CustomerId", ((IForeignKey)foreignKey).Sqlite().Name);
 
             foreignKey.Relational().Name = "FK";
 
@@ -217,8 +217,8 @@ namespace Microsoft.Data.Entity.Sqlite.Metadata
                 .Index(e => e.Id)
                 .Metadata;
 
-            Assert.Null(index.Sqlite().Name);
-            Assert.Null(((IIndex)index).Sqlite().Name);
+            Assert.Equal("IX_Customer_Id", index.Sqlite().Name);
+            Assert.Equal("IX_Customer_Id", ((IIndex)index).Sqlite().Name);
 
             index.Relational().Name = "MyIndex";
 


### PR DESCRIPTION
Note, the constraint names are now based on the on the domain model, not the database artifacts.