### PR TITLE
Fix for E2E RevEng test

### DIFF
--- a/src/EntityFramework.SqlServer.Design/ReverseEngineering/Templates/SqlServerDbContextTemplate.cshtml
+++ b/src/EntityFramework.SqlServer.Design/ReverseEngineering/Templates/SqlServerDbContextTemplate.cshtml
@@ -87,9 +87,9 @@ var firstEntity = true;
         firstProperty = false;
         var propertyConfigurationLines = LayoutPropertyConfigurationLines(propertyConfig, "property", "    ");
         var propertyConfigurationLineCount = propertyConfigurationLines.Count;
-        if (propertyConfigurationLineCount == 1)
+        @if (propertyConfigurationLineCount == 1)
         {
-            foreach (var line in propertyConfigurationLines)
+            @foreach (var line in propertyConfigurationLines)
             {
 @:                entity.Property(e => e.@(propertyConfig.Property.Name))@(line);
             }
@@ -98,7 +98,7 @@ var firstEntity = true;
         {
 @:                entity.Property(e => e.@(propertyConfig.Property.Name))
             var lineCount = 0;
-            foreach (var line in propertyConfigurationLines)
+            @foreach (var line in propertyConfigurationLines)
             {
                 var outputLine = line;
                 if (++lineCount == propertyConfigurationLineCount)


### PR DESCRIPTION
Part of issue #2257.
Recent check-in a787a61 seems to have caused a problem interpreting the DbContext template. This fix adds back in the @ symbols before if and foreach in part of the template.