### PR TITLE
Allow multiple providers for reverse engineering.

### DIFF
--- a/src/EntityFramework.Commands/Executor.cs
+++ b/src/EntityFramework.Commands/Executor.cs
@@ -248,8 +248,7 @@ namespace Microsoft.Data.Entity.Commands
                 Check.NotNull(args, nameof(args));
 
                 var connectionString = (string)args["connectionString"];
-
-                var providerAssemblyName = DatabaseTool._defaultReverseEngineeringProviderAssembly;
+                var providerAssemblyName = (string)args["provider"];
 
                 Execute(() => executor.ReverseEngineerImplAsync(providerAssemblyName, connectionString).GetAwaiter().GetResult());
             }

--- a/src/EntityFramework.Commands/Program.cs
+++ b/src/EntityFramework.Commands/Program.cs
@@ -223,9 +223,14 @@ namespace Microsoft.Data.Entity.Commands
                     var connectionString = revEng.Argument(
                             "[connectionString]",
                             "The connection string of the database");
+                    var providerAssemblyName = revEng.Argument(
+                            "[provider]",
+                            "The assembly name of the runtime provider");
 
                     revEng.OnExecute(() => ReverseEngineerAsync(
-                                connectionString.Value, _applicationShutdown.ShutdownRequested));
+                                connectionString.Value,
+                                providerAssemblyName.Value,
+                                _applicationShutdown.ShutdownRequested));
                 });
             _app.Command(
                 "help",
@@ -364,11 +369,11 @@ namespace Microsoft.Data.Entity.Commands
 
         public virtual async Task<int> ReverseEngineerAsync(
             [NotNull] string connectionString,
+            [NotNull] string providerAssemblyName,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             await _databaseTool.ReverseEngineerAsync(
-                DatabaseTool._defaultReverseEngineeringProviderAssembly,
-                connectionString, _rootNamespace, _projectDir);
+                providerAssemblyName, connectionString, _rootNamespace, _projectDir);
 
             _logger.LogInformation("Done.");
 

--- a/src/EntityFramework.Commands/Properties/Strings.Designer.cs
+++ b/src/EntityFramework.Commands/Properties/Strings.Designer.cs
@@ -157,11 +157,11 @@ namespace Microsoft.Data.Entity.Commands
         }
 
         /// <summary>
-        /// Unable to find asssembly with name {assemblyName}.
+        /// Unable to find runtime provider assembly with name {assemblyName}. Ensure the specified name is correct and is referenced by the project.
         /// </summary>
-        public static string CannotFindAssembly([CanBeNull] object assemblyName)
+        public static string CannotFindRuntimeProviderAssembly([CanBeNull] object assemblyName)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("CannotFindAssembly", "assemblyName"), assemblyName);
+            return string.Format(CultureInfo.CurrentCulture, GetString("CannotFindRuntimeProviderAssembly", "assemblyName"), assemblyName);
         }
 
         /// <summary>
@@ -218,6 +218,38 @@ namespace Microsoft.Data.Entity.Commands
         public static string ReusingSnapshotName([CanBeNull] object name)
         {
             return string.Format(CultureInfo.CurrentCulture, GetString("ReusingSnapshotName", "name"), name);
+        }
+
+        /// <summary>
+        /// Unable to find design-time provider assembly with name {designTimeProviderAssemblyName}. Ensure that the assembly is referenced by the project.
+        /// </summary>
+        public static string CannotFindDesignTimeProviderAssembly([CanBeNull] object designTimeProviderAssemblyName)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("CannotFindDesignTimeProviderAssembly", "designTimeProviderAssemblyName"), designTimeProviderAssemblyName);
+        }
+
+        /// <summary>
+        /// The type {typeName} in the design-time provider assembly {assemblyName} exists but does not implement interface {metadataModelProviderInterfaceName}.
+        /// </summary>
+        public static string SpecifiedDesignTimeTypeDoesNotImplementInterface([CanBeNull] object typeName, [CanBeNull] object assemblyName, [CanBeNull] object metadataModelProviderInterfaceName)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("SpecifiedDesignTimeTypeDoesNotImplementInterface", "typeName", "assemblyName", "metadataModelProviderInterfaceName"), typeName, assemblyName, metadataModelProviderInterfaceName);
+        }
+
+        /// <summary>
+        /// Unable to find expected assembly attribute named {attributeName} in runtime provider assembly {runtimeProviderAssemblyName}. This attribute is required to identify the design-time provider type.
+        /// </summary>
+        public static string CannotFindDesignTimeProviderAssemblyAttribute([CanBeNull] object attributeName, [CanBeNull] object runtimeProviderAssemblyName)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("CannotFindDesignTimeProviderAssemblyAttribute", "attributeName", "runtimeProviderAssemblyName"), attributeName, runtimeProviderAssemblyName);
+        }
+
+        /// <summary>
+        /// Design-time provider assembly {assemblyName} does not contain the specified type {typeName}.
+        /// </summary>
+        public static string DesignTimeAssemblyProviderDoesNotContainSpecifiedType([CanBeNull] object assemblyName, [CanBeNull] object typeName)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("DesignTimeAssemblyProviderDoesNotContainSpecifiedType", "assemblyName", "typeName"), assemblyName, typeName);
         }
 
         private static string GetString(string name, params string[] formatterNames)

--- a/src/EntityFramework.Commands/Properties/Strings.resx
+++ b/src/EntityFramework.Commands/Properties/Strings.resx
@@ -171,8 +171,8 @@
   <data name="UnknownLiteral" xml:space="preserve">
     <value>The current CSharpHelper cannot scaffold literals of type '{literalType}'. Configure your services to use one that can.</value>
   </data>
-  <data name="CannotFindAssembly" xml:space="preserve">
-    <value>Unable to find asssembly with name {assemblyName}.</value>
+  <data name="CannotFindRuntimeProviderAssembly" xml:space="preserve">
+    <value>Unable to find runtime provider assembly with name {assemblyName}. Ensure the specified name is correct and is referenced by the project.</value>
   </data>
   <data name="DestructiveOperation" xml:space="preserve">
     <value>An operation was scaffolded that may result in the loss of data. Please review the migration for accuracy.</value>
@@ -194,5 +194,17 @@
   </data>
   <data name="ReusingSnapshotName" xml:space="preserve">
     <value>Reusing model snapshot name '{name}'.</value>
+  </data>
+  <data name="CannotFindDesignTimeProviderAssembly" xml:space="preserve">
+    <value>Unable to find design-time provider assembly with name {designTimeProviderAssemblyName}. Ensure that the assembly is referenced by the project.</value>
+  </data>
+  <data name="SpecifiedDesignTimeTypeDoesNotImplementInterface" xml:space="preserve">
+    <value>The type {typeName} in the design-time provider assembly {assemblyName} exists but does not implement interface {metadataModelProviderInterfaceName}.</value>
+  </data>
+  <data name="CannotFindDesignTimeProviderAssemblyAttribute" xml:space="preserve">
+    <value>Unable to find expected assembly attribute named {attributeName} in runtime provider assembly {runtimeProviderAssemblyName}. This attribute is required to identify the design-time provider type.</value>
+  </data>
+  <data name="DesignTimeAssemblyProviderDoesNotContainSpecifiedType" xml:space="preserve">
+    <value>Design-time provider assembly {assemblyName} does not contain the specified type {typeName}.</value>
   </data>
 </root>

--- a/src/EntityFramework.Relational.Design/Properties/Strings.Designer.cs
+++ b/src/EntityFramework.Relational.Design/Properties/Strings.Designer.cs
@@ -13,14 +13,6 @@ namespace Microsoft.Data.Entity.Relational.Design
             = new ResourceManager("EntityFramework.Relational.Design.Strings", typeof(Strings).GetTypeInfo().Assembly);
 
         /// <summary>
-        /// Assembly {assemblyName} does not contain an implemetation of {metadataModelProviderInterfaceName}.
-        /// </summary>
-        public static string AssemblyDoesNotContainMetadataModelProvider([CanBeNull] object assemblyName, [CanBeNull] object metadataModelProviderInterfaceName)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("AssemblyDoesNotContainMetadataModelProvider", "assemblyName", "metadataModelProviderInterfaceName"), assemblyName, metadataModelProviderInterfaceName);
-        }
-
-        /// <summary>
         /// ConnectionString is required to generate code.
         /// </summary>
         public static string ConnectionStringRequired
@@ -77,11 +69,11 @@ namespace Microsoft.Data.Entity.Relational.Design
         }
 
         /// <summary>
-        /// ProviderAssembly is required to generate code.
+        /// Provider is required to generate code.
         /// </summary>
-        public static string ProviderAssemblyRequired
+        public static string ProviderRequired
         {
-            get { return GetString("ProviderAssemblyRequired"); }
+            get { return GetString("ProviderRequired"); }
         }
 
         /// <summary>

--- a/src/EntityFramework.Relational.Design/Properties/Strings.resx
+++ b/src/EntityFramework.Relational.Design/Properties/Strings.resx
@@ -117,9 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="AssemblyDoesNotContainMetadataModelProvider" xml:space="preserve">
-    <value>Assembly {assemblyName} does not contain an implemetation of {metadataModelProviderInterfaceName}.</value>
-  </data>
   <data name="ConnectionStringRequired" xml:space="preserve">
     <value>ConnectionString is required to generate code.</value>
   </data>
@@ -141,8 +138,8 @@
   <data name="OutputPathRequired" xml:space="preserve">
     <value>OutputPath is required to generate code.</value>
   </data>
-  <data name="ProviderAssemblyRequired" xml:space="preserve">
-    <value>ProviderAssembly is required to generate code.</value>
+  <data name="ProviderRequired" xml:space="preserve">
+    <value>Provider is required to generate code.</value>
   </data>
   <data name="ProviderReturnedNullModel" xml:space="preserve">
     <value>Metadata model returned should not be null. Provider: {providerTypeName} , connection string: {connectionString}.</value>

--- a/src/EntityFramework.Relational.Design/ReverseEngineering/BaseGeneratorModel.cs
+++ b/src/EntityFramework.Relational.Design/ReverseEngineering/BaseGeneratorModel.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering
     {
         public virtual string ClassName { get; [param: CanBeNull] set; }
         public virtual string Namespace { get; [param: CanBeNull] set; }
-        public virtual string ProviderAssembly { get; [param: NotNull] set; }
         public virtual string ConnectionString { get; [param: NotNull] set; }
         public virtual ReverseEngineeringGenerator Generator { get; [param: NotNull] set; }
     }

--- a/src/EntityFramework.Relational.Design/ReverseEngineering/ReverseEngineeringConfiguration.cs
+++ b/src/EntityFramework.Relational.Design/ReverseEngineering/ReverseEngineeringConfiguration.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering
 {
     public class ReverseEngineeringConfiguration
     {
-        public virtual Assembly ProviderAssembly { get; [param: NotNull] set; }
+        public virtual IDatabaseMetadataModelProvider Provider { get; [param: NotNull] set; }
         public virtual string ConnectionString { get; [param: NotNull] set; }
         public virtual string OutputPath { get; [param: NotNull] set; }
         public virtual string Namespace { get; [param: NotNull] set; }

--- a/src/EntityFramework.Relational.Design/ReverseEngineering/ReverseEngineeringGenerator.cs
+++ b/src/EntityFramework.Relational.Design/ReverseEngineering/ReverseEngineeringGenerator.cs
@@ -55,15 +55,13 @@ namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering
             CheckConfiguration(configuration);
 
             var resultingFiles = new List<string>();
-            var providerAssembly = configuration.ProviderAssembly;
-            var provider = GetProvider(providerAssembly);
+            var provider = configuration.Provider;
             var metadataModel = GetMetadataModel(provider, configuration);
 
             var dbContextGeneratorModel = new DbContextGeneratorModel
             {
                 ClassName = configuration.ContextClassName,
                 Namespace = configuration.Namespace,
-                ProviderAssembly = configuration.ProviderAssembly.FullName,
                 ConnectionString = configuration.ConnectionString,
                 Generator = this,
                 MetadataModel = metadataModel
@@ -98,7 +96,6 @@ namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering
                 {
                     EntityType = entityType,
                     Namespace = configuration.Namespace,
-                    ProviderAssembly = configuration.ProviderAssembly.FullName,
                     ConnectionString = configuration.ConnectionString,
                     Generator = this
                 };
@@ -121,23 +118,6 @@ namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering
             }
 
             return resultingFiles;
-        }
-
-        public virtual IDatabaseMetadataModelProvider GetProvider([NotNull] Assembly providerAssembly)
-        {
-            Check.NotNull(providerAssembly, nameof(providerAssembly));
-
-            var type = providerAssembly.GetExportedTypes()
-                .FirstOrDefault(t => typeof(IDatabaseMetadataModelProvider).IsAssignableFrom(t));
-            if (type == null)
-            {
-                throw new InvalidOperationException(
-                    Strings.AssemblyDoesNotContainMetadataModelProvider(
-                        providerAssembly.FullName,
-                        typeof(IDatabaseMetadataModelProvider).FullName));
-            }
-
-            return (IDatabaseMetadataModelProvider)Activator.CreateInstance(type, _serviceProvider);
         }
 
         public virtual IModel GetMetadataModel(
@@ -200,9 +180,9 @@ namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering
 
         private static void CheckConfiguration(ReverseEngineeringConfiguration configuration)
         {
-            if (configuration.ProviderAssembly == null)
+            if (configuration.Provider == null)
             {
-                throw new ArgumentException(Strings.ProviderAssemblyRequired);
+                throw new ArgumentException(Strings.ProviderRequired);
             }
 
             if (string.IsNullOrEmpty(configuration.ConnectionString))

--- a/src/EntityFramework.Relational/EntityFramework.Relational.csproj
+++ b/src/EntityFramework.Relational/EntityFramework.Relational.csproj
@@ -165,6 +165,7 @@
     <Compile Include="Storage\IRelationalTypeMapper.cs" />
     <Compile Include="Storage\IRelationalValueBufferFactory.cs" />
     <Compile Include="Storage\IRelationalValueBufferFactoryFactory.cs" />
+    <Compile Include="Storage\ProviderDesignTimeServicesAttribute.cs" />
     <Compile Include="Storage\RelationalConnection.cs" />
     <Compile Include="Storage\RelationalDatabase.cs" />
     <Compile Include="Storage\RelationalDatabaseCreator.cs" />

--- a/src/EntityFramework.Relational/Storage/ProviderDesignTimeServicesAttribute.cs
+++ b/src/EntityFramework.Relational/Storage/ProviderDesignTimeServicesAttribute.cs
@@ -1,0 +1,30 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Storage
+{
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false)]
+    public class ProviderDesignTimeServicesAttribute : Attribute
+    {
+        public ProviderDesignTimeServicesAttribute([NotNull] string typeName)
+            : this(typeName, null)
+        {
+        }
+
+        public ProviderDesignTimeServicesAttribute(
+            [NotNull] string typeName, [CanBeNull] string assemblyName)
+        {
+            Check.NotNull(typeName, nameof(typeName));
+
+            TypeName = typeName;
+            AssemblyName = assemblyName;
+        }
+
+        public virtual string TypeName { get; }
+        public virtual string AssemblyName { get; }
+    }
+}

--- a/src/EntityFramework.SqlServer/Properties/AssemblyInfo.cs
+++ b/src/EntityFramework.SqlServer/Properties/AssemblyInfo.cs
@@ -3,6 +3,10 @@
 
 using System.Reflection;
 using System.Resources;
+using Microsoft.Data.Entity.Storage;
 
 [assembly: NeutralResourcesLanguage("en-US")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
+[assembly: ProviderDesignTimeServices(
+    typeName: "Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering.SqlServerMetadataModelProvider",
+    assemblyName: "EntityFramework.SqlServer.Design")]


### PR DESCRIPTION
See issue #830. This should free the way up to allow for RevEng providers beyond our standard SQL Server one.

Also it updates the way we locate the design-time provider to instead use an attribute on the runtime
provider.