### PR TITLE
[TINY] Enable result saving for EF6 perf tests

### DIFF
--- a/test/EntityFramework7.Microbenchmarks.EF6/Query/FuncletizationTests.cs
+++ b/test/EntityFramework7.Microbenchmarks.EF6/Query/FuncletizationTests.cs
@@ -6,7 +6,7 @@ using EntityFramework.Microbenchmarks.Core;
 using EntityFramework.Microbenchmarks.EF6.Models.Orders;
 using Xunit;
 
-namespace EntityFramework.Microbenchmarks.Query
+namespace EntityFramework.Microbenchmarks.EF6.Query
 {
     public class FuncletizationTests : IClassFixture<FuncletizationTests.FuncletizationFixture>
     {

--- a/test/EntityFramework7.Microbenchmarks.EF6/Query/SimpleQueryTests.cs
+++ b/test/EntityFramework7.Microbenchmarks.EF6/Query/SimpleQueryTests.cs
@@ -7,7 +7,7 @@ using EntityFramework.Microbenchmarks.Core;
 using EntityFramework.Microbenchmarks.EF6.Models.Orders;
 using Xunit;
 
-namespace EntityFramework.Microbenchmarks.Query
+namespace EntityFramework.Microbenchmarks.EF6.Query
 {
     public class SimpleQueryTests : IClassFixture<SimpleQueryTests.SimpleQueryFixture>
     {

--- a/test/EntityFramework7.Microbenchmarks.EF6/config.json
+++ b/test/EntityFramework7.Microbenchmarks.EF6/config.json
@@ -1,6 +1,7 @@
 ﻿{
   "benchmarks": {
     "runIterations": false,
+    "resultsDatabase": "Server=(localdb)\\mssqllocaldb;Database=Benchmarks;Trusted_Connection=True;",
     "benchmarkDatabaseInstance": "(localdb)\\mssqllocaldb",
     "productReportingVersion":  "EF6"
   }


### PR DESCRIPTION
The perf infrastructure uses EF7 to persist results. Enabling saving of
results for EF6 tests now that we support EF6/EF7 loaded in the same
AppDomain.
Also fixing a couple of incorrect namespaces in test files.