### PR TITLE
Fix #2444 - change data type of DiscriminatorValue to object.

### DIFF
--- a/src/EntityFramework.Relational/Metadata/IRelationalEntityTypeAnnotations.cs
+++ b/src/EntityFramework.Relational/Metadata/IRelationalEntityTypeAnnotations.cs
@@ -8,6 +8,6 @@ namespace Microsoft.Data.Entity.Metadata
         string Table { get; }
         string Schema { get; }
         IProperty DiscriminatorProperty { get; }
-        string DiscriminatorValue { get; } // TODO: should be object
+        object DiscriminatorValue { get; }
     }
 }

--- a/src/EntityFramework.Relational/Metadata/ReadOnlyRelationalEntityTypeAnnotations.cs
+++ b/src/EntityFramework.Relational/Metadata/ReadOnlyRelationalEntityTypeAnnotations.cs
@@ -35,8 +35,8 @@ namespace Microsoft.Data.Entity.Metadata
                     (string)_entityType.RootType()
                         .GetAnnotation(DiscriminatorPropertyAnnotation).Value);
 
-        public virtual string DiscriminatorValue
-            => _entityType[DiscriminatorValueAnnotation] as string
+        public virtual object DiscriminatorValue
+            => _entityType[DiscriminatorValueAnnotation]
                ?? _entityType.DisplayName();
 
         protected virtual IEntityType EntityType => _entityType;

--- a/src/EntityFramework.Relational/Metadata/RelationalEntityTypeAnnotations.cs
+++ b/src/EntityFramework.Relational/Metadata/RelationalEntityTypeAnnotations.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Data.Entity.Metadata
             }
         }
 
-        public new virtual string DiscriminatorValue
+        public new virtual object DiscriminatorValue
         {
             get { return base.DiscriminatorValue; }
             [param: CanBeNull] set { EntityType[DiscriminatorValueAnnotation] = value; }

--- a/src/EntityFramework.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/EntityFramework.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -873,6 +873,9 @@ namespace Microsoft.Data.Entity.Query.Sql
         protected virtual string GenerateLiteral([NotNull] object value)
             => string.Format(CultureInfo.InvariantCulture, "{0}", value);
 
+        protected virtual string GenerateLiteral([NotNull] Enum value)
+            => string.Format(CultureInfo.InvariantCulture, "{0:d}", value);
+
         protected virtual string GenerateLiteral(int value)
             => value.ToString();
 

--- a/test/EntityFramework.Core.FunctionalTests/EntityFramework.Core.FunctionalTests.csproj
+++ b/test/EntityFramework.Core.FunctionalTests/EntityFramework.Core.FunctionalTests.csproj
@@ -76,8 +76,13 @@
     <Compile Include="TestModels\Inheritance\Bird.cs" />
     <Compile Include="TestModels\Inheritance\Country.cs" />
     <Compile Include="TestModels\Inheritance\Eagle.cs" />
+    <Compile Include="TestModels\Inheritance\Flower.cs" />
     <Compile Include="TestModels\Inheritance\Kiwi.cs" />
-    <Compile Include="TestModels\Inheritance\AnimalContext.cs" />
+    <Compile Include="TestModels\Inheritance\InheritanceContext.cs" />
+    <Compile Include="TestModels\Inheritance\Plant.cs" />
+    <Compile Include="TestModels\Inheritance\PlantGenus.cs" />
+    <Compile Include="TestModels\Inheritance\Rose.cs" />
+    <Compile Include="TestModels\Inheritance\Daisy.cs" />
     <Compile Include="TestModels\Northwind\Customer.cs" />
     <Compile Include="TestModels\Northwind\Employee.cs" />
     <Compile Include="TestModels\Northwind\NorthwindContext.cs" />

--- a/test/EntityFramework.Core.FunctionalTests/InheritanceFixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/InheritanceFixtureBase.cs
@@ -38,15 +38,31 @@ namespace Microsoft.Data.Entity.FunctionalTests
             eagle.BaseType = bird;
             eagle.AddProperty("Group", typeof(EagleGroup));
 
+            var plant = model.AddEntityType(typeof(Plant));
+            var plantSpeciesProperty = plant.AddProperty("Species", typeof(string));
+            plantSpeciesProperty.RequiresValueGenerator = true;
+            var plantKey = plant.SetPrimaryKey(plantSpeciesProperty);
+            plant.AddProperty("Name", typeof(string));
+
+            var flower = model.AddEntityType(typeof(Flower));
+            flower.BaseType = plant;
+
+            var rose = model.AddEntityType(typeof(Rose));
+            rose.BaseType = flower;
+            rose.AddProperty("HasThorns", typeof(bool));
+
+            var daisy = model.AddEntityType(typeof(Daisy));
+            daisy.BaseType = flower;
+
             var eagleFk = bird.AddForeignKey(bird.AddProperty("EagleId", typeof(string)), animalKey, eagle);
 
             country.AddNavigation("Animals", countryFk, false);
             eagle.AddNavigation("Prey", eagleFk, false);
         }
 
-        public abstract AnimalContext CreateContext();
+        public abstract InheritanceContext CreateContext();
 
-        protected void SeedData(AnimalContext context)
+        protected void SeedData(InheritanceContext context)
         {
             var kiwi = new Kiwi
                 {
@@ -65,6 +81,19 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
             eagle.Prey.Add(kiwi);
 
+            var rose = new Rose
+                {
+                    Species = "Rosa canina",
+                    Name = "Dog-rose",
+                    HasThorns = true
+                };
+
+            var daisy = new Daisy
+                {
+                    Species = "Bellis perennis",
+                    Name = "Common daisy"
+                };
+
             var nz = new Country { Id = 1, Name = "New Zealand" };
 
             nz.Animals.Add(kiwi);
@@ -77,6 +106,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
             context.Set<Bird>().Add(eagle);
             context.Set<Country>().Add(nz);
             context.Set<Country>().Add(usa);
+            context.Set<Rose>().Add(rose);
+            context.Set<Daisy>().Add(daisy);
 
             context.SaveChanges();
         }

--- a/test/EntityFramework.Core.FunctionalTests/InheritanceTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/InheritanceTestBase.cs
@@ -65,6 +65,19 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
+        public virtual void Can_use_of_type_rose()
+        {
+            using (var context = CreateContext())
+            {
+                var plants = context.Set<Plant>().OfType<Rose>().ToList();
+
+                Assert.Equal(1, plants.Count);
+                Assert.IsType<Rose>(plants[0]);
+                Assert.Equal(1, context.ChangeTracker.Entries().Count());
+            }
+        }
+
+        [Fact]
         public virtual void Can_query_all_animals()
         {
             using (var context = CreateContext())
@@ -74,6 +87,19 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 Assert.Equal(2, animals.Count);
                 Assert.IsType<Kiwi>(animals[0]);
                 Assert.IsType<Eagle>(animals[1]);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_query_all_plants()
+        {
+            using (var context = CreateContext())
+            {
+                var plants = context.Set<Plant>().OrderBy(a => a.Species).ToList();
+
+                Assert.Equal(2, plants.Count);
+                Assert.IsType<Daisy>(plants[0]);
+                Assert.IsType<Rose>(plants[1]);
             }
         }
 
@@ -114,6 +140,17 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 var kiwi = context.Set<Kiwi>().Single();
 
                 Assert.NotNull(kiwi);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_query_just_roses()
+        {
+            using (var context = CreateContext())
+            {
+                var rose = context.Set<Rose>().Single();
+
+                Assert.NotNull(rose);
             }
         }
 
@@ -197,7 +234,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        protected AnimalContext CreateContext()
+        protected InheritanceContext CreateContext()
         {
             return Fixture.CreateContext();
         }

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/Inheritance/Country.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/Inheritance/Country.cs
@@ -16,5 +16,6 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.Inheritance
         public string Name { get; set; }
 
         public IList<Animal> Animals { get; set; }
+        public IList<Plant> Plants { get; set; }
     }
 }

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/Inheritance/Daisy.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/Inheritance/Daisy.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Data.Entity.FunctionalTests.TestModels.Inheritance
+{
+    public class Daisy : Flower
+    {
+    }
+}

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/Inheritance/Flower.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/Inheritance/Flower.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Data.Entity.FunctionalTests.TestModels.Inheritance
+{
+    public abstract class Flower : Plant
+    {
+    }
+}

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/Inheritance/InheritanceContext.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/Inheritance/InheritanceContext.cs
@@ -6,11 +6,11 @@ using Microsoft.Data.Entity.Infrastructure;
 
 namespace Microsoft.Data.Entity.FunctionalTests.TestModels.Inheritance
 {
-    public class AnimalContext : DbContext
+    public class InheritanceContext : DbContext
     {
-        public static readonly string StoreName = "Animals";
+        public static readonly string StoreName = "Inheritance";
 
-        public AnimalContext(IServiceProvider serviceProvider, DbContextOptions options)
+        public InheritanceContext(IServiceProvider serviceProvider, DbContextOptions options)
             : base(serviceProvider, options)
         {
         }

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/Inheritance/Plant.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/Inheritance/Plant.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Data.Entity.FunctionalTests.TestModels.Inheritance
+{
+    public abstract class Plant
+    {
+        public PlantGenus Genus { get; set; }
+        public string Species { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/Inheritance/PlantGenus.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/Inheritance/PlantGenus.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Data.Entity.FunctionalTests.TestModels.Inheritance
+{
+    public enum PlantGenus
+    {
+        Rose,
+        Daisy
+    }
+}

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/Inheritance/Rose.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/Inheritance/Rose.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Data.Entity.FunctionalTests.TestModels.Inheritance
+{
+    public class Rose : Flower
+    {
+        public bool HasThorns { get; set; }
+    }
+}

--- a/test/EntityFramework.InMemory.FunctionalTests/InheritanceInMemoryFixture.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/InheritanceInMemoryFixture.cs
@@ -31,9 +31,9 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
             }
         }
 
-        public override AnimalContext CreateContext()
+        public override InheritanceContext CreateContext()
         {
-            return new AnimalContext(_serviceProvider, _optionsBuilder.Options);
+            return new InheritanceContext(_serviceProvider, _optionsBuilder.Options);
         }
     }
 }

--- a/test/EntityFramework.Relational.FunctionalTests/EntityFramework.Relational.FunctionalTests.csproj
+++ b/test/EntityFramework.Relational.FunctionalTests/EntityFramework.Relational.FunctionalTests.csproj
@@ -8,7 +8,7 @@
     <ProjectGuid>{82FAD20C-28C6-4B48-B7E4-971AC821E27A}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Microsoft.Data.Entity.Relational.FunctionalTests</RootNamespace>
+    <RootNamespace>Microsoft.Data.Entity.FunctionalTests</RootNamespace>
     <AssemblyName>EntityFramework.Relational.FunctionalTests</AssemblyName>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
@@ -38,6 +38,7 @@
     <Compile Include="AsyncFromSqlQueryTestBase.cs" />
     <Compile Include="AsyncFromSqlSprocQueryTestBase.cs" />
     <Compile Include="FromSqlSprocQueryTestBase.cs" />
+    <Compile Include="InheritanceRelationalFixture.cs" />
     <Compile Include="NorthwindSprocQueryRelationalFixture.cs" />
     <Compile Include="MappingQueryTestBase.cs" />
     <Compile Include="MappingQueryFixtureBase.cs" />

--- a/test/EntityFramework.Relational.FunctionalTests/InheritanceRelationalFixture.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/InheritanceRelationalFixture.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.FunctionalTests.TestModels.Inheritance;
+
+namespace Microsoft.Data.Entity.FunctionalTests
+{
+    public abstract class InheritanceRelationalFixture : InheritanceFixtureBase
+    {
+        public override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            // TODO: Code First this
+
+            var animal = modelBuilder.Entity<Animal>().Metadata;
+
+            var animalDiscriminatorProperty
+                = animal.AddProperty("Discriminator", typeof(string), shadowProperty: true);
+
+            animalDiscriminatorProperty.IsNullable = false;
+            //animalDiscriminatorProperty.IsReadOnlyBeforeSave = true; // #2132
+            animalDiscriminatorProperty.IsReadOnlyAfterSave = true;
+            animalDiscriminatorProperty.RequiresValueGenerator = true;
+
+            animal.Relational().DiscriminatorProperty = animalDiscriminatorProperty;
+
+
+            var plant = modelBuilder.Entity<Plant>().Metadata;
+
+            var plantDiscriminatorProperty
+                = plant.AddProperty("Genus", typeof(PlantGenus));
+
+            plantDiscriminatorProperty.IsNullable = false;
+            //plantDiscriminatorProperty.IsReadOnlyBeforeSave = true; // #2132
+            plantDiscriminatorProperty.IsReadOnlyAfterSave = true;
+            plantDiscriminatorProperty.RequiresValueGenerator = true;
+
+            plant.Relational().DiscriminatorProperty = plantDiscriminatorProperty;
+
+            var rose = modelBuilder.Entity<Rose>().Metadata;
+            rose.Relational().DiscriminatorValue = PlantGenus.Rose;
+
+            var daisy = modelBuilder.Entity<Daisy>().Metadata;
+            daisy.Relational().DiscriminatorValue = PlantGenus.Daisy;
+        }
+    }
+}

--- a/test/EntityFramework.SqlServer.FunctionalTests/InheritanceSqlServerFixture.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/InheritanceSqlServerFixture.cs
@@ -10,7 +10,7 @@ using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 {
-    public class InheritanceSqlServerFixture : InheritanceFixtureBase
+    public class InheritanceSqlServerFixture : InheritanceRelationalFixture
     {
         private readonly DbContextOptions _options;
         private readonly IServiceProvider _serviceProvider;
@@ -49,6 +49,13 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                     [Group] int,
                     FoundOn tinyint,
                     Discriminator nvarchar(255) NOT NULL
+                );
+
+                CREATE TABLE Plant(
+                    Genus int NOT NULL,
+                    Species nvarchar(100) NOT NULL PRIMARY KEY,
+                    Name nvarchar(100) NOT NULL,
+                    HasThorns bit
                 );");
 
             using (var context = CreateContext())
@@ -57,28 +64,9 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             }
         }
 
-        public override AnimalContext CreateContext()
+        public override InheritanceContext CreateContext()
         {
-            return new AnimalContext(_serviceProvider, _options);
-        }
-
-        public override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            base.OnModelCreating(modelBuilder);
-
-            // TODO: Code First this
-
-            var animal = modelBuilder.Entity<Animal>().Metadata;
-
-            var discriminatorProperty
-                = animal.AddProperty("Discriminator", typeof(string), shadowProperty: true);
-
-            discriminatorProperty.IsNullable = false;
-            //discriminatorProperty.IsReadOnlyBeforeSave = true; // #2132
-            discriminatorProperty.IsReadOnlyAfterSave = true;
-            discriminatorProperty.RequiresValueGenerator = true;
-
-            animal.Relational().DiscriminatorProperty = discriminatorProperty;
+            return new InheritanceContext(_serviceProvider, _options);
         }
     }
 }

--- a/test/EntityFramework.SqlServer.FunctionalTests/InheritanceSqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/InheritanceSqlServerTest.cs
@@ -55,6 +55,17 @@ WHERE [a].[Discriminator] = 'Kiwi'",
                 Sql);
         }
 
+        public override void Can_use_of_type_rose()
+        {
+            base.Can_use_of_type_rose();
+
+            Assert.Equal(
+                @"SELECT [p].[Species], [p].[Genus], [p].[Name], [p].[HasThorns]
+FROM [Plant] AS [p]
+WHERE [p].[Genus] = 0",
+                Sql);
+        }
+
         public override void Can_query_all_animals()
         {
             base.Can_query_all_animals();
@@ -63,6 +74,18 @@ WHERE [a].[Discriminator] = 'Kiwi'",
                 @"SELECT [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
 FROM [Animal] AS [a]
 WHERE [a].[Discriminator] IN ('Kiwi', 'Eagle')
+ORDER BY [a].[Species]",
+                Sql);
+        }
+
+        public override void Can_query_all_plants()
+        {
+            base.Can_query_all_plants();
+
+            Assert.Equal(
+                @"SELECT [a].[Species], [a].[Genus], [a].[Name], [a].[HasThorns]
+FROM [Plant] AS [a]
+WHERE [a].[Genus] IN (0, 1)
 ORDER BY [a].[Species]",
                 Sql);
         }
@@ -100,6 +123,18 @@ ORDER BY [a].[Species]",
 FROM [Animal] AS [a]
 WHERE [a].[Discriminator] = 'Kiwi'",
                 Sql);
+        }
+
+        public override void Can_query_just_roses()
+        {
+            base.Can_query_just_roses();
+
+            Assert.Equal(
+                @"SELECT TOP(2) [p].[Species], [p].[Genus], [p].[Name], [p].[HasThorns]
+FROM [Plant] AS [p]
+WHERE [p].[Genus] = 0",
+                Sql
+                );
         }
 
         public override void Can_include_prey()

--- a/test/EntityFramework.Sqlite.FunctionalTests/InheritanceSqliteFixture.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/InheritanceSqliteFixture.cs
@@ -10,7 +10,7 @@ using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
 {
-    public class InheritanceSqliteFixture : InheritanceFixtureBase
+    public class InheritanceSqliteFixture : InheritanceRelationalFixture
     {
         private readonly DbContextOptions _options;
         private readonly IServiceProvider _serviceProvider;
@@ -56,6 +56,13 @@ namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
                     FOREIGN KEY(countryId) REFERENCES Country(Id),
                     FOREIGN KEY(EagleId) REFERENCES Animal(Species)
                 );
+
+                CREATE TABLE Plant (
+                    Genus int NOT NULL,
+                    Species nvarchar(100) NOT NULL PRIMARY KEY,
+                    Name nvarchar(100) NOT NULL,
+                    HasThorns bit
+                );
             ");
 
             using (var context = CreateContext())
@@ -65,28 +72,9 @@ namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
             TestSqlLoggerFactory.Reset();
         }
 
-        public override AnimalContext CreateContext()
+        public override InheritanceContext CreateContext()
         {
-            return new AnimalContext(_serviceProvider, _options);
-        }
-
-        public override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            base.OnModelCreating(modelBuilder);
-
-            // TODO: Code First this
-
-            var animal = modelBuilder.Entity<Animal>().Metadata;
-
-            var discriminatorProperty
-                = animal.AddProperty("Discriminator", typeof(string), shadowProperty: true);
-
-            discriminatorProperty.IsNullable = false;
-            //discriminatorProperty.IsReadOnlyBeforeSave = true; // #2132
-            discriminatorProperty.IsReadOnlyAfterSave = true;
-            discriminatorProperty.RequiresValueGenerator = true;
-
-            animal.Relational().DiscriminatorProperty = discriminatorProperty;
+            return new InheritanceContext(_serviceProvider, _options);
         }
     }
 }

--- a/test/EntityFramework.Sqlite.FunctionalTests/InheritanceSqliteTest.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/InheritanceSqliteTest.cs
@@ -32,6 +32,19 @@ ORDER BY ""a"".""Species""",
                 Sql);
         }
 
+        public override void Can_use_of_type_bird_first()
+        {
+            base.Can_use_of_type_bird_first();
+
+            Assert.Equal(
+                @"SELECT ""a"".""Species"", ""a"".""CountryId"", ""a"".""Discriminator"", ""a"".""Name"", ""a"".""EagleId"", ""a"".""IsFlightless"", ""a"".""Group"", ""a"".""FoundOn""
+FROM ""Animal"" AS ""a""
+WHERE ""a"".""Discriminator"" IN ('Kiwi', 'Eagle')
+ORDER BY ""a"".""Species""
+LIMIT 1",
+                Sql);
+        }
+
         public override void Can_use_of_type_kiwi()
         {
             base.Can_use_of_type_kiwi();
@@ -43,6 +56,17 @@ WHERE ""a"".""Discriminator"" = 'Kiwi'",
                 Sql);
         }
 
+        public override void Can_use_of_type_rose()
+        {
+            base.Can_use_of_type_rose();
+
+            Assert.Equal(
+                @"SELECT ""p"".""Species"", ""p"".""Genus"", ""p"".""Name"", ""p"".""HasThorns""
+FROM ""Plant"" AS ""p""
+WHERE ""p"".""Genus"" = 0",
+                Sql);
+        }
+
         public override void Can_query_all_animals()
         {
             base.Can_query_all_animals();
@@ -51,6 +75,18 @@ WHERE ""a"".""Discriminator"" = 'Kiwi'",
                 @"SELECT ""a"".""Species"", ""a"".""CountryId"", ""a"".""Discriminator"", ""a"".""Name"", ""a"".""EagleId"", ""a"".""IsFlightless"", ""a"".""Group"", ""a"".""FoundOn""
 FROM ""Animal"" AS ""a""
 WHERE ""a"".""Discriminator"" IN ('Kiwi', 'Eagle')
+ORDER BY ""a"".""Species""",
+                Sql);
+        }
+
+        public override void Can_query_all_plants()
+        {
+            base.Can_query_all_plants();
+
+            Assert.Equal(
+                @"SELECT ""a"".""Species"", ""a"".""Genus"", ""a"".""Name"", ""a"".""HasThorns""
+FROM ""Plant"" AS ""a""
+WHERE ""a"".""Genus"" IN (0, 1)
 ORDER BY ""a"".""Species""",
                 Sql);
         }
@@ -87,6 +123,18 @@ ORDER BY ""a"".""Species""",
                 @"SELECT ""a"".""Species"", ""a"".""CountryId"", ""a"".""Discriminator"", ""a"".""Name"", ""a"".""EagleId"", ""a"".""IsFlightless"", ""a"".""FoundOn""
 FROM ""Animal"" AS ""a""
 WHERE ""a"".""Discriminator"" = 'Kiwi'
+LIMIT 2",
+                Sql);
+        }
+
+        public override void Can_query_just_roses()
+        {
+            base.Can_query_just_roses();
+
+            Assert.Equal(
+                @"SELECT ""p"".""Species"", ""p"".""Genus"", ""p"".""Name"", ""p"".""HasThorns""
+FROM ""Plant"" AS ""p""
+WHERE ""p"".""Genus"" = 0
 LIMIT 2",
                 Sql);
         }
@@ -132,6 +180,57 @@ INNER JOIN (
 ) AS ""c"" ON ""a"".""CountryId"" = ""c"".""Id""
 WHERE (""a"".""Discriminator"" = 'Kiwi' OR ""a"".""Discriminator"" = 'Eagle')
 ORDER BY ""c"".""Name"", ""c"".""Id""",
+                Sql);
+        }
+
+        public override void Can_insert_update_delete()
+        {
+            base.Can_insert_update_delete();
+
+            Assert.Equal(
+                @"SELECT ""c"".""Id"", ""c"".""Name""
+FROM ""Country"" AS ""c""
+WHERE ""c"".""Id"" = 1
+LIMIT 2
+
+@p0: Apteryx owenii
+@p1: 1
+@p2: Kiwi
+@p3: Little spotted kiwi
+@p4: 
+@p5: True
+@p6: North
+
+INSERT INTO ""Animal"" (""Species"", ""CountryId"", ""Discriminator"", ""Name"", ""EagleId"", ""IsFlightless"", ""FoundOn"")
+VALUES (@p0, @p1, @p2, @p3, @p4, @p5, @p6);
+SELECT changes();
+
+SELECT ""k"".""Species"", ""k"".""CountryId"", ""k"".""Discriminator"", ""k"".""Name"", ""k"".""EagleId"", ""k"".""IsFlightless"", ""k"".""FoundOn""
+FROM ""Animal"" AS ""k""
+WHERE (""k"".""Discriminator"" = 'Kiwi' AND ""k"".""Species"" LIKE '%' || 'owenii')
+LIMIT 2
+
+@p1: Apteryx owenii
+@p0: Aquila chrysaetos canadensis
+
+UPDATE ""Animal"" SET ""EagleId"" = @p0
+WHERE ""Species"" = @p1;
+SELECT changes();
+
+SELECT ""k"".""Species"", ""k"".""CountryId"", ""k"".""Discriminator"", ""k"".""Name"", ""k"".""EagleId"", ""k"".""IsFlightless"", ""k"".""FoundOn""
+FROM ""Animal"" AS ""k""
+WHERE (""k"".""Discriminator"" = 'Kiwi' AND ""k"".""Species"" LIKE '%' || 'owenii')
+LIMIT 2
+
+@p0: Apteryx owenii
+
+DELETE FROM ""Animal""
+WHERE ""Species"" = @p0;
+SELECT changes();
+
+SELECT COUNT(*)
+FROM ""Animal"" AS ""k""
+WHERE (""k"".""Discriminator"" = 'Kiwi' AND ""k"".""Species"" LIKE '%' || 'owenii')",
                 Sql);
         }
 


### PR DESCRIPTION
Fix is as described in #2057, Query uses the `DiscriminatorValue` in a `ConstantExpression` and the `DefaultQuerySqlGenerator` needs to translate `Enum`s accordingly.

The SQL for the provided example now generates as:
```
@__p_0: 1
SELECT [x].[Id], [x].[Discriminator]
FROM [Address] AS [x]
WHERE ([x].[Discriminator] IN (2, 1) AND [x].[Discriminator] = @__p_0)
```

@anpete 