### PR TITLE
Improve core metadata inheritance support

### DIFF
--- a/src/EntityFramework.Commands/Migrations/CSharpModelGenerator.cs
+++ b/src/EntityFramework.Commands/Migrations/CSharpModelGenerator.cs
@@ -328,7 +328,7 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                     stringBuilder
                         .AppendLine(".InverseReference()")
                         .Append(".ForeignKey(")
-                        .Append(_code.Literal(foreignKey.EntityType.Name))
+                        .Append(_code.Literal(foreignKey.DeclaringEntityType.Name))
                         .Append(", ")
                         .Append(string.Join(", ", foreignKey.Properties.Select(p => _code.Literal(p.Name))))
                         .Append(")");

--- a/src/EntityFramework.Core/ChangeTracking/EntityEntry`.cs
+++ b/src/EntityFramework.Core/ChangeTracking/EntityEntry`.cs
@@ -7,6 +7,7 @@ using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Internal;
+using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.ChangeTracking
@@ -69,7 +70,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
 
             if (property.ClrType != typeof(TProperty))
             {
-                throw new ArgumentException(Strings.WrongGenericPropertyType(propertyName, property.EntityType.Name, property.ClrType.Name, typeof(TProperty).Name));
+                throw new ArgumentException(Strings.WrongGenericPropertyType(propertyName, property.DeclaringEntityType.Name, property.ClrType.Name, typeof(TProperty).Name));
             }
 
             return new PropertyEntry<TEntity, TProperty>(this.GetService(), propertyName);

--- a/src/EntityFramework.Core/ChangeTracking/Internal/ChangeDetector.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/ChangeDetector.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
                 var navigation = propertyBase as INavigation;
                 if ((navigation != null && !navigation.IsCollection())
-                    || (property != null && (property.IsKey() || property.IsForeignKey())))
+                    || (property != null && (property.IsKey() || property.IsForeignKey(entry.EntityType))))
                 {
                     // TODO: Consider making snapshot temporary here since it is no longer required after PropertyChanged is called
                     // See issue #730
@@ -148,11 +148,10 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
             {
                 return;
             }
-
-            // TODO: Perf: make it fast to check if a property is part of any key
+            
             var isPrimaryKey = property.IsPrimaryKey();
             var isPrincipalKey = _model.GetReferencingForeignKeys(property).Any();
-            var isForeignKey = property.IsForeignKey();
+            var isForeignKey = property.IsForeignKey(entry.EntityType);
 
             if (isPrimaryKey
                 || isPrincipalKey

--- a/src/EntityFramework.Core/ChangeTracking/Internal/CompositeEntityKey.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/CompositeEntityKey.cs
@@ -12,12 +12,11 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class CompositeEntityKey : EntityKey
     {
-        private readonly IEntityType _entityType;
         private readonly object[] _keyValueParts;
 
         public CompositeEntityKey([NotNull] IEntityType entityType, [NotNull] object[] keyValueParts)
         {
-            _entityType = entityType;
+            EntityType = entityType;
             _keyValueParts = keyValueParts;
         }
 
@@ -27,7 +26,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
         private bool Equals(CompositeEntityKey other)
         {
-            if (_entityType != other._entityType)
+            if (EntityType != other.EntityType)
             {
                 return false;
             }
@@ -66,11 +65,11 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
         public override int GetHashCode()
             => _keyValueParts.Aggregate(
-                _entityType.GetHashCode() * 397,
+                EntityType.GetHashCode() * 397,
                 (t, v) => (t * 397) ^ (v != null ? StructuralComparisons.StructuralEqualityComparer.GetHashCode(v) : 0));
 
         [UsedImplicitly]
         private string DebuggerDisplay
-            => $"{_entityType.Name}({string.Join(", ", _keyValueParts.Select(k => k.ToString()))})";
+            => $"{EntityType.Name}({string.Join(", ", _keyValueParts.Select(k => k.ToString()))})";
     }
 }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/EntityKey.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/EntityKey.cs
@@ -1,12 +1,15 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.Data.Entity.Metadata;
+
 namespace Microsoft.Data.Entity.ChangeTracking.Internal
 {
     public abstract class EntityKey
     {
         public static readonly EntityKey InvalidEntityKey = new InvalidEntityKeySentinel();
 
+        public virtual IEntityType EntityType { get; protected set; }
         public virtual object Value => GetValue();
 
         protected abstract object GetValue();

--- a/src/EntityFramework.Core/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -325,13 +325,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
             [NotNull] IPropertyAccessor propertyAccessor) => MetadataServices.CreateKey(entityType, properties, propertyAccessor);
 
         public virtual EntityKey GetDependentKeySnapshot([NotNull] IForeignKey foreignKey)
-            => CreateKey(foreignKey.PrincipalEntityType, foreignKey.Properties, RelationshipsSnapshot);
-
-        // TODO cache principal key in a way that does not break store-generated keys
-        public virtual EntityKey GetPrincipalKey(
-            [NotNull] IForeignKey foreignKey,
-            [NotNull] IEntityType principalEntityType,
-            [NotNull] IReadOnlyList<IProperty> principalProperties) => CreateKey(principalEntityType, principalProperties, this);
+            => CreateKey(foreignKey.PrincipalEntityType.RootType(), foreignKey.Properties, RelationshipsSnapshot);
 
         public virtual object[] GetValueBuffer() => EntityType.GetProperties().Select(p => this[p]).ToArray();
 

--- a/src/EntityFramework.Core/ChangeTracking/Internal/KeyPropagator.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/KeyPropagator.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
         public virtual void PropagateValue(InternalEntityEntry entry, IProperty property)
         {
-            Debug.Assert(property.IsForeignKey());
+            Debug.Assert(property.IsForeignKey(entry.EntityType));
 
             if (!TryPropagateValue(entry, property)
                 && property.IsKey())
@@ -44,7 +44,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
         private bool TryPropagateValue(InternalEntityEntry entry, IProperty property)
         {
-            var entityType = property.EntityType;
+            var entityType = entry.EntityType;
             var stateManager = entry.StateManager;
 
             foreach (var foreignKey in entityType.GetForeignKeys())
@@ -94,7 +94,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
             if (generationProperty != null)
             {
-                return _valueGeneratorSelector.Select(generationProperty, generationProperty.EntityType);
+                return _valueGeneratorSelector.Select(generationProperty, generationProperty.DeclaringEntityType);
             }
 
             return null;
@@ -109,7 +109,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
             // TODO: Perf
             foreach (var principalEntry in stateManager.Entries
-                .Where(e => e.EntityType == navigation.ForeignKey.PrincipalEntityType))
+                .Where(e => navigation.ForeignKey.PrincipalEntityType.IsAssignableFrom(e.EntityType)))
             {
                 if (navigation.IsCollection())
                 {

--- a/src/EntityFramework.Core/ChangeTracking/Internal/PropertyAccessorExtensions.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/PropertyAccessorExtensions.cs
@@ -9,14 +9,16 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
     public static class PropertyAccessorExtensions
     {
         public static EntityKey GetDependentKeyValue([NotNull] this IPropertyAccessor propertyAccessor, [NotNull] IForeignKey foreignKey)
-            => propertyAccessor.InternalEntityEntry.CreateKey(foreignKey.PrincipalEntityType, foreignKey.Properties, propertyAccessor);
+            => propertyAccessor.InternalEntityEntry.CreateKey(
+                foreignKey.PrincipalEntityType.RootType(), foreignKey.Properties, propertyAccessor);
 
         public static EntityKey GetPrincipalKeyValue([NotNull] this IPropertyAccessor propertyAccessor, [NotNull] IForeignKey foreignKey)
-            => propertyAccessor.InternalEntityEntry.CreateKey(foreignKey.PrincipalEntityType, foreignKey.PrincipalKey.Properties, propertyAccessor);
+            => propertyAccessor.InternalEntityEntry.CreateKey(
+                foreignKey.PrincipalEntityType.RootType(), foreignKey.PrincipalKey.Properties, propertyAccessor);
 
         public static EntityKey GetPrimaryKeyValue([NotNull] this IPropertyAccessor propertyAccessor)
         {
-            var entityType = propertyAccessor.InternalEntityEntry.EntityType;
+            var entityType = propertyAccessor.InternalEntityEntry.EntityType.RootType();
             return propertyAccessor.InternalEntityEntry.CreateKey(entityType, entityType.GetPrimaryKey().Properties, propertyAccessor);
         }
     }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/SimpleEntityKey.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/SimpleEntityKey.cs
@@ -13,15 +13,14 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
     public class SimpleEntityKey<TKey> : EntityKey
     {
         private static readonly IEqualityComparer _equalityComparer = EqualityComparer<TKey>.Default;
-
-        private readonly IEntityType _entityType;
+        
         private readonly TKey _keyValue;
 
         public SimpleEntityKey([NotNull] IEntityType entityType, [CanBeNull] TKey keyValue)
         {
             Debug.Assert(entityType != null); // hot path
 
-            _entityType = entityType;
+            EntityType = entityType;
             _keyValue = keyValue;
         }
 
@@ -36,14 +35,14 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
                        && Equals((SimpleEntityKey<TKey>)obj)));
 
         private bool Equals(SimpleEntityKey<TKey> other)
-            => _entityType == other._entityType
+            => EntityType == other.EntityType
                && _equalityComparer.Equals(_keyValue, other._keyValue);
 
         public override int GetHashCode()
-            => (_entityType.GetHashCode() * 397)
+            => (EntityType.GetHashCode() * 397)
                ^ _equalityComparer.GetHashCode(_keyValue);
 
         [UsedImplicitly]
-        private string DebuggerDisplay => $"{_entityType.Name}({string.Join(", ", _keyValue)})";
+        private string DebuggerDisplay => $"{EntityType.Name}({string.Join(", ", _keyValue)})";
     }
 }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/ValueGenerationManager.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/ValueGenerationManager.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         {
             foreach (var property in entry.EntityType.GetProperties())
             {
-                var isForeignKey = property.IsForeignKey();
+                var isForeignKey = property.IsForeignKey(entry.EntityType);
 
                 if ((property.RequiresValueGenerator || isForeignKey)
                     && property.IsSentinelValue(entry[property]))

--- a/src/EntityFramework.Core/Internal/ModelForeignKeyUndirectedGraphAdapter.cs
+++ b/src/EntityFramework.Core/Internal/ModelForeignKeyUndirectedGraphAdapter.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Data.Entity.Internal
 
         public override IEnumerable<EntityType> GetOutgoingNeighbours(EntityType from)
             => @from.GetForeignKeys().Select(fk => fk.PrincipalEntityType)
-                .Union(_model.GetReferencingForeignKeys(@from).Select(fk => fk.EntityType));
+                .Union(_model.GetReferencingForeignKeys(@from).Select(fk => fk.DeclaringEntityType));
 
         public override IEnumerable<EntityType> GetIncomingNeighbours(EntityType to)
             => GetOutgoingNeighbours(to);

--- a/src/EntityFramework.Core/Internal/ModelNavigationsGraphAdapter.cs
+++ b/src/EntityFramework.Core/Internal/ModelNavigationsGraphAdapter.cs
@@ -21,10 +21,10 @@ namespace Microsoft.Data.Entity.Internal
 
         public override IEnumerable<EntityType> GetOutgoingNeighbours(EntityType from)
             => @from.GetForeignKeys().Where(fk => fk.DependentToPrincipal != null).Select(fk => fk.PrincipalEntityType)
-                .Union(_model.GetReferencingForeignKeys(@from).Where(fk => fk.PrincipalToDependent != null).Select(fk => fk.EntityType));
+                .Union(_model.GetReferencingForeignKeys(@from).Where(fk => fk.PrincipalToDependent != null).Select(fk => fk.DeclaringEntityType));
 
         public override IEnumerable<EntityType> GetIncomingNeighbours(EntityType to)
             => to.GetForeignKeys().Where(fk => fk.PrincipalToDependent != null).Select(fk => fk.PrincipalEntityType)
-                .Union(_model.GetReferencingForeignKeys(to).Where(fk => fk.DependentToPrincipal != null).Select(fk => fk.EntityType));
+                .Union(_model.GetReferencingForeignKeys(to).Where(fk => fk.DependentToPrincipal != null).Select(fk => fk.DeclaringEntityType));
     }
 }

--- a/src/EntityFramework.Core/Internal/ModelValidator.cs
+++ b/src/EntityFramework.Core/Internal/ModelValidator.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Data.Entity.Internal
                                 entityType.Name,
                                 Property.Format(key.Properties.Where(p => p.IsShadowProperty)),
                                 Property.Format(referencingFk.Properties),
-                                referencingFk.EntityType.Name);
+                                referencingFk.DeclaringEntityType.Name);
                         }
                         else
                         {
@@ -94,7 +94,7 @@ namespace Microsoft.Data.Entity.Internal
             }
 
             var rootPrincipals = new Dictionary<IProperty, IForeignKey>();
-            foreach (var foreignKey in principalProperty.EntityType.GetForeignKeys())
+            foreach (var foreignKey in principalProperty.DeclaringEntityType.GetForeignKeys())
             {
                 for (var index = 0; index < foreignKey.Properties.Count; index++)
                 {
@@ -122,7 +122,7 @@ namespace Microsoft.Data.Entity.Internal
                         {
                             ShowError(Strings.ForeignKeyValueGenerationOnAdd(
                                 principalProperty.Name,
-                                principalProperty.EntityType.DisplayName(),
+                                principalProperty.DeclaringEntityType.DisplayName(),
                                 Property.Format(foreignKey.Properties)));
                             return principalProperty;
                         }
@@ -141,7 +141,7 @@ namespace Microsoft.Data.Entity.Internal
 
                 if (!principalProperty.RequiresValueGenerator)
                 {
-                    ShowError(Strings.PrincipalKeyNoValueGenerationOnAdd(principalProperty.Name, principalProperty.EntityType.DisplayName()));
+                    ShowError(Strings.PrincipalKeyNoValueGenerationOnAdd(principalProperty.Name, principalProperty.DeclaringEntityType.DisplayName()));
                     return null;
                 }
 
@@ -153,12 +153,12 @@ namespace Microsoft.Data.Entity.Internal
                 var firstRoot = rootPrincipals.Keys.ElementAt(0);
                 var secondRoot = rootPrincipals.Keys.ElementAt(1);
                 ShowWarning(Strings.MultipleRootPrincipals(
-                    rootPrincipals[firstRoot].EntityType.DisplayName(),
+                    rootPrincipals[firstRoot].DeclaringEntityType.DisplayName(),
                     Property.Format(rootPrincipals[firstRoot].Properties),
-                    firstRoot.EntityType.DisplayName(),
+                    firstRoot.DeclaringEntityType.DisplayName(),
                     firstRoot.Name,
                     Property.Format(rootPrincipals[secondRoot].Properties),
-                    secondRoot.EntityType.DisplayName(),
+                    secondRoot.DeclaringEntityType.DisplayName(),
                     secondRoot.Name));
 
                 return firstRoot;

--- a/src/EntityFramework.Core/Metadata/Builders/ReferenceNavigationBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Builders/ReferenceNavigationBuilder.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         protected virtual InternalRelationshipBuilder InverseCollectionBuilder([CanBeNull] string collection)
         {
             var needToInvert = _builder.Metadata.PrincipalEntityType != RelatedEntityType;
-            Debug.Assert((needToInvert && _builder.Metadata.EntityType == RelatedEntityType)
+            Debug.Assert((needToInvert && _builder.Metadata.DeclaringEntityType == RelatedEntityType)
                          || _builder.Metadata.PrincipalEntityType == RelatedEntityType);
 
             var builder = Builder;
@@ -141,7 +141,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
             var foreignKey = builder.Metadata;
 
             var inverseToPrincipal = !foreignKey.IsSelfReferencing()
-                                     && foreignKey.EntityType == RelatedEntityType
+                                     && foreignKey.DeclaringEntityType == RelatedEntityType
                                      && foreignKey.PrincipalToDependent?.Name == ReferenceName;
 
             Debug.Assert(inverseToPrincipal

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/KeyAttributeConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/KeyAttributeConvention.cs
@@ -18,7 +18,14 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
             Check.NotNull(propertyBuilder, nameof(propertyBuilder));
             Check.NotNull(attribute, nameof(attribute));
 
-            var entityTypeBuilder = propertyBuilder.ModelBuilder.Entity(propertyBuilder.Metadata.EntityType.Name, ConfigurationSource.DataAnnotation);
+            var entityType = propertyBuilder.Metadata.DeclaringEntityType;
+            if (entityType.BaseType != null)
+            {
+                // TODO: Log warning
+                return propertyBuilder;
+            }
+
+            var entityTypeBuilder = propertyBuilder.ModelBuilder.Entity(entityType.Name, ConfigurationSource.DataAnnotation);
             var currentKey = entityTypeBuilder.Metadata.FindPrimaryKey();
             var properties = new List<string> { propertyBuilder.Metadata.Name };
 

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/KeyConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/KeyConvention.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
         {
             Check.NotNull(keyBuilder, nameof(keyBuilder));
 
-            var entityTypeBuilder = keyBuilder.ModelBuilder.Entity(keyBuilder.Metadata.EntityType.Name, ConfigurationSource.Convention);
+            var entityTypeBuilder = keyBuilder.ModelBuilder.Entity(keyBuilder.Metadata.DeclaringEntityType.Name, ConfigurationSource.Convention);
             var properties = keyBuilder.Metadata.Properties;
 
             SetValueGeneration(entityTypeBuilder, properties);
@@ -73,7 +73,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
                     if ((propertyType.IsInteger()
                         || propertyType == typeof(Guid))
                         && entityTypeBuilder.Metadata.FindPrimaryKey(properties) != null
-                        && !property.IsForeignKey())
+                        && !property.IsForeignKey(entityTypeBuilder.Metadata))
                     {
                         entityTypeBuilder.Property(property.ClrType, property.Name, ConfigurationSource.Convention)
                             ?.ValueGenerated(ValueGenerated.OnAdd, ConfigurationSource.Convention);

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/PropertyAttributeConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/PropertyAttributeConvention.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
         {
             Check.NotNull(propertyBuilder, nameof(propertyBuilder));
 
-            var clrType = propertyBuilder.Metadata.EntityType.ClrType;
+            var clrType = propertyBuilder.Metadata.DeclaringEntityType.ClrType;
             var propertyName = propertyBuilder.Metadata.Name;
 
             var attributes = clrType?.GetProperty(propertyName)?.GetCustomAttributes<TAttribute>(true);

--- a/src/EntityFramework.Core/Metadata/EntityTypeExtensions.cs
+++ b/src/EntityFramework.Core/Metadata/EntityTypeExtensions.cs
@@ -20,6 +20,9 @@ namespace Microsoft.Data.Entity.Metadata
             return GetDerivedTypes(entityType.Model, entityType);
         }
 
+        public static IEnumerable<EntityType> GetDerivedTypes([NotNull] this EntityType entityType)
+            => ((IEntityType)entityType).GetDerivedTypes().Cast<EntityType>();
+
         public static IEnumerable<IEntityType> GetConcreteTypesInHierarchy([NotNull] this IEntityType entityType)
         {
             Check.NotNull(entityType, nameof(entityType));
@@ -31,8 +34,7 @@ namespace Microsoft.Data.Entity.Metadata
 
         private static IEnumerable<IEntityType> GetDerivedTypes(IModel model, IEntityType entityType)
         {
-            foreach (var et1 in model.EntityTypes
-                .Where(et1 => et1.BaseType == entityType))
+            foreach (var et1 in GetDirectlyDerivedTypes(model, entityType))
             {
                 yield return et1;
 
@@ -42,6 +44,21 @@ namespace Microsoft.Data.Entity.Metadata
                 }
             }
         }
+
+        public static IEnumerable<IEntityType> GetDirectlyDerivedTypes([NotNull] this IEntityType entityType)
+        {
+            Check.NotNull(entityType, nameof(entityType));
+
+            return GetDirectlyDerivedTypes(entityType.Model, entityType);
+        }
+
+        public static IEnumerable<EntityType> GetDirectlyDerivedTypes([NotNull] this EntityType entityType)
+        {
+            return ((IEntityType)entityType).GetDirectlyDerivedTypes().Cast<EntityType>();
+        }
+
+        private static IEnumerable<IEntityType> GetDirectlyDerivedTypes(IModel model, IEntityType entityType)
+            => model.EntityTypes.Where(et1 => et1.BaseType == entityType);
 
         public static string DisplayName([NotNull] this IEntityType entityType)
         {
@@ -92,11 +109,87 @@ namespace Microsoft.Data.Entity.Metadata
             return entityType.BaseType?.RootType() ?? entityType;
         }
 
+        public static bool IsAssignableFrom([NotNull] this IEntityType entityType, [NotNull] IEntityType derivedType)
+        {
+            Check.NotNull(entityType, nameof(entityType));
+            Check.NotNull(derivedType, nameof(derivedType));
+
+            var baseType = derivedType;
+            while (baseType != null)
+            {
+                if (baseType == entityType)
+                {
+                    return true;
+                }
+                baseType = baseType.BaseType;
+            }
+            return false;
+        }
+
         public static IEnumerable<IProperty> GetDeclaredProperties([NotNull] this IEntityType entityType)
         {
             Check.NotNull(entityType, nameof(entityType));
 
-            return entityType.GetProperties().Where(p => p.EntityType == entityType);
+            return entityType.GetProperties().Where(p => p.DeclaringEntityType == entityType);
+        }
+
+        public static IProperty GetProperty([NotNull] this IEntityType entityType, [NotNull] PropertyInfo propertyInfo)
+        {
+            Check.NotNull(entityType, nameof(entityType));
+            Check.NotNull(propertyInfo, nameof(propertyInfo));
+
+            return entityType.GetProperty(propertyInfo.Name);
+        }
+
+        public static IProperty GetProperty([NotNull] this IEntityType entityType, [NotNull] string propertyName)
+        {
+            Check.NotNull(entityType, nameof(entityType));
+            Check.NotEmpty(propertyName, nameof(propertyName));
+
+            var property = entityType.FindProperty(propertyName);
+            if (property == null)
+            {
+                throw new ModelItemNotFoundException(Strings.PropertyNotFound(propertyName, entityType.Name));
+            }
+
+            return property;
+        }
+
+        [NotNull]
+        public static Property GetProperty([NotNull] this EntityType entityType, [NotNull] PropertyInfo propertyInfo)
+        {
+            Check.NotNull(propertyInfo, nameof(propertyInfo));
+
+            return entityType.GetProperty(propertyInfo.Name);
+        }
+
+        [NotNull]
+        public static Property GetProperty([NotNull] this EntityType entityType, [NotNull] string propertyName) =>
+            (Property)((IEntityType)entityType).GetProperty(propertyName);
+
+        [NotNull]
+        public static INavigation GetNavigation([NotNull] this IEntityType entityType, [NotNull] string name)
+        {
+            Check.NotNull(entityType, nameof(entityType));
+            Check.NotNull(name, nameof(name));
+
+            var navigation = entityType.FindNavigation(name);
+            if (navigation == null)
+            {
+                throw new ModelItemNotFoundException(Strings.NavigationNotFound(name, entityType.Name));
+            }
+            return navigation;
+        }
+
+        [NotNull]
+        public static Navigation GetNavigation([NotNull] this EntityType entityType, [NotNull] string name)
+            => (Navigation)((IEntityType)entityType).GetNavigation(name);
+
+        public static IEnumerable<INavigation> GetDeclaredNavigations([NotNull] this IEntityType entityType)
+        {
+            Check.NotNull(entityType, nameof(entityType));
+
+            return entityType.GetNavigations().Where(p => p.DeclaringEntityType == entityType);
         }
 
         public static IEnumerable<IPropertyBase> GetPropertiesAndNavigations(
@@ -128,6 +221,94 @@ namespace Microsoft.Data.Entity.Metadata
 
             return entityType.ClrType == null
                    || typeof(INotifyPropertyChanged).GetTypeInfo().IsAssignableFrom(entityType.ClrType.GetTypeInfo());
+        }
+
+        public static IIndex GetIndex([NotNull] this IEntityType entityType, [NotNull] Property property)
+            => entityType.GetIndex(new[] { property });
+
+        public static IIndex GetIndex([NotNull] this IEntityType entityType, [NotNull] IReadOnlyList<Property> properties)
+        {
+            var index = entityType.FindIndex(properties);
+            if (index == null)
+            {
+                throw new ModelItemNotFoundException(Strings.IndexNotFound(Property.Format(properties), entityType.Name));
+            }
+            return index;
+        }
+
+        public static IEnumerable<IIndex> GetDeclaredIndexes([NotNull] this IEntityType entityType)
+        {
+            Check.NotNull(entityType, nameof(entityType));
+
+            return entityType.GetIndexes().Where(p => p.DeclaringEntityType == entityType);
+        }
+
+        public static IForeignKey GetForeignKey([NotNull] this IEntityType entityType, [NotNull] Property property)
+            => entityType.GetForeignKey(new[] { property });
+
+        public static IForeignKey GetForeignKey([NotNull] this IEntityType entityType, [NotNull] IReadOnlyList<Property> properties)
+        {
+            var foreignKey = entityType.FindForeignKey(properties);
+            if (foreignKey == null)
+            {
+                throw new ModelItemNotFoundException(Strings.ForeignKeyNotFound(Property.Format(properties), entityType.Name));
+            }
+
+            return foreignKey;
+        }
+
+        public static IEnumerable<IForeignKey> GetDeclaredForeignKeys([NotNull] this IEntityType entityType)
+        {
+            Check.NotNull(entityType, nameof(entityType));
+
+            return entityType.GetForeignKeys().Where(p => p.DeclaringEntityType == entityType);
+        }
+
+        public static ForeignKey FindForeignKey(
+            [NotNull] this EntityType entityType,
+            [NotNull] EntityType principalType,
+            [CanBeNull] string navigationToPrincipal,
+            [CanBeNull] string navigationToDependent,
+            [CanBeNull] IReadOnlyList<Property> foreignKeyProperties,
+            [CanBeNull] IReadOnlyList<Property> principalProperties,
+            bool? isUnique)
+        {
+            Check.NotNull(principalType, nameof(principalType));
+
+            return entityType.GetForeignKeys().FirstOrDefault(fk =>
+                fk.IsCompatible(
+                    principalType,
+                    entityType,
+                    navigationToPrincipal,
+                    navigationToDependent,
+                    foreignKeyProperties,
+                    principalProperties,
+                    isUnique));
+        }
+
+        public static IKey GetPrimaryKey([NotNull] this IEntityType entityType)
+        {
+            var primaryKey = entityType.FindPrimaryKey();
+            if (primaryKey == null)
+            {
+                throw new ModelItemNotFoundException(Strings.EntityRequiresKey(entityType.Name));
+            }
+
+            return primaryKey;
+        }
+
+        public static IKey GetKey([NotNull] this IEntityType entityType, [NotNull] Property property)
+            => entityType.GetKey(new[] { property });
+
+        public static IKey GetKey([NotNull] this IEntityType entityType, [NotNull] IReadOnlyList<Property> properties)
+        {
+            var key = entityType.FindKey(properties);
+            if (key == null)
+            {
+                throw new ModelItemNotFoundException(Strings.KeyNotFound(Property.Format(properties), entityType.Name));
+            }
+
+            return key;
         }
     }
 }

--- a/src/EntityFramework.Core/Metadata/ForeignKeyExtensions.cs
+++ b/src/EntityFramework.Core/Metadata/ForeignKeyExtensions.cs
@@ -1,9 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Metadata
@@ -11,11 +13,11 @@ namespace Microsoft.Data.Entity.Metadata
     public static class ForeignKeyExtensions
     {
         public static bool IsSelfReferencing(
-            [NotNull] this ForeignKey foreignKey)
+            [NotNull] this IForeignKey foreignKey)
         {
             Check.NotNull(foreignKey, nameof(foreignKey));
 
-            return foreignKey.EntityType == foreignKey.PrincipalEntityType;
+            return foreignKey.DeclaringEntityType == foreignKey.PrincipalEntityType;
         }
 
         public static bool IsCompatible(
@@ -30,7 +32,7 @@ namespace Microsoft.Data.Entity.Metadata
 
             return (isUnique == null || ((IForeignKey)foreignKey).IsUnique == isUnique)
                    && foreignKey.PrincipalEntityType == principalType
-                   && foreignKey.EntityType == dependentType;
+                   && foreignKey.DeclaringEntityType == dependentType;
         }
 
         public static bool IsCompatible(
@@ -73,6 +75,88 @@ namespace Microsoft.Data.Entity.Metadata
             return foreignKey.IsCompatible(principalType, dependentType, foreignKeyProperties, principalProperties, isUnique)
                    && (existingNavigationToPrincipal == null || existingNavigationToPrincipal.Name == navigationToPrincipal)
                    && (existingNavigationToDependent == null || existingNavigationToDependent.Name == navigationToDependent);
+        }
+
+        public static INavigation FindNavigationFrom(
+            [NotNull] this IForeignKey foreignKey, [NotNull] IEntityType entityType)
+        {
+            Check.NotNull(foreignKey, nameof(foreignKey));
+            Check.NotNull(entityType, nameof(entityType));
+
+            if (foreignKey.DeclaringEntityType != entityType
+                && foreignKey.PrincipalEntityType != entityType)
+            {
+                throw new ArgumentException(Strings.EntityTypeNotInRelationship(
+                    entityType.Name, foreignKey.DeclaringEntityType.Name, foreignKey.PrincipalEntityType.Name), nameof(entityType));
+            }
+
+            if (foreignKey.IsSelfReferencing())
+            {
+                throw new InvalidOperationException(Strings.SelfRefAmbiguousNavigation(entityType.Name, Property.Format(foreignKey.Properties)));
+            }
+
+            return foreignKey.DeclaringEntityType == entityType
+                ? foreignKey.DependentToPrincipal
+                : foreignKey.PrincipalToDependent;
+        }
+
+        public static Navigation FindNavigationFrom(
+            [NotNull] this ForeignKey foreignKey, [NotNull] EntityType entityType)
+        {
+            return (Navigation)((IForeignKey)foreignKey).FindNavigationFrom(entityType);
+        }
+
+        public static INavigation FindNavigationTo(
+            [NotNull] this IForeignKey foreignKey, [NotNull] IEntityType entityType)
+        {
+            Check.NotNull(foreignKey, nameof(foreignKey));
+            Check.NotNull(entityType, nameof(entityType));
+
+            if (foreignKey.DeclaringEntityType != entityType
+                && foreignKey.PrincipalEntityType != entityType)
+            {
+                throw new ArgumentException(Strings.EntityTypeNotInRelationship(
+                    entityType.Name, foreignKey.DeclaringEntityType.Name, foreignKey.PrincipalEntityType.Name), nameof(entityType));
+            }
+
+            if (foreignKey.IsSelfReferencing())
+            {
+                throw new InvalidOperationException(Strings.SelfRefAmbiguousNavigation(entityType.Name, Property.Format(foreignKey.Properties)));
+            }
+
+            return foreignKey.DeclaringEntityType == entityType
+                ? foreignKey.PrincipalToDependent
+                : foreignKey.DependentToPrincipal;
+        }
+
+        public static Navigation FindNavigationTo(
+            [NotNull] this ForeignKey foreignKey, [NotNull] EntityType entityType)
+        {
+            return (Navigation)((IForeignKey)foreignKey).FindNavigationTo(entityType);
+        }
+
+        public static IEntityType GetOtherEntityType(
+            [NotNull] this IForeignKey foreignKey, [NotNull] IEntityType entityType)
+        {
+            Check.NotNull(foreignKey, nameof(foreignKey));
+            Check.NotNull(entityType, nameof(entityType));
+
+            if (foreignKey.DeclaringEntityType != entityType
+                && foreignKey.PrincipalEntityType != entityType)
+            {
+                throw new ArgumentException(Strings.EntityTypeNotInRelationship(
+                    entityType.Name, foreignKey.DeclaringEntityType.Name, foreignKey.PrincipalEntityType.Name), nameof(entityType));
+            }
+
+            return foreignKey.DeclaringEntityType == entityType
+                ? foreignKey.PrincipalEntityType
+                : foreignKey.DeclaringEntityType;
+        }
+
+        public static EntityType GetOtherEntityType(
+            [NotNull] this ForeignKey foreignKey, [NotNull] EntityType entityType)
+        {
+            return (EntityType)((IForeignKey)foreignKey).GetOtherEntityType(entityType);
         }
     }
 }

--- a/src/EntityFramework.Core/Metadata/IEntityType.cs
+++ b/src/EntityFramework.Core/Metadata/IEntityType.cs
@@ -20,15 +20,17 @@ namespace Microsoft.Data.Entity.Metadata
 
         Type ClrType { get; }
 
-        IKey GetPrimaryKey();
+        IKey FindPrimaryKey();
 
         IProperty FindProperty([NotNull] string name);
 
-        IProperty GetProperty([NotNull] string name);
+        IForeignKey FindForeignKey([NotNull] IReadOnlyList<IProperty> properties);
 
         INavigation FindNavigation([NotNull] string name);
 
-        INavigation GetNavigation([NotNull] string name);
+        IIndex FindIndex([NotNull] IReadOnlyList<IProperty> properties);
+
+        IKey FindKey([NotNull] IReadOnlyList<IProperty> properties);
 
         IEnumerable<IProperty> GetProperties();
 

--- a/src/EntityFramework.Core/Metadata/IForeignKey.cs
+++ b/src/EntityFramework.Core/Metadata/IForeignKey.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Data.Entity.Metadata
 {
     public interface IForeignKey : IAnnotatable
     {
-        IEntityType EntityType { get; }
+        IEntityType DeclaringEntityType { get; }
         IReadOnlyList<IProperty> Properties { get; }
         IEntityType PrincipalEntityType { get; }
         IKey PrincipalKey { get; }

--- a/src/EntityFramework.Core/Metadata/IIndex.cs
+++ b/src/EntityFramework.Core/Metadata/IIndex.cs
@@ -10,6 +10,6 @@ namespace Microsoft.Data.Entity.Metadata
     {
         IReadOnlyList<IProperty> Properties { get; }
         bool IsUnique { get; }
-        IEntityType EntityType { get; }
+        IEntityType DeclaringEntityType { get; }
     }
 }

--- a/src/EntityFramework.Core/Metadata/IPropertyBase.cs
+++ b/src/EntityFramework.Core/Metadata/IPropertyBase.cs
@@ -8,6 +8,6 @@ namespace Microsoft.Data.Entity.Metadata
     public interface IPropertyBase : IAnnotatable
     {
         string Name { get; }
-        IEntityType EntityType { get; }
+        IEntityType DeclaringEntityType { get; }
     }
 }

--- a/src/EntityFramework.Core/Metadata/Index.cs
+++ b/src/EntityFramework.Core/Metadata/Index.cs
@@ -26,11 +26,11 @@ namespace Microsoft.Data.Entity.Metadata
 
         public virtual IReadOnlyList<Property> Properties { get; }
 
-        public virtual EntityType EntityType => Properties[0].EntityType;
+        public virtual EntityType DeclaringEntityType => Properties[0].DeclaringEntityType;
 
         IReadOnlyList<IProperty> IIndex.Properties => Properties;
 
-        IEntityType IIndex.EntityType => EntityType;
+        IEntityType IIndex.DeclaringEntityType => DeclaringEntityType;
 
         bool IIndex.IsUnique => IsUnique ?? DefaultIsUnique;
     }

--- a/src/EntityFramework.Core/Metadata/Internal/ClrAccessorSource.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/ClrAccessorSource.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             = new ThreadSafeDictionaryCache<Tuple<Type, string>, TAccessor>();
 
         public virtual TAccessor GetAccessor(IPropertyBase property)
-            => property as TAccessor ?? GetAccessor(property.EntityType.ClrType, property.Name);
+            => property as TAccessor ?? GetAccessor(property.DeclaringEntityType.ClrType, property.Name);
 
         public virtual TAccessor GetAccessor(Type declaringType, string propertyName)
             => _cache.GetOrAdd(Tuple.Create(declaringType, propertyName), k => Create(k.Item1.GetAnyProperty(k.Item2)));

--- a/src/EntityFramework.Core/Metadata/Internal/ClrCollectionAccessorSource.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/ClrCollectionAccessorSource.cs
@@ -38,13 +38,13 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             }
 
             return _cache.GetOrAdd(
-                Tuple.Create(navigation.EntityType.ClrType, navigation.Name),
+                Tuple.Create(navigation.DeclaringEntityType.ClrType, navigation.Name),
                 k => Create(navigation));
         }
 
         private IClrCollectionAccessor Create(INavigation navigation)
         {
-            var property = navigation.EntityType.ClrType.GetAnyProperty(navigation.Name);
+            var property = navigation.DeclaringEntityType.ClrType.GetAnyProperty(navigation.Name);
             var elementType = property.PropertyType.TryGetElementType(typeof(ICollection<>));
 
             // TODO: Only ICollections supported; add support for enumerables with add/remove methods
@@ -53,18 +53,18 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             {
                 throw new NotSupportedException(
                     Strings.NavigationBadType(
-                        navigation.Name, navigation.EntityType.Name, property.PropertyType.FullName, navigation.GetTargetType().Name));
+                        navigation.Name, navigation.DeclaringEntityType.Name, property.PropertyType.FullName, navigation.GetTargetType().Name));
             }
 
             if (property.PropertyType.IsArray)
             {
                 throw new NotSupportedException(
-                    Strings.NavigationArray(navigation.Name, navigation.EntityType.Name, property.PropertyType.FullName));
+                    Strings.NavigationArray(navigation.Name, navigation.DeclaringEntityType.Name, property.PropertyType.FullName));
             }
 
             if (property.GetMethod == null)
             {
-                throw new NotSupportedException(Strings.NavigationNoGetter(navigation.Name, navigation.EntityType.Name));
+                throw new NotSupportedException(Strings.NavigationNoGetter(navigation.Name, navigation.DeclaringEntityType.Name));
             }
 
             var boundMethod = _genericCreate.MakeGenericMethod(

--- a/src/EntityFramework.Core/Metadata/Internal/MetadataHelper.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/MetadataHelper.cs
@@ -13,11 +13,11 @@ namespace Microsoft.Data.Entity.Metadata.Internal
         {
             if (properties.Count > 1)
             {
-                var entityType = properties[0].EntityType;
+                var entityType = properties[0].DeclaringEntityType;
 
                 for (var i = 1; i < properties.Count; i++)
                 {
-                    if (properties[i].EntityType != entityType)
+                    if (properties[i].DeclaringEntityType != entityType)
                     {
                         throw new ArgumentException(
                             Strings.InconsistentEntityType(argumentName));

--- a/src/EntityFramework.Core/Metadata/Key.cs
+++ b/src/EntityFramework.Core/Metadata/Key.cs
@@ -22,10 +22,10 @@ namespace Microsoft.Data.Entity.Metadata
 
         public virtual IReadOnlyList<Property> Properties { get; }
 
-        public virtual EntityType EntityType => Properties[0].EntityType;
+        public virtual EntityType DeclaringEntityType => Properties[0].DeclaringEntityType;
 
         IReadOnlyList<IProperty> IKey.Properties => Properties;
 
-        IEntityType IKey.EntityType => EntityType;
+        IEntityType IKey.EntityType => DeclaringEntityType;
     }
 }

--- a/src/EntityFramework.Core/Metadata/Model.cs
+++ b/src/EntityFramework.Core/Metadata/Model.cs
@@ -127,7 +127,9 @@ namespace Microsoft.Data.Entity.Metadata
 
             // TODO: Perf: Add additional indexes so that this isn't a linear lookup
             // Issue #1179
-            return EntityTypes.SelectMany(et => et.GetForeignKeys()).Where(fk => fk.PrincipalEntityType == entityType).ToList();
+            return EntityTypes.SelectMany(et => et.GetForeignKeys())
+                .Where(fk => fk.PrincipalEntityType.IsAssignableFrom(entityType))
+                .ToList();
         }
 
         public virtual IReadOnlyList<ForeignKey> GetReferencingForeignKeys([NotNull] IKey key)

--- a/src/EntityFramework.Core/Metadata/Navigation.cs
+++ b/src/EntityFramework.Core/Metadata/Navigation.cs
@@ -10,22 +10,12 @@ namespace Microsoft.Data.Entity.Metadata
     {
         private ForeignKey _foreignKey;
 
-        public Navigation(
-            [NotNull] string name, [NotNull] ForeignKey foreignKey, bool pointsToPrincipal)
+        public Navigation([NotNull] string name, [NotNull] ForeignKey foreignKey)
             : base(Check.NotEmpty(name, nameof(name)))
         {
             Check.NotNull(foreignKey, nameof(foreignKey));
 
             _foreignKey = foreignKey;
-
-            if (pointsToPrincipal)
-            {
-                foreignKey.DependentToPrincipal = this;
-            }
-            else
-            {
-                foreignKey.PrincipalToDependent = this;
-            }
         }
 
         public virtual ForeignKey ForeignKey
@@ -40,13 +30,13 @@ namespace Microsoft.Data.Entity.Metadata
             }
         }
 
-        public override EntityType EntityType
+        public override EntityType DeclaringEntityType
             => this.PointsToPrincipal()
-                ? ForeignKey.EntityType
+                ? ForeignKey.DeclaringEntityType
                 : ForeignKey.PrincipalEntityType;
 
         IForeignKey INavigation.ForeignKey => ForeignKey;
 
-        public override string ToString() => EntityType + "." + Name;
+        public override string ToString() => DeclaringEntityType + "." + Name;
     }
 }

--- a/src/EntityFramework.Core/Metadata/NavigationExtensions.cs
+++ b/src/EntityFramework.Core/Metadata/NavigationExtensions.cs
@@ -19,15 +19,6 @@ namespace Microsoft.Data.Entity.Metadata
             return !navigation.PointsToPrincipal() && !navigation.ForeignKey.IsUnique;
         }
 
-        public static Navigation FindInverse([NotNull] this Navigation navigation)
-        {
-            Check.NotNull(navigation, nameof(navigation));
-
-            return navigation.PointsToPrincipal()
-                ? navigation.ForeignKey.PrincipalToDependent
-                : navigation.ForeignKey.DependentToPrincipal;
-        }
-
         public static INavigation FindInverse([NotNull] this INavigation navigation)
         {
             Check.NotNull(navigation, nameof(navigation));
@@ -37,13 +28,9 @@ namespace Microsoft.Data.Entity.Metadata
                 : navigation.ForeignKey.DependentToPrincipal;
         }
 
-        public static EntityType GetTargetType([NotNull] this Navigation navigation)
+        public static Navigation FindInverse([NotNull] this Navigation navigation)
         {
-            Check.NotNull(navigation, nameof(navigation));
-
-            return navigation.PointsToPrincipal()
-                ? navigation.ForeignKey.PrincipalEntityType
-                : navigation.ForeignKey.EntityType;
+            return (Navigation)((INavigation)navigation).FindInverse();
         }
 
         public static IEntityType GetTargetType([NotNull] this INavigation navigation)
@@ -52,7 +39,12 @@ namespace Microsoft.Data.Entity.Metadata
 
             return navigation.PointsToPrincipal()
                 ? navigation.ForeignKey.PrincipalEntityType
-                : navigation.ForeignKey.EntityType;
+                : navigation.ForeignKey.DeclaringEntityType;
+        }
+
+        public static EntityType GetTargetType([NotNull] this Navigation navigation)
+        {
+            return (EntityType)((INavigation)navigation).GetTargetType();
         }
 
         public static bool IsCompatible(

--- a/src/EntityFramework.Core/Metadata/PropertyBase.cs
+++ b/src/EntityFramework.Core/Metadata/PropertyBase.cs
@@ -8,7 +8,7 @@ using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Metadata
 {
-    [DebuggerDisplay("{EntityType.Name,nq}.{Name,nq}")]
+    [DebuggerDisplay("{DeclaringEntityType.Name,nq}.{Name,nq}")]
     public abstract class PropertyBase : Annotatable, IPropertyBase
     {
         protected PropertyBase([NotNull] string name)
@@ -22,8 +22,8 @@ namespace Microsoft.Data.Entity.Metadata
 
         // TODO: Consider properties that are part of some complex/value type
         // Issue #246
-        public abstract EntityType EntityType { get; }
+        public abstract EntityType DeclaringEntityType { get; }
 
-        IEntityType IPropertyBase.EntityType => EntityType;
+        IEntityType IPropertyBase.DeclaringEntityType => DeclaringEntityType;
     }
 }

--- a/src/EntityFramework.Core/Properties/Strings.Designer.cs
+++ b/src/EntityFramework.Core/Properties/Strings.Designer.cs
@@ -405,11 +405,11 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
-        /// The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because it already belongs to entity type '{existingEntityType}'.
+        /// The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because according to the specified foreign key it should belong to entity type '{existingEntityType}'.
         /// </summary>
-        public static string NavigationAlreadyOwned([CanBeNull] object navigation, [CanBeNull] object entityType, [CanBeNull] object existingEntityType)
+        public static string NavigationOnWrongEntityType([CanBeNull] object navigation, [CanBeNull] object entityType, [CanBeNull] object existingEntityType)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("NavigationAlreadyOwned", "navigation", "entityType", "existingEntityType"), navigation, entityType, existingEntityType);
+            return string.Format(CultureInfo.CurrentCulture, GetString("NavigationOnWrongEntityType", "navigation", "entityType", "existingEntityType"), navigation, entityType, existingEntityType);
         }
 
         /// <summary>
@@ -1042,6 +1042,38 @@ namespace Microsoft.Data.Entity.Internal
         public static string CompositePKWithDataAnnotation([CanBeNull] object entityType)
         {
             return string.Format(CultureInfo.CurrentCulture, GetString("CompositePKWithDataAnnotation", "entityType"), entityType);
+        }
+
+        /// <summary>
+        /// The navigation property '{navigation}' cannot be removed because it is still referenced from entity type '{entityType}'.
+        /// </summary>
+        public static string NavigationStillOnEntityType([CanBeNull] object navigation, [CanBeNull] object entityType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("NavigationStillOnEntityType", "navigation", "entityType"), navigation, entityType);
+        }
+
+        /// <summary>
+        /// The navigation property declared on '{entityType}' cannot be determined because the associated  foreign key {foreignKey} references the same entity type that it is declared on.
+        /// </summary>
+        public static string SelfRefAmbiguousNavigation([CanBeNull] object entityType, [CanBeNull] object foreignKey)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("SelfRefAmbiguousNavigation", "entityType", "foreignKey"), entityType, foreignKey);
+        }
+
+        /// <summary>
+        /// The type '{entityType}' cannot have base type '{baseType}' because both types include the navigations: {navigations}.
+        /// </summary>
+        public static string DuplicateNavigationsOnBase([CanBeNull] object entityType, [CanBeNull] object baseType, [CanBeNull] object navigations)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("DuplicateNavigationsOnBase", "entityType", "baseType", "navigations"), entityType, baseType, navigations);
+        }
+
+        /// <summary>
+        /// The entity types '{firstEntityType}' and '{secondEntityType}' do not belong to the same model.
+        /// </summary>
+        public static string EntityTypeModelMismatch([CanBeNull] object firstEntityType, [CanBeNull] object secondEntityType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("EntityTypeModelMismatch", "firstEntityType", "secondEntityType"), firstEntityType, secondEntityType);
         }
 
         /// <summary>

--- a/src/EntityFramework.Core/Properties/Strings.resx
+++ b/src/EntityFramework.Core/Properties/Strings.resx
@@ -264,8 +264,8 @@
   <data name="ForeignKeyInUse" xml:space="preserve">
     <value>Cannot remove foreign key {foreignKey} from entity type '{entityType}' because it is referenced by navigation property '{navigation}' in entity type '{dependentType}'. All navigations must be removed or redefined before the referenced foreign key can be removed.</value>
   </data>
-  <data name="NavigationAlreadyOwned" xml:space="preserve">
-    <value>The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because it already belongs to entity type '{existingEntityType}'.</value>
+  <data name="NavigationOnWrongEntityType" xml:space="preserve">
+    <value>The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because according to the specified foreign key it should belong to entity type '{existingEntityType}'.</value>
   </data>
   <data name="DuplicateNavigation" xml:space="preserve">
     <value>The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because a navigation property with the same name already exists.</value>
@@ -503,6 +503,18 @@
   </data>
   <data name="CompositePKWithDataAnnotation" xml:space="preserve">
     <value>Entity type '{entityType}' has composite primary key defined with data annotations. To set composite primary key, use fluent API.</value>
+  </data>
+  <data name="NavigationStillOnEntityType" xml:space="preserve">
+    <value>The navigation property '{navigation}' cannot be removed because it is still referenced from entity type '{entityType}'.</value>
+  </data>
+  <data name="SelfRefAmbiguousNavigation" xml:space="preserve">
+    <value>The navigation property declared on '{entityType}' cannot be determined because the associated  foreign key {foreignKey} references the same entity type that it is declared on.</value>
+  </data>
+  <data name="DuplicateNavigationsOnBase" xml:space="preserve">
+    <value>The type '{entityType}' cannot have base type '{baseType}' because both types include the navigations: {navigations}.</value>
+  </data>
+  <data name="EntityTypeModelMismatch" xml:space="preserve">
+    <value>The entity types '{firstEntityType}' and '{secondEntityType}' do not belong to the same model.</value>
   </data>
   <data name="TimestampAttributeOnNonBinary" xml:space="preserve">
     <value>The property '{property}' is not a Byte array. TimestampAttribute can only be applied for Byte array properties.</value>

--- a/src/EntityFramework.Core/Query/EntityTrackingInfo.cs
+++ b/src/EntityFramework.Core/Query/EntityTrackingInfo.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Data.Entity.Query
 
             stateManager.StartTracking(
                 _entityType,
-                _entityKeyFactory.Create(_entityType, _entityKeyProperties, valueBuffer),
+                _entityKeyFactory.Create(_entityType.RootType(), _entityKeyProperties, valueBuffer),
                 entity,
                 valueBuffer);
         }
@@ -111,7 +111,7 @@ namespace Microsoft.Data.Entity.Query
 
             public virtual EntityKey CreateEntityKey(ValueBuffer valueBuffer)
             {
-                return EntityKeyFactory.Create(EntityType, EntityKeyProperties, valueBuffer);
+                return EntityKeyFactory.Create(EntityType.RootType(), EntityKeyProperties, valueBuffer);
             }
         }
 

--- a/src/EntityFramework.Core/Query/QueryBuffer.cs
+++ b/src/EntityFramework.Core/Query/QueryBuffer.cs
@@ -224,7 +224,7 @@ namespace Microsoft.Data.Entity.Query
                         {
                             var entityKey
                                 = entityKeyFactory
-                                    .Create(targetEntityType, keyProperties, eli.ValueBuffer);
+                                    .Create(targetEntityType.RootType(), keyProperties, eli.ValueBuffer);
 
                             object targetEntity = null;
 
@@ -303,7 +303,7 @@ namespace Microsoft.Data.Entity.Query
                     {
                         var entityKey
                             = entityKeyFactory
-                                .Create(targetEntityType, keyProperties, eli.ValueBuffer);
+                                .Create(targetEntityType.RootType(), keyProperties, eli.ValueBuffer);
 
                         object targetEntity = null;
 
@@ -365,12 +365,12 @@ namespace Microsoft.Data.Entity.Query
                     = navigation.PointsToPrincipal()
                         ? foreignKeyFactory
                             .Create(
-                                targetEntityType,
+                                targetEntityType.RootType(),
                                 navigation.ForeignKey.Properties,
                                 (ValueBuffer)boxedValueBuffer)
                         : primaryKeyFactory
                             .Create(
-                                navigation.EntityType,
+                                navigation.DeclaringEntityType.RootType(),
                                 navigation.ForeignKey.PrincipalKey.Properties,
                                 (ValueBuffer)boxedValueBuffer);
             }
@@ -381,7 +381,7 @@ namespace Microsoft.Data.Entity.Query
                     = valueBuffer =>
                         primaryKeyFactory
                             .Create(
-                                targetEntityType,
+                                targetEntityType.RootType(),
                                 navigation.ForeignKey.PrincipalKey.Properties,
                                 valueBuffer);
             }
@@ -391,7 +391,7 @@ namespace Microsoft.Data.Entity.Query
                     = valueBuffer =>
                         foreignKeyFactory
                             .Create(
-                                navigation.EntityType,
+                                navigation.DeclaringEntityType.RootType(),
                                 navigation.ForeignKey.Properties,
                                 valueBuffer);
             }

--- a/src/EntityFramework.Core/ValueGeneration/TemporaryNumberValueGeneratorFactory.cs
+++ b/src/EntityFramework.Core/ValueGeneration/TemporaryNumberValueGeneratorFactory.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Data.Entity.ValueGeneration
             }
 
             throw new ArgumentException(Strings.InvalidValueGeneratorFactoryProperty(
-                nameof(TemporaryNumberValueGeneratorFactory), property.Name, property.EntityType.DisplayName()));
+                nameof(TemporaryNumberValueGeneratorFactory), property.Name, property.DeclaringEntityType.DisplayName()));
         }
     }
 }

--- a/src/EntityFramework.Core/ValueGeneration/ValueGeneratorSelector.cs
+++ b/src/EntityFramework.Core/ValueGeneration/ValueGeneratorSelector.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Data.Entity.ValueGeneration
             }
 
             throw new NotSupportedException(
-                Strings.NoValueGenerator(property.Name, property.EntityType.DisplayName(), propertyType.Name));
+                Strings.NoValueGenerator(property.Name, property.DeclaringEntityType.DisplayName(), propertyType.Name));
         }
     }
 }

--- a/src/EntityFramework.InMemory/InMemoryIntegerValueGeneratorFactory.cs
+++ b/src/EntityFramework.InMemory/InMemoryIntegerValueGeneratorFactory.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Data.Entity.InMemory
             }
 
             throw new ArgumentException(Internal.Strings.InvalidValueGeneratorFactoryProperty(
-                nameof(InMemoryIntegerValueGeneratorFactory), property.Name, property.EntityType.DisplayName()));
+                nameof(InMemoryIntegerValueGeneratorFactory), property.Name, property.DeclaringEntityType.DisplayName()));
         }
     }
 }

--- a/src/EntityFramework.InMemory/Query/InMemoryQueryModelVisitor.cs
+++ b/src/EntityFramework.InMemory/Query/InMemoryQueryModelVisitor.cs
@@ -202,7 +202,7 @@ namespace Microsoft.Data.Entity.InMemory.Query
                         .EntityKeyFactorySource.GetKeyFactory(keyProperties);
 
                 Func<ValueBuffer, EntityKey> entityKeyFactory
-                    = vr => keyFactory.Create(entityType, keyProperties, vr);
+                    = vr => keyFactory.Create(entityType.RootType(), keyProperties, vr);
 
                 var materializer
                     = new MaterializerFactory(QueryModelVisitor

--- a/src/EntityFramework.Relational.Design/Utilities/ModelUtilities.cs
+++ b/src/EntityFramework.Relational.Design/Utilities/ModelUtilities.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Data.Entity.Relational.Design.Utilities
         {
             Check.NotNull(foreignKey, nameof(foreignKey));
 
-            return foreignKey.EntityType.DisplayName();
+            return foreignKey.DeclaringEntityType.DisplayName();
         }
 
         public virtual string ConstructNavigationConfiguration([NotNull] NavigationConfiguration navigationConfiguration)

--- a/src/EntityFramework.Relational/Metadata/ReadOnlyRelationalForeignKeyAnnotations.cs
+++ b/src/EntityFramework.Relational/Metadata/ReadOnlyRelationalForeignKeyAnnotations.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Data.Entity.Metadata
 
         protected virtual string GetDefaultName()
             => "FK_" +
-               _foreignKey.EntityType.DisplayName() +
+               _foreignKey.DeclaringEntityType.DisplayName() +
                "_" +
                _foreignKey.PrincipalEntityType.DisplayName() +
                "_" +

--- a/src/EntityFramework.Relational/Metadata/ReadOnlyRelationalIndexAnnotations.cs
+++ b/src/EntityFramework.Relational/Metadata/ReadOnlyRelationalIndexAnnotations.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Data.Entity.Metadata
 
         protected virtual string GetDefaultName()
             => "IX_" +
-               _index.EntityType.DisplayName() +
+               _index.DeclaringEntityType.DisplayName() +
                "_" +
                string.Join("_", _index.Properties.Select(p => p.Name));
     }

--- a/src/EntityFramework.Relational/Metadata/RelationalEntityTypeAnnotations.cs
+++ b/src/EntityFramework.Relational/Metadata/RelationalEntityTypeAnnotations.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Data.Entity.Metadata
                             Strings.DiscriminatorPropertyMustBeOnRoot(EntityType));
                     }
 
-                    if (value.EntityType != EntityType)
+                    if (value.DeclaringEntityType != EntityType)
                     {
                         throw new InvalidOperationException(
                             Strings.DiscriminatorPropertyNotFound(value, EntityType));

--- a/src/EntityFramework.Relational/Migrations/Infrastructure/ModelDiffer.cs
+++ b/src/EntityFramework.Relational/Migrations/Infrastructure/ModelDiffer.cs
@@ -401,7 +401,7 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
         protected virtual IEnumerable<MigrationOperation> Diff(IProperty source, IProperty target)
         {
             var sourceExtensions = MetadataExtensions.Extensions(source);
-            var sourceEntityTypeExtensions = MetadataExtensions.Extensions(source.EntityType);
+            var sourceEntityTypeExtensions = MetadataExtensions.Extensions(source.DeclaringEntityType);
             var targetExtensions = MetadataExtensions.Extensions(target);
 
             if (sourceExtensions.Column != targetExtensions.Column)
@@ -455,7 +455,7 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
         protected virtual IEnumerable<MigrationOperation> Add(IProperty target, bool inline = false)
         {
             var targetExtensions = MetadataExtensions.Extensions(target);
-            var targetEntityTypeExtensions = MetadataExtensions.Extensions(target.EntityType);
+            var targetEntityTypeExtensions = MetadataExtensions.Extensions(target.DeclaringEntityType);
 
             var operation = new AddColumnOperation
             {
@@ -478,7 +478,7 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
         protected virtual IEnumerable<MigrationOperation> Remove(IProperty source)
         {
             var sourceExtensions = MetadataExtensions.Extensions(source);
-            var sourceEntityTypeExtensions = MetadataExtensions.Extensions(source.EntityType);
+            var sourceEntityTypeExtensions = MetadataExtensions.Extensions(source.DeclaringEntityType);
 
             yield return new DropColumnOperation
             {
@@ -594,7 +594,7 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
         protected virtual IEnumerable<MigrationOperation> Add(IForeignKey target, ModelDifferContext diffContext)
         {
             var targetExtensions = MetadataExtensions.Extensions(target);
-            var targetEntityTypeExtensions = MetadataExtensions.Extensions(target.EntityType);
+            var targetEntityTypeExtensions = MetadataExtensions.Extensions(target.DeclaringEntityType);
             var targetPrincipalEntityTypeExtensions = MetadataExtensions.Extensions(target.PrincipalEntityType);
 
             // TODO: Set OnDelete (See #1084)
@@ -610,7 +610,7 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
             };
             CopyAnnotations(Annotations.For(target), operation);
 
-            var createTableOperation = diffContext.FindCreate(target.EntityType);
+            var createTableOperation = diffContext.FindCreate(target.DeclaringEntityType);
             if (createTableOperation != null)
             {
                 createTableOperation.ForeignKeys.Add(operation);
@@ -624,9 +624,9 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
         protected virtual IEnumerable<MigrationOperation> Remove(IForeignKey source, ModelDifferContext diffContext)
         {
             var sourceExtensions = MetadataExtensions.Extensions(source);
-            var sourceEntityTypeExtensions = MetadataExtensions.Extensions(source.EntityType);
+            var sourceEntityTypeExtensions = MetadataExtensions.Extensions(source.DeclaringEntityType);
 
-            var dropTableOperation = diffContext.FindDrop(source.EntityType);
+            var dropTableOperation = diffContext.FindDrop(source.DeclaringEntityType);
             if (dropTableOperation == null)
             {
                 yield return new DropForeignKeyOperation
@@ -658,7 +658,7 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
 
         protected virtual IEnumerable<MigrationOperation> Diff(IIndex source, IIndex target)
         {
-            var sourceEntityTypeExtensions = MetadataExtensions.Extensions(source.EntityType);
+            var sourceEntityTypeExtensions = MetadataExtensions.Extensions(source.DeclaringEntityType);
             var sourceName = MetadataExtensions.Extensions(source).Name;
             var targetName = MetadataExtensions.Extensions(target).Name;
 
@@ -687,7 +687,7 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
         protected virtual IEnumerable<MigrationOperation> Add(IIndex target)
         {
             var targetExtensions = MetadataExtensions.Extensions(target);
-            var targetEntityTypeExtensions = MetadataExtensions.Extensions(target.EntityType);
+            var targetEntityTypeExtensions = MetadataExtensions.Extensions(target.DeclaringEntityType);
 
             var operation = new CreateIndexOperation
             {
@@ -705,7 +705,7 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
         protected virtual IEnumerable<MigrationOperation> Remove(IIndex source)
         {
             var sourceExtensions = MetadataExtensions.Extensions(source);
-            var sourceEntityTypeExtensions = MetadataExtensions.Extensions(source.EntityType);
+            var sourceEntityTypeExtensions = MetadataExtensions.Extensions(source.DeclaringEntityType);
 
             yield return new DropIndexOperation
             {

--- a/src/EntityFramework.Relational/Query/ExpressionVisitors/IncludeExpressionVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionVisitors/IncludeExpressionVisitor.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
                             navigation,
                             (navigation.PointsToPrincipal()
                                 ? targetEntityType
-                                : navigation.EntityType)
+                                : navigation.DeclaringEntityType)
                                 .GetPrimaryKey().Properties,
                             navigation.PointsToPrincipal() ? targetTableExpression : joinExpression,
                             navigation.PointsToPrincipal() ? joinExpression : targetTableExpression);
@@ -169,7 +169,7 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
                     var principalTable
                         = selectExpression.Tables.Last(t => t.QuerySource == querySource);
 
-                    foreach (var property in navigation.EntityType.GetPrimaryKey().Properties)
+                    foreach (var property in navigation.DeclaringEntityType.GetPrimaryKey().Properties)
                     {
                         selectExpression
                             .AddToOrderBy(
@@ -219,7 +219,7 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
 
                     innerJoinSelectExpression.ClearOrderBy();
 
-                    var primaryKeyProperties = navigation.EntityType.GetPrimaryKey().Properties;
+                    var primaryKeyProperties = navigation.DeclaringEntityType.GetPrimaryKey().Properties;
 
                     var innerJoinExpression
                         = targetSelectExpression.AddInnerJoin(innerJoinSelectExpression);

--- a/src/EntityFramework.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Query.Annotations;
 using Microsoft.Data.Entity.Query.Expressions;
 using Microsoft.Data.Entity.Query.Sql;

--- a/src/EntityFramework.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EntityFramework.Relational/Query/RelationalQueryModelVisitor.cs
@@ -599,7 +599,7 @@ namespace Microsoft.Data.Entity.Query
             valueBuffer = valueBuffer.WithOffset(valueBufferOffset);
 
             var entityKey
-                = entityKeyFactory.Create(entityType, keyProperties, valueBuffer);
+                = entityKeyFactory.Create(entityType.RootType(), keyProperties, valueBuffer);
 
             return new QueryResultScope<TEntity>(
                 querySource,

--- a/src/EntityFramework.Relational/Storage/RelationalTypeMapper.cs
+++ b/src/EntityFramework.Relational/Storage/RelationalTypeMapper.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
@@ -80,7 +81,7 @@ namespace Microsoft.Data.Entity.Storage
                     ? _boundedStringMappings.GetOrAdd(maxLength.Value, boundedMapping)
                     : unboundedMapping
                 : (keyMapping != null
-                   && (property.IsKey() || property.IsForeignKey())
+                   && (property.IsKey() || property.FindContainingEntityTypes().Any(property.IsForeignKey))
                     ? keyMapping
                     : defaultMapping);
         }
@@ -110,7 +111,7 @@ namespace Microsoft.Data.Entity.Storage
                     ? _boundedBinaryMappings.GetOrAdd(maxLength.Value, boundedMapping)
                     : unboundedMapping
                 : (keyMapping != null
-                   && (property.IsKey() || property.IsForeignKey())
+                   && (property.IsKey() || property.FindContainingEntityTypes().Any(property.IsForeignKey))
                     ? keyMapping
                     : defaultMapping);
         }

--- a/src/EntityFramework.Relational/ValueGeneration/RelationalValueGeneratorSelector.cs
+++ b/src/EntityFramework.Relational/ValueGeneration/RelationalValueGeneratorSelector.cs
@@ -22,10 +22,10 @@ namespace Microsoft.Data.Entity.ValueGeneration
 
             var propertyType = property.ClrType.UnwrapNullableType();
 
-            if (property.EntityType.BaseType == null)
+            if (property.DeclaringEntityType.BaseType == null)
             {
                 var discriminatorPropertyName
-                    = property.EntityType[ReadOnlyRelationalEntityTypeAnnotations.DiscriminatorPropertyAnnotation]
+                    = property.DeclaringEntityType[ReadOnlyRelationalEntityTypeAnnotations.DiscriminatorPropertyAnnotation]
                         as string;
 
                 if (discriminatorPropertyName != null

--- a/src/EntityFramework.SqlServer.Design/ReverseEngineering/SqlServerEntityTypeCodeGeneratorHelper.cs
+++ b/src/EntityFramework.SqlServer.Design/ReverseEngineering/SqlServerEntityTypeCodeGeneratorHelper.cs
@@ -102,8 +102,8 @@ namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering
                     if (((ForeignKey)foreignKey).IsSelfReferencing())
                     {
                         var referencedType = foreignKey.IsUnique
-                            ? foreignKey.EntityType.Name
-                            : "ICollection<" + foreignKey.EntityType.Name + ">";
+                            ? foreignKey.DeclaringEntityType.Name
+                            : "ICollection<" + foreignKey.DeclaringEntityType.Name + ">";
                         navProps.Add(new SqlServerNavigationProperty(
                             referencedType,
                             (string)foreignKey[SqlServerMetadataModelProvider.AnnotationNamePrincipalEndNavPropName]));

--- a/src/EntityFramework.SqlServer.Design/ReverseEngineering/SqlServerMetadataModelProvider.cs
+++ b/src/EntityFramework.SqlServer.Design/ReverseEngineering/SqlServerMetadataModelProvider.cs
@@ -395,7 +395,7 @@ namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering
                         foreignKeyConstraintRelationalPropertyList[0].Name);
                     if (targetRelationalProperty != null)
                     {
-                        var targetRelationalEntityType = targetRelationalProperty.EntityType;
+                        var targetRelationalEntityType = targetRelationalProperty.DeclaringEntityType;
                         var targetCodeGenEntityType = _relationalEntityTypeToCodeGenEntityTypeMap[targetRelationalEntityType];
                         var targetPrimaryKey = targetCodeGenEntityType.GetPrimaryKey();
 
@@ -418,7 +418,7 @@ namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering
                         // Note: SQL Server allows more than 1 foreign key on the exact same
                         // set of properties. Here we just conflate into one foreign key.
                         var codeGenForeignKey = codeGenEntityType
-                            .GetOrAddForeignKey(foreignKeyCodeGenProperties, targetPrimaryKey);
+                            .GetOrAddForeignKey(foreignKeyCodeGenProperties, targetPrimaryKey, targetCodeGenEntityType);
 
                         if (_uniqueConstraintColumns.Contains(
                             ConstructIdForCombinationOfColumns(
@@ -640,7 +640,7 @@ namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering
                     _logger.LogWarning(
                         Strings.UnableToConvertDefaultValue(
                             tableColumn.Id, tableColumn.DefaultValue,
-                            property.ClrType, property.Name, property.EntityType.Name));
+                            property.ClrType, property.Name, property.DeclaringEntityType.Name));
                 }
             }
         }

--- a/src/EntityFramework.SqlServer/Metadata/ReadOnlySqlServerPropertyAnnotations.cs
+++ b/src/EntityFramework.SqlServer/Metadata/ReadOnlySqlServerPropertyAnnotations.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Data.Entity.SqlServer.Metadata
                     ? null
                     : (SqlServerIdentityStrategy?)Enum.Parse(typeof(SqlServerIdentityStrategy), value);
 
-                return strategy ?? Property.EntityType.Model.SqlServer().IdentityStrategy;
+                return strategy ?? Property.DeclaringEntityType.Model.SqlServer().IdentityStrategy;
             }
         }
 
@@ -72,7 +72,7 @@ namespace Microsoft.Data.Entity.SqlServer.Metadata
 
         public virtual Sequence TryGetSequence()
         {
-            var modelExtensions = Property.EntityType.Model.SqlServer();
+            var modelExtensions = Property.DeclaringEntityType.Model.SqlServer();
 
             if (IdentityStrategy != SqlServerIdentityStrategy.SequenceHiLo)
             {

--- a/src/EntityFramework.SqlServer/Metadata/SqlServerPropertyAnnotations.cs
+++ b/src/EntityFramework.SqlServer/Metadata/SqlServerPropertyAnnotations.cs
@@ -128,14 +128,14 @@ namespace Microsoft.Data.Entity.SqlServer.Metadata
                             || propertyType == typeof(byte?)))
                     {
                         throw new ArgumentException(Strings.IdentityBadType(
-                            Property.Name, Property.EntityType.Name, propertyType.Name));
+                            Property.Name, Property.DeclaringEntityType.Name, propertyType.Name));
                     }
 
                     if (value == SqlServerIdentityStrategy.SequenceHiLo
                         && !propertyType.IsInteger())
                     {
                         throw new ArgumentException(Strings.SequenceBadType(
-                            Property.Name, Property.EntityType.Name, propertyType.Name));
+                            Property.Name, Property.DeclaringEntityType.Name, propertyType.Name));
                     }
 
                     // TODO: Issue #777: Non-string annotations

--- a/src/EntityFramework.SqlServer/Metadata/SqlServerPropertyBuilder.cs
+++ b/src/EntityFramework.SqlServer/Metadata/SqlServerPropertyBuilder.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Data.Entity.SqlServer.Metadata
 
         public virtual SqlServerPropertyBuilder UseSequence()
         {
-            var sequence = _property.EntityType.Model.SqlServer().GetOrAddSequence();
+            var sequence = _property.DeclaringEntityType.Model.SqlServer().GetOrAddSequence();
 
             _property.SqlServer().IdentityStrategy = SqlServerIdentityStrategy.SequenceHiLo;
             _property.ValueGenerated = ValueGenerated.OnAdd;
@@ -78,7 +78,7 @@ namespace Microsoft.Data.Entity.SqlServer.Metadata
             Check.NotEmpty(name, nameof(name));
             Check.NullButNotEmpty(schema, nameof(schema));
 
-            var sequence = _property.EntityType.Model.SqlServer().GetOrAddSequence(name, schema);
+            var sequence = _property.DeclaringEntityType.Model.SqlServer().GetOrAddSequence(name, schema);
 
             _property.SqlServer().IdentityStrategy = SqlServerIdentityStrategy.SequenceHiLo;
             _property.ValueGenerated = ValueGenerated.OnAdd;

--- a/src/EntityFramework.SqlServer/SqlServerPropertyBuilderExtensions.cs
+++ b/src/EntityFramework.SqlServer/SqlServerPropertyBuilderExtensions.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Data.Entity
             Check.NullButNotEmpty(schema, nameof(schema));
 
             var property = propertyBuilder.Metadata;
-            var sequence = property.EntityType.Model.SqlServer().GetOrAddSequence(name, schema);
+            var sequence = property.DeclaringEntityType.Model.SqlServer().GetOrAddSequence(name, schema);
 
             property.SqlServer().IdentityStrategy = SqlServerIdentityStrategy.SequenceHiLo;
             property.ValueGenerated = ValueGenerated.OnAdd;

--- a/src/EntityFramework.SqlServer/ValueGeneration/SqlServerSequenceValueGeneratorFactory.cs
+++ b/src/EntityFramework.SqlServer/ValueGeneration/SqlServerSequenceValueGeneratorFactory.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Data.Entity.SqlServer.ValueGeneration
             }
 
             throw new ArgumentException(Internal.Strings.InvalidValueGeneratorFactoryProperty(
-                nameof(SqlServerSequenceValueGeneratorFactory), property.Name, property.EntityType.DisplayName()));
+                nameof(SqlServerSequenceValueGeneratorFactory), property.Name, property.DeclaringEntityType.DisplayName()));
         }
     }
 }

--- a/test/EntityFramework.Core.FunctionalTests/InheritanceFixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/InheritanceFixtureBase.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             animalSpeciesProperty.RequiresValueGenerator = true;
             var animalKey = animal.SetPrimaryKey(animalSpeciesProperty);
             animal.AddProperty("Name", typeof(string));
-            var countryFk = animal.AddForeignKey(animal.AddProperty("CountryId", typeof(int)), countryKey);
+            var countryFk = animal.AddForeignKey(animal.AddProperty("CountryId", typeof(int)), countryKey, country);
 
             var bird = model.AddEntityType(typeof(Bird));
             bird.BaseType = animal;

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/MonsterContext`.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/MonsterContext`.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
 
 namespace Microsoft.Data.Entity.FunctionalTests.TestModels
 {
@@ -320,7 +321,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
 
                     var entityType = b.Metadata;
                     var activityEntityType = entityType.Model.GetEntityType(typeof(TSuspiciousActivity));
-                    activityEntityType.AddForeignKey(activityEntityType.GetProperty("Username"), key.Metadata);
+                    activityEntityType.AddForeignKey(activityEntityType.GetProperty("Username"), key.Metadata, entityType);
 
                     b.Reference(e => (TLastLogin)e.LastLogin).InverseReference(e => (TLogin)e.Login)
                         .ForeignKey<TLastLogin>(e => e.Username);

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/Northwind/NorthwindData.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/Northwind/NorthwindData.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -9,6 +9,7 @@ using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Query;
 using Microsoft.Data.Entity.Query.ExpressionVisitors;
 

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/CompositeEntityKeyFactoryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/CompositeEntityKeyFactoryTest.cs
@@ -217,7 +217,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var property6 = entityType.GetOrAddProperty("P6", typeof(Random));
 
             entityType.GetOrSetPrimaryKey(new[] { property1, property2, property3 });
-            entityType.GetOrAddForeignKey(new[] { property4, property5, property6 }, entityType.GetPrimaryKey());
+            entityType.GetOrAddForeignKey(new[] { property4, property5, property6 }, entityType.GetPrimaryKey(), entityType);
 
             return model;
         }

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalMixedEntityEntryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalMixedEntityEntryTest.cs
@@ -121,37 +121,16 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
         protected override Model BuildModel()
         {
-            var model = new Model();
+            var model = base.BuildModel();
 
-            var entityType1 = model.AddEntityType(typeof(SomeEntity));
-            var key1 = entityType1.GetOrAddProperty("Id", typeof(int), shadowProperty: true);
-            key1.RequiresValueGenerator = true;
-            entityType1.GetOrSetPrimaryKey(key1);
-            entityType1.GetOrAddProperty("Name", typeof(string));
+            var someSimpleEntityType = model.GetEntityType(typeof(SomeSimpleEntityBase));
+            someSimpleEntityType.GetProperty("Id").IsShadowProperty = true;
 
-            var entityType2 = model.AddEntityType(typeof(SomeDependentEntity));
-            var key2a = entityType2.GetOrAddProperty("Id1", typeof(int));
-            var key2b = entityType2.GetOrAddProperty("Id2", typeof(string));
-            entityType2.GetOrSetPrimaryKey(new[] { key2a, key2b });
-            var fk = entityType2.GetOrAddProperty("SomeEntityId", typeof(int), shadowProperty: true);
-            entityType2.GetOrAddForeignKey(new[] { fk }, entityType1.GetPrimaryKey());
-            var justAProperty = entityType2.GetOrAddProperty("JustAProperty", typeof(int));
-            justAProperty.RequiresValueGenerator = true;
+            var entityType1 = model.GetEntityType(typeof(SomeEntity));
+            entityType1.GetOrAddProperty("Name", typeof(string)).IsConcurrencyToken = false;
 
-            var entityType3 = model.AddEntityType(typeof(FullNotificationEntity));
-            entityType3.GetOrSetPrimaryKey(entityType3.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
-            entityType3.GetOrAddProperty("Name", typeof(string)).IsConcurrencyToken = true;
-
-            var entityType4 = model.AddEntityType(typeof(ChangedOnlyEntity));
-            entityType4.GetOrSetPrimaryKey(entityType4.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
-            entityType4.GetOrAddProperty("Name", typeof(string)).IsConcurrencyToken = true;
-
-            var entityType5 = model.AddEntityType(typeof(SomeMoreDependentEntity));
-            var key5 = entityType5.GetOrAddProperty("Id", typeof(int));
-            entityType5.GetOrSetPrimaryKey(key5);
-            var fk5a = entityType5.GetOrAddProperty("Fk1", typeof(int));
-            var fk5b = entityType5.GetOrAddProperty("Fk2", typeof(string));
-            entityType5.GetOrAddForeignKey(new[] { fk5a, fk5b }, entityType2.GetPrimaryKey());
+            var entityType2 = model.GetEntityType(typeof(SomeDependentEntity));
+            entityType2.GetProperty("SomeEntityId").IsShadowProperty = true;
 
             return model;
         }

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/KeyPropagatorTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/KeyPropagatorTest.cs
@@ -173,18 +173,19 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             keyPropagator.PropagateValue(dependentEntry, property);
         }
 
-        private class Category
+        private class BaseType
         {
             public int Id { get; set; }
+            public int CategoryId { get; set; }
+        }
 
+        private class Category : BaseType
+        {
             public ICollection<Product> Products { get; } = new List<Product>();
         }
 
-        private class Product
+        private class Product : BaseType
         {
-            public int Id { get; set; }
-
-            public int CategoryId { get; set; }
             public Category Category { get; set; }
 
             public ProductDetail Detail { get; set; }
@@ -192,17 +193,13 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             public ICollection<OrderLine> OrderLines { get; } = new List<OrderLine>();
         }
 
-        private class ProductDetail
+        private class ProductDetail : BaseType
         {
-            public int Id { get; set; }
-
             public Product Product { get; set; }
         }
 
-        private class Order
+        private class Order : BaseType
         {
-            public int Id { get; set; }
-
             public ICollection<OrderLine> OrderLines { get; } = new List<OrderLine>();
         }
 

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/NavigationFixerTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/NavigationFixerTest.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Metadata;
-using Microsoft.Data.Entity.Metadata.Builders;
 using Microsoft.Framework.DependencyInjection;
 using Xunit;
 

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/RelationshipsSnapshotTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/RelationshipsSnapshotTest.cs
@@ -300,7 +300,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var fkProperty = entityType.GetOrAddProperty("Fk", typeof(int));
 
             entityType.GetOrSetPrimaryKey(pkProperty);
-            var fk = entityType.GetOrAddForeignKey(fkProperty, entityType.GetPrimaryKey());
+            var fk = entityType.GetOrAddForeignKey(fkProperty, entityType.GetPrimaryKey(), entityType);
 
             entityType.GetOrAddProperty("Name", typeof(string));
 

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/SidecarTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/SidecarTest.cs
@@ -394,21 +394,21 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var idProperty = entityType.GetOrAddProperty("Id", typeof(int));
             idProperty.IsConcurrencyToken = true;
             idProperty.RequiresValueGenerator = true;
-            entityType.GetOrSetPrimaryKey(idProperty);
+            var key = entityType.GetOrSetPrimaryKey(idProperty);
 
             entityType.GetOrAddProperty("Name", typeof(string));
             entityType.GetOrAddProperty("State", typeof(string)).IsConcurrencyToken = true;
 
             var fkProperty = entityType.GetOrAddProperty("Fk", typeof(int?));
             fkProperty.IsConcurrencyToken = true;
-            entityType.GetOrAddForeignKey(fkProperty, new Key(new[] { idProperty }));
+            entityType.GetOrAddForeignKey(fkProperty, key, entityType);
 
             var entityType2 = model.AddEntityType(typeof(SomeDependentEntity));
             var key2A = entityType2.GetOrAddProperty("Id1", typeof(int));
             var key2B = entityType2.GetOrAddProperty("Id2", typeof(string));
             entityType2.GetOrSetPrimaryKey(new[] { key2A, key2B });
             var fk = entityType2.GetOrAddProperty("SomeEntityId", typeof(int));
-            entityType2.GetOrAddForeignKey(new[] { fk }, entityType.GetPrimaryKey());
+            entityType2.GetOrAddForeignKey(new[] { fk }, key, entityType);
             var justAProperty = entityType2.GetOrAddProperty("JustAProperty", typeof(int));
             justAProperty.RequiresValueGenerator = true;
 
@@ -417,7 +417,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             entityType5.GetOrSetPrimaryKey(key5);
             var fk5A = entityType5.GetOrAddProperty("Fk1", typeof(int));
             var fk5B = entityType5.GetOrAddProperty("Fk2", typeof(string));
-            entityType5.GetOrAddForeignKey(new[] { fk5A, fk5B }, entityType2.GetPrimaryKey());
+            entityType5.GetOrAddForeignKey(new[] { fk5A, fk5B }, entityType2.GetPrimaryKey(), entityType2);
 
             return model;
         }

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/SimpleEntityKeyFactoryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/SimpleEntityKeyFactoryTest.cs
@@ -268,14 +268,14 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var property2 = entityType.GetOrAddProperty("P2", typeof(int?));
 
             entityType.GetOrSetPrimaryKey(property1);
-            entityType.GetOrAddForeignKey(property2, entityType.GetPrimaryKey());
+            entityType.GetOrAddForeignKey(property2, entityType.GetPrimaryKey(), entityType);
 
             entityType = model.AddEntityType(typeof(Kiwi));
             property1 = entityType.GetOrAddProperty("P1", typeof(string));
             property2 = entityType.GetOrAddProperty("P2", typeof(string));
 
             entityType.GetOrSetPrimaryKey(property1);
-            entityType.GetOrAddForeignKey(property2, entityType.GetPrimaryKey());
+            entityType.GetOrAddForeignKey(property2, entityType.GetPrimaryKey(), entityType);
 
             return model;
         }

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/SimpleNullableEntityKeyFactoryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/SimpleNullableEntityKeyFactoryTest.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var property2 = entityType.GetOrAddProperty("P2", typeof(int?));
 
             entityType.GetOrSetPrimaryKey(property1);
-            entityType.GetOrAddForeignKey(property2, entityType.GetPrimaryKey());
+            entityType.GetOrAddForeignKey(property2, entityType.GetPrimaryKey(), entityType);
 
             return model;
         }

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/StoreGeneratedValuesTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/StoreGeneratedValuesTest.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
+using Microsoft.Data.Entity.Metadata;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal

--- a/test/EntityFramework.Core.Tests/Extensions/PropertyExtensionsTest.cs
+++ b/test/EntityFramework.Core.Tests/Extensions/PropertyExtensionsTest.cs
@@ -46,11 +46,11 @@ namespace Microsoft.Data.Entity.Tests
             var secondType = new EntityType("Second", model);
             var secondProperty = secondType.AddProperty("ID", typeof(int), true);
             var secondKey = secondType.AddKey(secondProperty);
-            var secondForeignKey = secondType.AddForeignKey(secondProperty, firstKey);
+            var secondForeignKey = secondType.AddForeignKey(secondProperty, firstKey, firstType);
 
             var thirdType = new EntityType("Third", model);
             var thirdProperty = thirdType.AddProperty("ID", typeof(int), true);
-            var thirdForeignKey = thirdType.AddForeignKey(thirdProperty, secondKey);
+            var thirdForeignKey = thirdType.AddForeignKey(thirdProperty, secondKey, secondType);
 
             firstProperty.RequiresValueGenerator = true;
 
@@ -75,13 +75,13 @@ namespace Microsoft.Data.Entity.Tests
             var middleProperty1 = middleType.AddProperty("FK1", typeof(int), true);
             var middleProperty2 = middleType.AddProperty("FK2", typeof(int), true);
             var middleKey1 = middleType.AddKey(middleProperty1);
-            var middleFK1 = middleType.AddForeignKey(middleProperty1, leftKey);
-            var middleFK2 = middleType.AddForeignKey(new[] { middleProperty2, middleProperty1 }, rightKey);
+            var middleFK1 = middleType.AddForeignKey(middleProperty1, leftKey, leftType);
+            var middleFK2 = middleType.AddForeignKey(new[] { middleProperty2, middleProperty1 }, rightKey, rightType);
 
             var endType = new EntityType("End", model);
             var endProperty = endType.AddProperty("FK", typeof(int), true);
 
-            var endFK = endType.AddForeignKey(endProperty, middleKey1);
+            var endFK = endType.AddForeignKey(endProperty, middleKey1, middleType);
 
             rightId2.RequiresValueGenerator = true;
 
@@ -101,17 +101,15 @@ namespace Microsoft.Data.Entity.Tests
             var firstType = new EntityType("First", model);
             var firstId = firstType.AddProperty("Id", typeof(int), true);
             var firstKey = firstType.AddKey(firstId);
-
-
-
+            
             var secondType = new EntityType("Second", model);
             var secondId1 = secondType.AddProperty("Id1", typeof(int), true);
             var secondId2 = secondType.AddProperty("Id2", typeof(int), true);
             var secondKey = secondType.AddKey(secondId1);
 
-            var firstForeignKey = firstType.AddForeignKey(firstId, secondKey);
-            var secondForeignKey1 = secondType.AddForeignKey(secondId1, firstKey);
-            var secondForeignKey2 = secondType.AddForeignKey(new[] { secondId1, secondId2 }, leafKey);
+            var firstForeignKey = firstType.AddForeignKey(firstId, secondKey, secondType);
+            var secondForeignKey1 = secondType.AddForeignKey(secondId1, firstKey, firstType);
+            var secondForeignKey2 = secondType.AddForeignKey(new[] { secondId1, secondId2 }, leafKey, leafType);
 
             leafId1.RequiresValueGenerator = true;
 

--- a/test/EntityFramework.Core.Tests/Infrastructure/ModelValidatorTest.cs
+++ b/test/EntityFramework.Core.Tests/Infrastructure/ModelValidatorTest.cs
@@ -250,7 +250,7 @@ namespace Microsoft.Data.Entity.Tests.Infrastructure
 
         private ForeignKey CreateForeignKey(Key dependentKey, Key principalKey)
         {
-            var foreignKey = dependentKey.EntityType.AddForeignKey(dependentKey.Properties, principalKey);
+            var foreignKey = dependentKey.DeclaringEntityType.AddForeignKey(dependentKey.Properties, principalKey, principalKey.DeclaringEntityType);
             foreignKey.IsUnique = true;
             foreignKey.IsRequired = false;
             foreach (var property in dependentKey.Properties)

--- a/test/EntityFramework.Core.Tests/Metadata/ClrCollectionAccessorSourceTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ClrCollectionAccessorSourceTest.cs
@@ -131,9 +131,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         [Fact]
         public void Delegate_getter_is_cached_by_type_and_property_name()
         {
-            var entityType = new Model().AddEntityType(typeof(MyEntity));
-            var otherType = new Model().AddEntityType(typeof(MyOtherEntity));
-            var foreignKey = otherType.GetOrAddForeignKey(otherType.GetOrAddProperty("MyEntityId", typeof(int), shadowProperty: true), entityType.GetOrSetPrimaryKey(entityType.GetOrAddProperty("Id", typeof(int), shadowProperty: true)));
+            var model = new Model();
+            var entityType = model.AddEntityType(typeof(MyEntity));
+            var otherType = model.AddEntityType(typeof(MyOtherEntity));
+            var foreignKey = otherType.GetOrAddForeignKey(otherType.GetOrAddProperty("MyEntityId", typeof(int), shadowProperty: true),
+                entityType.GetOrSetPrimaryKey(entityType.GetOrAddProperty("Id", typeof(int), shadowProperty: true)),
+                entityType);
 
             var navigation = entityType.AddNavigation("AsICollection", foreignKey, pointsToPrincipal: false);
 
@@ -215,9 +218,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
         private static Navigation CreateNavigation(string navigationName)
         {
-            var entityType = new Model().AddEntityType(typeof(MyEntity));
-            var otherType = new Model().AddEntityType(typeof(MyOtherEntity));
-            var foreignKey = otherType.GetOrAddForeignKey(otherType.GetOrAddProperty("MyEntityId", typeof(int), shadowProperty: true), entityType.GetOrSetPrimaryKey(entityType.GetOrAddProperty("Id", typeof(int), shadowProperty: true)));
+            var model = new Model();
+            var entityType = model.AddEntityType(typeof(MyEntity));
+            var otherType = model.AddEntityType(typeof(MyOtherEntity));
+            var foreignKey = otherType.GetOrAddForeignKey(otherType.GetOrAddProperty("MyEntityId", typeof(int), shadowProperty: true),
+                entityType.GetOrSetPrimaryKey(entityType.GetOrAddProperty("Id", typeof(int), shadowProperty: true)),
+                entityType);
 
             return entityType.AddNavigation(navigationName, foreignKey, pointsToPrincipal: false);
         }

--- a/test/EntityFramework.Core.Tests/Metadata/Internal/InternalEntityBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/Internal/InternalEntityBuilderTest.cs
@@ -815,9 +815,9 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
             Assert.Empty(dependentEntityBuilder.Metadata.Properties.Where(p => p.Name == Order.CustomerIdProperty.Name));
             var newFk = dependentEntityBuilder.Metadata.GetForeignKeys().Single();
-            Assert.Same(fk.EntityType, newFk.EntityType);
+            Assert.Same(fk.DeclaringEntityType, newFk.DeclaringEntityType);
             Assert.Same(fk.PrincipalEntityType, newFk.PrincipalEntityType);
-            Assert.NotEqual(fk.Properties, newFk.EntityType.Properties);
+            Assert.NotEqual(fk.Properties, newFk.DeclaringEntityType.Properties);
             Assert.Same(fk.PrincipalKey, newFk.PrincipalKey);
             Assert.Equal(Order.CustomerProperty.Name, newFk.DependentToPrincipal.Name);
             Assert.Equal(Customer.OrdersProperty.Name, newFk.PrincipalToDependent.Name);
@@ -918,9 +918,9 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
             Assert.Empty(principalEntityBuilder.Metadata.Properties.Where(p => p.Name == Customer.UniqueProperty.Name));
             var newFk = dependentEntityBuilder.Metadata.GetForeignKeys().Single();
-            Assert.Same(fk.EntityType, newFk.EntityType);
+            Assert.Same(fk.DeclaringEntityType, newFk.DeclaringEntityType);
             Assert.Same(fk.PrincipalEntityType, newFk.PrincipalEntityType);
-            Assert.Equal(fk.Properties, newFk.EntityType.Properties);
+            Assert.Equal(fk.Properties, newFk.DeclaringEntityType.Properties);
             Assert.NotSame(fk.PrincipalKey, newFk.PrincipalKey);
             Assert.Equal(Order.CustomerProperty.Name, newFk.DependentToPrincipal.Name);
             Assert.Equal(Customer.OrdersProperty.Name, newFk.PrincipalToDependent.Name);
@@ -1067,7 +1067,8 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                         dependentEntityBuilder.Metadata.GetOrAddProperty(Order.CustomerIdProperty.Name, typeof(int)),
                         dependentEntityBuilder.Metadata.GetOrAddProperty(Order.CustomerUniqueProperty.Name, typeof(Guid))
                     },
-                principalEntityBuilder.Metadata.GetPrimaryKey());
+                principalEntityBuilder.Metadata.GetPrimaryKey(),
+                principalEntityBuilder.Metadata);
             var navigationToPrincipal = dependentEntityBuilder.Metadata.AddNavigation(Order.CustomerProperty.Name, foreignKey, pointsToPrincipal: true);
             var navigationToDependent = principalEntityBuilder.Metadata.AddNavigation(Customer.OrdersProperty.Name, foreignKey, pointsToPrincipal: false);
             Assert.True(dependentEntityBuilder.Navigation(Order.CustomerProperty.Name, foreignKey, pointsToPrincipal: true, configurationSource: ConfigurationSource.Convention));

--- a/test/EntityFramework.Core.Tests/Metadata/Internal/InternalRelationshipBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/Internal/InternalRelationshipBuilderTest.cs
@@ -90,7 +90,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Internal
                         orderEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention).Metadata,
                         orderEntityBuilder.Property(Order.CustomerUniqueProperty, ConfigurationSource.Convention).Metadata
                     },
-                customerKeyBuilder.Metadata);
+                customerKeyBuilder.Metadata,
+                customerEntityBuilder.Metadata);
             foreignKey.IsUnique = true;
 
             var relationshipBuilder = orderEntityBuilder.Relationship(foreignKey, true, ConfigurationSource.Convention);
@@ -179,31 +180,31 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Internal
             var relationshipBuilder = orderEntityBuilder
                 .Relationship(typeof(Customer), typeof(Order), null, null, ConfigurationSource.Convention, isUnique: true);
 
-            Assert.Same(orderEntityBuilder.Metadata, relationshipBuilder.Metadata.EntityType);
+            Assert.Same(orderEntityBuilder.Metadata, relationshipBuilder.Metadata.DeclaringEntityType);
 
             relationshipBuilder = relationshipBuilder.Invert(ConfigurationSource.Convention);
-            Assert.Same(customerEntityBuilder.Metadata, relationshipBuilder.Metadata.EntityType);
+            Assert.Same(customerEntityBuilder.Metadata, relationshipBuilder.Metadata.DeclaringEntityType);
 
             relationshipBuilder = relationshipBuilder.PrincipalKey(
                 orderEntityBuilder.PrimaryKey(new[] { Order.IdProperty }, ConfigurationSource.Convention).Metadata.Properties,
                 ConfigurationSource.Convention);
 
             Assert.Null(relationshipBuilder.Invert(ConfigurationSource.Convention));
-            Assert.Same(customerEntityBuilder.Metadata, relationshipBuilder.Metadata.EntityType);
+            Assert.Same(customerEntityBuilder.Metadata, relationshipBuilder.Metadata.DeclaringEntityType);
 
             relationshipBuilder = relationshipBuilder.Invert(ConfigurationSource.DataAnnotation);
-            Assert.Same(orderEntityBuilder.Metadata, relationshipBuilder.Metadata.EntityType);
+            Assert.Same(orderEntityBuilder.Metadata, relationshipBuilder.Metadata.DeclaringEntityType);
 
             relationshipBuilder = relationshipBuilder.Invert(ConfigurationSource.DataAnnotation);
-            Assert.Same(customerEntityBuilder.Metadata, relationshipBuilder.Metadata.EntityType);
+            Assert.Same(customerEntityBuilder.Metadata, relationshipBuilder.Metadata.DeclaringEntityType);
 
             Assert.Null(relationshipBuilder.Invert(ConfigurationSource.Convention));
-            Assert.Same(customerEntityBuilder.Metadata, relationshipBuilder.Metadata.EntityType);
+            Assert.Same(customerEntityBuilder.Metadata, relationshipBuilder.Metadata.DeclaringEntityType);
 
             relationshipBuilder = relationshipBuilder.ForeignKey(new[] { Customer.IdProperty }, ConfigurationSource.DataAnnotation);
 
             Assert.Null(relationshipBuilder.Invert(ConfigurationSource.DataAnnotation));
-            Assert.Same(customerEntityBuilder.Metadata, relationshipBuilder.Metadata.EntityType);
+            Assert.Same(customerEntityBuilder.Metadata, relationshipBuilder.Metadata.DeclaringEntityType);
         }
 
         private InternalModelBuilder CreateInternalModelBuilder()

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/ConventionDispatcherTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/ConventionDispatcherTest.cs
@@ -187,7 +187,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
             var foreignKey = new ForeignKey(
                 new[] { entityBuilder.Property(typeof(int), "FK", ConfigurationSource.Convention).Metadata },
-                entityBuilder.Key(new[] { entityBuilder.Property(typeof(int), "OrderId", ConfigurationSource.Convention).Metadata }, ConfigurationSource.Convention).Metadata);
+                entityBuilder.Key(new[] { entityBuilder.Property(typeof(int), "OrderId", ConfigurationSource.Convention).Metadata }, ConfigurationSource.Convention).Metadata,
+                entityBuilder.Metadata);
             var conventionDispatcher = new ConventionDispatcher(conventions);
             conventionDispatcher.OnForeignKeyRemoved(entityBuilder, foreignKey);
 

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/ForeignKeyPropertyDiscoveryConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/ForeignKeyPropertyDiscoveryConventionTest.cs
@@ -670,7 +670,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
 
             var newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder);
             Assert.NotSame(relationshipBuilder, newRelationshipBuilder);
-            Assert.Same(DependentType.Metadata, newRelationshipBuilder.Metadata.EntityType);
+            Assert.Same(DependentType.Metadata, newRelationshipBuilder.Metadata.DeclaringEntityType);
 
             newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(newRelationshipBuilder);
 
@@ -699,7 +699,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
 
             var newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder);
             Assert.NotSame(relationshipBuilder, newRelationshipBuilder);
-            Assert.Same(DependentType.Metadata, newRelationshipBuilder.Metadata.EntityType);
+            Assert.Same(DependentType.Metadata, newRelationshipBuilder.Metadata.DeclaringEntityType);
 
             newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(newRelationshipBuilder);
 
@@ -729,7 +729,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
 
             var newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder);
             Assert.NotSame(relationshipBuilder, newRelationshipBuilder);
-            Assert.Same(PrincipalType.Metadata, newRelationshipBuilder.Metadata.EntityType);
+            Assert.Same(PrincipalType.Metadata, newRelationshipBuilder.Metadata.DeclaringEntityType);
 
             newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(newRelationshipBuilder);
 
@@ -758,7 +758,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
 
             var newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder);
             Assert.NotSame(relationshipBuilder, newRelationshipBuilder);
-            Assert.Same(PrincipalType.Metadata, newRelationshipBuilder.Metadata.EntityType);
+            Assert.Same(PrincipalType.Metadata, newRelationshipBuilder.Metadata.DeclaringEntityType);
 
             newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(newRelationshipBuilder);
 
@@ -786,7 +786,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
 
             var newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder);
             Assert.NotSame(relationshipBuilder, newRelationshipBuilder);
-            Assert.Same(DependentType.Metadata, newRelationshipBuilder.Metadata.EntityType);
+            Assert.Same(DependentType.Metadata, newRelationshipBuilder.Metadata.DeclaringEntityType);
 
             newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(newRelationshipBuilder);
 
@@ -813,7 +813,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
 
             var newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder);
             Assert.NotSame(relationshipBuilder, newRelationshipBuilder);
-            Assert.Same(DependentType.Metadata, newRelationshipBuilder.Metadata.EntityType);
+            Assert.Same(DependentType.Metadata, newRelationshipBuilder.Metadata.DeclaringEntityType);
 
             newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(newRelationshipBuilder);
 
@@ -840,7 +840,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
 
             var newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder);
             Assert.NotSame(relationshipBuilder, newRelationshipBuilder);
-            Assert.Same(PrincipalType.Metadata, newRelationshipBuilder.Metadata.EntityType);
+            Assert.Same(PrincipalType.Metadata, newRelationshipBuilder.Metadata.DeclaringEntityType);
 
             newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(newRelationshipBuilder);
 
@@ -870,7 +870,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
 
             var newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder);
             Assert.NotSame(relationshipBuilder, newRelationshipBuilder);
-            Assert.Same(DependentType.Metadata, newRelationshipBuilder.Metadata.EntityType);
+            Assert.Same(DependentType.Metadata, newRelationshipBuilder.Metadata.DeclaringEntityType);
 
             newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(newRelationshipBuilder);
 
@@ -901,7 +901,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
 
             var newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder);
             Assert.NotSame(relationshipBuilder, newRelationshipBuilder);
-            Assert.Same(PrincipalType.Metadata, newRelationshipBuilder.Metadata.EntityType);
+            Assert.Same(PrincipalType.Metadata, newRelationshipBuilder.Metadata.DeclaringEntityType);
 
             newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(newRelationshipBuilder);
 

--- a/test/EntityFramework.Core.Tests/Metadata/ModelTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelTest.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var orderType = model.GetOrAddEntityType(typeof(Order));
             var customerFk = orderType.GetOrAddProperty(Order.CustomerIdProperty);
 
-            orderType.AddForeignKey(customerFk, customerKey);
+            orderType.AddForeignKey(customerFk, customerKey, customerType);
 
             Assert.Equal(
                 Strings.EntityTypeInUse(typeof(Customer).FullName),
@@ -148,7 +148,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var entityType2 = model.AddEntityType(typeof(Order));
             var keyProperty = new Property("Id", typeof(int), entityType1);
             var fkProperty = new Property("CustomerId", typeof(int?), entityType2);
-            var foreignKey = entityType2.GetOrAddForeignKey(fkProperty, new Key(new[] { keyProperty }));
+            var foreignKey = entityType2.GetOrAddForeignKey(fkProperty, entityType1.AddKey(keyProperty), entityType1);
 
             var referencingForeignKeys = model.GetReferencingForeignKeys(entityType1);
 

--- a/test/EntityFramework.Core.Tests/Metadata/NavigationExtensionsTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/NavigationExtensionsTest.cs
@@ -103,8 +103,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var categoryType = model.GetEntityType(typeof(Category));
             var productType = model.GetEntityType(typeof(Product));
 
-            var categoryFk = productType.GetOrAddForeignKey(productType.GetProperty("CategoryId"), categoryType.GetPrimaryKey());
-            var featuredProductFk = categoryType.GetOrAddForeignKey(categoryType.GetProperty("FeaturedProductId"), productType.GetPrimaryKey());
+            var categoryFk = productType.GetOrAddForeignKey(productType.GetProperty("CategoryId"), categoryType.GetPrimaryKey(), categoryType);
+            var featuredProductFk = categoryType.GetOrAddForeignKey(categoryType.GetProperty("FeaturedProductId"), productType.GetPrimaryKey(), productType);
             featuredProductFk.IsUnique = true;
 
             if (createProducts)

--- a/test/EntityFramework.Core.Tests/Metadata/NavigationTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/NavigationTest.cs
@@ -9,48 +9,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
     public class NavigationTest
     {
         [Fact]
-        public void Can_create_navigation_to_principal()
+        public void Can_create_navigation()
         {
             var foreignKey = CreateForeignKey();
-            foreignKey.IsUnique = false;
 
-            var navigation = new Navigation("Deception", foreignKey, pointsToPrincipal: true);
+            var navigation = new Navigation("Deception", foreignKey);
 
             Assert.Same(foreignKey, navigation.ForeignKey);
             Assert.Equal("Deception", navigation.Name);
-            Assert.NotNull(navigation.EntityType);
-            Assert.True(navigation.PointsToPrincipal());
-            Assert.False(navigation.IsCollection());
-        }
-
-        [Fact]
-        public void Can_create_navigation_to_unique_dependent()
-        {
-            var foreignKey = CreateForeignKey();
-            foreignKey.IsUnique = true;
-
-            var navigation = new Navigation("Deception", foreignKey, pointsToPrincipal: false);
-
-            Assert.Same(foreignKey, navigation.ForeignKey);
-            Assert.Equal("Deception", navigation.Name);
-            Assert.NotNull(navigation.EntityType);
-            Assert.False(navigation.PointsToPrincipal());
-            Assert.False(navigation.IsCollection());
-        }
-
-        [Fact]
-        public void Can_create_navigation_to_collection_of_dependents()
-        {
-            var foreignKey = CreateForeignKey();
-            foreignKey.IsUnique = false;
-
-            var navigation = new Navigation("Deception", foreignKey, pointsToPrincipal: false);
-
-            Assert.Same(foreignKey, navigation.ForeignKey);
-            Assert.Equal("Deception", navigation.Name);
-            Assert.NotNull(navigation.EntityType);
-            Assert.False(navigation.PointsToPrincipal());
-            Assert.True(navigation.IsCollection());
+            Assert.Same(foreignKey.DeclaringEntityType, navigation.DeclaringEntityType);
         }
 
         private ForeignKey CreateForeignKey()
@@ -59,7 +26,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var entityType = model.AddEntityType("E");
             var property = entityType.AddProperty("p", typeof(int), shadowProperty: true);
             var key = entityType.SetPrimaryKey(property);
-            return new ForeignKey(new[] { property }, key);
+            return new ForeignKey(new[] { property }, key, entityType);
         }
     }
 }

--- a/test/EntityFramework.Core.Tests/Metadata/PropertyTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/PropertyTest.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             stringProperty.IsNullable = true;
             Assert.True(stringProperty.IsNullable.Value);
 
-            stringProperty.EntityType.SetPrimaryKey(stringProperty);
+            stringProperty.DeclaringEntityType.SetPrimaryKey(stringProperty);
 
             Assert.Null(stringProperty.IsNullable);
             Assert.False(((IProperty)stringProperty).IsNullable);
@@ -89,7 +89,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Properties_which_are_part_of_primary_key_cannot_be_made_nullable()
         {
             var stringProperty = new Property("Name", typeof(string), new Model().AddEntityType(typeof(object)));
-            stringProperty.EntityType.SetPrimaryKey(stringProperty);
+            stringProperty.DeclaringEntityType.SetPrimaryKey(stringProperty);
 
             Assert.Equal(
                 Strings.CannotBeNullablePK("Name", "object"),

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/OneToOneTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/OneToOneTestBase.cs
@@ -279,7 +279,7 @@ namespace Microsoft.Data.Entity.Tests
                 modelBuilder.Entity<Customer>().Reference(e => e.Details).InverseReference();
 
                 var fk = dependentType.Navigations.Single().ForeignKey;
-                if (fk.EntityType == dependentType)
+                if (fk.DeclaringEntityType == dependentType)
                 {
                     Assert.Empty(principalType.GetForeignKeys());
                 }
@@ -312,11 +312,11 @@ namespace Microsoft.Data.Entity.Tests
                 foreach (var navigation in principalType.Navigations.ToList())
                 {
                     var inverse = navigation.FindInverse();
-                    inverse?.EntityType.RemoveNavigation(inverse);
+                    inverse?.DeclaringEntityType.RemoveNavigation(inverse);
                     principalType.RemoveNavigation(navigation);
 
                     var foreignKey = navigation.ForeignKey;
-                    foreignKey.EntityType.RemoveForeignKey(foreignKey);
+                    foreignKey.DeclaringEntityType.RemoveForeignKey(foreignKey);
                 }
 
                 var principalKey = principalType.GetKeys().Single();
@@ -450,9 +450,8 @@ namespace Microsoft.Data.Entity.Tests
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
                 modelBuilder.Entity<BigMak>();
-                modelBuilder.Entity<Bun>().Metadata.AddForeignKey(
-                    model.GetEntityType(typeof(Bun)).GetProperty("BurgerId"),
-                    model.GetEntityType(typeof(BigMak)).GetPrimaryKey());
+                modelBuilder.Entity<Bun>().Reference<BigMak>().InverseReference()
+                    .ForeignKey<Bun>(e => e.BurgerId);
                 modelBuilder.Ignore<Pickle>();
 
                 var dependentType = model.GetEntityType(typeof(Bun));
@@ -629,9 +628,8 @@ namespace Microsoft.Data.Entity.Tests
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
                 modelBuilder.Entity<BigMak>();
-                modelBuilder.Entity<Bun>().Metadata.AddForeignKey(
-                    model.GetEntityType(typeof(Bun)).GetProperty("BurgerId"),
-                    model.GetEntityType(typeof(BigMak)).GetPrimaryKey());
+                modelBuilder.Entity<Bun>().Reference<BigMak>().InverseCollection()
+                    .ForeignKey(e => e.BurgerId);
                 modelBuilder.Ignore<Pickle>();
 
                 var dependentType = (IEntityType)model.GetEntityType(typeof(Bun));
@@ -1808,9 +1806,8 @@ namespace Microsoft.Data.Entity.Tests
                 var modelBuilder = CreateModelBuilder(model);
                 modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
                 var dependentType = model.GetEntityType(typeof(ToastedBun));
-                modelBuilder.Entity<ToastedBun>().Metadata.AddForeignKey(
-                    new[] { dependentType.GetProperty("BurgerId1"), dependentType.GetProperty("BurgerId2") },
-                    model.GetEntityType(typeof(Whoopper)).GetPrimaryKey());
+                modelBuilder.Entity<ToastedBun>().Reference<Whoopper>().InverseReference()
+                    .ForeignKey<ToastedBun>(e => new { e.BurgerId1, e.BurgerId2 });
                 modelBuilder.Ignore<Tomato>();
                 modelBuilder.Ignore<Moostard>();
 
@@ -2402,8 +2399,8 @@ namespace Microsoft.Data.Entity.Tests
 
                 var fk = dependentType.GetForeignKeys().Single();
                 Assert.True(fk.IsUnique);
-                Assert.Equal(1, dependentType.Navigations.Count);
-                Assert.Equal(1, principalType.Navigations.Count);
+                Assert.Equal(1, dependentType.Navigations.Count());
+                Assert.Equal(1, principalType.Navigations.Count());
                 AssertEqual(expectedPrincipalProperties, principalType.Properties);
                 AssertEqual(expectedDependentProperties, dependentType.Properties);
                 Assert.Empty(principalType.GetForeignKeys());
@@ -2431,8 +2428,8 @@ namespace Microsoft.Data.Entity.Tests
 
                 var fk = dependentType.GetForeignKeys().Single();
                 Assert.True(fk.IsUnique);
-                Assert.Equal(1, dependentType.Navigations.Count);
-                Assert.Equal(1, principalType.Navigations.Count);
+                Assert.Equal(1, dependentType.Navigations.Count());
+                Assert.Equal(1, principalType.Navigations.Count());
                 AssertEqual(expectedPrincipalProperties, principalType.Properties);
                 AssertEqual(expectedDependentProperties, dependentType.Properties);
                 Assert.Empty(principalType.GetForeignKeys());

--- a/test/EntityFramework.Core.Tests/Utilities/MultigraphTest.cs
+++ b/test/EntityFramework.Core.Tests/Utilities/MultigraphTest.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Data.Entity.Tests.Utilities
                 {
                     foreach (var foreignKey in entityType.GetForeignKeys())
                     {
-                        AddEdge(foreignKey.PrincipalEntityType, foreignKey.EntityType, foreignKey);
+                        AddEdge(foreignKey.PrincipalEntityType, foreignKey.DeclaringEntityType, foreignKey);
                     }
                 }
             }
@@ -508,8 +508,8 @@ namespace Microsoft.Data.Entity.Tests.Utilities
             entityTypeC.GetOrSetPrimaryKey(entityTypeC.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
 
             // B -> A -> C
-            entityTypeC.GetOrAddForeignKey(entityTypeC.GetOrAddProperty("P", typeof(int)), entityTypeA.GetPrimaryKey());
-            entityTypeA.GetOrAddForeignKey(entityTypeA.GetOrAddProperty("P", typeof(int)), entityTypeB.GetPrimaryKey());
+            entityTypeC.GetOrAddForeignKey(entityTypeC.GetOrAddProperty("P", typeof(int)), entityTypeA.GetPrimaryKey(), entityTypeA);
+            entityTypeA.GetOrAddForeignKey(entityTypeA.GetOrAddProperty("P", typeof(int)), entityTypeB.GetPrimaryKey(), entityTypeB);
 
             var graph = new EntityTypeGraph();
             graph.Populate(entityTypeA, entityTypeB, entityTypeC);
@@ -534,8 +534,8 @@ namespace Microsoft.Data.Entity.Tests.Utilities
             entityTypeC.GetOrSetPrimaryKey(entityTypeC.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
 
             // C -> B -> A
-            entityTypeA.GetOrAddForeignKey(entityTypeA.GetOrAddProperty("P", typeof(int)), entityTypeB.GetPrimaryKey());
-            entityTypeB.GetOrAddForeignKey(entityTypeB.GetOrAddProperty("P", typeof(int)), entityTypeC.GetPrimaryKey());
+            entityTypeA.GetOrAddForeignKey(entityTypeA.GetOrAddProperty("P", typeof(int)), entityTypeB.GetPrimaryKey(), entityTypeB);
+            entityTypeB.GetOrAddForeignKey(entityTypeB.GetOrAddProperty("P", typeof(int)), entityTypeC.GetPrimaryKey(), entityTypeC);
 
             var graph = new EntityTypeGraph();
             graph.Populate(entityTypeA, entityTypeB, entityTypeC);
@@ -560,8 +560,8 @@ namespace Microsoft.Data.Entity.Tests.Utilities
             entityTypeC.GetOrSetPrimaryKey(entityTypeC.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
 
             // B -> A -> C
-            entityTypeC.GetOrAddForeignKey(entityTypeC.GetOrAddProperty("P", typeof(int)), entityTypeA.GetPrimaryKey());
-            entityTypeA.GetOrAddForeignKey(entityTypeA.GetOrAddProperty("P", typeof(int)), entityTypeB.GetPrimaryKey());
+            entityTypeC.GetOrAddForeignKey(entityTypeC.GetOrAddProperty("P", typeof(int)), entityTypeA.GetPrimaryKey(), entityTypeA);
+            entityTypeA.GetOrAddForeignKey(entityTypeA.GetOrAddProperty("P", typeof(int)), entityTypeB.GetPrimaryKey(), entityTypeB);
 
             var graph = new EntityTypeGraph();
             graph.Populate(entityTypeA, entityTypeB, entityTypeC);
@@ -602,9 +602,9 @@ namespace Microsoft.Data.Entity.Tests.Utilities
             entityTypeC.GetOrSetPrimaryKey(entityTypeC.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
 
             // A -> B, A -> C, C -> B
-            entityTypeB.GetOrAddForeignKey(entityTypeB.GetOrAddProperty("P", typeof(int)), entityTypeA.GetPrimaryKey());
-            entityTypeC.GetOrAddForeignKey(entityTypeC.GetOrAddProperty("P", typeof(int)), entityTypeA.GetPrimaryKey());
-            entityTypeB.GetOrAddForeignKey(entityTypeB.GetOrAddProperty("P2", typeof(int)), entityTypeC.GetPrimaryKey());
+            entityTypeB.GetOrAddForeignKey(entityTypeB.GetOrAddProperty("P", typeof(int)), entityTypeA.GetPrimaryKey(), entityTypeA);
+            entityTypeC.GetOrAddForeignKey(entityTypeC.GetOrAddProperty("P", typeof(int)), entityTypeA.GetPrimaryKey(), entityTypeA);
+            entityTypeB.GetOrAddForeignKey(entityTypeB.GetOrAddProperty("P2", typeof(int)), entityTypeC.GetPrimaryKey(), entityTypeC);
 
             var graph = new EntityTypeGraph();
             graph.Populate(entityTypeA, entityTypeB, entityTypeC);
@@ -646,7 +646,7 @@ namespace Microsoft.Data.Entity.Tests.Utilities
             entityTypeA.GetOrSetPrimaryKey(entityTypeA.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
 
             // A -> A
-            entityTypeA.GetOrAddForeignKey(entityTypeA.GetOrAddProperty("P", typeof(int)), entityTypeA.GetPrimaryKey());
+            entityTypeA.GetOrAddForeignKey(entityTypeA.GetOrAddProperty("P", typeof(int)), entityTypeA.GetPrimaryKey(), entityTypeA);
 
             var graph = new EntityTypeGraph();
             graph.Populate(entityTypeA);
@@ -671,8 +671,8 @@ namespace Microsoft.Data.Entity.Tests.Utilities
             entityTypeC.GetOrSetPrimaryKey(entityTypeC.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
 
             // C, A -> B -> A
-            entityTypeA.GetOrAddForeignKey(entityTypeA.GetOrAddProperty("P", typeof(int)), entityTypeB.GetPrimaryKey());
-            entityTypeB.GetOrAddForeignKey(entityTypeB.GetOrAddProperty("P", typeof(int)), entityTypeA.GetPrimaryKey());
+            entityTypeA.GetOrAddForeignKey(entityTypeA.GetOrAddProperty("P", typeof(int)), entityTypeB.GetPrimaryKey(), entityTypeB);
+            entityTypeB.GetOrAddForeignKey(entityTypeB.GetOrAddProperty("P", typeof(int)), entityTypeA.GetPrimaryKey(), entityTypeA);
 
             var graph = new EntityTypeGraph();
             graph.Populate(entityTypeC, entityTypeA, entityTypeB);
@@ -697,9 +697,9 @@ namespace Microsoft.Data.Entity.Tests.Utilities
             entityTypeC.GetOrSetPrimaryKey(entityTypeC.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
 
             // A -> C -> B -> A
-            entityTypeA.GetOrAddForeignKey(entityTypeA.GetOrAddProperty("P", typeof(int)), entityTypeB.GetPrimaryKey());
-            entityTypeB.GetOrAddForeignKey(entityTypeB.GetOrAddProperty("P", typeof(int)), entityTypeC.GetPrimaryKey());
-            entityTypeC.GetOrAddForeignKey(entityTypeC.GetOrAddProperty("P", typeof(int)), entityTypeA.GetPrimaryKey());
+            entityTypeA.GetOrAddForeignKey(entityTypeA.GetOrAddProperty("P", typeof(int)), entityTypeB.GetPrimaryKey(), entityTypeB);
+            entityTypeB.GetOrAddForeignKey(entityTypeB.GetOrAddProperty("P", typeof(int)), entityTypeC.GetPrimaryKey(), entityTypeC);
+            entityTypeC.GetOrAddForeignKey(entityTypeC.GetOrAddProperty("P", typeof(int)), entityTypeA.GetPrimaryKey(), entityTypeA);
 
             var graph = new EntityTypeGraph();
             graph.Populate(entityTypeA, entityTypeB, entityTypeC);
@@ -730,14 +730,14 @@ namespace Microsoft.Data.Entity.Tests.Utilities
             entityTypeE.GetOrSetPrimaryKey(entityTypeE.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
 
             // A -> C -> B -> A
-            entityTypeA.GetOrAddForeignKey(entityTypeA.GetOrAddProperty("P", typeof(int)), entityTypeB.GetPrimaryKey());
-            entityTypeB.GetOrAddForeignKey(entityTypeB.GetOrAddProperty("P", typeof(int)), entityTypeC.GetPrimaryKey());
-            entityTypeC.GetOrAddForeignKey(entityTypeC.GetOrAddProperty("P", typeof(int)), entityTypeA.GetPrimaryKey());
+            entityTypeA.GetOrAddForeignKey(entityTypeA.GetOrAddProperty("P", typeof(int)), entityTypeB.GetPrimaryKey(), entityTypeB);
+            entityTypeB.GetOrAddForeignKey(entityTypeB.GetOrAddProperty("P", typeof(int)), entityTypeC.GetPrimaryKey(), entityTypeC);
+            entityTypeC.GetOrAddForeignKey(entityTypeC.GetOrAddProperty("P", typeof(int)), entityTypeA.GetPrimaryKey(), entityTypeA);
 
             // A -> E -> D -> A
-            entityTypeA.GetOrAddForeignKey(entityTypeA.GetOrAddProperty("P2", typeof(int)), entityTypeD.GetPrimaryKey());
-            entityTypeD.GetOrAddForeignKey(entityTypeD.GetOrAddProperty("P2", typeof(int)), entityTypeE.GetPrimaryKey());
-            entityTypeE.GetOrAddForeignKey(entityTypeE.GetOrAddProperty("P2", typeof(int)), entityTypeA.GetPrimaryKey());
+            entityTypeA.GetOrAddForeignKey(entityTypeA.GetOrAddProperty("P2", typeof(int)), entityTypeD.GetPrimaryKey(), entityTypeD);
+            entityTypeD.GetOrAddForeignKey(entityTypeD.GetOrAddProperty("P2", typeof(int)), entityTypeE.GetPrimaryKey(), entityTypeE);
+            entityTypeE.GetOrAddForeignKey(entityTypeE.GetOrAddProperty("P2", typeof(int)), entityTypeA.GetPrimaryKey(), entityTypeA);
 
             var graph = new EntityTypeGraph();
             graph.Populate(entityTypeA, entityTypeB, entityTypeC, entityTypeD, entityTypeE);
@@ -762,9 +762,9 @@ namespace Microsoft.Data.Entity.Tests.Utilities
             entityTypeC.GetOrSetPrimaryKey(entityTypeC.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
 
             // C -> B -> C -> A
-            entityTypeB.GetOrAddForeignKey(entityTypeB.GetOrAddProperty("P", typeof(int)), entityTypeC.GetPrimaryKey());
-            entityTypeC.GetOrAddForeignKey(entityTypeC.GetOrAddProperty("P", typeof(int)), entityTypeB.GetPrimaryKey());
-            entityTypeA.GetOrAddForeignKey(entityTypeA.GetOrAddProperty("P", typeof(int)), entityTypeC.GetPrimaryKey());
+            entityTypeB.GetOrAddForeignKey(entityTypeB.GetOrAddProperty("P", typeof(int)), entityTypeC.GetPrimaryKey(), entityTypeC);
+            entityTypeC.GetOrAddForeignKey(entityTypeC.GetOrAddProperty("P", typeof(int)), entityTypeB.GetPrimaryKey(), entityTypeB);
+            entityTypeA.GetOrAddForeignKey(entityTypeA.GetOrAddProperty("P", typeof(int)), entityTypeC.GetPrimaryKey(), entityTypeC);
 
             var graph = new EntityTypeGraph();
             graph.Populate(entityTypeA, entityTypeB, entityTypeC);

--- a/test/EntityFramework.CrossStore.FunctionalTests/EndToEndTest.cs
+++ b/test/EntityFramework.CrossStore.FunctionalTests/EndToEndTest.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Microsoft.Data.Entity.FunctionalTests.TestModels;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.InMemory.FunctionalTests;
+using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Sqlite.FunctionalTests;
 using Microsoft.Data.Entity.SqlServer.FunctionalTests;
 using Xunit;

--- a/test/EntityFramework.SqlServer.Tests/SqlServerTypeMapperTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerTypeMapperTest.cs
@@ -210,7 +210,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         public void Does_key_SQL_Server_string_mapping()
         {
             var property = CreateEntityType().AddProperty("MyProp", typeof(string), shadowProperty: true);
-            property.EntityType.SetPrimaryKey(property);
+            property.DeclaringEntityType.SetPrimaryKey(property);
             property.IsNullable = false;
 
             var typeMapping = new SqlServerTypeMapper().MapPropertyType(property);
@@ -224,9 +224,9 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         public void Does_foreign_key_SQL_Server_string_mapping()
         {
             var property = CreateEntityType().AddProperty("MyProp", typeof(string), shadowProperty: true);
-            var fkProperty = property.EntityType.AddProperty("FK", typeof(string), shadowProperty: true);
-            var pk = property.EntityType.SetPrimaryKey(property);
-            property.EntityType.AddForeignKey(fkProperty, pk);
+            var fkProperty = property.DeclaringEntityType.AddProperty("FK", typeof(string), shadowProperty: true);
+            var pk = property.DeclaringEntityType.SetPrimaryKey(property);
+            property.DeclaringEntityType.AddForeignKey(fkProperty, pk, property.DeclaringEntityType);
 
             var typeMapping = new SqlServerTypeMapper().MapPropertyType(fkProperty);
 
@@ -239,9 +239,9 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         public void Does_required_foreign_key_SQL_Server_string_mapping()
         {
             var property = CreateEntityType().AddProperty("MyProp", typeof(string), shadowProperty: true);
-            var fkProperty = property.EntityType.AddProperty("FK", typeof(string), shadowProperty: true);
-            var pk = property.EntityType.SetPrimaryKey(property);
-            property.EntityType.AddForeignKey(fkProperty, pk);
+            var fkProperty = property.DeclaringEntityType.AddProperty("FK", typeof(string), shadowProperty: true);
+            var pk = property.DeclaringEntityType.SetPrimaryKey(property);
+            property.DeclaringEntityType.AddForeignKey(fkProperty, pk, property.DeclaringEntityType);
             fkProperty.IsNullable = false;
 
             var typeMapping = new SqlServerTypeMapper().MapPropertyType(fkProperty);
@@ -305,7 +305,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         public void Does_key_SQL_Server_binary_mapping()
         {
             var property = CreateEntityType().AddProperty("MyProp", typeof(byte[]), shadowProperty: true);
-            property.EntityType.SetPrimaryKey(property);
+            property.DeclaringEntityType.SetPrimaryKey(property);
             property.IsNullable = false;
 
             var typeMapping = new SqlServerTypeMapper().MapPropertyType(property);
@@ -319,9 +319,9 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         public void Does_foreign_key_SQL_Server_binary_mapping()
         {
             var property = CreateEntityType().AddProperty("MyProp", typeof(byte[]), shadowProperty: true);
-            var fkProperty = property.EntityType.AddProperty("FK", typeof(byte[]), shadowProperty: true);
-            var pk = property.EntityType.SetPrimaryKey(property);
-            property.EntityType.AddForeignKey(fkProperty, pk);
+            var fkProperty = property.DeclaringEntityType.AddProperty("FK", typeof(byte[]), shadowProperty: true);
+            var pk = property.DeclaringEntityType.SetPrimaryKey(property);
+            property.DeclaringEntityType.AddForeignKey(fkProperty, pk, property.DeclaringEntityType);
 
             var typeMapping = new SqlServerTypeMapper().MapPropertyType(fkProperty);
 
@@ -334,9 +334,9 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         public void Does_required_foreign_key_SQL_Server_binary_mapping()
         {
             var property = CreateEntityType().AddProperty("MyProp", typeof(byte[]), shadowProperty: true);
-            var fkProperty = property.EntityType.AddProperty("FK", typeof(byte[]), shadowProperty: true);
-            var pk = property.EntityType.SetPrimaryKey(property);
-            property.EntityType.AddForeignKey(fkProperty, pk);
+            var fkProperty = property.DeclaringEntityType.AddProperty("FK", typeof(byte[]), shadowProperty: true);
+            var pk = property.DeclaringEntityType.SetPrimaryKey(property);
+            property.DeclaringEntityType.AddForeignKey(fkProperty, pk, property.DeclaringEntityType);
             fkProperty.IsNullable = false;
 
             var typeMapping = new SqlServerTypeMapper().MapPropertyType(fkProperty);

--- a/tools/Resources.cs
+++ b/tools/Resources.cs
@@ -1,4 +1,0 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-
-


### PR DESCRIPTION
Add inheritance support to EntityType.Navigations and EntityType.GetForeignKeys()
Use the root type for key values
Expose EntityType on EntityKey
Use inherited FKs and referencing FKs when finding related entities
Make the principal entity type required on FK constructor
Rename Navigation.EntityType, Property.EntityType, Key.EntityType, Index.EntityType and ForeignKey.EntityType to DeclaringEntityType
Move IEntityType.GetProperty(string) and IEntityType.GetNavigation(string) to extension methods
Add FindForeignKey, FindIndex and FindKey to IEntityType