### PR TITLE
Fix to #2274 - Chaining multiple Include with ThenInclude throws Sysem.InvalidOperationException

### DIFF
--- a/src/EntityFramework.InMemory/Query/InMemoryQueryModelVisitor.cs
+++ b/src/EntityFramework.InMemory/Query/InMemoryQueryModelVisitor.cs
@@ -30,19 +30,18 @@ namespace Microsoft.Data.Entity.InMemory.Query
         }
 
         protected override void IncludeNavigations(
-            IQuerySource querySource,
+            IncludeSpecification includeSpecification,
             Type resultType,
             LambdaExpression accessorLambda,
-            IReadOnlyList<INavigation> navigationPath,
             bool querySourceRequiresTracking)
         {
-            Check.NotNull(querySource, nameof(querySource));
+            Check.NotNull(includeSpecification, nameof(includeSpecification));
             Check.NotNull(resultType, nameof(resultType));
             Check.NotNull(accessorLambda, nameof(accessorLambda));
-            Check.NotNull(navigationPath, nameof(navigationPath));
 
             var primaryKeyParameter = Expression.Parameter(typeof(EntityKey));
             var relatedKeyFactoryParameter = Expression.Parameter(typeof(Func<ValueBuffer, EntityKey>));
+            var navigationPath = includeSpecification.NavigationPath;
 
             Expression
                 = Expression.Call(

--- a/src/EntityFramework.Relational/Query/ExpressionVisitors/IncludeExpressionVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionVisitors/IncludeExpressionVisitor.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Data.Entity.Relational.Query.ExpressionVisitors
         private readonly IQuerySource _querySource;
         private readonly IReadOnlyList<INavigation> _navigationPath;
         private readonly RelationalQueryCompilationContext _queryCompilationContext;
+        private readonly IReadOnlyList<int> _readerIndexes;
         private readonly bool _querySourceRequiresTracking;
 
         private bool _foundCreateEntityForQuerySource;
@@ -29,6 +30,7 @@ namespace Microsoft.Data.Entity.Relational.Query.ExpressionVisitors
             [NotNull] IQuerySource querySource,
             [NotNull] IReadOnlyList<INavigation> navigationPath,
             [NotNull] RelationalQueryCompilationContext queryCompilationContext,
+            [NotNull] IReadOnlyList<int> readerIndexes,
             bool querySourceRequiresTracking)
         {
             Check.NotNull(querySource, nameof(querySource));
@@ -38,6 +40,7 @@ namespace Microsoft.Data.Entity.Relational.Query.ExpressionVisitors
             _querySource = querySource;
             _navigationPath = navigationPath;
             _queryCompilationContext = queryCompilationContext;
+            _readerIndexes = readerIndexes;
             _querySourceRequiresTracking = querySourceRequiresTracking;
         }
 
@@ -89,9 +92,9 @@ namespace Microsoft.Data.Entity.Relational.Query.ExpressionVisitors
             var targetTableExpression
                 = selectExpression.GetTableForQuerySource(querySource);
 
-            var readerIndex = 0;
             var canProduceInnerJoin = true;
 
+            var includeReferenceCount = 0;
             foreach (var navigation in navigationPath)
             {
                 var targetEntityType = navigation.GetTargetType();
@@ -147,6 +150,9 @@ namespace Microsoft.Data.Entity.Relational.Query.ExpressionVisitors
                             navigation.PointsToPrincipal() ? joinExpression : targetTableExpression);
 
                     targetTableExpression = joinedTableExpression;
+
+                    var readerIndex = _readerIndexes[includeReferenceCount];
+                    includeReferenceCount++;
 
                     yield return
                         Expression.Lambda(
@@ -230,7 +236,6 @@ namespace Microsoft.Data.Entity.Relational.Query.ExpressionVisitors
                             innerJoinExpression);
 
                     selectExpression = targetSelectExpression;
-                    readerIndex++;
 
                     yield return
                         Expression.Lambda(

--- a/test/EntityFramework.Core.FunctionalTests/GearsOfWarQueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/GearsOfWarQueryTestBase.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel;
 using Xunit;
+using System.Collections.Generic;
 
 namespace Microsoft.Data.Entity.FunctionalTests
 {
@@ -27,6 +28,10 @@ namespace Microsoft.Data.Entity.FunctionalTests
         protected TFixture Fixture { get; }
 
         protected TTestStore TestStore { get; }
+
+        protected virtual void ClearLog()
+        {
+        }
 
         public void Dispose()
         {
@@ -118,6 +123,110 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 Assert.Equal(1, result.Count);
                 Assert.Equal("Jacinto", result.Single().CityOfBirth.Name);
                 Assert.Equal(2, result.Single().CityOfBirth.StationedGears.Count);
+            }
+        }
+
+        [Fact]
+        public virtual void Include_multiple_include_then_include()
+        {
+            var gearAssignedCities = new Dictionary<string, string>();
+            var gearCitiesOfBirth = new Dictionary<string, string>();
+            var gearTagNotes = new Dictionary<string, string>();
+            var cityStationedGears = new Dictionary<string, List<string>>();
+            var cityBornGears = new Dictionary<string, List<string>>();
+
+            using (var context = CreateContext())
+            {
+                gearAssignedCities = context.Gears
+                    .Include(g => g.AssignedCity)
+                    .ToDictionary(g => g.Nickname, g => g.AssignedCity?.Name);
+
+                gearCitiesOfBirth = context.Gears
+                    .Include(g => g.CityOfBirth)
+                    .ToDictionary(g => g.Nickname, g => g.CityOfBirth?.Name);
+
+                gearTagNotes = context.Gears
+                    .Include(g => g.Tag)
+                    .ToDictionary(g => g.Nickname, g => g.Tag.Note);
+
+                cityBornGears = context.Cities
+                    .Include(c => c.BornGears)
+                    .ToDictionary(
+                        c => c.Name, 
+                        c => c.BornGears != null 
+                            ? c.BornGears.Select(g => g.Nickname).ToList() 
+                            : new List<string>());
+
+                cityStationedGears = context.Cities
+                    .Include(c => c.StationedGears)
+                    .ToDictionary(
+                        c => c.Name, 
+                        c => c.StationedGears != null 
+                            ? c.StationedGears.Select(g => g.Nickname).ToList()
+                            : new List<string>());
+            }
+
+            ClearLog();
+            using (var context = CreateContext())
+            {
+                var query = context.Gears
+                    .Include(g => g.AssignedCity.BornGears).ThenInclude(g => g.Tag)
+                    .Include(g => g.AssignedCity.StationedGears).ThenInclude(g => g.Tag)
+                    .Include(g => g.CityOfBirth.BornGears).ThenInclude(g => g.Tag)
+                    .Include(g => g.CityOfBirth.StationedGears).ThenInclude(g => g.Tag)
+                    .OrderBy(g => g.Nickname);
+
+                var result = query.ToList();
+
+                var expectedGearCount = 5;
+                Assert.Equal(expectedGearCount, result.Count);
+                Assert.Equal("Baird", result[0].Nickname);
+                Assert.Equal("Cole Train", result[1].Nickname);
+                Assert.Equal("Dom", result[2].Nickname);
+                Assert.Equal("Marcus", result[3].Nickname);
+                Assert.Equal("Paduk", result[4].Nickname);
+
+                for (int i = 0; i < expectedGearCount; i++)
+                {
+                    Assert.Equal(gearAssignedCities[result[i]?.Nickname], result[i].AssignedCity?.Name);
+                    Assert.Equal(gearCitiesOfBirth[result[i]?.Nickname], result[i].CityOfBirth?.Name);
+
+                    var assignedCity = result[i].AssignedCity;
+                    if (assignedCity != null)
+                    {
+                        Assert.Equal(cityBornGears[assignedCity.Name].Count, assignedCity.BornGears.Count);
+                        foreach (var bornGear in assignedCity.BornGears)
+                        {
+                            Assert.True(cityBornGears[assignedCity.Name].Contains(bornGear.Nickname));
+                            Assert.Equal(gearTagNotes[bornGear.Nickname], bornGear.Tag.Note);
+                        }
+
+                        Assert.Equal(cityStationedGears[assignedCity.Name].Count, assignedCity.StationedGears.Count);
+                        foreach (var stationedGear in assignedCity.StationedGears)
+                        {
+                            Assert.True(cityStationedGears[assignedCity.Name].Contains(stationedGear.Nickname));
+                            Assert.Equal(gearTagNotes[stationedGear.Nickname], stationedGear.Tag.Note);
+                        }
+                    }
+
+                    var cityOfBirth = result[i].CityOfBirth;
+                    if (cityOfBirth != null)
+                    {
+                        Assert.Equal(cityBornGears[cityOfBirth.Name].Count, cityOfBirth.BornGears.Count);
+                        foreach (var bornGear in cityOfBirth.BornGears)
+                        {
+                            Assert.True(cityBornGears[cityOfBirth.Name].Contains(bornGear.Nickname));
+                            Assert.Equal(gearTagNotes[bornGear.Nickname], bornGear.Tag.Note);
+                        }
+
+                        Assert.Equal(cityStationedGears[cityOfBirth.Name].Count, cityOfBirth.StationedGears.Count);
+                        foreach (var stationedGear in cityOfBirth.StationedGears)
+                        {
+                            Assert.True(cityStationedGears[cityOfBirth.Name].Contains(stationedGear.Nickname));
+                            Assert.Equal(gearTagNotes[stationedGear.Nickname], stationedGear.Tag.Note);
+                        }
+                    }
+                }
             }
         }
     }

--- a/test/EntityFramework.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -14,6 +14,11 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         {
         }
 
+        protected override void ClearLog()
+        {
+            TestSqlLoggerFactory.Reset();
+        }
+
         public override void Include_multiple_one_to_one_and_one_to_many()
         {
             base.Include_multiple_one_to_one_and_one_to_many();
@@ -130,6 +135,67 @@ INNER JOIN (
     WHERE [g].[Nickname] = 'Marcus'
 ) AS [c] ON [g].[AssignedCityName] = [c].[Name]
 ORDER BY [c].[Name]",
+                Sql);
+        }
+
+        public override void Include_multiple_include_then_include()
+        {
+            base.Include_multiple_include_then_include();
+
+            Assert.Equal(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [c].[Name], [c].[Location], [c0].[Name], [c0].[Location], [c1].[Name], [c1].[Location], [c2].[Name], [c2].[Location]
+FROM [Gear] AS [g]
+LEFT JOIN [City] AS [c] ON [g].[AssignedCityName] = [c].[Name]
+LEFT JOIN [City] AS [c0] ON [g].[AssignedCityName] = [c0].[Name]
+INNER JOIN [City] AS [c1] ON [g].[CityOrBirthName] = [c1].[Name]
+INNER JOIN [City] AS [c2] ON [g].[CityOrBirthName] = [c2].[Name]
+ORDER BY [g].[Nickname], [c].[Name], [c0].[Name], [c1].[Name], [c2].[Name]
+
+SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [c].[Id], [c].[GearNickName], [c].[GearSquadId], [c].[Note]
+FROM [Gear] AS [g]
+INNER JOIN (
+    SELECT DISTINCT [g].[Nickname], [c].[Name], [c0].[Name] AS [Name0], [c1].[Name] AS [Name1], [c2].[Name] AS [Name2]
+    FROM [Gear] AS [g]
+    LEFT JOIN [City] AS [c] ON [g].[AssignedCityName] = [c].[Name]
+    LEFT JOIN [City] AS [c0] ON [g].[AssignedCityName] = [c0].[Name]
+    INNER JOIN [City] AS [c1] ON [g].[CityOrBirthName] = [c1].[Name]
+    INNER JOIN [City] AS [c2] ON [g].[CityOrBirthName] = [c2].[Name]
+) AS [c2] ON [g].[AssignedCityName] = [c2].[Name2]
+LEFT JOIN [CogTag] AS [c] ON ([c].[GearNickName] = [g].[Nickname] AND [c].[GearSquadId] = [g].[SquadId])
+ORDER BY [c2].[Nickname], [c2].[Name]
+
+SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [c].[Id], [c].[GearNickName], [c].[GearSquadId], [c].[Note]
+FROM [Gear] AS [g]
+INNER JOIN (
+    SELECT DISTINCT [g].[Nickname], [c].[Name], [c0].[Name] AS [Name0], [c1].[Name] AS [Name1]
+    FROM [Gear] AS [g]
+    LEFT JOIN [City] AS [c] ON [g].[AssignedCityName] = [c].[Name]
+    LEFT JOIN [City] AS [c0] ON [g].[AssignedCityName] = [c0].[Name]
+    INNER JOIN [City] AS [c1] ON [g].[CityOrBirthName] = [c1].[Name]
+) AS [c1] ON [g].[CityOrBirthName] = [c1].[Name1]
+LEFT JOIN [CogTag] AS [c] ON ([c].[GearNickName] = [g].[Nickname] AND [c].[GearSquadId] = [g].[SquadId])
+ORDER BY [c1].[Nickname], [c1].[Name]
+
+SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [c].[Id], [c].[GearNickName], [c].[GearSquadId], [c].[Note]
+FROM [Gear] AS [g]
+INNER JOIN (
+    SELECT DISTINCT [g].[Nickname], [c].[Name], [c0].[Name] AS [Name0]
+    FROM [Gear] AS [g]
+    LEFT JOIN [City] AS [c] ON [g].[AssignedCityName] = [c].[Name]
+    LEFT JOIN [City] AS [c0] ON [g].[AssignedCityName] = [c0].[Name]
+) AS [c0] ON [g].[AssignedCityName] = [c0].[Name0]
+LEFT JOIN [CogTag] AS [c] ON ([c].[GearNickName] = [g].[Nickname] AND [c].[GearSquadId] = [g].[SquadId])
+ORDER BY [c0].[Nickname], [c0].[Name]
+
+SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [c0].[Id], [c0].[GearNickName], [c0].[GearSquadId], [c0].[Note]
+FROM [Gear] AS [g]
+INNER JOIN (
+    SELECT DISTINCT [g].[Nickname], [c].[Name]
+    FROM [Gear] AS [g]
+    LEFT JOIN [City] AS [c] ON [g].[AssignedCityName] = [c].[Name]
+) AS [c] ON [g].[CityOrBirthName] = [c].[Name]
+LEFT JOIN [CogTag] AS [c0] ON ([c0].[GearNickName] = [g].[Nickname] AND [c0].[GearSquadId] = [g].[SquadId])
+ORDER BY [c].[Nickname], [c].[Name]",
                 Sql);
         }
 


### PR DESCRIPTION
Problem is that for complex queries with multiple includes we were attempting to materialize entities based on incorrect readers. Basically the way it works is that when we process include we build a factories that produce entities from actively opened readers.

Those were being build in isolation, starting fresh for each IncludeSpecification. Problem is that multiple include chains can leave readers open, that the other include chain was not aware of. This would produce errors like NRE, index outside bounds, invalid cast etc, when attempting to access incorrect reader while materializing entities.

Fix is to correctly compute indeces (which reader should be accessed for each entity) that each include chain needs to access. Computation is being done in the reverse order because this is the order that readers will eventually be executed in. Also we only compute indeces for Reference includes - Collections don't need them as they always open a new reader.