### PR TITLE
Query: Don't throw when no orderby present when skip operation.

### DIFF
--- a/src/EntityFramework.Core/Query/CompiledQueryCache.cs
+++ b/src/EntityFramework.Core/Query/CompiledQueryCache.cs
@@ -234,7 +234,7 @@ namespace Microsoft.Data.Entity.Query
 
                         var parameterValue = Evaluate(e, out parameterName);
 
-                        var compilerPrefixIndex = parameterName.LastIndexOf(">");
+                        var compilerPrefixIndex = parameterName.LastIndexOf(">", StringComparison.Ordinal);
                         if (compilerPrefixIndex != -1)
                         {
                             parameterName = parameterName.Substring(compilerPrefixIndex + 1);

--- a/src/EntityFramework.Relational/Properties/Strings.Designer.cs
+++ b/src/EntityFramework.Relational/Properties/Strings.Designer.cs
@@ -109,14 +109,6 @@ namespace Microsoft.Data.Entity.Relational
         }
 
         /// <summary>
-        /// A query containing the Skip operator must include at least one OrderBy operation.
-        /// </summary>
-        public static string SkipNeedsOrderBy
-        {
-            get { return GetString("SkipNeedsOrderBy"); }
-        }
-
-        /// <summary>
         /// The SQL Server sequence '{sequenceName}' was already specified with a different definition.
         /// </summary>
         public static string SequenceDefinitionMismatch([CanBeNull] object sequenceName)
@@ -341,14 +333,6 @@ namespace Microsoft.Data.Entity.Relational
         }
 
         /// <summary>
-        /// The required column '{column}' was not present in the results of a 'FromSql' operation.
-        /// </summary>
-        public static string FromSqlMissingColumn([CanBeNull] object column)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("FromSqlMissingColumn", "column"), column);
-        }
-
-        /// <summary>
         /// Generating down script for migration '{migration}'.
         /// </summary>
         public static string GeneratingDown([CanBeNull] object migration)
@@ -386,6 +370,14 @@ namespace Microsoft.Data.Entity.Relational
         public static string UsingConnection([CanBeNull] object database, [CanBeNull] object dataSource)
         {
             return string.Format(CultureInfo.CurrentCulture, GetString("UsingConnection", "database", "dataSource"), database, dataSource);
+        }
+
+        /// <summary>
+        /// The required column '{column}' was not present in the results of a 'FromSql' operation.
+        /// </summary>
+        public static string FromSqlMissingColumn([CanBeNull] object column)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("FromSqlMissingColumn", "column"), column);
         }
 
         private static string GetString(string name, params string[] formatterNames)

--- a/src/EntityFramework.Relational/Properties/Strings.resx
+++ b/src/EntityFramework.Relational/Properties/Strings.resx
@@ -153,9 +153,6 @@
   <data name="TransactionAssociatedWithDifferentConnection" xml:space="preserve">
     <value>The specified transaction is not associated with the current connection. Only transactions associated with the current connection may be used.</value>
   </data>
-  <data name="SkipNeedsOrderBy" xml:space="preserve">
-    <value>A query containing the Skip operator must include at least one OrderBy operation.</value>
-  </data>
   <data name="SequenceDefinitionMismatch" xml:space="preserve">
     <value>The SQL Server sequence '{sequenceName}' was already specified with a different definition.</value>
   </data>

--- a/src/EntityFramework.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/EntityFramework.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -498,12 +498,8 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
 
             if (selectExpression.Offset != null)
             {
-                if (!selectExpression.OrderBy.Any())
-                {
-                    throw new InvalidOperationException(Strings.SkipNeedsOrderBy);
-                }
-
-                _sql.Append(" OFFSET ")
+                _sql.AppendLine()
+                    .Append("OFFSET ")
                     .Append(selectExpression.Offset)
                     .Append(" ROWS");
 

--- a/src/EntityFramework.SqlServer/Query/SqlServerQuerySqlGenerator.cs
+++ b/src/EntityFramework.SqlServer/Query/SqlServerQuerySqlGenerator.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Linq;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Relational.Query.Expressions;
@@ -16,7 +17,7 @@ namespace Microsoft.Data.Entity.SqlServer.Query
         {
         }
 
-        protected override string DelimitIdentifier(string identifier) 
+        protected override string DelimitIdentifier(string identifier)
             => "[" + identifier.Replace("]", "]]") + "]";
 
         public override Expression VisitCountExpression(CountExpression countExpression)
@@ -26,10 +27,22 @@ namespace Microsoft.Data.Entity.SqlServer.Query
             if (countExpression.Type == typeof(long))
             {
                 Sql.Append("COUNT_BIG(*)");
+
                 return countExpression;
             }
 
             return base.VisitCountExpression(countExpression);
+        }
+
+        protected override void GenerateLimitOffset(SelectExpression selectExpression)
+        {
+            if (selectExpression.Offset != null
+                && !selectExpression.OrderBy.Any())
+            {
+                Sql.AppendLine().Append("ORDER BY 1");
+            }
+
+            base.GenerateLimitOffset(selectExpression);
         }
     }
 }

--- a/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
@@ -67,6 +67,15 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 assertOrder: true,
                 entryCount: 86);
         }
+        
+        [Fact]
+        public virtual void Skip_no_orderby()
+        {
+            AssertQuery<Customer>(
+                cs => cs.Skip(5),
+                entryCount: 86,
+                asserter: (_, __) => { /* non-deterministic */ });
+        }
 
         [Fact]
         public virtual void Take_Skip()

--- a/test/EntityFramework.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
@@ -519,7 +519,8 @@ ORDER BY [c].[CustomerID]
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-ORDER BY [c].[CustomerID] OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
+ORDER BY [c].[CustomerID]
+OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
@@ -528,14 +529,16 @@ INNER JOIN (
     FROM (
         SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
         FROM [Customers] AS [c]
-        ORDER BY [c].[CustomerID] OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
+        ORDER BY [c].[CustomerID]
+        OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
     ) AS [t0]
 ) AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 ORDER BY [c].[CustomerID]
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-ORDER BY [c].[CustomerID] OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
+ORDER BY [c].[CustomerID]
+OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
@@ -544,7 +547,8 @@ INNER JOIN (
     FROM (
         SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
         FROM [Customers] AS [c]
-        ORDER BY [c].[CustomerID] OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
+        ORDER BY [c].[CustomerID]
+        OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
     ) AS [t0]
 ) AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 ORDER BY [c].[CustomerID]",
@@ -570,7 +574,8 @@ ORDER BY [c].[CustomerID]
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-ORDER BY [c].[CustomerID] OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
+ORDER BY [c].[CustomerID]
+OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
@@ -579,7 +584,8 @@ INNER JOIN (
     FROM (
         SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
         FROM [Customers] AS [c]
-        ORDER BY [c].[CustomerID] OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
+        ORDER BY [c].[CustomerID]
+        OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
     ) AS [t0]
 ) AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 ORDER BY [c].[CustomerID]",
@@ -654,7 +660,8 @@ ORDER BY [c].[CustomerID]
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-ORDER BY [c].[CustomerID] OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY",
+ORDER BY [c].[CustomerID]
+OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY",
                 Sql);
         }
 
@@ -705,12 +712,14 @@ ORDER BY [o].[CustomerID]
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-ORDER BY [o].[CustomerID] OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
+ORDER BY [o].[CustomerID]
+OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-ORDER BY [o].[CustomerID] OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY",
+ORDER BY [o].[CustomerID]
+OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY",
                 Sql);
         }
 
@@ -726,11 +735,13 @@ ORDER BY [o].[OrderID]
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-ORDER BY [o].[OrderID] OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
+ORDER BY [o].[OrderID]
+OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-ORDER BY [o].[OrderID] OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY",
+ORDER BY [o].[OrderID]
+OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY",
                 Sql);
         }
 
@@ -746,12 +757,14 @@ ORDER BY [o].[OrderID]
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-ORDER BY [o].[OrderID] OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
+ORDER BY [o].[OrderID]
+OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
-ORDER BY [o].[OrderID] OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY",
+ORDER BY [o].[OrderID]
+OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY",
                 Sql);
         }
 

--- a/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -554,7 +554,20 @@ FROM (
             Assert.Equal(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-ORDER BY [c].[CustomerID] OFFSET 5 ROWS",
+ORDER BY [c].[CustomerID]
+OFFSET 5 ROWS",
+                Sql);
+        }
+
+        public override void Skip_no_orderby()
+        {
+            base.Skip_no_orderby();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY 1
+OFFSET 5 ROWS",
                 Sql);
         }
 
@@ -565,7 +578,8 @@ ORDER BY [c].[CustomerID] OFFSET 5 ROWS",
             Assert.Equal(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-ORDER BY [c].[ContactName] OFFSET 5 ROWS FETCH NEXT 10 ROWS ONLY",
+ORDER BY [c].[ContactName]
+OFFSET 5 ROWS FETCH NEXT 10 ROWS ONLY",
                 Sql);
         }
 
@@ -580,7 +594,8 @@ FROM (
     FROM [Customers] AS [c]
     ORDER BY [c].[ContactName]
 ) AS [t0]
-ORDER BY [t0].[ContactName] OFFSET 5 ROWS",
+ORDER BY [t0].[ContactName]
+OFFSET 5 ROWS",
                 Sql);
         }
 
@@ -597,7 +612,8 @@ FROM (
         FROM [Customers] AS [c]
         ORDER BY [c].[ContactName]
     ) AS [t0]
-    ORDER BY [t0].[ContactName] OFFSET 5 ROWS
+    ORDER BY [t0].[ContactName]
+    OFFSET 5 ROWS
 ) AS [t1]",
                 Sql);
         }
@@ -2593,7 +2609,8 @@ FROM (
         FROM [Customers] AS [c]
         ORDER BY COALESCE([c].[Region], 'ZZ')
     ) AS [t0]
-    ORDER BY COALESCE([t0].[Region], 'ZZ') OFFSET 5 ROWS
+    ORDER BY COALESCE([t0].[Region], 'ZZ')
+    OFFSET 5 ROWS
 ) AS [t1]", Sql);
         }
 
@@ -2617,7 +2634,8 @@ FROM (
     FROM [Customers] AS [c]
     ORDER BY [Coalesce]
 ) AS [t0]
-ORDER BY [Coalesce] OFFSET 5 ROWS",
+ORDER BY [Coalesce]
+OFFSET 5 ROWS",
             Sql);
         }
 


### PR DESCRIPTION
- Append ORDER BY 1 on SQL Server.

Fix #1607

@divega Updated with ORDER BY 1