### PR TITLE
SQLite: Add monster fixup test and fix getters in query complication

### DIFF
--- a/src/EntityFramework.Sqlite/Query/SqliteQueryCompilationContext.cs
+++ b/src/EntityFramework.Sqlite/Query/SqliteQueryCompilationContext.cs
@@ -11,6 +11,7 @@ using Microsoft.Data.Entity.Relational.Query;
 using Microsoft.Data.Entity.Relational.Query.Expressions;
 using Microsoft.Data.Entity.Relational.Query.Methods;
 using Microsoft.Data.Entity.Relational.Query.Sql;
+using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.Sqlite.Query
@@ -30,21 +31,30 @@ namespace Microsoft.Data.Entity.Sqlite.Query
             [NotNull] IMemberTranslator compositeMemberTranslator,
             [NotNull] IRelationalValueBufferFactoryFactory valueBufferFactoryFactory)
             : base(
-                  model,
-                  logger,
-                  linqOperatorProvider,
-                  resultOperatorHandler,
-                  entityMaterializerSource,
-                  entityKeyFactorySource,
-                  clrPropertyGetterSource,
-                  queryMethodProvider,
-                  compositeMethodCallTranslator,
-                  compositeMemberTranslator,
-                  valueBufferFactoryFactory)
+                model,
+                logger,
+                linqOperatorProvider,
+                resultOperatorHandler,
+                entityMaterializerSource,
+                entityKeyFactorySource,
+                clrPropertyGetterSource,
+                queryMethodProvider,
+                compositeMethodCallTranslator,
+                compositeMemberTranslator,
+                valueBufferFactoryFactory)
         {
         }
 
         public override ISqlQueryGenerator CreateSqlQueryGenerator(SelectExpression selectExpression) =>
             new SqliteQuerySqlGenerator(selectExpression);
+
+        public override string GetColumnName(IProperty property) =>
+            Check.NotNull(property, nameof(property)).Sqlite().Column;
+
+        public override string GetSchema(IEntityType entityType) =>
+            Check.NotNull(entityType, nameof(entityType)).Sqlite().Schema;
+
+        public override string GetTableName(IEntityType entityType) =>
+            Check.NotNull(entityType, nameof(entityType)).Sqlite().Table;
     }
 }

--- a/test/EntityFramework.Sqlite.FunctionalTests/EntityFramework.Sqlite.FunctionalTests.csproj
+++ b/test/EntityFramework.Sqlite.FunctionalTests/EntityFramework.Sqlite.FunctionalTests.csproj
@@ -54,6 +54,7 @@
     <Compile Include="InheritanceSqliteTest.cs" />
     <Compile Include="MappingQuerySqliteFixture.cs" />
     <Compile Include="MappingQuerySqliteTest.cs" />
+    <Compile Include="MonsterFixupSqliteTest.cs" />
     <Compile Include="NorthwindQuerySqliteFixture.cs" />
     <Compile Include="NullKeysSqliteTest.cs" />
     <Compile Include="NullSemanticsQuerySqliteFixture.cs" />

--- a/test/EntityFramework.Sqlite.FunctionalTests/MonsterFixupSqliteTest.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/MonsterFixupSqliteTest.cs
@@ -1,0 +1,83 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Data.Entity.ChangeTracking.Internal;
+using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Data.Entity.FunctionalTests.TestModels;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Utilities;
+using Microsoft.Data.Sqlite;
+using Microsoft.Framework.DependencyInjection;
+
+namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
+{
+    public class MonsterFixupSqliteTest : MonsterFixupTestBase
+    {
+        private static readonly HashSet<string> _createdDatabases = new HashSet<string>();
+
+        private static readonly ConcurrentDictionary<string, AsyncLock> _creationLocks
+            = new ConcurrentDictionary<string, AsyncLock>();
+
+        protected override IServiceProvider CreateServiceProvider(bool throwingStateManager = false)
+        {
+            var serviceCollection = new ServiceCollection()
+                .AddEntityFramework()
+                .AddSqlite()
+                .ServiceCollection();
+
+            if (throwingStateManager)
+            {
+                serviceCollection.AddScoped<IStateManager, ThrowingMonsterStateManager>();
+            }
+
+            return serviceCollection.BuildServiceProvider();
+        }
+
+        protected override EntityOptions CreateOptions(string databaseName)
+        {
+            var optionsBuilder = new EntityOptionsBuilder();
+            optionsBuilder.UseSqlite(CreateConnectionString(databaseName));
+
+            return optionsBuilder.Options;
+        }
+
+        private static string CreateConnectionString(string name)
+        {
+            return new SqliteConnectionStringBuilder
+                {
+                    DataSource = name + ".db"
+                }.ConnectionString;
+        }
+
+        protected override async Task CreateAndSeedDatabase(string databaseName, Func<MonsterContext> createContext)
+        {
+            var creationLock = _creationLocks.GetOrAdd(databaseName, n => new AsyncLock());
+            using (await creationLock.LockAsync())
+            {
+                if (!_createdDatabases.Contains(databaseName))
+                {
+                    using (var context = createContext())
+                    {
+                        context.Database.EnsureDeleted();
+                        context.Database.EnsureCreated();
+                        context.SeedUsingFKs();
+                    }
+
+                    _createdDatabases.Add(databaseName);
+                }
+            }
+        }
+
+        public override void OnModelCreating<TMessage, TProductPhoto, TProductReview>(ModelBuilder builder)
+        {
+            base.OnModelCreating<TMessage, TProductPhoto, TProductReview>(builder);
+            builder.Entity<TMessage>().Key("MessageId");
+            builder.Entity<TProductPhoto>().Key("PhotoId");
+            builder.Entity<TProductReview>().Key("ReviewId");
+        }
+    }
+}


### PR DESCRIPTION
More tests for SQLite and a minor fix to query compilation.

To make MonsterFixup tests work on SQLite, the model must use MessageId, PhotoId, and ReviewId as the key for the model.

Almost completes #2121 