### PR TITLE
More API review stuff

### DIFF
--- a/src/EntityFramework.Relational/EntityFramework.Relational.csproj
+++ b/src/EntityFramework.Relational/EntityFramework.Relational.csproj
@@ -56,7 +56,7 @@
     <Compile Include="IRelationalTransaction.cs" />
     <Compile Include="IRelationalTypeMapper.cs" />
     <Compile Include="IRelationalValueBufferFactoryFactory.cs" />
-    <Compile Include="ISqlGenerator.cs" />
+    <Compile Include="IUpdateSqlGenerator.cs" />
     <Compile Include="ISqlStatementExecutor.cs" />
     <Compile Include="Metadata\IRelationalMetadataExtensionProvider.cs" />
     <Compile Include="Metadata\RelationalReferenceReferenceBuilderExtensions.cs" />
@@ -151,8 +151,8 @@
     <Compile Include="RelationalDatabaseProviderServices.cs" />
     <Compile Include="RelationalModelValidator.cs" />
     <Compile Include="RelationalTypeMapperExtensions.cs" />
-    <Compile Include="RemappingUntypedValueBufferFactory.cs" />
-    <Compile Include="UntypedValueBufferFactory.cs" />
+    <Compile Include="RemappingUntypedRelationalValueBufferFactory.cs" />
+    <Compile Include="UntypedRelationalValueBufferFactory.cs" />
     <Compile Include="UntypedValueBufferFactoryFactory.cs" />
     <Compile Include="Query\AsyncQueryingEnumerable.cs" />
     <Compile Include="Query\AsyncQueryMethodProvider.cs" />
@@ -224,7 +224,7 @@
     <Compile Include="RelationalOptionsExtension.cs" />
     <Compile Include="RelationalConnection.cs" />
     <Compile Include="RelationalDatabase.cs" />
-    <Compile Include="RelationalEntityServicesBuilderExtensions.cs" />
+    <Compile Include="RelationalEntityFrameworkServicesBuilderExtensions.cs" />
     <Compile Include="RelationalLoggerExtensions.cs" />
     <Compile Include="RelationalLoggingEventIds.cs" />
     <Compile Include="Query\RelationalQueryContext.cs" />
@@ -232,7 +232,7 @@
     <Compile Include="IRelationalValueBufferFactory.cs" />
     <Compile Include="SqlBatch.cs" />
     <Compile Include="SqlBatchBuilder.cs" />
-    <Compile Include="SqlGenerator.cs" />
+    <Compile Include="UpdateSqlGenerator.cs" />
     <Compile Include="SqlStatementExecutor.cs" />
     <Compile Include="RelationalSizedTypeMapping.cs" />
     <Compile Include="RelationalTypeMapper.cs" />
@@ -242,7 +242,7 @@
     <Compile Include="Properties\Strings.Designer.cs">
       <DependentUpon>Strings.resx</DependentUpon>
     </Compile>
-    <Compile Include="TypedValueBufferFactory.cs" />
+    <Compile Include="TypedRelationalValueBufferFactory.cs" />
     <Compile Include="TypedValueBufferFactoryFactory.cs" />
     <Compile Include="Update\AffectedCountModificationCommandBatch.cs" />
     <Compile Include="Update\BatchExecutor.cs" />

--- a/src/EntityFramework.Relational/IRelationalDatabaseProviderServices.cs
+++ b/src/EntityFramework.Relational/IRelationalDatabaseProviderServices.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Data.Entity.Relational
         IMigrationSqlGenerator MigrationSqlGenerator { get; }
         IRelationalConnection RelationalConnection { get; }
         IRelationalTypeMapper TypeMapper { get; }
-        ISqlGenerator SqlGenerator { get; }
+        IUpdateSqlGenerator UpdateSqlGenerator { get; }
         IModificationCommandBatchFactory ModificationCommandBatchFactory { get; }
         ICommandBatchPreparer CommandBatchPreparer { get; }
         IBatchExecutor BatchExecutor { get; }

--- a/src/EntityFramework.Relational/ISqlStatementExecutor.cs
+++ b/src/EntityFramework.Relational/ISqlStatementExecutor.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Threading;
@@ -24,11 +23,6 @@ namespace Microsoft.Data.Entity.Relational
             [NotNull] string sql,
             CancellationToken cancellationToken = default(CancellationToken));
 
-        Task<object> ExecuteAsync(
-            [NotNull] IRelationalConnection connection,
-            [NotNull] Func<Task<object>> action,
-            CancellationToken cancellationToken = default(CancellationToken));
-
         void ExecuteNonQuery(
             [NotNull] IRelationalConnection connection,
             [CanBeNull] DbTransaction transaction,
@@ -38,9 +32,5 @@ namespace Microsoft.Data.Entity.Relational
             [NotNull] IRelationalConnection connection,
             [CanBeNull] DbTransaction transaction,
             [NotNull] string sql);
-
-        object Execute(
-            [NotNull] IRelationalConnection connection,
-            [NotNull] Func<object> action);
     }
 }

--- a/src/EntityFramework.Relational/IUpdateSqlGenerator.cs
+++ b/src/EntityFramework.Relational/IUpdateSqlGenerator.cs
@@ -8,7 +8,7 @@ using Microsoft.Data.Entity.Relational.Update;
 
 namespace Microsoft.Data.Entity.Relational
 {
-    public interface ISqlGenerator
+    public interface IUpdateSqlGenerator
     {
         string BatchCommandSeparator { get; }
         string BatchSeparator { get; }

--- a/src/EntityFramework.Relational/Migrations/Migrator.cs
+++ b/src/EntityFramework.Relational/Migrations/Migrator.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Data.Entity.Relational.Migrations
         private readonly IModelDiffer _modelDiffer;
         private readonly IModel _model;
         private readonly IMigrationIdGenerator _idGenerator;
-        private readonly ISqlGenerator _sqlGenerator;
+        private readonly IUpdateSqlGenerator _sqlGenerator;
         private readonly LazyRef<ILogger> _logger;
         private readonly IMigrationModelFactory _modelFactory;
 
@@ -45,7 +45,7 @@ namespace Microsoft.Data.Entity.Relational.Migrations
             [NotNull] IModelDiffer modelDiffer,
             [NotNull] IModel model,
             [NotNull] IMigrationIdGenerator idGenerator,
-            [NotNull] ISqlGenerator sqlGenerator,
+            [NotNull] IUpdateSqlGenerator sqlGenerator,
             [NotNull] ILoggerFactory loggerFactory,
             [NotNull] IMigrationModelFactory modelFactory)
         {

--- a/src/EntityFramework.Relational/Migrations/Sql/MigrationSqlGenerator.cs
+++ b/src/EntityFramework.Relational/Migrations/Sql/MigrationSqlGenerator.cs
@@ -14,9 +14,9 @@ namespace Microsoft.Data.Entity.Relational.Migrations.Sql
 {
     public abstract class MigrationSqlGenerator : IMigrationSqlGenerator
     {
-        private readonly ISqlGenerator _sql;
+        private readonly IUpdateSqlGenerator _sql;
 
-        protected MigrationSqlGenerator([NotNull] ISqlGenerator sqlGenerator)
+        protected MigrationSqlGenerator([NotNull] IUpdateSqlGenerator sqlGenerator)
         {
             Check.NotNull(sqlGenerator, nameof(sqlGenerator));
 

--- a/src/EntityFramework.Relational/RelationalDatabaseProviderServices.cs
+++ b/src/EntityFramework.Relational/RelationalDatabaseProviderServices.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Data.Entity.Relational
         public abstract IHistoryRepository HistoryRepository { get; }
         public abstract IMigrationSqlGenerator MigrationSqlGenerator { get; }
         public abstract IRelationalConnection RelationalConnection { get; }
-        public abstract ISqlGenerator SqlGenerator { get; }
+        public abstract IUpdateSqlGenerator UpdateSqlGenerator { get; }
         public abstract IModificationCommandBatchFactory ModificationCommandBatchFactory { get; }
         public abstract IRelationalDatabaseCreator RelationalDatabaseCreator { get; }
         public abstract IRelationalMetadataExtensionProvider MetadataExtensionProvider { get; }

--- a/src/EntityFramework.Relational/RelationalEntityFrameworkServicesBuilderExtensions.cs
+++ b/src/EntityFramework.Relational/RelationalEntityFrameworkServicesBuilderExtensions.cs
@@ -19,7 +19,7 @@ using Microsoft.Framework.DependencyInjection;
 
 namespace Microsoft.Data.Entity.Relational
 {
-    public static class RelationalEntityServicesBuilderExtensions
+    public static class RelationalEntityFrameworkServicesBuilderExtensions
     {
         public static EntityFrameworkServicesBuilder AddRelational([NotNull] this EntityFrameworkServicesBuilder builder)
         {
@@ -57,7 +57,7 @@ namespace Microsoft.Data.Entity.Relational
                 .AddScoped(p => GetProviderServices(p).BatchExecutor)
                 .AddScoped(p => GetProviderServices(p).ValueBufferFactoryFactory)
                 .AddScoped(p => GetProviderServices(p).RelationalDatabaseCreator)
-                .AddScoped(p => GetProviderServices(p).SqlGenerator)
+                .AddScoped(p => GetProviderServices(p).UpdateSqlGenerator)
                 .AddScoped(p => GetProviderServices(p).MetadataExtensionProvider));
 
             return builder;

--- a/src/EntityFramework.Relational/RelationalLoggerExtensions.cs
+++ b/src/EntityFramework.Relational/RelationalLoggerExtensions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Framework.Logging
     internal static class RelationalLoggerExtensions
     {
         public static void LogSql([NotNull] this ILogger logger, [NotNull] string sql)
-            => logger.LogVerbose(RelationalLoggingEventIds.Sql, sql);
+            => logger.LogVerbose(RelationalLoggingEventIds.ExecutingSql, sql);
 
         public static void LogParameters([NotNull] this ILogger logger, [NotNull] DbParameterCollection parameters)
         {
@@ -32,7 +32,7 @@ namespace Microsoft.Framework.Logging
                 paramList.AppendLine();
                 paramList.AppendFormat("{0}: {1}", (parameters[i]).ParameterName, Convert.ToString((parameters[i]).Value, CultureInfo.InvariantCulture));
             }
-            logger.LogDebug(RelationalLoggingEventIds.Sql, paramList.ToString());
+            logger.LogDebug(RelationalLoggingEventIds.ExecutingSql, paramList.ToString());
         }
 
         public static void LogCommand([NotNull] this ILogger logger, [NotNull] DbCommand command)

--- a/src/EntityFramework.Relational/RelationalLoggingEventIds.cs
+++ b/src/EntityFramework.Relational/RelationalLoggingEventIds.cs
@@ -5,12 +5,12 @@ namespace Microsoft.Data.Entity.Relational
 {
     public static class RelationalLoggingEventIds
     {
-        public static readonly int Sql = 42;
-        public static readonly int CreatingDatabase = 43;
-        public static readonly int OpeningConnection = 44;
-        public static readonly int ClosingConnection = 45;
-        public static readonly int BeginningTransaction = 46;
-        public static readonly int CommittingTransaction = 47;
-        public static readonly int RollingbackTransaction = 48;
+        public const int ExecutingSql = 42;
+        public const int CreatingDatabase = 43;
+        public const int OpeningConnection = 44;
+        public const int ClosingConnection = 45;
+        public const int BeginningTransaction = 46;
+        public const int CommittingTransaction = 47;
+        public const int RollingbackTransaction = 48;
     }
 }

--- a/src/EntityFramework.Relational/RemappingUntypedRelationalValueBufferFactory.cs
+++ b/src/EntityFramework.Relational/RemappingUntypedRelationalValueBufferFactory.cs
@@ -11,11 +11,11 @@ using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Relational
 {
-    public class RemappingUntypedValueBufferFactory : IRelationalValueBufferFactory
+    public class RemappingUntypedRelationalValueBufferFactory : IRelationalValueBufferFactory
     {
         private readonly IReadOnlyList<int> _indexMap;
 
-        public RemappingUntypedValueBufferFactory([NotNull] IReadOnlyList<int> indexMap)
+        public RemappingUntypedRelationalValueBufferFactory([NotNull] IReadOnlyList<int> indexMap)
         {
             Check.NotNull(indexMap, nameof(indexMap));
 

--- a/src/EntityFramework.Relational/SqlStatementExecutor.cs
+++ b/src/EntityFramework.Relational/SqlStatementExecutor.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Data.Entity.Relational
                 cancellationToken);
         }
 
-        public virtual async Task<object> ExecuteAsync(
+        protected virtual async Task<object> ExecuteAsync(
             IRelationalConnection connection,
             Func<Task<object>> action,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -145,7 +145,7 @@ namespace Microsoft.Data.Entity.Relational
                     });
         }
 
-        public virtual object Execute(
+        protected virtual object Execute(
             IRelationalConnection connection,
             Func<object> action)
         {

--- a/src/EntityFramework.Relational/TypedRelationalValueBufferFactory.cs
+++ b/src/EntityFramework.Relational/TypedRelationalValueBufferFactory.cs
@@ -10,11 +10,11 @@ using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Relational
 {
-    public class TypedValueBufferFactory : IRelationalValueBufferFactory
+    public class TypedRelationalValueBufferFactory : IRelationalValueBufferFactory
     {
         private readonly Func<DbDataReader, object[]> _valueFactory;
 
-        public TypedValueBufferFactory([NotNull] Func<DbDataReader, object[]> valueFactory)
+        public TypedRelationalValueBufferFactory([NotNull] Func<DbDataReader, object[]> valueFactory)
         {
             Check.NotNull(valueFactory, nameof(valueFactory));
 

--- a/src/EntityFramework.Relational/TypedValueBufferFactoryFactory.cs
+++ b/src/EntityFramework.Relational/TypedValueBufferFactoryFactory.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Data.Entity.Relational
         {
             Check.NotNull(valueTypes, nameof(valueTypes));
 
-            return new TypedValueBufferFactory(
+            return new TypedRelationalValueBufferFactory(
                 _cache.GetOrAdd(
                     new CacheKey(valueTypes.ToArray(), indexMap),
                     CreateArrayInitializer));

--- a/src/EntityFramework.Relational/UntypedRelationalValueBufferFactory.cs
+++ b/src/EntityFramework.Relational/UntypedRelationalValueBufferFactory.cs
@@ -8,7 +8,7 @@ using Microsoft.Data.Entity.Storage;
 
 namespace Microsoft.Data.Entity.Relational
 {
-    public class UntypedValueBufferFactory : IRelationalValueBufferFactory
+    public class UntypedRelationalValueBufferFactory : IRelationalValueBufferFactory
     {
         public virtual ValueBuffer Create(DbDataReader dataReader)
         {

--- a/src/EntityFramework.Relational/UntypedValueBufferFactoryFactory.cs
+++ b/src/EntityFramework.Relational/UntypedValueBufferFactoryFactory.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Data.Entity.Relational
         public virtual IRelationalValueBufferFactory Create(
             IReadOnlyCollection<Type> _, IReadOnlyList<int> indexMap)
             => indexMap == null
-                ? (IRelationalValueBufferFactory)new UntypedValueBufferFactory()
-                : new RemappingUntypedValueBufferFactory(indexMap);
+                ? (IRelationalValueBufferFactory)new UntypedRelationalValueBufferFactory()
+                : new RemappingUntypedRelationalValueBufferFactory(indexMap);
     }
 }

--- a/src/EntityFramework.Relational/Update/AffectedCountModificationCommandBatch.cs
+++ b/src/EntityFramework.Relational/Update/AffectedCountModificationCommandBatch.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Data.Entity.Relational.Update
         private readonly List<bool> _resultSetEnd = new List<bool>();
 
         protected AffectedCountModificationCommandBatch(
-            [NotNull] ISqlGenerator sqlGenerator)
+            [NotNull] IUpdateSqlGenerator sqlGenerator)
             : base(sqlGenerator)
         {
         }

--- a/src/EntityFramework.Relational/Update/ModificationCommandBatch.cs
+++ b/src/EntityFramework.Relational/Update/ModificationCommandBatch.cs
@@ -12,14 +12,14 @@ namespace Microsoft.Data.Entity.Relational.Update
 {
     public abstract class ModificationCommandBatch
     {
-        protected ModificationCommandBatch([NotNull] ISqlGenerator sqlGenerator)
+        protected ModificationCommandBatch([NotNull] IUpdateSqlGenerator sqlGenerator)
         {
             Check.NotNull(sqlGenerator, nameof(sqlGenerator));
 
-            SqlGenerator = sqlGenerator;
+            UpdateSqlGenerator = sqlGenerator;
         }
 
-        protected ISqlGenerator SqlGenerator { get; private set; }
+        protected IUpdateSqlGenerator UpdateSqlGenerator { get; private set; }
 
         public abstract IReadOnlyList<ModificationCommand> ModificationCommands { get; }
 

--- a/src/EntityFramework.Relational/Update/ModificationCommandBatchFactory.cs
+++ b/src/EntityFramework.Relational/Update/ModificationCommandBatchFactory.cs
@@ -11,14 +11,14 @@ namespace Microsoft.Data.Entity.Relational.Update
     public abstract class ModificationCommandBatchFactory : IModificationCommandBatchFactory
     {
         protected ModificationCommandBatchFactory(
-            [NotNull] ISqlGenerator sqlGenerator)
+            [NotNull] IUpdateSqlGenerator sqlGenerator)
         {
             Check.NotNull(sqlGenerator, nameof(sqlGenerator));
 
-            SqlGenerator = sqlGenerator;
+            UpdateSqlGenerator = sqlGenerator;
         }
 
-        protected ISqlGenerator SqlGenerator { get; }
+        protected IUpdateSqlGenerator UpdateSqlGenerator { get; }
 
         public abstract ModificationCommandBatch Create(
             IDbContextOptions options,

--- a/src/EntityFramework.Relational/Update/ReaderModificationCommandBatch.cs
+++ b/src/EntityFramework.Relational/Update/ReaderModificationCommandBatch.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Data.Entity.Relational.Update
         protected int LastCachedCommandIndex;
 
         protected ReaderModificationCommandBatch(
-            [NotNull] ISqlGenerator sqlGenerator)
+            [NotNull] IUpdateSqlGenerator sqlGenerator)
             : base(sqlGenerator)
         {
         }
@@ -61,7 +61,7 @@ namespace Microsoft.Data.Entity.Relational.Update
         protected virtual void ResetCommandText()
         {
             CachedCommandText = new StringBuilder();
-            SqlGenerator.AppendBatchHeader(CachedCommandText);
+            UpdateSqlGenerator.AppendBatchHeader(CachedCommandText);
             LastCachedCommandIndex = -1;
         }
 
@@ -86,13 +86,13 @@ namespace Microsoft.Data.Entity.Relational.Update
             switch (newModificationCommand.EntityState)
             {
                 case EntityState.Added:
-                    SqlGenerator.AppendInsertOperation(CachedCommandText, newModificationCommand);
+                    UpdateSqlGenerator.AppendInsertOperation(CachedCommandText, newModificationCommand);
                     break;
                 case EntityState.Modified:
-                    SqlGenerator.AppendUpdateOperation(CachedCommandText, newModificationCommand);
+                    UpdateSqlGenerator.AppendUpdateOperation(CachedCommandText, newModificationCommand);
                     break;
                 case EntityState.Deleted:
-                    SqlGenerator.AppendDeleteOperation(CachedCommandText, newModificationCommand);
+                    UpdateSqlGenerator.AppendDeleteOperation(CachedCommandText, newModificationCommand);
                     break;
             }
 

--- a/src/EntityFramework.Relational/Update/SingularModificationCommandBatch.cs
+++ b/src/EntityFramework.Relational/Update/SingularModificationCommandBatch.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Data.Entity.Relational.Update
     public class SingularModificationCommandBatch : AffectedCountModificationCommandBatch
     {
         public SingularModificationCommandBatch(
-            [NotNull] ISqlGenerator sqlGenerator)
+            [NotNull] IUpdateSqlGenerator sqlGenerator)
             : base(sqlGenerator)
         {
         }

--- a/src/EntityFramework.Relational/UpdateSqlGenerator.cs
+++ b/src/EntityFramework.Relational/UpdateSqlGenerator.cs
@@ -12,7 +12,7 @@ using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Relational
 {
-    public abstract class SqlGenerator : ISqlGenerator
+    public abstract class UpdateSqlGenerator : IUpdateSqlGenerator
     {
         public virtual void AppendInsertOperation(StringBuilder commandStringBuilder, ModificationCommand command)
         {

--- a/src/EntityFramework.SqlServer/EntityFramework.SqlServer.csproj
+++ b/src/EntityFramework.SqlServer/EntityFramework.SqlServer.csproj
@@ -45,7 +45,7 @@
     </Compile>
     <Compile Include="Extensions\SqlServerDbContextOptionsBuilder.cs" />
     <Compile Include="ISqlServerConnection.cs" />
-    <Compile Include="ISqlServerSqlGenerator.cs" />
+    <Compile Include="ISqlServerUpdateSqlGenerator.cs" />
     <Compile Include="Metadata\ISqlServerEntityTypeAnnotations.cs" />
     <Compile Include="Metadata\ISqlServerForeignKeyAnnotations.cs" />
     <Compile Include="Metadata\ISqlServerIndexAnnotations.cs" />
@@ -109,7 +109,7 @@
     <Compile Include="SqlServerDatabase.cs" />
     <Compile Include="SqlServerDatabaseCreator.cs" />
     <Compile Include="Migrations\SqlServerMigrationSqlGenerator.cs" />
-    <Compile Include="SqlServerSqlGenerator.cs" />
+    <Compile Include="SqlServerUpdateSqlGenerator.cs" />
     <Compile Include="SqlServerTypeMapper.cs" />
     <Compile Include="Extensions\SqlServerDbContextOptionsExtensions.cs" />
     <Compile Include="Extensions\SqlServerEntityServicesBuilderExtensions.cs" />

--- a/src/EntityFramework.SqlServer/Extensions/SqlServerEntityServicesBuilderExtensions.cs
+++ b/src/EntityFramework.SqlServer/Extensions/SqlServerEntityServicesBuilderExtensions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Framework.DependencyInjection
                 .TryAdd(new ServiceCollection()
                     .AddSingleton<SqlServerConventionSetBuilder>()
                     .AddSingleton<ISqlServerValueGeneratorCache, SqlServerValueGeneratorCache>()
-                    .AddSingleton<ISqlServerSqlGenerator, SqlServerSqlGenerator>()
+                    .AddSingleton<ISqlServerUpdateSqlGenerator, SqlServerUpdateSqlGenerator>()
                     .AddSingleton<SqlServerTypeMapper>()
                     .AddSingleton<SqlServerModelSource>()
                     .AddSingleton<SqlServerMetadataExtensionProvider>()

--- a/src/EntityFramework.SqlServer/ISqlServerUpdateSqlGenerator.cs
+++ b/src/EntityFramework.SqlServer/ISqlServerUpdateSqlGenerator.cs
@@ -10,9 +10,9 @@ using Microsoft.Data.Entity.Relational.Update;
 
 namespace Microsoft.Data.Entity.SqlServer
 {
-    public interface ISqlServerSqlGenerator : ISqlGenerator
+    public interface ISqlServerUpdateSqlGenerator : IUpdateSqlGenerator
     {
-        SqlServerSqlGenerator.ResultsGrouping AppendBulkInsertOperation(
+        SqlServerUpdateSqlGenerator.ResultsGrouping AppendBulkInsertOperation(
             [NotNull] StringBuilder commandStringBuilder,
             [NotNull] IReadOnlyList<ModificationCommand> modificationCommands);
 

--- a/src/EntityFramework.SqlServer/Migrations/SqlServerHistoryRepository.cs
+++ b/src/EntityFramework.SqlServer/Migrations/SqlServerHistoryRepository.cs
@@ -22,13 +22,13 @@ namespace Microsoft.Data.Entity.SqlServer.Migrations
         private readonly ISqlServerConnection _connection;
         private readonly IRelationalDatabaseCreator _creator;
         private readonly Type _contextType;
-        private readonly ISqlServerSqlGenerator _sql;
+        private readonly ISqlServerUpdateSqlGenerator _sql;
 
         public SqlServerHistoryRepository(
             [NotNull] ISqlServerConnection connection,
             [NotNull] IRelationalDatabaseCreator creator,
             [NotNull] DbContext context,
-            [NotNull] ISqlServerSqlGenerator sqlGenerator)
+            [NotNull] ISqlServerUpdateSqlGenerator sqlGenerator)
         {
             Check.NotNull(connection, nameof(connection));
             Check.NotNull(creator, nameof(creator));

--- a/src/EntityFramework.SqlServer/Migrations/SqlServerMigrationSqlGenerator.cs
+++ b/src/EntityFramework.SqlServer/Migrations/SqlServerMigrationSqlGenerator.cs
@@ -16,9 +16,9 @@ namespace Microsoft.Data.Entity.SqlServer
 {
     public class SqlServerMigrationSqlGenerator : MigrationSqlGenerator
     {
-        private readonly ISqlServerSqlGenerator _sql;
+        private readonly ISqlServerUpdateSqlGenerator _sql;
 
-        public SqlServerMigrationSqlGenerator([NotNull] ISqlServerSqlGenerator sqlGenerator)
+        public SqlServerMigrationSqlGenerator([NotNull] ISqlServerUpdateSqlGenerator sqlGenerator)
             : base(Check.NotNull(sqlGenerator, nameof(sqlGenerator)))
         {
             _sql = sqlGenerator;

--- a/src/EntityFramework.SqlServer/SqlServerDatabaseProviderServices.cs
+++ b/src/EntityFramework.SqlServer/SqlServerDatabaseProviderServices.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Data.Entity.SqlServer
         public override IHistoryRepository HistoryRepository => GetService<SqlServerHistoryRepository>();
         public override IMigrationSqlGenerator MigrationSqlGenerator => GetService<SqlServerMigrationSqlGenerator>();
         public override IModelSource ModelSource => GetService<SqlServerModelSource>();
-        public override ISqlGenerator SqlGenerator => GetService<ISqlServerSqlGenerator>();
+        public override IUpdateSqlGenerator UpdateSqlGenerator => GetService<ISqlServerUpdateSqlGenerator>();
         public override IValueGeneratorCache ValueGeneratorCache => GetService<ISqlServerValueGeneratorCache>();
         public override IRelationalTypeMapper TypeMapper => GetService<SqlServerTypeMapper>();
         public override IModificationCommandBatchFactory ModificationCommandBatchFactory => GetService<SqlServerModificationCommandBatchFactory>();

--- a/src/EntityFramework.SqlServer/SqlServerUpdateSqlGenerator.cs
+++ b/src/EntityFramework.SqlServer/SqlServerUpdateSqlGenerator.cs
@@ -12,7 +12,7 @@ using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.SqlServer
 {
-    public class SqlServerSqlGenerator : SqlGenerator, ISqlServerSqlGenerator
+    public class SqlServerUpdateSqlGenerator : UpdateSqlGenerator, ISqlServerUpdateSqlGenerator
     {
         public override void AppendInsertOperation(
             StringBuilder commandStringBuilder,

--- a/src/EntityFramework.SqlServer/Update/SqlServerModificationCommandBatch.cs
+++ b/src/EntityFramework.SqlServer/Update/SqlServerModificationCommandBatch.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Data.Entity.SqlServer.Update
         private int _commandsLeftToLengthCheck = 50;
 
         public SqlServerModificationCommandBatch(
-            [NotNull] ISqlServerSqlGenerator sqlGenerator,
+            [NotNull] ISqlServerUpdateSqlGenerator sqlGenerator,
             [CanBeNull] int? maxBatchSize)
             : base(sqlGenerator)
         {
@@ -108,10 +108,10 @@ namespace Microsoft.Data.Entity.SqlServer.Update
             }
 
             var stringBuilder = new StringBuilder();
-            var grouping = ((ISqlServerSqlGenerator)SqlGenerator).AppendBulkInsertOperation(stringBuilder, _bulkInsertCommands);
+            var grouping = ((ISqlServerUpdateSqlGenerator)UpdateSqlGenerator).AppendBulkInsertOperation(stringBuilder, _bulkInsertCommands);
             for (var i = lastIndex - _bulkInsertCommands.Count; i < lastIndex; i++)
             {
-                ResultSetEnds[i] = grouping == SqlServerSqlGenerator.ResultsGrouping.OneCommandPerResultSet;
+                ResultSetEnds[i] = grouping == SqlServerUpdateSqlGenerator.ResultsGrouping.OneCommandPerResultSet;
             }
 
             ResultSetEnds[lastIndex - 1] = true;

--- a/src/EntityFramework.SqlServer/Update/SqlServerModificationCommandBatchFactory.cs
+++ b/src/EntityFramework.SqlServer/Update/SqlServerModificationCommandBatchFactory.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Data.Entity.SqlServer.Update
     public class SqlServerModificationCommandBatchFactory : ModificationCommandBatchFactory
     {
         public SqlServerModificationCommandBatchFactory(
-            [NotNull] ISqlServerSqlGenerator sqlGenerator)
+            [NotNull] ISqlServerUpdateSqlGenerator sqlGenerator)
             : base(sqlGenerator)
         {
         }
@@ -29,7 +29,7 @@ namespace Microsoft.Data.Entity.SqlServer.Update
 
             var maxBatchSize = optionsExtension?.MaxBatchSize;
 
-            return new SqlServerModificationCommandBatch((ISqlServerSqlGenerator)SqlGenerator, maxBatchSize);
+            return new SqlServerModificationCommandBatch((ISqlServerUpdateSqlGenerator)UpdateSqlGenerator, maxBatchSize);
         }
     }
 }

--- a/src/EntityFramework.SqlServer/ValueGeneration/SqlServerSequenceValueGenerator.cs
+++ b/src/EntityFramework.SqlServer/ValueGeneration/SqlServerSequenceValueGenerator.cs
@@ -13,13 +13,13 @@ namespace Microsoft.Data.Entity.SqlServer.ValueGeneration
     public class SqlServerSequenceValueGenerator<TValue> : HiLoValueGenerator<TValue>
     {
         private readonly ISqlStatementExecutor _executor;
-        private readonly ISqlServerSqlGenerator _sqlGenerator;
+        private readonly ISqlServerUpdateSqlGenerator _sqlGenerator;
         private readonly ISqlServerConnection _connection;
         private readonly string _sequenceName;
 
         public SqlServerSequenceValueGenerator(
             [NotNull] ISqlStatementExecutor executor,
-            [NotNull] ISqlServerSqlGenerator sqlGenerator,
+            [NotNull] ISqlServerUpdateSqlGenerator sqlGenerator,
             [NotNull] SqlServerSequenceValueGeneratorState generatorState,
             [NotNull] ISqlServerConnection connection)
             : base(Check.NotNull(generatorState, nameof(generatorState)))

--- a/src/EntityFramework.SqlServer/ValueGeneration/SqlServerSequenceValueGeneratorFactory.cs
+++ b/src/EntityFramework.SqlServer/ValueGeneration/SqlServerSequenceValueGeneratorFactory.cs
@@ -13,11 +13,11 @@ namespace Microsoft.Data.Entity.SqlServer.ValueGeneration
     public class SqlServerSequenceValueGeneratorFactory : ISqlServerSequenceValueGeneratorFactory
     {
         private readonly ISqlStatementExecutor _executor;
-        private readonly ISqlServerSqlGenerator _sqlGenerator;
+        private readonly ISqlServerUpdateSqlGenerator _sqlGenerator;
 
         public SqlServerSequenceValueGeneratorFactory(
             [NotNull] ISqlStatementExecutor executor,
-            [NotNull] ISqlServerSqlGenerator sqlGenerator)
+            [NotNull] ISqlServerUpdateSqlGenerator sqlGenerator)
         {
             Check.NotNull(executor, nameof(executor));
             Check.NotNull(sqlGenerator, nameof(sqlGenerator));

--- a/src/EntityFramework.Sqlite/EntityFramework.Sqlite.csproj
+++ b/src/EntityFramework.Sqlite/EntityFramework.Sqlite.csproj
@@ -106,7 +106,7 @@
     <Compile Include="SqliteEntityFrameworkServicesBuilderExtensions.cs" />
     <Compile Include="SqliteCompositeMethodCallTranslator.cs" />
     <Compile Include="SqliteModelSource.cs" />
-    <Compile Include="SqliteSqlGenerator.cs" />
+    <Compile Include="SqliteUpdateSqlGenerator.cs" />
     <Compile Include="SqliteTypeMapper.cs" />
     <Compile Include="Update\SqliteModificationCommandBatchFactory.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/EntityFramework.Sqlite/Migrations/SqliteHistoryRepository.cs
+++ b/src/EntityFramework.Sqlite/Migrations/SqliteHistoryRepository.cs
@@ -17,14 +17,14 @@ namespace Microsoft.Data.Entity.Sqlite.Migrations
     {
         private readonly IRelationalConnection _connection;
         private readonly string _contextKey;
-        private readonly SqliteSqlGenerator _sql;
+        private readonly SqliteUpdateSqlGenerator _sql;
 
         protected string MigrationTableName { get; } = "__migrationHistory";
 
         public SqliteHistoryRepository(
             [NotNull] IRelationalConnection connection,
             [NotNull] DbContext context,
-            [NotNull] SqliteSqlGenerator sql)
+            [NotNull] SqliteUpdateSqlGenerator sql)
         {
             Check.NotNull(connection, nameof(connection));
             Check.NotNull(context, nameof(context));

--- a/src/EntityFramework.Sqlite/Migrations/SqliteMigrationSqlGenerator.cs
+++ b/src/EntityFramework.Sqlite/Migrations/SqliteMigrationSqlGenerator.cs
@@ -17,11 +17,11 @@ namespace Microsoft.Data.Entity.Sqlite.Migrations
 {
     public class SqliteMigrationSqlGenerator : MigrationSqlGenerator
     {
-        private readonly ISqlGenerator _sql;
+        private readonly IUpdateSqlGenerator _sql;
         private readonly SqliteOperationTransformer _transformer;
 
         public SqliteMigrationSqlGenerator(
-            [NotNull] ISqlGenerator sqlGenerator,
+            [NotNull] IUpdateSqlGenerator sqlGenerator,
             [CanBeNull] SqliteOperationTransformer transformer)
             : base(sqlGenerator)
         {

--- a/src/EntityFramework.Sqlite/SqliteDatabaseProviderServices.cs
+++ b/src/EntityFramework.Sqlite/SqliteDatabaseProviderServices.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Data.Entity.Sqlite
         public override IMigrationSqlGenerator MigrationSqlGenerator => GetService<SqliteMigrationSqlGenerator>();
         public override IModelSource ModelSource => GetService<SqliteModelSource>();
         public override IRelationalConnection RelationalConnection => GetService<SqliteDatabaseConnection>();
-        public override ISqlGenerator SqlGenerator => GetService<SqliteSqlGenerator>();
+        public override IUpdateSqlGenerator UpdateSqlGenerator => GetService<SqliteUpdateSqlGenerator>();
         public override IDatabase Database => GetService<SqliteDatabase>();
         public override IValueGeneratorCache ValueGeneratorCache => GetService<SqliteValueGeneratorCache>();
         public override IRelationalTypeMapper TypeMapper => GetService<SqliteTypeMapper>();

--- a/src/EntityFramework.Sqlite/SqliteEntityFrameworkServicesBuilderExtensions.cs
+++ b/src/EntityFramework.Sqlite/SqliteEntityFrameworkServicesBuilderExtensions.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Framework.DependencyInjection
                 .AddSingleton<IDatabaseProvider, DatabaseProvider<SqliteDatabaseProviderServices, SqliteOptionsExtension>>()
                 .TryAdd(new ServiceCollection()
                     .AddSingleton<SqliteValueGeneratorCache>()
-                    .AddSingleton<SqliteSqlGenerator>()
+                    .AddSingleton<SqliteUpdateSqlGenerator>()
                     .AddSingleton<SqliteMetadataExtensionProvider>()
                     .AddSingleton<SqliteTypeMapper>()
                     .AddSingleton<SqliteModelSource>()

--- a/src/EntityFramework.Sqlite/SqliteUpdateSqlGenerator.cs
+++ b/src/EntityFramework.Sqlite/SqliteUpdateSqlGenerator.cs
@@ -8,7 +8,7 @@ using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Sqlite
 {
-    public class SqliteSqlGenerator : SqlGenerator
+    public class SqliteUpdateSqlGenerator : UpdateSqlGenerator
     {
         // TODO throw a logger warning that this call was improperly made. The SQLite provider should never specify a schema
         public override string DelimitIdentifier(string name, string schemaName) => base.DelimitIdentifier(name);

--- a/src/EntityFramework.Sqlite/Update/SqliteModificationCommandBatchFactory.cs
+++ b/src/EntityFramework.Sqlite/Update/SqliteModificationCommandBatchFactory.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Data.Entity.Sqlite.Update
 {
     public class SqliteModificationCommandBatchFactory : ModificationCommandBatchFactory
     {
-        public SqliteModificationCommandBatchFactory([NotNull] ISqlGenerator sqlGenerator)
+        public SqliteModificationCommandBatchFactory([NotNull] IUpdateSqlGenerator sqlGenerator)
             : base(sqlGenerator)
         {
         }
@@ -19,6 +19,6 @@ namespace Microsoft.Data.Entity.Sqlite.Update
         public override ModificationCommandBatch Create(
             IDbContextOptions options,
             IRelationalMetadataExtensionProvider metadataExtensionProvider)
-            => new SingularModificationCommandBatch(SqlGenerator);
+            => new SingularModificationCommandBatch(UpdateSqlGenerator);
     }
 }

--- a/test/EntityFramework.Relational.FunctionalTests/TestSqlLoggerFactory.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/TestSqlLoggerFactory.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
 
                 if (format != null)
                 {
-                    if (eventId == RelationalLoggingEventIds.Sql)
+                    if (eventId == RelationalLoggingEventIds.ExecutingSql)
                     {
                         if (_cancellationTokenSource != null)
                         {

--- a/test/EntityFramework.Relational.Tests/Migrations/Sql/MigrationSqlGeneratorTest.cs
+++ b/test/EntityFramework.Relational.Tests/Migrations/Sql/MigrationSqlGeneratorTest.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Data.Entity.Relational.Migrations.Sql
         {
             get
             {
-                var sqlGenerator = new Mock<SqlGenerator>() { CallBase = true };
+                var sqlGenerator = new Mock<UpdateSqlGenerator>() { CallBase = true };
                 var migrationSqlGenerator = new Mock<MigrationSqlGenerator>(sqlGenerator.Object) { CallBase = true };
 
                 return migrationSqlGenerator.Object;

--- a/test/EntityFramework.Relational.Tests/RelationalEntityServicesBuilderExtensionsTest.cs
+++ b/test/EntityFramework.Relational.Tests/RelationalEntityServicesBuilderExtensionsTest.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
             VerifyScoped<ICommandBatchPreparer>();
             VerifyScoped<IRelationalValueBufferFactoryFactory>();
             VerifyScoped<IRelationalDatabaseCreator>();
-            VerifyScoped<ISqlGenerator>();
+            VerifyScoped<IUpdateSqlGenerator>();
             VerifyScoped<IRelationalMetadataExtensionProvider>();
         }
     }

--- a/test/EntityFramework.Relational.Tests/SqlGeneratorTest.cs
+++ b/test/EntityFramework.Relational.Tests/SqlGeneratorTest.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
 {
     public class SqlGeneratorTest : SqlGeneratorTestBase
     {
-        protected override ISqlGenerator CreateSqlGenerator()
+        protected override IUpdateSqlGenerator CreateSqlGenerator()
         {
             return new ConcreteSqlGenerator();
         }
@@ -24,7 +24,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
             get { return "provider_specific_identity()"; }
         }
 
-        private class ConcreteSqlGenerator : SqlGenerator
+        private class ConcreteSqlGenerator : UpdateSqlGenerator
         {
             protected override void AppendIdentityWhereCondition(StringBuilder commandStringBuilder, ColumnModification columnModification)
             {

--- a/test/EntityFramework.Relational.Tests/SqlGeneratorTestBase.cs
+++ b/test/EntityFramework.Relational.Tests/SqlGeneratorTestBase.cs
@@ -353,7 +353,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
                 statement);
         }
 
-        protected abstract ISqlGenerator CreateSqlGenerator();
+        protected abstract IUpdateSqlGenerator CreateSqlGenerator();
 
         protected abstract string RowsAffected { get; }
 

--- a/test/EntityFramework.Relational.Tests/Update/BatchExecutorTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/BatchExecutorTest.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         [Fact]
         public async Task ExecuteAsync_calls_Commit_if_no_transaction()
         {
-            var sqlGenerator = new Mock<ISqlGenerator>().Object;
+            var sqlGenerator = new Mock<IUpdateSqlGenerator>().Object;
             var mockModificationCommandBatch = new Mock<ModificationCommandBatch>(sqlGenerator);
             mockModificationCommandBatch.Setup(m => m.ModificationCommands.Count).Returns(1);
 
@@ -51,7 +51,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         [Fact]
         public async Task ExecuteAsync_does_not_call_Commit_if_existing_transaction()
         {
-            var sqlGenerator = new Mock<ISqlGenerator>().Object;
+            var sqlGenerator = new Mock<IUpdateSqlGenerator>().Object;
             var mockModificationCommandBatch = new Mock<ModificationCommandBatch>(sqlGenerator);
             mockModificationCommandBatch.Setup(m => m.ModificationCommands.Count).Returns(1);
 

--- a/test/EntityFramework.Relational.Tests/Update/CommandBatchPreparerTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/CommandBatchPreparerTest.cs
@@ -273,7 +273,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         {
             modificationCommandBatchFactory =
                 modificationCommandBatchFactory ?? new TestModificationCommandBatchFactory(
-                    Mock.Of<ISqlGenerator>());
+                    Mock.Of<IUpdateSqlGenerator>());
 
             return new TestCommandBatchPreparer(modificationCommandBatchFactory,
                 new ParameterNameGeneratorFactory(),
@@ -374,7 +374,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         private class TestModificationCommandBatchFactory : ModificationCommandBatchFactory
         {
             public TestModificationCommandBatchFactory(
-                ISqlGenerator sqlGenerator)
+                IUpdateSqlGenerator sqlGenerator)
                 : base(sqlGenerator)
             {
             }
@@ -383,7 +383,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
                 IDbContextOptions options,
                 IRelationalMetadataExtensionProvider metadataExtensionProvider)
             {
-                return new SingularModificationCommandBatch(SqlGenerator);
+                return new SingularModificationCommandBatch(UpdateSqlGenerator);
             }
         }
     }

--- a/test/EntityFramework.Relational.Tests/Update/ModificationCommandBatchFactoryTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/ModificationCommandBatchFactoryTest.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         public void Create_returns_new_instances()
         {
             var factory = new TestModificationCommandBatchFactory(
-                Mock.Of<ISqlGenerator>());
+                Mock.Of<IUpdateSqlGenerator>());
 
             var options = new Mock<IDbContextOptions>().Object;
             var metadataExtensionProvider = Mock.Of<IRelationalMetadataExtensionProvider>();
@@ -33,7 +33,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         [Fact]
         public void AddCommand_delegates()
         {
-            var sqlGenerator = new Mock<ISqlGenerator>().Object;
+            var sqlGenerator = new Mock<IUpdateSqlGenerator>().Object;
             var factory = new TestModificationCommandBatchFactory(sqlGenerator);
 
             var modificationCommandBatchMock = new Mock<ModificationCommandBatch>(sqlGenerator);
@@ -52,7 +52,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         private class TestModificationCommandBatchFactory : ModificationCommandBatchFactory
         {
             public TestModificationCommandBatchFactory(
-                ISqlGenerator sqlGenerator)
+                IUpdateSqlGenerator sqlGenerator)
                 : base(sqlGenerator)
             {
             }
@@ -61,7 +61,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
                 IDbContextOptions options,
                 IRelationalMetadataExtensionProvider metadataExtensionProvider)
             {
-                return new SingularModificationCommandBatch(SqlGenerator);
+                return new SingularModificationCommandBatch(UpdateSqlGenerator);
             }
         }
     }

--- a/test/EntityFramework.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational(), new TypedValueBufferFactoryFactory());
             command.AddEntry(entry);
 
-            var sqlGeneratorMock = new Mock<ISqlGenerator>();
+            var sqlGeneratorMock = new Mock<IUpdateSqlGenerator>();
             var batch = new ModificationCommandBatchFake(sqlGeneratorMock.Object);
             batch.AddCommand(command);
 
@@ -97,7 +97,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational(), new TypedValueBufferFactoryFactory());
             command.AddEntry(entry);
 
-            var sqlGeneratorMock = new Mock<ISqlGenerator>();
+            var sqlGeneratorMock = new Mock<IUpdateSqlGenerator>();
             var batch = new ModificationCommandBatchFake(sqlGeneratorMock.Object);
             batch.AddCommand(command);
 
@@ -115,7 +115,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             var command = new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.Relational(), new TypedValueBufferFactoryFactory());
             command.AddEntry(entry);
 
-            var sqlGeneratorMock = new Mock<ISqlGenerator>();
+            var sqlGeneratorMock = new Mock<IUpdateSqlGenerator>();
             var batch = new ModificationCommandBatchFake(sqlGeneratorMock.Object);
             batch.AddCommand(command);
 
@@ -143,7 +143,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             Assert.Equal(1, fakeSqlGenerator.AppendBatchHeaderCalls);
         }
 
-        private class FakeSqlGenerator : SqlGenerator
+        private class FakeSqlGenerator : UpdateSqlGenerator
         {
             public override void AppendInsertOperation(StringBuilder commandStringBuilder, ModificationCommand command)
             {
@@ -617,14 +617,14 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         {
             private readonly DbDataReader _reader;
 
-            public ModificationCommandBatchFake(ISqlGenerator sqlGenerator = null)
+            public ModificationCommandBatchFake(IUpdateSqlGenerator sqlGenerator = null)
                 : base(sqlGenerator ?? new FakeSqlGenerator())
             {
                 ShouldAddCommand = true;
                 ShouldValidateSql = true;
             }
 
-            public ModificationCommandBatchFake(DbDataReader reader, ISqlGenerator sqlGenerator = null)
+            public ModificationCommandBatchFake(DbDataReader reader, IUpdateSqlGenerator sqlGenerator = null)
                 : base(sqlGenerator ?? new FakeSqlGenerator())
             {
                 _reader = reader;

--- a/test/EntityFramework.SqlServer.FunctionalTests/CommandConfigurationTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/CommandConfigurationTest.cs
@@ -356,7 +356,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             }
 
             public TestSqlServerModificationCommandBatch(
-                ISqlServerSqlGenerator sqlGenerator,
+                ISqlServerUpdateSqlGenerator sqlGenerator,
                 int? maxBatchSize)
                 : base(sqlGenerator, maxBatchSize)
             {
@@ -366,7 +366,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         public class TestSqlServerModificationCommandBatchFactory : SqlServerModificationCommandBatchFactory
         {
             public TestSqlServerModificationCommandBatchFactory(
-                ISqlServerSqlGenerator sqlGenerator)
+                ISqlServerUpdateSqlGenerator sqlGenerator)
                 : base(sqlGenerator)
             {
             }
@@ -380,7 +380,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 var maxBatchSize = optionsExtension?.MaxBatchSize;
 
                 return new TestSqlServerModificationCommandBatch(
-                    (ISqlServerSqlGenerator)SqlGenerator,
+                    (ISqlServerUpdateSqlGenerator)UpdateSqlGenerator,
                     maxBatchSize);
             }
         }

--- a/test/EntityFramework.SqlServer.Tests/Migrations/SqlServerHistoryRepositoryTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/Migrations/SqlServerHistoryRepositoryTest.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Data.Entity.SqlServer.Migrations
                 Mock.Of<ISqlServerConnection>(),
                 Mock.Of<IRelationalDatabaseCreator>(),
                 new Context(),
-                new SqlServerSqlGenerator());
+                new SqlServerUpdateSqlGenerator());
         }
 
         private class Context : DbContext

--- a/test/EntityFramework.SqlServer.Tests/Migrations/SqlServerMigrationSqlGeneratorTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/Migrations/SqlServerMigrationSqlGeneratorTest.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Data.Entity.SqlServer.Migrations
     public class SqlServerMigrationSqlGeneratorTest : MigrationSqlGeneratorTestBase
     {
         protected override IMigrationSqlGenerator SqlGenerator =>
-            new SqlServerMigrationSqlGenerator(new SqlServerSqlGenerator());
+            new SqlServerMigrationSqlGenerator(new SqlServerUpdateSqlGenerator());
 
         [Fact]
         public virtual void AddColumnOperation_with_computedSql()

--- a/test/EntityFramework.SqlServer.Tests/SqlServerEntityServicesBuilderExtensionsTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerEntityServicesBuilderExtensionsTest.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             // SQL Server dingletones
             VerifySingleton<SqlServerConventionSetBuilder>();
             VerifySingleton<ISqlServerValueGeneratorCache>();
-            VerifySingleton<ISqlServerSqlGenerator>();
+            VerifySingleton<ISqlServerUpdateSqlGenerator>();
             VerifySingleton<SqlServerTypeMapper>();
             VerifySingleton<SqlServerModelSource>();
             VerifySingleton<SqlServerMetadataExtensionProvider>();

--- a/test/EntityFramework.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             var state = new SqlServerSequenceValueGeneratorState("Foo", blockSize, poolSize);
             var generator = new SqlServerSequenceValueGenerator<TValue>(
                 new FakeSqlStatementExecutor(blockSize),
-                new SqlServerSqlGenerator(),
+                new SqlServerUpdateSqlGenerator(),
                 state,
                 CreateConnection());
 
@@ -142,7 +142,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             var serviceProvider = SqlServerTestHelpers.Instance.CreateServiceProvider();
             var state = new SqlServerSequenceValueGeneratorState("Foo", blockSize, poolSize);
             var executor = new FakeSqlStatementExecutor(blockSize);
-            var sqlGenerator = new SqlServerSqlGenerator();
+            var sqlGenerator = new SqlServerUpdateSqlGenerator();
 
             var tests = new Action[threadCount];
             var generatedValues = new List<long>[threadCount];
@@ -173,7 +173,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             var state = new SqlServerSequenceValueGeneratorState("Foo", 4, 3);
             var generator = new SqlServerSequenceValueGenerator<int>(
                 new FakeSqlStatementExecutor(4),
-                new SqlServerSqlGenerator(),
+                new SqlServerUpdateSqlGenerator(),
                 state,
                 CreateConnection());
 

--- a/test/EntityFramework.SqlServer.Tests/SqlServerSqlGeneratorTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerSqlGeneratorTest.cs
@@ -11,9 +11,9 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
 {
     public class SqlServerSqlGeneratorTest : SqlGeneratorTestBase
     {
-        protected override ISqlGenerator CreateSqlGenerator()
+        protected override IUpdateSqlGenerator CreateSqlGenerator()
         {
-            return new SqlServerSqlGenerator();
+            return new SqlServerUpdateSqlGenerator();
         }
 
         [Fact]
@@ -21,7 +21,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         {
             var sb = new StringBuilder();
 
-            new SqlServerSqlGenerator().AppendBatchHeader(sb);
+            new SqlServerUpdateSqlGenerator().AppendBatchHeader(sb);
 
             Assert.Equal("SET NOCOUNT OFF;" + Environment.NewLine, sb.ToString());
         }
@@ -95,7 +95,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             var stringBuilder = new StringBuilder();
             var command = CreateInsertCommand(identityKey: true, isComputed: true);
 
-            var sqlGenerator = (ISqlServerSqlGenerator)CreateSqlGenerator();
+            var sqlGenerator = (ISqlServerUpdateSqlGenerator)CreateSqlGenerator();
             var grouping = sqlGenerator.AppendBulkInsertOperation(stringBuilder, new[] { command, command });
 
             Assert.Equal(
@@ -104,7 +104,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                 "VALUES (@p0, @p1, @p2)," + Environment.NewLine +
                 "(@p0, @p1, @p2);" + Environment.NewLine,
                 stringBuilder.ToString());
-            Assert.Equal(SqlServerSqlGenerator.ResultsGrouping.OneResultSet, grouping);
+            Assert.Equal(SqlServerUpdateSqlGenerator.ResultsGrouping.OneResultSet, grouping);
         }
 
         [Fact]
@@ -113,7 +113,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             var stringBuilder = new StringBuilder();
             var command = CreateInsertCommand(identityKey: false, isComputed: false);
 
-            var sqlGenerator = (ISqlServerSqlGenerator)CreateSqlGenerator();
+            var sqlGenerator = (ISqlServerUpdateSqlGenerator)CreateSqlGenerator();
             var grouping = sqlGenerator.AppendBulkInsertOperation(stringBuilder, new[] { command, command });
 
             Assert.Equal(
@@ -122,7 +122,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                 "(@p0, @p1, @p2, @p3);" + Environment.NewLine +
                 "SELECT @@ROWCOUNT;" + Environment.NewLine,
                 stringBuilder.ToString());
-            Assert.Equal(SqlServerSqlGenerator.ResultsGrouping.OneResultSet, grouping);
+            Assert.Equal(SqlServerUpdateSqlGenerator.ResultsGrouping.OneResultSet, grouping);
         }
 
         [Fact]
@@ -131,7 +131,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             var stringBuilder = new StringBuilder();
             var command = CreateInsertCommand(identityKey: true, isComputed: true, defaultsOnly: true);
 
-            var sqlGenerator = (ISqlServerSqlGenerator)CreateSqlGenerator();
+            var sqlGenerator = (ISqlServerUpdateSqlGenerator)CreateSqlGenerator();
             var grouping = sqlGenerator.AppendBulkInsertOperation(stringBuilder, new[] { command, command });
 
             var expectedText = "INSERT INTO [dbo].[Ducks]" + Environment.NewLine +
@@ -139,7 +139,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                                "DEFAULT VALUES;" + Environment.NewLine;
             Assert.Equal(expectedText + expectedText,
                 stringBuilder.ToString());
-            Assert.Equal(SqlServerSqlGenerator.ResultsGrouping.OneCommandPerResultSet, grouping);
+            Assert.Equal(SqlServerUpdateSqlGenerator.ResultsGrouping.OneCommandPerResultSet, grouping);
         }
 
         [Fact]
@@ -148,7 +148,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             var stringBuilder = new StringBuilder();
             var command = CreateInsertCommand(identityKey: false, isComputed: false, defaultsOnly: true);
 
-            var sqlGenerator = (ISqlServerSqlGenerator)CreateSqlGenerator();
+            var sqlGenerator = (ISqlServerUpdateSqlGenerator)CreateSqlGenerator();
             var grouping = sqlGenerator.AppendBulkInsertOperation(stringBuilder, new[] { command, command });
 
             var expectedText = "INSERT INTO [dbo].[Ducks]" + Environment.NewLine +
@@ -156,7 +156,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                                "SELECT @@ROWCOUNT;" + Environment.NewLine;
             Assert.Equal(expectedText + expectedText,
                 stringBuilder.ToString());
-            Assert.Equal(SqlServerSqlGenerator.ResultsGrouping.OneCommandPerResultSet, grouping);
+            Assert.Equal(SqlServerUpdateSqlGenerator.ResultsGrouping.OneCommandPerResultSet, grouping);
         }
 
         [Fact]

--- a/test/EntityFramework.SqlServer.Tests/Update/SqlServerModificationCommandBatchFactoryTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/Update/SqlServerModificationCommandBatchFactoryTest.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Update
         [Fact]
         public void Uses_MaxBatchSize_specified_in_SqlServerOptionsExtension()
         {
-            var factory = new SqlServerModificationCommandBatchFactory(new SqlServerSqlGenerator());
+            var factory = new SqlServerModificationCommandBatchFactory(new SqlServerUpdateSqlGenerator());
 
             var optionsBuilder = new DbContextOptionsBuilder();
             optionsBuilder.UseSqlServer("Database=Crunchie").MaxBatchSize(1);
@@ -30,7 +30,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Update
         [Fact]
         public void MaxBatchSize_is_optional()
         {
-            var factory = new SqlServerModificationCommandBatchFactory(new SqlServerSqlGenerator());
+            var factory = new SqlServerModificationCommandBatchFactory(new SqlServerUpdateSqlGenerator());
 
             var optionsBuilder = new DbContextOptionsBuilder();
             optionsBuilder.UseSqlServer("Database=Crunchie");
@@ -44,7 +44,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Update
         [Fact]
         public void SqlServerOptionsExtension_is_optional()
         {
-            var factory = new SqlServerModificationCommandBatchFactory(new SqlServerSqlGenerator());
+            var factory = new SqlServerModificationCommandBatchFactory(new SqlServerUpdateSqlGenerator());
 
             var optionsBuilder = new DbContextOptionsBuilder();
             optionsBuilder.UseSqlServer("Database=Crunchie");

--- a/test/EntityFramework.SqlServer.Tests/Update/SqlServerModificationCommandBatchTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/Update/SqlServerModificationCommandBatchTest.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Update
         [Fact]
         public void AddCommand_returns_false_when_max_batch_size_is_reached()
         {
-            var batch = new SqlServerModificationCommandBatch(new SqlServerSqlGenerator(), 1);
+            var batch = new SqlServerModificationCommandBatch(new SqlServerUpdateSqlGenerator(), 1);
 
             Assert.True(batch.AddCommand(new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.SqlServer(), new UntypedValueBufferFactoryFactory())));
             Assert.False(batch.AddCommand(new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.SqlServer(), new UntypedValueBufferFactoryFactory())));

--- a/test/EntityFramework.Sqlite.Tests/Metadata/SqliteHistoryRepositoryTest.cs
+++ b/test/EntityFramework.Sqlite.Tests/Metadata/SqliteHistoryRepositoryTest.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Data.Entity.Sqlite.Metadata
             var mockConnection = new Mock<IRelationalConnection>();
             mockConnection.SetupGet(p => p.DbConnection).Returns(connection);
 
-            var hp = new SqliteHistoryRepository(mockConnection.Object, new TestContext(), new SqliteSqlGenerator());
+            var hp = new SqliteHistoryRepository(mockConnection.Object, new TestContext(), new SqliteUpdateSqlGenerator());
 
             Assert.True(hp.Exists());
         }
@@ -106,7 +106,7 @@ namespace Microsoft.Data.Entity.Sqlite.Metadata
             var mockConnection = new Mock<IRelationalConnection>();
             mockConnection.SetupGet(p => p.DbConnection).Returns(connection);
 
-            var hp = new SqliteHistoryRepository(mockConnection.Object, new TestContext(), new SqliteSqlGenerator());
+            var hp = new SqliteHistoryRepository(mockConnection.Object, new TestContext(), new SqliteUpdateSqlGenerator());
 
             Assert.False(hp.Exists());
         }
@@ -140,7 +140,7 @@ namespace Microsoft.Data.Entity.Sqlite.Metadata
             }
 
 
-            var hp = new SqliteHistoryRepository(mockConnection.Object, new TestContext(), new SqliteSqlGenerator());
+            var hp = new SqliteHistoryRepository(mockConnection.Object, new TestContext(), new SqliteUpdateSqlGenerator());
 
             Assert.Collection(hp.GetAppliedMigrations(), p =>
                 {
@@ -150,7 +150,7 @@ namespace Microsoft.Data.Entity.Sqlite.Metadata
 
         }
 
-        private static SqliteHistoryRepository CreateSqliteHistoryRepo() => new SqliteHistoryRepository(Mock.Of<IRelationalConnection>(), new TestContext(), new SqliteSqlGenerator());
+        private static SqliteHistoryRepository CreateSqliteHistoryRepo() => new SqliteHistoryRepository(Mock.Of<IRelationalConnection>(), new TestContext(), new SqliteUpdateSqlGenerator());
 
         private class TestContext : DbContext
         {

--- a/test/EntityFramework.Sqlite.Tests/Migrations/SqliteMigrationSqlGeneratorTest.cs
+++ b/test/EntityFramework.Sqlite.Tests/Migrations/SqliteMigrationSqlGeneratorTest.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Data.Entity.Sqlite.Migrations
 {
     public class SqliteMigrationSqlGeneratorTest : MigrationSqlGeneratorTestBase
     {
-        protected override IMigrationSqlGenerator SqlGenerator => new SqliteMigrationSqlGenerator(new SqliteSqlGenerator(), transformer: null);
+        protected override IMigrationSqlGenerator SqlGenerator => new SqliteMigrationSqlGenerator(new SqliteUpdateSqlGenerator(), transformer: null);
 
         [Fact]
         public void Insert_into_select()

--- a/test/EntityFramework.Sqlite.Tests/SqliteSqlGeneratorTest.cs
+++ b/test/EntityFramework.Sqlite.Tests/SqliteSqlGeneratorTest.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Data.Entity.Sqlite
 {
     public class SqliteSqlGeneratorTest : SqlGeneratorTestBase
     {
-        protected override ISqlGenerator CreateSqlGenerator() => new SqliteSqlGenerator();
+        protected override IUpdateSqlGenerator CreateSqlGenerator() => new SqliteUpdateSqlGenerator();
         protected override string RowsAffected => "changes()";
         protected override string Identity => "last_insert_rowid()";
         protected override string SchemaName => null;


### PR DESCRIPTION
- Renamed ISqlGenerator to IUpdateSqlGenerator
- Remove Execute methods from contract  of ISqlStatementExecutor
- Renamed RelationalEntityServicesBuilderExtensions to RelationalEntityFrameworkServicesBuilderExtensions
- Made RelationalLoggingEventIds consts and renamed members
- Rename TypedValueBufferFactory to TypedRelationalValueBufferFactory and related classes