### PR TITLE
Remove GenerateValueOnAdd from fluent API

### DIFF
--- a/src/EntityFramework.Commands/Migrations/CSharpModelGenerator.cs
+++ b/src/EntityFramework.Commands/Migrations/CSharpModelGenerator.cs
@@ -168,13 +168,6 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                         .Append(".ConcurrencyToken()");
                 }
 
-                if (property.IsValueGeneratedOnAdd)
-                {
-                    stringBuilder
-                        .AppendLine()
-                        .Append(".GenerateValueOnAdd()");
-                }
-
                 if (property.IsNullable != (property.ClrType.IsNullableType() && !property.IsPrimaryKey()))
                 {
                     stringBuilder

--- a/src/EntityFramework.Core/Metadata/Builders/PropertyBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Builders/PropertyBuilder.cs
@@ -116,21 +116,6 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         }
 
         /// <summary>
-        ///     Configures whether a value is generated for this property when a new instance of the entity type
-        ///     is added to a context. Data stores will typically register an appropriate
-        ///     <see cref="ValueGenerator" /> to handle generating values. This functionality is typically
-        ///     used for key values and is switched on by convention.
-        /// </summary>
-        /// <param name="generateValue"> A value indicating whether a value should be generated. </param>
-        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
-        public virtual PropertyBuilder GenerateValueOnAdd(bool generateValue = true)
-        {
-            Builder.GenerateValueOnAdd(generateValue, ConfigurationSource.Explicit);
-
-            return this;
-        }
-
-        /// <summary>
         ///     <para>
         ///         Configures whether a value is generated for this property by the data store when an
         ///         instance of this entity type is saved.

--- a/src/EntityFramework.Core/Metadata/Builders/PropertyBuilder`.cs
+++ b/src/EntityFramework.Core/Metadata/Builders/PropertyBuilder`.cs
@@ -76,17 +76,6 @@ namespace Microsoft.Data.Entity.Metadata.Builders
             => (PropertyBuilder<TProperty>)base.ConcurrencyToken(isConcurrencyToken);
 
         /// <summary>
-        ///     Configures whether a value is generated for this property when a new instance of the entity type
-        ///     is added to a context. Data stores will typically register an appropriate
-        ///     <see cref="ValueGenerator" /> to handle generating values. This functionality is typically
-        ///     used for key values and is switched on by convention.
-        /// </summary>
-        /// <param name="generateValue"> A value indicating whether a value should be generated. </param>
-        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
-        public new virtual PropertyBuilder<TProperty> GenerateValueOnAdd(bool generateValue = true)
-            => (PropertyBuilder<TProperty>)base.GenerateValueOnAdd(generateValue);
-
-        /// <summary>
         ///     <para>
         ///         Configures whether a value is generated for this property by the data store when an
         ///         instance of this entity type is saved.

--- a/src/EntityFramework.Core/Metadata/Internal/InternalPropertyBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/InternalPropertyBuilder.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
         private ConfigurationSource? _maxLengthConfigurationSource;
         private ConfigurationSource? _isConcurrencyTokenConfigurationSource;
         private ConfigurationSource _isShadowPropertyConfigurationSource;
-        private ConfigurationSource? _generateValueOnAddConfigurationSource;
+        private ConfigurationSource? _isValueGeneratedOnAddConfigurationSource;
         private ConfigurationSource? _storeGeneratedPatternConfigurationSource;
 
         public InternalPropertyBuilder(
@@ -108,20 +108,20 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
         public virtual bool GenerateValueOnAdd(bool? generateValue, ConfigurationSource configurationSource)
         {
-            if (configurationSource.CanSet(_generateValueOnAddConfigurationSource, Metadata.GenerateValueOnAdd.HasValue)
-                || Metadata.GenerateValueOnAdd.Value == generateValue)
+            if (configurationSource.CanSet(_isValueGeneratedOnAddConfigurationSource, Metadata.IsValueGeneratedOnAdd.HasValue)
+                || Metadata.IsValueGeneratedOnAdd.Value == generateValue)
             {
-                if (_generateValueOnAddConfigurationSource == null
-                    && Metadata.GenerateValueOnAdd != null)
+                if (_isValueGeneratedOnAddConfigurationSource == null
+                    && Metadata.IsValueGeneratedOnAdd != null)
                 {
-                    _generateValueOnAddConfigurationSource = ConfigurationSource.Explicit;
+                    _isValueGeneratedOnAddConfigurationSource = ConfigurationSource.Explicit;
                 }
                 else
                 {
-                    _generateValueOnAddConfigurationSource = configurationSource.Max(_generateValueOnAddConfigurationSource);
+                    _isValueGeneratedOnAddConfigurationSource = configurationSource.Max(_isValueGeneratedOnAddConfigurationSource);
                 }
 
-                Metadata.GenerateValueOnAdd = generateValue;
+                Metadata.IsValueGeneratedOnAdd = generateValue;
                 return true;
             }
 

--- a/src/EntityFramework.Core/Metadata/Property.cs
+++ b/src/EntityFramework.Core/Metadata/Property.cs
@@ -121,13 +121,13 @@ namespace Microsoft.Data.Entity.Metadata
             => StoreGeneratedPattern == Metadata.StoreGeneratedPattern.Computed
                || this.IsKey();
 
-        public virtual bool? GenerateValueOnAdd
+        public virtual bool? IsValueGeneratedOnAdd
         {
-            get { return GetFlag(PropertyFlags.GenerateValueOnAdd); }
-            set { SetFlag(value, PropertyFlags.GenerateValueOnAdd); }
+            get { return GetFlag(PropertyFlags.IsValueGeneratedOnAdd); }
+            set { SetFlag(value, PropertyFlags.IsValueGeneratedOnAdd); }
         }
 
-        protected virtual bool DefaultGenerateValueOnAdd => false;
+        protected virtual bool DefaultIsValueGeneratedOnAdd => false;
 
         public virtual bool IsShadowProperty
         {
@@ -236,7 +236,7 @@ namespace Microsoft.Data.Entity.Metadata
 
         bool IProperty.IsReadOnlyAfterSave => IsReadOnlyAfterSave ?? DefaultIsReadOnlyAfterSave;
 
-        bool IProperty.IsValueGeneratedOnAdd => GenerateValueOnAdd ?? DefaultGenerateValueOnAdd;
+        bool IProperty.IsValueGeneratedOnAdd => IsValueGeneratedOnAdd ?? DefaultIsValueGeneratedOnAdd;
 
         bool IProperty.IsConcurrencyToken => IsConcurrencyToken ?? DefaultIsConcurrencyToken;
 
@@ -251,7 +251,7 @@ namespace Microsoft.Data.Entity.Metadata
             IsReadOnlyAfterSave = 8,
             IsIdentity = 16,
             IsComputed = 32,
-            GenerateValueOnAdd = 64,
+            IsValueGeneratedOnAdd = 64,
             IsShadowProperty = 128
         }
     }

--- a/src/EntityFramework.SqlServer/Metadata/SqlServerPropertyExtensions.cs
+++ b/src/EntityFramework.SqlServer/Metadata/SqlServerPropertyExtensions.cs
@@ -117,7 +117,6 @@ namespace Microsoft.Data.Entity.SqlServer.Metadata
                 if (value == null)
                 {
                     property[SqlServerValueGenerationAnnotation] = null;
-                    property.GenerateValueOnAdd = null;
                 }
                 else
                 {
@@ -141,7 +140,6 @@ namespace Microsoft.Data.Entity.SqlServer.Metadata
 
                     // TODO: Issue #777: Non-string annotations
                     property[SqlServerValueGenerationAnnotation] = value.ToString();
-                    property.GenerateValueOnAdd = true;
                 }
             }
         }

--- a/test/EntityFramework.Commands.FunctionalTests/Migrations/ModelSnapshotTest.cs
+++ b/test/EntityFramework.Commands.FunctionalTests/Migrations/ModelSnapshotTest.cs
@@ -70,7 +70,6 @@ namespace Microsoft.Data.Entity.Commands.Migrations
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithOneProperty"", b =>
     {
         b.Property<int>(""Id"")
-            .GenerateValueOnAdd()
             .StoreGeneratedPattern(StoreGeneratedPattern.Identity);
 
         b.Key(""Id"");
@@ -79,7 +78,6 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", b =>
     {
         b.Property<int>(""Id"")
-            .GenerateValueOnAdd()
             .StoreGeneratedPattern(StoreGeneratedPattern.Identity);
 
         b.Property<int>(""AlternateId"");
@@ -113,7 +111,6 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithOneProperty"", b =>
     {
         b.Property<int>(""Id"")
-            .GenerateValueOnAdd()
             .StoreGeneratedPattern(StoreGeneratedPattern.Identity);
 
         b.Key(""Id"");
@@ -140,7 +137,6 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", b =>
     {
         b.Property<int>(""Id"")
-            .GenerateValueOnAdd()
             .StoreGeneratedPattern(StoreGeneratedPattern.Identity);
 
         b.Property<int>(""AlternateId"");
@@ -170,11 +166,9 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
                 @"
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", b =>
     {
-        b.Property<int>(""Id"")
-            .GenerateValueOnAdd();
+        b.Property<int>(""Id"");
 
-        b.Property<int>(""AlternateId"")
-            .GenerateValueOnAdd();
+        b.Property<int>(""AlternateId"");
 
         b.Key(""Id"", ""AlternateId"");
     });
@@ -202,7 +196,6 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", b =>
     {
         b.Property<int>(""Id"")
-            .GenerateValueOnAdd()
             .StoreGeneratedPattern(StoreGeneratedPattern.Identity);
 
         b.Property<int>(""AlternateId"");
@@ -231,7 +224,6 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", b =>
     {
         b.Property<int>(""Id"")
-            .GenerateValueOnAdd()
             .StoreGeneratedPattern(StoreGeneratedPattern.Identity);
 
         b.Property<int>(""AlternateId"");
@@ -263,7 +255,6 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithOneProperty"", b =>
     {
         b.Property<int>(""Id"")
-            .GenerateValueOnAdd()
             .StoreGeneratedPattern(StoreGeneratedPattern.Identity);
 
         b.Key(""Id"");
@@ -272,7 +263,6 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", b =>
     {
         b.Property<int>(""Id"")
-            .GenerateValueOnAdd()
             .StoreGeneratedPattern(StoreGeneratedPattern.Identity);
 
         b.Property<int>(""AlternateId"");
@@ -315,11 +305,9 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", b =>
     {
         b.Property<int>(""Id"")
-            .GenerateValueOnAdd()
             .StoreGeneratedPattern(StoreGeneratedPattern.Identity);
 
-        b.Property<int>(""AlternateId"")
-            .GenerateValueOnAdd();
+        b.Property<int>(""AlternateId"");
 
         b.Key(""Id"");
     });
@@ -355,7 +343,6 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithOneProperty"", b =>
     {
         b.Property<int>(""Id"")
-            .GenerateValueOnAdd()
             .StoreGeneratedPattern(StoreGeneratedPattern.Identity)
             .Annotation(""AnnotationName"", ""AnnotationValue"");
 
@@ -382,7 +369,6 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithStringProperty"", b =>
     {
         b.Property<int>(""Id"")
-            .GenerateValueOnAdd()
             .StoreGeneratedPattern(StoreGeneratedPattern.Identity);
 
         b.Property<string>(""Name"")
@@ -409,7 +395,6 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", b =>
     {
         b.Property<int>(""Id"")
-            .GenerateValueOnAdd()
             .StoreGeneratedPattern(StoreGeneratedPattern.Identity);
 
         b.Property<int>(""AlternateId"")
@@ -436,7 +421,6 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithStringProperty"", b =>
     {
         b.Property<int>(""Id"")
-            .GenerateValueOnAdd()
             .StoreGeneratedPattern(StoreGeneratedPattern.Identity);
 
         b.Property<string>(""Name"")
@@ -452,29 +436,27 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
         }
 
         [Fact]
-        public void Property_generateValueOnAdd_is_stored_in_snapshot()
+        public void Property_isValueGeneratedOnAdd_is_not_stored_in_snapshot()
         {
             Test(
                 builder =>
                     {
-                        builder.Entity<EntityWithTwoProperties>().Property<int>("AlternateId").GenerateValueOnAdd();
+                        builder.Entity<EntityWithTwoProperties>().Property<int>("AlternateId").Metadata.IsValueGeneratedOnAdd = true;
                     },
                 @"
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", b =>
     {
         b.Property<int>(""Id"")
-            .GenerateValueOnAdd()
             .StoreGeneratedPattern(StoreGeneratedPattern.Identity);
 
-        b.Property<int>(""AlternateId"")
-            .GenerateValueOnAdd();
+        b.Property<int>(""AlternateId"");
 
         b.Key(""Id"");
     });
 ",
                 o =>
                     {
-                        Assert.Equal(true, o.EntityTypes[0].GetProperty("AlternateId").IsValueGeneratedOnAdd);
+                        Assert.Equal(false, o.EntityTypes[0].GetProperty("AlternateId").IsValueGeneratedOnAdd);
                     });
         }
 
@@ -490,7 +472,6 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", b =>
     {
         b.Property<int>(""Id"")
-            .GenerateValueOnAdd()
             .StoreGeneratedPattern(StoreGeneratedPattern.Identity);
 
         b.Property<int>(""AlternateId"")
@@ -521,7 +502,6 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", b =>
     {
         b.Property<int>(""Id"")
-            .GenerateValueOnAdd()
             .StoreGeneratedPattern(StoreGeneratedPattern.Identity);
 
         b.Property<int>(""AlternateId"");
@@ -550,7 +530,6 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", b =>
     {
         b.Property<int>(""Id"")
-            .GenerateValueOnAdd()
             .StoreGeneratedPattern(StoreGeneratedPattern.Identity);
 
         b.Property<int>(""AlternateId"");
@@ -587,7 +566,6 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithOneProperty"", b =>
     {
         b.Property<int>(""Id"")
-            .GenerateValueOnAdd()
             .StoreGeneratedPattern(StoreGeneratedPattern.Identity);
 
         b.Key(""Id"");
@@ -596,7 +574,6 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", b =>
     {
         b.Property<int>(""Id"")
-            .GenerateValueOnAdd()
             .StoreGeneratedPattern(StoreGeneratedPattern.Identity);
 
         b.Property<int>(""AlternateId"");
@@ -633,8 +610,7 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
                 @"
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithStringKey"", b =>
     {
-        b.Property<string>(""Id"")
-            .GenerateValueOnAdd();
+        b.Property<string>(""Id"");
 
         b.Key(""Id"");
     });
@@ -642,7 +618,6 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithStringProperty"", b =>
     {
         b.Property<int>(""Id"")
-            .GenerateValueOnAdd()
             .StoreGeneratedPattern(StoreGeneratedPattern.Identity);
 
         b.Property<string>(""Name"")
@@ -678,8 +653,7 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
                 @"
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithStringKey"", b =>
     {
-        b.Property<string>(""Id"")
-            .GenerateValueOnAdd();
+        b.Property<string>(""Id"");
 
         b.Key(""Id"");
     });
@@ -687,7 +661,6 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithStringProperty"", b =>
     {
         b.Property<int>(""Id"")
-            .GenerateValueOnAdd()
             .StoreGeneratedPattern(StoreGeneratedPattern.Identity);
 
         b.Property<string>(""Name"");

--- a/test/EntityFramework.Core.FunctionalTests/InheritanceFixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/InheritanceFixtureBase.cs
@@ -15,13 +15,13 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
             var country = model.AddEntityType(typeof(Country));
             var countryIdProperty = country.AddProperty("Id", typeof(int));
-            countryIdProperty.GenerateValueOnAdd = true;
+            countryIdProperty.IsValueGeneratedOnAdd = true;
             var countryKey = country.SetPrimaryKey(countryIdProperty);
             country.AddProperty("Name", typeof(string));
 
             var animal = model.AddEntityType(typeof(Animal));
             var animalSpeciesProperty = animal.AddProperty("Species", typeof(string));
-            animalSpeciesProperty.GenerateValueOnAdd = true;
+            animalSpeciesProperty.IsValueGeneratedOnAdd = true;
             var animalKey = animal.SetPrimaryKey(animalSpeciesProperty);
             animal.AddProperty("Name", typeof(string));
             var countryFk = animal.AddForeignKey(animal.AddProperty("CountryId", typeof(int)), countryKey);

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
@@ -1806,7 +1806,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
                     b.Reference(e => e.Tag).InverseReference(e => e.Product)
                         .PrincipalKey<Product>(e => e.TagId)
                         .ForeignKey<ProductTag>(e => e.ProductId);
-                    b.Property(e => e.TagId).GenerateValueOnAdd(false);
+                    b.Property(e => e.TagId).Metadata.IsValueGeneratedOnAdd = false;
                 });
 
             builder.Entity<Category>(b =>
@@ -1814,12 +1814,12 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
                     b.Collection(e => e.Products).InverseReference(e => e.Category)
                         .ForeignKey(e => e.DependentId)
                         .PrincipalKey(e => e.PrincipalId);
-                    b.Property(e => e.PrincipalId).GenerateValueOnAdd(false);
+                    b.Property(e => e.PrincipalId).Metadata.IsValueGeneratedOnAdd = false;
 
                     b.Reference(e => e.Tag).InverseReference(e => e.Category)
                         .ForeignKey<CategoryTag>(e => e.CategoryId)
                         .PrincipalKey<Category>(e => e.TagId);
-                    b.Property(e => e.TagId).GenerateValueOnAdd(false);
+                    b.Property(e => e.TagId).Metadata.IsValueGeneratedOnAdd = false;
                 });
 
             builder.Entity<Person>()
@@ -2031,7 +2031,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
                     b.Reference(e => e.Tag).InverseReference(e => e.Product)
                         .PrincipalKey<NotifyingProduct>(e => e.TagId)
                         .ForeignKey<NotifyingProductTag>(e => e.ProductId);
-                    b.Property(e => e.TagId).GenerateValueOnAdd(false);
+                    b.Property(e => e.TagId).Metadata.IsValueGeneratedOnAdd = false;
                 });
 
 
@@ -2040,12 +2040,12 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
                     b.Collection(e => e.Products).InverseReference(e => e.Category)
                         .ForeignKey(e => e.DependentId)
                         .PrincipalKey(e => e.PrincipalId);
-                    b.Property(e => e.PrincipalId).GenerateValueOnAdd(false);
+                    b.Property(e => e.PrincipalId).Metadata.IsValueGeneratedOnAdd = false;
 
                     b.Reference(e => e.Tag).InverseReference(e => e.Category)
                         .ForeignKey<NotifyingCategoryTag>(e => e.CategoryId)
                         .PrincipalKey<NotifyingCategory>(e => e.TagId);
-                    b.Property(e => e.TagId).GenerateValueOnAdd(false);
+                    b.Property(e => e.TagId).Metadata.IsValueGeneratedOnAdd = false;
                 });
 
             builder.Entity<NotifyingPerson>()

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntityEntryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntityEntryTest.cs
@@ -1505,7 +1505,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var entityType1 = model.AddEntityType(typeof(SomeEntity));
             var key1 = entityType1.GetOrAddProperty("Id", typeof(int));
-            key1.GenerateValueOnAdd = true;
+            key1.IsValueGeneratedOnAdd = true;
             entityType1.GetOrSetPrimaryKey(key1);
             entityType1.GetOrAddProperty("Name", typeof(string)).IsConcurrencyToken = true;
 
@@ -1516,7 +1516,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var fk = entityType2.GetOrAddProperty("SomeEntityId", typeof(int));
             entityType2.GetOrAddForeignKey(new[] { fk }, entityType1.GetPrimaryKey());
             var justAProperty = entityType2.GetOrAddProperty("JustAProperty", typeof(int));
-            justAProperty.GenerateValueOnAdd = true;
+            justAProperty.IsValueGeneratedOnAdd = true;
 
             var entityType3 = model.AddEntityType(typeof(FullNotificationEntity));
             entityType3.GetOrSetPrimaryKey(entityType3.GetOrAddProperty("Id", typeof(int)));

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalMixedEntityEntryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalMixedEntityEntryTest.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             var entityType1 = model.AddEntityType(typeof(SomeEntity));
             var key1 = entityType1.GetOrAddProperty("Id", typeof(int), shadowProperty: true);
-            key1.GenerateValueOnAdd = true;
+            key1.IsValueGeneratedOnAdd = true;
             entityType1.GetOrSetPrimaryKey(key1);
             entityType1.GetOrAddProperty("Name", typeof(string));
 
@@ -136,7 +136,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var fk = entityType2.GetOrAddProperty("SomeEntityId", typeof(int), shadowProperty: true);
             entityType2.GetOrAddForeignKey(new[] { fk }, entityType1.GetPrimaryKey());
             var justAProperty = entityType2.GetOrAddProperty("JustAProperty", typeof(int));
-            justAProperty.GenerateValueOnAdd = true;
+            justAProperty.IsValueGeneratedOnAdd = true;
 
             var entityType3 = model.AddEntityType(typeof(FullNotificationEntity));
             entityType3.GetOrSetPrimaryKey(entityType3.GetOrAddProperty("Id", typeof(int), shadowProperty: true));

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalShadowEntityEntryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalShadowEntityEntryTest.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             var entityType1 = model.AddEntityType(typeof(SomeEntity).FullName);
             var key1 = entityType1.GetOrAddProperty("Id", typeof(int), shadowProperty: true);
-            key1.GenerateValueOnAdd = true;
+            key1.IsValueGeneratedOnAdd = true;
             entityType1.GetOrSetPrimaryKey(key1);
             entityType1.GetOrAddProperty("Name", typeof(string), shadowProperty: true).IsConcurrencyToken = true;
 
@@ -62,7 +62,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var fk = entityType2.GetOrAddProperty("SomeEntityId", typeof(int), shadowProperty: true);
             entityType2.GetOrAddForeignKey(new[] { fk }, entityType1.GetPrimaryKey());
             var justAProperty = entityType2.GetOrAddProperty("JustAProperty", typeof(int), shadowProperty: true);
-            justAProperty.GenerateValueOnAdd = true;
+            justAProperty.IsValueGeneratedOnAdd = true;
 
             var entityType3 = model.AddEntityType(typeof(FullNotificationEntity));
             entityType3.GetOrSetPrimaryKey(entityType3.GetOrAddProperty("Id", typeof(int), shadowProperty: true));

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/SidecarTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/SidecarTest.cs
@@ -393,7 +393,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             var idProperty = entityType.GetOrAddProperty("Id", typeof(int));
             idProperty.IsConcurrencyToken = true;
-            idProperty.GenerateValueOnAdd = true;
+            idProperty.IsValueGeneratedOnAdd = true;
             entityType.GetOrSetPrimaryKey(idProperty);
 
             entityType.GetOrAddProperty("Name", typeof(string));
@@ -410,7 +410,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var fk = entityType2.GetOrAddProperty("SomeEntityId", typeof(int));
             entityType2.GetOrAddForeignKey(new[] { fk }, entityType.GetPrimaryKey());
             var justAProperty = entityType2.GetOrAddProperty("JustAProperty", typeof(int));
-            justAProperty.GenerateValueOnAdd = true;
+            justAProperty.IsValueGeneratedOnAdd = true;
 
             var entityType5 = model.AddEntityType(typeof(SomeMoreDependentEntity));
             var key5 = entityType5.GetOrAddProperty("Id", typeof(int));

--- a/test/EntityFramework.Core.Tests/Extensions/PropertyExtensionsTest.cs
+++ b/test/EntityFramework.Core.Tests/Extensions/PropertyExtensionsTest.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Data.Entity.Tests
             var entityType = new EntityType("Entity", model);
             var property = entityType.AddProperty("Property", typeof(int), true);
 
-            property.GenerateValueOnAdd = true;
+            property.IsValueGeneratedOnAdd = true;
 
             Assert.Equal(property, property.GetGenerationProperty());
         }
@@ -52,7 +52,7 @@ namespace Microsoft.Data.Entity.Tests
             var thirdProperty = thirdType.AddProperty("ID", typeof(int), true);
             var thirdForeignKey = thirdType.AddForeignKey(thirdProperty, secondKey);
 
-            firstProperty.GenerateValueOnAdd = true;
+            firstProperty.IsValueGeneratedOnAdd = true;
 
             Assert.Equal(firstProperty, thirdProperty.GetGenerationProperty());
         }
@@ -83,7 +83,7 @@ namespace Microsoft.Data.Entity.Tests
 
             var endFK = endType.AddForeignKey(endProperty, middleKey1);
 
-            rightId2.GenerateValueOnAdd = true;
+            rightId2.IsValueGeneratedOnAdd = true;
 
             Assert.Equal(rightId2, endProperty.GetGenerationProperty());
         }
@@ -113,7 +113,7 @@ namespace Microsoft.Data.Entity.Tests
             var secondForeignKey1 = secondType.AddForeignKey(secondId1, firstKey);
             var secondForeignKey2 = secondType.AddForeignKey(new[] { secondId1, secondId2 }, leafKey);
 
-            leafId1.GenerateValueOnAdd = true;
+            leafId1.IsValueGeneratedOnAdd = true;
 
             Assert.Equal(leafId1, secondId1.GetGenerationProperty());
         }

--- a/test/EntityFramework.Core.Tests/Infrastructure/ModelValidatorTest.cs
+++ b/test/EntityFramework.Core.Tests/Infrastructure/ModelValidatorTest.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Data.Entity.Tests.Infrastructure
             CreateForeignKey(keyA, keyB);
             CreateForeignKey(keyB, keyA);
 
-            keyA.Properties[0].GenerateValueOnAdd = true;
+            keyA.Properties[0].IsValueGeneratedOnAdd = true;
 
             Validate(model);
         }
@@ -112,8 +112,8 @@ namespace Microsoft.Data.Entity.Tests.Infrastructure
             CreateForeignKey(keyA, keyB);
             CreateForeignKey(keyB, keyA);
             
-            keyA.Properties[0].GenerateValueOnAdd = true;
-            keyB.Properties[0].GenerateValueOnAdd = true;
+            keyA.Properties[0].IsValueGeneratedOnAdd = true;
+            keyB.Properties[0].IsValueGeneratedOnAdd = true;
 
             VerifyError(Strings.ForeignKeyValueGenerationOnAdd("P0", "A", "{'P0'}"), model);
         }
@@ -129,7 +129,7 @@ namespace Microsoft.Data.Entity.Tests.Infrastructure
 
             CreateForeignKey(keyA, keyB);
 
-            keyA.Properties[0].GenerateValueOnAdd = true;
+            keyA.Properties[0].IsValueGeneratedOnAdd = true;
 
             VerifyError(Strings.ForeignKeyValueGenerationOnAdd("P0", "A", "{'P0'}"), model);
         }
@@ -147,7 +147,7 @@ namespace Microsoft.Data.Entity.Tests.Infrastructure
             CreateForeignKey(keyA1, keyB);
             CreateForeignKey(keyB, keyA2);
 
-            keyB.Properties[0].GenerateValueOnAdd = true;
+            keyB.Properties[0].IsValueGeneratedOnAdd = true;
 
             VerifyError(Strings.ForeignKeyValueGenerationOnAdd("P0", "B", "{'P0'}"), model);
         }
@@ -163,7 +163,7 @@ namespace Microsoft.Data.Entity.Tests.Infrastructure
 
             CreateForeignKey(keyA, keyB);
 
-            keyB.Properties[0].GenerateValueOnAdd = false;
+            keyB.Properties[0].IsValueGeneratedOnAdd = false;
 
             VerifyError(Strings.PrincipalKeyNoValueGenerationOnAdd("P0", "B"), model);
         }
@@ -234,7 +234,7 @@ namespace Microsoft.Data.Entity.Tests.Infrastructure
             for (int i = 0; i < propertyCount; i++)
             {
                 keyProperties[i] = entityType.GetOrAddProperty("P" + (startingPropertyIndex + i), typeof(int?));
-                keyProperties[i].GenerateValueOnAdd = true;
+                keyProperties[i].IsValueGeneratedOnAdd = true;
             }
             return entityType.AddKey(keyProperties);
         }
@@ -246,7 +246,7 @@ namespace Microsoft.Data.Entity.Tests.Infrastructure
             foreignKey.IsRequired = false;
             foreach (var property in dependentKey.Properties)
             {
-                property.GenerateValueOnAdd = false;
+                property.IsValueGeneratedOnAdd = false;
             }
 
             return foreignKey;

--- a/test/EntityFramework.Core.Tests/Metadata/Internal/InternalPropertyBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/Internal/InternalPropertyBuilderTest.cs
@@ -49,10 +49,10 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             Assert.True(builder.GenerateValueOnAdd(true, ConfigurationSource.Convention));
             Assert.True(builder.GenerateValueOnAdd(false, ConfigurationSource.DataAnnotation));
 
-            Assert.Equal(false, metadata.GenerateValueOnAdd);
+            Assert.Equal(false, metadata.IsValueGeneratedOnAdd);
 
             Assert.False(builder.GenerateValueOnAdd(true, ConfigurationSource.Convention));
-            Assert.Equal(false, metadata.GenerateValueOnAdd);
+            Assert.Equal(false, metadata.IsValueGeneratedOnAdd);
         }
 
         [Fact]
@@ -60,15 +60,15 @@ namespace Microsoft.Data.Entity.Metadata.Internal
         {
             var builder = CreateInternalPropertyBuilder();
             var metadata = builder.Metadata;
-            metadata.GenerateValueOnAdd = true;
+            metadata.IsValueGeneratedOnAdd = true;
 
             Assert.True(builder.GenerateValueOnAdd(true, ConfigurationSource.DataAnnotation));
             Assert.False(builder.GenerateValueOnAdd(false, ConfigurationSource.DataAnnotation));
 
-            Assert.Equal(true, metadata.GenerateValueOnAdd);
+            Assert.Equal(true, metadata.IsValueGeneratedOnAdd);
 
             Assert.True(builder.GenerateValueOnAdd(false, ConfigurationSource.Explicit));
-            Assert.Equal(false, metadata.GenerateValueOnAdd);
+            Assert.Equal(false, metadata.IsValueGeneratedOnAdd);
         }
 
         [Fact]

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/KeyConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/KeyConventionTest.cs
@@ -25,10 +25,10 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             public int SampleEntityId { get; set; }
         }
 
-        #region GenerateValueOnAdd
+        #region IsValueGeneratedOnAdd
 
         [Fact]
-        public void GenerateValueOnAdd_flag_is_set_for_key_properties()
+        public void IsValueGeneratedOnAdd_flag_is_set_for_key_properties()
         {
             var modelBuilder = CreateInternalModelBuilder();
             var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
@@ -40,15 +40,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
 
             var keyProperties = keyBuilder.Metadata.Properties;
 
-            Assert.NotNull(keyProperties[0].GenerateValueOnAdd);
-            Assert.NotNull(keyProperties[1].GenerateValueOnAdd);
+            Assert.NotNull(keyProperties[0].IsValueGeneratedOnAdd);
+            Assert.NotNull(keyProperties[1].IsValueGeneratedOnAdd);
 
-            Assert.True(keyProperties[0].GenerateValueOnAdd.Value);
-            Assert.True(keyProperties[1].GenerateValueOnAdd.Value);
+            Assert.True(keyProperties[0].IsValueGeneratedOnAdd.Value);
+            Assert.True(keyProperties[1].IsValueGeneratedOnAdd.Value);
         }
 
         [Fact]
-        public void GenerateValueOnAdd_flag_is_not_set_for_foreign_key()
+        public void IsValueGeneratedOnAdd_flag_is_not_set_for_foreign_key()
         {
             var modelBuilder = CreateInternalModelBuilder();
 
@@ -71,11 +71,11 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
 
             var keyProperties = keyBuilder.Metadata.Properties;
 
-            Assert.Null(keyProperties[0].GenerateValueOnAdd);
+            Assert.Null(keyProperties[0].IsValueGeneratedOnAdd);
         }
 
         [Fact]
-        public void GenerateValueOnAdd_flag_is_set_for_property_which_are_not_part_of_any_foreign_key()
+        public void IsValueGeneratedOnAdd_flag_is_set_for_property_which_are_not_part_of_any_foreign_key()
         {
             var modelBuilder = CreateInternalModelBuilder();
 
@@ -98,12 +98,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
 
             var keyProperties = keyBuilder.Metadata.Properties;
 
-            Assert.True(keyProperties[0].GenerateValueOnAdd);
-            Assert.Null(keyProperties[1].GenerateValueOnAdd);
+            Assert.True(keyProperties[0].IsValueGeneratedOnAdd);
+            Assert.Null(keyProperties[1].IsValueGeneratedOnAdd);
         }
 
         [Fact]
-        public void GenerateValueOnAdd_flag_is_not_set_for_properties_which_are_part_of_a_foreign_key()
+        public void IsValueGeneratedOnAdd_flag_is_not_set_for_properties_which_are_part_of_a_foreign_key()
         {
             var modelBuilder = CreateInternalModelBuilder();
 
@@ -126,11 +126,11 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
 
             var keyProperties = keyBuilder.Metadata.Properties;
 
-            Assert.Null(keyProperties[0].GenerateValueOnAdd);
+            Assert.Null(keyProperties[0].IsValueGeneratedOnAdd);
         }
 
         [Fact]
-        public void KeyConvention_does_not_override_GenerateValueOnAddFlag_when_configured_explicitly()
+        public void KeyConvention_does_not_override_IsValueGeneratedOnAdd_when_configured_explicitly()
         {
             var modelBuilder = CreateInternalModelBuilder();
             var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
@@ -144,11 +144,11 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
 
             var keyProperties = keyBuilder.Metadata.Properties;
 
-            Assert.False(keyProperties[0].GenerateValueOnAdd.Value);
+            Assert.False(keyProperties[0].IsValueGeneratedOnAdd.Value);
         }
 
         [Fact]
-        public void GenerateValueOnAdd_flag_is_turned_off_when_foreign_key_is_added()
+        public void IsValueGeneratedOnAdd_flag_is_turned_off_when_foreign_key_is_added()
         {
             var modelBuilder = CreateInternalModelBuilder();
 
@@ -162,7 +162,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
 
             var keyProperties = keyBuilder.Metadata.Properties;
 
-            Assert.True(keyProperties[0].GenerateValueOnAdd);
+            Assert.True(keyProperties[0].IsValueGeneratedOnAdd);
 
             principalEntityBuilder.Relationship(
                 principalEntityBuilder,
@@ -173,11 +173,11 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
                 null,
                 ConfigurationSource.Convention);
 
-            Assert.Null(keyProperties[0].GenerateValueOnAdd);
+            Assert.Null(keyProperties[0].IsValueGeneratedOnAdd);
         }
 
         [Fact]
-        public void GenerateValueOnAdd_flag_is_set_when_foreign_key_is_removed()
+        public void IsValueGeneratedOnAdd_flag_is_set_when_foreign_key_is_removed()
         {
             var modelBuilder = CreateInternalModelBuilder();
 
@@ -191,7 +191,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
 
             var keyProperties = keyBuilder.Metadata.Properties;
 
-            Assert.True(keyProperties[0].GenerateValueOnAdd);
+            Assert.True(keyProperties[0].IsValueGeneratedOnAdd);
 
             var relationshipBuilder = principalEntityBuilder.Relationship(
                 principalEntityBuilder,
@@ -202,11 +202,11 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
                 null,
                 ConfigurationSource.Convention);
 
-            Assert.Null(keyProperties[0].GenerateValueOnAdd);
+            Assert.Null(keyProperties[0].IsValueGeneratedOnAdd);
 
             referencedEntityBuilder.RemoveRelationship(relationshipBuilder.Metadata, ConfigurationSource.Convention);
 
-            Assert.True(keyProperties[0].GenerateValueOnAdd);
+            Assert.True(keyProperties[0].IsValueGeneratedOnAdd);
         }
 
         #endregion

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest.cs
@@ -692,24 +692,24 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             modelBuilder.Entity<Quarks>(b =>
                 {
-                    b.Property(e => e.Id).GenerateValueOnAdd(false);
-                    b.Property(e => e.Up).GenerateValueOnAdd();
-                    b.Property(e => e.Down).GenerateValueOnAdd(true);
-                    b.Property<int>("Charm").GenerateValueOnAdd();
-                    b.Property<string>("Strange").GenerateValueOnAdd(false);
-                    b.Property(typeof(int), "Top").GenerateValueOnAdd();
-                    b.Property(typeof(string), "Bottom").GenerateValueOnAdd(false);
+                    b.Property(e => e.Id).Metadata.IsValueGeneratedOnAdd = false;
+                    b.Property(e => e.Up).Metadata.IsValueGeneratedOnAdd = true;
+                    b.Property(e => e.Down).Metadata.IsValueGeneratedOnAdd = true;
+                    b.Property<int>("Charm").Metadata.IsValueGeneratedOnAdd = true;
+                    b.Property<string>("Strange").Metadata.IsValueGeneratedOnAdd = false;
+                    b.Property(typeof(int), "Top").Metadata.IsValueGeneratedOnAdd = true;
+                    b.Property(typeof(string), "Bottom").Metadata.IsValueGeneratedOnAdd = false;
                 });
 
             var entityType = model.GetEntityType(typeof(Quarks));
 
-            Assert.Equal(false, entityType.GetProperty(Customer.IdProperty.Name).GenerateValueOnAdd);
-            Assert.Equal(true, entityType.GetProperty("Up").GenerateValueOnAdd);
-            Assert.Equal(true, entityType.GetProperty("Down").GenerateValueOnAdd);
-            Assert.Equal(true, entityType.GetProperty("Charm").GenerateValueOnAdd);
-            Assert.Equal(false, entityType.GetProperty("Strange").GenerateValueOnAdd);
-            Assert.Equal(true, entityType.GetProperty("Top").GenerateValueOnAdd);
-            Assert.Equal(false, entityType.GetProperty("Bottom").GenerateValueOnAdd);
+            Assert.Equal(false, entityType.GetProperty(Customer.IdProperty.Name).IsValueGeneratedOnAdd);
+            Assert.Equal(true, entityType.GetProperty("Up").IsValueGeneratedOnAdd);
+            Assert.Equal(true, entityType.GetProperty("Down").IsValueGeneratedOnAdd);
+            Assert.Equal(true, entityType.GetProperty("Charm").IsValueGeneratedOnAdd);
+            Assert.Equal(false, entityType.GetProperty("Strange").IsValueGeneratedOnAdd);
+            Assert.Equal(true, entityType.GetProperty("Top").IsValueGeneratedOnAdd);
+            Assert.Equal(false, entityType.GetProperty("Bottom").IsValueGeneratedOnAdd);
         }
 
         [Fact]
@@ -776,7 +776,6 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .Annotation("A", "V")
                 .ConcurrencyToken()
                 .StoreGeneratedPattern(StoreGeneratedPattern.Computed)
-                .GenerateValueOnAdd()
                 .MaxLength(100)
                 .Required();
         }

--- a/test/EntityFramework.Core.Tests/ValueGeneration/ValueGeneratorCacheTest.cs
+++ b/test/EntityFramework.Core.Tests/ValueGeneration/ValueGeneratorCacheTest.cs
@@ -47,9 +47,9 @@ namespace Microsoft.Data.Entity.Tests.ValueGeneration
 
             var entityType = model.AddEntityType("Led");
             var property1 = entityType.GetOrAddProperty("Zeppelin", typeof(Guid), shadowProperty: true);
-            property1.GenerateValueOnAdd = generateValues;
+            property1.IsValueGeneratedOnAdd = generateValues;
             var property2 = entityType.GetOrAddProperty("Stairway", typeof(Guid), shadowProperty: true);
-            property2.GenerateValueOnAdd = generateValues;
+            property2.IsValueGeneratedOnAdd = generateValues;
 
             return model;
         }

--- a/test/EntityFramework.Core.Tests/ValueGeneration/ValueGeneratorSelectorTest.cs
+++ b/test/EntityFramework.Core.Tests/ValueGeneration/ValueGeneratorSelectorTest.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Data.Entity.Tests.ValueGeneration
 
             foreach (var property in entityType.Properties)
             {
-                property.GenerateValueOnAdd = generateValues;
+                property.IsValueGeneratedOnAdd = generateValues;
             }
 
             return model;

--- a/test/EntityFramework.InMemory.Tests/InMemoryValueGeneratorSelectorTest.cs
+++ b/test/EntityFramework.InMemory.Tests/InMemoryValueGeneratorSelectorTest.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
 
             foreach (var property in entityType.Properties)
             {
-                property.GenerateValueOnAdd = generateValues;
+                property.IsValueGeneratedOnAdd = generateValues;
             }
 
             return model;

--- a/test/EntityFramework.Relational.Tests/Update/ModificationCommandTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/ModificationCommandTest.cs
@@ -2,9 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
-using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Relational.Update;
 using Xunit;
@@ -371,7 +369,6 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             var entityType = model.AddEntityType(typeof(T1));
 
             var key = entityType.GetOrAddProperty("Id", typeof(int));
-            key.GenerateValueOnAdd = generateKeyValues;
             key.StoreGeneratedPattern = generateKeyValues ? StoreGeneratedPattern.Identity : StoreGeneratedPattern.None;
             key.Relational().Column = "Col1";
             entityType.GetOrSetPrimaryKey(key);

--- a/test/EntityFramework.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
@@ -600,7 +600,6 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
 
             var key = entityType.GetOrAddProperty("Id", typeof(int));
             key.StoreGeneratedPattern = generateKeyValues ? StoreGeneratedPattern.Identity : StoreGeneratedPattern.None;
-            key.GenerateValueOnAdd = generateKeyValues;
             key.Relational().Column = "Col1";
             entityType.GetOrSetPrimaryKey(key);
 

--- a/test/EntityFramework.SqlServer.FunctionalTests/InheritanceSqlServerFixture.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/InheritanceSqlServerFixture.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             discriminatorProperty.IsNullable = false;
             //discriminatorProperty.IsReadOnlyBeforeSave = true; // #2132
             discriminatorProperty.IsReadOnlyAfterSave = true;
-            discriminatorProperty.GenerateValueOnAdd = true;
+            discriminatorProperty.IsValueGeneratedOnAdd = true;
 
             animal.Relational().DiscriminatorProperty = discriminatorProperty;
         }

--- a/test/EntityFramework.SqlServer.Tests/Metadata/SqlServerMetadataExtensionsTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/Metadata/SqlServerMetadataExtensionsTest.cs
@@ -672,20 +672,20 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
 
             Assert.Null(property.SqlServer().ValueGenerationStrategy);
             Assert.Null(((IProperty)property).SqlServer().ValueGenerationStrategy);
-            Assert.Null(property.GenerateValueOnAdd);
+            Assert.Null(property.IsValueGeneratedOnAdd);
             Assert.False(((IProperty)property).IsValueGeneratedOnAdd);
 
             property.SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.Sequence;
 
             Assert.Equal(SqlServerValueGenerationStrategy.Sequence, property.SqlServer().ValueGenerationStrategy);
             Assert.Equal(SqlServerValueGenerationStrategy.Sequence, ((IProperty)property).SqlServer().ValueGenerationStrategy);
-            Assert.Equal(true, property.GenerateValueOnAdd);
+            Assert.Null(property.IsValueGeneratedOnAdd);
 
             property.SqlServer().ValueGenerationStrategy = null;
 
             Assert.Null(property.SqlServer().ValueGenerationStrategy);
             Assert.Null(((IProperty)property).SqlServer().ValueGenerationStrategy);
-            Assert.Null(property.GenerateValueOnAdd);
+            Assert.Null(property.IsValueGeneratedOnAdd);
         }
 
         [Fact]
@@ -700,20 +700,20 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
 
             Assert.Null(property.SqlServer().ValueGenerationStrategy);
             Assert.Null(((IProperty)property).SqlServer().ValueGenerationStrategy);
-            Assert.Null(property.GenerateValueOnAdd);
+            Assert.Null(property.IsValueGeneratedOnAdd);
             Assert.False(((IProperty)property).IsValueGeneratedOnAdd);
 
             property.SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.Sequence;
 
             Assert.Equal(SqlServerValueGenerationStrategy.Sequence, property.SqlServer().ValueGenerationStrategy);
             Assert.Equal(SqlServerValueGenerationStrategy.Sequence, ((IProperty)property).SqlServer().ValueGenerationStrategy);
-            Assert.Equal(true, property.GenerateValueOnAdd);
+            Assert.Null(property.IsValueGeneratedOnAdd);
 
             property.SqlServer().ValueGenerationStrategy = null;
 
             Assert.Null(property.SqlServer().ValueGenerationStrategy);
             Assert.Null(((IProperty)property).SqlServer().ValueGenerationStrategy);
-            Assert.Null(property.GenerateValueOnAdd);
+            Assert.Null(property.IsValueGeneratedOnAdd);
         }
 
         [Fact]

--- a/test/EntityFramework.SqlServer.Tests/SqlServerValueGeneratorCacheTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerValueGeneratorCacheTest.cs
@@ -92,7 +92,6 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                 .ForSqlServer(b => b.UseSequence())
                 .Entity<Robot>()
                 .Property(e => e.Id)
-                .GenerateValueOnAdd()
                 .Metadata;
 
             var cache = new SqlServerValueGeneratorCache();
@@ -107,7 +106,6 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                 .ForSqlServer(b => b.UseSequence("DaneelOlivaw"))
                 .Entity<Robot>()
                 .Property(e => e.Id)
-                .GenerateValueOnAdd()
                 .Metadata;
 
             var cache = new SqlServerValueGeneratorCache();
@@ -156,7 +154,6 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                     })
                 .Entity<Robot>()
                 .Property(e => e.Id)
-                .GenerateValueOnAdd()
                 .Metadata;
 
             var cache = new SqlServerValueGeneratorCache();
@@ -192,7 +189,6 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                     })
                 .Entity<Robot>()
                 .Property(e => e.Id)
-                .GenerateValueOnAdd()
                 .Metadata;
 
             var cache = new SqlServerValueGeneratorCache();
@@ -235,7 +231,6 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                 .ForSqlServer(b => b.UseSequence())
                 .Entity<Robot>()
                 .Property(e => e.Id)
-                .GenerateValueOnAdd()
                 .Metadata;
 
             var cache = new SqlServerValueGeneratorCache();
@@ -250,7 +245,6 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                 .ForSqlServer(b => b.UseSequence("DaneelOlivaw"))
                 .Entity<Robot>()
                 .Property(e => e.Id)
-                .GenerateValueOnAdd()
                 .Metadata;
 
             var cache = new SqlServerValueGeneratorCache();
@@ -299,7 +293,6 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                     })
                 .Entity<Robot>()
                 .Property(e => e.Id)
-                .GenerateValueOnAdd()
                 .Metadata;
 
             var cache = new SqlServerValueGeneratorCache();
@@ -318,7 +311,6 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                     })
                 .Entity<Robot>()
                 .Property(e => e.Id)
-                .GenerateValueOnAdd()
                 .Metadata;
 
             var cache = new SqlServerValueGeneratorCache();
@@ -347,7 +339,6 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                 .ForSqlServer(b => b.UseSequence("DaneelOlivaw", "R"))
                 .Entity<Robot>()
                 .Property(e => e.Id)
-                .GenerateValueOnAdd()
                 .Metadata;
 
             var cache = new SqlServerValueGeneratorCache();
@@ -381,7 +372,6 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                     })
                 .Entity<Robot>()
                 .Property(e => e.Id)
-                .GenerateValueOnAdd()
                 .Metadata;
 
             var cache = new SqlServerValueGeneratorCache();

--- a/test/EntityFramework.SqlServer.Tests/SqlServerValueGeneratorSelectorTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerValueGeneratorSelectorTest.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
 
             foreach (var property in entityType.Properties)
             {
-                property.GenerateValueOnAdd = generateValues;
+                property.IsValueGeneratedOnAdd = generateValues;
             }
 
             entityType.GetProperty("AlwaysIdentity").SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.Identity;

--- a/test/EntityFramework.Sqlite.FunctionalTests/InheritanceSqliteFixture.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/InheritanceSqliteFixture.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
             discriminatorProperty.IsNullable = false;
             //discriminatorProperty.IsReadOnlyBeforeSave = true; // #2132
             discriminatorProperty.IsReadOnlyAfterSave = true;
-            discriminatorProperty.GenerateValueOnAdd = true;
+            discriminatorProperty.IsValueGeneratedOnAdd = true;
 
             animal.Relational().DiscriminatorProperty = discriminatorProperty;
         }


### PR DESCRIPTION
The problem with this is that it is really an internal detail which should never be switched off even when explicit key values are being used. Occasionally it cab be useful to switch it on for non-key, non-discriminator properties, but this would not be a common case and dropping down to core metadata is fine for this.

Also, removed it from the model snapshot since it really has no impact on store generation--StoreGeneratedPattern is for that. Removing it from the snapshot makes diffs easier to handle.

Also, did a name change that got missed when the reat of the metadata API review changes were applied.