### PR TITLE
Make it possible for providers to change IParameterNameGeneratorFactory service

### DIFF
--- a/src/EntityFramework.Relational/IRelationalDatabaseProviderServices.cs
+++ b/src/EntityFramework.Relational/IRelationalDatabaseProviderServices.cs
@@ -28,5 +28,6 @@ namespace Microsoft.Data.Entity.Relational
         ISqlStatementExecutor SqlStatementExecutor { get; }
         IMethodCallTranslator CompositeMethodCallTranslator { get; }
         IMemberTranslator CompositeMemberTranslator { get; }
+        IParameterNameGeneratorFactory ParameterNameGeneratorFactory { get; }
     }
 }

--- a/src/EntityFramework.Relational/RelationalDatabaseProviderServices.cs
+++ b/src/EntityFramework.Relational/RelationalDatabaseProviderServices.cs
@@ -27,13 +27,15 @@ namespace Microsoft.Data.Entity.Relational
 
         public override IQueryContextFactory QueryContextFactory => GetService<RelationalQueryContextFactory>();
         public override IValueGeneratorSelector ValueGeneratorSelector => GetService<RelationalValueGeneratorSelector>();
+        public override IModelValidator ModelValidator => GetService<RelationalModelValidator>();
+
         public virtual IRelationalTypeMapper TypeMapper => GetService<RelationalTypeMapper>();
         public virtual IMigrationAnnotationProvider MigrationAnnotationProvider => GetService<MigrationAnnotationProvider>();
         public virtual IBatchExecutor BatchExecutor => GetService<BatchExecutor>();
         public virtual IRelationalValueBufferFactoryFactory ValueBufferFactoryFactory => GetService<TypedValueBufferFactoryFactory>();
         public virtual ICommandBatchPreparer CommandBatchPreparer => GetService<CommandBatchPreparer>();
         public virtual ISqlStatementExecutor SqlStatementExecutor => GetService<SqlStatementExecutor>();
-        public override IModelValidator ModelValidator => GetService<RelationalModelValidator>();
+        public virtual IParameterNameGeneratorFactory ParameterNameGeneratorFactory => GetService<ParameterNameGeneratorFactory>();
 
         public abstract IMethodCallTranslator CompositeMethodCallTranslator { get; }
         public abstract IMemberTranslator CompositeMemberTranslator { get; }

--- a/src/EntityFramework.Relational/RelationalEntityServicesBuilderExtensions.cs
+++ b/src/EntityFramework.Relational/RelationalEntityServicesBuilderExtensions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Data.Entity.Relational
             Check.NotNull(builder, nameof(builder));
 
             builder.GetService().TryAdd(new ServiceCollection()
-                .AddSingleton<IParameterNameGeneratorFactory, ParameterNameGeneratorFactory>()
+                .AddSingleton<ParameterNameGeneratorFactory>()
                 .AddSingleton<IComparer<ModificationCommand>, ModificationCommandComparer>()
                 .AddSingleton<IMigrationIdGenerator, MigrationIdGenerator>()
                 .AddSingleton<SqlStatementExecutor>()
@@ -43,6 +43,7 @@ namespace Microsoft.Data.Entity.Relational
                 .AddScoped<RelationalValueGeneratorSelector>()
                 .AddScoped<CommandBatchPreparer>()
                 .AddScoped<IModelDiffer, ModelDiffer>()
+                .AddScoped(p => GetProviderServices(p).ParameterNameGeneratorFactory)
                 .AddScoped(p => GetProviderServices(p).SqlStatementExecutor)
                 .AddScoped(p => GetProviderServices(p).CompositeMethodCallTranslator)
                 .AddScoped(p => GetProviderServices(p).CompositeMemberTranslator)


### PR DESCRIPTION
Per request from Oracle to generate Oracle-specific parameter names. To use, add an override something like this in your XxxDatabaseProviderServices class:

```
public override IParameterNameGeneratorFactory ParameterNameGeneratorFactory => GetService<XxxParameterNameGeneratorFactory>();
```

And register XxxParameterNameGeneratorFactory in your AddXxx method.