### PR TITLE
Support value generation for 'char' properties

### DIFF
--- a/src/EntityFramework.Core/ValueGeneration/TemporaryNumberValueGeneratorFactory.cs
+++ b/src/EntityFramework.Core/ValueGeneration/TemporaryNumberValueGeneratorFactory.cs
@@ -36,6 +36,11 @@ namespace Microsoft.Data.Entity.ValueGeneration
                 return new TemporaryNumberValueGenerator<byte>();
             }
 
+            if (type == typeof(char))
+            {
+                return new TemporaryNumberValueGenerator<char>();
+            }
+
             if (type == typeof(ulong))
             {
                 return new TemporaryNumberValueGenerator<ulong>();

--- a/src/EntityFramework.SqlServer/ValueGeneration/SqlServerSequenceValueGeneratorFactory.cs
+++ b/src/EntityFramework.SqlServer/ValueGeneration/SqlServerSequenceValueGeneratorFactory.cs
@@ -52,6 +52,11 @@ namespace Microsoft.Data.Entity.SqlServer.ValueGeneration
                 return new SqlServerSequenceValueGenerator<byte>(_executor, _sqlGenerator, generatorState, connection);
             }
 
+            if (property.ClrType.UnwrapNullableType() == typeof(char))
+            {
+                return new SqlServerSequenceValueGenerator<char>(_executor, _sqlGenerator, generatorState, connection);
+            }
+
             if (property.ClrType.UnwrapNullableType() == typeof(ulong))
             {
                 return new SqlServerSequenceValueGenerator<ulong>(_executor, _sqlGenerator, generatorState, connection);

--- a/src/Shared/SharedTypeExtensions.cs
+++ b/src/Shared/SharedTypeExtensions.cs
@@ -39,7 +39,8 @@ namespace System
                    || type == typeof(uint)
                    || type == typeof(ulong)
                    || type == typeof(ushort)
-                   || type == typeof(sbyte);
+                   || type == typeof(sbyte)
+                   || type == typeof(char);
         }
 
         public static PropertyInfo GetAnyProperty(this Type type, string name)
@@ -59,7 +60,6 @@ namespace System
 
             return type == typeof(bool)
                    || type == typeof(byte[])
-                   || type == typeof(char)
                    || type == typeof(DateTime)
                    || type == typeof(DateTimeOffset)
                    || type == typeof(decimal)

--- a/test/EntityFramework.SqlServer.Tests/SqlServerValueGeneratorSelectorTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerValueGeneratorSelectorTest.cs
@@ -27,10 +27,12 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             Assert.IsType<TemporaryNumberValueGenerator<long>>(selector.Select(entityType.GetProperty("Long"), entityType));
             Assert.IsType<TemporaryNumberValueGenerator<short>>(selector.Select(entityType.GetProperty("Short"), entityType));
             Assert.IsType<TemporaryNumberValueGenerator<byte>>(selector.Select(entityType.GetProperty("Byte"), entityType));
+            Assert.IsType<TemporaryNumberValueGenerator<char>>(selector.Select(entityType.GetProperty("Char"), entityType));
             Assert.IsType<TemporaryNumberValueGenerator<int>>(selector.Select(entityType.GetProperty("NullableInt"), entityType));
             Assert.IsType<TemporaryNumberValueGenerator<long>>(selector.Select(entityType.GetProperty("NullableLong"), entityType));
             Assert.IsType<TemporaryNumberValueGenerator<short>>(selector.Select(entityType.GetProperty("NullableShort"), entityType));
             Assert.IsType<TemporaryNumberValueGenerator<byte>>(selector.Select(entityType.GetProperty("NullableByte"), entityType));
+            Assert.IsType<TemporaryNumberValueGenerator<char>>(selector.Select(entityType.GetProperty("NullableChar"), entityType));
             Assert.IsType<TemporaryNumberValueGenerator<uint>>(selector.Select(entityType.GetProperty("UInt"), entityType));
             Assert.IsType<TemporaryNumberValueGenerator<ulong>>(selector.Select(entityType.GetProperty("ULong"), entityType));
             Assert.IsType<TemporaryNumberValueGenerator<ushort>>(selector.Select(entityType.GetProperty("UShort"), entityType));
@@ -59,10 +61,12 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             Assert.IsType<SqlServerSequenceValueGenerator<long>>(selector.Select(entityType.GetProperty("Long"), entityType));
             Assert.IsType<SqlServerSequenceValueGenerator<short>>(selector.Select(entityType.GetProperty("Short"), entityType));
             Assert.IsType<SqlServerSequenceValueGenerator<byte>>(selector.Select(entityType.GetProperty("Byte"), entityType));
+            Assert.IsType<SqlServerSequenceValueGenerator<char>>(selector.Select(entityType.GetProperty("Char"), entityType));
             Assert.IsType<SqlServerSequenceValueGenerator<int>>(selector.Select(entityType.GetProperty("NullableInt"), entityType));
             Assert.IsType<SqlServerSequenceValueGenerator<long>>(selector.Select(entityType.GetProperty("NullableLong"), entityType));
             Assert.IsType<SqlServerSequenceValueGenerator<short>>(selector.Select(entityType.GetProperty("NullableShort"), entityType));
             Assert.IsType<SqlServerSequenceValueGenerator<byte>>(selector.Select(entityType.GetProperty("NullableByte"), entityType));
+            Assert.IsType<SqlServerSequenceValueGenerator<char>>(selector.Select(entityType.GetProperty("NullableChar"), entityType));
             Assert.IsType<SqlServerSequenceValueGenerator<uint>>(selector.Select(entityType.GetProperty("UInt"), entityType));
             Assert.IsType<SqlServerSequenceValueGenerator<ulong>>(selector.Select(entityType.GetProperty("ULong"), entityType));
             Assert.IsType<SqlServerSequenceValueGenerator<ushort>>(selector.Select(entityType.GetProperty("UShort"), entityType));
@@ -141,10 +145,12 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             public long Long { get; set; }
             public short Short { get; set; }
             public byte Byte { get; set; }
+            public char Char { get; set; }
             public int? NullableInt { get; set; }
             public long? NullableLong { get; set; }
             public short? NullableShort { get; set; }
             public byte? NullableByte { get; set; }
+            public char? NullableChar { get; set; }
             public uint UInt { get; set; }
             public ulong ULong { get; set; }
             public ushort UShort { get; set; }


### PR DESCRIPTION
Fixes #2217.

Note this only works for mapping char properties to some form of integer column. String columns (char, nchar, etc) must be mapped to strings until we can do type conversion between the SQL Client layer and the EF entity.