### PR TITLE
Select distinct data store services to allow multiple calls to AddProvider

### DIFF
--- a/src/EntityFramework.Core/Storage/DataStoreSelector.cs
+++ b/src/EntityFramework.Core/Storage/DataStoreSelector.cs
@@ -27,7 +27,10 @@ namespace Microsoft.Data.Entity.Storage
 
             _serviceProvider = serviceProvider;
             _contextOptions = contextOptions;
-            _sources = sources == null ? new IDataStoreSource[0] : sources.ToArray();
+            _sources = sources == null
+                ? new IDataStoreSource[0]
+                : sources.Distinct((source, storeSource) => source.GetType() == storeSource.GetType())
+                    .ToArray();
         }
 
         public virtual IDataStoreServices SelectDataStore(ServiceProviderSource providerSource)

--- a/test/EntityFramework.Core.Tests/Storage/DataStoreSelectorTest.cs
+++ b/test/EntityFramework.Core.Tests/Storage/DataStoreSelectorTest.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Data.Entity.Tests.Storage
         public void Selects_single_configured_store()
         {
             var services = Mock.Of<IDataStoreServices>();
-            var source = CreateSource("DataStore1", configured: true, available: false, services: services);
+            var source = new TestDataStoreSource1(configured: true, services: services);
 
             var selector = new DataStoreSelector(Mock.Of<IServiceProvider>(), Mock.Of<IDbContextOptions>(), new[] { source });
 
@@ -24,17 +24,32 @@ namespace Microsoft.Data.Entity.Tests.Storage
         }
 
         [Fact]
-        public void Throws_if_multiple_stores_configured()
+        public void Selects_single_configured_store_with_duplicates()
         {
-            var source1 = CreateSource("DataStore1", configured: true, available: false);
-            var source2 = CreateSource("DataStore2", configured: true, available: false);
-            var source3 = CreateSource("DataStore3", configured: false, available: true);
-            var source4 = CreateSource("DataStore4", configured: true, available: false);
+            var services = Mock.Of<IDataStoreServices>();
+            var source1 = new TestDataStoreSource1(configured: true, services: services);
+            var source2 = new TestDataStoreSource1(configured: true, services: services);
 
             var selector = new DataStoreSelector(
-                Mock.Of<IServiceProvider>(), 
-                Mock.Of<IDbContextOptions>(), 
-                new[] { source1, source2, source3, source4 });
+                Mock.Of<IServiceProvider>(),
+                Mock.Of<IDbContextOptions>(),
+                new IDataStoreSource[] { source1, source2 });
+
+            Assert.Same(services, selector.SelectDataStore(ServiceProviderSource.Explicit));
+        }
+
+        [Fact]
+        public void Throws_if_multiple_stores_configured()
+        {
+            var source1 = new TestDataStoreSource1(configured: true);
+            var source2 = new TestDataStoreSource2(configured: true);
+            var source3 = new TestDataStoreSource3(configured: false);
+            var source4 = new TestDataStoreSource4(configured: true);
+
+            var selector = new DataStoreSelector(
+                Mock.Of<IServiceProvider>(),
+                Mock.Of<IDbContextOptions>(),
+                new IDataStoreSource[] { source1, source2, source3, source4 });
 
             Assert.Equal(Strings.MultipleDataStoresConfigured("'DataStore1' 'DataStore2' 'DataStore4' "),
                 Assert.Throws<InvalidOperationException>(
@@ -70,14 +85,14 @@ namespace Microsoft.Data.Entity.Tests.Storage
         [Fact]
         public void Throws_if_multiple_store_services_are_registered_but_none_are_configured()
         {
-            var source1 = CreateSource("DataStore1", configured: false, available: true);
-            var source2 = CreateSource("DataStore2", configured: false, available: false);
-            var source3 = CreateSource("DataStore3", configured: false, available: false);
+            var source1 = new TestDataStoreSource1(configured: false);
+            var source2 = new TestDataStoreSource2(configured: false);
+            var source3 = new TestDataStoreSource3(configured: false);
 
             var selector = new DataStoreSelector(
                 Mock.Of<IServiceProvider>(),
                 Mock.Of<IDbContextOptions>(),
-                new[] { source1, source2, source3 });
+                new IDataStoreSource[] { source1, source2, source3 });
 
             Assert.Equal(Strings.MultipleDataStoresAvailable("'DataStore1' 'DataStore2' 'DataStore3' "),
                 Assert.Throws<InvalidOperationException>(
@@ -87,7 +102,7 @@ namespace Microsoft.Data.Entity.Tests.Storage
         [Fact]
         public void Throws_if_one_store_service_is_registered_but_not_configured_and_cannot_be_used_without_configuration()
         {
-            var source = CreateSource("DataStore1", configured: false, available: false);
+            var source = new TestDataStoreSource1(configured: false);
 
             var selector = new DataStoreSelector(
                 Mock.Of<IServiceProvider>(),
@@ -99,14 +114,61 @@ namespace Microsoft.Data.Entity.Tests.Storage
                     () => selector.SelectDataStore(ServiceProviderSource.Explicit)).Message);
         }
 
-        private static IDataStoreSource CreateSource(string name, bool configured, bool available, IDataStoreServices services = null)
+        private abstract class TestDataStoreSource : IDataStoreSource
         {
-            var sourceMock = new Mock<IDataStoreSource>();
-            sourceMock.Setup(m => m.IsConfigured(It.IsAny<IDbContextOptions>())).Returns(configured);
-            sourceMock.Setup(m => m.GetStoreServices(It.IsAny<IServiceProvider>())).Returns(services);
-            sourceMock.Setup(m => m.Name).Returns(name);
+            private readonly bool _isConfigured;
+            private readonly IDataStoreServices _services;
 
-            return sourceMock.Object;
+            public TestDataStoreSource(bool configured, IDataStoreServices services)
+            {
+                _isConfigured = configured;
+                _services = services;
+            }
+
+            public bool IsConfigured(IDbContextOptions options) => _isConfigured;
+            public IDataStoreServices GetStoreServices(IServiceProvider serviceProvider) => _services;
+            public virtual string Name { get { throw new NotImplementedException(); } }
+            public void AutoConfigure(DbContextOptionsBuilder optionsBuilder) { }
+        }
+
+        private class TestDataStoreSource1 : TestDataStoreSource
+        {
+            public TestDataStoreSource1(bool configured, IDataStoreServices services = null)
+                : base(configured, services)
+            {
+            }
+
+            public override string Name => "DataStore1";
+        }
+
+        private class TestDataStoreSource2 : TestDataStoreSource
+        {
+            public TestDataStoreSource2(bool configured, IDataStoreServices services = null)
+                : base(configured, services)
+            {
+            }
+
+            public override string Name => "DataStore2";
+        }
+
+        private class TestDataStoreSource3 : TestDataStoreSource
+        {
+            public TestDataStoreSource3(bool configured, IDataStoreServices services = null)
+                : base(configured, services)
+            {
+            }
+
+            public override string Name => "DataStore3";
+        }
+
+        private class TestDataStoreSource4 : TestDataStoreSource
+        {
+            public TestDataStoreSource4(bool configured, IDataStoreServices services = null)
+                : base(configured, services)
+            {
+            }
+
+            public override string Name => "DataStore4";
         }
     }
 }


### PR DESCRIPTION
Fix for #2090, throwing when multiple registrations of the same ```IDataStoreSource``` implementation exist.
Two possible solutions to the issue are:
* Ensuring the class is only added once - This is non-trivial because there are multiple ```IDataStoreSource```s expected in the cross-store scenario and we either need to track if the provider-specific implementation has been added or query the container to see if a registration exists
* Ignoring duplicates when selecting the ```IDataStoreSource``` in the ```DataStoreSelector```

This PR uses the second approach, filtering in the ```DataStoreSelector```
@rowanmiller 