### PR TITLE
Use `[ReplaceCulture]` to get tests running with different time formats

### DIFF
--- a/test/EntityFramework.SqlServer.FunctionalTests/FromSqlQuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/FromSqlQuerySqlServerTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.AspNet.Testing;
 using Microsoft.Data.Entity.Relational.FunctionalTests;
 using Xunit;
 
@@ -64,13 +65,14 @@ WHERE [c].[CustomerID] = [o].[CustomerID]",
                 Sql);
         }
 
+        [ReplaceCulture]
         public override void From_sql_queryable_multiple_composed_with_closure_parameters()
         {
             base.From_sql_queryable_multiple_composed_with_closure_parameters();
 
             Assert.Equal(
-                @"@p0: 1/1/1997 12:00:00 AM
-@p1: 1/1/1998 12:00:00 AM
+                @"@p0: 01/01/1997 00:00:00
+@p1: 01/01/1998 00:00:00
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM (

--- a/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
+using Microsoft.AspNet.Testing;
 using Microsoft.Data.Entity.FunctionalTests;
 using Microsoft.Data.Entity.FunctionalTests.TestModels.Northwind;
 using Microsoft.Data.Entity.Relational.FunctionalTests;
@@ -1470,7 +1471,7 @@ CROSS JOIN [Employees] AS [e3]",
             Assert.Equal(
                 @"SELECT COUNT(*)
 FROM [Customers] AS [c]
-CROSS JOIN [Orders] AS [o]", 
+CROSS JOIN [Orders] AS [o]",
                 Sql);
         }
 
@@ -1481,7 +1482,7 @@ CROSS JOIN [Orders] AS [o]",
             Assert.Equal(
                 @"SELECT COUNT_BIG(*)
 FROM [Customers] AS [c]
-CROSS JOIN [Orders] AS [o]", 
+CROSS JOIN [Orders] AS [o]",
                 Sql);
         }
 
@@ -1498,7 +1499,7 @@ CROSS JOIN [Orders] AS [o]",
             CROSS JOIN [Orders] AS [o])
         )
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END", 
+END",
                 Sql);
         }
 
@@ -2384,12 +2385,13 @@ INNER JOIN [Orders] AS [o0] ON [o].[CustomerID] = [o0].[CustomerID]",
                 Sql);
         }
 
+        [ReplaceCulture]
         public override void Where_chain()
         {
             base.Where_chain();
 
             Assert.Equal(
-                @"@__p_0: 1/1/1998 12:00:00 AM
+                @"@__p_0: 01/01/1998 00:00:00
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]

--- a/test/EntityFramework.SqlServer.FunctionalTests/project.json
+++ b/test/EntityFramework.SqlServer.FunctionalTests/project.json
@@ -1,7 +1,8 @@
 {
     "dependencies": {
         "EntityFramework.Relational.FunctionalTests": "7.0.0-*",
-        "EntityFramework.SqlServer": "7.0.0-*"
+        "EntityFramework.SqlServer": "7.0.0-*",
+        "Microsoft.AspNet.Testing": "1.0.0-*"
     },
     "commands": {
         "test": "xunit.runner.aspnet"

--- a/test/EntityFramework.Sqlite.FunctionalTests/EntityFramework.Sqlite.FunctionalTests.xproj
+++ b/test/EntityFramework.Sqlite.FunctionalTests/EntityFramework.Sqlite.FunctionalTests.xproj
@@ -13,5 +13,8 @@
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/test/EntityFramework.Sqlite.FunctionalTests/QuerySqliteTest.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/QuerySqliteTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
+using Microsoft.AspNet.Testing;
 using Microsoft.Data.Entity.FunctionalTests;
 using Microsoft.Data.Entity.FunctionalTests.TestModels.Northwind;
 using Microsoft.Data.Entity.Relational.FunctionalTests;
@@ -2388,12 +2389,13 @@ INNER JOIN ""Orders"" AS ""o0"" ON ""o"".""CustomerID"" = ""o0"".""CustomerID"""
                 Sql);
         }
 
+        [ReplaceCulture]
         public override void Where_chain()
         {
             base.Where_chain();
 
             Assert.Equal(
-                @"@__p_0: 1/1/1998 12:00:00 AM
+                @"@__p_0: 01/01/1998 00:00:00
 
 SELECT ""o"".""OrderID"", ""o"".""CustomerID"", ""o"".""EmployeeID"", ""o"".""OrderDate""
 FROM ""Orders"" AS ""o""

--- a/test/EntityFramework.Sqlite.FunctionalTests/project.json
+++ b/test/EntityFramework.Sqlite.FunctionalTests/project.json
@@ -1,7 +1,8 @@
 {
     "dependencies": {
         "EntityFramework.Relational.FunctionalTests": "7.0.0-*",
-        "EntityFramework.Sqlite": "7.0.0-*"
+        "EntityFramework.Sqlite": "7.0.0-*",
+        "Microsoft.AspNet.Testing": "1.0.0-*"
     },
     "commands": {
         "test": "xunit.runner.aspnet"


### PR DESCRIPTION
- #2160

nits:
- auto-remove trailing whitespace
- let VS do its thing w.r.t. test services in an .xproj file