### PR TITLE
Fix Commands.FunctionalTests in csproj-based solution

### DIFF
--- a/test/EntityFramework7.Commands.FunctionalTests/App.config
+++ b/test/EntityFramework7.Commands.FunctionalTests/App.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a"/>
+        <bindingRedirect oldVersion="1.1.36.0" newVersion="1.1.37.0"/>
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/test/EntityFramework7.Commands.FunctionalTests/EntityFramework7.Commands.FunctionalTests.csproj
+++ b/test/EntityFramework7.Commands.FunctionalTests/EntityFramework7.Commands.FunctionalTests.csproj
@@ -47,6 +47,7 @@
     <Compile Include="TestUtilities\CommandException.cs" />
     <Compile Include="TestUtilities\ExecutorWrapper.cs" />
     <Compile Include="TestUtilities\TempDirectory.cs" />
+    <None Include="App.config" />
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Roslyn is compiled against an older version of Immutable Collections. Adding a binding redirect to compensate.

@smitpatel 