### PR TITLE
[SQLite] Enable column renames in migrations

### DIFF
--- a/makefile.shade
+++ b/makefile.shade
@@ -54,6 +54,7 @@ var sqliteTestDir='test/EntityFramework.Sqlite.FunctionalTests/bin/${E("Configur
     var sourceDir='${Directory.EnumerateDirectories(packagesDir, "Microsoft.Data.Sqlite/*").OrderByDescending(d => d).First() + "/redist/x86"}'
     copy outputDir='${sqliteTestDir}'
     copy outputDir='test/EntityFramework.CrossStore.FunctionalTests/bin/${E("Configuration")}/x86'
+    copy outputDir='test/EntityFramework.Sqlite.Tests/bin/${E("Configuration")}/x86'
 
 #nuspec-pack target="compile"
     var DNX_BUILD_VERSION='${E("DNX_BUILD_VERSION")}'

--- a/src/EntityFramework.Sqlite/EntityFramework.Sqlite.csproj
+++ b/src/EntityFramework.Sqlite/EntityFramework.Sqlite.csproj
@@ -85,11 +85,12 @@
     <Compile Include="Metadata\SqliteMetadataExtensions.cs" />
     <Compile Include="Metadata\SqliteModelAnnotations.cs" />
     <Compile Include="Metadata\SqlitePropertyAnnotations.cs" />
+    <Compile Include="Migrations\Operations\MoveDataOperation.cs" />
+    <Compile Include="Migrations\Operations\TableRebuildOperation.cs" />
     <Compile Include="Migrations\SqliteHistoryRepository.cs" />
     <Compile Include="Migrations\SqliteMigrationAnnotationProvider.cs" />
     <Compile Include="Migrations\SqliteMigrationSqlGenerator.cs" />
     <Compile Include="Migrations\SqliteOperationTransformer.cs" />
-    <Compile Include="Migrations\MoveDataOperation.cs" />
     <Compile Include="Properties\Strings.Designer.cs">
       <DependentUpon>Strings.resx</DependentUpon>
     </Compile>

--- a/src/EntityFramework.Sqlite/Migrations/Operations/MoveDataOperation.cs
+++ b/src/EntityFramework.Sqlite/Migrations/Operations/MoveDataOperation.cs
@@ -1,20 +1,19 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Migrations.Operations;
 
-namespace Microsoft.Data.Entity.Sqlite.Migrations
+namespace Microsoft.Data.Entity.Sqlite.Migrations.Operations
 {
     public class MoveDataOperation : MigrationOperation
     {
-        // TODO handle renaming columns
-        public MoveDataOperation()
-        {
-            IsDestructiveChange = true;
-        }
+        /// <summary>
+        ///     Key = destination column name, value = source column name
+        /// </summary>
+        public virtual IDictionary<string, string> ColumnMapping { get; [param: NotNull] set; } = new Dictionary<string, string>();
 
-        public virtual string[] Columns { get; [param: NotNull] set; }
         public virtual string OldTable { get; [param: NotNull] set; }
         public virtual string NewTable { get; [param: NotNull] set; }
     }

--- a/src/EntityFramework.Sqlite/Migrations/Operations/TableRebuildOperation.cs
+++ b/src/EntityFramework.Sqlite/Migrations/Operations/TableRebuildOperation.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Migrations.Operations;
+
+namespace Microsoft.Data.Entity.Sqlite.Migrations.Operations
+{
+    public class TableRebuildOperation : MigrationOperation
+    {
+        public virtual string Table { get; [param: NotNull] set; }
+        public virtual List<MigrationOperation> Operations { get; [param: NotNull] set; } = new List<MigrationOperation>();
+    }
+}

--- a/test/EntityFramework.Sqlite.FunctionalTests/MigrationTest.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/MigrationTest.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
         [Fact]
         public void DropColumn_rebuilds_table()
         {
-            _testStore.ExecuteNonQuery(@"CREATE TABLE Table1 (Id INT PRIMARY KEY, Col1, Col2); 
+            _testStore.ExecuteNonQuery(@"CREATE TABLE Table1 (Id INTEGER PRIMARY KEY, Col1, Col2); 
 INSERT INTO Table1 (Col1, Col2) Values('dropped value','preserved entry');");
 
             Migrate(up => { up.DropColumn("Col1", "Table1"); }, targetModel =>
@@ -56,6 +56,41 @@ INSERT INTO Table1 (Col1, Col2) Values('dropped value','preserved entry');");
                 Assert.Equal("preserved entry", all[0].Col2);
             }
         }
+
+        [Fact]
+        public void RenameColumn_rebuilds_table()
+        {
+            _testStore.ExecuteNonQuery(@"CREATE TABLE Table1 (Id INTEGER PRIMARY KEY, OriginalCol); 
+INSERT INTO Table1 (OriginalCol) Values('renamed');");
+
+            Migrate(up => { up.RenameColumn("OriginalCol", "Table1","Col2"); }, targetModel =>
+            {
+                targetModel.Entity<UpdatedTableType>(b =>
+                {
+                    b.Key(p => p.Id);
+                    b.Property(p => p.Id)
+                        .StoreGeneratedPattern(StoreGeneratedPattern.Identity);
+
+                    b.Property(p => p.Col2);
+                    b.ToSqliteTable("Table1");
+                });
+            });
+
+            AssertColumns("Table1", new List<string>
+            {
+                "Id", "Col2"
+            });
+
+            using (var context = CreateContext())
+            {
+                // Assert data moved
+                var all = context.Set<UpdatedTableType>().ToList();
+                Assert.Equal(1, all.Count);
+                Assert.Equal(1, all[0].Id);
+                Assert.Equal("renamed", all[0].Col2);
+            }
+        }
+
 
         public MigrationTest()
         {

--- a/test/EntityFramework.Sqlite.Tests/Migrations/SqliteMigrationSqlGeneratorTest.cs
+++ b/test/EntityFramework.Sqlite.Tests/Migrations/SqliteMigrationSqlGeneratorTest.cs
@@ -5,6 +5,7 @@ using System;
 using Microsoft.Data.Entity.Migrations.Operations;
 using Microsoft.Data.Entity.Migrations.Sql;
 using Microsoft.Data.Entity.Sqlite.Metadata;
+using Microsoft.Data.Entity.Sqlite.Migrations.Operations;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Sqlite.Migrations
@@ -18,7 +19,11 @@ namespace Microsoft.Data.Entity.Sqlite.Migrations
         {
             var operation = new MoveDataOperation
             {
-                Columns = new[] { "col1", "col2" },
+                ColumnMapping =
+                {
+                    { "col1", "col1" },
+                    { "col2", "col2" }
+                },
                 OldTable = "OldTable",
                 NewTable = "RebuiltTable"
             };
@@ -36,7 +41,7 @@ namespace Microsoft.Data.Entity.Sqlite.Migrations
             {
                 Name = "Id",
                 Type = "INTEGER",
-                IsNullable = false,
+                IsNullable = false
             };
             if (autoincrement)
             {
@@ -44,11 +49,11 @@ namespace Microsoft.Data.Entity.Sqlite.Migrations
             }
 
             Generate(
-                 new CreateTableOperation
-                 {
-                     Name = "People",
-                     Columns =
-                     {
+                new CreateTableOperation
+                {
+                    Name = "People",
+                    Columns =
+                    {
                         addIdColumn,
                         new AddColumnOperation
                         {
@@ -56,33 +61,33 @@ namespace Microsoft.Data.Entity.Sqlite.Migrations
                             Type = "int",
                             IsNullable = true
                         },
-                         new AddColumnOperation
+                        new AddColumnOperation
                         {
                             Name = "SSN",
                             Type = "char(11)",
                             IsNullable = true
                         }
-                     },
-                     PrimaryKey = new AddPrimaryKeyOperation
-                     {
-                         Columns = new[] { "Id" }
-                     },
-                     UniqueConstraints =
-                     {
+                    },
+                    PrimaryKey = new AddPrimaryKeyOperation
+                    {
+                        Columns = new[] { "Id" }
+                    },
+                    UniqueConstraints =
+                    {
                         new AddUniqueConstraintOperation
                         {
                             Columns = new[] { "SSN" }
                         }
-                     },
-                     ForeignKeys =
-                     {
+                    },
+                    ForeignKeys =
+                    {
                         new AddForeignKeyOperation
                         {
                             Columns = new[] { "EmployerId" },
                             ReferencedTable = "Companies"
                         }
-                     }
-                 });
+                    }
+                });
 
             Assert.Equal(
                 "CREATE TABLE \"People\" (" + EOL +

--- a/test/EntityFramework.Sqlite.Tests/Migrations/SqliteOperationTransformBase.cs
+++ b/test/EntityFramework.Sqlite.Tests/Migrations/SqliteOperationTransformBase.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Metadata.Conventions;
+using Microsoft.Data.Entity.Migrations.Builders;
+using Microsoft.Data.Entity.Migrations.Operations;
+using Microsoft.Data.Entity.Sqlite.Migrations.Operations;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Sqlite.Migrations
+{
+    public abstract class SqliteOperationTransformBase
+    {
+        protected abstract SqliteOperationTransformer CreateTransformer();
+
+        protected Action<MigrationOperation> AssertCreateIndex(
+            string tableName,
+            string[] columns,
+            bool unique = false)
+            => operation =>
+                {
+                    var index = Assert.IsType<CreateIndexOperation>(operation);
+                    Assert.Equal(tableName, index.Table);
+                    Assert.Equal(unique, index.IsUnique);
+                    Assert.Equal(index.Columns, columns);
+                };
+
+        protected static Action<MigrationOperation> AssertCreateTable(
+            string tableName,
+            string[] columns,
+            string[] primaryKey = null)
+            => operation =>
+                {
+                    var create = Assert.IsType<CreateTableOperation>(operation);
+                    Assert.Equal(tableName, create.Name);
+                    Assert.Equal(columns, create.Columns.Select(c => c.Name).ToArray());
+                    if (primaryKey != null)
+                    {
+                        Assert.Equal(primaryKey, create.PrimaryKey.Columns);
+                    }
+                };
+
+        protected static Action<MigrationOperation> AssertDropTemp(string name)
+            => operation =>
+                {
+                    var drop = Assert.IsType<DropTableOperation>(operation);
+                    Assert.Equal(name + "_temp", drop.Name);
+                };
+
+        protected static Action<MigrationOperation> AssertMoveData(
+            string tableName,
+            string[] oldColumns,
+            string[] newColumns)
+            => op =>
+                {
+                    var move = Assert.IsType<MoveDataOperation>(op);
+                    Assert.Equal(tableName + "_temp", move.OldTable);
+                    Assert.Equal(tableName, move.NewTable);
+                    Assert.Equal(oldColumns, move.ColumnMapping.Values.ToArray());
+                    Assert.Equal(newColumns, move.ColumnMapping.Keys.ToArray());
+                };
+
+        protected static Action<MigrationOperation> AssertRenameTemp(string name)
+            => operation =>
+                {
+                    var rename = Assert.IsType<RenameTableOperation>(operation);
+                    Assert.Equal(name, rename.Name);
+                    Assert.Equal(name + "_temp", rename.NewName);
+                };
+
+        protected IReadOnlyList<MigrationOperation> Transform(Action<MigrationBuilder> migrationBuilder, Action<ModelBuilder> modelBuilder)
+        {
+            var migration = new MigrationBuilder();
+            migrationBuilder(migration);
+            var model = new ModelBuilder(new ConventionSet(), new Model());
+            modelBuilder(model);
+            var transformer = CreateTransformer();
+            return transformer.Transform(migration.Operations.ToList(), model.Model);
+        }
+    }
+}


### PR DESCRIPTION
Enables column renames with a table rebuild.

Also, improve implementation of transforms and cleanup testing.