### PR TITLE
Option to not test dirty reads

### DIFF
--- a/test/EntityFramework.Relational.FunctionalTests/TransactionTestBase.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/TransactionTestBase.cs
@@ -270,9 +270,12 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
 
                     using (var innerContext = CreateContext())
                     {
-                        using (innerContext.Database.BeginTransaction(IsolationLevel.ReadUncommitted))
+                        if (DirtyReadsOccur)
                         {
-                            Assert.Equal(Fixture.Customers.Count - 1, innerContext.Set<TransactionCustomer>().Count());
+                            using (innerContext.Database.BeginTransaction(IsolationLevel.ReadUncommitted))
+                            {
+                                Assert.Equal(Fixture.Customers.Count - 1, innerContext.Set<TransactionCustomer>().Count());
+                            }
                         }
 
                         if (SnapshotSupported)
@@ -305,9 +308,12 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
 
                     using (var innerContext = CreateContext())
                     {
-                        using (await innerContext.Database.BeginTransactionAsync(IsolationLevel.ReadUncommitted))
+                        if (DirtyReadsOccur)
                         {
-                            Assert.Equal(Fixture.Customers.Count - 1, await innerContext.Set<TransactionCustomer>().CountAsync());
+                            using (await innerContext.Database.BeginTransactionAsync(IsolationLevel.ReadUncommitted))
+                            {
+                                Assert.Equal(Fixture.Customers.Count - 1, await innerContext.Set<TransactionCustomer>().CountAsync());
+                            }
                         }
 
                         if (SnapshotSupported)
@@ -417,6 +423,8 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
         }
 
         protected abstract bool SnapshotSupported { get; }
+
+        protected virtual bool DirtyReadsOccur => true;
 
         protected DbContext CreateContext()
         {


### PR DESCRIPTION
In PostgreSQL, dirty reads don't ever occur, even in isolation level "read uncommitted". Added an option to skip the dirty read check in the transaction tests.

http://www.postgresql.org/docs/9.4/static/transaction-iso.html