### PR TITLE
Migrations: Detect added schemas

### DIFF
--- a/src/EntityFramework.Relational/Migrations/Sql/MigrationSqlGenerator.cs
+++ b/src/EntityFramework.Relational/Migrations/Sql/MigrationSqlGenerator.cs
@@ -171,18 +171,10 @@ namespace Microsoft.Data.Entity.Migrations.Sql
                 .Append(")");
         }
 
-        public virtual void Generate(
+        public abstract void Generate(
             [NotNull] CreateSchemaOperation operation,
             [CanBeNull] IModel model,
-            [NotNull] SqlBatchBuilder builder)
-        {
-            Check.NotNull(operation, nameof(operation));
-            Check.NotNull(builder, nameof(builder));
-
-            builder
-                .Append("CREATE SCHEMA ")
-                .Append(_sql.DelimitIdentifier(operation.Name));
-        }
+            [NotNull] SqlBatchBuilder builder);
 
         public virtual void Generate(
             [NotNull] CreateSequenceOperation operation,

--- a/src/EntityFramework.SqlServer/Migrations/SqlServerHistoryRepository.cs
+++ b/src/EntityFramework.SqlServer/Migrations/SqlServerHistoryRepository.cs
@@ -51,14 +51,12 @@ namespace Microsoft.Data.Entity.SqlServer.Migrations
             }
 
             var command = (SqlCommand)_connection.DbConnection.CreateCommand();
-            command.CommandText =
-                @"SELECT 1 FROM [INFORMATION_SCHEMA].[TABLES]
-WHERE [TABLE_SCHEMA] = N'dbo' AND [TABLE_NAME] = '" + MigrationHistoryTableName + "' AND [TABLE_TYPE] = 'BASE TABLE'";
+            command.CommandText = "SELECT OBJECT_ID(N'dbo." + MigrationHistoryTableName + "');";
 
             _connection.Open();
             try
             {
-                exists = command.ExecuteScalar() != null;
+                exists = command.ExecuteScalar() != DBNull.Value;
             }
             finally
             {
@@ -109,7 +107,7 @@ WHERE [ContextKey] = @ContextKey ORDER BY [MigrationId]";
 
             if (ifNotExists)
             {
-                builder.AppendLine("IF NOT EXISTS(SELECT * FROM [INFORMATION_SCHEMA].[TABLES] WHERE [TABLE_SCHEMA] = N'dbo' AND [TABLE_NAME] = '" + MigrationHistoryTableName + "' AND [TABLE_TYPE] = 'BASE TABLE')");
+                builder.AppendLine("IF OBJECT_ID(N'dbo." + MigrationHistoryTableName + "') IS NULL");
                 builder.IncrementIndent();
             }
 

--- a/test/EntityFramework.Relational.Tests/Migrations/Infrastructure/ModelDifferTest.cs
+++ b/test/EntityFramework.Relational.Tests/Migrations/Infrastructure/ModelDifferTest.cs
@@ -75,17 +75,20 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
                     }),
                 operations =>
                 {
-                    Assert.Equal(2, operations.Count);
+                    Assert.Equal(3, operations.Count);
 
-                    var operation = Assert.IsType<CreateTableOperation>(operations[0]);
-                    Assert.Equal("Node", operation.Name);
-                    Assert.Equal("dbo", operation.Schema);
-                    Assert.Equal(3, operation.Columns.Count);
-                    Assert.NotNull(operation.PrimaryKey);
-                    Assert.Equal(1, operation.UniqueConstraints.Count);
-                    Assert.Equal(1, operation.ForeignKeys.Count);
+                    var createSchemaOperation = Assert.IsType<CreateSchemaOperation>(operations[0]);
+                    Assert.Equal("dbo", createSchemaOperation.Name);
 
-                    Assert.IsType<CreateIndexOperation>(operations[1]);
+                    var createTableOperation = Assert.IsType<CreateTableOperation>(operations[1]);
+                    Assert.Equal("Node", createTableOperation.Name);
+                    Assert.Equal("dbo", createTableOperation.Schema);
+                    Assert.Equal(3, createTableOperation.Columns.Count);
+                    Assert.NotNull(createTableOperation.PrimaryKey);
+                    Assert.Equal(1, createTableOperation.UniqueConstraints.Count);
+                    Assert.Equal(1, createTableOperation.ForeignKeys.Count);
+
+                    Assert.IsType<CreateIndexOperation>(operations[2]);
                 });
         }
 
@@ -158,13 +161,16 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
                     }),
                 operations =>
                 {
-                    Assert.Equal(1, operations.Count);
+                    Assert.Equal(2, operations.Count);
 
-                    var operation = Assert.IsType<RenameTableOperation>(operations[0]);
-                    Assert.Equal("People", operation.Name);
-                    Assert.Equal("dbo", operation.Schema);
-                    Assert.Null(operation.NewName);
-                    Assert.Equal("public", operation.NewSchema);
+                    var createSchemaOperation = Assert.IsType<CreateSchemaOperation>(operations[0]);
+                    Assert.Equal("public", createSchemaOperation.Name);
+
+                    var renameTableOperation = Assert.IsType<RenameTableOperation>(operations[1]);
+                    Assert.Equal("People", renameTableOperation.Name);
+                    Assert.Equal("dbo", renameTableOperation.Schema);
+                    Assert.Null(renameTableOperation.NewName);
+                    Assert.Equal("public", renameTableOperation.NewSchema);
                 });
         }
 

--- a/test/EntityFramework.SqlServer.Tests/Migrations/SqlServerHistoryRepositoryTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/Migrations/SqlServerHistoryRepositoryTest.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Data.Entity.SqlServer.Migrations
             var sql = CreateHistoryRepository().Create(ifNotExists: true);
 
             Assert.Equal(
-                "IF NOT EXISTS(SELECT * FROM [INFORMATION_SCHEMA].[TABLES] WHERE [TABLE_SCHEMA] = N'dbo' AND [TABLE_NAME] = '__MigrationHistory' AND [TABLE_TYPE] = 'BASE TABLE')" + EOL +
+                "IF OBJECT_ID(N'dbo.__MigrationHistory') IS NULL" + EOL +
                 "    CREATE TABLE [dbo].[__MigrationHistory] (" + EOL +
                 "        [MigrationId] nvarchar(150) NOT NULL," + EOL +
                 "        [ContextKey] nvarchar(300) NOT NULL," + EOL +

--- a/test/EntityFramework.SqlServer.Tests/Migrations/SqlServerMigrationSqlGeneratorTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/Migrations/SqlServerMigrationSqlGeneratorTest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Data.Entity.SqlServer.Migrations
                 "CREATE DATABASE [Northwind]" + EOL +
                 "GO" + EOL +
                 EOL +
-                "IF SERVERPROPERTY('EngineEdition') <> 5 EXECUTE sp_executesql N'ALTER DATABASE [Northwind] SET READ_COMMITTED_SNAPSHOT ON';" + EOL,
+                "IF SERVERPROPERTY('EngineEdition') <> 5 EXEC(N'ALTER DATABASE [Northwind] SET READ_COMMITTED_SNAPSHOT ON');" + EOL,
                 Sql);
         }
 
@@ -106,12 +106,32 @@ namespace Microsoft.Data.Entity.SqlServer.Migrations
         }
 
         [Fact]
+        public virtual void CreateSchemaOperation()
+        {
+            Generate(new CreateSchemaOperation { Name = "my" });
+
+            Assert.Equal(
+                "IF SCHEMA_ID(N'my') IS NULL EXEC(N'CREATE SCHEMA [my]');" + EOL,
+                Sql);
+        }
+
+        [Fact]
+        public virtual void CreateSchemaOperation_dbo()
+        {
+            Generate(new CreateSchemaOperation { Name = "dbo" });
+
+            Assert.Equal(
+                ";" + EOL,
+                Sql);
+        }
+
+        [Fact]
         public virtual void DropDatabaseOperation()
         {
             Generate(new DropDatabaseOperation { Name = "Northwind" });
 
             Assert.Equal(
-                "IF SERVERPROPERTY('EngineEdition') <> 5 EXECUTE sp_executesql N'ALTER DATABASE [Northwind] SET SINGLE_USER WITH ROLLBACK IMMEDIATE'" + EOL +
+                "IF SERVERPROPERTY('EngineEdition') <> 5 EXEC(N'ALTER DATABASE [Northwind] SET SINGLE_USER WITH ROLLBACK IMMEDIATE')" + EOL +
                 "GO" + EOL +
                 EOL +
                 "DROP DATABASE [Northwind];" + EOL,
@@ -172,7 +192,7 @@ namespace Microsoft.Data.Entity.SqlServer.Migrations
                 });
 
             Assert.Equal(
-                "EXECUTE sp_rename 'dbo.People.Name', 'FullName', 'COLUMN';" + EOL,
+                "EXEC sp_rename N'dbo.People.Name', N'FullName', 'COLUMN';" + EOL,
                 Sql);
         }
 
@@ -189,7 +209,7 @@ namespace Microsoft.Data.Entity.SqlServer.Migrations
                 });
 
             Assert.Equal(
-                "EXECUTE sp_rename 'dbo.People.IX_People_Name', 'IX_People_FullName', 'INDEX';" + EOL,
+                "EXEC sp_rename N'dbo.People.IX_People_Name', N'IX_People_FullName', 'INDEX';" + EOL,
                 Sql);
         }
 
@@ -205,7 +225,7 @@ namespace Microsoft.Data.Entity.SqlServer.Migrations
                 });
 
             Assert.Equal(
-                "EXECUTE sp_rename 'dbo.DefaultSequence', 'MySequence';" + EOL,
+                "EXEC sp_rename N'dbo.DefaultSequence', N'MySequence';" + EOL,
                 Sql);
         }
 
@@ -221,7 +241,7 @@ namespace Microsoft.Data.Entity.SqlServer.Migrations
                 });
 
             Assert.Equal(
-                "EXECUTE sp_rename 'dbo.People', 'Person';" + EOL,
+                "EXEC sp_rename N'dbo.People', N'Person';" + EOL,
                 Sql);
         }
     }

--- a/test/EntityFramework.SqlServer.Tests/Migrations/SqlServerModelDifferTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/Migrations/SqlServerModelDifferTest.cs
@@ -27,9 +27,12 @@ namespace Microsoft.Data.Entity.SqlServer.Migrations
                     }),
                 operations =>
                 {
-                    Assert.Equal(1, operations.Count);
+                    Assert.Equal(2, operations.Count);
 
-                    var addTableOperation = Assert.IsType<CreateTableOperation>(operations[0]);
+                    var createSchemaOperation = Assert.IsType<CreateSchemaOperation>(operations[0]);
+                    Assert.Equal("dbo", createSchemaOperation.Name);
+
+                    var addTableOperation = Assert.IsType<CreateTableOperation>(operations[1]);
                     Assert.Equal("dbo", addTableOperation.Schema);
                     Assert.Equal("People", addTableOperation.Name);
 
@@ -58,9 +61,12 @@ namespace Microsoft.Data.Entity.SqlServer.Migrations
                     }),
                 operations =>
                 {
-                    Assert.Equal(1, operations.Count);
+                    Assert.Equal(2, operations.Count);
 
-                    var addTableOperation = Assert.IsType<RenameTableOperation>(operations[0]);
+                    var createSchemaOperation = Assert.IsType<CreateSchemaOperation>(operations[0]);
+                    Assert.Equal("dbo", createSchemaOperation.Name);
+
+                    var addTableOperation = Assert.IsType<RenameTableOperation>(operations[1]);
                     Assert.Equal("Person", addTableOperation.Name);
                     Assert.Equal("dbo", addTableOperation.NewSchema);
                     Assert.Equal("People", addTableOperation.NewName);


### PR DESCRIPTION
Per the notes on the bug, this will only generate CreateSchema (not DropSchema) calls. CreateSchema is now behaves more like "EnsureSchema". We'll discuss the name during API Review.

Other minor changes:
* Use OBJECT_ID to check if tables exist
* Use EXEC instead of sp_executesql
* Use nchar literals where appropriate

Fixes #948 & fixes #2112