### PR TITLE
Write perf results to diagnostics

### DIFF
--- a/test/EntityFramework7.Microbenchmarks.Core/BenchmarkRunSummary.cs
+++ b/test/EntityFramework7.Microbenchmarks.Core/BenchmarkRunSummary.cs
@@ -68,6 +68,15 @@ namespace EntityFramework.Microbenchmarks.Core
             MemoryDeltaStandardDeviation = StandardDeviation(memoryDeltas, MemoryDeltaAverage);
         }
 
+        public override string ToString()
+        {
+            return $@"{TestClass}.{TestMethod} (Variation={Variation})
+    Warmup Iterations: {WarmupIterations}
+    Collection Iterations: {Iterations}
+    Time Elapsed (95th Percentile): {TimeElapsedPercentile95}ms
+    Memory Delta (95th Percentile): {MemoryDeltaPercentile95}";
+        }
+
         private static long Percentile(IEnumerable<long> results, double percentile)
         {
             return results.OrderBy(r => r).ElementAt((int)(results.Count() * percentile));

--- a/test/EntityFramework7.Microbenchmarks.Core/BenchmarkTestCase.cs
+++ b/test/EntityFramework7.Microbenchmarks.Core/BenchmarkTestCase.cs
@@ -13,6 +13,8 @@ namespace EntityFramework.Microbenchmarks.Core
 {
     public class BenchmarkTestCase : XunitTestCase
     {
+        private readonly IMessageSink _diagnosticMessageSink;
+
         public BenchmarkTestCase(
                 int iterations,
                 int warmupIterations,
@@ -28,6 +30,7 @@ namespace EntityFramework.Microbenchmarks.Core
                 .First()
                 .GetNamedArgument<string>("DisplayName");
 
+            _diagnosticMessageSink = diagnosticMessageSink;
             DisplayName = suppliedDisplayName ?? BaseDisplayName;
             Variation = variation;
             Iterations = iterations;
@@ -62,7 +65,8 @@ namespace EntityFramework.Microbenchmarks.Core
                 TestMethodArguments, 
                 messageBus, 
                 aggregator,
-                cancellationTokenSource).RunAsync();
+                cancellationTokenSource,
+                _diagnosticMessageSink).RunAsync();
         }
     }
 

--- a/test/EntityFramework7.Microbenchmarks.EF6/EntityFramework7.Microbenchmarks.EF6.csproj
+++ b/test/EntityFramework7.Microbenchmarks.EF6/EntityFramework7.Microbenchmarks.EF6.csproj
@@ -50,6 +50,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="project.json" />
+    <None Include="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EntityFramework7.Microbenchmarks.Core\EntityFramework7.Microbenchmarks.Core.csproj">

--- a/test/EntityFramework7.Microbenchmarks.EF6/xunit.runner.json
+++ b/test/EntityFramework7.Microbenchmarks.EF6/xunit.runner.json
@@ -1,0 +1,3 @@
+﻿{
+  "diagnosticMessages": false
+}

--- a/test/EntityFramework7.Microbenchmarks/EntityFramework7.Microbenchmarks.csproj
+++ b/test/EntityFramework7.Microbenchmarks/EntityFramework7.Microbenchmarks.csproj
@@ -69,6 +69,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="project.json" />
+    <None Include="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.

--- a/test/EntityFramework7.Microbenchmarks/xunit.runner.json
+++ b/test/EntityFramework7.Microbenchmarks/xunit.runner.json
@@ -1,0 +1,3 @@
+﻿{
+  "diagnosticMessages": false
+}


### PR DESCRIPTION
This allows us to switch on diagnostics and see the perf results in VS
output window or on the command line. This makes it easy to use perf
tests as a harness when working on perf improvements.
Also adding config files so that the diagnostic messages can be easily
switched on.