### PR TITLE
Make IDataStoreCreators get the model through DI

### DIFF
--- a/src/EntityFramework.Core/Infrastructure/Database.cs
+++ b/src/EntityFramework.Core/Infrastructure/Database.cs
@@ -33,18 +33,18 @@ namespace Microsoft.Data.Entity.Infrastructure
         }
 
         // TODO: Make sure API docs say that return value indicates whether or not the database or tables were created
-        public virtual bool EnsureCreated() => _dataStoreCreator.EnsureCreated(_context.Model);
+        public virtual bool EnsureCreated() => _dataStoreCreator.EnsureCreated();
 
         // TODO: Make sure API docs say that return value indicates whether or not the database or tables were created
         public virtual Task<bool> EnsureCreatedAsync(CancellationToken cancellationToken = default(CancellationToken))
-            => _dataStoreCreator.EnsureCreatedAsync(_context.Model, cancellationToken);
+            => _dataStoreCreator.EnsureCreatedAsync(cancellationToken);
 
         // TODO: Make sure API docs say that return value indicates whether or not the database was deleted
-        public virtual bool EnsureDeleted() => _dataStoreCreator.EnsureDeleted(_context.Model);
+        public virtual bool EnsureDeleted() => _dataStoreCreator.EnsureDeleted();
 
         // TODO: Make sure API docs say that return value indicates whether or not the database was deleted
         public virtual Task<bool> EnsureDeletedAsync(CancellationToken cancellationToken = default(CancellationToken))
-            => _dataStoreCreator.EnsureDeletedAsync(_context.Model, cancellationToken);
+            => _dataStoreCreator.EnsureDeletedAsync(cancellationToken);
 
         IDataStoreCreator IAccessor<IDataStoreCreator>.Service => _dataStoreCreator;
 

--- a/src/EntityFramework.Core/Storage/IDataStoreCreator.cs
+++ b/src/EntityFramework.Core/Storage/IDataStoreCreator.cs
@@ -3,16 +3,14 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using JetBrains.Annotations;
-using Microsoft.Data.Entity.Metadata;
 
 namespace Microsoft.Data.Entity.Storage
 {
     public interface IDataStoreCreator
     {
-        bool EnsureDeleted([NotNull] IModel model);
-        Task<bool> EnsureDeletedAsync([NotNull] IModel model, CancellationToken cancellationToken = default(CancellationToken));
-        bool EnsureCreated([NotNull] IModel model);
-        Task<bool> EnsureCreatedAsync([NotNull] IModel model, CancellationToken cancellationToken = default(CancellationToken));
+        bool EnsureDeleted();
+        Task<bool> EnsureDeletedAsync(CancellationToken cancellationToken = default(CancellationToken));
+        bool EnsureCreated();
+        Task<bool> EnsureCreatedAsync(CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/EntityFramework.InMemory/InMemoryDataStoreCreator.cs
+++ b/src/EntityFramework.InMemory/InMemoryDataStoreCreator.cs
@@ -13,16 +13,19 @@ namespace Microsoft.Data.Entity.InMemory
 {
     public class InMemoryDataStoreCreator : IDataStoreCreator
     {
+        private readonly IModel _model;
         private readonly IInMemoryDataStore _dataStore;
 
-        public InMemoryDataStoreCreator([NotNull] IInMemoryDataStore dataStore)
+        public InMemoryDataStoreCreator([NotNull] IInMemoryDataStore dataStore, [NotNull] IModel model)
         {
             Check.NotNull(dataStore, nameof(dataStore));
+            Check.NotNull(model, nameof(model));
 
             _dataStore = dataStore;
+            _model = model;
         }
 
-        public virtual bool EnsureDeleted(IModel model)
+        public virtual bool EnsureDeleted()
         {
             if (_dataStore.Database.Any())
             {
@@ -32,12 +35,12 @@ namespace Microsoft.Data.Entity.InMemory
             return false;
         }
 
-        public virtual Task<bool> EnsureDeletedAsync(IModel model, CancellationToken cancellationToken = default(CancellationToken))
-            => Task.FromResult(EnsureDeleted(model));
+        public virtual Task<bool> EnsureDeletedAsync(CancellationToken cancellationToken = default(CancellationToken))
+            => Task.FromResult(EnsureDeleted());
 
-        public virtual bool EnsureCreated(IModel model) => _dataStore.EnsureDatabaseCreated(model);
+        public virtual bool EnsureCreated() => _dataStore.EnsureDatabaseCreated(_model);
 
-        public virtual Task<bool> EnsureCreatedAsync(IModel model, CancellationToken cancellationToken = default(CancellationToken))
-            => Task.FromResult(_dataStore.EnsureDatabaseCreated(model));
+        public virtual Task<bool> EnsureCreatedAsync(CancellationToken cancellationToken = default(CancellationToken))
+            => Task.FromResult(_dataStore.EnsureDatabaseCreated(_model));
     }
 }

--- a/src/EntityFramework.Relational/IRelationalDataStoreCreator.cs
+++ b/src/EntityFramework.Relational/IRelationalDataStoreCreator.cs
@@ -3,8 +3,6 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using JetBrains.Annotations;
-using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
 
 namespace Microsoft.Data.Entity.Relational
@@ -23,9 +21,9 @@ namespace Microsoft.Data.Entity.Relational
 
         Task DeleteAsync(CancellationToken cancellationToken = default(CancellationToken));
 
-        void CreateTables([NotNull] IModel model);
+        void CreateTables();
 
-        Task CreateTablesAsync([NotNull] IModel model, CancellationToken cancellationToken = default(CancellationToken));
+        Task CreateTablesAsync(CancellationToken cancellationToken = default(CancellationToken));
 
         bool HasTables();
 

--- a/src/EntityFramework.Relational/RelationalDatabase.cs
+++ b/src/EntityFramework.Relational/RelationalDatabase.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
-using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Relational.Migrations;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Utilities;
@@ -52,10 +51,10 @@ namespace Microsoft.Data.Entity.Relational
             return RelationalDataStoreCreator.CreateAsync(cancellationToken);
         }
 
-        public virtual void CreateTables() => RelationalDataStoreCreator.CreateTables(Model);
+        public virtual void CreateTables() => RelationalDataStoreCreator.CreateTables();
 
         public virtual Task CreateTablesAsync(CancellationToken cancellationToken = default(CancellationToken))
-            => RelationalDataStoreCreator.CreateTablesAsync(Model, cancellationToken);
+            => RelationalDataStoreCreator.CreateTablesAsync(cancellationToken);
 
         public virtual void Delete() => RelationalDataStoreCreator.Delete();
 
@@ -76,7 +75,5 @@ namespace Microsoft.Data.Entity.Relational
         private IRelationalDataStoreCreator RelationalDataStoreCreator => (IRelationalDataStoreCreator)((IAccessor<IDataStoreCreator>)this).Service;
 
         private ILogger Logger => ((IAccessor<ILogger>)this).Service;
-
-        private IModel Model => ((IAccessor<IModel>)this).Service;
     }
 }

--- a/src/EntityFramework.Sqlite/SqliteDataStoreCreator.cs
+++ b/src/EntityFramework.Sqlite/SqliteDataStoreCreator.cs
@@ -14,8 +14,6 @@ namespace Microsoft.Data.Entity.Sqlite
 {
     public class SqliteDataStoreCreator : RelationalDataStoreCreator
     {
-        private const int SQLITE_CANTOPEN = 14;
-
         private readonly IRelationalConnection _connection;
         private readonly IModelDiffer _modelDiffer;
         private readonly IMigrationSqlGenerator _migrationSqlGenerator;
@@ -25,7 +23,9 @@ namespace Microsoft.Data.Entity.Sqlite
             [NotNull] IRelationalConnection connection,
             [NotNull] IModelDiffer modelDiffer,
             [NotNull] IMigrationSqlGenerator migrationSqlGenerator,
-            [NotNull] ISqlStatementExecutor sqlStatementExecutor)
+            [NotNull] ISqlStatementExecutor sqlStatementExecutor,
+            [NotNull] IModel model)
+            : base(model)
         {
             Check.NotNull(connection, nameof(connection));
             Check.NotNull(modelDiffer, nameof(modelDiffer));
@@ -44,12 +44,10 @@ namespace Microsoft.Data.Entity.Sqlite
             _connection.Close();
         }
 
-        public override void CreateTables(IModel model)
+        public override void CreateTables()
         {
-            Check.NotNull(model, nameof(model));
-
-            var operations = _modelDiffer.GetDifferences(null, model);
-            var statements = _migrationSqlGenerator.Generate(operations, model);
+            var operations = _modelDiffer.GetDifferences(null, Model);
+            var statements = _migrationSqlGenerator.Generate(operations, Model);
             _executor.ExecuteNonQuery(_connection, null, statements);
         }
 

--- a/test/EntityFramework.Core.Tests/DatabaseTest.cs
+++ b/test/EntityFramework.Core.Tests/DatabaseTest.cs
@@ -20,11 +20,10 @@ namespace Microsoft.Data.Entity.Tests
         public void Methods_delegate_to_configured_store_creator()
         {
             var context = TestHelpers.Instance.CreateContext();
-            var model = context.Model;
 
             var creatorMock = new Mock<IDataStoreCreator>();
-            creatorMock.Setup(m => m.EnsureCreated(model)).Returns(true);
-            creatorMock.Setup(m => m.EnsureDeleted(model)).Returns(true);
+            creatorMock.Setup(m => m.EnsureCreated()).Returns(true);
+            creatorMock.Setup(m => m.EnsureDeleted()).Returns(true);
 
             var database = new ConcreteDatabase(
                 context,
@@ -32,22 +31,21 @@ namespace Microsoft.Data.Entity.Tests
                 new LoggerFactory());
 
             Assert.True(database.EnsureCreated());
-            creatorMock.Verify(m => m.EnsureCreated(model), Times.Once);
+            creatorMock.Verify(m => m.EnsureCreated(), Times.Once);
 
             Assert.True(database.EnsureDeleted());
-            creatorMock.Verify(m => m.EnsureDeleted(model), Times.Once);
+            creatorMock.Verify(m => m.EnsureDeleted(), Times.Once);
         }
 
         [Fact]
         public async void Async_methods_delegate_to_configured_store_creator()
         {
             var context = TestHelpers.Instance.CreateContext();
-            var model = context.Model;
             var cancellationToken = new CancellationTokenSource().Token;
 
             var creatorMock = new Mock<IDataStoreCreator>();
-            creatorMock.Setup(m => m.EnsureCreatedAsync(model, cancellationToken)).Returns(Task.FromResult(true));
-            creatorMock.Setup(m => m.EnsureDeletedAsync(model, cancellationToken)).Returns(Task.FromResult(true));
+            creatorMock.Setup(m => m.EnsureCreatedAsync(cancellationToken)).Returns(Task.FromResult(true));
+            creatorMock.Setup(m => m.EnsureDeletedAsync(cancellationToken)).Returns(Task.FromResult(true));
 
             var database = new ConcreteDatabase(
                 context,
@@ -55,10 +53,10 @@ namespace Microsoft.Data.Entity.Tests
                 new LoggerFactory());
 
             Assert.True(await database.EnsureCreatedAsync(cancellationToken));
-            creatorMock.Verify(m => m.EnsureCreatedAsync(model, cancellationToken), Times.Once);
+            creatorMock.Verify(m => m.EnsureCreatedAsync(cancellationToken), Times.Once);
 
             Assert.True(await database.EnsureDeletedAsync(cancellationToken));
-            creatorMock.Verify(m => m.EnsureDeletedAsync(model, cancellationToken), Times.Once);
+            creatorMock.Verify(m => m.EnsureDeletedAsync(cancellationToken), Times.Once);
         }
 
         [Fact]

--- a/test/EntityFramework.InMemory.Tests/InMemoryDataStoreCreatorTest.cs
+++ b/test/EntityFramework.InMemory.Tests/InMemoryDataStoreCreatorTest.cs
@@ -18,15 +18,15 @@ namespace Microsoft.Data.Entity.InMemory.Tests
         {
             var serviceProvider = InMemoryTestHelpers.Instance.CreateServiceProvider();
             var model = CreateModel();
-            var creator = new InMemoryDataStoreCreator(CreateStore(serviceProvider, persist: true));
+            var creator = new InMemoryDataStoreCreator(CreateStore(serviceProvider, persist: true), model);
 
-            Assert.True(creator.EnsureCreated(model));
-            Assert.False(creator.EnsureCreated(model));
-            Assert.False(creator.EnsureCreated(model));
+            Assert.True(creator.EnsureCreated());
+            Assert.False(creator.EnsureCreated());
+            Assert.False(creator.EnsureCreated());
 
-            creator = new InMemoryDataStoreCreator(CreateStore(serviceProvider, persist: true));
+            creator = new InMemoryDataStoreCreator(CreateStore(serviceProvider, persist: true), model);
 
-            Assert.False(creator.EnsureCreated(model));
+            Assert.False(creator.EnsureCreated());
         }
 
         [Fact]
@@ -34,17 +34,17 @@ namespace Microsoft.Data.Entity.InMemory.Tests
         {
             var serviceProvider = InMemoryTestHelpers.Instance.CreateServiceProvider();
             var model = CreateModel();
-            var creator = new InMemoryDataStoreCreator(CreateStore(serviceProvider, persist: false));
+            var creator = new InMemoryDataStoreCreator(CreateStore(serviceProvider, persist: false), model);
 
-            Assert.True(creator.EnsureCreated(model));
-            Assert.False(creator.EnsureCreated(model));
-            Assert.False(creator.EnsureCreated(model));
+            Assert.True(creator.EnsureCreated());
+            Assert.False(creator.EnsureCreated());
+            Assert.False(creator.EnsureCreated());
 
-            creator = new InMemoryDataStoreCreator(CreateStore(serviceProvider, persist: false));
+            creator = new InMemoryDataStoreCreator(CreateStore(serviceProvider, persist: false), model);
 
-            Assert.True(creator.EnsureCreated(model));
-            Assert.False(creator.EnsureCreated(model));
-            Assert.False(creator.EnsureCreated(model));
+            Assert.True(creator.EnsureCreated());
+            Assert.False(creator.EnsureCreated());
+            Assert.False(creator.EnsureCreated());
         }
 
         [Fact]
@@ -52,15 +52,15 @@ namespace Microsoft.Data.Entity.InMemory.Tests
         {
             var serviceProvider = InMemoryTestHelpers.Instance.CreateServiceProvider();
             var model = CreateModel();
-            var creator = new InMemoryDataStoreCreator(CreateStore(serviceProvider, persist: true));
+            var creator = new InMemoryDataStoreCreator(CreateStore(serviceProvider, persist: true), model);
 
-            Assert.True(await creator.EnsureCreatedAsync(model));
-            Assert.False(await creator.EnsureCreatedAsync(model));
-            Assert.False(await creator.EnsureCreatedAsync(model));
+            Assert.True(await creator.EnsureCreatedAsync());
+            Assert.False(await creator.EnsureCreatedAsync());
+            Assert.False(await creator.EnsureCreatedAsync());
 
-            creator = new InMemoryDataStoreCreator(CreateStore(serviceProvider, persist: true));
+            creator = new InMemoryDataStoreCreator(CreateStore(serviceProvider, persist: true), model);
 
-            Assert.False(await creator.EnsureCreatedAsync(model));
+            Assert.False(await creator.EnsureCreatedAsync());
         }
 
         [Fact]
@@ -68,17 +68,17 @@ namespace Microsoft.Data.Entity.InMemory.Tests
         {
             var serviceProvider = InMemoryTestHelpers.Instance.CreateServiceProvider();
             var model = CreateModel();
-            var creator = new InMemoryDataStoreCreator(CreateStore(serviceProvider, persist: false));
+            var creator = new InMemoryDataStoreCreator(CreateStore(serviceProvider, persist: false), model);
 
-            Assert.True(await creator.EnsureCreatedAsync(model));
-            Assert.False(await creator.EnsureCreatedAsync(model));
-            Assert.False(await creator.EnsureCreatedAsync(model));
+            Assert.True(await creator.EnsureCreatedAsync());
+            Assert.False(await creator.EnsureCreatedAsync());
+            Assert.False(await creator.EnsureCreatedAsync());
 
-            creator = new InMemoryDataStoreCreator(CreateStore(serviceProvider, persist: false));
+            creator = new InMemoryDataStoreCreator(CreateStore(serviceProvider, persist: false), model);
 
-            Assert.True(await creator.EnsureCreatedAsync(model));
-            Assert.False(await creator.EnsureCreatedAsync(model));
-            Assert.False(await creator.EnsureCreatedAsync(model));
+            Assert.True(await creator.EnsureCreatedAsync());
+            Assert.False(await creator.EnsureCreatedAsync());
+            Assert.False(await creator.EnsureCreatedAsync());
         }
 
         private static IInMemoryDataStore CreateStore(IServiceProvider serviceProvider, bool persist)

--- a/test/EntityFramework.Relational.Tests/RelationalDatabaseTest.cs
+++ b/test/EntityFramework.Relational.Tests/RelationalDatabaseTest.cs
@@ -19,11 +19,11 @@ namespace Microsoft.Data.Entity.Relational.Tests
         {
             var context = TestHelpers.Instance.CreateContext();
             var model = context.Model;
-            var creatorMock = new Mock<RelationalDataStoreCreator>();
+            var creatorMock = new Mock<RelationalDataStoreCreator>(model);
             creatorMock.Setup(m => m.Exists()).Returns(true);
             creatorMock.Setup(m => m.HasTables()).Returns(true);
-            creatorMock.Setup(m => m.EnsureCreated(model)).Returns(true);
-            creatorMock.Setup(m => m.EnsureDeleted(model)).Returns(true);
+            creatorMock.Setup(m => m.EnsureCreated()).Returns(true);
+            creatorMock.Setup(m => m.EnsureDeleted()).Returns(true);
 
             var connectionMock = new Mock<IRelationalConnection>();
             var dbConnectionMock = new Mock<DbConnection>();
@@ -44,7 +44,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
             creatorMock.Verify(m => m.Create(), Times.Once);
 
             database.CreateTables();
-            creatorMock.Verify(m => m.CreateTables(model), Times.Once);
+            creatorMock.Verify(m => m.CreateTables(), Times.Once);
 
             Assert.True(database.HasTables());
             creatorMock.Verify(m => m.HasTables(), Times.Once);
@@ -53,10 +53,10 @@ namespace Microsoft.Data.Entity.Relational.Tests
             creatorMock.Verify(m => m.Delete(), Times.Once);
 
             Assert.True(database.EnsureCreated());
-            creatorMock.Verify(m => m.EnsureCreated(model), Times.Once);
+            creatorMock.Verify(m => m.EnsureCreated(), Times.Once);
 
             Assert.True(database.EnsureDeleted());
-            creatorMock.Verify(m => m.EnsureDeleted(model), Times.Once);
+            creatorMock.Verify(m => m.EnsureDeleted(), Times.Once);
 
             Assert.Same(connectionMock.Object, database.Connection);
         }
@@ -68,11 +68,11 @@ namespace Microsoft.Data.Entity.Relational.Tests
             var model = context.Model;
             var cancellationToken = new CancellationTokenSource().Token;
 
-            var creatorMock = new Mock<RelationalDataStoreCreator>();
+            var creatorMock = new Mock<RelationalDataStoreCreator>(model);
             creatorMock.Setup(m => m.ExistsAsync(cancellationToken)).Returns(Task.FromResult(true));
             creatorMock.Setup(m => m.HasTablesAsync(cancellationToken)).Returns(Task.FromResult(true));
-            creatorMock.Setup(m => m.EnsureCreatedAsync(model, cancellationToken)).Returns(Task.FromResult(true));
-            creatorMock.Setup(m => m.EnsureDeletedAsync(model, cancellationToken)).Returns(Task.FromResult(true));
+            creatorMock.Setup(m => m.EnsureCreatedAsync(cancellationToken)).Returns(Task.FromResult(true));
+            creatorMock.Setup(m => m.EnsureDeletedAsync(cancellationToken)).Returns(Task.FromResult(true));
 
             var connectionMock = new Mock<IRelationalConnection>();
             var dbConnectionMock = new Mock<DbConnection>();
@@ -93,7 +93,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
             creatorMock.Verify(m => m.CreateAsync(cancellationToken), Times.Once);
 
             await database.CreateTablesAsync(cancellationToken);
-            creatorMock.Verify(m => m.CreateTablesAsync(model, cancellationToken), Times.Once);
+            creatorMock.Verify(m => m.CreateTablesAsync(cancellationToken), Times.Once);
 
             Assert.True(await database.HasTablesAsync(cancellationToken));
             creatorMock.Verify(m => m.HasTablesAsync(cancellationToken), Times.Once);
@@ -102,10 +102,10 @@ namespace Microsoft.Data.Entity.Relational.Tests
             creatorMock.Verify(m => m.DeleteAsync(cancellationToken), Times.Once);
 
             Assert.True(await database.EnsureCreatedAsync(cancellationToken));
-            creatorMock.Verify(m => m.EnsureCreatedAsync(model, cancellationToken), Times.Once);
+            creatorMock.Verify(m => m.EnsureCreatedAsync(cancellationToken), Times.Once);
 
             Assert.True(await database.EnsureDeletedAsync(cancellationToken));
-            creatorMock.Verify(m => m.EnsureDeletedAsync(model, cancellationToken), Times.Once);
+            creatorMock.Verify(m => m.EnsureDeletedAsync(cancellationToken), Times.Once);
         }
 
         private class ConcreteRelationalDatabase : RelationalDatabase

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerDataStoreCreatorTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerDataStoreCreatorTest.cs
@@ -237,11 +237,11 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
                     if (async)
                     {
-                        await creator.CreateTablesAsync(context.Model);
+                        await creator.CreateTablesAsync();
                     }
                     else
                     {
-                        creator.CreateTables(context.Model);
+                        creator.CreateTables();
                     }
 
                     if (testDatabase.Connection.State != ConnectionState.Open)
@@ -281,8 +281,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
                 var errorNumber
                     = async
-                        ? (await Assert.ThrowsAsync<SqlException>(() => creator.CreateTablesAsync(new Model()))).Number
-                        : Assert.Throws<SqlException>(() => creator.CreateTables(new Model())).Number;
+                        ? (await Assert.ThrowsAsync<SqlException>(() => creator.CreateTablesAsync())).Number
+                        : Assert.Throws<SqlException>(() => creator.CreateTables()).Number;
 
                 if (errorNumber != 233) // skip if no-process transient failure
                 {


### PR DESCRIPTION
We were making choices about which methods to pass the context model to based on heuristics about when it might be needed. However, it was always possible to get the model in any of the methods. This change cleans up the code and allows the model to be used in any method for which it is useful. This potentially makes it more likely that the semantics of deleting a database or checking for tables will be inconsistent, but as discussed in a recent API review the best thing some providers can do is to use the current model for things like deletion.