### PR TITLE
Remove column order metadata and API

### DIFF
--- a/src/EntityFramework7.Relational/Metadata/Conventions/Internal/RelationalColumnAttributeConvention.cs
+++ b/src/EntityFramework7.Relational/Metadata/Conventions/Internal/RelationalColumnAttributeConvention.cs
@@ -19,11 +19,6 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
                 propertyBuilder.Annotation(RelationalAnnotationNames.Prefix + RelationalAnnotationNames.ColumnName, attribute.Name, ConfigurationSource.DataAnnotation);
             }
 
-            if (attribute.Order != -1)
-            {
-                propertyBuilder.Annotation(RelationalAnnotationNames.Prefix + RelationalAnnotationNames.ColumnOrder, attribute.Order, ConfigurationSource.DataAnnotation);
-            }
-
             if (!string.IsNullOrWhiteSpace(attribute.TypeName))
             {
                 propertyBuilder.Annotation(RelationalAnnotationNames.Prefix + RelationalAnnotationNames.ColumnType, attribute.TypeName, ConfigurationSource.DataAnnotation);

--- a/src/EntityFramework7.Relational/Metadata/IRelationalPropertyAnnotations.cs
+++ b/src/EntityFramework7.Relational/Metadata/IRelationalPropertyAnnotations.cs
@@ -6,7 +6,6 @@ namespace Microsoft.Data.Entity.Metadata
     public interface IRelationalPropertyAnnotations
     {
         string ColumnName { get; }
-        int? ColumnOrder { get; }
         string ColumnType { get; }
         string GeneratedValueSql { get; }
         object DefaultValue { get; }

--- a/src/EntityFramework7.Relational/Metadata/ReadOnlyRelationalPropertyAnnotations.cs
+++ b/src/EntityFramework7.Relational/Metadata/ReadOnlyRelationalPropertyAnnotations.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Data.Entity.Metadata
     public class ReadOnlyRelationalPropertyAnnotations : IRelationalPropertyAnnotations
     {
         protected const string NameAnnotation = RelationalAnnotationNames.Prefix + RelationalAnnotationNames.ColumnName;
-        protected const string ColumnOrderAnnotation = RelationalAnnotationNames.Prefix + RelationalAnnotationNames.ColumnOrder;
         protected const string ColumnTypeAnnotation = RelationalAnnotationNames.Prefix + RelationalAnnotationNames.ColumnType;
         protected const string GeneratedValueSqlAnnotation = RelationalAnnotationNames.Prefix + RelationalAnnotationNames.GeneratedValueSql;
         protected const string DefaultValueAnnotation = RelationalAnnotationNames.Prefix + RelationalAnnotationNames.DefaultValue;
@@ -25,7 +24,6 @@ namespace Microsoft.Data.Entity.Metadata
         }
 
         public virtual string ColumnName => _property[NameAnnotation] as string ?? _property.Name;
-        public virtual int? ColumnOrder => _property[ColumnOrderAnnotation] as int?;
         public virtual string ColumnType => _property[ColumnTypeAnnotation] as string;
         public virtual string GeneratedValueSql => _property[GeneratedValueSqlAnnotation] as string;
 

--- a/src/EntityFramework7.Relational/Metadata/RelationalAnnotationNames.cs
+++ b/src/EntityFramework7.Relational/Metadata/RelationalAnnotationNames.cs
@@ -7,7 +7,6 @@ namespace Microsoft.Data.Entity.Metadata
     {
         public const string Prefix = "Relational:";
         public const string ColumnName = "ColumnName";
-        public const string ColumnOrder = "ColumnOrder";
         public const string ColumnType = "ColumnType";
         public const string GeneratedValueSql = "GeneratedValueSql";
         public const string DefaultValue = "DefaultValue";

--- a/src/EntityFramework7.Relational/Metadata/RelationalPropertyAnnotations.cs
+++ b/src/EntityFramework7.Relational/Metadata/RelationalPropertyAnnotations.cs
@@ -25,16 +25,6 @@ namespace Microsoft.Data.Entity.Metadata
             }
         }
 
-        public new virtual int? ColumnOrder
-        {
-            get { return base.ColumnOrder; }
-            [param: CanBeNull]
-            set
-            {
-                ((Property)Property)[ColumnOrderAnnotation] = value;
-            }
-        }
-
         public new virtual string ColumnType
         {
             get { return base.ColumnType; }

--- a/src/EntityFramework7.Relational/RelationalPropertyBuilderExtensions.cs
+++ b/src/EntityFramework7.Relational/RelationalPropertyBuilderExtensions.cs
@@ -28,22 +28,6 @@ namespace Microsoft.Data.Entity
             [CanBeNull] string name)
             => (PropertyBuilder<TProperty>)HasColumnName((PropertyBuilder)propertyBuilder, name);
 
-        public static PropertyBuilder HasColumnOrder(
-            [NotNull] this PropertyBuilder propertyBuilder,
-            [CanBeNull] int? columnOrder)
-        {
-            Check.NotNull(propertyBuilder, nameof(propertyBuilder));
-
-            propertyBuilder.Metadata.Relational().ColumnOrder = columnOrder;
-
-            return propertyBuilder;
-        }
-
-        public static PropertyBuilder<TProperty> HasColumnOrder<TProperty>(
-            [NotNull] this PropertyBuilder<TProperty> propertyBuilder,
-            [CanBeNull] int? columnOrder)
-            => (PropertyBuilder<TProperty>)HasColumnOrder((PropertyBuilder)propertyBuilder, columnOrder);
-
         public static PropertyBuilder HasColumnType(
             [NotNull] this PropertyBuilder propertyBuilder,
             [CanBeNull] string typeName)

--- a/test/EntityFramework7.Relational.Tests/Metadata/RelationalBuilderExtensionsTest.cs
+++ b/test/EntityFramework7.Relational.Tests/Metadata/RelationalBuilderExtensionsTest.cs
@@ -30,21 +30,6 @@ namespace Microsoft.Data.Entity.Metadata.Tests
         }
 
         [Fact]
-        public void Can_set_column_order_with_convention_builder()
-        {
-            var modelBuilder = CreateConventionModelBuilder();
-
-            modelBuilder
-                .Entity<Customer>()
-                .Property(e => e.Name)
-                .HasColumnOrder(1);
-
-            var property = modelBuilder.Model.GetEntityType(typeof(Customer)).GetProperty("Name");
-
-            Assert.Equal(1, property.Relational().ColumnOrder);
-        }
-
-        [Fact]
         public void Can_set_column_type_with_convention_builder()
         {
             var modelBuilder = CreateConventionModelBuilder();

--- a/test/EntityFramework7.Relational.Tests/Metadata/RelationalMetadataExtensionsTest.cs
+++ b/test/EntityFramework7.Relational.Tests/Metadata/RelationalMetadataExtensionsTest.cs
@@ -84,30 +84,6 @@ namespace Microsoft.Data.Entity.Metadata.Tests
         }
 
         [Fact]
-        public void Can_get_and_set_column_order()
-        {
-            var modelBuilder = new ModelBuilder(new ConventionSet());
-
-            var property = modelBuilder
-                .Entity<Customer>()
-                .Property(e => e.Name)
-                .Metadata;
-
-            Assert.Null(property.Relational().ColumnOrder);
-            Assert.Null(((IProperty)property).Relational().ColumnOrder);
-
-            property.Relational().ColumnOrder = 2;
-
-            Assert.Equal(2, property.Relational().ColumnOrder);
-            Assert.Equal(2, ((IProperty)property).Relational().ColumnOrder);
-
-            property.Relational().ColumnOrder = null;
-
-            Assert.Null(property.Relational().ColumnOrder);
-            Assert.Null(((IProperty)property).Relational().ColumnOrder);
-        }
-
-        [Fact]
         public void Can_get_and_set_column_type()
         {
             var modelBuilder = new ModelBuilder(new ConventionSet());

--- a/test/EntityFramework7.Relational.Tests/Metadata/RelationalPropertyAttributeConventionTest.cs
+++ b/test/EntityFramework7.Relational.Tests/Metadata/RelationalPropertyAttributeConventionTest.cs
@@ -20,14 +20,13 @@ namespace Microsoft.Data.Entity.Metadata
         }
 
         [Fact]
-        public void ColumnAttribute_sets_column_name_order_and_type_with_conventional_builder()
+        public void ColumnAttribute_sets_column_name_and_type_with_conventional_builder()
         {
             var modelBuilder = new ModelBuilder(new TestConventionalSetBuilder().AddConventions(new CoreConventionSetBuilder().CreateConventionSet()));
 
             var entityBuilder = modelBuilder.Entity<A>();
 
             Assert.Equal("Post Name", entityBuilder.Property(e => e.Name).Metadata.Relational().ColumnName);
-            Assert.Equal(1, entityBuilder.Property(e => e.Name).Metadata.Relational().ColumnOrder);
             Assert.Equal("DECIMAL", entityBuilder.Property(e => e.Name).Metadata.Relational().ColumnType);
         }
 
@@ -40,13 +39,11 @@ namespace Microsoft.Data.Entity.Metadata
             var propertyBuilder = entityBuilder.Property(typeof(string), "Name", ConfigurationSource.Explicit);
 
             propertyBuilder.Annotation(RelationalAnnotationNames.Prefix + RelationalAnnotationNames.ColumnName, "ConventionalName", ConfigurationSource.Convention);
-            propertyBuilder.Annotation(RelationalAnnotationNames.Prefix + RelationalAnnotationNames.ColumnOrder, 3, ConfigurationSource.Convention);
             propertyBuilder.Annotation(RelationalAnnotationNames.Prefix + RelationalAnnotationNames.ColumnType, "BYTE", ConfigurationSource.Convention);
 
             new RelationalColumnAttributeConvention().Apply(propertyBuilder);
 
             Assert.Equal("Post Name", propertyBuilder.Metadata.Relational().ColumnName);
-            Assert.Equal(1, propertyBuilder.Metadata.Relational().ColumnOrder);
             Assert.Equal("DECIMAL", propertyBuilder.Metadata.Relational().ColumnType);
 
         }
@@ -59,13 +56,11 @@ namespace Microsoft.Data.Entity.Metadata
             var propertyBuilder = entityBuilder.Property(typeof(string), "Name", ConfigurationSource.Explicit);
 
             propertyBuilder.Annotation(RelationalAnnotationNames.Prefix + RelationalAnnotationNames.ColumnName, "ExplicitName", ConfigurationSource.Explicit);
-            propertyBuilder.Annotation(RelationalAnnotationNames.Prefix + RelationalAnnotationNames.ColumnOrder, 0, ConfigurationSource.Explicit);
             propertyBuilder.Annotation(RelationalAnnotationNames.Prefix + RelationalAnnotationNames.ColumnType, "BYTE", ConfigurationSource.Explicit);
 
             new RelationalColumnAttributeConvention().Apply(propertyBuilder);
 
             Assert.Equal("ExplicitName", propertyBuilder.Metadata.Relational().ColumnName);
-            Assert.Equal(0, propertyBuilder.Metadata.Relational().ColumnOrder);
             Assert.Equal("BYTE", propertyBuilder.Metadata.Relational().ColumnType);
         }
 


### PR DESCRIPTION
We don't use it for key ordering anymore and it isn't preserved across multiple migrations, so we are removing for now. Order can be changed by editing the migration. Could re-introduce a limited form in the future depending on feedback.