### PR TITLE
[SMALL] Fix to #2554 - Relational: Incorrect column binding with the same column name

### DIFF
--- a/src/EntityFramework.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EntityFramework.Relational/Query/RelationalQueryModelVisitor.cs
@@ -220,10 +220,7 @@ namespace Microsoft.Data.Entity.Query
 
             if (selectExpression != null)
             {
-                var previousQuerySource
-                    = index == 0
-                        ? queryModel.MainFromClause
-                        : queryModel.BodyClauses[index - 1] as IQuerySource;
+                var previousQuerySource = FindPreviousQuerySource(queryModel, index);
 
                 if (previousQuerySource != null)
                 {
@@ -251,6 +248,23 @@ namespace Microsoft.Data.Entity.Query
                     }
                 }
             }
+        }
+
+        private IQuerySource FindPreviousQuerySource(QueryModel queryModel, int index)
+        {
+            for (int i = index; i >= 0; i--)
+            {
+                var candidate = i == 0
+                    ? queryModel.MainFromClause
+                    : queryModel.BodyClauses[i - 1] as IQuerySource;
+
+                if (candidate != null)
+                {
+                    return candidate;
+                }
+            }
+
+            return null;
         }
 
         protected override Expression CompileAdditionalFromClauseExpression(
@@ -349,10 +363,7 @@ namespace Microsoft.Data.Entity.Query
             Check.NotNull(joinClause, nameof(joinClause));
             Check.NotNull(queryModel, nameof(queryModel));
 
-            var previousQuerySource
-                = index == 0
-                    ? queryModel.MainFromClause
-                    : queryModel.BodyClauses[index - 1] as IQuerySource;
+            var previousQuerySource = FindPreviousQuerySource(queryModel, index);
 
             var previousSelectExpression
                 = previousQuerySource != null

--- a/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
@@ -2021,6 +2021,60 @@ namespace Microsoft.Data.Entity.FunctionalTests
                  select c).Count());
         }
 
+        [Fact]
+        public virtual void Where_join_select()
+        {
+            AssertQuery<Customer, Order>((cs, os) =>
+                (from c in cs
+                 where c.CustomerID == "ALFKI"
+                 join o in os on c.CustomerID equals o.CustomerID
+                 select c));
+        }
+
+        [Fact]
+        public virtual void Where_orderby_join_select()
+        {
+            AssertQuery<Customer, Order>((cs, os) =>
+                (from c in cs
+                 where c.CustomerID != "ALFKI"
+                 orderby c.CustomerID
+                 join o in os on c.CustomerID equals o.CustomerID
+                 select c));
+        }
+
+        [Fact]
+        public virtual void Where_join_orderby_join_select()
+        {
+            AssertQuery<Customer, Order, OrderDetail>((cs, os, ods) =>
+                (from c in cs
+                 where c.CustomerID != "ALFKI"
+                 join o in os on c.CustomerID equals o.CustomerID
+                 orderby c.CustomerID
+                 join od in ods on o.OrderID equals od.OrderID
+                 select c));
+        }
+
+        [Fact]
+        public virtual void Where_select_many()
+        {
+            AssertQuery<Customer, Order>((cs, os) =>
+                (from c in cs
+                 where c.CustomerID == "ALFKI"
+                 from o in os
+                 select c));
+        }
+
+        [Fact]
+        public virtual void Where_orderby_select_many()
+        {
+            AssertQuery<Customer, Order>((cs, os) =>
+                (from c in cs
+                 where c.CustomerID == "ALFKI"
+                 orderby c.CustomerID
+                 from o in os
+                 select c));
+        }
+
         private class Foo
         {
             // ReSharper disable once UnusedAutoPropertyAccessor.Local

--- a/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -1785,6 +1785,65 @@ INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]", Sql);
 END", Sql);
         }
 
+        public override void Where_join_select()
+        {
+            base.Where_join_select();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] = 'ALFKI'", Sql);
+        }
+
+        public override void Where_orderby_join_select()
+        {
+            base.Where_orderby_join_select();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] <> 'ALFKI'
+ORDER BY [c].[CustomerID]", Sql);
+        }
+
+        public override void Where_join_orderby_join_select()
+        {
+            base.Where_join_orderby_join_select();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+INNER JOIN [Order Details] AS [od] ON [o].[OrderID] = [od].[OrderID]
+WHERE [c].[CustomerID] <> 'ALFKI'
+ORDER BY [c].[CustomerID]", Sql);
+        }
+
+        public override void Where_select_many()
+        {
+            base.Where_select_many();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+CROSS JOIN [Orders] AS [o]
+WHERE [c].[CustomerID] = 'ALFKI'", Sql);
+        }
+
+        public override void Where_orderby_select_many()
+        {
+            base.Where_orderby_select_many();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+CROSS JOIN [Orders] AS [o]
+WHERE [c].[CustomerID] = 'ALFKI'
+ORDER BY [c].[CustomerID]", Sql);
+        }
+
         public override void GroupBy_Distinct()
         {
             base.GroupBy_Distinct();


### PR DESCRIPTION
Problem was that we incorrectly assumed that join body clause will be placed directly after the main clause in the QueryModel. In fact, body clauses are added to the collection in the order in which the query was built. This caused us to be unable to find the previous query source (which we want to join with) and therefore we would not be able to produce a join query on the server.

Fix is to go through list of previously processed body clauses until we find a previous query source, rather than just checking one (previous) body clause.