### PR TITLE
Implementation of DropColumn for SQLite using migration transforms.

### DIFF
--- a/src/EntityFramework.Sqlite/EntityFramework.Sqlite.csproj
+++ b/src/EntityFramework.Sqlite/EntityFramework.Sqlite.csproj
@@ -33,6 +33,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <ProjectReference Include="..\EntityFramework.Core\EntityFramework.Core.csproj">
@@ -86,6 +87,8 @@
     <Compile Include="Metadata\SqlitePropertyExtensions.cs" />
     <Compile Include="Migrations\SqliteHistoryRepository.cs" />
     <Compile Include="Migrations\SqliteMigrationSqlGenerator.cs" />
+    <Compile Include="Migrations\SqliteOperationTransformer.cs" />
+    <Compile Include="Migrations\MoveDataOperation.cs" />
     <Compile Include="Properties\Strings.Designer.cs">
       <DependentUpon>Strings.resx</DependentUpon>
     </Compile>

--- a/src/EntityFramework.Sqlite/Migrations/MoveDataOperation.cs
+++ b/src/EntityFramework.Sqlite/Migrations/MoveDataOperation.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Relational.Migrations.Operations;
+
+namespace Microsoft.Data.Entity.Sqlite.Migrations
+{
+    public class MoveDataOperation : MigrationOperation
+    {
+        public MoveDataOperation()
+        {
+            IsDestructiveChange = true;
+        }
+
+        public virtual string[] Columns { get; [param: NotNull] set; }
+        public virtual string OldTable { get; [param: NotNull] set; }
+        public virtual string NewTable { get; [param: NotNull] set; }
+    }
+}

--- a/src/EntityFramework.Sqlite/Migrations/SqliteOperationTransformer.cs
+++ b/src/EntityFramework.Sqlite/Migrations/SqliteOperationTransformer.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Relational.Migrations.Infrastructure;
+using Microsoft.Data.Entity.Relational.Migrations.Operations;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Sqlite.Migrations
+{
+    public class SqliteOperationTransformer
+    {
+        private readonly IModelDiffer _differ;
+
+        public SqliteOperationTransformer([NotNull] IModelDiffer differ)
+        {
+            Check.NotNull(differ, nameof(differ));
+
+            _differ = differ;
+        }
+
+        protected IList<MigrationOperation> TransformOperation(MigrationOperation operation, IModel model) => 
+            new[] { operation };
+
+        // TODO prevent multiple DropColumnOperations on the same table
+        private IList<MigrationOperation> TransformOperation(DropColumnOperation operation, IModel model)
+        {
+            Check.NotNull(model, nameof(model));
+
+            // TODO ensure this temporary table does not conflict with an existing table
+            var tempTableName = operation.Table + "_temp";
+
+            // TODO find more efficient way to get a create table operation. Expose ModelDiffer.Add?
+            var createTableOperation = _differ.GetDifferences(null, model)
+                .FirstOrDefault(o => (o as CreateTableOperation)?.Name == operation.Table);
+
+            if (!(createTableOperation is CreateTableOperation))
+            {
+                return new MigrationOperation[] { operation };
+            }
+
+            return new[]
+            {
+                new RenameTableOperation
+                {
+                    Name = operation.Table,
+                    NewName = tempTableName
+                },
+                createTableOperation,
+                new MoveDataOperation
+                {
+                    OldTable = tempTableName,
+                    NewTable = operation.Table,
+                    Columns = ((CreateTableOperation)createTableOperation)
+                        .Columns
+                        .Select(c => c.Name)
+                        .ToArray()
+                },
+                new DropTableOperation
+                {
+                    Name = tempTableName
+                }
+            };
+        }
+
+        public virtual IReadOnlyList<MigrationOperation> Transform(
+            [NotNull] IReadOnlyList<MigrationOperation> operations,
+            [CanBeNull] IModel model = null)
+        {
+            Check.NotNull(operations, nameof(operations));
+
+            var finalOperations = new List<MigrationOperation>();
+            foreach (var operation in operations)
+            {
+                finalOperations.AddRange(TransformOperation((dynamic)operation, model));
+            }
+            return finalOperations.AsReadOnly();
+        }
+    }
+}

--- a/src/EntityFramework.Sqlite/SqliteEntityFrameworkServicesBuilderExtensions.cs
+++ b/src/EntityFramework.Sqlite/SqliteEntityFrameworkServicesBuilderExtensions.cs
@@ -4,6 +4,7 @@
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Relational;
+using Microsoft.Data.Entity.Relational.Migrations;
 using Microsoft.Data.Entity.Sqlite;
 using Microsoft.Data.Entity.Sqlite.Metadata;
 using Microsoft.Data.Entity.Sqlite.Migrations;
@@ -32,6 +33,7 @@ namespace Microsoft.Framework.DependencyInjection
                     .AddScoped<SqliteDataStoreServices>()
                     .AddScoped<SqliteDataStore>()
                     .AddScoped<SqliteDataStoreConnection>()
+                    .AddScoped<SqliteOperationTransformer>()
                     .AddScoped<SqliteMigrationSqlGenerator>()
                     .AddScoped<SqliteDataStoreCreator>()
                     .AddScoped<SqliteHistoryRepository>()

--- a/src/EntityFramework.Sqlite/project.json
+++ b/src/EntityFramework.Sqlite/project.json
@@ -16,7 +16,8 @@
     "net45": { },
     "dotnet": {
       "dependencies": {
-        "System.IO.FileSystem": "4.0.0-*"
+        "System.IO.FileSystem": "4.0.0-*",
+        "Microsoft.CSharp":  "4.0.0-*"
       }
     }
   }

--- a/test/EntityFramework.Sqlite.FunctionalTests/EntityFramework.Sqlite.FunctionalTests.csproj
+++ b/test/EntityFramework.Sqlite.FunctionalTests/EntityFramework.Sqlite.FunctionalTests.csproj
@@ -56,6 +56,7 @@
     <Compile Include="InheritanceSqliteTest.cs" />
     <Compile Include="MappingQuerySqliteFixture.cs" />
     <Compile Include="MappingQuerySqliteTest.cs" />
+    <Compile Include="MigrationTest.cs" />
     <Compile Include="MonsterFixupSqliteTest.cs" />
     <Compile Include="NorthwindQuerySqliteFixture.cs" />
     <Compile Include="NullKeysSqliteTest.cs" />

--- a/test/EntityFramework.Sqlite.FunctionalTests/MigrationTest.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/MigrationTest.cs
@@ -1,0 +1,160 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Relational;
+using Microsoft.Data.Entity.Relational.Migrations;
+using Microsoft.Data.Entity.Relational.Migrations.Builders;
+using Microsoft.Data.Entity.Relational.Migrations.Infrastructure;
+using Microsoft.Data.Entity.Relational.Migrations.Sql;
+using Microsoft.Framework.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
+{
+    public class MigrationTest
+    {
+        private readonly DbContextOptionsBuilder _options;
+        private readonly IServiceProvider _provider;
+        private readonly SqliteTestStore _testStore;
+
+        [Fact]
+        public void DropColumn_rebuilds_table()
+        {
+            _testStore.ExecuteNonQuery(@"CREATE TABLE Table1 (Id INT PRIMARY KEY, Col1, Col2); 
+INSERT INTO Table1 (Col1, Col2) Values('dropped value','preserved entry');");
+
+            Migrate(up => { up.DropColumn("Col1", "Table1"); }, targetModel =>
+                {
+                    targetModel.Entity<UpdatedTableType>(b =>
+                        {
+                            b.Key(p => p.Id);
+                            b.Property(p => p.Id)
+                                .StoreGeneratedPattern(StoreGeneratedPattern.Identity);
+
+                            b.Property(p => p.Col2);
+                            b.SqliteTable("Table1");
+                        });
+                });
+
+            AssertColumns("Table1", new List<string>
+            {
+                "Id", "Col2"
+            });
+
+            using (var context = CreateContext())
+            {
+                // Assert data moved
+                var all = context.Set<UpdatedTableType>().ToList();
+                Assert.Equal(1, all.Count);
+                Assert.Equal(1, all[0].Id);
+                Assert.Equal("preserved entry", all[0].Col2);
+            }
+        }
+
+        public MigrationTest()
+        {
+            _testStore = SqliteTestStore.CreateScratch();
+
+            _provider = new ServiceCollection()
+                .AddEntityFramework()
+                .AddSqlite()
+                .AddDbContext<TestContext>()
+                .ServiceCollection()
+                .BuildServiceProvider();
+
+            _options = new DbContextOptionsBuilder(new DbContextOptions<TestContext>());
+            _options.UseSqlite(_testStore.Connection);
+        }
+
+        private void AssertColumns(string tableName, List<string> columnNames)
+        {
+            var command = _testStore.Connection.CreateCommand();
+            command.CommandText = $"PRAGMA table_info({tableName});";
+            var columns = new List<string>();
+            using (var reader = command.ExecuteReader())
+            {
+                while (reader.Read())
+                {
+                    columns.Add(reader.GetFieldValue<string>(1));
+                }
+            }
+            Assert.Equal(columnNames, columns);
+        }
+
+        private void Migrate(Action<MigrationBuilder> up, Action<ModelBuilder> targetModel)
+        {
+            var migration = new TestMigration(up, targetModel);
+            var builder = new MigrationBuilder();
+            migration.Up(builder);
+            var operations = builder.Operations.ToList();
+
+            using (var context = CreateContext())
+            {
+                var model = context.GetService<IMigrationModelFactory>().CreateModel(migration.BuildTargetModel);
+                var command = context.GetService<IMigrationSqlGenerator>().Generate(operations, model);
+
+                using (var transaction = context.Database.GetDbConnection().BeginTransaction())
+                {
+                    context.GetService<ISqlStatementExecutor>()
+                        .ExecuteNonQuery(context.Database.GetService<IRelationalConnection>(), transaction, command);
+                    transaction.Commit();
+                }
+            }
+        }
+
+        private TestContext CreateContext() => new TestContext(_provider, _options.Options);
+
+        public class TestContext : DbContext
+        {
+            public TestContext(IServiceProvider serviceProvider, DbContextOptions options)
+                : base(serviceProvider, options)
+            {
+            }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<UpdatedTableType>().SqliteTable("Table1");
+            }
+        }
+
+        public class UpdatedTableType
+        {
+            public int Id { get; set; }
+            public string Col2 { get; set; }
+        }
+
+        public class TestMigration : Migration
+        {
+            private readonly Action<ModelBuilder> _targetModel;
+            private readonly Action<MigrationBuilder> _up;
+
+            public TestMigration(Action<MigrationBuilder> up, Action<ModelBuilder> targetModel)
+            {
+                _up = up;
+                _targetModel = targetModel;
+            }
+
+            public override string Id { get; } = "TestMigration";
+
+            public override void Up(MigrationBuilder migrationBuilder)
+            {
+                _up?.Invoke(migrationBuilder);
+            }
+
+            public override void Down(MigrationBuilder migrationBuilder)
+            {
+            }
+
+            public override void BuildTargetModel(ModelBuilder modelBuilder)
+            {
+                _targetModel?.Invoke(modelBuilder);
+            }
+        }
+    }
+}

--- a/test/EntityFramework.Sqlite.Tests/EntityFramework.Sqlite.Tests.csproj
+++ b/test/EntityFramework.Sqlite.Tests/EntityFramework.Sqlite.Tests.csproj
@@ -41,6 +41,7 @@
     <Compile Include="Metadata\SqliteHistoryRepositoryTest.cs" />
     <Compile Include="Metadata\SqliteMetadataExtensionsTest.cs" />
     <Compile Include="Migrations\SqliteMigrationSqlGeneratorTest.cs" />
+    <Compile Include="Migrations\SqliteOperationTransformTest.cs" />
     <Compile Include="SqliteSqlGeneratorTest.cs" />
     <None Include="project.json" />
   </ItemGroup>

--- a/test/EntityFramework.Sqlite.Tests/Migrations/SqliteOperationTransformTest.cs
+++ b/test/EntityFramework.Sqlite.Tests/Migrations/SqliteOperationTransformTest.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Metadata.ModelConventions;
+using Microsoft.Data.Entity.Relational.Migrations.Infrastructure;
+using Microsoft.Data.Entity.Relational.Migrations.Operations;
+using Microsoft.Data.Entity.Sqlite.Metadata;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Sqlite.Migrations
+{
+    public class SqliteOperationTransformTest
+    {
+        [Fact]
+        public void DropColumn_to_TableRebuild()
+        {
+            var input = new DropColumnOperation { Name = "col1", Table = "A" };
+            var model = new ModelBuilder(new ConventionSet(), new Model());
+            model.Entity("a", b =>
+                {
+                    b.SqliteTable("A");
+                    b.Property<string>("2").SqliteColumn("col2");
+                    b.Property<string>("3").Column("col3");
+                    b.Key("3");
+                });
+            var transformer = new SqliteOperationTransformer(
+                new ModelDiffer(new SqliteTypeMapper(), new SqliteMetadataExtensionProvider()));
+            var actual = transformer.Transform(new[] { input }, model.Model);
+
+            Assert.Collection(actual, op1 =>
+                {
+                    var rename = Assert.IsType<RenameTableOperation>(op1);
+                    Assert.Equal("A", rename.Name);
+                    Assert.Equal("A_temp", rename.NewName);
+                },
+                op2 =>
+                    {
+                        var create = Assert.IsType<CreateTableOperation>(op2);
+                        Assert.Equal("A", create.Name);
+                        Assert.Equal(2, create.Columns.Count);
+                        Assert.Equal(new [] { "col3" }, create.PrimaryKey.Columns);
+                    },
+                op3 =>
+                    {
+                        var move = Assert.IsType<MoveDataOperation>(op3);
+                        Assert.Equal("A_temp", move.OldTable);
+                        Assert.Equal("A", move.NewTable);
+                        Assert.Equal(new[] { "col3", "col2" }, move.Columns);
+                    },
+                op4 =>
+                    {
+                        var drop = Assert.IsType<DropTableOperation>(op4);
+                        Assert.Equal("A_temp", drop.Name);
+                    });
+        }
+    }
+}


### PR DESCRIPTION
This is a first-cut of implementing a migration operation that requires table-rebuild.

Deliberate design choices:
 - Modifying the operation is provider specific and happens just before SQL generation
 - Migration API remains unchanged
 - Relies on the model to determine which columns are used in the table-rebuild.


Future improvements:
 - Add support for the many migration operations not available to SQLite
 - Allow users to opt-in for potentially-destructive table-rebuilds, instead of running them by-default.
 - Better logging/warning users of what is going to happen.