### PR TITLE
RevEng: Hook up IApplicationShutdown Cancel event and use async methods where possible

### DIFF
--- a/src/EntityFramework.Commands/DatabaseTool.cs
+++ b/src/EntityFramework.Commands/DatabaseTool.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Data.Entity.Commands
             };
 
             var generator = new ReverseEngineeringGenerator(_serviceProvider);
-            return generator.GenerateAsync(configuration).Result;
+            return generator.GenerateAsync(configuration).GetAwaiter().GetResult();
         }
     }
 }

--- a/src/EntityFramework.Commands/DatabaseTool.cs
+++ b/src/EntityFramework.Commands/DatabaseTool.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Commands.Utilities;
 using Microsoft.Data.Entity.Internal;
@@ -44,11 +46,12 @@ namespace Microsoft.Data.Entity.Commands
             _serviceProvider.AddService(typeof(ITemplating), new RazorTemplating(compilationService, metadataReferencesProvider));
         }
 
-        public virtual IEnumerable<string> ReverseEngineer(
+        public virtual async Task<IEnumerable<string>> ReverseEngineerAsync(
             [NotNull] string providerAssemblyName,
             [NotNull] string connectionString,
             [NotNull] string rootNamespace,
-            [NotNull] string projectDir)
+            [NotNull] string projectDir,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             Check.NotNull(providerAssemblyName, nameof(providerAssemblyName));
             Check.NotEmpty(connectionString, nameof(connectionString));
@@ -70,7 +73,7 @@ namespace Microsoft.Data.Entity.Commands
             };
 
             var generator = new ReverseEngineeringGenerator(_serviceProvider);
-            return generator.GenerateAsync(configuration).GetAwaiter().GetResult();
+            return await generator.GenerateAsync(configuration, cancellationToken);
         }
     }
 }

--- a/src/EntityFramework.Commands/Executor.cs
+++ b/src/EntityFramework.Commands/Executor.cs
@@ -8,6 +8,8 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Commands.Utilities;
 using Microsoft.Data.Entity.Utilities;
@@ -249,13 +251,18 @@ namespace Microsoft.Data.Entity.Commands
 
                 var providerAssemblyName = DatabaseTool._defaultReverseEngineeringProviderAssembly;
 
-                Execute(() => executor.ReverseEngineerImpl(providerAssemblyName, connectionString));
+                Execute(() => executor.ReverseEngineerImplAsync(providerAssemblyName, connectionString).GetAwaiter().GetResult());
             }
         }
 
-        public virtual IEnumerable<string> ReverseEngineerImpl(
-            [NotNull] string providerAssemblyName, [NotNull] string connectionString) =>
-                _databaseTool.ReverseEngineer(providerAssemblyName, connectionString, _rootNamespace, _projectDir);
+        public virtual async Task<IEnumerable<string>> ReverseEngineerImplAsync(
+            [NotNull] string providerAssemblyName,
+            [NotNull] string connectionString,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await _databaseTool.ReverseEngineerAsync(
+                providerAssemblyName, connectionString, _rootNamespace, _projectDir, cancellationToken);
+        }
 
         public abstract class OperationBase : MarshalByRefObject
         {

--- a/src/EntityFramework.Commands/Program.cs
+++ b/src/EntityFramework.Commands/Program.cs
@@ -363,9 +363,9 @@ namespace Microsoft.Data.Entity.Commands
 
         public virtual int ReverseEngineer([NotNull] string connectionString)
         {
-            _databaseTool.ReverseEngineer(
+            _databaseTool.ReverseEngineerAsync(
                 DatabaseTool._defaultReverseEngineeringProviderAssembly,
-                connectionString, _rootNamespace, _projectDir);
+                connectionString, _rootNamespace, _projectDir).GetAwaiter().GetResult();
 
             _logger.LogInformation("Done.");
 

--- a/src/EntityFramework.Relational.Design/ReverseEngineering/ReverseEngineeringGenerator.cs
+++ b/src/EntityFramework.Relational.Design/ReverseEngineering/ReverseEngineeringGenerator.cs
@@ -75,7 +75,8 @@ namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering
 
             var templating = _serviceProvider.GetRequiredService<ITemplating>();
             var dbContextTemplate = provider.DbContextTemplate;
-            var templateResult = await templating.RunTemplateAsync(dbContextTemplate, dbContextGeneratorModel, provider);
+            var templateResult = await templating.RunTemplateAsync(
+                dbContextTemplate, dbContextGeneratorModel, provider, cancellationToken);
             if (templateResult.ProcessingException != null)
             {
                 throw new InvalidOperationException(
@@ -102,7 +103,8 @@ namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering
                 var entityTypeCodeGeneratorHelper = provider.EntityTypeCodeGeneratorHelper(entityTypeGeneratorModel);
                 entityTypeGeneratorModel.Helper = entityTypeCodeGeneratorHelper;
 
-                templateResult = await templating.RunTemplateAsync(entityTypeTemplate, entityTypeGeneratorModel, provider);
+                templateResult = await templating.RunTemplateAsync(
+                    entityTypeTemplate, entityTypeGeneratorModel, provider, cancellationToken);
                 if (templateResult.ProcessingException != null)
                 {
                     throw new InvalidOperationException(

--- a/src/EntityFramework.Relational.Design/ReverseEngineering/ReverseEngineeringGenerator.cs
+++ b/src/EntityFramework.Relational.Design/ReverseEngineering/ReverseEngineeringGenerator.cs
@@ -50,6 +50,8 @@ namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering
         {
             Check.NotNull(configuration, nameof(configuration));
 
+            cancellationToken.ThrowIfCancellationRequested();
+
             CheckConfiguration(configuration);
 
             var resultingFiles = new List<string>();

--- a/src/EntityFramework.Relational.Design/Templating/RazorReverseEngineeringBase.cs
+++ b/src/EntityFramework.Relational.Design/Templating/RazorReverseEngineeringBase.cs
@@ -28,6 +28,8 @@ namespace Microsoft.Data.Entity.Relational.Design.Templating
         public virtual async Task<string> ExecuteTemplateAsync(
             CancellationToken cancellationToken = default(CancellationToken))
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             var output = new StringBuilder();
             using (var writer = new StringWriter(output))
             {

--- a/src/EntityFramework.Relational.Design/Templating/RazorTemplating.cs
+++ b/src/EntityFramework.Relational.Design/Templating/RazorTemplating.cs
@@ -33,6 +33,8 @@ namespace Microsoft.Data.Entity.Relational.Design.Templating
             dynamic templateModel, IDatabaseMetadataModelProvider provider,
             CancellationToken cancellationToken = default(CancellationToken))
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             var host = new RazorTemplatingHost(typeof(RazorReverseEngineeringBase));
             var engine = new RazorTemplateEngine(host);
 
@@ -70,7 +72,7 @@ namespace Microsoft.Data.Entity.Relational.Design.Templating
                 {
                     razorTemplate.Model = templateModel;
                     //ToDo: If there are errors executing the code, they are missed here.
-                    result = await razorTemplate.ExecuteTemplateAsync();
+                    result = await razorTemplate.ExecuteTemplateAsync(cancellationToken);
                 }
 
                 return new TemplateResult


### PR DESCRIPTION
@AndriySvyryd @divega Updating as agreed. Using .GetAwaiter().GetResult() instead of .Result returns the underlying exception rather than an AggregateException if an exception is thrown.