### PR TITLE
Refactor ReaderModificationCommandBatch

### DIFF
--- a/src/EntityFramework.Relational/SqlGenerator.cs
+++ b/src/EntityFramework.Relational/SqlGenerator.cs
@@ -129,10 +129,12 @@ namespace Microsoft.Data.Entity.Relational
             commandStringBuilder.Append(BatchCommandSeparator).AppendLine();
         }
 
-        public abstract void AppendSelectAffectedCountCommand(
+        public virtual void AppendSelectAffectedCountCommand(
             [NotNull] StringBuilder commandStringBuilder,
             [NotNull] string name,
-            [CanBeNull] string schemaName);
+            [CanBeNull] string schemaName)
+        {
+        }
 
         public virtual void AppendSelectAffectedCommand(
             [NotNull] StringBuilder commandStringBuilder,

--- a/src/EntityFramework.Relational/Update/AffectedCountModificationCommandBatch.cs
+++ b/src/EntityFramework.Relational/Update/AffectedCountModificationCommandBatch.cs
@@ -1,0 +1,259 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.ChangeTracking.Internal;
+using Microsoft.Data.Entity.Update;
+using Microsoft.Data.Entity.Utilities;
+using Microsoft.Framework.Logging;
+
+namespace Microsoft.Data.Entity.Relational.Update
+{
+    /// <summary>
+    /// A <see cref="ReaderModificationCommandBatch"/> for providers which append an SQL query to find out
+    /// how many rows were affected (see <see cref="SqlGenerator.AppendSelectAffectedCountCommand"/>).
+    /// </summary>
+    public abstract class AffectedCountModificationCommandBatch : ReaderModificationCommandBatch
+    {
+        private readonly List<bool> _resultSetEnd = new List<bool>();
+
+        protected AffectedCountModificationCommandBatch(
+            [NotNull] ISqlGenerator sqlGenerator)
+            : base(sqlGenerator)
+        {
+        }
+
+        // contains true if the command at the corresponding index is the last command in its result set
+        // the last value will not be read
+        protected IList<bool> ResultSetEnds => _resultSetEnd;
+
+        public override bool AddCommand(ModificationCommand modificationCommand)
+        {
+            _resultSetEnd.Add(true);
+            var added = base.AddCommand(modificationCommand);
+            if (!added)
+            {
+                _resultSetEnd.RemoveAt(_resultSetEnd.Count - 1);
+            }
+            return added;
+        }
+
+        protected override void Consume(DbDataReader reader, DbContext context)
+        {
+            Debug.Assert(ResultSetEnds.Count == ModificationCommands.Count);
+            var commandIndex = 0;
+
+            try
+            {
+                var actualResultSetCount = 0;
+                do
+                {
+                    commandIndex = ModificationCommands[commandIndex].RequiresResultPropagation
+                        ? ConsumeResultSetWithPropagation(commandIndex, reader, context)
+                        : ConsumeResultSetWithoutPropagation(commandIndex, reader, context);
+                    actualResultSetCount++;
+                } while (commandIndex < ResultSetEnds.Count
+                         && reader.NextResult());
+
+                Debug.Assert(commandIndex == ModificationCommands.Count,
+                    "Expected " + ModificationCommands.Count + " results, got " + commandIndex);
+#if DEBUG
+                var expectedResultSetCount = 1 + ResultSetEnds.Count(e => e);
+                expectedResultSetCount += ResultSetEnds[ResultSetEnds.Count - 1] ? -1 : 0;
+
+                Debug.Assert(actualResultSetCount == expectedResultSetCount,
+                    "Expected " + expectedResultSetCount + " result sets, got " + actualResultSetCount);
+#endif
+            }
+            catch (DbUpdateException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new DbUpdateException(
+                    Strings.UpdateStoreException,
+                    ex,
+                    ModificationCommands[commandIndex].Entries);
+            }
+        }
+
+        protected override async Task ConsumeAsync(
+            DbDataReader reader,
+            DbContext context,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Debug.Assert(ResultSetEnds.Count == ModificationCommands.Count);
+            var commandIndex = 0;
+
+            try
+            {
+                var actualResultSetCount = 0;
+                do
+                {
+                    commandIndex = ModificationCommands[commandIndex].RequiresResultPropagation
+                        ? await ConsumeResultSetWithPropagationAsync(commandIndex, reader, context, cancellationToken)
+                        : await ConsumeResultSetWithoutPropagationAsync(commandIndex, reader, context, cancellationToken);
+                    actualResultSetCount++;
+                }
+                while (commandIndex < ResultSetEnds.Count
+                       && await reader.NextResultAsync(cancellationToken));
+
+                Debug.Assert(commandIndex == ModificationCommands.Count, "Expected " + ModificationCommands.Count + " results, got " + commandIndex);
+#if DEBUG
+                var expectedResultSetCount = 1 + ResultSetEnds.Count(e => e);
+                expectedResultSetCount += ResultSetEnds[ResultSetEnds.Count - 1] ? -1 : 0;
+
+                Debug.Assert(actualResultSetCount == expectedResultSetCount, "Expected " + expectedResultSetCount + " result sets, got " + actualResultSetCount);
+#endif
+            }
+            catch (DbUpdateException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new DbUpdateException(
+                    Strings.UpdateStoreException,
+                    ex,
+                    ModificationCommands[commandIndex].Entries);
+            }
+        }
+
+        protected virtual int ConsumeResultSetWithPropagation(int commandIndex, DbDataReader reader, DbContext context)
+        {
+            var rowsAffected = 0;
+            do
+            {
+                var tableModification = ModificationCommands[commandIndex];
+                Debug.Assert(tableModification.RequiresResultPropagation);
+
+                if (!reader.Read())
+                {
+                    var expectedRowsAffected = rowsAffected + 1;
+                    while (++commandIndex < ResultSetEnds.Count
+                           && !ResultSetEnds[commandIndex - 1])
+                    {
+                        expectedRowsAffected++;
+                    }
+
+                    ThrowAggregateUpdateConcurrencyException(commandIndex, expectedRowsAffected, rowsAffected);
+                }
+
+                tableModification.PropagateResults(tableModification.ValueBufferFactory.Create(reader));
+                rowsAffected++;
+            }
+            while (++commandIndex < ResultSetEnds.Count
+                   && !ResultSetEnds[commandIndex - 1]);
+
+            return commandIndex;
+        }
+
+        protected virtual async Task<int> ConsumeResultSetWithPropagationAsync(int commandIndex, DbDataReader reader, DbContext context, CancellationToken cancellationToken)
+        {
+            var rowsAffected = 0;
+            do
+            {
+                var tableModification = ModificationCommands[commandIndex];
+                Debug.Assert(tableModification.RequiresResultPropagation);
+
+                if (!await reader.ReadAsync(cancellationToken))
+                {
+                    var expectedRowsAffected = rowsAffected + 1;
+                    while (++commandIndex < ResultSetEnds.Count
+                           && !ResultSetEnds[commandIndex - 1])
+                    {
+                        expectedRowsAffected++;
+                    }
+
+                    ThrowAggregateUpdateConcurrencyException(commandIndex, expectedRowsAffected, rowsAffected);
+                }
+
+                tableModification.PropagateResults(tableModification.ValueBufferFactory.Create(reader));
+                rowsAffected++;
+            }
+            while (++commandIndex < ResultSetEnds.Count
+                   && !ResultSetEnds[commandIndex - 1]);
+
+            return commandIndex;
+        }
+
+        protected virtual int ConsumeResultSetWithoutPropagation(int commandIndex, DbDataReader reader, DbContext context)
+        {
+            var expectedRowsAffected = 1;
+            while (++commandIndex < ResultSetEnds.Count
+                   && !ResultSetEnds[commandIndex - 1])
+            {
+                Debug.Assert(!ModificationCommands[commandIndex].RequiresResultPropagation);
+
+                expectedRowsAffected++;
+            }
+
+            if (reader.Read())
+            {
+                var rowsAffected = reader.GetInt32(0);
+                if (rowsAffected != expectedRowsAffected)
+                {
+                    ThrowAggregateUpdateConcurrencyException(commandIndex, expectedRowsAffected, rowsAffected);
+                }
+            }
+            else
+            {
+                ThrowAggregateUpdateConcurrencyException(commandIndex, 1, 0);
+            }
+
+            return commandIndex;
+        }
+
+        protected virtual async Task<int> ConsumeResultSetWithoutPropagationAsync(int commandIndex, DbDataReader reader, DbContext context, CancellationToken cancellationToken)
+        {
+            var expectedRowsAffected = 1;
+            while (++commandIndex < ResultSetEnds.Count
+                   && !ResultSetEnds[commandIndex - 1])
+            {
+                Debug.Assert(!ModificationCommands[commandIndex].RequiresResultPropagation);
+
+                expectedRowsAffected++;
+            }
+
+            if (await reader.ReadAsync(cancellationToken))
+            {
+                var rowsAffected = reader.GetInt32(0);
+                if (rowsAffected != expectedRowsAffected)
+                {
+                    ThrowAggregateUpdateConcurrencyException(commandIndex, expectedRowsAffected, rowsAffected);
+                }
+            }
+            else
+            {
+                ThrowAggregateUpdateConcurrencyException(commandIndex, 1, 0);
+            }
+
+            return commandIndex;
+        }
+
+        private IReadOnlyList<InternalEntityEntry> AggregateEntries(int endIndex, int commandCount)
+        {
+            var entries = new List<InternalEntityEntry>();
+            for (var i = endIndex - commandCount; i < endIndex; i++)
+            {
+                entries.AddRange(ModificationCommands[i].Entries);
+            }
+            return entries;
+        }
+
+        protected void ThrowAggregateUpdateConcurrencyException(
+            int commandIndex,
+            int expectedRowsAffected,
+            int rowsAffected)
+        {
+            throw new DbUpdateConcurrencyException(
+                Strings.UpdateConcurrencyException(expectedRowsAffected, rowsAffected),
+                AggregateEntries(commandIndex, expectedRowsAffected));
+        }
+    }
+}

--- a/src/EntityFramework.Relational/Update/BatchExecutor.cs
+++ b/src/EntityFramework.Relational/Update/BatchExecutor.cs
@@ -52,11 +52,12 @@ namespace Microsoft.Data.Entity.Relational.Update
 
                 foreach (var commandbatch in commandBatches)
                 {
-                    rowsAffected += commandbatch.Execute(
+                    commandbatch.Execute(
                         connection.Transaction,
                         _typeMapper,
                         _context,
                         Logger);
+                    rowsAffected += commandbatch.ModificationCommands.Count;
                 }
 
                 startedTransaction?.Commit();
@@ -90,11 +91,12 @@ namespace Microsoft.Data.Entity.Relational.Update
 
                 foreach (var commandbatch in commandBatches)
                 {
-                    rowsAffected += await commandbatch.ExecuteAsync(
+                    await commandbatch.ExecuteAsync(
                         connection.Transaction,
                         _typeMapper,
                         _context,
                         Logger, cancellationToken);
+                    rowsAffected += commandbatch.ModificationCommands.Count;
                 }
 
                 startedTransaction?.Commit();

--- a/src/EntityFramework.Relational/Update/ModificationCommandBatch.cs
+++ b/src/EntityFramework.Relational/Update/ModificationCommandBatch.cs
@@ -25,13 +25,13 @@ namespace Microsoft.Data.Entity.Relational.Update
 
         public abstract bool AddCommand([NotNull] ModificationCommand modificationCommand);
 
-        public abstract int Execute(
+        public abstract void Execute(
             [NotNull] IRelationalTransaction transaction,
             [NotNull] IRelationalTypeMapper typeMapper,
             [NotNull] DbContext context,
             [NotNull] ILogger logger);
 
-        public abstract Task<int> ExecuteAsync(
+        public abstract Task ExecuteAsync(
             [NotNull] IRelationalTransaction transaction,
             [NotNull] IRelationalTypeMapper typeMapper,
             [NotNull] DbContext context,

--- a/src/EntityFramework.Relational/Update/SingularModificationCommandBatch.cs
+++ b/src/EntityFramework.Relational/Update/SingularModificationCommandBatch.cs
@@ -5,7 +5,7 @@ using JetBrains.Annotations;
 
 namespace Microsoft.Data.Entity.Relational.Update
 {
-    public class SingularModificationCommandBatch : ReaderModificationCommandBatch
+    public class SingularModificationCommandBatch : AffectedCountModificationCommandBatch
     {
         public SingularModificationCommandBatch(
             [NotNull] ISqlGenerator sqlGenerator)

--- a/src/EntityFramework.SqlServer/Update/SqlServerModificationCommandBatch.cs
+++ b/src/EntityFramework.SqlServer/Update/SqlServerModificationCommandBatch.cs
@@ -11,7 +11,7 @@ using RelationalStrings = Microsoft.Data.Entity.Relational.Strings;
 
 namespace Microsoft.Data.Entity.SqlServer.Update
 {
-    public class SqlServerModificationCommandBatch : ReaderModificationCommandBatch
+    public class SqlServerModificationCommandBatch : AffectedCountModificationCommandBatch
     {
         private const int DefaultNetworkPacketSizeBytes = 4096;
         private const int MaxScriptLength = 65536 * DefaultNetworkPacketSizeBytes / 2;

--- a/test/EntityFramework.Relational.Tests/Update/BatchExecutorTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/BatchExecutorTest.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         {
             var sqlGenerator = new Mock<ISqlGenerator>().Object;
             var mockModificationCommandBatch = new Mock<ModificationCommandBatch>(sqlGenerator);
+            mockModificationCommandBatch.Setup(m => m.ModificationCommands.Count).Returns(1);
 
             var mockRelationalConnection = new Mock<IRelationalConnection>();
             var transactionMock = new Mock<IRelationalTransaction>();
@@ -52,6 +53,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         {
             var sqlGenerator = new Mock<ISqlGenerator>().Object;
             var mockModificationCommandBatch = new Mock<ModificationCommandBatch>(sqlGenerator);
+            mockModificationCommandBatch.Setup(m => m.ModificationCommands.Count).Returns(1);
 
             var mockRelationalConnection = new Mock<IRelationalConnection>();
             var transactionMock = new Mock<IRelationalTransaction>();

--- a/test/EntityFramework.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
@@ -613,7 +613,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             return RelationalTestHelpers.Instance.CreateInternalEntry(model, entityState, new T1 { Id = 1, Name = computeNonKeyValue ? null : "Test" });
         }
 
-        private class ModificationCommandBatchFake : ReaderModificationCommandBatch
+        private class ModificationCommandBatchFake : AffectedCountModificationCommandBatch
         {
             private readonly DbDataReader _reader;
 


### PR DESCRIPTION
The previous implementation of ReaderModificationCommandBatch was written around the assumption that the number of affected rows is fetched via an additional SQL query appended to the batch. This isn't for PostgreSQL, where the affected rows are only returned in the protocol and exposed via a special Npgsql API.

Closes #1956