### PR TITLE
Fix: #2071 - OrderBy() not translating to SQL ORDER BY?

### DIFF
--- a/src/EntityFramework.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EntityFramework.Relational/Query/RelationalQueryModelVisitor.cs
@@ -104,10 +104,12 @@ namespace Microsoft.Data.Entity.Relational.Query
         public override void VisitQueryModel(QueryModel queryModel)
         {
             base.VisitQueryModel(queryModel);
-            var compositePredicateVisitor = new CompositePredicateExpressionVisitor(
-                QueryCompilationContext
-                    .GetCustomQueryAnnotations(RelationalQueryableExtensions.UseRelationalNullSemanticsMethodInfo)
-                    .Any());
+
+            var compositePredicateVisitor
+                = new CompositePredicateExpressionVisitor(
+                    QueryCompilationContext
+                        .GetCustomQueryAnnotations(RelationalQueryableExtensions.UseRelationalNullSemanticsMethodInfo)
+                        .Any());
 
             foreach (var selectExpression in _queriesBySource.Values.Where(se => se.Predicate != null))
             {

--- a/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -1823,7 +1823,7 @@ FROM [Customers] AS [c]",
 
             Assert.Equal(
                 @"SELECT DISTINCT [c].[City]
-FROM [Customers] AS [c]", // Ordering not preserved by distinct
+FROM [Customers] AS [c]", // Ordering not preserved by distinct when ordering columns not projected.
                 Sql);
         }
 
@@ -1852,6 +1852,17 @@ FROM (
     FROM [Customers] AS [c]
 ) AS [t0]
 ORDER BY [t0].[CustomerID]",
+                Sql);
+        }
+
+        public override void Take_Distinct()
+        {
+            base.Take_Distinct();
+
+            Assert.Equal(
+                @"SELECT DISTINCT TOP(5) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+ORDER BY [o].[OrderID]",
                 Sql);
         }
 


### PR DESCRIPTION
- Improve translation of Distinct such that OrderBys are preserved when the ordering columns are present in the projection.