### PR TITLE
Add functional tests for SQLite type mappings

### DIFF
--- a/test/EntityFramework.Sqlite.FunctionalTests/BuiltInDataTypesSqliteFixture.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/BuiltInDataTypesSqliteFixture.cs
@@ -1,0 +1,140 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Framework.DependencyInjection;
+
+namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
+{
+    public class BuiltInDataTypesSqliteFixture : BuiltInDataTypesFixtureBase
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly EntityOptions _options;
+        private readonly SqliteTestStore _testStore;
+
+        public BuiltInDataTypesSqliteFixture()
+        {
+            _testStore = SqliteTestStore.CreateScratch();
+
+            _serviceProvider = new ServiceCollection()
+                .AddEntityFramework()
+                .AddSqlite()
+                .ServiceCollection()
+                .AddSingleton(TestSqliteModelSource.GetFactory(OnModelCreating))
+                .BuildServiceProvider();
+
+            var optionsBuilder = new EntityOptionsBuilder();
+            optionsBuilder.UseSqlite(_testStore.Connection);
+
+            _options = optionsBuilder.Options;
+
+            using (var context = new DbContext(_serviceProvider, _options))
+            {
+                context.Database.EnsureCreated();
+            }
+        }
+
+        public override DbContext CreateContext()
+        {
+            var context = new DbContext(_serviceProvider, _options);
+            context.Database.AsRelational().Connection.UseTransaction(_testStore.Transaction);
+            return context;
+        }
+
+        public override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<MappedDataTypes>(b =>
+                {
+                    b.Property(e => e.Integer).ColumnType("Integer");
+                    b.Property(e => e.Real).ColumnType("Real");
+                    b.Property(e => e.Text).ColumnType("Text").Required();
+                    b.Property(e => e.Blob).ColumnType("Blob").Required();
+                    b.Property(e => e.SomeString).ColumnType("SomeString").Required();
+                    b.Property(e => e.Int).ColumnType("Int");
+                });
+
+            modelBuilder.Entity<MappedNullableDataTypes>(b =>
+                {
+                    b.Property(e => e.Integer).ColumnType("Integer");
+                    b.Property(e => e.Real).ColumnType("Real");
+                    b.Property(e => e.Text).ColumnType("Text");
+                    b.Property(e => e.Blob).ColumnType("Blob");
+                    b.Property(e => e.SomeString).ColumnType("SomeString");
+                    b.Property(e => e.Int).ColumnType("Int");
+                });
+
+            modelBuilder.Entity<MappedSizedDataTypes>(b =>
+            {
+                b.Property(e => e.Nvarchar).ColumnType("nvarchar(3)");
+                b.Property(e => e.Binary).ColumnType("varbinary(3)");
+            });
+
+            modelBuilder.Entity<MappedScaledDataTypes>(b =>
+            {
+                b.Property(e => e.Float).ColumnType("real(3)");
+                b.Property(e => e.Datetimeoffset).ColumnType("datetimeoffset(3)");
+                b.Property(e => e.Datetime2).ColumnType("datetime2(3)");
+                b.Property(e => e.Decimal).ColumnType("decimal(3)");
+            });
+
+            modelBuilder.Entity<MappedPrecisionAndScaledDataTypes>(b =>
+            {
+                b.Property(e => e.Decimal).ColumnType("decimal(5, 2)");
+            });
+        }
+
+        public override void Dispose() => _testStore.Dispose();
+
+        public override bool SupportsBinaryKeys => true;
+
+        public override bool SupportsMaxLength => false;
+    }
+
+    public class MappedDataTypes
+    {
+        public int Id { get; set; }
+        public long Integer { get; set; }
+        public double Real { get; set; }
+        public string Text { get; set; }
+        public byte[] Blob { get; set; }
+        public string SomeString { get; set; }
+        public int Int { get; set; }
+    }
+
+    public class MappedSizedDataTypes
+    {
+        public int Id { get; set; }
+        public string Nvarchar { get; set; }
+        public byte[] Binary { get; set; }
+    }
+
+    public class MappedScaledDataTypes
+    {
+        public int Id { get; set; }
+        public float Float { get; set; }
+        public DateTimeOffset Datetimeoffset { get; set; }
+        public DateTime Datetime2 { get; set; }
+        public decimal Decimal { get; set; }
+    }
+
+    public class MappedPrecisionAndScaledDataTypes
+    {
+        public int Id { get; set; }
+        public decimal Decimal { get; set; }
+    }
+
+    public class MappedNullableDataTypes
+    {
+        public int Id { get; set; }
+        public long? Integer { get; set; }
+        public double? Real { get; set; }
+        public string Text { get; set; }
+        public byte[] Blob { get; set; }
+        public string SomeString { get; set; }
+        public int? Int { get; set; }
+    }
+}

--- a/test/EntityFramework.Sqlite.FunctionalTests/BuiltInDataTypesSqliteTest.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/BuiltInDataTypesSqliteTest.cs
@@ -1,0 +1,217 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.Data.Entity.FunctionalTests;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
+{
+    public class BuiltInDataTypesSqliteTest : BuiltInDataTypesTestBase<BuiltInDataTypesSqliteFixture>
+    {
+        public BuiltInDataTypesSqliteTest(BuiltInDataTypesSqliteFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_data_types()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<MappedDataTypes>().Add(
+                    new MappedDataTypes
+                        {
+                            Id = 66,
+                            Int = 77,
+                            Integer = 78L,
+                            Real = 84.4,
+                            SomeString = "don't",
+                            Text = "G",
+                            Blob = new byte[] { 86 }
+                        });
+
+                Assert.Equal(1, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                var entity = context.Set<MappedDataTypes>().Single(e => e.Id == 66);
+
+                Assert.Equal(77, entity.Int);
+                Assert.Equal(78L, entity.Integer);
+                Assert.Equal(84.4, entity.Real);
+                Assert.Equal("don't", entity.SomeString);
+                Assert.Equal("G", entity.Text);
+                Assert.Equal(new byte[] { 86 }, entity.Blob);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_nullable_data_types()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<MappedNullableDataTypes>().Add(
+                    new MappedNullableDataTypes
+                        {
+                            Id = 69,
+                            Int = 77,
+                            Integer = 78L,
+                            Real = 84.4,
+                            SomeString = "don't",
+                            Text = "G",
+                            Blob = new byte[] { 86 }
+                        });
+
+                Assert.Equal(1, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                var entity = context.Set<MappedNullableDataTypes>().Single(e => e.Id == 69);
+
+                Assert.Equal(77, entity.Int);
+                Assert.Equal(78L, entity.Integer);
+                Assert.Equal(84.4, entity.Real);
+                Assert.Equal("don't", entity.SomeString);
+                Assert.Equal("G", entity.Text);
+                Assert.Equal(new byte[] { 86 }, entity.Blob);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_data_types_set_to_null()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<MappedNullableDataTypes>().Add(
+                    new MappedNullableDataTypes
+                        {
+                            Id = 78
+                        });
+
+                Assert.Equal(1, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                var entity = context.Set<MappedNullableDataTypes>().Single(e => e.Id == 78);
+
+                Assert.Null(entity.Integer);
+                Assert.Null(entity.Real);
+                Assert.Null(entity.Text);
+                Assert.Null(entity.SomeString);
+                Assert.Null(entity.Blob);
+                Assert.Null(entity.Int);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_sized_data_types()
+        {
+            // Size expected to be ignored, but everything should still work
+
+            using (var context = CreateContext())
+            {
+                context.Set<MappedSizedDataTypes>().Add(
+                    new MappedSizedDataTypes
+                        {
+                            Id = 77,
+                            Nvarchar = "Into",
+                            Binary = new byte[] { 10, 11, 12, 13 }
+                        });
+
+                Assert.Equal(1, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                var entity = context.Set<MappedSizedDataTypes>().Single(e => e.Id == 77);
+
+                Assert.Equal("Into", entity.Nvarchar);
+                Assert.Equal(new byte[] { 10, 11, 12, 13 }, entity.Binary);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_nulls_for_all_mapped_sized_data_types()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<MappedSizedDataTypes>().Add(
+                    new MappedSizedDataTypes
+                        {
+                            Id = 78
+                        });
+
+                Assert.Equal(1, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                var entity = context.Set<MappedSizedDataTypes>().Single(e => e.Id == 78);
+
+                Assert.Null(entity.Nvarchar);
+                Assert.Null(entity.Binary);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_data_types_with_scale()
+        {
+            // Scale expected to be ignored, but everything should still work
+
+            using (var context = CreateContext())
+            {
+                context.Set<MappedScaledDataTypes>().Add(
+                    new MappedScaledDataTypes
+                        {
+                            Id = 77,
+                            Float = 83.3f,
+                            Datetimeoffset = new DateTimeOffset(new DateTime(2016, 1, 2, 11, 11, 12), TimeSpan.Zero),
+                            Datetime2 = new DateTime(2017, 1, 2, 12, 11, 12),
+                            Decimal = 101.1m
+                        });
+
+                Assert.Equal(1, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                var entity = context.Set<MappedScaledDataTypes>().Single(e => e.Id == 77);
+
+                Assert.Equal(83.3f, entity.Float);
+                Assert.Equal(new DateTimeOffset(new DateTime(2016, 1, 2, 11, 11, 12), TimeSpan.Zero), entity.Datetimeoffset);
+                Assert.Equal(new DateTime(2017, 1, 2, 12, 11, 12), entity.Datetime2);
+                Assert.Equal(101.1m, entity.Decimal);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_data_types_with_precision_and_scale()
+        {
+            // Precision and scale expected to be ignored, but everything should still work
+
+            using (var context = CreateContext())
+            {
+                context.Set<MappedPrecisionAndScaledDataTypes>().Add(
+                    new MappedPrecisionAndScaledDataTypes
+                        {
+                            Id = 77,
+                            Decimal = 101.1m
+                        });
+
+                Assert.Equal(1, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                var entity = context.Set<MappedPrecisionAndScaledDataTypes>().Single(e => e.Id == 77);
+
+                Assert.Equal(101.1m, entity.Decimal);
+            }
+        }
+    }
+}

--- a/test/EntityFramework.Sqlite.FunctionalTests/EntityFramework.Sqlite.FunctionalTests.csproj
+++ b/test/EntityFramework.Sqlite.FunctionalTests/EntityFramework.Sqlite.FunctionalTests.csproj
@@ -74,6 +74,8 @@
     <Compile Include="AsNoTrackingSqliteTest.cs" />
     <Compile Include="AsyncFromSqlQuerySqliteTest.cs" />
     <Compile Include="AsyncQuerySqliteTest.cs" />
+    <Compile Include="BuiltInDataTypesSqliteFixture.cs" />
+    <Compile Include="BuiltInDataTypesSqliteTest.cs" />
     <Compile Include="ChangeTrackingSqliteTest.cs" />
     <Compile Include="ComplexNavigationsQuerySqliteFixture.cs" />
     <Compile Include="ComplexNavigationsQuerySqliteTest.cs" />


### PR DESCRIPTION
SQLite type mapping is extremely simple so this is mostly enabling the provider-agnostic tests for SQLite--which all work, even the ones that don't work on SQL Server!--and then adding SQLite specific tests that make sure that nothing barfs.

Note that size, precision, and scale are all ignored by SQLite, so tests for these just show that things still round-trip without issue.