### PR TITLE
Fix #2192. Throw only one level of AggregateException.

### DIFF
--- a/src/EntityFramework.Core/Query/AsyncLinqOperatorProvider.cs
+++ b/src/EntityFramework.Core/Query/AsyncLinqOperatorProvider.cs
@@ -149,6 +149,16 @@ namespace Microsoft.Data.Entity.Query
 
                         return await _inner.MoveNext(cancellationToken);
                     }
+                    catch (AggregateException aggregateException)
+                    {
+                        _exceptionInterceptor._queryContext.Logger.LogError(
+                           new DatabaseErrorLogState(_exceptionInterceptor._queryContext.ContextType),
+                           aggregateException.GetBaseException(),
+                           (state, exception) =>
+                               Strings.LogExceptionDuringQueryIteration(Environment.NewLine, exception));
+
+                        throw aggregateException.GetBaseException();
+                    }
                     catch (Exception e)
                     {
                         _exceptionInterceptor._queryContext.Logger.LogError(

--- a/src/EntityFramework.Relational/Migrations/IMigrator.cs
+++ b/src/EntityFramework.Relational/Migrations/IMigrator.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 
 namespace Microsoft.Data.Entity.Migrations
@@ -11,6 +12,8 @@ namespace Microsoft.Data.Entity.Migrations
         IReadOnlyList<Migration> GetUnappliedMigrations();
 
         bool HasPendingModelChanges();
+
+        Task ApplyMigrationsAsync([CanBeNull] string targetMigration = null);
 
         void ApplyMigrations([CanBeNull] string targetMigration = null);
 

--- a/src/EntityFramework.Relational/Migrations/Migrator.cs
+++ b/src/EntityFramework.Relational/Migrations/Migrator.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Internal;
@@ -93,6 +94,11 @@ namespace Microsoft.Data.Entity.Migrations
         }
 
         public virtual bool HasPendingModelChanges() => _modelDiffer.HasDifferences(_migrationAssembly.LastModel, _model);
+
+        public async Task ApplyMigrationsAsync(string targetMigration = null)
+        {
+            await Task.Run(() => ApplyMigrations(targetMigration));
+        }
 
         public virtual void ApplyMigrations(string targetMigration = null)
         {

--- a/src/EntityFramework.Relational/RelationalDatabaseFacadeExtensions.cs
+++ b/src/EntityFramework.Relational/RelationalDatabaseFacadeExtensions.cs
@@ -20,6 +20,9 @@ namespace Microsoft.Data.Entity
         public static void ApplyMigrations([NotNull] this DatabaseFacade databaseFacade)
             => Check.NotNull(databaseFacade, nameof(databaseFacade)).GetService<IMigrator>().ApplyMigrations();
 
+        public static async Task ApplyMigrationsAsync([NotNull] this DatabaseFacade databaseFacade)
+            => await Check.NotNull(databaseFacade, nameof(databaseFacade)).GetService<IMigrator>().ApplyMigrationsAsync();
+
         public static DbConnection GetDbConnection([NotNull] this DatabaseFacade databaseFacade)
             => GetRelationalConnection(databaseFacade).DbConnection;
 

--- a/test/EntityFramework.Relational.Tests/RelationalDatabaseFacadeExtensionsTest.cs
+++ b/test/EntityFramework.Relational.Tests/RelationalDatabaseFacadeExtensionsTest.cs
@@ -6,9 +6,9 @@ using System.Data;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Data.Entity.Migrations;
 using Microsoft.Data.Entity.Relational.Internal;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Data.Entity.Tests;
 using Microsoft.Framework.DependencyInjection;
 using Moq;
 using Xunit;
@@ -220,6 +220,31 @@ namespace Microsoft.Data.Entity.Tests
             context.Database.RollbackTransaction();
 
             transactionMock.Verify(m => m.Rollback(), Times.Once);
+        }
+
+        [Fact]
+        public void Can_apply_migration()
+        {
+            var migratorMock = new Mock<IMigrator>();
+
+            var context = RelationalTestHelpers.Instance.CreateContext(
+                new ServiceCollection().AddInstance(migratorMock.Object));
+
+            context.Database.ApplyMigrations();
+
+            migratorMock.Verify(m => m.ApplyMigrations(null), Times.Once);
+        }
+
+        [Fact]
+        public void Can_apply_migration_async()
+        {
+            var migratorMock = new Mock<IMigrator>();
+            var context = RelationalTestHelpers.Instance.CreateContext(
+                new ServiceCollection().AddInstance(migratorMock.Object));
+
+            context.Database.ApplyMigrationsAsync();
+
+            migratorMock.Verify(m => m.ApplyMigrationsAsync(null), Times.Once);
         }
     }
 }

--- a/test/EntityFramework.SqlServer.FunctionalTests/AsyncQuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/AsyncQuerySqlServerTest.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         {
             await AssertQuery<Customer>(
                 cs => cs.Where(c => c.ContactName.Contains("M")), // case-insensitive
-                cs => cs.Where(c => c.ContactName.Contains("M") 
+                cs => cs.Where(c => c.ContactName.Contains("M")
                                      || c.ContactName.Contains("m")), // case-sensitive
                 entryCount: 34);
         }
@@ -44,7 +44,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         {
             await AssertQuery<Customer>(
                 cs => cs.Where(c => c.ContactName.Contains(LocalMethod1())), // case-insensitive
-                cs => cs.Where(c => c.ContactName.Contains(LocalMethod1()) 
+                cs => cs.Where(c => c.ContactName.Contains(LocalMethod1())
                                     || c.ContactName.Contains(LocalMethod2())), // case-sensitive
                 entryCount: 34);
         }
@@ -59,6 +59,24 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         {
             await Assert.ThrowsAsync<TaskCanceledException>(async () =>
                 await Single_Predicate_Cancellation(TestSqlLoggerFactory.CancelQuery()));
+        }
+
+        [Fact]
+        public async Task Invalid_query_should_not_generate_nested_aggregates()
+        {
+            AggregateException exception = await Assert.ThrowsAsync<AggregateException>(async () =>
+                {
+                    using (var context = CreateContext())
+                    {
+                        await context.Products
+                            .Where(p => p.ProductID == 1)
+                            .Take(50)
+                            .Skip(5)
+                            .ToArrayAsync();
+                    }
+                });
+
+            Assert.IsNotType<AggregateException>(exception.InnerException);
         }
 
         public AsyncQuerySqlServerTest(NorthwindQuerySqlServerFixture fixture)

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerMigrationsTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerMigrationsTest.cs
@@ -30,6 +30,20 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             }
         }
 
+        [Fact]
+        public async Task Empty_Migration_Creates_Database_Async()
+        {
+            using (var testDatabase = await SqlServerTestStore.CreateScratchAsync(createDatabase: false))
+            {
+                using (var context = CreateContext(testDatabase))
+                {
+                    await context.Database.ApplyMigrationsAsync();
+
+                    Assert.True(context.GetService<IRelationalDatabaseCreator>().Exists());
+                }
+            }
+        }
+
         private static BloggingContext CreateContext(SqlServerTestStore testStore)
         {
             var serviceProvider =


### PR DESCRIPTION
I added specific catch for AggregateException.  [As per SO answer here](http://stackoverflow.com/questions/30233542/many-nested-aggregateexceptions) i just applied GetBaseException() method to catched exception for logger (to log actual error) and rethrow this actual error to clean all redundant layers of aggregation.