### PR TITLE
Skip sentinel values when generating keys

### DIFF
--- a/src/EntityFramework.Core/ChangeTracking/Internal/KeyPropagator.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/KeyPropagator.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
                 if (valueGenerator != null)
                 {
-                    entry[property] = valueGenerator.Next();
+                    entry[property] = valueGenerator.NextSkippingSentinel(property);
                 }
             }
         }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/ValueGenerationManager.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/ValueGenerationManager.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
                         Debug.Assert(valueGenerator != null);
 
-                        var generatedValue = valueGenerator.Next();
+                        var generatedValue = valueGenerator.NextSkippingSentinel(property);
                         SetGeneratedValue(entry, property, generatedValue, valueGenerator.GeneratesTemporaryValues);
                     }
                 }

--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -365,6 +365,7 @@
     <Compile Include="ValueGeneration\TemporaryDateTimeValueGenerator.cs" />
     <Compile Include="ValueGeneration\TemporaryGuidValueGenerator.cs" />
     <Compile Include="ValueGeneration\ValueGeneratorCache.cs" />
+    <Compile Include="ValueGeneration\ValueGeneratorExtensions.cs" />
     <Compile Include="ValueGeneration\ValueGeneratorFactory`.cs" />
     <Compile Include="ValueGeneration\ValueGenerator.cs" />
     <Compile Include="ValueGeneration\ValueGeneratorFactory.cs" />

--- a/src/EntityFramework.Core/ValueGeneration/ValueGeneratorExtensions.cs
+++ b/src/EntityFramework.Core/ValueGeneration/ValueGeneratorExtensions.cs
@@ -1,0 +1,27 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.ValueGeneration
+{
+    public static class ValueGeneratorExtensions
+    {
+        public static object NextSkippingSentinel([NotNull] this ValueGenerator valueGenerator, [NotNull] IProperty property)
+        {
+            Check.NotNull(valueGenerator, nameof(valueGenerator));
+            Check.NotNull(property, nameof(property));
+
+            var value = valueGenerator.Next();
+
+            if (property.IsSentinelValue(value))
+            {
+                value = valueGenerator.Next();
+            }
+
+            return value;
+        }
+    }
+}

--- a/test/EntityFramework.Core.Tests/EntityFramework.Core.Tests.csproj
+++ b/test/EntityFramework.Core.Tests/EntityFramework.Core.Tests.csproj
@@ -147,6 +147,7 @@
     <Compile Include="ValueGeneration\TemporaryDateTimeOffsetValueGeneratorTest.cs" />
     <Compile Include="ValueGeneration\TemporaryDateTimeValueGeneratorTest.cs" />
     <Compile Include="ValueGeneration\ValueGeneratorCacheTest.cs" />
+    <Compile Include="ValueGeneration\ValueGeneratorExtensionsTest.cs" />
     <Compile Include="ValueGeneration\ValueGeneratorFactoryTest.cs" />
     <Compile Include="ValueGeneration\TemporaryBinaryValueGeneratorTest.cs" />
     <Compile Include="ValueGeneration\TemporaryNumberValueGeneratorFactoryTest.cs" />

--- a/test/EntityFramework.Core.Tests/ValueGeneration/ValueGeneratorExtensionsTest.cs
+++ b/test/EntityFramework.Core.Tests/ValueGeneration/ValueGeneratorExtensionsTest.cs
@@ -1,0 +1,69 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.ValueGeneration;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Tests.ValueGeneration
+{
+    public class ValueGeneratorExtensionsTest
+    {
+        [Fact]
+        public void Sentinel_value_can_be_skipped_by_value_generator()
+        {
+            var property = GetEntityType().GetProperty("Id");
+
+            var valueGenerator = new TemporaryNumberValueGeneratorFactory().Create(property);
+
+            Assert.Equal(
+                new[] { -2, -3, -4 },
+                new[]
+                {
+                    (int)valueGenerator.NextSkippingSentinel(property),
+                    (int)valueGenerator.NextSkippingSentinel(property),
+                    (int)valueGenerator.NextSkippingSentinel(property)
+                });
+        }
+
+        [Fact]
+        public void Sentinel_value_on_nullable_property_can_be_skipped_by_value_generator()
+        {
+            var property = GetEntityType().GetProperty("NullableInt");
+
+            var valueGenerator = new TemporaryNumberValueGeneratorFactory().Create(property);
+
+            Assert.Equal(
+                new[] { -1, -3, -4 },
+                new[]
+                {
+                    (int)valueGenerator.NextSkippingSentinel(property),
+                    (int)valueGenerator.NextSkippingSentinel(property),
+                    (int)valueGenerator.NextSkippingSentinel(property)
+                });
+        }
+
+        private static IEntityType GetEntityType()
+        {
+            var builder = TestHelpers.Instance.CreateConventionBuilder();
+
+            builder.Entity<AnEntity>()
+                .Property(e => e.Id)
+                .Metadata
+                .SentinelValue = -1;
+
+            builder.Entity<AnEntity>()
+                .Property(e => e.NullableInt)
+                .Metadata
+                .SentinelValue = -2;
+
+            return builder.Model.GetEntityType(typeof(AnEntity));
+        }
+
+        private class AnEntity
+        {
+            public int Id { get; set; }
+            public int? NullableInt { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
This covers the case where the sentinel has been set to, for example, -1, and then the temp key generator tries to generate -1 as a temp key.