### PR TITLE
Fix #783 - replace Property extension method on object in fluent API

### DIFF
--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -183,6 +183,7 @@
     <Compile Include="ModelBuilder.cs" />
     <Compile Include="Query\Annotations\QueryAnnotation.cs" />
     <Compile Include="Query\Annotations\IncludeQueryAnnotation.cs" />
+    <Compile Include="Query\EF.cs" />
     <Compile Include="Query\EntityLoadInfo.cs" />
     <Compile Include="Query\EntityTrackingInfo.cs" />
     <Compile Include="Query\ExpressionEvaluationHelpers.cs" />

--- a/src/EntityFramework.Core/Properties/Strings.Designer.cs
+++ b/src/EntityFramework.Core/Properties/Strings.Designer.cs
@@ -341,11 +341,11 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
-        /// The Property&lt;T&gt; extension method may only be used within LINQ queries.
+        /// The EF.Property&lt;T&gt; method may only be used within LINQ queries.
         /// </summary>
-        public static string PropertyExtensionInvoked
+        public static string PropertyMethodInvoked
         {
-            get { return GetString("PropertyExtensionInvoked"); }
+            get { return GetString("PropertyMethodInvoked"); }
         }
 
         /// <summary>

--- a/src/EntityFramework.Core/Properties/Strings.resx
+++ b/src/EntityFramework.Core/Properties/Strings.resx
@@ -240,8 +240,8 @@
   <data name="LogExceptionDuringSaveChanges" xml:space="preserve">
     <value>An exception occurred in the database while saving changes.{newline}{error}</value>
   </data>
-  <data name="PropertyExtensionInvoked" xml:space="preserve">
-    <value>The Property&amp;lt;T&amp;gt; extension method may only be used within LINQ queries.</value>
+  <data name="PropertyMethodInvoked" xml:space="preserve">
+    <value>The EF.Property&amp;lt;T&amp;gt; method may only be used within LINQ queries.</value>
   </data>
   <data name="DuplicateProperty" xml:space="preserve">
     <value>The property '{property}' cannot be added to the entity type '{entityType}' because a property with the same name already exists.</value>

--- a/src/EntityFramework.Core/Query/EF.cs
+++ b/src/EntityFramework.Core/Query/EF.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Internal;
+using System;
+
+namespace Microsoft.Data.Entity.Query
+{
+    public static class EF
+    {
+        public static TProperty Property<TProperty>([NotNull] object entity, [NotNull] string propertyName)
+        {
+            throw new InvalidOperationException(Strings.PropertyMethodInvoked);
+        }
+    }
+}
+

--- a/src/EntityFramework.Core/Query/EntityQueryModelVisitor.cs
+++ b/src/EntityFramework.Core/Query/EntityQueryModelVisitor.cs
@@ -31,6 +31,9 @@ namespace Microsoft.Data.Entity.Query
         public static readonly ParameterExpression QueryResultScopeParameter
             = Expression.Parameter(typeof(QueryResultScope));
 
+        public static readonly MethodInfo PropertyMethodInfo
+            = typeof(EF).GetTypeInfo().GetDeclaredMethod(nameof(EF.Property));
+
         private readonly QueryCompilationContext _queryCompilationContext;
 
         private Expression _expression;
@@ -1085,7 +1088,7 @@ namespace Microsoft.Data.Entity.Query
             {
                 var methodInfo = methodCallExpression.Method.GetGenericMethodDefinition();
 
-                if (ReferenceEquals(methodInfo, QueryExtensions.PropertyMethodInfo)
+                if (ReferenceEquals(methodInfo, PropertyMethodInfo)
                     || ReferenceEquals(methodInfo, QueryExtensions.ValueBufferPropertyMethodInfo))
                 {
                     var targetExpression = methodCallExpression.Arguments[0];

--- a/src/EntityFramework.Core/Query/ExpressionVisitors/FunctionEvaluationDisablingVisitor.cs
+++ b/src/EntityFramework.Core/Query/ExpressionVisitors/FunctionEvaluationDisablingVisitor.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
             if (expression.Method.IsGenericMethod)
             {
                 var genericMethodDefinition = expression.Method.GetGenericMethodDefinition();
-                if (ReferenceEquals(genericMethodDefinition, QueryExtensions.PropertyMethodInfo)
+                if (ReferenceEquals(genericMethodDefinition, EntityQueryModelVisitor.PropertyMethodInfo)
                     || ReferenceEquals(genericMethodDefinition, DbContextSetMethodInfo))
                 {
                     return base.VisitMethodCall(expression);

--- a/src/EntityFramework.Core/Query/ExpressionVisitors/MemberAccessBindingExpressionVisitor.cs
+++ b/src/EntityFramework.Core/Query/ExpressionVisitors/MemberAccessBindingExpressionVisitor.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
             if (methodCallExpression.Method.IsGenericMethod
                 && ReferenceEquals(
                     methodCallExpression.Method.GetGenericMethodDefinition(),
-                    QueryExtensions.PropertyMethodInfo))
+                    EntityQueryModelVisitor.PropertyMethodInfo))
             {
                 _inMember = true;
 

--- a/src/EntityFramework.Core/Query/ExpressionVisitors/ParameterExtractingExpressionVisitor.cs
+++ b/src/EntityFramework.Core/Query/ExpressionVisitors/ParameterExtractingExpressionVisitor.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
             {
                 var methodInfo = methodCallExpression.Method.GetGenericMethodDefinition();
 
-                if (ReferenceEquals(methodInfo, QueryExtensions.PropertyMethodInfo)
+                if (ReferenceEquals(methodInfo, EntityQueryModelVisitor.PropertyMethodInfo)
                     || ReferenceEquals(methodInfo, QueryExtensions.ValueBufferPropertyMethodInfo))
                 {
                     return methodCallExpression;

--- a/src/EntityFramework.Core/Query/QueryExtensions.cs
+++ b/src/EntityFramework.Core/Query/QueryExtensions.cs
@@ -4,22 +4,12 @@
 using System;
 using System.Reflection;
 using JetBrains.Annotations;
-using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Storage;
 
 namespace Microsoft.Data.Entity.Query
 {
     public static class QueryExtensions
     {
-        public static readonly MethodInfo PropertyMethodInfo
-            = typeof(QueryExtensions).GetTypeInfo().GetDeclaredMethod(nameof(Property));
-
-        public static TProperty Property<TProperty>(
-            [NotNull] this object entity, [NotNull] string propertyName)
-        {
-            throw new InvalidOperationException(Strings.PropertyExtensionInvoked);
-        }
-
         public static readonly MethodInfo ValueBufferPropertyMethodInfo
             = typeof(QueryExtensions).GetTypeInfo().GetDeclaredMethod(nameof(ValueBufferProperty));
 

--- a/src/EntityFramework.Relational/Query/ExpressionVisitors/RelationalProjectionExpressionVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionVisitors/RelationalProjectionExpressionVisitor.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Data.Entity.Relational.Query.ExpressionVisitors
             {
                 var methodInfo = methodCallExpression.Method.GetGenericMethodDefinition();
 
-                if (ReferenceEquals(methodInfo, QueryExtensions.PropertyMethodInfo)
+                if (ReferenceEquals(methodInfo, EntityQueryModelVisitor.PropertyMethodInfo)
                     || ReferenceEquals(methodInfo, QueryExtensions.ValueBufferPropertyMethodInfo))
                 {
                     var newArg0 = Visit(methodCallExpression.Arguments[0]);

--- a/test/EntityFramework.Core.FunctionalTests/AsyncQueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/AsyncQueryTestBase.cs
@@ -618,7 +618,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         public virtual async Task Where_simple_shadow()
         {
             await AssertQuery<Employee>(
-                es => es.Where(e => e.Property<string>("Title") == "Sales Representative"),
+                es => es.Where(e => EF.Property<string>(e, "Title") == "Sales Representative"),
                 entryCount: 6);
         }
 
@@ -626,15 +626,15 @@ namespace Microsoft.Data.Entity.FunctionalTests
         public virtual async Task Where_simple_shadow_projection()
         {
             await AssertQuery<Employee>(
-                es => es.Where(e => e.Property<string>("Title") == "Sales Representative")
-                    .Select(e => e.Property<string>("Title")));
+                es => es.Where(e => EF.Property<string>(e, "Title") == "Sales Representative")
+                    .Select(e => EF.Property<string>(e, "Title")));
         }
 
         public virtual async Task Where_simple_shadow_projection_mixed()
         {
             await AssertQuery<Employee>(
-                es => es.Where(e => e.Property<string>("Title") == "Sales Representative")
-                    .Select(e => new { e, Title = e.Property<string>("Title") }),
+                es => es.Where(e => EF.Property<string>(e, "Title") == "Sales Representative")
+                    .Select(e => new { e, Title = EF.Property<string>(e, "Title") }),
                 entryCount: 6);
         }
 
@@ -643,7 +643,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             await AssertQuery<Employee>(
                 es => from e in es.OrderBy(e => e.EmployeeID).Take(5)
-                      where e.Property<string>("Title") == "Sales Representative"
+                      where EF.Property<string>(e, "Title") == "Sales Representative"
                       select e,
                 entryCount: 3);
         }
@@ -653,8 +653,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             await AssertQuery<Employee>(es =>
                 from e in es
-                where e.Property<string>("Title")
-                      == es.OrderBy(e2 => e2.Property<string>("Title")).First().Property<string>("Title")
+                where EF.Property<string>(e, "Title")
+                      == EF.Property<string>(es.OrderBy(e2 => EF.Property<string>(e2, "Title")).First(), "Title")
                 select e,
                 entryCount: 1);
         }
@@ -966,13 +966,13 @@ namespace Microsoft.Data.Entity.FunctionalTests
         [Fact]
         public virtual async Task Where_bool_member_shadow()
         {
-            await AssertQuery<Product>(ps => ps.Where(p => p.Property<bool>("Discontinued")), entryCount: 8);
+            await AssertQuery<Product>(ps => ps.Where(p => EF.Property<bool>(p, "Discontinued")), entryCount: 8);
         }
 
         [Fact]
         public virtual async Task Where_bool_member_false_shadow()
         {
-            await AssertQuery<Product>(ps => ps.Where(p => !p.Property<bool>("Discontinued")), entryCount: 69);
+            await AssertQuery<Product>(ps => ps.Where(p => !EF.Property<bool>(p, "Discontinued")), entryCount: 69);
         }
 
         [Fact]
@@ -1724,8 +1724,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 from c in cs
                 join o1 in
                     (from o2 in os orderby o2.OrderID select new { o2 }) on c.CustomerID equals o1.o2.CustomerID
-                where o1.o2.Property<string>("CustomerID") == "ALFKI"
-                select new { o1, o1.o2, Shadow = o1.o2.Property<DateTime?>("OrderDate") });
+                where EF.Property<string>(o1.o2, "CustomerID") == "ALFKI"
+                select new { o1, o1.o2, Shadow = EF.Property<DateTime?>(o1.o2, "OrderDate") });
         }
 
         [Fact]
@@ -1849,7 +1849,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     .Select(e =>
                         new
                         {
-                            Title = e.Property<string>("Title"),
+                            Title = EF.Property<string>(e, "Title"),
                             Id = e.EmployeeID
                         }));
         }
@@ -1865,7 +1865,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     .Select(e =>
                         new
                         {
-                            Title = e.Property<string>("Title"),
+                            Title = EF.Property<string>(e, "Title"),
                             Id = e.EmployeeID
                         }));
         }
@@ -1969,7 +1969,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         public virtual async Task OrderBy_shadow()
         {
             await AssertQuery<Employee>(
-                es => es.OrderBy(e => e.Property<string>("Title")).ThenBy(e => e.EmployeeID),
+                es => es.OrderBy(e => EF.Property<string>(e, "Title")).ThenBy(e => e.EmployeeID),
                 assertOrder: true,
                 entryCount: 9);
         }
@@ -2197,19 +2197,19 @@ namespace Microsoft.Data.Entity.FunctionalTests
         public virtual async Task GroupBy_Shadow()
         {
             await AssertQuery<Employee>(es =>
-                es.Where(e => e.Property<string>("Title") == "Sales Representative"
+                es.Where(e => EF.Property<string>(e, "Title") == "Sales Representative"
                               && e.EmployeeID == 1)
-                    .GroupBy(e => e.Property<string>("Title"))
-                    .Select(g => g.First().Property<string>("Title")));
+                    .GroupBy(e => EF.Property<string>(e, "Title"))
+                    .Select(g => EF.Property<string>(g.First(), "Title")));
         }
 
         [Fact]
         public virtual async Task GroupBy_Shadow2()
         {
             await AssertQuery<Employee>(es =>
-                es.Where(e => e.Property<string>("Title") == "Sales Representative"
+                es.Where(e => EF.Property<string>(e, "Title") == "Sales Representative"
                               && e.EmployeeID == 1)
-                    .GroupBy(e => e.Property<string>("Title"))
+                    .GroupBy(e => EF.Property<string>(e, "Title"))
                     .Select(g => g.First()));
         }
 
@@ -2219,7 +2219,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             await AssertQuery<Employee>(es =>
                 es.Where(e => e.EmployeeID == 1)
                     .GroupBy(e => e.EmployeeID)
-                    .Select(g => g.First().Property<string>("Title")));
+                    .Select(g => EF.Property<string>(g.First(), "Title")));
         }
 
         [Fact]
@@ -2307,7 +2307,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             await AssertQuery<Employee>(es =>
                 es.GroupBy(e => e.EmployeeID)
                     .OrderBy(g => g.Key)
-                    .Select(g => g.Select(e => new { Title = e.Property<string>("Title"), e }).ToList()),
+                    .Select(g => g.Select(e => new { Title = EF.Property<string>(e, "Title"), e }).ToList()),
                 assertOrder: true);
         }
 
@@ -2361,7 +2361,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 es.OrderBy(e => e.EmployeeID)
                     .GroupBy(e => e.EmployeeID)
                     .SelectMany(g => g)
-                    .Select(g => g.Property<string>("Title")));
+                    .Select(g => EF.Property<string>(g, "Title")));
         }
 
         [Fact]

--- a/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 assertOrder: true,
                 entryCount: 86);
         }
-        
+
         [Fact]
         public virtual void Skip_no_orderby()
         {
@@ -633,7 +633,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         public virtual void Where_simple_shadow()
         {
             AssertQuery<Employee>(
-                es => es.Where(e => e.Property<string>("Title") == "Sales Representative"),
+                es => es.Where(e => EF.Property<string>(e, "Title") == "Sales Representative"),
                 entryCount: 6);
         }
 
@@ -641,15 +641,15 @@ namespace Microsoft.Data.Entity.FunctionalTests
         public virtual void Where_simple_shadow_projection()
         {
             AssertQuery<Employee>(
-                es => es.Where(e => e.Property<string>("Title") == "Sales Representative")
-                    .Select(e => e.Property<string>("Title")));
+                es => es.Where(e => EF.Property<string>(e, "Title") == "Sales Representative")
+                    .Select(e => EF.Property<string>(e, "Title")));
         }
 
         public virtual void Where_simple_shadow_projection_mixed()
         {
             AssertQuery<Employee>(
-                es => es.Where(e => e.Property<string>("Title") == "Sales Representative")
-                    .Select(e => new { e, Title = e.Property<string>("Title") }),
+                es => es.Where(e => EF.Property<string>(e, "Title") == "Sales Representative")
+                    .Select(e => new { e, Title = EF.Property<string>(e, "Title") }),
                 entryCount: 6);
         }
 
@@ -658,7 +658,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             AssertQuery<Employee>(
                 es => from e in es.OrderBy(e => e.EmployeeID).Take(5)
-                      where e.Property<string>("Title") == "Sales Representative"
+                      where EF.Property<string>(e, "Title") == "Sales Representative"
                       select e,
                 entryCount: 3);
         }
@@ -668,8 +668,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             AssertQuery<Employee>(es =>
                 from e in es
-                where e.Property<string>("Title")
-                      == es.OrderBy(e2 => e2.Property<string>("Title")).First().Property<string>("Title")
+                where EF.Property<string>(e, "Title")
+                      == EF.Property<string>(es.OrderBy(e2 => EF.Property<string>(e2, "Title")).First(), "Title")
                 select e,
                 entryCount: 1);
         }
@@ -1100,13 +1100,13 @@ namespace Microsoft.Data.Entity.FunctionalTests
         [Fact]
         public virtual void Where_bool_member_shadow()
         {
-            AssertQuery<Product>(ps => ps.Where(p => p.Property<bool>("Discontinued")), entryCount: 8);
+            AssertQuery<Product>(ps => ps.Where(p => EF.Property<bool>(p, "Discontinued")), entryCount: 8);
         }
 
         [Fact]
         public virtual void Where_bool_member_false_shadow()
         {
-            AssertQuery<Product>(ps => ps.Where(p => !p.Property<bool>("Discontinued")), entryCount: 69);
+            AssertQuery<Product>(ps => ps.Where(p => !EF.Property<bool>(p, "Discontinued")), entryCount: 69);
         }
 
         [Fact]
@@ -1880,8 +1880,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 from c in cs
                 join o1 in
                     (from o2 in os orderby o2.OrderID select new { o2 }) on c.CustomerID equals o1.o2.CustomerID
-                where o1.o2.Property<string>("CustomerID") == "ALFKI"
-                select new { o1, o1.o2, Shadow = o1.o2.Property<DateTime?>("OrderDate") });
+                where EF.Property<string>(o1.o2, "CustomerID") == "ALFKI"
+                select new { o1, o1.o2, Shadow = EF.Property<DateTime?>(o1.o2, "OrderDate") });
         }
 
         [Fact]
@@ -2005,7 +2005,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     .Select(e =>
                         new
                         {
-                            Title = e.Property<string>("Title"),
+                            Title = EF.Property<string>(e, "Title"),
                             Id = e.EmployeeID
                         }));
         }
@@ -2021,7 +2021,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     .Select(e =>
                         new
                         {
-                            Title = e.Property<string>("Title"),
+                            Title = EF.Property<string>(e, "Title"),
                             Id = e.EmployeeID
                         }));
         }
@@ -2125,7 +2125,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         public virtual void OrderBy_shadow()
         {
             AssertQuery<Employee>(
-                es => es.OrderBy(e => e.Property<string>("Title")).ThenBy(e => e.EmployeeID),
+                es => es.OrderBy(e => EF.Property<string>(e, "Title")).ThenBy(e => e.EmployeeID),
                 assertOrder: true,
                 entryCount: 9);
         }
@@ -2353,19 +2353,19 @@ namespace Microsoft.Data.Entity.FunctionalTests
         public virtual void GroupBy_Shadow()
         {
             AssertQuery<Employee>(es =>
-                es.Where(e => e.Property<string>("Title") == "Sales Representative"
+                es.Where(e => EF.Property<string>(e, "Title") == "Sales Representative"
                               && e.EmployeeID == 1)
-                    .GroupBy(e => e.Property<string>("Title"))
-                    .Select(g => g.First().Property<string>("Title")));
+                    .GroupBy(e => EF.Property<string>(e, "Title"))
+                    .Select(g => EF.Property<string>(g.First(), "Title")));
         }
 
         [Fact]
         public virtual void GroupBy_Shadow2()
         {
             AssertQuery<Employee>(es =>
-                es.Where(e => e.Property<string>("Title") == "Sales Representative"
+                es.Where(e => EF.Property<string>(e, "Title") == "Sales Representative"
                               && e.EmployeeID == 1)
-                    .GroupBy(e => e.Property<string>("Title"))
+                    .GroupBy(e => EF.Property<string>(e, "Title"))
                     .Select(g => g.First()));
         }
 
@@ -2375,7 +2375,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             AssertQuery<Employee>(es =>
                 es.Where(e => e.EmployeeID == 1)
                     .GroupBy(e => e.EmployeeID)
-                    .Select(g => g.First().Property<string>("Title")));
+                    .Select(g => EF.Property<string>(g.First(), "Title")));
         }
 
         [Fact]
@@ -2465,7 +2465,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             AssertQuery<Employee>(es =>
                 es.GroupBy(e => e.EmployeeID)
                     .OrderBy(g => g.Key)
-                    .Select(g => g.Select(e => new { Title = e.Property<string>("Title"), e }).ToList()),
+                    .Select(g => g.Select(e => new { Title = EF.Property<string>(e, "Title"), e }).ToList()),
                 assertOrder: true);
         }
 
@@ -2519,7 +2519,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 es.OrderBy(e => e.EmployeeID)
                     .GroupBy(e => e.EmployeeID)
                     .SelectMany(g => g)
-                    .Select(g => g.Property<string>("Title")));
+                    .Select(g => EF.Property<string>(g, "Title")));
         }
 
         [Fact]
@@ -3411,7 +3411,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             AssertQuery<Order>(os =>
                 from o in os
-                select o.Property<int>("OrderID"));
+                select EF.Property<int>(o, "OrderID"));
         }
 
         [Fact]
@@ -3419,7 +3419,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             AssertQuery<Order>(os =>
                 from o in os
-                where o.Property<int>("OrderID") == 10248
+                where EF.Property<int>(o, "OrderID") == 10248
                 select o,
                 entryCount: 1);
         }
@@ -3429,7 +3429,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             AssertQuery<Employee>(es =>
                 from e in es
-                select e.Property<string>("Title"));
+                select EF.Property<string>(e, "Title"));
         }
 
         [Fact]
@@ -3437,7 +3437,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             AssertQuery<Employee>(es =>
                 from e in es
-                where e.Property<string>("Title") == "Sales Representative"
+                where EF.Property<string>(e, "Title") == "Sales Representative"
                 select e,
                 entryCount: 6);
         }

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/Northwind/NorthwindData.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/Northwind/NorthwindData.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Query;
 using Microsoft.Data.Entity.Query.ExpressionVisitors;
@@ -130,7 +129,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.Northwind
                 {
                     var methodInfo = methodCallExpression.Method.GetGenericMethodDefinition();
 
-                    if (ReferenceEquals(methodInfo, QueryExtensions.PropertyMethodInfo)
+                    if (ReferenceEquals(methodInfo, EntityQueryModelVisitor.PropertyMethodInfo)
                         || ReferenceEquals(methodInfo, QueryExtensions.ValueBufferPropertyMethodInfo))
                     {
                         return Expression.Property(

--- a/test/EntityFramework.CrossStore.FunctionalTests/EndToEndTest.cs
+++ b/test/EntityFramework.CrossStore.FunctionalTests/EndToEndTest.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 var secondEntity = context.SimpleEntities.Single(e => e.Id == 42);
                 Assert.Equal("Entity 2", secondEntity.StringProperty);
 
-                var thirdEntity = context.SimpleEntities.Single(e => e.Property<string>(SimpleEntity.ShadowPropertyName) == "shadow");
+                var thirdEntity = context.SimpleEntities.Single(e => EF.Property<string>(e, SimpleEntity.ShadowPropertyName) == "shadow");
                 Assert.Same(secondEntity, thirdEntity);
 
                 firstEntity.StringProperty = "first";


### PR DESCRIPTION
A new Ef helper class as an alternative to ```object.Property<T>()``` in the fluent API
@divega @rowanmiller 