### PR TITLE
[SMALL] Moving non-SqlServer-specific code into Relational.Design for re-use

### DIFF
--- a/src/EntityFramework.Relational.Design/EntityFramework.Relational.Design.csproj
+++ b/src/EntityFramework.Relational.Design/EntityFramework.Relational.Design.csproj
@@ -62,8 +62,10 @@
     <Compile Include="..\Shared\SharedTypeExtensions.cs" />
     <Compile Include="ReverseEngineering\Configuration\EntityConfiguration.cs" />
     <Compile Include="ReverseEngineering\Configuration\FacetConfiguration.cs" />
-    <Compile Include="ReverseEngineering\Configuration\NavigationConfiguration.cs" />
+    <Compile Include="ReverseEngineering\Configuration\NavigationPropertyConfiguration.cs" />
+    <Compile Include="ReverseEngineering\Configuration\NavigationPropertyInitializerConfiguration.cs" />
     <Compile Include="ReverseEngineering\Configuration\PropertyConfiguration.cs" />
+    <Compile Include="ReverseEngineering\Configuration\RelationshipConfiguration.cs" />
     <Compile Include="ReverseEngineering\DbContextCodeGeneratorHelper.cs" />
     <Compile Include="ReverseEngineering\DbContextGeneratorModel.cs" />
     <Compile Include="ReverseEngineering\EntityTypeCodeGeneratorHelper.cs" />
@@ -72,6 +74,7 @@
     <Compile Include="ReverseEngineering\IDatabaseMetadataModelProvider.cs" />
     <Compile Include="ReverseEngineering\IDesignTimeMetadataProviderFactory.cs" />
     <Compile Include="ReverseEngineering\IFileService.cs" />
+    <Compile Include="ReverseEngineering\MetadataModelNameMapper.cs" />
     <Compile Include="ReverseEngineering\ReverseEngineeringConfiguration.cs" />
     <Compile Include="ReverseEngineering\ReverseEngineeringGenerator.cs" />
     <Compile Include="Templating\Compilation\CompiledAssemblyResult.cs" />

--- a/src/EntityFramework.Relational.Design/ReverseEngineering/Configuration/EntityConfiguration.cs
+++ b/src/EntityFramework.Relational.Design/ReverseEngineering/Configuration/EntityConfiguration.cs
@@ -20,6 +20,6 @@ namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering.Configurati
         public virtual IEntityType EntityType { get; [param: NotNull] private set; }
         public virtual List<FacetConfiguration> FacetConfigurations { get; } = new List<FacetConfiguration>();
         public virtual List<PropertyConfiguration> PropertyConfigurations { get; } = new List<PropertyConfiguration>();
-        public virtual List<NavigationConfiguration> NavigationConfigurations { get; } = new List<NavigationConfiguration>();
+        public virtual List<RelationshipConfiguration> RelationshipConfigurations { get; } = new List<RelationshipConfiguration>();
     }
 }

--- a/src/EntityFramework.Relational.Design/ReverseEngineering/Configuration/NavigationPropertyConfiguration.cs
+++ b/src/EntityFramework.Relational.Design/ReverseEngineering/Configuration/NavigationPropertyConfiguration.cs
@@ -4,18 +4,18 @@
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Utilities;
 
-namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering.Configuration
+namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering.Configuration
 {
-    public class SqlServerNavigationProperty
+    public class NavigationPropertyConfiguration
     {
-        public SqlServerNavigationProperty([NotNull] string errorAnnotation)
+        public NavigationPropertyConfiguration([NotNull] string errorAnnotation)
         {
             Check.NotEmpty(errorAnnotation, nameof(errorAnnotation));
 
             ErrorAnnotation = errorAnnotation;
         }
 
-        public SqlServerNavigationProperty([NotNull] string type, [NotNull] string name)
+        public NavigationPropertyConfiguration([NotNull] string type, [NotNull] string name)
         {
             Check.NotNull(type, nameof(type));
             Check.NotEmpty(name, nameof(name));

--- a/src/EntityFramework.Relational.Design/ReverseEngineering/Configuration/NavigationPropertyInitializerConfiguration.cs
+++ b/src/EntityFramework.Relational.Design/ReverseEngineering/Configuration/NavigationPropertyInitializerConfiguration.cs
@@ -4,11 +4,11 @@
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Utilities;
 
-namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering.Configuration
+namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering.Configuration
 {
-    public class SqlServerNavigationPropertyInitializer
+    public class NavigationPropertyInitializerConfiguration
     {
-        public SqlServerNavigationPropertyInitializer([NotNull] string navPropName, [NotNull] string principalEntityTypeName)
+        public NavigationPropertyInitializerConfiguration([NotNull] string navPropName, [NotNull] string principalEntityTypeName)
         {
             Check.NotEmpty(navPropName, nameof(navPropName));
             Check.NotEmpty(principalEntityTypeName, nameof(principalEntityTypeName));

--- a/src/EntityFramework.Relational.Design/ReverseEngineering/Configuration/RelationshipConfiguration.cs
+++ b/src/EntityFramework.Relational.Design/ReverseEngineering/Configuration/RelationshipConfiguration.cs
@@ -7,9 +7,9 @@ using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering.Configuration
 {
-    public class NavigationConfiguration
+    public class RelationshipConfiguration
     {
-        public NavigationConfiguration([NotNull] EntityConfiguration entityConfiguration,
+        public RelationshipConfiguration([NotNull] EntityConfiguration entityConfiguration,
             [NotNull] IForeignKey foreignKey, [NotNull] string dependentEndNavigationPropertyName,
             [NotNull] string principalEndNavigationPropertyName)
         {

--- a/src/EntityFramework.Relational.Design/ReverseEngineering/DbContextCodeGeneratorHelper.cs
+++ b/src/EntityFramework.Relational.Design/ReverseEngineering/DbContextCodeGeneratorHelper.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering
 
                     if (entityConfiguration.FacetConfigurations.Any()
                         || entityConfiguration.PropertyConfigurations.Any()
-                        || entityConfiguration.NavigationConfigurations.Any())
+                        || entityConfiguration.RelationshipConfigurations.Any())
                     {
                         entityConfigurations.Add(entityConfiguration);
                     }

--- a/src/EntityFramework.Relational.Design/ReverseEngineering/MetadataModelNameMapper.cs
+++ b/src/EntityFramework.Relational.Design/ReverseEngineering/MetadataModelNameMapper.cs
@@ -9,9 +9,9 @@ using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Relational.Design.CodeGeneration;
 using Microsoft.Data.Entity.Utilities;
 
-namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering
+namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering
 {
-    public class SqlServerNameMapper
+    public class MetadataModelNameMapper
     {
         private readonly IModel _sourceModel;
         private readonly Func<IEntityType, string> _defaultEntityNameFunc;
@@ -19,7 +19,7 @@ namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering
         private Dictionary<IEntityType, string> _entityTypeToClassNameMap;
         private Dictionary<IProperty, string> _propertyToPropertyNameMap;
 
-        public SqlServerNameMapper([NotNull] IModel sourceModel,
+        public MetadataModelNameMapper([NotNull] IModel sourceModel,
             [NotNull] Func<IEntityType, string> defaultEntityNameFunc,
             [NotNull] Func<IProperty, string> defaultPropertyNameFunc)
         {

--- a/src/EntityFramework.Relational.Design/Utilities/ModelUtilities.cs
+++ b/src/EntityFramework.Relational.Design/Utilities/ModelUtilities.cs
@@ -81,17 +81,18 @@ namespace Microsoft.Data.Entity.Relational.Design.Utilities
             return foreignKey.DeclaringEntityType.DisplayName();
         }
 
-        public virtual string ConstructNavigationConfiguration([NotNull] NavigationConfiguration navigationConfiguration)
+        public virtual string ConstructRelationshipConfiguration(
+            [NotNull] RelationshipConfiguration relationshipConfiguration)
         {
-            Check.NotNull(navigationConfiguration, nameof(navigationConfiguration));
+            Check.NotNull(relationshipConfiguration, nameof(relationshipConfiguration));
 
             var sb = new StringBuilder();
             sb.Append("Reference");
             sb.Append("(d => d.");
-            sb.Append(navigationConfiguration.DependentEndNavigationPropertyName);
+            sb.Append(relationshipConfiguration.DependentEndNavigationPropertyName);
             sb.Append(")");
 
-            if (navigationConfiguration.ForeignKey.IsUnique)
+            if (relationshipConfiguration.ForeignKey.IsUnique)
             {
                 sb.Append(".InverseReference(");
             }
@@ -99,25 +100,25 @@ namespace Microsoft.Data.Entity.Relational.Design.Utilities
             {
                 sb.Append(".InverseCollection(");
             }
-            if (!string.IsNullOrEmpty(navigationConfiguration.PrincipalEndNavigationPropertyName))
+            if (!string.IsNullOrEmpty(relationshipConfiguration.PrincipalEndNavigationPropertyName))
             {
                 sb.Append("p => p.");
-                sb.Append(navigationConfiguration.PrincipalEndNavigationPropertyName);
+                sb.Append(relationshipConfiguration.PrincipalEndNavigationPropertyName);
             }
             sb.Append(")");
 
             sb.Append(".ForeignKey");
-            if (navigationConfiguration.ForeignKey.IsUnique)
+            if (relationshipConfiguration.ForeignKey.IsUnique)
             {
                 // If the relationship is 1:1 need to define to which end
                 // the ForeignKey properties belong.
                 sb.Append("<");
-                sb.Append(navigationConfiguration.EntityConfiguration.EntityType.DisplayName());
+                sb.Append(relationshipConfiguration.EntityConfiguration.EntityType.DisplayName());
                 sb.Append(">");
             }
 
             sb.Append("(d => ");
-            sb.Append(GenerateLambdaToKey(navigationConfiguration.ForeignKey.Properties, "d"));
+            sb.Append(GenerateLambdaToKey(relationshipConfiguration.ForeignKey.Properties, "d"));
             sb.Append(")");
 
             return sb.ToString();

--- a/src/EntityFramework.SqlServer.Design/EntityFramework.SqlServer.Design.csproj
+++ b/src/EntityFramework.SqlServer.Design/EntityFramework.SqlServer.Design.csproj
@@ -43,8 +43,6 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.tt</DependentUpon>
     </Compile>
-    <Compile Include="ReverseEngineering\Configuration\SqlServerNavigationProperty.cs" />
-    <Compile Include="ReverseEngineering\Configuration\SqlServerNavigationPropertyInitializer.cs" />
     <Compile Include="ReverseEngineering\Model\ForeignKeyColumnMapping.cs" />
     <Compile Include="ReverseEngineering\Model\TableColumn.cs" />
     <Compile Include="ReverseEngineering\Model\TableConstraintColumn.cs" />
@@ -53,7 +51,6 @@
     <Compile Include="ReverseEngineering\SqlServerDesignTimeMetadataProviderFactory.cs" />
     <Compile Include="ReverseEngineering\SqlServerEntityTypeCodeGeneratorHelper.cs" />
     <Compile Include="ReverseEngineering\SqlServerMetadataModelProvider.cs" />
-    <Compile Include="ReverseEngineering\SqlServerNameMapper.cs" />
     <Compile Include="Utilities\SqlServerLiteralUtilities.cs" />
     <Compile Include="Utilities\SqlServerTypeMapping.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/EntityFramework.SqlServer.Design/ReverseEngineering/SqlServerDbContextCodeGeneratorHelper.cs
+++ b/src/EntityFramework.SqlServer.Design/ReverseEngineering/SqlServerDbContextCodeGeneratorHelper.cs
@@ -58,8 +58,8 @@ namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering
                 var principalEndNavigationPropertyName =
                     (string)foreignKey[SqlServerMetadataModelProvider.AnnotationNamePrincipalEndNavPropName];
 
-                entityConfiguration.NavigationConfigurations.Add(
-                    new NavigationConfiguration(entityConfiguration, foreignKey,
+                entityConfiguration.RelationshipConfigurations.Add(
+                    new RelationshipConfiguration(entityConfiguration, foreignKey,
                         dependentEndNavigationPropertyName, principalEndNavigationPropertyName));
             }
         }

--- a/src/EntityFramework.SqlServer.Design/ReverseEngineering/SqlServerEntityTypeCodeGeneratorHelper.cs
+++ b/src/EntityFramework.SqlServer.Design/ReverseEngineering/SqlServerEntityTypeCodeGeneratorHelper.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Relational.Design.ReverseEngineering;
-using Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering.Configuration;
+using Microsoft.Data.Entity.Relational.Design.ReverseEngineering.Configuration;
 
 namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering
 {
@@ -27,11 +27,11 @@ namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering
             }
         }
 
-        public virtual IEnumerable<SqlServerNavigationPropertyInitializer> NavPropInitializers
+        public virtual IEnumerable<NavigationPropertyInitializerConfiguration> NavPropInitializers
         {
             get
             {
-                var navPropInitializers = new List<SqlServerNavigationPropertyInitializer>();
+                var navPropInitializers = new List<NavigationPropertyInitializerConfiguration>();
 
                 foreach (var otherEntityType in GeneratorModel.EntityType.Model
                     .EntityTypes.Where(et => et != GeneratorModel.EntityType))
@@ -48,7 +48,7 @@ namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering
                             if (!foreignKey.IsUnique)
                             {
                                 navPropInitializers.Add(
-                                    new SqlServerNavigationPropertyInitializer(
+                                    new NavigationPropertyInitializerConfiguration(
                                         navigationPropertyName, otherEntityType.Name));
                             }
                         }
@@ -59,11 +59,11 @@ namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering
             }
         }
 
-        public virtual IEnumerable<SqlServerNavigationProperty> NavigationProperties
+        public virtual IEnumerable<NavigationPropertyConfiguration> NavigationProperties
         {
             get
             {
-                var navProps = new List<SqlServerNavigationProperty>();
+                var navProps = new List<NavigationPropertyConfiguration>();
 
                 foreach (var otherEntityType in GeneratorModel.EntityType.Model
                     .EntityTypes.Where(et => et != GeneratorModel.EntityType))
@@ -76,7 +76,7 @@ namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering
                         if (((EntityType)otherEntityType)
                             .FindAnnotation(SqlServerMetadataModelProvider.AnnotationNameEntityTypeError) != null)
                         {
-                            navProps.Add(new SqlServerNavigationProperty(
+                            navProps.Add(new NavigationPropertyConfiguration(
                                 Strings.UnableToAddNavigationProperty(otherEntityType.Name)));
                         }
                         else
@@ -84,7 +84,7 @@ namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering
                             var referencedType = foreignKey.IsUnique
                                 ? otherEntityType.Name
                                 : "ICollection<" + otherEntityType.Name + ">";
-                            navProps.Add(new SqlServerNavigationProperty(
+                            navProps.Add(new NavigationPropertyConfiguration(
                                 referencedType,
                                 (string)foreignKey[SqlServerMetadataModelProvider.AnnotationNamePrincipalEndNavPropName]));
                         }
@@ -94,7 +94,7 @@ namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering
                 foreach (var foreignKey in GeneratorModel.EntityType.GetForeignKeys())
                 {
                     // set up the navigation property on this end of foreign keys owned by this EntityType
-                    navProps.Add(new SqlServerNavigationProperty(
+                    navProps.Add(new NavigationPropertyConfiguration(
                         foreignKey.PrincipalEntityType.Name,
                         (string)foreignKey[SqlServerMetadataModelProvider.AnnotationNameDependentEndNavPropName]));
 
@@ -104,7 +104,7 @@ namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering
                         var referencedType = foreignKey.IsUnique
                             ? foreignKey.DeclaringEntityType.Name
                             : "ICollection<" + foreignKey.DeclaringEntityType.Name + ">";
-                        navProps.Add(new SqlServerNavigationProperty(
+                        navProps.Add(new NavigationPropertyConfiguration(
                             referencedType,
                             (string)foreignKey[SqlServerMetadataModelProvider.AnnotationNamePrincipalEndNavPropName]));
                     }

--- a/src/EntityFramework.SqlServer.Design/ReverseEngineering/SqlServerMetadataModelProvider.cs
+++ b/src/EntityFramework.SqlServer.Design/ReverseEngineering/SqlServerMetadataModelProvider.cs
@@ -247,7 +247,7 @@ namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering
             // names fit CSharp conventions etc.
             var relationalModel = ConstructRelationalModel();
 
-            var nameMapper = new SqlServerNameMapper(
+            var nameMapper = new MetadataModelNameMapper(
                 relationalModel,
                 entity => _tables[entity.Name].TableName,
                 property => _tableColumns[property.Name].ColumnName);
@@ -297,7 +297,7 @@ namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering
         }
 
         public virtual IModel ConstructCodeGenModel(
-            [NotNull] IModel relationalModel, [NotNull] SqlServerNameMapper nameMapper)
+            [NotNull] IModel relationalModel, [NotNull] MetadataModelNameMapper nameMapper)
         {
             Check.NotNull(relationalModel, nameof(relationalModel));
             Check.NotNull(nameMapper, nameof(nameMapper));

--- a/src/EntityFramework.SqlServer.Design/ReverseEngineering/Templates/SqlServerDbContextTemplate.cshtml
+++ b/src/EntityFramework.SqlServer.Design/ReverseEngineering/Templates/SqlServerDbContextTemplate.cshtml
@@ -112,14 +112,14 @@ var firstEntity = true;
         }
     }
     var firstNavigation = true;
-    @foreach (var navigationConfig in entityConfig.NavigationConfigurations)
+    @foreach (var relationshipConfig in entityConfig.RelationshipConfigurations)
     {
         @if (!firstEntityFacet || !firstProperty || !firstNavigation)
         {
 @:
         }
         firstNavigation = false;
-@:                entity.@Model.Generator.ModelUtilities.ConstructNavigationConfiguration(navigationConfig);
+@:                entity.@Model.Generator.ModelUtilities.ConstructRelationshipConfiguration(relationshipConfig);
     }
 @:            });
 }

--- a/src/EntityFramework.SqlServer.Design/ReverseEngineering/Templates/SqlServerEntityTypeTemplate.cshtml
+++ b/src/EntityFramework.SqlServer.Design/ReverseEngineering/Templates/SqlServerEntityTypeTemplate.cshtml
@@ -1,6 +1,5 @@
 @inherits Microsoft.Data.Entity.Relational.Design.Templating.RazorReverseEngineeringBase
-@using Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering
-@using Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering.Configuration
+@using Microsoft.Data.Entity.Relational.Design.ReverseEngineering.Configuration
 @{
     string errorMessageAnnotation = Model.Helper.ErrorMessageAnnotation;
 }@if (errorMessageAnnotation != null) {
@@ -34,7 +33,7 @@ else {
     @if ((int)(Model.Helper.NavigationProperties.Count) > 0)
     {
 @:
-        @foreach (SqlServerNavigationProperty navProp in Model.Helper.NavigationProperties)
+        @foreach (NavigationPropertyConfiguration navProp in Model.Helper.NavigationProperties)
         {
             @if (navProp.ErrorAnnotation != null)
             {


### PR DESCRIPTION
See #830. This is mostly just moving classes from SqlServer.Design to Relational.Design. Other providers can use these classes if we move them there. Also renamed NavigationConfiguration to RelationshipConfiguration which better describes it.

@ErikEJ - this will help with your provider.