### PR TITLE
Fix to #2365 - ArgumentNullException when querying with nullable byte, short, or enum parameters

### DIFF
--- a/src/EntityFramework.Core/Extensions/Internal/ExpressionExtensions.cs
+++ b/src/EntityFramework.Core/Extensions/Internal/ExpressionExtensions.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Internal;
+using Microsoft.Data.Entity.Utilities;
 
 // ReSharper disable once CheckNamespace
 
@@ -143,8 +144,10 @@ namespace System.Linq.Expressions
             return propertyInfos.ToArray();
         }
 
-        private static Expression RemoveConvert(this Expression expression)
+        public static Expression RemoveConvert([NotNull] this Expression expression)
         {
+            Check.NotNull(expression, nameof(expression));
+
             while ((expression != null)
                    && (expression.NodeType == ExpressionType.Convert
                        || expression.NodeType == ExpressionType.ConvertChecked))

--- a/src/EntityFramework.Relational/Extensions/ExpressionExtensions.cs
+++ b/src/EntityFramework.Relational/Extensions/ExpressionExtensions.cs
@@ -33,19 +33,13 @@ namespace System.Linq.Expressions
 
         public static bool IsSimpleExpression([NotNull] this Expression expression)
         {
-            var unaryExpression = expression as UnaryExpression;
+            var unwrappedExpression = expression.RemoveConvert();
 
-            if (unaryExpression != null
-                && unaryExpression.NodeType == ExpressionType.Convert)
-            {
-                return IsSimpleExpression(unaryExpression.Operand);
-            }
-
-            return expression is ConstantExpression
-                   || expression is ColumnExpression
-                   || expression is ParameterExpression
-                   || expression is LiteralExpression
-                   || expression.IsAliasWithColumnExpression();
+            return unwrappedExpression is ConstantExpression
+                   || unwrappedExpression is ColumnExpression
+                   || unwrappedExpression is ParameterExpression
+                   || unwrappedExpression is LiteralExpression
+                   || unwrappedExpression.IsAliasWithColumnExpression();
         }
     }
 }

--- a/src/EntityFramework.Relational/Query/Methods/EqualsTranslator.cs
+++ b/src/EntityFramework.Relational/Query/Methods/EqualsTranslator.cs
@@ -34,13 +34,7 @@ namespace Microsoft.Data.Entity.Query.Methods
                 if (methodCallExpression.Method.GetParameters()[0].ParameterType == typeof(object)
                     && @object.Type != argument.Type)
                 {
-                    var unaryArgument = argument as UnaryExpression;
-                    if (unaryArgument != null
-                        && argument.NodeType == ExpressionType.Convert)
-                    {
-                        argument = unaryArgument.Operand;
-                    }
-
+                    argument = argument.RemoveConvert();
                     var unwrappedObjectType = @object.Type.UnwrapNullableType();
                     var unwrappedArgumentType = argument.Type.UnwrapNullableType();
                     if (unwrappedObjectType == unwrappedArgumentType)

--- a/src/EntityFramework.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/EntityFramework.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -18,6 +18,7 @@ using Microsoft.Data.Entity.Utilities;
 using Remotion.Linq.Clauses;
 using Remotion.Linq.Parsing;
 
+
 namespace Microsoft.Data.Entity.Query.Sql
 {
     public class DefaultQuerySqlGenerator : ThrowingExpressionVisitor, ISqlExpressionVisitor, ISqlQueryGenerator
@@ -941,8 +942,8 @@ namespace Microsoft.Data.Entity.Query.Sql
                         && parameterValue == null)
                     {
                         var columnExpression
-                            = expression.Left.TryGetColumnExpression()
-                              ?? expression.Right.TryGetColumnExpression();
+                            = expression.Left.RemoveConvert().TryGetColumnExpression()
+                              ?? expression.Right.RemoveConvert().TryGetColumnExpression();
 
                         if (columnExpression != null)
                         {

--- a/test/EntityFramework.Core.FunctionalTests/BuiltInDataTypesTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/BuiltInDataTypesTestBase.cs
@@ -332,9 +332,9 @@ namespace Microsoft.Data.Entity.FunctionalTests
             {
                 var entity = context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 711);
 
-                // See issue #2365
-                // short? param1 = null;
-                // Assert.Same(entity, context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 711 && e.TestNullableInt16 == param1));
+                short? param1 = null;
+                Assert.Same(entity, context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 711 && e.TestNullableInt16 == param1));
+                Assert.Same(entity, context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 711 && ((long?)((int?)(e.TestNullableInt16))) == param1));
 
                 int? param2 = null;
                 Assert.Same(entity, context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 711 && e.TestNullableInt32 == param2));
@@ -363,22 +363,20 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 bool? param10 = null;
                 Assert.Same(entity, context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 711 && e.TestNullableBoolean == param10));
 
-                // See issue #2365
-                // byte? param11 = null;
-                // Assert.Same(entity, context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 711 && e.TestNullableByte == param11));
+                byte? param11 = null;
+                Assert.Same(entity, context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 711 && e.TestNullableByte == param11));
 
-                // See issue #2365
-                //Enum64? param12 = null;
-                //Assert.Same(entity, context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 711 && e.Enum64 == param12));
+                Enum64? param12 = null;
+                Assert.Same(entity, context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 711 && e.Enum64 == param12));
 
-                //Enum32? param13 = null;
-                //Assert.Same(entity, context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 711 && e.Enum32 == param13));
+                Enum32? param13 = null;
+                Assert.Same(entity, context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 711 && e.Enum32 == param13));
 
-                //Enum16? param14 = null;
-                //Assert.Same(entity, context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 711 && e.Enum16 == param14));
+                Enum16? param14 = null;
+                Assert.Same(entity, context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 711 && e.Enum16 == param14));
 
-                //Enum8? param15 = null;
-                //Assert.Same(entity, context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 711 && e.Enum8 == param15));
+                Enum8? param15 = null;
+                Assert.Same(entity, context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 711 && e.Enum8 == param15));
 
                 var entityType = context.Model.GetEntityType(typeof(BuiltInNullableDataTypes));
                 if (entityType.FindProperty("TestUnsignedInt16") != null)

--- a/test/EntityFramework.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
@@ -217,13 +217,12 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 long? param1 = null;
                 Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.Bigint == param1));
 
-                // See issue #2365
-                //short? param2 = null;
-                //Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.Smallint == param2));
+                short? param2 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.Smallint == param2));
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && ((long?)((int?)e.Smallint)) == param2));
 
-                // See issue #2365
-                //byte? param3 = null;
-                //Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.Tinyint == param3));
+                byte? param3 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.Tinyint == param3));
 
                 bool? param4 = null;
                 Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.Bit == param4));


### PR DESCRIPTION
Problem was that in some cases of column == variable, compiler wraps the column expression into a Convert. As later stage in the query pipeline we try to recognize the pattern where column == null_valued_parameter and convert it to IsNull(column). However, we were not detecting it properly for columns wrapped in Convert. 

Fix is to unwrap converts in the pattern detection logic. We don't really need the information about the converted type, since the result expression is either the original (we didn't find the right pattern) or IsNull(column), that returns save boolean value regardless of the cast.