### PR TITLE
Fix to make Reverse Engineering work on dnxcore50

### DIFF
--- a/src/EntityFramework.SqlServer.Design/ReverseEngineering/Templates/SqlServerDbContextTemplate.cshtml
+++ b/src/EntityFramework.SqlServer.Design/ReverseEngineering/Templates/SqlServerDbContextTemplate.cshtml
@@ -51,16 +51,16 @@ var className = Model.ClassName ?? Model.Helper.ClassName(Model.ConnectionString
     {
         protected override void OnConfiguring(DbContextOptionsBuilder options)
         {
-            options.UseSqlServer(@Model.Helper.VerbatimStringLiteral(@Model.ConnectionString));
+            options.UseSqlServer(@Model.Helper.VerbatimStringLiteral(Model.ConnectionString));
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
 @{
 var firstEntity = true;
-}@foreach(var entityConfig in Model.Helper.EntityConfigurations)
+}@foreach (var entityConfig in Model.Helper.EntityConfigurations)
 {
-    @if(!firstEntity)
+    @if (!firstEntity)
     {
 @:
     }
@@ -68,9 +68,9 @@ var firstEntity = true;
 @:            modelBuilder.Entity<@entityConfig.EntityType.DisplayName()>(entity =>
 @:            {
     var firstEntityFacet = true;
-    @foreach (var entityFacet in @entityConfig.FacetConfigurations)
+    @foreach (var entityFacet in entityConfig.FacetConfigurations)
     {
-        @if(!firstEntityFacet)
+        @if (!firstEntityFacet)
         {
 @:
         }
@@ -78,7 +78,7 @@ var firstEntity = true;
 @:                entity.@(entityFacet.ToString());
     }                        
     var firstProperty = true;
-    @foreach (var propertyConfig in @entityConfig.PropertyConfigurations)
+    @foreach (var propertyConfig in entityConfig.PropertyConfigurations)
     {
         @if (!firstEntityFacet || !firstProperty)
         {
@@ -86,7 +86,7 @@ var firstEntity = true;
         }
         firstProperty = false;
         var propertyConfigurationLines = LayoutPropertyConfigurationLines(propertyConfig, "property", "    ");
-        var propertyConfigurationLineCount = propertyConfigurationLines.Count;
+        int propertyConfigurationLineCount = propertyConfigurationLines.Count;
         @if (propertyConfigurationLineCount == 1)
         {
             @foreach (var line in propertyConfigurationLines)
@@ -98,7 +98,7 @@ var firstEntity = true;
         {
 @:                entity.Property(e => e.@(propertyConfig.Property.Name))
             var lineCount = 0;
-            @foreach (var line in propertyConfigurationLines)
+            @foreach (string line in propertyConfigurationLines)
             {
                 var outputLine = line;
                 if (++lineCount == propertyConfigurationLineCount)
@@ -110,7 +110,7 @@ var firstEntity = true;
         }
     }
     var firstNavigation = true;
-    @foreach (var navigationConfig in @entityConfig.NavigationConfigurations)
+    @foreach (var navigationConfig in entityConfig.NavigationConfigurations)
     {
         @if (!firstEntityFacet || !firstProperty || !firstNavigation)
         {
@@ -123,7 +123,7 @@ var firstEntity = true;
 }
         }@* End of OnModelCreating() *@
 
-@foreach(var et in Model.Helper.OrderedEntityTypes())
+@foreach (var et in Model.Helper.OrderedEntityTypes())
 {
 @:        public virtual DbSet<@et.Name> @et.Name { get; set; }
 }

--- a/src/EntityFramework.SqlServer.Design/ReverseEngineering/Templates/SqlServerEntityTypeTemplate.cshtml
+++ b/src/EntityFramework.SqlServer.Design/ReverseEngineering/Templates/SqlServerEntityTypeTemplate.cshtml
@@ -1,8 +1,9 @@
 @inherits Microsoft.Data.Entity.Relational.Design.Templating.RazorReverseEngineeringBase
 @using Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering
+@using Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering.Configuration
 @{
     string errorMessageAnnotation = Model.Helper.ErrorMessageAnnotation;
-}@if(errorMessageAnnotation != null) {
+}@if (errorMessageAnnotation != null) {
 @:// @errorMessageAnnotation
 }
 else {
@@ -15,24 +16,24 @@ else {
 @:{
 @:    public class @Model.EntityType.Name
 @:    {
-    @if(Model.Helper.NavPropInitializers.Count > 0) {
+    @if ((int)(Model.Helper.NavPropInitializers.Count) > 0) {
 @:        public @(Model.EntityType.Name)()
 @:        {
-        @foreach(var navPropInitializer in Model.Helper.NavPropInitializers)
+        @foreach (var navPropInitializer in Model.Helper.NavPropInitializers)
         {
 @:            @navPropInitializer.NavigationPropertyName = new HashSet<@navPropInitializer.PrincipalEntityTypeName>();
         }
 @:        }
 @:
     }
-    @foreach(var property in Model.Helper.OrderedEntityProperties)
+    @foreach (var property in Model.Helper.OrderedEntityProperties)
     {
-@:        public @Model.Generator.CSharpCodeGeneratorHelper.GetTypeName(@property.ClrType) @property.Name { get; set; }
+@:        public @Model.Generator.CSharpCodeGeneratorHelper.GetTypeName(property.ClrType) @property.Name { get; set; }
     }
-    @if (Model.Helper.NavigationProperties.Count > 0)
+    @if ((int)(Model.Helper.NavigationProperties.Count) > 0)
     {
 @:
-        @foreach (var navProp in Model.Helper.NavigationProperties)
+        @foreach (SqlServerNavigationProperty navProp in Model.Helper.NavigationProperties)
         {
             @if (navProp.ErrorAnnotation != null)
             {

--- a/src/EntityFramework.SqlServer.Design/project.json
+++ b/src/EntityFramework.SqlServer.Design/project.json
@@ -14,6 +14,7 @@
   },
   "resource": "ReverseEngineering/Templates/*.cshtml",
   "frameworks": {
-    "net45": { }
+    "net45": { },
+    "dnxcore50": { }
   }
 }

--- a/test/EntityFramework.SqlServer.Design.FunctionalTests/project.json
+++ b/test/EntityFramework.SqlServer.Design.FunctionalTests/project.json
@@ -11,6 +11,7 @@
   },
   "frameworks": {
     "net46": { },
-    "dnx451": { }
+    "dnx451": { },
+    "dnxcore50": { }
   }
 }


### PR DESCRIPTION
Enabled the E2E test on dnxcore50 as well.

The important part of the change is using the explicit data type instead of var in cases where a) the variable being used was dependent on Model, which is a dynamic property declared on the base class, and b) that variable was later used in a binary operation.

Also took the chance to remove @ symbols that weren't being used and to make the spacing of foreach's and if's consistent across both templates.