### PR TITLE
Remove GetDbTransaction method

### DIFF
--- a/src/EntityFramework7.Relational/RelationalDatabaseFacadeExtensions.cs
+++ b/src/EntityFramework7.Relational/RelationalDatabaseFacadeExtensions.cs
@@ -44,9 +44,6 @@ namespace Microsoft.Data.Entity
         public static void CloseConnection([NotNull] this DatabaseFacade databaseFacade)
             => GetRelationalConnection(databaseFacade).Close();
 
-        public static DbTransaction GetDbTransaction([NotNull] this DatabaseFacade databaseFacade)
-            => GetRelationalConnection(databaseFacade).DbTransaction;
-
         public static IRelationalTransaction BeginTransaction([NotNull] this DatabaseFacade databaseFacade)
             => GetRelationalConnection(databaseFacade).BeginTransaction();
 

--- a/test/EntityFramework7.Relational.Tests/RelationalDatabaseFacadeExtensionsTest.cs
+++ b/test/EntityFramework7.Relational.Tests/RelationalDatabaseFacadeExtensionsTest.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.Entity.Relational.Internal;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Data.Entity.Tests;
 using Microsoft.Framework.DependencyInjection;
 using Moq;
 using Xunit;
@@ -29,20 +28,6 @@ namespace Microsoft.Data.Entity.Tests
                 new ServiceCollection().AddInstance(connectionMock.Object));
 
             Assert.Same(dbConnection, context.Database.GetDbConnection());
-        }
-
-        [Fact]
-        public void GetDbConnection_returns_the_current_transaction()
-        {
-            var dbTransaction = Mock.Of<DbTransaction>();
-
-            var connectionMock = new Mock<IRelationalConnection>();
-            connectionMock.SetupGet(m => m.DbTransaction).Returns(dbTransaction);
-
-            var context = RelationalTestHelpers.Instance.CreateContext(
-                new ServiceCollection().AddInstance(connectionMock.Object));
-
-            Assert.Same(dbTransaction, context.Database.GetDbTransaction());
         }
 
         [Fact]


### PR DESCRIPTION
Can get it off the returned RelationalTransaction when needed. See Issue #2494