### PR TITLE
[TINY] Support additional metadata on perf runs

### DIFF
--- a/test/EntityFramework7.Microbenchmarks.Core/BenchmarkConfig.cs
+++ b/test/EntityFramework7.Microbenchmarks.Core/BenchmarkConfig.cs
@@ -20,7 +20,8 @@ namespace EntityFramework.Microbenchmarks.Core
                 RunIterations = bool.Parse(config.Get("benchmarks:runIterations")),
                 ResultsDatabase = config.Get("benchmarks:resultsDatabase"),
                 BenchmarkDatabaseInstance = config.Get("benchmarks:benchmarkDatabaseInstance"),
-                ProductReportingVersion = config.Get("benchmarks:productReportingVersion")
+                ProductReportingVersion = config.Get("benchmarks:productReportingVersion"),
+                CustomData = config.Get("benchmarks:customData")
             };
         });
 
@@ -36,5 +37,6 @@ namespace EntityFramework.Microbenchmarks.Core
         public string ResultsDatabase { get; private set; }
         public string BenchmarkDatabaseInstance { get; private set; }
         public string ProductReportingVersion { get; private set; }
+        public string CustomData { get; private set; }
     }
 }

--- a/test/EntityFramework7.Microbenchmarks.Core/BenchmarkRunSummary.cs
+++ b/test/EntityFramework7.Microbenchmarks.Core/BenchmarkRunSummary.cs
@@ -20,7 +20,7 @@ namespace EntityFramework.Microbenchmarks.Core
         public string MachineName { get; set; }
         public string ProductReportingVersion { get; set; }
         public string Framework { get; set; }
-        public string ExtraInfo { get; set; }
+        public string CustomData { get; set; }
         public DateTime RunStarted { get; set; }
         public int WarmupIterations { get; set; }
         public int Iterations { get; set; }

--- a/test/EntityFramework7.Microbenchmarks.Core/BenchmarkTestCaseRunner.cs
+++ b/test/EntityFramework7.Microbenchmarks.Core/BenchmarkTestCaseRunner.cs
@@ -76,7 +76,8 @@ namespace EntityFramework.Microbenchmarks.Core
                 MachineName = _machineName.Value,
                 Framework = _framwork.Value,
                 WarmupIterations = TestCase.WarmupIterations,
-                Iterations = TestCase.Iterations
+                Iterations = TestCase.Iterations,
+                CustomData = BenchmarkConfig.Instance.CustomData
             };
 
             for (int i = 0; i < TestCase.WarmupIterations; i++)


### PR DESCRIPTION
Allows extra info to be set (config file or environment variable) that
will then be written to the database. This enables scenarios such as
recording the commit hash against results during perf runs.