### PR TITLE
Fix #2096 - Add timeout to all regex expressions

### DIFF
--- a/src/EntityFramework.Relational/Migrations/Infrastructure/MigrationIdGenerator.cs
+++ b/src/EntityFramework.Relational/Migrations/Infrastructure/MigrationIdGenerator.cs
@@ -17,7 +17,8 @@ namespace Microsoft.Data.Entity.Relational.Migrations.Infrastructure
 
         public virtual string CreateId(string name) => NextTimestamp() + "_" + name;
         public virtual string GetName(string id) => id.Substring(Format.Length + 1);
-        public virtual bool IsValidId(string value) => Regex.IsMatch(value, "[0-9]{" + Format.Length + "}_.+");
+        public virtual bool IsValidId(string value)
+            => Regex.IsMatch(value, $"[0-9]{{{Format.Length}}}_.+", default(RegexOptions), TimeSpan.FromMilliseconds(1000.0));
 
         public virtual string ResolveId(string nameOrId, IReadOnlyList<Migration> migrations)
         {

--- a/src/EntityFramework.SqlServer.Design/Utilities/SqlServerLiteralUtilities.cs
+++ b/src/EntityFramework.SqlServer.Design/Utilities/SqlServerLiteralUtilities.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Data.Entity.SqlServer.Design.Utilities
     public class SqlServerLiteralUtilities
     {
         public static readonly Regex _defaultValueIsExpression =
-            new Regex(@"^[@\$\w]+\(.*\)$", RegexOptions.Compiled);
+            new Regex(@"^[@\$\w]+\(.*\)$", RegexOptions.Compiled, TimeSpan.FromMilliseconds(1000.0));
 
         public SqlServerLiteralUtilities([NotNull] ILogger logger)
         {

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerTestStore.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerTestStore.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                             var script = File.ReadAllText(scriptPath);
 
                             foreach (var batch
-                                in new Regex("^GO", RegexOptions.IgnoreCase | RegexOptions.Multiline)
+                                in new Regex("^GO", RegexOptions.IgnoreCase | RegexOptions.Multiline, TimeSpan.FromMilliseconds(1000.0))
                                     .Split(script))
                             {
                                 command.CommandText = batch;
@@ -223,7 +223,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                             var script = File.ReadAllText(scriptPath);
 
                             foreach (var batch
-                                in new Regex("^GO", RegexOptions.IgnoreCase | RegexOptions.Multiline)
+                                in new Regex("^GO", RegexOptions.IgnoreCase | RegexOptions.Multiline, TimeSpan.FromMilliseconds(1000.0))
                                     .Split(script))
                             {
                                 command.CommandText = batch;

--- a/tools/Resources.tt
+++ b/tools/Resources.tt
@@ -25,8 +25,8 @@
     var templateNamespace = (string)templateProjectItem.Properties.Item("CustomToolNamespace").Value;
     var fileNamespace = !string.IsNullOrEmpty(templateNamespace) ? templateNamespace : projectNamespace;
     var projectName = Path.GetFileName(projectDirectory.TrimEnd('/'));
-    var namedParameterMatcher = new Regex(@"\{([a-z]\w+)\}", RegexOptions.IgnoreCase);
-    var numberParameterMatcher = new Regex(@"\{(\d+)\}");
+    var namedParameterMatcher = new Regex(@"\{([a-z]\w+)\}", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(1000.0));
+    var numberParameterMatcher = new Regex(@"\{(\d+)\}", default(RegexOptions), TimeSpan.FromMilliseconds(1000.0);
 
     foreach (var resxFile in Directory.EnumerateFiles(projectDirectory, "*.resx", SearchOption.AllDirectories))
     {


### PR DESCRIPTION
Matching the timeout we previously had in CSharpUtilities, though we may want to consider something configurable / global for all regexes

@rowanmiller @divega 