### PR TITLE
Count right, SQLite.

### DIFF
--- a/src/EntityFramework.Sqlite/EntityFramework.Sqlite.csproj
+++ b/src/EntityFramework.Sqlite/EntityFramework.Sqlite.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Metadata\SqliteModelAnnotations.cs" />
     <Compile Include="Metadata\SqlitePropertyAnnotations.cs" />
     <Compile Include="Migrations\SqliteHistoryRepository.cs" />
+    <Compile Include="Migrations\SqliteMigrationAnnotationProvider.cs" />
     <Compile Include="Migrations\SqliteMigrationSqlGenerator.cs" />
     <Compile Include="Migrations\SqliteOperationTransformer.cs" />
     <Compile Include="Migrations\MoveDataOperation.cs" />

--- a/src/EntityFramework.Sqlite/Metadata/SqliteAnnotationNames.cs
+++ b/src/EntityFramework.Sqlite/Metadata/SqliteAnnotationNames.cs
@@ -6,5 +6,7 @@ namespace Microsoft.Data.Entity.Sqlite.Metadata
     public static class SqliteAnnotationNames
     {
         public const string Prefix = "Sqlite:";
+        public const string Autoincrement = "Autoincrement";
+        public const string InlinePrimaryKey = "InlinePrimaryKey";
     }
 }

--- a/src/EntityFramework.Sqlite/Migrations/SqliteMigrationAnnotationProvider.cs
+++ b/src/EntityFramework.Sqlite/Migrations/SqliteMigrationAnnotationProvider.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Relational.Migrations.Infrastructure;
+using Microsoft.Data.Entity.Sqlite.Metadata;
+
+namespace Microsoft.Data.Entity.Sqlite.Migrations
+{
+    public class SqliteMigrationAnnotationProvider : MigrationAnnotationProvider
+    {
+        public override IEnumerable<IAnnotation> For(IProperty property)
+        {
+            if (property.StoreGeneratedPattern == StoreGeneratedPattern.Identity)
+            {
+                yield return new Annotation(SqliteAnnotationNames.Prefix + SqliteAnnotationNames.Autoincrement, true);
+            }
+        }
+    }
+}

--- a/src/EntityFramework.Sqlite/SqliteDatabaseProviderServices.cs
+++ b/src/EntityFramework.Sqlite/SqliteDatabaseProviderServices.cs
@@ -8,6 +8,7 @@ using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Relational;
 using Microsoft.Data.Entity.Relational.Metadata;
 using Microsoft.Data.Entity.Relational.Migrations.History;
+using Microsoft.Data.Entity.Relational.Migrations.Infrastructure;
 using Microsoft.Data.Entity.Relational.Migrations.Sql;
 using Microsoft.Data.Entity.Relational.Query.Methods;
 using Microsoft.Data.Entity.Relational.Update;
@@ -42,5 +43,6 @@ namespace Microsoft.Data.Entity.Sqlite
         public override IRelationalMetadataExtensionProvider MetadataExtensionProvider => GetService<SqliteMetadataExtensionProvider>();
         public override IMethodCallTranslator CompositeMethodCallTranslator => GetService<SqliteCompositeMethodCallTranslator>();
         public override IMemberTranslator CompositeMemberTranslator => GetService<SqliteCompositeMemberTranslator>();
+        public override IMigrationAnnotationProvider MigrationAnnotationProvider => GetService<SqliteMigrationAnnotationProvider>();
     }
 }

--- a/src/EntityFramework.Sqlite/SqliteEntityFrameworkServicesBuilderExtensions.cs
+++ b/src/EntityFramework.Sqlite/SqliteEntityFrameworkServicesBuilderExtensions.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Framework.DependencyInjection
                     .AddSingleton<SqliteMetadataExtensionProvider>()
                     .AddSingleton<SqliteTypeMapper>()
                     .AddSingleton<SqliteModelSource>()
+                    .AddSingleton<SqliteMigrationAnnotationProvider>()
                     .AddScoped<SqliteModificationCommandBatchFactory>()
                     .AddScoped<SqliteOperationTransformer>()
                     .AddScoped<SqliteDatabaseProviderServices>()

--- a/test/EntityFramework.Sqlite.FunctionalTests/AutoincrementTest.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/AutoincrementTest.cs
@@ -1,0 +1,112 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Sqlite;
+using Microsoft.Framework.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
+{
+    public class AutoincrementTest : IDisposable
+    {
+        private readonly DbContextOptions _options;
+        private readonly IServiceProvider _provider;
+        private readonly SqliteTestStore _testStore;
+
+        [Fact]
+        public void Autoincrement_prevents_reusing_rowid()
+        {
+            using (var context = CreateContext())
+            {
+                context.Database.EnsureCreated();
+                context.People.Add(new Person { Name = "Bruce" });
+                context.SaveChanges();
+
+                var hero = context.People.First(p => p.Id == 1);
+
+                context.People.Remove(hero);
+                context.SaveChanges();
+                context.People.Add(new Person { Name = "Batman" });
+                context.SaveChanges();
+                var gone = context.People.FirstOrDefault(p => p.Id == 1);
+                var begins = context.People.FirstOrDefault(p => p.Id == 2);
+
+                Assert.Null(gone);
+                Assert.NotNull(begins);
+            }
+        }
+
+        [Fact]
+        public void Autoincrement_not_on_text()
+        {
+            using (var context = new JokerContext(_provider, _options))
+            {
+                var ex = Assert.Throws<SqliteException>(() => context.Database.EnsureCreated());
+                Assert.Contains("AUTOINCREMENT is only allowed on an INTEGER PRIMARY KEY", ex.Message);
+            }
+        }
+
+        public AutoincrementTest()
+        {
+            _testStore = SqliteTestStore.CreateScratch();
+
+            var builder = new DbContextOptionsBuilder();
+            builder.UseSqlite(_testStore.Connection);
+            _options = builder.Options;
+            _provider = new ServiceCollection()
+                .AddEntityFramework()
+                .AddSqlite()
+                .AddDbContext<BatContext>()
+                .ServiceCollection()
+                .BuildServiceProvider();
+        }
+
+        private BatContext CreateContext() => new BatContext(_provider, _options);
+
+        public void Dispose()
+        {
+            _testStore?.Dispose();
+        }
+    }
+
+    public class JokerContext : DbContext
+    {
+        public JokerContext(IServiceProvider serviceProvider, DbContextOptions options)
+            : base(serviceProvider, options)
+        {
+        }
+
+        public DbSet<Person> People { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Person>(b =>
+                {
+                    b.SqliteTable("People2");
+                    b.Key(t => t.Name);
+                    b.Property(t => t.Name).StoreGeneratedPattern(StoreGeneratedPattern.Identity);
+                });
+        }
+    }
+
+    public class BatContext : DbContext
+    {
+        public BatContext(IServiceProvider serviceProvider, DbContextOptions options)
+            : base(serviceProvider, options)
+        {
+        }
+
+        public DbSet<Person> People { get; set; }
+    }
+
+    public class Person
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/test/EntityFramework.Sqlite.FunctionalTests/EntityFramework.Sqlite.FunctionalTests.csproj
+++ b/test/EntityFramework.Sqlite.FunctionalTests/EntityFramework.Sqlite.FunctionalTests.csproj
@@ -38,6 +38,7 @@
     <Compile Include="AsNoTrackingSqliteTest.cs" />
     <Compile Include="AsyncFromSqlQuerySqliteTest.cs" />
     <Compile Include="AsyncQuerySqliteTest.cs" />
+    <Compile Include="AutoincrementTest.cs" />
     <Compile Include="BuiltInDataTypesSqliteFixture.cs" />
     <Compile Include="BuiltInDataTypesSqliteTest.cs" />
     <Compile Include="ChangeTrackingSqliteTest.cs" />

--- a/test/EntityFramework.Sqlite.Tests/EntityFramework.Sqlite.Tests.csproj
+++ b/test/EntityFramework.Sqlite.Tests/EntityFramework.Sqlite.Tests.csproj
@@ -40,6 +40,7 @@
     <Compile Include="Metadata\Builders\SqliteBuilderExtensionsTest.cs" />
     <Compile Include="Metadata\SqliteHistoryRepositoryTest.cs" />
     <Compile Include="Metadata\SqliteMetadataExtensionsTest.cs" />
+    <Compile Include="Migrations\SqliteMigrationAnnotationProviderTest.cs" />
     <Compile Include="Migrations\SqliteMigrationSqlGeneratorTest.cs" />
     <Compile Include="Migrations\SqliteOperationTransformTest.cs" />
     <Compile Include="SqliteSqlGeneratorTest.cs" />

--- a/test/EntityFramework.Sqlite.Tests/Migrations/SqliteMigrationAnnotationProviderTest.cs
+++ b/test/EntityFramework.Sqlite.Tests/Migrations/SqliteMigrationAnnotationProviderTest.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Metadata.ModelConventions;
+using Microsoft.Data.Entity.Sqlite.Metadata;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Sqlite.Migrations
+{
+    public class SqliteMigrationAnnotationProviderTest
+    {
+        private readonly ModelBuilder _modelBuilder;
+        private readonly SqliteMigrationAnnotationProvider _provider;
+
+        private readonly Annotation _autoincrement = new Annotation(SqliteAnnotationNames.Prefix + SqliteAnnotationNames.Autoincrement, true);
+
+        public SqliteMigrationAnnotationProviderTest()
+        {
+            _modelBuilder = new ModelBuilder(new CoreConventionSetBuilder().CreateConventionSet(), new Model());
+            _provider = new SqliteMigrationAnnotationProvider();
+        }
+
+        [Theory]
+        [InlineData(StoreGeneratedPattern.Computed, false)]
+        [InlineData(StoreGeneratedPattern.Identity, true)]
+        [InlineData(StoreGeneratedPattern.None, false)]
+        public void Adds_Autoincrement_by_store_generated_pattern(StoreGeneratedPattern pattern, bool addsAnnotation)
+        {
+            _modelBuilder.Entity<Entity>(b =>
+                {
+                    b.Property(e => e.Prop).StoreGeneratedPattern(pattern);
+                });
+            var property = _modelBuilder.Model.GetEntityType(typeof(Entity)).GetProperty("Prop");
+
+            var annotation = _provider.For(property);
+            if (addsAnnotation)
+            {
+                Assert.Contains(annotation, a=>a.Name==_autoincrement.Name && (bool)a.Value);
+            }
+            else
+            {
+                Assert.DoesNotContain(annotation, a=>a.Name==_autoincrement.Name && (bool)a.Value);
+            }
+        }
+
+        private class Entity
+        {
+            public int Id { get; set; }
+            public string Prop { get; set; }
+        }
+    }
+}

--- a/test/EntityFramework.Sqlite.Tests/SqliteSqlGeneratorTest.cs
+++ b/test/EntityFramework.Sqlite.Tests/SqliteSqlGeneratorTest.cs
@@ -1,11 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Text;
 using Microsoft.Data.Entity.Relational;
 using Microsoft.Data.Entity.Relational.Tests;
-using Xunit;
 
 namespace Microsoft.Data.Entity.Sqlite
 {


### PR DESCRIPTION
Fix #2432. Uses AUTOINCREMENT keyword in SQLite to handle quirks in their rowid algorithm.
