### PR TITLE
Prevent unnecessary parameterization of enum constants

### DIFF
--- a/src/EntityFramework7.Core/Query/ExpressionVisitors/ParameterExtractingExpressionVisitor.cs
+++ b/src/EntityFramework7.Core/Query/ExpressionVisitors/ParameterExtractingExpressionVisitor.cs
@@ -66,6 +66,11 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
 
             if (expression.NodeType == ExpressionType.Convert)
             {
+                if(expression.RemoveConvert() is ConstantExpression )
+                {
+                    return expression;
+                }
+
                 var unaryExpression = (UnaryExpression)expression;
 
                 if ((unaryExpression.Type.IsNullableType()

--- a/test/EntityFramework7.Core.FunctionalTests/EntityFramework7.Core.FunctionalTests.csproj
+++ b/test/EntityFramework7.Core.FunctionalTests/EntityFramework7.Core.FunctionalTests.csproj
@@ -72,6 +72,7 @@
     <Compile Include="TestModels\ComplexNavigationsModel\Level2.cs" />
     <Compile Include="TestModels\ComplexNavigationsModel\Level3.cs" />
     <Compile Include="TestModels\ComplexNavigationsModel\Level4.cs" />
+    <Compile Include="TestModels\GearsOfWarModel\AmmunitionType.cs" />
     <Compile Include="TestModels\Inheritance\Animal.cs" />
     <Compile Include="TestModels\Inheritance\Bird.cs" />
     <Compile Include="TestModels\Inheritance\Country.cs" />

--- a/test/EntityFramework7.Core.FunctionalTests/GearsOfWarQueryTestBase.cs
+++ b/test/EntityFramework7.Core.FunctionalTests/GearsOfWarQueryTestBase.cs
@@ -152,16 +152,16 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cityBornGears = context.Cities
                     .Include(c => c.BornGears)
                     .ToDictionary(
-                        c => c.Name, 
-                        c => c.BornGears != null 
-                            ? c.BornGears.Select(g => g.Nickname).ToList() 
+                        c => c.Name,
+                        c => c.BornGears != null
+                            ? c.BornGears.Select(g => g.Nickname).ToList()
                             : new List<string>());
 
                 cityStationedGears = context.Cities
                     .Include(c => c.StationedGears)
                     .ToDictionary(
-                        c => c.Name, 
-                        c => c.StationedGears != null 
+                        c => c.Name,
+                        c => c.StationedGears != null
                             ? c.StationedGears.Select(g => g.Nickname).ToList()
                             : new List<string>());
             }
@@ -227,6 +227,86 @@ namespace Microsoft.Data.Entity.FunctionalTests
                         }
                     }
                 }
+            }
+        }
+
+        [Fact]
+        public virtual void Where_enum()
+        {
+            using (var context = CreateContext())
+            {
+                var gears = context.Gears
+                    .Where(g => g.Rank == MilitaryRank.Sergeant)
+                    .ToList();
+
+                Assert.Equal(1, gears.Count);
+            }
+        }
+
+        [Fact]
+        public virtual void Where_nullable_enum_with_constant()
+        {
+            using (var context = CreateContext())
+            {
+                var weapons = context.Weapons
+                    .Where(w => w.AmmunitionType == AmmunitionType.Cartridge)
+                    .ToList();
+
+                Assert.Equal(5, weapons.Count);
+            }
+        }
+
+        [Fact]
+        public virtual void Where_nullable_enum_with_null_constant()
+        {
+            using (var context = CreateContext())
+            {
+                var weapons = context.Weapons
+                    .Where(w => w.AmmunitionType == null)
+                    .ToList();
+
+                Assert.Equal(1, weapons.Count);
+            }
+        }
+
+        [Fact]
+        public virtual void Where_nullable_enum_with_non_nullable_parameter()
+        {
+            var ammunitionType = AmmunitionType.Cartridge;
+
+            using (var context = CreateContext())
+            {
+                var weapons = context.Weapons
+                    .Where(w => w.AmmunitionType == ammunitionType)
+                    .ToList();
+
+                Assert.Equal(5, weapons.Count);
+            }
+        }
+
+        [Fact]
+        public virtual void Where_nullable_enum_with_nullable_parameter()
+        {
+            AmmunitionType? ammunitionType = AmmunitionType.Cartridge;
+
+            using (var context = CreateContext())
+            {
+                var weapons = context.Weapons
+                    .Where(w => w.AmmunitionType == ammunitionType)
+                    .ToList();
+
+                Assert.Equal(5, weapons.Count);
+            }
+
+            ammunitionType = null;
+
+            using (var context = CreateContext())
+            {
+                var weapons = context.Weapons
+                    .Where(w => w.AmmunitionType == ammunitionType)
+                    .ToList();
+
+                Assert.Equal(1, weapons.Count);
             }
         }
     }

--- a/test/EntityFramework7.Core.FunctionalTests/TestModels/GearsOfWarModel/AmmunitionType.cs
+++ b/test/EntityFramework7.Core.FunctionalTests/TestModels/GearsOfWarModel/AmmunitionType.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel
+{
+    public enum AmmunitionType
+    {
+        Cartridge = 1,
+        Shell = 2
+    }
+}

--- a/test/EntityFramework7.Core.FunctionalTests/TestModels/GearsOfWarModel/GearsOfWarModelInitializer.cs
+++ b/test/EntityFramework7.Core.FunctionalTests/TestModels/GearsOfWarModel/GearsOfWarModelInitializer.cs
@@ -65,48 +65,62 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel
 
                 var marcusLancer = new Weapon
                     {
-                        Name = "Marcus' Lancer"
+                        Name = "Marcus' Lancer",
+                        AmmunitionType = AmmunitionType.Cartridge
                     };
 
                 var marcusGnasher = new Weapon
                     {
                         Name = "Marcus' Gnasher",
+                        AmmunitionType = AmmunitionType.Shell,
                         SynergyWith = marcusLancer
                     };
 
                 var domsHammerburst = new Weapon
                     {
-                        Name = "Dom's Hammerburst"
+                        Name = "Dom's Hammerburst",
+                        AmmunitionType = AmmunitionType.Cartridge
                     };
 
                 var domsGnasher = new Weapon
                     {
-                        Name = "Dom's Gnasher"
+                        Name = "Dom's Gnasher",
+                        AmmunitionType = AmmunitionType.Shell
                     };
 
                 var colesGnasher = new Weapon
                     {
-                        Name = "Cole's Gnasher"
+                        Name = "Cole's Gnasher",
+                        AmmunitionType = AmmunitionType.Shell
                     };
 
                 var colesMulcher = new Weapon
                     {
-                        Name = "Cole's Mulcher"
+                        Name = "Cole's Mulcher",
+                        AmmunitionType = AmmunitionType.Cartridge
                     };
 
                 var bairdsLancer = new Weapon
                     {
-                        Name = "Baird's Lancer"
+                        Name = "Baird's Lancer",
+                        AmmunitionType = AmmunitionType.Cartridge
                     };
 
                 var bairdsGnasher = new Weapon
                     {
-                        Name = "Baird's Gnasher"
+                        Name = "Baird's Gnasher",
+                        AmmunitionType = AmmunitionType.Shell
                     };
 
                 var paduksMarkza = new Weapon
                     {
-                        Name = "Paduk's Markza"
+                        Name = "Paduk's Markza",
+                        AmmunitionType = AmmunitionType.Cartridge
+                    };
+
+                var maulersFlail = new Weapon
+                    {
+                        Name = "Mauler's Flail"
                     };
 
                 context.Weapons.Add(marcusLancer);
@@ -118,6 +132,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel
                 context.Weapons.Add(bairdsLancer);
                 context.Weapons.Add(bairdsGnasher);
                 context.Weapons.Add(paduksMarkza);
+                context.Weapons.Add(maulersFlail);
                 context.SaveChanges();
 
                 var marcusTag = new CogTag

--- a/test/EntityFramework7.Core.FunctionalTests/TestModels/GearsOfWarModel/Weapon.cs
+++ b/test/EntityFramework7.Core.FunctionalTests/TestModels/GearsOfWarModel/Weapon.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel
         // auto generated key (sequence) TODO: make nullable when issue #478 is fixed
         public int Id { get; set; }
         public string Name { get; set; }
+        public AmmunitionType? AmmunitionType { get; set; }
 
         // 1 - 1 self reference
         public int? SynergyWithId { get; set; }

--- a/test/EntityFramework7.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EntityFramework7.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -28,7 +28,7 @@ FROM [CogTag] AS [t]
 LEFT JOIN [Gear] AS [g] ON ([t].[GearNickName] = [g].[Nickname] AND [t].[GearSquadId] = [g].[SquadId])
 ORDER BY [g].[Nickname], [g].[SquadId]
 
-SELECT [w].[Id], [w].[Name], [w].[OwnerNickname], [w].[OwnerSquadId], [w].[SynergyWithId]
+SELECT [w].[Id], [w].[AmmunitionType], [w].[Name], [w].[OwnerNickname], [w].[OwnerSquadId], [w].[SynergyWithId]
 FROM [Weapon] AS [w]
 INNER JOIN (
     SELECT DISTINCT [g].[Nickname], [g].[SquadId]
@@ -195,6 +195,69 @@ INNER JOIN (
 ) AS [c] ON [g].[CityOrBirthName] = [c].[Name]
 LEFT JOIN [CogTag] AS [c0] ON ([c0].[GearNickName] = [g].[Nickname] AND [c0].[GearSquadId] = [g].[SquadId])
 ORDER BY [c].[Nickname], [c].[Name]",
+                Sql);
+        }
+
+        public override void Where_enum()
+        {
+            base.Where_enum();
+
+            Assert.Equal(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+FROM [Gear] AS [g]
+WHERE [g].[Rank] = 2",
+                Sql);
+        }
+
+        public override void Where_nullable_enum_with_constant()
+        {
+            base.Where_nullable_enum_with_constant();
+
+            Assert.Equal(
+                @"SELECT [w].[Id], [w].[AmmunitionType], [w].[Name], [w].[OwnerNickname], [w].[OwnerSquadId], [w].[SynergyWithId]
+FROM [Weapon] AS [w]
+WHERE [w].[AmmunitionType] = 1",
+                Sql);
+        }
+
+        public override void Where_nullable_enum_with_null_constant()
+        {
+            base.Where_nullable_enum_with_null_constant();
+
+            Assert.Equal(
+                @"SELECT [w].[Id], [w].[AmmunitionType], [w].[Name], [w].[OwnerNickname], [w].[OwnerSquadId], [w].[SynergyWithId]
+FROM [Weapon] AS [w]
+WHERE [w].[AmmunitionType] IS NULL",
+                Sql);
+        }
+
+        public override void Where_nullable_enum_with_non_nullable_parameter()
+        {
+            base.Where_nullable_enum_with_non_nullable_parameter();
+
+            Assert.Equal(
+                @"@__p_0: 1
+
+SELECT [w].[Id], [w].[AmmunitionType], [w].[Name], [w].[OwnerNickname], [w].[OwnerSquadId], [w].[SynergyWithId]
+FROM [Weapon] AS [w]
+WHERE [w].[AmmunitionType] = @__p_0",
+                Sql);
+        }
+
+        public override void Where_nullable_enum_with_nullable_parameter()
+        {
+            base.Where_nullable_enum_with_nullable_parameter();
+
+            Assert.Equal(
+                @"@__p_0: 1
+
+SELECT [w].[Id], [w].[AmmunitionType], [w].[Name], [w].[OwnerNickname], [w].[OwnerSquadId], [w].[SynergyWithId]
+FROM [Weapon] AS [w]
+WHERE [w].[AmmunitionType] = @__p_0
+
+SELECT [w].[Id], [w].[AmmunitionType], [w].[Name], [w].[OwnerNickname], [w].[OwnerSquadId], [w].[SynergyWithId]
+FROM [Weapon] AS [w]
+WHERE [w].[AmmunitionType] IS NULL",
                 Sql);
         }
 

--- a/test/EntityFramework7.Sqlite.FunctionalTests/GearsOfWarQuerySqliteTest.cs
+++ b/test/EntityFramework7.Sqlite.FunctionalTests/GearsOfWarQuerySqliteTest.cs
@@ -23,7 +23,7 @@ FROM ""CogTag"" AS ""t""
 LEFT JOIN ""Gear"" AS ""g"" ON (""t"".""GearNickName"" = ""g"".""Nickname"" AND ""t"".""GearSquadId"" = ""g"".""SquadId"")
 ORDER BY ""g"".""Nickname"", ""g"".""SquadId""
 
-SELECT ""w"".""Id"", ""w"".""Name"", ""w"".""OwnerNickname"", ""w"".""OwnerSquadId"", ""w"".""SynergyWithId""
+SELECT ""w"".""Id"", ""w"".""AmmunitionType"", ""w"".""Name"", ""w"".""OwnerNickname"", ""w"".""OwnerSquadId"", ""w"".""SynergyWithId""
 FROM ""Weapon"" AS ""w""
 INNER JOIN (
     SELECT DISTINCT ""g"".""Nickname"", ""g"".""SquadId""
@@ -129,6 +129,69 @@ INNER JOIN (
     WHERE ""g"".""Nickname"" = 'Marcus'
 ) AS ""c"" ON ""g"".""AssignedCityName"" = ""c"".""Name""
 ORDER BY ""c"".""Name""",
+                Sql);
+        }
+
+        public override void Where_enum()
+        {
+            base.Where_enum();
+
+            Assert.Equal(
+                @"SELECT ""g"".""Nickname"", ""g"".""SquadId"", ""g"".""AssignedCityName"", ""g"".""CityOrBirthName"", ""g"".""FullName"", ""g"".""LeaderNickname"", ""g"".""LeaderSquadId"", ""g"".""Rank""
+FROM ""Gear"" AS ""g""
+WHERE ""g"".""Rank"" = 2",
+                Sql);
+        }
+
+        public override void Where_nullable_enum_with_constant()
+        {
+            base.Where_nullable_enum_with_constant();
+
+            Assert.Equal(
+                @"SELECT ""w"".""Id"", ""w"".""AmmunitionType"", ""w"".""Name"", ""w"".""OwnerNickname"", ""w"".""OwnerSquadId"", ""w"".""SynergyWithId""
+FROM ""Weapon"" AS ""w""
+WHERE ""w"".""AmmunitionType"" = 1",
+                Sql);
+        }
+
+        public override void Where_nullable_enum_with_null_constant()
+        {
+            base.Where_nullable_enum_with_null_constant();
+
+            Assert.Equal(
+                @"SELECT ""w"".""Id"", ""w"".""AmmunitionType"", ""w"".""Name"", ""w"".""OwnerNickname"", ""w"".""OwnerSquadId"", ""w"".""SynergyWithId""
+FROM ""Weapon"" AS ""w""
+WHERE ""w"".""AmmunitionType"" IS NULL",
+                Sql);
+        }
+
+        public override void Where_nullable_enum_with_non_nullable_parameter()
+        {
+            base.Where_nullable_enum_with_non_nullable_parameter();
+
+            Assert.Equal(
+                @"@__p_0: 1
+
+SELECT ""w"".""Id"", ""w"".""AmmunitionType"", ""w"".""Name"", ""w"".""OwnerNickname"", ""w"".""OwnerSquadId"", ""w"".""SynergyWithId""
+FROM ""Weapon"" AS ""w""
+WHERE ""w"".""AmmunitionType"" = @__p_0",
+                Sql);
+        }
+
+        public override void Where_nullable_enum_with_nullable_parameter()
+        {
+            base.Where_nullable_enum_with_nullable_parameter();
+
+            Assert.Equal(
+                @"@__p_0: 1
+
+SELECT ""w"".""Id"", ""w"".""AmmunitionType"", ""w"".""Name"", ""w"".""OwnerNickname"", ""w"".""OwnerSquadId"", ""w"".""SynergyWithId""
+FROM ""Weapon"" AS ""w""
+WHERE ""w"".""AmmunitionType"" = @__p_0
+
+SELECT ""w"".""Id"", ""w"".""AmmunitionType"", ""w"".""Name"", ""w"".""OwnerNickname"", ""w"".""OwnerSquadId"", ""w"".""SynergyWithId""
+FROM ""Weapon"" AS ""w""
+WHERE ""w"".""AmmunitionType"" IS NULL",
                 Sql);
         }
 


### PR DESCRIPTION
Prevent unnecessary parameterization of enum constants
Add test coverage for query with nullable enum parameters

@anpete 