### PR TITLE
Swap back to Identity as the default for SQL Server

### DIFF
--- a/EntityFramework.sln.DotSettings
+++ b/EntityFramework.sln.DotSettings
@@ -21,7 +21,7 @@
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_USING_BRACES_STYLE/@EntryValue">ALWAYS_ADD</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_WHILE_BRACES_STYLE/@EntryValue">ALWAYS_ADD</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INDENT_NESTED_USINGS_STMT/@EntryValue">True</s:Boolean>
-	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INITIALIZER_BRACES/@EntryValue">NEXT_LINE_SHIFTED_2</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INITIALIZER_BRACES/@EntryValue">NEXT_LINE</s:String>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_BLANK_LINES_IN_CODE/@EntryValue">1</s:Int64>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_BLANK_LINES_IN_DECLARATIONS/@EntryValue">1</s:Int64>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/LINE_FEED_AT_FILE_END/@EntryValue">True</s:Boolean>

--- a/src/EntityFramework.Relational/Update/ReaderModificationCommandBatch.cs
+++ b/src/EntityFramework.Relational/Update/ReaderModificationCommandBatch.cs
@@ -12,8 +12,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
-using Microsoft.Data.Entity.Metadata;
-using Microsoft.Data.Entity.Relational.Metadata;
 using Microsoft.Data.Entity.Update;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
@@ -24,18 +22,13 @@ namespace Microsoft.Data.Entity.Relational.Update
     {
         private readonly List<ModificationCommand> _modificationCommands = new List<ModificationCommand>();
         private readonly List<bool> _resultSetEnd = new List<bool>();
-        private readonly IRelationalMetadataExtensionProvider _metadataExtensionProvider;
         protected StringBuilder CachedCommandText { get; set; }
         protected int LastCachedCommandIndex;
 
         protected ReaderModificationCommandBatch(
-            [NotNull] ISqlGenerator sqlGenerator,
-            [NotNull] IRelationalMetadataExtensionProvider metadataExtensionProvider)
+            [NotNull] ISqlGenerator sqlGenerator)
             : base(sqlGenerator)
         {
-            Check.NotNull(metadataExtensionProvider, nameof(metadataExtensionProvider));
-
-            _metadataExtensionProvider = metadataExtensionProvider;
         }
 
         public override IReadOnlyList<ModificationCommand> ModificationCommands => _modificationCommands;

--- a/src/EntityFramework.Relational/Update/SingularModificationCommandBatch.cs
+++ b/src/EntityFramework.Relational/Update/SingularModificationCommandBatch.cs
@@ -2,16 +2,14 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
-using Microsoft.Data.Entity.Relational.Metadata;
 
 namespace Microsoft.Data.Entity.Relational.Update
 {
     public class SingularModificationCommandBatch : ReaderModificationCommandBatch
     {
         public SingularModificationCommandBatch(
-            [NotNull] ISqlGenerator sqlGenerator,
-            [NotNull] IRelationalMetadataExtensionProvider metadataExtensionProvider)
-            : base(sqlGenerator, metadataExtensionProvider)
+            [NotNull] ISqlGenerator sqlGenerator)
+            : base(sqlGenerator)
         {
         }
 

--- a/src/EntityFramework.SqlServer/Metadata/ModelConventions/SqlServerValueGenerationStrategyConvention.cs
+++ b/src/EntityFramework.SqlServer/Metadata/ModelConventions/SqlServerValueGenerationStrategyConvention.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Metadata.ModelConventions;
-using Microsoft.Data.Entity.Relational.Metadata;
 
 namespace Microsoft.Data.Entity.SqlServer.Metadata.ModelConventions
 {
@@ -13,26 +12,8 @@ namespace Microsoft.Data.Entity.SqlServer.Metadata.ModelConventions
         {
             modelBuilder.Annotation(
                 SqlServerAnnotationNames.Prefix + SqlServerAnnotationNames.ValueGeneration,
-                SqlServerValueGenerationStrategy.Sequence.ToString(),
+                SqlServerValueGenerationStrategy.Identity.ToString(),
                 ConfigurationSource.Convention);
-
-            var sequence = new Sequence(Sequence.DefaultName) { Model = modelBuilder.Metadata };
-            modelBuilder.Annotation(
-                SqlServerAnnotationNames.Prefix + RelationalAnnotationNames.Sequence + sequence.Schema + "." + sequence.Name,
-                sequence.Serialize(),
-                ConfigurationSource.Convention
-                );
-
-            modelBuilder.Annotation(
-                SqlServerAnnotationNames.Prefix + SqlServerAnnotationNames.DefaultSequenceName,
-                sequence.Name,
-                ConfigurationSource.Convention);
-
-            modelBuilder.Annotation(
-                SqlServerAnnotationNames.Prefix + SqlServerAnnotationNames.DefaultSequenceSchema,
-                sequence.Schema,
-                ConfigurationSource.Convention);
-
             return modelBuilder;
         }
     }

--- a/src/EntityFramework.SqlServer/Metadata/ReadOnlySqlServerPropertyExtensions.cs
+++ b/src/EntityFramework.SqlServer/Metadata/ReadOnlySqlServerPropertyExtensions.cs
@@ -57,11 +57,7 @@ namespace Microsoft.Data.Entity.SqlServer.Metadata
                     ? null
                     : (SqlServerValueGenerationStrategy?)Enum.Parse(typeof(SqlServerValueGenerationStrategy), value);
 
-                return (strategy == null
-                        && Property.StoreGeneratedPattern == StoreGeneratedPattern.Identity)
-                       || strategy == SqlServerValueGenerationStrategy.Default
-                    ? Property.EntityType.Model.SqlServer().ValueGenerationStrategy
-                    : strategy;
+                return strategy ?? Property.EntityType.Model.SqlServer().ValueGenerationStrategy;
             }
         }
 

--- a/src/EntityFramework.SqlServer/Metadata/SqlServerPropertyBuilder.cs
+++ b/src/EntityFramework.SqlServer/Metadata/SqlServerPropertyBuilder.cs
@@ -97,24 +97,5 @@ namespace Microsoft.Data.Entity.SqlServer.Metadata
 
             return this;
         }
-
-        public virtual SqlServerPropertyBuilder UseDefaultValueGeneration()
-        {
-            _property.SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.Default;
-            _property.StoreGeneratedPattern = StoreGeneratedPattern.Identity;
-            _property.SqlServer().SequenceName = null;
-            _property.SqlServer().SequenceSchema = null;
-
-            return this;
-        }
-
-        public virtual SqlServerPropertyBuilder UseNoValueGeneration()
-        {
-            _property.SqlServer().ValueGenerationStrategy = null;
-            _property.SqlServer().SequenceName = null;
-            _property.SqlServer().SequenceSchema = null;
-
-            return this;
-        }
     }
 }

--- a/src/EntityFramework.SqlServer/Metadata/SqlServerValueGenerationStrategy.cs
+++ b/src/EntityFramework.SqlServer/Metadata/SqlServerValueGenerationStrategy.cs
@@ -5,7 +5,6 @@ namespace Microsoft.Data.Entity.SqlServer.Metadata
 {
     public enum SqlServerValueGenerationStrategy
     {
-        Default,
         Sequence,
         Identity
     }

--- a/src/EntityFramework.SqlServer/Migrations/SqlServerModelDiffer.cs
+++ b/src/EntityFramework.SqlServer/Migrations/SqlServerModelDiffer.cs
@@ -94,7 +94,12 @@ namespace Microsoft.Data.Entity.SqlServer.Migrations
         }
 
         // TODO: Move to metadata API?
-        private SqlServerValueGenerationStrategy? GetValueGenerationStrategy(IProperty property) => property.SqlServer().ValueGenerationStrategy;
+        private static SqlServerValueGenerationStrategy? GetValueGenerationStrategy(IProperty property)
+            => property.StoreGeneratedPattern == StoreGeneratedPattern.Identity
+               && property.SqlServer().DefaultExpression == null
+               && property.SqlServer().DefaultValue == null
+                ? property.SqlServer().ValueGenerationStrategy
+                : null;
 
         #endregion
 

--- a/src/EntityFramework.SqlServer/Update/SqlServerModificationCommandBatch.cs
+++ b/src/EntityFramework.SqlServer/Update/SqlServerModificationCommandBatch.cs
@@ -25,9 +25,8 @@ namespace Microsoft.Data.Entity.SqlServer.Update
 
         public SqlServerModificationCommandBatch(
             [NotNull] ISqlServerSqlGenerator sqlGenerator,
-            [NotNull] IRelationalMetadataExtensionProvider metadataExtensionProvider,
             [CanBeNull] int? maxBatchSize)
-            : base(sqlGenerator, metadataExtensionProvider)
+            : base(sqlGenerator)
         {
             if (maxBatchSize.HasValue
                 && maxBatchSize.Value <= 0)

--- a/src/EntityFramework.SqlServer/Update/SqlServerModificationCommandBatchFactory.cs
+++ b/src/EntityFramework.SqlServer/Update/SqlServerModificationCommandBatchFactory.cs
@@ -29,10 +29,7 @@ namespace Microsoft.Data.Entity.SqlServer.Update
 
             var maxBatchSize = optionsExtension?.MaxBatchSize;
 
-            return new SqlServerModificationCommandBatch(
-                (ISqlServerSqlGenerator)SqlGenerator,
-                metadataExtensionProvider,
-                maxBatchSize);
+            return new SqlServerModificationCommandBatch((ISqlServerSqlGenerator)SqlGenerator, maxBatchSize);
         }
     }
 }

--- a/src/EntityFramework.Sqlite/Update/SqliteModificationCommandBatchFactory.cs
+++ b/src/EntityFramework.Sqlite/Update/SqliteModificationCommandBatchFactory.cs
@@ -19,6 +19,6 @@ namespace Microsoft.Data.Entity.Sqlite.Update
         public override ModificationCommandBatch Create(
             IDbContextOptions options,
             IRelationalMetadataExtensionProvider metadataExtensionProvider)
-            => new SingularModificationCommandBatch(SqlGenerator, metadataExtensionProvider);
+            => new SingularModificationCommandBatch(SqlGenerator);
     }
 }

--- a/test/EntityFramework.Core.FunctionalTests/BuiltInDataTypesFixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/BuiltInDataTypesFixtureBase.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Reflection;
 using System.Collections.Generic;
+using Microsoft.Data.Entity.Metadata;
 
 namespace Microsoft.Data.Entity.FunctionalTests
 {
@@ -20,10 +21,27 @@ namespace Microsoft.Data.Entity.FunctionalTests
             modelBuilder.Entity<StringKeyDataType>();
             modelBuilder.Entity<StringForeignKeyDataType>();
 
+            modelBuilder.Entity<BuiltInDataTypes>()
+                .Property(e => e.Id)
+                .StoreGeneratedPattern(StoreGeneratedPattern.None);
+
+            modelBuilder.Entity<BuiltInNullableDataTypes>()
+                .Property(e => e.Id)
+                .StoreGeneratedPattern(StoreGeneratedPattern.None);
+
+            modelBuilder.Entity<BinaryForeignKeyDataType>()
+                .Property(e => e.Id)
+                .StoreGeneratedPattern(StoreGeneratedPattern.None);
+
+            modelBuilder.Entity<StringForeignKeyDataType>()
+                .Property(e => e.Id)
+                .StoreGeneratedPattern(StoreGeneratedPattern.None);
+
             MakeRequired<BuiltInDataTypes>(modelBuilder);
 
             modelBuilder.Entity<MaxLengthDataTypes>(b =>
                 {
+                    b.Property(e => e.Id).StoreGeneratedPattern(StoreGeneratedPattern.None);
                     b.Property(e => e.ByteArray5).MaxLength(5);
                     b.Property(e => e.String3).MaxLength(3);
                     b.Property(e => e.ByteArray9000).MaxLength(9000);

--- a/test/EntityFramework.Core.FunctionalTests/ComplexNavigationsQueryFixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/ComplexNavigationsQueryFixtureBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Data.Entity.FunctionalTests.TestModels.ComplexNavigationsModel;
+using Microsoft.Data.Entity.Metadata;
 
 namespace Microsoft.Data.Entity.FunctionalTests
 {
@@ -14,10 +15,10 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
         protected virtual void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.Entity<Level1>().Key(e => e.Id);
-            modelBuilder.Entity<Level2>().Key(e => e.Id);
-            modelBuilder.Entity<Level3>().Key(e => e.Id);
-            modelBuilder.Entity<Level4>().Key(e => e.Id);
+            modelBuilder.Entity<Level1>().Property(e => e.Id).StoreGeneratedPattern(StoreGeneratedPattern.None);
+            modelBuilder.Entity<Level2>().Property(e => e.Id).StoreGeneratedPattern(StoreGeneratedPattern.None);
+            modelBuilder.Entity<Level3>().Property(e => e.Id).StoreGeneratedPattern(StoreGeneratedPattern.None);
+            modelBuilder.Entity<Level4>().Property(e => e.Id).StoreGeneratedPattern(StoreGeneratedPattern.None);
 
             modelBuilder.Entity<Level1>().Reference(e => e.OneToOne_Required_PK).InverseReference(e => e.OneToOne_Required_PK_Inverse).PrincipalKey<Level1>(e => e.Id).Required(true);
             modelBuilder.Entity<Level1>().Reference(e => e.OneToOne_Optional_PK).InverseReference(e => e.OneToOne_Optional_PK_Inverse).PrincipalKey<Level1>(e => e.Id).Required(false);

--- a/test/EntityFramework.Core.FunctionalTests/ComplexNavigationsQueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/ComplexNavigationsQueryTestBase.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
                 Assert.Equal(10, result.Count);
 
-                var level1 = result.Where(e => e.Name == "L1 01").Single();
+                var level1 = result.Single(e => e.Name == "L1 01");
 
                 Assert.Equal(5, level1.OneToMany_Optional.Count);
                 Assert.True(level1.OneToMany_Optional.Select(e => e.Name).Contains("L2 02"));
@@ -65,7 +65,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 Assert.True(level1.OneToMany_Optional.Select(e => e.Name).Contains("L2 08"));
                 Assert.True(level1.OneToMany_Optional.Select(e => e.Name).Contains("L2 10"));
 
-                var level2 = level1.OneToMany_Optional.Where(e => e.Name == "L2 02").Single();
+                var level2 = level1.OneToMany_Optional.Single(e => e.Name == "L2 02");
 
                 Assert.Equal(2, level2.OneToMany_Optional.Count);
                 Assert.True(level2.OneToMany_Optional.Select(e => e.Name).Contains("L3 04"));
@@ -82,7 +82,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
                 Assert.Equal(10, result.Count);
 
-                var level1 = result.Where(e => e.Name == "L1 01").Single();
+                var level1 = result.Single(e => e.Name == "L1 01");
 
                 Assert.Equal(5, level1.OneToMany_Optional.Count);
                 Assert.True(level1.OneToMany_Optional.Select(e => e.Name).Contains("L2 02"));
@@ -91,7 +91,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 Assert.True(level1.OneToMany_Optional.Select(e => e.Name).Contains("L2 08"));
                 Assert.True(level1.OneToMany_Optional.Select(e => e.Name).Contains("L2 10"));
 
-                var level2 = level1.OneToMany_Optional.Where(e => e.Name == "L2 02").Single();
+                var level2 = level1.OneToMany_Optional.Single(e => e.Name == "L2 02");
 
                 Assert.Equal(2, level2.OneToMany_Optional.Count);
                 Assert.True(level2.OneToMany_Optional.Select(e => e.Name).Contains("L3 04"));

--- a/test/EntityFramework.Core.FunctionalTests/NullKeysTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/NullKeysTestBase.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Data.Entity.Metadata;
 using Xunit;
 
 namespace Microsoft.Data.Entity.FunctionalTests
@@ -192,15 +193,27 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     .InverseReference(e => e.Self)
                     .ForeignKey<WithStringFk>(e => e.SelfFk);
 
-                modelBuilder.Entity<WithIntKey>()
-                    .Collection(e => e.Dependents)
-                    .InverseReference(e => e.Principal)
-                    .ForeignKey(e => e.Fk);
+                modelBuilder.Entity<WithIntKey>(b =>
+                    {
+                        b.Property(e => e.Id).StoreGeneratedPattern(StoreGeneratedPattern.None);
+                        b.Collection(e => e.Dependents)
+                            .InverseReference(e => e.Principal)
+                            .ForeignKey(e => e.Fk);
+                    });
 
-                modelBuilder.Entity<WithNullableIntKey>()
-                    .Collection(e => e.Dependents)
-                    .InverseReference(e => e.Principal)
-                    .ForeignKey(e => e.Fk);
+                modelBuilder.Entity<WithNullableIntKey>(b =>
+                    {
+                        b.Property(e => e.Id).StoreGeneratedPattern(StoreGeneratedPattern.None);
+                        b.Collection(e => e.Dependents)
+                            .InverseReference(e => e.Principal)
+                            .ForeignKey(e => e.Fk);
+                    });
+
+                modelBuilder.Entity<WithIntFk>()
+                    .Property(e => e.Id).StoreGeneratedPattern(StoreGeneratedPattern.None);
+
+                modelBuilder.Entity<WithNullableIntFk>()
+                    .Property(e => e.Id).StoreGeneratedPattern(StoreGeneratedPattern.None);
             }
 
             protected void EnsureCreated()

--- a/test/EntityFramework.Relational.FunctionalTests/F1RelationalFixture.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/F1RelationalFixture.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Data.Entity.FunctionalTests;
 using Microsoft.Data.Entity.FunctionalTests.TestModels.ConcurrencyModel;
+using Microsoft.Data.Entity.Metadata;
 
 namespace Microsoft.Data.Entity.Relational.FunctionalTests
 {
@@ -14,7 +15,7 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
             base.OnModelCreating(modelBuilder);
 
             modelBuilder.Entity<Chassis>().Table("Chassis");
-            modelBuilder.Entity<Team>().Table("Teams");
+            modelBuilder.Entity<Team>().Table("Teams").Property(e => e.Id).StoreGeneratedPattern(StoreGeneratedPattern.None);
             modelBuilder.Entity<Driver>().Table("Drivers");
             modelBuilder.Entity<Engine>().Table("Engines");
             modelBuilder.Entity<EngineSupplier>().Table("EngineSuppliers");

--- a/test/EntityFramework.Relational.FunctionalTests/NullSemanticsQueryRelationalFixture.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/NullSemanticsQueryRelationalFixture.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Data.Entity.FunctionalTests;
 using Microsoft.Data.Entity.FunctionalTests.TestModels.NullSemantics;
+using Microsoft.Data.Entity.Metadata;
 
 namespace Microsoft.Data.Entity.Relational.FunctionalTests
 {
@@ -15,19 +16,17 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
 
         protected virtual void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.Entity<NullSemanticsEntity1>().Key(e => e.Id);
-            modelBuilder.Entity<NullSemanticsEntity1>().Property(e => e.Id).GenerateValueOnAdd(false);
+            modelBuilder.Entity<NullSemanticsEntity1>().Property(e => e.Id).StoreGeneratedPattern(StoreGeneratedPattern.None);
 
-            modelBuilder.Entity<NullSemanticsEntity1>().Property(e => e.StringA).Required(true);
-            modelBuilder.Entity<NullSemanticsEntity1>().Property(e => e.StringB).Required(true);
-            modelBuilder.Entity<NullSemanticsEntity1>().Property(e => e.StringC).Required(true);
+            modelBuilder.Entity<NullSemanticsEntity1>().Property(e => e.StringA).Required();
+            modelBuilder.Entity<NullSemanticsEntity1>().Property(e => e.StringB).Required();
+            modelBuilder.Entity<NullSemanticsEntity1>().Property(e => e.StringC).Required();
 
-            modelBuilder.Entity<NullSemanticsEntity2>().Key(e => e.Id);
-            modelBuilder.Entity<NullSemanticsEntity2>().Property(e => e.Id).GenerateValueOnAdd(false);
+            modelBuilder.Entity<NullSemanticsEntity2>().Property(e => e.Id).StoreGeneratedPattern(StoreGeneratedPattern.None);
 
-            modelBuilder.Entity<NullSemanticsEntity2>().Property(e => e.StringA).Required(true);
-            modelBuilder.Entity<NullSemanticsEntity2>().Property(e => e.StringB).Required(true);
-            modelBuilder.Entity<NullSemanticsEntity2>().Property(e => e.StringC).Required(true);
+            modelBuilder.Entity<NullSemanticsEntity2>().Property(e => e.StringA).Required();
+            modelBuilder.Entity<NullSemanticsEntity2>().Property(e => e.StringB).Required();
+            modelBuilder.Entity<NullSemanticsEntity2>().Property(e => e.StringC).Required();
         }
     }
 }

--- a/test/EntityFramework.Relational.FunctionalTests/TransactionFixtureBase.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/TransactionFixtureBase.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Data.Common;
 using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Data.Entity.Metadata;
 
 namespace Microsoft.Data.Entity.Relational.FunctionalTests
 {
@@ -20,7 +21,7 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
         {
             modelBuilder.Entity<TransactionCustomer>(ps =>
                 {
-                    ps.Property(c => c.Id).GenerateValueOnAdd(generateValue: false);
+                    ps.Property(c => c.Id).StoreGeneratedPattern(StoreGeneratedPattern.None);
                     ps.Table("Customers");
                 });
         }
@@ -38,18 +39,18 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
         }
 
         public readonly IReadOnlyList<TransactionCustomer> Customers = new List<TransactionCustomer>
+        {
+            new TransactionCustomer
             {
-                new TransactionCustomer
-                    {
-                        Id = 1,
-                        Name = "Bob"
-                    },
-                new TransactionCustomer
-                    {
-                        Id = 2,
-                        Name = "Dave"
-                    }
-            };
+                Id = 1,
+                Name = "Bob"
+            },
+            new TransactionCustomer
+            {
+                Id = 2,
+                Name = "Dave"
+            }
+        };
     }
 
     public class TransactionCustomer
@@ -69,14 +70,8 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
                    && Name == otherCustomer.Name;
         }
 
-        public override string ToString()
-        {
-            return "Id = " + Id + ", Name = " + Name;
-        }
+        public override string ToString() => "Id = " + Id + ", Name = " + Name;
 
-        public override int GetHashCode()
-        {
-            return base.GetHashCode();
-        }
+        public override int GetHashCode() => Id.GetHashCode() * 397 ^ Name.GetHashCode();
     }
 }

--- a/test/EntityFramework.Relational.Tests/Update/CommandBatchPreparerTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/CommandBatchPreparerTest.cs
@@ -383,7 +383,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
                 IDbContextOptions options,
                 IRelationalMetadataExtensionProvider metadataExtensionProvider)
             {
-                return new SingularModificationCommandBatch(SqlGenerator, metadataExtensionProvider);
+                return new SingularModificationCommandBatch(SqlGenerator);
             }
         }
     }

--- a/test/EntityFramework.Relational.Tests/Update/ModificationCommandBatchFactoryTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/ModificationCommandBatchFactoryTest.cs
@@ -49,16 +49,6 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             modificationCommandBatchMock.Verify(mcb => mcb.AddCommand(mockModificationCommand));
         }
 
-        private class TestMetadataExtensionProvider : IRelationalMetadataExtensionProvider
-        {
-            public IRelationalEntityTypeExtensions Extensions(IEntityType entityType) => entityType.Relational();
-            public IRelationalForeignKeyExtensions Extensions(IForeignKey foreignKey) => foreignKey.Relational();
-            public IRelationalIndexExtensions Extensions(IIndex index) => index.Relational();
-            public IRelationalKeyExtensions Extensions(IKey key) => key.Relational();
-            public IRelationalPropertyExtensions Extensions(IProperty property) => property.Relational();
-            public IRelationalModelExtensions Extensions(IModel model) => model.Relational();
-        }
-
         private class TestModificationCommandBatchFactory : ModificationCommandBatchFactory
         {
             public TestModificationCommandBatchFactory(
@@ -71,7 +61,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
                 IDbContextOptions options,
                 IRelationalMetadataExtensionProvider metadataExtensionProvider)
             {
-                return new SingularModificationCommandBatch(SqlGenerator, metadataExtensionProvider);
+                return new SingularModificationCommandBatch(SqlGenerator);
             }
         }
     }

--- a/test/EntityFramework.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
@@ -621,29 +621,19 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             return RelationalTestHelpers.Instance.CreateInternalEntry(model, entityState, new T1 { Id = 1, Name = computeNonKeyValue ? null : "Test" });
         }
 
-        private class MetadataExtensionProviderFake : IRelationalMetadataExtensionProvider
-        {
-            public IRelationalEntityTypeExtensions Extensions(IEntityType entityType) => entityType.Relational();
-            public IRelationalForeignKeyExtensions Extensions(IForeignKey foreignKey) => foreignKey.Relational();
-            public IRelationalIndexExtensions Extensions(IIndex index) => index.Relational();
-            public IRelationalKeyExtensions Extensions(IKey key) => key.Relational();
-            public IRelationalPropertyExtensions Extensions(IProperty property) => property.Relational();
-            public IRelationalModelExtensions Extensions(IModel model) => model.Relational();
-        }
-
         private class ModificationCommandBatchFake : ReaderModificationCommandBatch
         {
             private readonly DbDataReader _reader;
 
             public ModificationCommandBatchFake(ISqlGenerator sqlGenerator = null)
-                : base(sqlGenerator ?? new FakeSqlGenerator(), new MetadataExtensionProviderFake())
+                : base(sqlGenerator ?? new FakeSqlGenerator())
             {
                 ShouldAddCommand = true;
                 ShouldValidateSql = true;
             }
 
             public ModificationCommandBatchFake(DbDataReader reader, ISqlGenerator sqlGenerator = null)
-                : base(sqlGenerator ?? new FakeSqlGenerator(), new MetadataExtensionProviderFake())
+                : base(sqlGenerator ?? new FakeSqlGenerator())
             {
                 _reader = reader;
                 ShouldAddCommand = true;

--- a/test/EntityFramework.SqlServer.FunctionalTests/BatchingTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/BatchingTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using Microsoft.Data.Entity.FunctionalTests;
 using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
 using Microsoft.Framework.DependencyInjection;
 using Xunit;
 
@@ -42,6 +43,11 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             public BloggingContext(IServiceProvider serviceProvider, DbContextOptions options)
                 : base(serviceProvider, options)
             {
+            }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<Blog>().Property(e => e.Id).StoreGeneratedPattern(StoreGeneratedPattern.None);
             }
 
             public DbSet<Blog> Blogs { get; set; }

--- a/test/EntityFramework.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerFixture.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerFixture.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Reflection;
 using Microsoft.Data.Entity.FunctionalTests;
 using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
 using Microsoft.Framework.DependencyInjection;
 
 namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
@@ -69,8 +70,31 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                     b.Ignore(dt => dt.TestNullableSignedByte);
                 });
 
-            modelBuilder.Entity<MappedDataTypes>().Key(e => e.Int);
-            modelBuilder.Entity<MappedNullableDataTypes>().Key(e => e.Int);
+            modelBuilder.Entity<MappedDataTypes>(b =>
+                {
+                    b.Key(e => e.Int);
+                    b.Property(e => e.Int)
+                        .StoreGeneratedPattern(StoreGeneratedPattern.None);
+                });
+
+            modelBuilder.Entity<MappedNullableDataTypes>(b =>
+            {
+                b.Key(e => e.Int);
+                b.Property(e => e.Int)
+                    .StoreGeneratedPattern(StoreGeneratedPattern.None);
+            });
+
+            modelBuilder.Entity<MappedSizedDataTypes>()
+                .Property(e => e.Id)
+                .StoreGeneratedPattern(StoreGeneratedPattern.None);
+
+            modelBuilder.Entity<MappedScaledDataTypes>()
+                .Property(e => e.Id)
+                .StoreGeneratedPattern(StoreGeneratedPattern.None);
+
+            modelBuilder.Entity<MappedPrecisionAndScaledDataTypes>()
+                .Property(e => e.Id)
+                .StoreGeneratedPattern(StoreGeneratedPattern.None);
 
             MapColumnTypes<MappedDataTypes>(modelBuilder);
             MapColumnTypes<MappedNullableDataTypes>(modelBuilder);

--- a/test/EntityFramework.SqlServer.FunctionalTests/CommandConfigurationTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/CommandConfigurationTest.cs
@@ -7,6 +7,7 @@ using System.Data.Common;
 using System.Linq;
 using Microsoft.Data.Entity.FunctionalTests;
 using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Query;
 using Microsoft.Data.Entity.Relational;
 using Microsoft.Data.Entity.Relational.FunctionalTests;
 using Microsoft.Data.Entity.Relational.Metadata;
@@ -362,9 +363,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
             public TestSqlServerModificationCommandBatch(
                 ISqlServerSqlGenerator sqlGenerator,
-                IRelationalMetadataExtensionProvider metadataExtensionProvider,
                 int? maxBatchSize)
-                : base(sqlGenerator, metadataExtensionProvider, maxBatchSize)
+                : base(sqlGenerator, maxBatchSize)
             {
             }
         }
@@ -387,7 +387,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
                 return new TestSqlServerModificationCommandBatch(
                     (ISqlServerSqlGenerator)SqlGenerator,
-                    metadataExtensionProvider,
                     maxBatchSize);
             }
         }
@@ -404,6 +403,11 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             {
                 optionsBuilder.UseSqlServer(SqlServerTestStore.CreateConnectionString(DatabaseName));
+            }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.ForSqlServer().UseSequence();
             }
         }
 

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
@@ -169,7 +169,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                     Assert.Equal(5, TestSqlLoggerFactory.SqlStatements.Count);
                     Assert.Contains("SELECT", TestSqlLoggerFactory.SqlStatements[0]);
                     Assert.Contains("SELECT", TestSqlLoggerFactory.SqlStatements[1]);
-                    Assert.Contains("@p0: 3", TestSqlLoggerFactory.SqlStatements[3]);
+                    Assert.Contains("@p0: 11", TestSqlLoggerFactory.SqlStatements[3]);
                     Assert.Contains("DELETE", TestSqlLoggerFactory.SqlStatements[4]);
                     Assert.Contains("UPDATE", TestSqlLoggerFactory.SqlStatements[4]);
                     Assert.Contains("INSERT", TestSqlLoggerFactory.SqlStatements[4]);
@@ -541,6 +541,11 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             public BloggingContext(IServiceProvider serviceProvider, DbContextOptions options)
                 : base(serviceProvider, options)
             {
+            }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.ForSqlServer().UseSequence();
             }
         }
 

--- a/test/EntityFramework.SqlServer.FunctionalTests/TransactionSqlServerFixture.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/TransactionSqlServerFixture.cs
@@ -4,9 +4,7 @@
 using System;
 using System.Data.Common;
 using Microsoft.Data.Entity.FunctionalTests;
-using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Relational.FunctionalTests;
-using Microsoft.Data.Entity.SqlServer.Metadata;
 using Microsoft.Framework.DependencyInjection;
 
 namespace Microsoft.Data.Entity.SqlServer.FunctionalTests

--- a/test/EntityFramework.SqlServer.FunctionalTests/TransactionSqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/TransactionSqlServerTest.cs
@@ -12,9 +12,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         {
         }
 
-        protected override bool SnapshotSupported
-        {
-            get { return true; }
-        }
+        protected override bool SnapshotSupported => true;
     }
 }

--- a/test/EntityFramework.SqlServer.Tests/Metadata/ModelConventions/SqlServerValueGenerationStrategyConventionTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/Metadata/ModelConventions/SqlServerValueGenerationStrategyConventionTest.cs
@@ -16,6 +16,20 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata.ModelConventions
         {
             var model = new SqlServerModelBuilderFactory().CreateConventionBuilder(new Model()).Model;
 
+            Assert.Equal(1, model.Annotations.Count());
+
+            Assert.Equal(SqlServerAnnotationNames.Prefix + SqlServerAnnotationNames.ValueGeneration, model.Annotations.Single().Name);
+            Assert.Equal(SqlServerValueGenerationStrategy.Identity.ToString(), model.Annotations.Single().Value);
+        }
+
+        [Fact]
+        public void Annotations_are_added_when_conventional_model_builder_is_used_with_sequences()
+        {
+            var model = new SqlServerModelBuilderFactory()
+                .CreateConventionBuilder(new Model())
+                .ForSqlServer(b => b.UseSequence())
+                .Model;
+
             Assert.Equal(3, model.Annotations.Count());
 
             Assert.Equal(SqlServerAnnotationNames.Prefix + SqlServerAnnotationNames.DefaultSequenceName, model.Annotations.ElementAt(0).Name);

--- a/test/EntityFramework.SqlServer.Tests/Metadata/SqlServerMetadataExtensionsTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/Metadata/SqlServerMetadataExtensionsTest.cs
@@ -891,7 +891,6 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             modelBuilder.Model.SqlServer().AddOrReplaceSequence(new Sequence("DaneelOlivaw"));
             modelBuilder.Model.SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.Sequence;
             property.SqlServer().SequenceName = "DaneelOlivaw";
-            property.SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.Default;
 
             Assert.Equal("DaneelOlivaw", property.SqlServer().TryGetSequence().Name);
             Assert.Equal("DaneelOlivaw", ((IProperty)property).SqlServer().TryGetSequence().Name);
@@ -928,7 +927,6 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             modelBuilder.Model.SqlServer().AddOrReplaceSequence(new Sequence("DaneelOlivaw"));
             modelBuilder.Model.SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.Sequence;
             modelBuilder.Model.SqlServer().DefaultSequenceName = "DaneelOlivaw";
-            property.SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.Default;
 
             Assert.Equal("DaneelOlivaw", property.SqlServer().TryGetSequence().Name);
             Assert.Equal("DaneelOlivaw", ((IProperty)property).SqlServer().TryGetSequence().Name);
@@ -969,7 +967,6 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             modelBuilder.Model.SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.Sequence;
             property.SqlServer().SequenceName = "DaneelOlivaw";
             property.SqlServer().SequenceSchema = "R";
-            property.SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.Default;
 
             Assert.Equal("DaneelOlivaw", property.SqlServer().TryGetSequence().Name);
             Assert.Equal("DaneelOlivaw", ((IProperty)property).SqlServer().TryGetSequence().Name);
@@ -1012,7 +1009,6 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             modelBuilder.Model.SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.Sequence;
             modelBuilder.Model.SqlServer().DefaultSequenceName = "DaneelOlivaw";
             modelBuilder.Model.SqlServer().DefaultSequenceSchema = "R";
-            property.SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.Default;
 
             Assert.Equal("DaneelOlivaw", property.SqlServer().TryGetSequence().Name);
             Assert.Equal("DaneelOlivaw", ((IProperty)property).SqlServer().TryGetSequence().Name);

--- a/test/EntityFramework.SqlServer.Tests/SqlServerValueGeneratorCacheTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerValueGeneratorCacheTest.cs
@@ -93,7 +93,6 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                 .Entity<Robot>()
                 .Property(e => e.Id)
                 .GenerateValueOnAdd()
-                .ForSqlServer(b => b.UseDefaultValueGeneration())
                 .Metadata;
 
             var cache = new SqlServerValueGeneratorCache();
@@ -109,7 +108,6 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                 .Entity<Robot>()
                 .Property(e => e.Id)
                 .GenerateValueOnAdd()
-                .ForSqlServer(b => b.UseDefaultValueGeneration())
                 .Metadata;
 
             var cache = new SqlServerValueGeneratorCache();
@@ -159,7 +157,6 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                 .Entity<Robot>()
                 .Property(e => e.Id)
                 .GenerateValueOnAdd()
-                .ForSqlServer(b => b.UseDefaultValueGeneration())
                 .Metadata;
 
             var cache = new SqlServerValueGeneratorCache();
@@ -196,7 +193,6 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                 .Entity<Robot>()
                 .Property(e => e.Id)
                 .GenerateValueOnAdd()
-                .ForSqlServer(b => b.UseDefaultValueGeneration())
                 .Metadata;
 
             var cache = new SqlServerValueGeneratorCache();
@@ -240,7 +236,6 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                 .Entity<Robot>()
                 .Property(e => e.Id)
                 .GenerateValueOnAdd()
-                .ForSqlServer(b => b.UseDefaultValueGeneration())
                 .Metadata;
 
             var cache = new SqlServerValueGeneratorCache();
@@ -256,7 +251,6 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                 .Entity<Robot>()
                 .Property(e => e.Id)
                 .GenerateValueOnAdd()
-                .ForSqlServer(b => b.UseDefaultValueGeneration())
                 .Metadata;
 
             var cache = new SqlServerValueGeneratorCache();
@@ -306,7 +300,6 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                 .Entity<Robot>()
                 .Property(e => e.Id)
                 .GenerateValueOnAdd()
-                .ForSqlServer(b => b.UseDefaultValueGeneration())
                 .Metadata;
 
             var cache = new SqlServerValueGeneratorCache();
@@ -326,7 +319,6 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                 .Entity<Robot>()
                 .Property(e => e.Id)
                 .GenerateValueOnAdd()
-                .ForSqlServer(b => b.UseDefaultValueGeneration())
                 .Metadata;
 
             var cache = new SqlServerValueGeneratorCache();
@@ -356,7 +348,6 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                 .Entity<Robot>()
                 .Property(e => e.Id)
                 .GenerateValueOnAdd()
-                .ForSqlServer(b => b.UseDefaultValueGeneration())
                 .Metadata;
 
             var cache = new SqlServerValueGeneratorCache();
@@ -391,7 +382,6 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                 .Entity<Robot>()
                 .Property(e => e.Id)
                 .GenerateValueOnAdd()
-                .ForSqlServer(b => b.UseDefaultValueGeneration())
                 .Metadata;
 
             var cache = new SqlServerValueGeneratorCache();

--- a/test/EntityFramework.SqlServer.Tests/SqlServerValueGeneratorSelectorTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerValueGeneratorSelectorTest.cs
@@ -107,20 +107,6 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             Assert.IsType<SqlServerSequenceValueGenerator<int>>(selector.Select(entityType.GetProperty("Id"), entityType));
         }
 
-        [Fact]
-        public void Does_not_return_generator_configured_on_model_when_default_is_not_set_on_property()
-        {
-            var model = SqlServerTestHelpers.Instance.BuildModelFor<AnEntity>();
-            model.SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.Sequence;
-            var entityType = model.GetEntityType(typeof(AnEntity));
-            var property = entityType.GetProperty("Id");
-            property.StoreGeneratedPattern = StoreGeneratedPattern.None;
-
-            var selector = SqlServerTestHelpers.Instance.CreateContextServices(model).GetRequiredService<IValueGeneratorSelector>();
-
-            Assert.IsType<TemporaryNumberValueGenerator<int>>(selector.Select(property, entityType));
-        }
-
         private static Model BuildModel(bool generateValues = true)
         {
             var model = SqlServerTestHelpers.Instance.BuildModelFor<AnEntity>();
@@ -130,7 +116,6 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             foreach (var property in entityType.Properties)
             {
                 property.GenerateValueOnAdd = generateValues;
-                property.SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.Default;
             }
 
             entityType.GetProperty("AlwaysIdentity").SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.Identity;

--- a/test/EntityFramework.SqlServer.Tests/Update/SqlServerModificationCommandBatchTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/Update/SqlServerModificationCommandBatchTest.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.Data.Entity.Relational;
 using Microsoft.Data.Entity.Relational.Update;
-using Microsoft.Data.Entity.SqlServer.Metadata;
 using Microsoft.Data.Entity.SqlServer.Update;
 using Xunit;
 
@@ -14,10 +13,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Update
         [Fact]
         public void AddCommand_returns_false_when_max_batch_size_is_reached()
         {
-            var batch = new SqlServerModificationCommandBatch(
-                new SqlServerSqlGenerator(),
-                new SqlServerMetadataExtensionProvider(),
-                1);
+            var batch = new SqlServerModificationCommandBatch(new SqlServerSqlGenerator(), 1);
 
             Assert.True(batch.AddCommand(new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.SqlServer(), new UntypedValueBufferFactoryFactory())));
             Assert.False(batch.AddCommand(new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.SqlServer(), new UntypedValueBufferFactoryFactory())));


### PR DESCRIPTION
Also remove all SQL Server-specific ways to change whether a property is considered StoreGneratedPattern.Identity or not. This is a core level concept that should be handled by the core.

Issue #2175.