### PR TITLE
[SMALL] Fix to #2246 - Assigning boolean in Select statement throws invalid cast

### DIFF
--- a/src/EntityFramework.Relational/Query/ExpressionVisitors/RelationalProjectionExpressionVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionVisitors/RelationalProjectionExpressionVisitor.cs
@@ -66,7 +66,8 @@ namespace Microsoft.Data.Entity.Relational.Query.ExpressionVisitors
         public override Expression Visit(Expression expression)
         {
             if (expression != null
-                && !(expression is QuerySourceReferenceExpression))
+                && !(expression is QuerySourceReferenceExpression)
+                && !(expression is ConstantExpression))
             {
                 var sqlExpression
                     = _sqlTranslatingExpressionVisitor.Visit(expression);

--- a/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
@@ -1342,6 +1342,20 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
+        public virtual void Select_anonymous_bool_constant_true()
+        {
+            AssertQuery<Customer>(
+                cs => cs.Select(c => new { c.CustomerID, ConstantTrue = true }));
+        }
+
+        [Fact]
+        public virtual void Select_anonymous_bool_constant_in_expression()
+        {
+            AssertQuery<Customer>(
+                cs => cs.Select(c => new { c.CustomerID, Expression = c.CustomerID.Length + 5 }));
+        }
+
+        [Fact]
         public virtual void Select_customer_table()
         {
             AssertQuery<Customer>(

--- a/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -773,6 +773,56 @@ FROM [Customers] AS [c]",
                 Sql);
         }
 
+        public override void Select_anonymous_one()
+        {
+            base.Select_anonymous_one();
+
+            Assert.Equal(
+                @"SELECT [c].[City]
+FROM [Customers] AS [c]",
+                Sql);
+        }
+
+        public override void Select_anonymous_two()
+        {
+            base.Select_anonymous_two();
+
+            Assert.Equal(
+                @"SELECT [c].[City], [c].[Phone]
+FROM [Customers] AS [c]",
+                Sql);
+        }
+
+        public override void Select_anonymous_three()
+        {
+            base.Select_anonymous_three();
+
+            Assert.Equal(
+                @"SELECT [c].[City], [c].[Phone], [c].[Country]
+FROM [Customers] AS [c]",
+                Sql);
+        }
+
+        public override void Select_anonymous_bool_constant_true()
+        {
+            base.Select_anonymous_bool_constant_true();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID]
+FROM [Customers] AS [c]",
+                Sql);
+        }
+
+        public override void Select_anonymous_bool_constant_in_expression()
+        {
+            base.Select_anonymous_bool_constant_in_expression();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], (LEN([c].[CustomerID]) + 5)
+FROM [Customers] AS [c]",
+                Sql);
+        }
+
         public override void Select_scalar_primitive_after_take()
         {
             base.Select_scalar_primitive_after_take();
@@ -788,7 +838,7 @@ FROM [Employees] AS [e]",
             base.Select_constant_null_string();
 
             Assert.Equal(
-                @"SELECT NULL
+                @"SELECT 1
 FROM [Customers] AS [c]",
                 Sql);
         }

--- a/test/EntityFramework.Sqlite.FunctionalTests/QuerySqliteTest.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/QuerySqliteTest.cs
@@ -783,7 +783,7 @@ LIMIT 9",
             base.Select_constant_null_string();
 
             Assert.Equal(
-                @"SELECT NULL
+                @"SELECT 1
 FROM ""Customers"" AS ""c""",
                 Sql);
         }


### PR DESCRIPTION
Problem is that a row projection containing a constant bool gets translated into integer (0 or 1) since 1 and 0 are the literal bit values for true and false. When we try to materialize, we try to cast integer 0 or 1 into bool, which causes an error.
Fix is to not send standalone constants to the store, but instead deal with them on the client. This is consistent with our approach to functions (funcletize as much as we can)