### PR TITLE
RevEng: Add testing that the generated files compile.

### DIFF
--- a/src/EntityFramework.Relational.Design/ReverseEngineering/DbContextCodeGeneratorHelper.cs
+++ b/src/EntityFramework.Relational.Design/ReverseEngineering/DbContextCodeGeneratorHelper.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering
             {
                 entityConfiguration.FacetConfigurations.Add(
                     new FacetConfiguration(
-                        string.Format(CultureInfo.InvariantCulture, "Table({0}, {1})",
+                        string.Format(CultureInfo.InvariantCulture, "ToTable({0}, {1})",
                             CSharpUtilities.Instance.DelimitString(entityType.Relational().Table),
                             CSharpUtilities.Instance.DelimitString(entityType.Relational().Schema))));
             }
@@ -135,7 +135,7 @@ namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering
             {
                 entityConfiguration.FacetConfigurations.Add(
                     new FacetConfiguration(
-                        string.Format(CultureInfo.InvariantCulture, "Table({0})",
+                        string.Format(CultureInfo.InvariantCulture, "ToTable({0})",
                             CSharpUtilities.Instance.DelimitString(entityType.Relational().Table))));
             }
         }

--- a/src/EntityFramework.Relational.Design/Templating/Compilation/CompilationResult.cs
+++ b/src/EntityFramework.Relational.Design/Templating/Compilation/CompilationResult.cs
@@ -13,19 +13,15 @@ namespace Microsoft.Data.Entity.Relational.Design.Templating.Compilation
     {
         private readonly Type _type;
 
-        private CompilationResult([NotNull] string generatedCode, [CanBeNull] Type type, [NotNull] IEnumerable<string> messages)
+        private CompilationResult([CanBeNull] Type type, [NotNull] IEnumerable<string> messages)
         {
-            Check.NotNull(generatedCode, nameof(generatedCode));
             Check.NotNull(messages, nameof(messages));
 
             _type = type;
-            GeneratedCode = generatedCode;
             Messages = messages;
         }
 
         public IEnumerable<string> Messages { get; }
-
-        public string GeneratedCode { get; }
 
         public Type CompiledType
         {
@@ -33,27 +29,25 @@ namespace Microsoft.Data.Entity.Relational.Design.Templating.Compilation
             {
                 if (_type == null)
                 {
-                    throw new TemplateProcessingException(Messages, GeneratedCode);
+                    throw new TemplateProcessingException(Messages);
                 }
 
                 return _type;
             }
         }
 
-        public static CompilationResult Failed([NotNull] string generatedCode, [NotNull] IEnumerable<string> messages)
+        public static CompilationResult Failed([NotNull] IEnumerable<string> messages)
         {
-            Check.NotNull(generatedCode, nameof(generatedCode));
             Check.NotNull(messages, nameof(messages));
 
-            return new CompilationResult(generatedCode, type: null, messages: messages);
+            return new CompilationResult(type: null, messages: messages);
         }
 
-        public static CompilationResult Successful([NotNull] string generatedCode, [NotNull] Type type)
+        public static CompilationResult Successful([NotNull] Type type)
         {
-            Check.NotNull(generatedCode, nameof(generatedCode));
             Check.NotNull(type, nameof(type));
 
-            return new CompilationResult(generatedCode, type, Enumerable.Empty<string>());
+            return new CompilationResult(type, Enumerable.Empty<string>());
         }
     }
 }

--- a/src/EntityFramework.Relational.Design/Templating/Compilation/ICompilationService.cs
+++ b/src/EntityFramework.Relational.Design/Templating/Compilation/ICompilationService.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Data.Entity.Relational.Design.Templating.Compilation
 {
     public interface ICompilationService
     {
-        CompilationResult Compile([NotNull] string content, [NotNull] List<MetadataReference> references);
+        CompilationResult Compile(
+            [NotNull] IEnumerable<string> contents, [NotNull] List<MetadataReference> references);
     }
 }

--- a/src/EntityFramework.Relational.Design/Templating/Compilation/RoslynCompilationService.cs
+++ b/src/EntityFramework.Relational.Design/Templating/Compilation/RoslynCompilationService.cs
@@ -16,12 +16,14 @@ namespace Microsoft.Data.Entity.Relational.Design.Templating.Compilation
 {
     public class RoslynCompilationService : ICompilationService
     {
-        public virtual CompilationResult Compile([NotNull] string content, [NotNull] List<MetadataReference> references)
+        public virtual CompilationResult Compile(
+            [NotNull] IEnumerable<string> contents, [NotNull] List<MetadataReference> references)
         {
-            Check.NotEmpty(content, nameof(content));
+            Check.NotNull(contents, nameof(contents));
             Check.NotNull(references, nameof(references));
 
-            var syntaxTrees = new[] { CSharpSyntaxTree.ParseText(content) };
+            var syntaxTrees = contents
+                .Select(content => CSharpSyntaxTree.ParseText(content));
 
             var assemblyName = Path.GetRandomFileName();
 
@@ -36,9 +38,9 @@ namespace Microsoft.Data.Entity.Relational.Design.Templating.Compilation
                 var type = result.Assembly.GetExportedTypes()
                     .First();
 
-                return CompilationResult.Successful(string.Empty, type);
+                return CompilationResult.Successful(type);
             }
-            return CompilationResult.Failed(content, result.ErrorMessages);
+            return CompilationResult.Failed(result.ErrorMessages);
         }
 
         public static CompiledAssemblyResult GetAssemblyFromCompilation(

--- a/src/EntityFramework.Relational.Design/Templating/RazorTemplating.cs
+++ b/src/EntityFramework.Relational.Design/Templating/RazorTemplating.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -48,19 +49,20 @@ namespace Microsoft.Data.Entity.Relational.Design.Templating
                     return new TemplateResult
                     {
                         GeneratedText = string.Empty,
-                        ProcessingException = new TemplateProcessingException(messages, generatorResults.GeneratedCode)
+                        ProcessingException = new TemplateProcessingException(messages)
                     };
                 }
 
                 provider.AddReferencesForTemplates(_metadataReferencesProvider);
                 var references = _metadataReferencesProvider.GetApplicationReferences();
-                var templateResult = _compilationService.Compile(generatorResults.GeneratedCode, references);
+                var templateResult = _compilationService.Compile(
+                    new List<string> { generatorResults.GeneratedCode }, references);
                 if (templateResult.Messages.Any())
                 {
                     return new TemplateResult
                     {
                         GeneratedText = string.Empty,
-                        ProcessingException = new TemplateProcessingException(templateResult.Messages, generatorResults.GeneratedCode)
+                        ProcessingException = new TemplateProcessingException(templateResult.Messages)
                     };
                 }
 

--- a/src/EntityFramework.Relational.Design/Templating/TemplateProcessingException.cs
+++ b/src/EntityFramework.Relational.Design/Templating/TemplateProcessingException.cs
@@ -9,14 +9,11 @@ namespace Microsoft.Data.Entity.Relational.Design.Templating
 {
     public class TemplateProcessingException : Exception
     {
-        public TemplateProcessingException([NotNull] IEnumerable<string> messages, [NotNull] string generatedCode)
+        public TemplateProcessingException([NotNull] IEnumerable<string> messages)
             : base(FormatMessage(messages))
         {
             Messages = messages;
-            GeneratedCode = generatedCode;
         }
-
-        public virtual string GeneratedCode { get; [param: NotNull] private set; }
 
         public virtual IEnumerable<string> Messages { get; }
 

--- a/test/EntityFramework.SqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E/SqlServerReverseEngineerTestE2EContext.expected
+++ b/test/EntityFramework.SqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E/SqlServerReverseEngineerTestE2EContext.expected
@@ -139,7 +139,7 @@ namespace E2ETest.Namespace
 
             modelBuilder.Entity<Test_Spaces_Keywords_Table>(entity =>
             {
-                entity.Table("Test Spaces Keywords Table");
+                entity.ToTable("Test Spaces Keywords Table");
 
                 entity.Property(e => e.Test_Spaces_Keywords_TableID).HasColumnName("Test Spaces Keywords TableID");
 


### PR DESCRIPTION
Also update the code generation to produce ToTable() instead of old Table() API.
And updated the exceptions to no longer carry around a GeneratedCode property as we were not using it.

See #1669.