### PR TITLE
[Testing] Configured SQL Server connection settings at runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ nuget.exe
 *.lock.json
 *.db
 .vs/
+config.test.json
+*.log

--- a/test/EntityFramework.Core.FunctionalTests/TestFileLogger.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestFileLogger.cs
@@ -8,6 +8,7 @@ using Microsoft.Framework.Logging;
 namespace Microsoft.Data.Entity.FunctionalTests
 {
     // Watch the log in PS with: "tail -f $env:userprofile\.klog\data-test.log"
+    // Watch the log in bash with: "tail -f ~/.klog/data-test.log"
     public class TestFileLogger : ILogger
     {
         public static readonly ILoggerFactory Factory = new TestFileLoggerFactory();
@@ -33,7 +34,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         protected TestFileLogger(string fileName = "data-test.log")
         {
             var logDirectory
-                = Path.Combine(Environment.ExpandEnvironmentVariables("%USERPROFILE%"), ".klog");
+                = Path.Combine(Environment.GetEnvironmentVariable("USERPROFILE") ?? Environment.GetEnvironmentVariable("HOME"), ".klog");
 
             if (!Directory.Exists(logDirectory))
             {

--- a/test/EntityFramework.CrossStore.FunctionalTests/EntityFramework.CrossStore.FunctionalTests.csproj
+++ b/test/EntityFramework.CrossStore.FunctionalTests/EntityFramework.CrossStore.FunctionalTests.csproj
@@ -77,6 +77,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="config.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>

--- a/test/EntityFramework.CrossStore.FunctionalTests/config.json
+++ b/test/EntityFramework.CrossStore.FunctionalTests/config.json
@@ -1,0 +1,11 @@
+{
+    "Test": {
+        "SqlServer": {
+            "DataSource": "(localdb)\\MSSQLLocalDB",
+            "IntegratedSecurity": true,
+            "ConnectTimeout": 30,
+            "UserId": null,
+            "Password": null
+        }
+    }
+}

--- a/test/EntityFramework.Microbenchmarks.Core/BenchmarkConfig.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/BenchmarkConfig.cs
@@ -12,6 +12,7 @@ namespace EntityFramework.Microbenchmarks.Core
         {
             var config = new ConfigurationBuilder(".")
                 .AddJsonFile("config.json")
+                .AddJsonFile("config.test.json", optional: true)
                 .AddEnvironmentVariables()
                 .Build();
 

--- a/test/EntityFramework.SqlServer.Design.FunctionalTests/EntityFramework.SqlServer.Design.FunctionalTests.csproj
+++ b/test/EntityFramework.SqlServer.Design.FunctionalTests/EntityFramework.SqlServer.Design.FunctionalTests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="..\..\tools\EntityFramework.props" />
@@ -34,6 +34,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\EntityFramework.Commands\EntityFramework.Commands.csproj">
@@ -71,6 +72,9 @@
     <Content Include="ReverseEngineering\E2E.sql" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="config.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="App.config" />
     <None Include="project.json" />
     <None Include="ReverseEngineering\ExpectedResults\E2E\AllDataTypes.expected">

--- a/test/EntityFramework.SqlServer.Design.FunctionalTests/README.md
+++ b/test/EntityFramework.SqlServer.Design.FunctionalTests/README.md
@@ -1,0 +1,5 @@
+EntityFramework.SqlServer.Design.FunctionalTests
+=======
+
+## Setting up the test SQL Server
+Configured using the same pattern as the EntityFramework.SqlServer.FunctionalTests project.

--- a/test/EntityFramework.SqlServer.Design.FunctionalTests/ReverseEngineering/E2EFixture.cs
+++ b/test/EntityFramework.SqlServer.Design.FunctionalTests/ReverseEngineering/E2EFixture.cs
@@ -10,7 +10,7 @@ namespace EntityFramework.SqlServer.Design.ReverseEngineering.FunctionalTests
         public E2EFixture()
         {
             SqlServerTestStore.CreateDatabase(
-                "SqlServerReverseEngineerTestE2E", @"ReverseEngineering\E2E.sql", true);
+                "SqlServerReverseEngineerTestE2E", "ReverseEngineering/E2E.sql", true);
         }
     }
 }

--- a/test/EntityFramework.SqlServer.Design.FunctionalTests/ReverseEngineering/E2ETests.cs
+++ b/test/EntityFramework.SqlServer.Design.FunctionalTests/ReverseEngineering/E2ETests.cs
@@ -1,20 +1,25 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Data.SqlClient;
 using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.Data.Entity.Relational.Design.ReverseEngineering;
+using Microsoft.Data.Entity.Relational.Design.Templating;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.Logging;
 using Microsoft.Data.Entity.Relational.Design.Templating.Compilation;
+using Microsoft.Data.Entity.SqlServer.FunctionalTests;
+using Microsoft.Framework.Logging;
 using Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering;
 using Xunit;
 using Xunit.Abstractions;
+
 #if DNX451 || DNXCORE50
 using System;
 using Microsoft.Framework.Runtime;
@@ -25,8 +30,6 @@ namespace EntityFramework.SqlServer.Design.ReverseEngineering.FunctionalTests
 {
     public class E2ETests : IClassFixture<E2EFixture>
     {
-        public const string E2EConnectionString =
-            @"Data Source=(LocalDB)\MSSQLLocalDB;Initial Catalog=SqlServerReverseEngineerTestE2E;Integrated Security=True;MultipleActiveResultSets=True;Connect Timeout=30";
         
         private const string ProviderAssembyName = "EntityFramework.SqlServer.Design";
         private const string ProviderFullClassPath =
@@ -36,8 +39,8 @@ namespace EntityFramework.SqlServer.Design.ReverseEngineering.FunctionalTests
         private const string ProviderEntityTypeTemplateName =
             ProviderAssembyName + "." + ReverseEngineeringGenerator.EntityTypeTemplateFileName;
         private const string TestNamespace = "E2ETest.Namespace";
-        private const string TestOutputDir = @"E2ETest\Output\Dir";
-        private const string CustomizedTemplateDir = @"E2ETest\CustomizedTemplate\Dir";
+        private const string TestOutputDir = "E2ETest/Output/Dir";
+        private const string CustomizedTemplateDir = "E2ETest/CustomizedTemplate/Dir";
 
         private static readonly List<string> _E2ETestExpectedWarnings = new List<string>
             {
@@ -79,10 +82,15 @@ namespace EntityFramework.SqlServer.Design.ReverseEngineering.FunctionalTests
             };
 
         private readonly ITestOutputHelper _output;
+        private readonly string _connStr;
 
         public E2ETests(ITestOutputHelper output)
         {
             _output = output;
+            var conn = SqlServerTestConfig.Instance.ConnectionStringBuilder;
+            conn.InitialCatalog = "SqlServerReverseEngineerTestE2E";
+            conn.MultipleActiveResultSets = true;
+            _connStr = conn.ConnectionString;
         }
 
         [Fact]
@@ -101,13 +109,16 @@ namespace EntityFramework.SqlServer.Design.ReverseEngineering.FunctionalTests
             var configuration = new ReverseEngineeringConfiguration
             {
                 Provider = provider,
-                ConnectionString = E2EConnectionString,
+                ConnectionString = _connStr,
                 Namespace = TestNamespace,
                 CustomTemplatePath = null, // not used for this test
                 OutputPath = TestOutputDir
             };
 
-            var expectedFileContents = InitializeE2EExpectedFileContents();
+            var expectedFileContents = InitializeE2EExpectedFileContents(new Dictionary<string, string>
+            {
+                { "$connection_string$", configuration.ConnectionString }
+            });
 
             var serviceProvider = serviceCollection.BuildServiceProvider();
             var generator = serviceProvider.GetRequiredService<ReverseEngineeringGenerator>();
@@ -127,7 +138,7 @@ namespace EntityFramework.SqlServer.Design.ReverseEngineering.FunctionalTests
             var expectedFilePaths = _E2ETestExpectedFileNames.Select(name => Path.Combine(TestOutputDir, name));
             Assert.Equal(expectedFilePaths.Count(), filePaths.Count);
             i = 0;
-            foreach(var expectedFilePath in expectedFilePaths)
+            foreach (var expectedFilePath in expectedFilePaths)
             {
                 Assert.Equal(expectedFilePath, filePaths[i++]);
             }
@@ -178,7 +189,7 @@ namespace EntityFramework.SqlServer.Design.ReverseEngineering.FunctionalTests
             var configuration = new ReverseEngineeringConfiguration
             {
                 Provider = provider,
-                ConnectionString = E2EConnectionString,
+                ConnectionString = _connStr,
                 Namespace = TestNamespace,
                 CustomTemplatePath = CustomizedTemplateDir,
                 OutputPath = TestOutputDir
@@ -278,13 +289,19 @@ namespace EntityFramework.SqlServer.Design.ReverseEngineering.FunctionalTests
             return serviceCollection;
         }
 
-        private Dictionary<string, string> InitializeE2EExpectedFileContents()
+        private Dictionary<string, string> InitializeE2EExpectedFileContents(IDictionary<string, string> templateValues)
         {
-            var expectedContents = new Dictionary<string, string>(); ;
+            var expectedContents = new Dictionary<string, string>();
+
             foreach (var fileName in _E2ETestExpectedFileNames)
             {
-                expectedContents[fileName] = File.ReadAllText(
-                    @"ReverseEngineering\ExpectedResults\E2E\" + fileName.Replace(".cs", ".expected"));
+                var contents = new StringBuilder(File.ReadAllText(
+                    Path.Combine("ReverseEngineering", "ExpectedResults", "E2E", fileName.Replace(".cs", ".expected"))));
+                foreach (var item in templateValues)
+                {
+                    contents.Replace(item.Key, item.Value);
+                }
+                expectedContents[fileName] = contents.ToString();
             }
 
             return expectedContents;

--- a/test/EntityFramework.SqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E/SqlServerReverseEngineerTestE2EContext.expected
+++ b/test/EntityFramework.SqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E/SqlServerReverseEngineerTestE2EContext.expected
@@ -7,7 +7,7 @@ namespace E2ETest.Namespace
     {
         protected override void OnConfiguring(DbContextOptionsBuilder options)
         {
-            options.UseSqlServer(@"Data Source=(LocalDB)\MSSQLLocalDB;Initial Catalog=SqlServerReverseEngineerTestE2E;Integrated Security=True;MultipleActiveResultSets=True;Connect Timeout=30");
+            options.UseSqlServer(@"$connection_string$");
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/test/EntityFramework.SqlServer.Design.FunctionalTests/config.json
+++ b/test/EntityFramework.SqlServer.Design.FunctionalTests/config.json
@@ -1,0 +1,11 @@
+{
+    "Test": {
+        "SqlServer": {
+            "DataSource": "(localdb)\\MSSQLLocalDB",
+            "IntegratedSecurity": true,
+            "ConnectTimeout": 30,
+            "UserId": null,
+            "Password": null
+        }
+    }
+}

--- a/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
+++ b/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
@@ -99,7 +99,12 @@
     <Compile Include="TransactionSqlServerTest.cs" />
     <Compile Include="TestModels\SqlServerNorthwindContext.cs" />
     <Compile Include="TestSqlServerModelSource.cs" />
+    <None Include="config.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="project.json" />
+    <Compile Include="SqlServerTestConfig.cs" />
+    <None Include="README.md" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\EntityFramework.Core\EntityFramework.Core.csproj">

--- a/test/EntityFramework.SqlServer.FunctionalTests/MonsterFixupSqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/MonsterFixupSqlServerTest.cs
@@ -46,14 +46,10 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
         private static string CreateConnectionString(string name)
         {
-            return new SqlConnectionStringBuilder
-            {
-                DataSource = @"(localdb)\MSSQLLocalDB",
-                MultipleActiveResultSets = true,
-                InitialCatalog = name,
-                IntegratedSecurity = true,
-                ConnectTimeout = 30
-            }.ConnectionString;
+            var builder = SqlServerTestConfig.Instance.ConnectionStringBuilder;
+            builder.MultipleActiveResultSets = true;
+            builder.InitialCatalog = name;
+            return builder.ConnectionString;
         }
 
         protected override async Task CreateAndSeedDatabase(string databaseName, Func<MonsterContext> createContext)

--- a/test/EntityFramework.SqlServer.FunctionalTests/NavigationTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/NavigationTest.cs
@@ -90,7 +90,12 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
-            optionsBuilder.UseSqlServer(@"Server=(localdb)\mssqllocaldb;Database=StateManagerBug;Trusted_Connection=True;MultipleActiveResultSets=true");
+            var builder = SqlServerTestConfig.Instance.ConnectionStringBuilder;
+            builder.MultipleActiveResultSets = true;
+            builder["Database"] = "StateManagerBug";
+            builder["Trusted_Connection"] = true;
+            
+            optionsBuilder.UseSqlServer(builder.ConnectionString);
         }
     }
 }

--- a/test/EntityFramework.SqlServer.FunctionalTests/README.md
+++ b/test/EntityFramework.SqlServer.FunctionalTests/README.md
@@ -1,0 +1,28 @@
+EntityFramework.SqlServer.FunctionalTests
+=======
+
+## Setting up the test SQL Server
+
+These tests use LocalDB by default. Default settings are loaded from `config.json`.
+
+To override this *per-machine*, copy `config.json` to `config.test.json` and change any of the settings that need be overwritten.
+Also, environment variables can be set to override these settings.
+
+Example:
+
+```json
+/// In config.test.json
+
+{
+    "Test": {
+        "SqlServer": {
+            "DataSource": "test.server.example.net",
+            "IntegratedSecurity": false,
+            "UserId": "test_user",
+            "Password": "<your_password_here>"
+        }
+    }
+}
+```
+
+The user account used to test against SQL Server requires ['sysadmin' privileges](https://msdn.microsoft.com/en-us/library/ms188659.aspx) on the server.

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerTestConfig.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerTestConfig.cs
@@ -1,0 +1,60 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Data.SqlClient;
+using Microsoft.Framework.Configuration;
+
+namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
+{
+    public class SqlServerTestConfig
+    {
+        private const string prefix = "Test:SqlServer:";
+
+        private static readonly Lazy<SqlServerTestConfig> _instance = new Lazy<SqlServerTestConfig>(() =>
+            {
+                var config = new ConfigurationBuilder(".")
+                    .AddJsonFile("config.json")
+                    .AddJsonFile("config.test.json", optional: true)
+                    .AddEnvironmentVariables()
+                    .Build();
+
+                int connectTimeout;
+                if (!int.TryParse(config.Get(prefix + "ConnectTimeout"), out connectTimeout))
+                {
+                    connectTimeout = 30;
+                }
+
+                return new SqlServerTestConfig
+                {
+                    DataSource = config.Get(prefix + "DataSource"),
+                    IntegratedSecurity = bool.Parse(config.Get(prefix + "IntegratedSecurity")),
+                    ConnectTimeout = connectTimeout,
+                    UserId = config.Get(prefix + "UserId"),
+                    Password = config.Get(prefix + "Password")
+                };
+            });
+
+        private SqlServerTestConfig()
+        {
+        }
+
+        public static SqlServerTestConfig Instance => _instance.Value;
+
+        public string DataSource { get; private set; }
+        public bool IntegratedSecurity { get; private set; }
+        public int ConnectTimeout { get; private set; }
+        public string UserId { get; private set; }
+        public string Password { get; private set; }
+
+        public SqlConnectionStringBuilder ConnectionStringBuilder
+            => new SqlConnectionStringBuilder
+            {
+                DataSource = DataSource,
+                IntegratedSecurity = IntegratedSecurity,
+                ConnectTimeout = ConnectTimeout,
+                UserID = UserId,
+                Password = Password
+            };
+    }
+}

--- a/test/EntityFramework.SqlServer.FunctionalTests/config.json
+++ b/test/EntityFramework.SqlServer.FunctionalTests/config.json
@@ -1,0 +1,11 @@
+{
+    "Test": {
+        "SqlServer": {
+            "DataSource": "(localdb)\\MSSQLLocalDB",
+            "IntegratedSecurity": true,
+            "ConnectTimeout": 30,
+            "UserId": null,
+            "Password": null
+        }
+    }
+}

--- a/test/EntityFramework.SqlServer.FunctionalTests/project.json
+++ b/test/EntityFramework.SqlServer.FunctionalTests/project.json
@@ -1,7 +1,9 @@
 {
   "dependencies": {
     "EntityFramework.Relational.FunctionalTests": "7.0.0-*",
-    "EntityFramework.SqlServer": "7.0.0-*"
+    "EntityFramework.SqlServer": "7.0.0-*",
+    "Microsoft.Framework.Configuration.Json": "1.0.0-*",
+    "Microsoft.Framework.Configuration.EnvironmentVariables": "1.0.0-*"
   },
   "commands": {
     "test": "xunit.runner.dnx"


### PR DESCRIPTION
Configure from config.json. Can be overridden with `config.test.json` in same folder, or with environment variables.

Also, includes other platform-dependent settings change and a workarounds.