### PR TITLE
Make optimistic concurrency usable

### DIFF
--- a/src/EntityFramework7.Core/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EntityFramework7.Core/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -471,9 +471,11 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
         public virtual bool StoreMustGenerateValue([NotNull] IProperty property)
             => property.ValueGenerated != ValueGenerated.Never
-               && ((EntityState == EntityState.Added && IsTemporaryOrSentinel(property))
+               && ((EntityState == EntityState.Added
+                    && (property.StoreGeneratedAlways|| IsTemporaryOrSentinel(property)))
                    || (property.ValueGenerated == ValueGenerated.OnAddOrUpdate
-                       && (EntityState == EntityState.Modified && !IsPropertyModified(property))));
+                       && (EntityState == EntityState.Modified
+                           && (property.StoreGeneratedAlways || !IsPropertyModified(property)))));
 
         private bool IsTemporaryOrSentinel(IProperty property) => HasTemporaryValue(property) || property.IsSentinelValue(this[property]);
 

--- a/src/EntityFramework7.Core/Metadata/IProperty.cs
+++ b/src/EntityFramework7.Core/Metadata/IProperty.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Data.Entity.Metadata
         bool IsNullable { get; }
         bool IsReadOnlyBeforeSave { get; }
         bool IsReadOnlyAfterSave { get; }
+        bool StoreGeneratedAlways { get; }
         ValueGenerated ValueGenerated { get; }
         bool RequiresValueGenerator { get; }
         int Index { get; }

--- a/src/EntityFramework7.Relational/Storage/RelationalTypeMapper.cs
+++ b/src/EntityFramework7.Relational/Storage/RelationalTypeMapper.cs
@@ -99,6 +99,7 @@ namespace Microsoft.Data.Entity.Storage
             Check.NotNull(defaultMapping, nameof(defaultMapping));
 
             if (property.IsConcurrencyToken
+                && property.ValueGenerated == ValueGenerated.OnAddOrUpdate
                 && rowVersionMapping != null)
             {
                 return rowVersionMapping;

--- a/test/EntityFramework7.Core.FunctionalTests/OptimisticConcurrencyTestBase.cs
+++ b/test/EntityFramework7.Core.FunctionalTests/OptimisticConcurrencyTestBase.cs
@@ -21,14 +21,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             foreach (var value in values)
             {
-                var property = value.Key;
-
-                internalEntry[property] = value.Value;
-
-                if (property.IsReadOnlyAfterSave)
-                {
-                    internalEntry.SetPropertyModified(property, isModified: false);
-                }
+                internalEntry[value.Key] = value.Value;
             }
         }
 
@@ -38,16 +31,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
             foreach (var value in values)
             {
-                var property = value.Key;
-
-                originalValues[property] = value.Value;
-
-                if (property.IsReadOnlyAfterSave)
-                {
-                    // Prevent DetectChanges from marking this property as Modified
-                    internalEntry[property] = value.Value;
-                    internalEntry.SetPropertyModified(property, isModified: false);
-                }
+                originalValues[value.Key] = value.Value;
             }
         }
 

--- a/test/EntityFramework7.Core.FunctionalTests/StoreGeneratedTestBase.cs
+++ b/test/EntityFramework7.Core.FunctionalTests/StoreGeneratedTestBase.cs
@@ -207,6 +207,180 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
+        public virtual void Always_identity_property_on_Added_entity_with_temporary_value_gets_value_from_store()
+        {
+            int id;
+
+            using (var context = CreateContext())
+            {
+                var entry = context.Add(new Gumball { AlwaysIdentity = "Masami" });
+                entry.GetService().MarkAsTemporary(entry.Property(e => e.AlwaysIdentity).Metadata);
+
+                context.SaveChanges();
+                id = entry.Entity.Id;
+
+                Assert.Equal("Banana Joe", entry.Entity.AlwaysIdentity);
+            }
+
+            using (var context = CreateContext())
+            {
+                Assert.Equal("Banana Joe", context.Gumballs.Single(e => e.Id == id).AlwaysIdentity);
+            }
+        }
+
+        [Fact]
+        public virtual void Always_identity_property_on_Added_entity_with_sentinel_value_gets_value_from_store()
+        {
+            int id;
+
+            using (var context = CreateContext())
+            {
+                var entity = context.Add(new Gumball()).Entity;
+
+                context.SaveChanges();
+                id = entity.Id;
+
+                Assert.Equal("Banana Joe", entity.AlwaysIdentity);
+            }
+
+            using (var context = CreateContext())
+            {
+                Assert.Equal("Banana Joe", context.Gumballs.Single(e => e.Id == id).AlwaysIdentity);
+            }
+        }
+
+        [Fact]
+        public virtual void Always_identity_property_on_Added_entity_with_read_only_before_save_throws_if_explicit_values_set()
+        {
+            using (var context = CreateContext())
+            {
+                context.Add(new Gumball { AlwaysIdentityReadOnlyBeforeSave = "Masami" });
+
+                Assert.Equal(
+                    Strings.PropertyReadOnlyBeforeSave("AlwaysIdentityReadOnlyBeforeSave", "Gumball"),
+                    Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Always_identity_property_on_Added_entity_gets_store_value_even_when_set_explicitly()
+        {
+            int id;
+
+            using (var context = CreateContext())
+            {
+                var entity = context.Add(new Gumball { AlwaysIdentity = "Masami" }).Entity;
+
+                context.SaveChanges();
+                id = entity.Id;
+
+                Assert.Equal("Banana Joe", entity.AlwaysIdentity);
+            }
+
+            using (var context = CreateContext())
+            {
+                Assert.Equal("Banana Joe", context.Gumballs.Single(e => e.Id == id).AlwaysIdentity);
+            }
+        }
+
+        [Fact]
+        public virtual void Always_identity_property_on_Modified_entity_with_read_only_after_save_throws_if_value_is_in_modified_state()
+        {
+            int id;
+
+            using (var context = CreateContext())
+            {
+                var entity = context.Add(new Gumball()).Entity;
+
+                context.SaveChanges();
+                id = entity.Id;
+            }
+
+            using (var context = CreateContext())
+            {
+                var gumball = context.Gumballs.Single(e => e.Id == id);
+
+                Assert.Equal("Anton", gumball.AlwaysIdentityReadOnlyAfterSave);
+
+                gumball.AlwaysIdentityReadOnlyAfterSave = "Masami";
+                gumball.NotStoreGenerated = "Larry Needlemeye";
+
+                Assert.Equal(
+                    Strings.PropertyReadOnlyAfterSave("AlwaysIdentityReadOnlyAfterSave", "Gumball"),
+                    Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Always_identity_property_on_Modified_entity_is_not_included_in_update_when_modified()
+        {
+            int id;
+
+            using (var context = CreateContext())
+            {
+                var entity = context.Add(new Gumball()).Entity;
+
+                context.SaveChanges();
+                id = entity.Id;
+            }
+
+            using (var context = CreateContext())
+            {
+                var gumball = context.Gumballs.Single(e => e.Id == id);
+
+                Assert.Equal("Banana Joe", gumball.AlwaysIdentity);
+
+                gumball.AlwaysIdentity = "Masami";
+                gumball.NotStoreGenerated = "Larry Needlemeye";
+
+                context.SaveChanges();
+
+                Assert.Equal("Masami", gumball.AlwaysIdentity);
+            }
+
+            using (var context = CreateContext())
+            {
+                Assert.Equal("Masami", context.Gumballs.Single(e => e.Id == id).AlwaysIdentity);
+            }
+        }
+
+        [Fact]
+        public virtual void Always_identity_property_on_Modified_entity_is_not_included_in_the_update_when_not_modified()
+        {
+            int id;
+
+            using (var context = CreateContext())
+            {
+                var entity = context.Add(new Gumball()).Entity;
+
+                context.SaveChanges();
+                id = entity.Id;
+            }
+
+            using (var context = CreateContext())
+            {
+                var gumball = context.Gumballs.Single(e => e.Id == id);
+
+                Assert.Equal("Banana Joe", gumball.AlwaysIdentity);
+
+                gumball.AlwaysIdentity = "Masami";
+                gumball.NotStoreGenerated = "Larry Needlemeye";
+
+                context.Entry(gumball).Property(e => e.AlwaysIdentity).OriginalValue = "Masami";
+                context.Entry(gumball).Property(e => e.AlwaysIdentity).IsModified = false;
+
+                context.SaveChanges();
+
+                Assert.Equal("Masami", gumball.AlwaysIdentity);
+            }
+
+            using (var context = CreateContext())
+            {
+                Assert.Equal("Banana Joe", context.Gumballs.Single(e => e.Id == id).AlwaysIdentity);
+            }
+        }
+
+        [Fact]
         public virtual void Computed_property_on_Added_entity_with_temporary_value_gets_value_from_store()
         {
             int id;
@@ -380,6 +554,180 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
+        [Fact]
+        public virtual void Always_computed_property_on_Added_entity_with_temporary_value_gets_value_from_store()
+        {
+            int id;
+
+            using (var context = CreateContext())
+            {
+                var entry = context.Add(new Gumball { AlwaysComputed = "Masami" });
+                entry.GetService().MarkAsTemporary(entry.Property(e => e.AlwaysComputed).Metadata);
+
+                context.SaveChanges();
+                id = entry.Entity.Id;
+
+                Assert.Equal("Alan", entry.Entity.AlwaysComputed);
+            }
+
+            using (var context = CreateContext())
+            {
+                Assert.Equal("Alan", context.Gumballs.Single(e => e.Id == id).AlwaysComputed);
+            }
+        }
+
+        [Fact]
+        public virtual void Always_computed_property_on_Added_entity_with_sentinel_value_gets_value_from_store()
+        {
+            int id;
+
+            using (var context = CreateContext())
+            {
+                var entity = context.Add(new Gumball()).Entity;
+
+                context.SaveChanges();
+                id = entity.Id;
+
+                Assert.Equal("Alan", entity.AlwaysComputed);
+            }
+
+            using (var context = CreateContext())
+            {
+                Assert.Equal("Alan", context.Gumballs.Single(e => e.Id == id).AlwaysComputed);
+            }
+        }
+
+        [Fact]
+        public virtual void Always_computed_property_on_Added_entity_with_read_only_before_save_throws_if_explicit_values_set()
+        {
+            using (var context = CreateContext())
+            {
+                context.Add(new Gumball { AlwaysComputedReadOnlyBeforeSave = "Masami" });
+
+                Assert.Equal(
+                    Strings.PropertyReadOnlyBeforeSave("AlwaysComputedReadOnlyBeforeSave", "Gumball"),
+                    Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Always_computed_property_on_Added_entity_cannot_have_value_set_explicitly()
+        {
+            int id;
+
+            using (var context = CreateContext())
+            {
+                var entity = context.Add(new Gumball { AlwaysComputed = "Masami" }).Entity;
+
+                context.SaveChanges();
+                id = entity.Id;
+
+                Assert.Equal("Alan", entity.AlwaysComputed);
+            }
+
+            using (var context = CreateContext())
+            {
+                Assert.Equal("Alan", context.Gumballs.Single(e => e.Id == id).AlwaysComputed);
+            }
+        }
+
+        [Fact]
+        public virtual void Always_computed_property_on_Modified_entity_with_read_only_after_save_throws_if_value_is_in_modified_state()
+        {
+            int id;
+
+            using (var context = CreateContext())
+            {
+                var entity = context.Add(new Gumball()).Entity;
+
+                context.SaveChanges();
+                id = entity.Id;
+            }
+
+            using (var context = CreateContext())
+            {
+                var gumball = context.Gumballs.Single(e => e.Id == id);
+
+                Assert.Equal("Tina Rex", gumball.AlwaysComputedReadOnlyAfterSave);
+
+                gumball.AlwaysComputedReadOnlyAfterSave = "Masami";
+                gumball.NotStoreGenerated = "Larry Needlemeye";
+
+                Assert.Equal(
+                    Strings.PropertyReadOnlyAfterSave("AlwaysComputedReadOnlyAfterSave", "Gumball"),
+                    Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Always_computed_property_on_Modified_entity_is_not_included_in_update_even_when_modified()
+        {
+            int id;
+
+            using (var context = CreateContext())
+            {
+                var entity = context.Add(new Gumball()).Entity;
+
+                context.SaveChanges();
+                id = entity.Id;
+            }
+
+            using (var context = CreateContext())
+            {
+                var gumball = context.Gumballs.Single(e => e.Id == id);
+
+                Assert.Equal("Alan", gumball.AlwaysComputed);
+
+                gumball.AlwaysComputed = "Masami";
+                gumball.NotStoreGenerated = "Larry Needlemeye";
+
+                context.SaveChanges();
+
+                Assert.Equal("Alan", gumball.AlwaysComputed);
+            }
+
+            using (var context = CreateContext())
+            {
+                Assert.Equal("Alan", context.Gumballs.Single(e => e.Id == id).AlwaysComputed);
+            }
+        }
+
+        [Fact]
+        public virtual void Always_computed_property_on_Modified_entity_is_read_from_store_when_not_modified()
+        {
+            int id;
+
+            using (var context = CreateContext())
+            {
+                var entity = context.Add(new Gumball()).Entity;
+
+                context.SaveChanges();
+                id = entity.Id;
+            }
+
+            using (var context = CreateContext())
+            {
+                var gumball = context.Gumballs.Single(e => e.Id == id);
+
+                Assert.Equal("Alan", gumball.AlwaysComputed);
+
+                gumball.AlwaysComputed = "Masami";
+                gumball.NotStoreGenerated = "Larry Needlemeye";
+
+                context.Entry(gumball).Property(e => e.AlwaysComputed).OriginalValue = "Masami";
+                context.Entry(gumball).Property(e => e.AlwaysComputed).IsModified = false;
+
+                context.SaveChanges();
+
+                Assert.Equal("Alan", gumball.AlwaysComputed);
+            }
+
+            using (var context = CreateContext())
+            {
+                Assert.Equal("Alan", context.Gumballs.Single(e => e.Id == id).AlwaysComputed);
+            }
+        }
+
         protected class Gumball
         {
             public int Id { get; set; }
@@ -389,9 +737,17 @@ namespace Microsoft.Data.Entity.FunctionalTests
             public string IdentityReadOnlyBeforeSave { get; set; }
             public string IdentityReadOnlyAfterSave { get; set; }
 
+            public string AlwaysIdentity { get; set; }
+            public string AlwaysIdentityReadOnlyBeforeSave { get; set; }
+            public string AlwaysIdentityReadOnlyAfterSave { get; set; }
+
             public string Computed { get; set; }
             public string ComputedReadOnlyBeforeSave { get; set; }
             public string ComputedReadOnlyAfterSave { get; set; }
+
+            public string AlwaysComputed { get; set; }
+            public string AlwaysComputedReadOnlyBeforeSave { get; set; }
+            public string AlwaysComputedReadOnlyAfterSave { get; set; }
         }
 
         protected class StoreGeneratedContext : DbContext
@@ -444,6 +800,21 @@ namespace Microsoft.Data.Entity.FunctionalTests
                         property.IsReadOnlyAfterSave = true;
                         property.IsReadOnlyBeforeSave = false;
 
+                        property = b.Property(e => e.AlwaysIdentity).ValueGeneratedOnAdd().Metadata;
+                        property.StoreGeneratedAlways = true;
+                        property.IsReadOnlyAfterSave = false;
+                        property.IsReadOnlyBeforeSave = false;
+
+                        property = b.Property(e => e.AlwaysIdentityReadOnlyBeforeSave).ValueGeneratedOnAdd().Metadata;
+                        property.StoreGeneratedAlways = true;
+                        property.IsReadOnlyAfterSave = false;
+                        property.IsReadOnlyBeforeSave = true;
+
+                        property = b.Property(e => e.AlwaysIdentityReadOnlyAfterSave).ValueGeneratedOnAdd().Metadata;
+                        property.StoreGeneratedAlways = true;
+                        property.IsReadOnlyAfterSave = true;
+                        property.IsReadOnlyBeforeSave = false;
+
                         property = b.Property(e => e.Computed).ValueGeneratedOnAddOrUpdate().Metadata;
                         property.IsReadOnlyAfterSave = false;
                         property.IsReadOnlyBeforeSave = false;
@@ -453,6 +824,21 @@ namespace Microsoft.Data.Entity.FunctionalTests
                         property.IsReadOnlyBeforeSave = true;
 
                         property = b.Property(e => e.ComputedReadOnlyAfterSave).ValueGeneratedOnAddOrUpdate().Metadata;
+                        property.IsReadOnlyAfterSave = true;
+                        property.IsReadOnlyBeforeSave = false;
+
+                        property = b.Property(e => e.AlwaysComputed).ValueGeneratedOnAddOrUpdate().Metadata;
+                        property.StoreGeneratedAlways = true;
+                        property.IsReadOnlyAfterSave = false;
+                        property.IsReadOnlyBeforeSave = false;
+
+                        property = b.Property(e => e.AlwaysComputedReadOnlyBeforeSave).ValueGeneratedOnAddOrUpdate().Metadata;
+                        property.StoreGeneratedAlways = true;
+                        property.IsReadOnlyAfterSave = false;
+                        property.IsReadOnlyBeforeSave = true;
+
+                        property = b.Property(e => e.AlwaysComputedReadOnlyAfterSave).ValueGeneratedOnAddOrUpdate().Metadata;
+                        property.StoreGeneratedAlways = true;
                         property.IsReadOnlyAfterSave = true;
                         property.IsReadOnlyBeforeSave = false;
                     });

--- a/test/EntityFramework7.Core.Tests/Metadata/EntityTypeTest.cs
+++ b/test/EntityFramework7.Core.Tests/Metadata/EntityTypeTest.cs
@@ -1411,6 +1411,33 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         }
 
         [Fact]
+        public void Store_always_computed_values_are_not_read_only_before_and_after_save_by_default()
+        {
+            var model = new Model();
+            var entityType = model.AddEntityType(typeof(Customer));
+            var nameProperty = entityType.GetOrAddProperty(Customer.NameProperty);
+
+            Assert.False(((IProperty)nameProperty).IsReadOnlyAfterSave);
+            Assert.False(((IProperty)nameProperty).IsReadOnlyBeforeSave);
+
+            nameProperty.ValueGenerated = ValueGenerated.OnAddOrUpdate;
+            nameProperty.StoreGeneratedAlways = true;
+
+            Assert.False(((IProperty)nameProperty).IsReadOnlyAfterSave);
+            Assert.False(((IProperty)nameProperty).IsReadOnlyBeforeSave);
+
+            nameProperty.IsReadOnlyBeforeSave = true;
+
+            Assert.False(((IProperty)nameProperty).IsReadOnlyAfterSave);
+            Assert.True(((IProperty)nameProperty).IsReadOnlyBeforeSave);
+
+            nameProperty.IsReadOnlyAfterSave = true;
+
+            Assert.True(((IProperty)nameProperty).IsReadOnlyAfterSave);
+            Assert.True(((IProperty)nameProperty).IsReadOnlyBeforeSave);
+        }
+
+        [Fact]
         public void Can_add_a_foreign_key()
         {
             var model = new Model();

--- a/test/EntityFramework7.Core.Tests/Metadata/PropertyTest.cs
+++ b/test/EntityFramework7.Core.Tests/Metadata/PropertyTest.cs
@@ -160,6 +160,50 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         }
 
         [Fact]
+        public void Can_mark_property_to_always_use_store_generated_values()
+        {
+            var property = new Property("Name", typeof(string), new Model().AddEntityType(typeof(Entity)));
+
+            Assert.Null(property.StoreGeneratedAlways);
+            Assert.False(((IProperty)property).StoreGeneratedAlways);
+
+            property.StoreGeneratedAlways = true;
+            Assert.True(property.StoreGeneratedAlways.Value);
+            Assert.True(((IProperty)property).StoreGeneratedAlways);
+
+            property.StoreGeneratedAlways = false;
+            Assert.False(property.StoreGeneratedAlways.Value);
+            Assert.False(((IProperty)property).StoreGeneratedAlways);
+
+            property.StoreGeneratedAlways = null;
+            Assert.Null(property.StoreGeneratedAlways);
+            Assert.False(((IProperty)property).StoreGeneratedAlways);
+        }
+
+        [Fact]
+        public void Store_generated_concurrency_tokens_always_use_store_values_by_default()
+        {
+            var property = new Property("Name", typeof(string), new Model().AddEntityType(typeof(Entity)));
+
+            Assert.False(((IProperty)property).StoreGeneratedAlways);
+
+            property.ValueGenerated = ValueGenerated.OnAddOrUpdate;
+            Assert.False(((IProperty)property).StoreGeneratedAlways);
+
+            property.IsConcurrencyToken = true;
+            Assert.True(((IProperty)property).StoreGeneratedAlways);
+
+            property.ValueGenerated = ValueGenerated.OnAdd;
+            Assert.False(((IProperty)property).StoreGeneratedAlways);
+
+            property.ValueGenerated = ValueGenerated.OnAddOrUpdate;
+            Assert.True(((IProperty)property).StoreGeneratedAlways);
+
+            property.StoreGeneratedAlways = false;
+            Assert.False(((IProperty)property).StoreGeneratedAlways);
+        }
+
+        [Fact]
         public void Property_is_read_write_by_default()
         {
             var property = new Property("Name", typeof(string), new Model().AddEntityType(typeof(object)));

--- a/test/EntityFramework7.InMemory.FunctionalTests/StoreGeneratedInMemoryTest.cs
+++ b/test/EntityFramework7.InMemory.FunctionalTests/StoreGeneratedInMemoryTest.cs
@@ -82,6 +82,90 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
             // In-memory store does not support store generation 
         }
 
+        [Fact]
+        public override void Always_computed_property_on_Added_entity_with_temporary_value_gets_value_from_store()
+        {
+            // In-memory store does not support store generation 
+        }
+
+        [Fact]
+        public override void Always_computed_property_on_Added_entity_with_sentinel_value_gets_value_from_store()
+        {
+            // In-memory store does not support store generation 
+        }
+
+        [Fact]
+        public override void Always_computed_property_on_Added_entity_with_read_only_before_save_throws_if_explicit_values_set()
+        {
+            // In-memory store does not support store generation 
+        }
+
+        [Fact]
+        public override void Always_computed_property_on_Added_entity_cannot_have_value_set_explicitly()
+        {
+            // In-memory store does not support store generation 
+        }
+
+        [Fact]
+        public override void Always_computed_property_on_Modified_entity_with_read_only_after_save_throws_if_value_is_in_modified_state()
+        {
+            // In-memory store does not support store generation 
+        }
+
+        [Fact]
+        public override void Always_computed_property_on_Modified_entity_is_not_included_in_update_even_when_modified()
+        {
+            // In-memory store does not support store generation 
+        }
+
+        [Fact]
+        public override void Always_computed_property_on_Modified_entity_is_read_from_store_when_not_modified()
+        {
+            // In-memory store does not support store generation 
+        }
+
+        [Fact]
+        public override void Always_identity_property_on_Added_entity_with_temporary_value_gets_value_from_store()
+        {
+            // In-memory store does not support store generation 
+        }
+
+        [Fact]
+        public override void Always_identity_property_on_Added_entity_with_sentinel_value_gets_value_from_store()
+        {
+            // In-memory store does not support store generation 
+        }
+
+        [Fact]
+        public override void Always_identity_property_on_Added_entity_with_read_only_before_save_throws_if_explicit_values_set()
+        {
+            // In-memory store does not support store generation 
+        }
+
+        [Fact]
+        public override void Always_identity_property_on_Added_entity_gets_store_value_even_when_set_explicitly()
+        {
+            // In-memory store does not support store generation 
+        }
+
+        [Fact]
+        public override void Always_identity_property_on_Modified_entity_with_read_only_after_save_throws_if_value_is_in_modified_state()
+        {
+            // In-memory store does not support store generation 
+        }
+
+        [Fact]
+        public override void Always_identity_property_on_Modified_entity_is_not_included_in_update_when_modified()
+        {
+            // In-memory store does not support store generation 
+        }
+
+        [Fact]
+        public override void Always_identity_property_on_Modified_entity_is_not_included_in_the_update_when_not_modified()
+        {
+            // In-memory store does not support store generation 
+        }
+
         public class StoreGeneratedInMemoryFixture : StoreGeneratedFixtureBase
         {
             private const string DatabaseName = "StoreGeneratedTest";

--- a/test/EntityFramework7.SqlServer.FunctionalTests/SqlServerDatabaseCreationTest.cs
+++ b/test/EntityFramework7.SqlServer.FunctionalTests/SqlServerDatabaseCreationTest.cs
@@ -328,7 +328,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 modelBuilder.Entity<Blog>(b =>
                     {
                         b.Key(e => new { e.Key1, e.Key2 });
-                        b.Property(e => e.AndRow).ConcurrencyToken();
+                        b.Property(e => e.AndRow).ConcurrencyToken().ValueGeneratedOnAddOrUpdate();
                     });
             }
 

--- a/test/EntityFramework7.SqlServer.FunctionalTests/SqlServerValueGenerationScenariosTest.cs
+++ b/test/EntityFramework7.SqlServer.FunctionalTests/SqlServerValueGenerationScenariosTest.cs
@@ -699,20 +699,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                             context.Entry(blog).Property(e => e.Name).OriginalValue = updatedBlog.Name;
                             context.Entry(blog).Property(e => e.Timestamp).OriginalValue = updatedBlog.Timestamp;
 
-                            // Calling SaveChanges will throw because "Timestamp is read-only" (Original and current values don't match)
-                            //context.SaveChanges();
-
-                            // Try to fix this by marking as not modified
-                            context.Entry(blog).Property(e => e.Timestamp).IsModified = false;
-
-                            // Still throws because DetectChanges marks as modified again
-                            // context.SaveChanges();
-
-                            // Try to fix this by making sure current and original values are same and marking as not modified
-                            context.Entry(blog).Property(e => e.Timestamp).CurrentValue = updatedBlog.Timestamp;
-                            context.Entry(blog).Property(e => e.Timestamp).IsModified = false;
-
-                            // Finally saves!
                             context.SaveChanges();
 
                             Assert.NotEqual(blog.Timestamp, currentTimestamp);

--- a/test/EntityFramework7.SqlServer.FunctionalTests/StoreGeneratedSqlServerTest.cs
+++ b/test/EntityFramework7.SqlServer.FunctionalTests/StoreGeneratedSqlServerTest.cs
@@ -75,6 +75,15 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                         b.Property(e => e.IdentityReadOnlyAfterSave)
                             .DefaultValue("Anton");
 
+                        b.Property(e => e.AlwaysIdentity)
+                            .DefaultValue("Banana Joe");
+
+                        b.Property(e => e.AlwaysIdentityReadOnlyBeforeSave)
+                            .DefaultValue("Doughnut Sheriff");
+
+                        b.Property(e => e.AlwaysIdentityReadOnlyAfterSave)
+                            .DefaultValue("Anton");
+
                         b.Property(e => e.Computed)
                             .DefaultValue("Alan");
 
@@ -82,6 +91,15 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                             .DefaultValue("Carmen");
 
                         b.Property(e => e.ComputedReadOnlyAfterSave)
+                            .DefaultValue("Tina Rex");
+
+                        b.Property(e => e.AlwaysComputed)
+                            .DefaultValue("Alan");
+
+                        b.Property(e => e.AlwaysComputedReadOnlyBeforeSave)
+                            .DefaultValue("Carmen");
+
+                        b.Property(e => e.AlwaysComputedReadOnlyAfterSave)
                             .DefaultValue("Tina Rex");
                     });
             }

--- a/test/EntityFramework7.SqlServer.Tests/SqlServerTypeMapperTest.cs
+++ b/test/EntityFramework7.SqlServer.Tests/SqlServerTypeMapperTest.cs
@@ -351,6 +351,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         {
             var property = CreateEntityType().AddProperty("MyProp", typeof(byte[]), shadowProperty: true);
             property.IsConcurrencyToken = true;
+            property.ValueGenerated = ValueGenerated.OnAddOrUpdate;
 
             var typeMapping = (RelationalSizedTypeMapping)new SqlServerTypeMapper().MapPropertyType(property);
 
@@ -365,6 +366,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         {
             var property = CreateEntityType().AddProperty("MyProp", typeof(byte[]), shadowProperty: true);
             property.IsConcurrencyToken = true;
+            property.ValueGenerated = ValueGenerated.OnAddOrUpdate;
             property.IsNullable = false;
 
             var typeMapping = (RelationalSizedTypeMapping)new SqlServerTypeMapper().MapPropertyType(property);
@@ -373,6 +375,18 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             Assert.Equal("rowversion", typeMapping.DefaultTypeName);
             Assert.Equal(8, typeMapping.Size);
             Assert.Equal(8, typeMapping.CreateParameter(new TestCommand(), "Name", new byte[8]).Size);
+        }
+
+        [Fact]
+        public void Does_not_do_rowversion_mapping_for_non_computed_concurrency_tokens()
+        {
+            var property = CreateEntityType().AddProperty("MyProp", typeof(byte[]), shadowProperty: true);
+            property.IsConcurrencyToken = true;
+
+            var typeMapping = (SqlServerMaxLengthMapping)new SqlServerTypeMapper().MapPropertyType(property);
+
+            Assert.Equal(DbType.Binary, typeMapping.StoreType);
+            Assert.Equal("varbinary(max)", typeMapping.DefaultTypeName);
         }
 
         private static RelationalTypeMapping GetTypeMapping(Type propertyType, bool? isNullable = null, int? maxLength = null)

--- a/test/EntityFramework7.Sqlite.FunctionalTests/StoreGeneratedSqliteTest.cs
+++ b/test/EntityFramework7.Sqlite.FunctionalTests/StoreGeneratedSqliteTest.cs
@@ -72,6 +72,15 @@ namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
                         b.Property(e => e.IdentityReadOnlyAfterSave)
                             .DefaultValue("Anton");
 
+                        b.Property(e => e.AlwaysIdentity)
+                            .DefaultValue("Banana Joe");
+
+                        b.Property(e => e.AlwaysIdentityReadOnlyBeforeSave)
+                            .DefaultValue("Doughnut Sheriff");
+
+                        b.Property(e => e.AlwaysIdentityReadOnlyAfterSave)
+                            .DefaultValue("Anton");
+
                         b.Property(e => e.Computed)
                             .DefaultValue("Alan");
 
@@ -79,6 +88,15 @@ namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
                             .DefaultValue("Carmen");
 
                         b.Property(e => e.ComputedReadOnlyAfterSave)
+                            .DefaultValue("Tina Rex");
+
+                        b.Property(e => e.AlwaysComputed)
+                            .DefaultValue("Alan");
+
+                        b.Property(e => e.AlwaysComputedReadOnlyBeforeSave)
+                            .DefaultValue("Carmen");
+
+                        b.Property(e => e.AlwaysComputedReadOnlyAfterSave)
                             .DefaultValue("Tina Rex");
                     });
             }


### PR DESCRIPTION
Introduces a new flag on property indicating that store generated values should always be used regardless of the current value in the property or whether or not it is marked as modified. By default any property that is a concurrency token and generated on add and update will also get this flag set, although it can be switched off. This makes rowversion optimistic concurrency just work out of the box.

See #1989