### PR TITLE
Make two Transaction tests overrideable

### DIFF
--- a/test/EntityFramework.Relational.FunctionalTests/TransactionTestBase.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/TransactionTestBase.cs
@@ -223,7 +223,7 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
         }
 
         [Fact]
-        public void Query_uses_explicit_transaction()
+        public virtual void Query_uses_explicit_transaction()
         {
             using (var context = CreateContext())
             {
@@ -258,7 +258,7 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
         }
 
         [Fact]
-        public async Task QueryAsync_uses_explicit_transaction()
+        public virtual async Task QueryAsync_uses_explicit_transaction()
         {
             using (var context = CreateContext())
             {


### PR DESCRIPTION
Fixes #2304 - some ADO.NET providers do not support ReadUncommited isolation level