### PR TITLE
React to Roslyn API change

### DIFF
--- a/src/EntityFramework.Relational.Design/Templating/Compilation/MetadataReferencesProvider.cs
+++ b/src/EntityFramework.Relational.Design/Templating/Compilation/MetadataReferencesProvider.cs
@@ -53,14 +53,14 @@ namespace Microsoft.Data.Entity.Relational.Design.Templating.Compilation
             AddReferenceFromName("System.Threading.Tasks");
             AddReferenceFromName("Microsoft.CSharp");
 #else
-            _references.Add(MetadataReference.CreateFromAssembly(
-                Assembly.Load(new AssemblyName("mscorlib"))));
-            _references.Add(MetadataReference.CreateFromAssembly(
-                Assembly.Load(new AssemblyName("System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"))));
-            _references.Add(MetadataReference.CreateFromAssembly(
-                Assembly.Load(new AssemblyName("System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"))));
-            _references.Add(MetadataReference.CreateFromAssembly(
-                Assembly.Load(new AssemblyName("Microsoft.CSharp, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"))));
+            _references.Add(MetadataReference.CreateFromFile(
+                Assembly.Load(new AssemblyName("mscorlib")).Location));
+            _references.Add(MetadataReference.CreateFromFile(
+                Assembly.Load(new AssemblyName("System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")).Location));
+            _references.Add(MetadataReference.CreateFromFile(
+                Assembly.Load(new AssemblyName("System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")).Location));
+            _references.Add(MetadataReference.CreateFromFile(
+                Assembly.Load(new AssemblyName("Microsoft.CSharp, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")).Location));
 #endif
             AddReferenceFromName("EntityFramework.Relational.Design");
         }
@@ -100,7 +100,7 @@ namespace Microsoft.Data.Entity.Relational.Design.Templating.Compilation
 
             throw new InvalidOperationException(Strings.UnableToCreateMetadataReference(name));
 #else
-            _references.Add(MetadataReference.CreateFromAssembly(Assembly.Load(name)));
+            _references.Add(MetadataReference.CreateFromFile(Assembly.Load(name).Location));
 #endif
         }
     }

--- a/test/EntityFramework.Commands.FunctionalTests/TestUtilities/BuildReference.cs
+++ b/test/EntityFramework.Commands.FunctionalTests/TestUtilities/BuildReference.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Data.Entity.Commands.TestUtilities
             if (!string.IsNullOrEmpty(assembly.Location))
             {
                 return new BuildReference(
-                    MetadataReference.CreateFromAssembly(assembly),
+                    MetadataReference.CreateFromFile(assembly.Location),
                     copyLocal,
                     new Uri(assembly.CodeBase).LocalPath);
             }


### PR DESCRIPTION
error CS0619: 'MetadataReference.CreateFromAssembly(Assembly)' is
obsolete: 'Use CreateFromFile(assembly.Location) instead'