### PR TITLE
Details, details...minor fixes to testing

### DIFF
--- a/makefile.shade
+++ b/makefile.shade
@@ -70,40 +70,40 @@ var sqliteTestDir='test/EntityFramework.Sqlite.FunctionalTests/bin/${E("Configur
             {
                 CreatePartFromFile(
                     package,
-                    @"src\EntityFramework.Commands\build\netcore50\EntityFramework.Commands.targets",
-                    @"build\netcore50\EntityFramework.Commands.targets");
+                    @"src/EntityFramework.Commands/build/netcore50/EntityFramework.Commands.targets",
+                    @"build/netcore50/EntityFramework.Commands.targets");
                 CreatePartFromFile(
                     package,
-                    @"src\EntityFramework.Commands\lib\netcore50\_._",
-                    @"lib\netcore50\_._");
+                    @"src/EntityFramework.Commands/lib/netcore50/_._",
+                    @"lib/netcore50/_._");
                 CreatePartFromFile(
                     package,
-                    @"src\EntityFramework.Commands\tools\about_EntityFramework.help.txt",
-                    @"tools\about_EntityFramework.help.txt");
+                    @"src/EntityFramework.Commands/tools/about_EntityFramework.help.txt",
+                    @"tools/about_EntityFramework.help.txt");
                 CreatePartFromFile(
                     package,
-                    @"src\EntityFramework.Commands\tools\EntityFramework.psd1",
-                    @"tools\EntityFramework.psd1");
+                    @"src/EntityFramework.Commands/tools/EntityFramework.psd1",
+                    @"tools/EntityFramework.psd1");
                 CreatePartFromFile(
                     package,
-                    @"src\EntityFramework.Commands\tools\EntityFramework.psm1",
-                    @"tools\EntityFramework.psm1");
+                    @"src/EntityFramework.Commands/tools/EntityFramework.psm1",
+                    @"tools/EntityFramework.psm1");
                 CreatePartFromFile(
                     package,
-                    @"src\EntityFramework.Commands\tools\Handlers.cs",
-                    @"tools\Handlers.cs");
+                    @"src/EntityFramework.Commands/tools/Handlers.cs",
+                    @"tools/Handlers.cs");
                 CreatePartFromFile(
                     package,
-                    @"src\EntityFramework.Commands\IHandlers.cs",
-                    @"tools\IHandlers.cs");
+                    @"src/EntityFramework.Commands/IHandlers.cs",
+                    @"tools/IHandlers.cs");
                 CreatePartFromFile(
                     package,
-                    @"src\EntityFramework.Commands\tools\init.ps1",
-                    @"tools\init.ps1");
+                    @"src/EntityFramework.Commands/tools/init.ps1",
+                    @"tools/init.ps1");
                 CreatePartFromFile(
                     package,
-                    @"src\EntityFramework.Commands\tools\install.ps1",
-                    @"tools\install.ps1");
+                    @"src/EntityFramework.Commands/tools/install.ps1",
+                    @"tools/install.ps1");
             }
         }
         
@@ -115,12 +115,12 @@ var sqliteTestDir='test/EntityFramework.Sqlite.FunctionalTests/bin/${E("Configur
             {
                 CreatePartFromFile(
                     package,
-                    @"src\EntityFramework.Relational.Design\build\netcore50\EntityFramework.Relational.Design.targets",
-                    @"build\netcore50\EntityFramework.Relational.Design.targets");
+                    @"src/EntityFramework.Relational.Design/build/netcore50/EntityFramework.Relational.Design.targets",
+                    @"build/netcore50/EntityFramework.Relational.Design.targets");
                 CreatePartFromFile(
                     package,
-                    @"src\EntityFramework.Relational.Design\lib\netcore50\_._",
-                    @"lib\netcore50\_._");
+                    @"src/EntityFramework.Relational.Design/lib/netcore50/_._",
+                    @"lib/netcore50/_._");
             }
         }
     }

--- a/test/EntityFramework.Commands.FunctionalTests/TestUtilities/BuildSource.cs
+++ b/test/EntityFramework.Commands.FunctionalTests/TestUtilities/BuildSource.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Data.Entity.Commands.TestUtilities
                 if (!result.Success)
                 {
                     throw new InvalidOperationException(
-                        $"Build failed. Diagnostics: {string.Join("\r\n", result.Diagnostics)}");
+                        $"Build failed. Diagnostics: {string.Join(Environment.NewLine, result.Diagnostics)}");
                 }
             }
 
@@ -87,7 +87,7 @@ namespace Microsoft.Data.Entity.Commands.TestUtilities
                 if (!result.Success)
                 {
                     throw new InvalidOperationException(
-                        $"Build failed. Diagnostics: {string.Join("\r\n", result.Diagnostics)}");
+                        $"Build failed. Diagnostics: {string.Join(Environment.NewLine, result.Diagnostics)}");
                 }
 
                 assembly = Assembly.Load(stream.ToArray());

--- a/test/EntityFramework.Core.FunctionalTests/MonsterFixupTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/MonsterFixupTestBase.cs
@@ -1701,9 +1701,9 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         public virtual void OnModelCreating<TMessage, TProductPhoto, TProductReview>(ModelBuilder builder)
-            where TMessage : class
-            where TProductPhoto : class
-            where TProductReview : class
+            where TMessage : class, IMessage
+            where TProductPhoto : class, IProductPhoto
+            where TProductReview : class, IProductReview
         {
         }
 

--- a/test/EntityFramework.Core.FunctionalTests/TestFileLogger.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestFileLogger.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 {
                     lock (_logFilePath)
                     {
-                        File.AppendAllText(_logFilePath, message + "\r\n");
+                        File.AppendAllText(_logFilePath, message + Environment.NewLine);
                     }
                 }
             }

--- a/test/EntityFramework.Core.Tests/ApiConsistencyTest.cs
+++ b/test/EntityFramework.Core.Tests/ApiConsistencyTest.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Data.Entity.Tests
                      && method.ReturnType == typeof(void)
                  select type.Name + "." + method.Name;
 
-            Assert.Equal("", string.Join("\r\n", voidMethods));
+            Assert.Equal("", string.Join(Environment.NewLine, voidMethods));
         }
 
         protected override Assembly TargetAssembly

--- a/test/EntityFramework.Core.Tests/ApiConsistencyTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ApiConsistencyTestBase.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Data.Entity
 
             Assert.False(
                 nonVirtualMethods.Any(),
-                "\r\n-- Missing virtual APIs --\r\n" + string.Join("\r\n", nonVirtualMethods));
+                "\r\n-- Missing virtual APIs --\r\n" + string.Join(Environment.NewLine, nonVirtualMethods));
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace Microsoft.Data.Entity
 
             Assert.False(
                 parametersMissingAttribute.Any(),
-                "\r\n-- Missing NotNull annotations --\r\n" + string.Join("\r\n", parametersMissingAttribute));
+                "\r\n-- Missing NotNull annotations --\r\n" + string.Join(Environment.NewLine, parametersMissingAttribute));
         }
 
         [Fact]
@@ -103,7 +103,7 @@ namespace Microsoft.Data.Entity
 
             Assert.False(
                 missingOverloads.Any(),
-                "\r\n-- Missing async overloads --\r\n" + string.Join("\r\n", missingOverloads));
+                "\r\n-- Missing async overloads --\r\n" + string.Join(Environment.NewLine, missingOverloads));
 
             var missingSuffixMethods
                 = asyncMethods
@@ -114,7 +114,7 @@ namespace Microsoft.Data.Entity
 
             Assert.False(
                 missingSuffixMethods.Any(),
-                "\r\n-- Missing async suffix --\r\n" + string.Join("\r\n", missingSuffixMethods));
+                "\r\n-- Missing async suffix --\r\n" + string.Join(Environment.NewLine, missingSuffixMethods));
         }
 
         protected virtual IEnumerable<string> GetCancellationTokenExceptions()

--- a/test/EntityFramework.Core.Tests/Utilities/IndentedStringBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Utilities/IndentedStringBuilderTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.Data.Entity.Utilities;
 using Xunit;
 
@@ -8,6 +9,8 @@ namespace Microsoft.Data.Entity.Tests.Utilities
 {
     public class IndentedStringBuilderTest
     {
+        private readonly string _nl = Environment.NewLine;
+
         [Fact]
         public void Append_at_start_with_indent()
         {
@@ -49,7 +52,7 @@ namespace Microsoft.Data.Entity.Tests.Utilities
                 indentedStringBuilder.AppendLine();
             }
 
-            Assert.Equal("Foo\r\n    Foo\r\n", indentedStringBuilder.ToString());
+            Assert.Equal($"Foo{_nl}    Foo{_nl}", indentedStringBuilder.ToString());
         }
 
         [Fact]
@@ -62,7 +65,7 @@ namespace Microsoft.Data.Entity.Tests.Utilities
                 indentedStringBuilder.AppendLine("Foo");
             }
 
-            Assert.Equal("    Foo\r\n", indentedStringBuilder.ToString());
+            Assert.Equal("    Foo" + _nl, indentedStringBuilder.ToString());
         }
 
         [Fact]
@@ -77,7 +80,7 @@ namespace Microsoft.Data.Entity.Tests.Utilities
                 indentedStringBuilder.AppendLine("Foo");
             }
 
-            Assert.Equal("Foo\r\n    Foo\r\n", indentedStringBuilder.ToString());
+            Assert.Equal($"Foo{_nl}    Foo{_nl}", indentedStringBuilder.ToString());
         }
 
         [Fact]
@@ -90,7 +93,7 @@ namespace Microsoft.Data.Entity.Tests.Utilities
                 indentedStringBuilder.AppendLine();
             }
 
-            Assert.Equal("\r\n", indentedStringBuilder.ToString());
+            Assert.Equal(Environment.NewLine, indentedStringBuilder.ToString());
         }
     }
 }

--- a/test/EntityFramework.Relational.FunctionalTests/TestSqlLoggerFactory.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/TestSqlLoggerFactory.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
         }
 
         public static string Log => Logger._log.ToString();
-        public static string Sql => string.Join("\r\n\r\n", Logger._sqlStatements);
+        public static string Sql => string.Join(Environment.NewLine + Environment.NewLine, Logger._sqlStatements);
         public static List<string> SqlStatements => Logger._sqlStatements;
 
         private class SqlLogger : ILogger

--- a/test/EntityFramework.SqlServer.FunctionalTests/MonsterFixupSqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/MonsterFixupSqlServerTest.cs
@@ -80,9 +80,9 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         {
             base.OnModelCreating<TMessage, TProductPhoto, TProductReview>(builder);
 
-            builder.Entity<TMessage>().Property(typeof(int), "MessageId").ForSqlServer().UseIdentity();
-            builder.Entity<TProductPhoto>().Property(typeof(int), "PhotoId").ForSqlServer().UseIdentity();
-            builder.Entity<TProductReview>().Property(typeof(int), "ReviewId").ForSqlServer().UseIdentity();
+            builder.Entity<TMessage>().Property(e => e.MessageId).ForSqlServer().UseIdentity();
+            builder.Entity<TProductPhoto>().Property(e => e.PhotoId).ForSqlServer().UseIdentity();
+            builder.Entity<TProductReview>().Property(e => e.ReviewId).ForSqlServer().UseIdentity();
         }
     }
 

--- a/test/EntityFramework.Sqlite.FunctionalTests/MonsterFixupSqliteTest.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/MonsterFixupSqliteTest.cs
@@ -75,9 +75,9 @@ namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
         public override void OnModelCreating<TMessage, TProductPhoto, TProductReview>(ModelBuilder builder)
         {
             base.OnModelCreating<TMessage, TProductPhoto, TProductReview>(builder);
-            builder.Entity<TMessage>().Key("MessageId");
-            builder.Entity<TProductPhoto>().Key("PhotoId");
-            builder.Entity<TProductReview>().Key("ReviewId");
+            builder.Entity<TMessage>().Key(e => e.MessageId);
+            builder.Entity<TProductPhoto>().Key(e => e.PhotoId);
+            builder.Entity<TProductReview>().Key(e => e.ReviewId);
         }
     }
 }


### PR DESCRIPTION
Various and small fixes to testing.

Replace \r\n with Environment.NewLine. (XPlat friendly)
Use lambda overload instead of strings in MonsterFixup tests. (refactor friendly)
Use forward slash as file separators. (xplat friendly)