### PR TITLE
Fix sentinel bug for nullable types

### DIFF
--- a/src/EntityFramework.Core/ChangeTracking/Internal/EntityKeyFactorySource.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/EntityKeyFactorySource.cs
@@ -34,9 +34,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
                             {
                                 var sentinel = keyProperty.SentinelValue;
 
-                                return (EntityKeyFactory)(keyType.IsNullableType()
-                                    ? Activator.CreateInstance(typeof(SimpleEntityKeyFactory<>).MakeGenericType(keyType.UnwrapNullableType()), sentinel)
-                                    : Activator.CreateInstance(typeof(SimpleEntityKeyFactory<>).MakeGenericType(keyType), sentinel));
+                                return (EntityKeyFactory)(sentinel == null
+                                    ? Activator.CreateInstance(typeof(SimpleNullSentinelEntityKeyFactory<>).MakeGenericType(keyType.UnwrapNullableType()))
+                                    : Activator.CreateInstance(typeof(SimpleEntityKeyFactory<>).MakeGenericType(keyType.UnwrapNullableType()), sentinel));
                             }
                         }
 

--- a/src/EntityFramework.Core/ChangeTracking/Internal/SimpleNullSentinelEntityKeyFactory.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/SimpleNullSentinelEntityKeyFactory.cs
@@ -1,0 +1,27 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Storage;
+
+namespace Microsoft.Data.Entity.ChangeTracking.Internal
+{
+    public class SimpleNullSentinelEntityKeyFactory<TKey> : EntityKeyFactory
+    {
+        public override EntityKey Create(
+            IEntityType entityType, IReadOnlyList<IProperty> properties, ValueBuffer valueBuffer)
+            => Create(entityType, valueBuffer[properties[0].Index]);
+
+        public override EntityKey Create(
+            IEntityType entityType, IReadOnlyList<IProperty> properties, IPropertyAccessor propertyAccessor)
+            => Create(entityType, propertyAccessor[properties[0]]);
+
+        private EntityKey Create(IEntityType entityType, object value)
+        {
+            return value != null
+                ? new SimpleEntityKey<TKey>(entityType, (TKey)value)
+                : EntityKey.InvalidEntityKey;
+        }
+    }
+}

--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -57,6 +57,7 @@
     </Compile>
     <Compile Include="ChangeTracking\ChangeTrackerFactory.cs" />
     <Compile Include="ChangeTracking\IChangeTrackerFactory.cs" />
+    <Compile Include="ChangeTracking\Internal\SimpleNullSentinelEntityKeyFactory.cs" />
     <Compile Include="DbUpdateConcurrencyException.cs" />
     <Compile Include="DbUpdateException.cs" />
     <Compile Include="Extensions\Internal\ExpressionExtensions.cs" />

--- a/test/EntityFramework.Core.FunctionalTests/GraphUpdatesTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/GraphUpdatesTestBase.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.Data.Entity.ChangeTracking;
-using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Internal;
 using Xunit;

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/EntityKeyFactorySourceTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/EntityKeyFactorySourceTest.cs
@@ -19,9 +19,17 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         }
 
         [Fact]
-        public void Returns_a_simple_entity_key_factory_for_single_nullable_property()
+        public void Returns_a_null_sentinel_entity_key_factory_for_single_nullable_property()
         {
             var property = GetEntityType().GetProperty("NullableInt");
+
+            Assert.IsType<SimpleNullSentinelEntityKeyFactory<int>>(CreateKeyFactorySource().GetKeyFactory(new[] { property }));
+        }
+
+        [Fact]
+        public void Returns_a_simple_entity_key_factory_for_single_nullable_property_with_sentinel_set()
+        {
+            var property = GetEntityType().GetProperty("NullableSentinelInt");
 
             Assert.IsType<SimpleEntityKeyFactory<int>>(CreateKeyFactorySource().GetKeyFactory(new[] { property }));
         }
@@ -89,12 +97,21 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         }
 
         [Fact]
-        public void Returns_a_simple_entity_key_factory_for_single_reference_property()
+        public void Returns_a_null_sentinel_entity_key_factory_for_single_reference_property()
         {
             var property = GetEntityType().GetProperty("String");
 
+            Assert.IsType<SimpleNullSentinelEntityKeyFactory<string>>(CreateKeyFactorySource().GetKeyFactory(new[] { property }));
+        }
+
+        [Fact]
+        public void Returns_a_simple_entity_key_factory_for_single_reference_property_with_sentinel_set()
+        {
+            var property = GetEntityType().GetProperty("SentinelString");
+
             Assert.IsType<SimpleEntityKeyFactory<string>>(CreateKeyFactorySource().GetKeyFactory(new[] { property }));
         }
+
 
         [Fact]
         public void Returns_a_composite_entity_key_factory_for_single_structural_property()
@@ -122,7 +139,15 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         {
             var builder = TestHelpers.Instance.CreateConventionBuilder();
 
-            builder.Entity<ScissorSister>();
+            builder.Entity<ScissorSister>()
+                .Property(e => e.NullableSentinelInt)
+                .Metadata
+                .SentinelValue = -1;
+
+            builder.Entity<ScissorSister>()
+                .Property(e => e.SentinelString)
+                .Metadata
+                .SentinelValue = "Excellent!";
 
             return builder.Model.GetEntityType(typeof(ScissorSister));
         }
@@ -131,7 +156,9 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         {
             public int Id { get; set; }
             public int? NullableInt { get; set; }
+            public int? NullableSentinelInt { get; set; }
             public string String { get; set; }
+            public string SentinelString { get; set; }
             public Guid Guid1 { get; set; }
             public Guid Guid2 { get; set; }
             public Guid? NullableGuid1 { get; set; }

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerValueGenerationScenariosTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerValueGenerationScenariosTest.cs
@@ -219,8 +219,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
         public class NoKeyGenerationNullableKey : TestBase<NoKeyGenerationNullableKey.BlogContext>
         {
-            //[Fact]
-            // TODO: Make sentinel null even if property is Required
+            [Fact]
             public void Insert_with_explicit_with_sentinel_keys()
             {
                 using (var context = new BlogContext())
@@ -246,7 +245,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 protected override void OnModelCreating(ModelBuilder modelBuilder)
                 {
                     modelBuilder
-                        .Entity<Blog>()
+                        .Entity<NullableKeyBlog>()
                         .Property(e => e.Id)
                         .ValueGeneratedNever();
                 }


### PR DESCRIPTION
Nullable types were still using the CLR default as a sentinel value in simple key factories. This was because the key factory is, by design, for the unwrapped type (e.g. for nullable FK to non-nullable PK associations.) This change makes a special key factory for the case where the sentinel is null to avoid needing to ever cast the sentinel value to the key type.