### PR TITLE
Fix bugs in DropColumn in SQLite

### DIFF
--- a/src/EntityFramework.Commands/Migrations/CSharpMigrationGenerator.cs
+++ b/src/EntityFramework.Commands/Migrations/CSharpMigrationGenerator.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                 .AppendLine("using Microsoft.Data.Entity.Migrations.Builders;")
                 .AppendLine("using Microsoft.Data.Entity.Migrations.Operations;")
                 .AppendLine()
-                .Append("namespace ").AppendLine(migrationNamespace)
+                .Append("namespace ").AppendLine(_code.Identifier(migrationNamespace))
                 .AppendLine("{");
             using (builder.Indent())
             {
@@ -109,7 +109,7 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                 .AppendLine("using Microsoft.Data.Entity.Migrations.Infrastructure;")
                 .Append("using ").Append(contextType.Namespace).AppendLine(";")
                 .AppendLine()
-                .Append("namespace ").AppendLine(migrationNamespace)
+                .Append("namespace ").AppendLine(_code.Identifier(migrationNamespace))
                 .AppendLine("{");
             using (builder.Indent())
             {
@@ -173,7 +173,7 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                 .AppendLine("using Microsoft.Data.Entity.Migrations.Infrastructure;")
                 .Append("using ").Append(contextType.Namespace).AppendLine(";")
                 .AppendLine()
-                .Append("namespace ").AppendLine(modelSnapshotNamespace)
+                .Append("namespace ").AppendLine(_code.Identifier(modelSnapshotNamespace))
                 .AppendLine("{");
             using (builder.Indent())
             {

--- a/src/EntityFramework.Sqlite/Migrations/MoveDataOperation.cs
+++ b/src/EntityFramework.Sqlite/Migrations/MoveDataOperation.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Data.Entity.Sqlite.Migrations
 {
     public class MoveDataOperation : MigrationOperation
     {
+        // TODO handle renaming columns
         public MoveDataOperation()
         {
             IsDestructiveChange = true;

--- a/src/EntityFramework.Sqlite/Migrations/SqliteHistoryRepository.cs
+++ b/src/EntityFramework.Sqlite/Migrations/SqliteHistoryRepository.cs
@@ -83,7 +83,9 @@ namespace Microsoft.Data.Entity.Sqlite.Migrations
                 }
                 using (var command = connection.CreateCommand())
                 {
-                    command.CommandText = $"SELECT 1 FROM sqlite_master WHERE tbl_name = '{_sql.EscapeLiteral(MigrationTableName)}' AND rootpage IS NOT NULL;";
+                    command.CommandText = $"SELECT 1 FROM sqlite_master WHERE type = 'table'" +
+                                          $" AND tbl_name = '{_sql.EscapeLiteral(MigrationTableName)}'" +
+                                          $" AND rootpage IS NOT NULL;";
                     var result = command.ExecuteScalar();
                     return result != null && (long)result == 1;
                 }


### PR DESCRIPTION
Fixes limitations in the original implementation of DropColumn for SQLite which didn't take into consideration multiple drop columns, or operations made redundant by the table-rebuild.

Also, fixed a few minor bugs in csharp generation for migrations.