### PR TITLE
Make common relational options available to all relational providers.

### DIFF
--- a/src/EntityFramework7.Relational/Infrastructure/RelationalDbContextOptionsBuilder.cs
+++ b/src/EntityFramework7.Relational/Infrastructure/RelationalDbContextOptionsBuilder.cs
@@ -1,20 +1,50 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Infrastructure
 {
-    public class RelationalDbContextOptionsBuilder
+    public abstract class RelationalDbContextOptionsBuilder<TBuilder, TExtension>
+        where TBuilder : RelationalDbContextOptionsBuilder<TBuilder, TExtension>
+        where TExtension : RelationalOptionsExtension
     {
-        public RelationalDbContextOptionsBuilder([NotNull] DbContextOptionsBuilder optionsBuilder)
+        protected RelationalDbContextOptionsBuilder([NotNull] DbContextOptionsBuilder optionsBuilder)
         {
             Check.NotNull(optionsBuilder, nameof(optionsBuilder));
 
             OptionsBuilder = optionsBuilder;
         }
 
-        protected DbContextOptionsBuilder OptionsBuilder { get; }
+        protected virtual DbContextOptionsBuilder OptionsBuilder { get; }
+
+        protected abstract TExtension CloneExtension();
+
+        public virtual TBuilder MaxBatchSize(int maxBatchSize)
+            => SetOption(e => e.MaxBatchSize = maxBatchSize);
+
+        public virtual TBuilder CommandTimeout(int? commandTimeout)
+            => SetOption(e => e.CommandTimeout = commandTimeout);
+
+        public virtual TBuilder MigrationsAssembly([NotNull] string assemblyName)
+            => SetOption(e => e.MigrationsAssembly = Check.NullButNotEmpty(assemblyName, nameof(assemblyName)));
+
+        public virtual TBuilder SuppressAmbientTransactionWarning()
+            => SetOption(e => e.ThrowOnAmbientTransaction = false);
+
+        protected virtual TBuilder SetOption([NotNull] Action<TExtension> setAction)
+        {
+            Check.NotNull(setAction, nameof(setAction));
+
+            var extension = CloneExtension();
+
+            setAction(extension);
+
+            ((IDbContextOptionsBuilderInfrastructure)OptionsBuilder).AddOrUpdateExtension(extension);
+
+            return (TBuilder)this;
+        }
     }
 }

--- a/src/EntityFramework7.SqlServer/Extensions/SqlServerDbContextOptionsBuilder.cs
+++ b/src/EntityFramework7.SqlServer/Extensions/SqlServerDbContextOptionsBuilder.cs
@@ -6,59 +6,14 @@ using Microsoft.Data.Entity.Infrastructure;
 
 namespace Microsoft.Data.Entity.SqlServer.Extensions
 {
-    public class SqlServerDbContextOptionsBuilder : RelationalDbContextOptionsBuilder
+    public class SqlServerDbContextOptionsBuilder : RelationalDbContextOptionsBuilder<SqlServerDbContextOptionsBuilder, SqlServerOptionsExtension>
     {
         public SqlServerDbContextOptionsBuilder([NotNull] DbContextOptionsBuilder optionsBuilder)
             : base(optionsBuilder)
         {
         }
 
-        public virtual SqlServerDbContextOptionsBuilder MaxBatchSize(int maxBatchSize)
-        {
-            var extension = new SqlServerOptionsExtension(OptionsBuilder.Options.GetExtension<SqlServerOptionsExtension>())
-            {
-                MaxBatchSize = maxBatchSize
-            };
-
-            ((IDbContextOptionsBuilderInfrastructure)OptionsBuilder).AddOrUpdateExtension(extension);
-
-            return this;
-        }
-
-        public virtual SqlServerDbContextOptionsBuilder CommandTimeout(int? commandTimeout)
-        {
-            var extension = new SqlServerOptionsExtension(OptionsBuilder.Options.GetExtension<SqlServerOptionsExtension>())
-            {
-                CommandTimeout = commandTimeout
-            };
-
-            ((IDbContextOptionsBuilderInfrastructure)OptionsBuilder).AddOrUpdateExtension(extension);
-
-            return this;
-        }
-
-        public virtual SqlServerDbContextOptionsBuilder MigrationsAssembly([NotNull] string assemblyName)
-        {
-            var extension = new SqlServerOptionsExtension(OptionsBuilder.Options.GetExtension<SqlServerOptionsExtension>())
-            {
-                MigrationsAssembly = assemblyName
-            };
-
-            ((IDbContextOptionsBuilderInfrastructure)OptionsBuilder).AddOrUpdateExtension(extension);
-
-            return this;
-        }
-
-        public virtual SqlServerDbContextOptionsBuilder SuppressAmbientTransactionWarning()
-        {
-            var extension = new SqlServerOptionsExtension(OptionsBuilder.Options.GetExtension<SqlServerOptionsExtension>())
-            {
-                ThrowOnAmbientTransaction = false
-            };
-
-            ((IDbContextOptionsBuilderInfrastructure)OptionsBuilder).AddOrUpdateExtension(extension);
-
-            return this;
-        }
+        protected override SqlServerOptionsExtension CloneExtension()
+            => new SqlServerOptionsExtension(OptionsBuilder.Options.GetExtension<SqlServerOptionsExtension>());
     }
 }

--- a/src/EntityFramework7.Sqlite/SqliteDbContextOptionsBuilder.cs
+++ b/src/EntityFramework7.Sqlite/SqliteDbContextOptionsBuilder.cs
@@ -7,23 +7,17 @@ using Microsoft.Data.Entity.Sqlite;
 
 namespace Microsoft.Data.Entity
 {
-    public class SqliteDbContextOptionsBuilder : RelationalDbContextOptionsBuilder
+    public class SqliteDbContextOptionsBuilder : RelationalDbContextOptionsBuilder<SqliteDbContextOptionsBuilder, SqliteOptionsExtension>
     {
         public SqliteDbContextOptionsBuilder([NotNull] DbContextOptionsBuilder optionsBuilder)
             : base(optionsBuilder)
         {
         }
 
+        protected override SqliteOptionsExtension CloneExtension()
+            => new SqliteOptionsExtension(OptionsBuilder.Options.GetExtension<SqliteOptionsExtension>());
+
         public virtual SqliteDbContextOptionsBuilder SuppressForeignKeysEnforcement()
-        {
-            var extension = new SqliteOptionsExtension(OptionsBuilder.Options.GetExtension<SqliteOptionsExtension>())
-            {
-                ForeignKeys = false
-            };
-
-            ((IDbContextOptionsBuilderInfrastructure)OptionsBuilder).AddOrUpdateExtension(extension);
-
-            return this;
-        }
+            => SetOption(e => ((SqliteOptionsExtension)e).ForeignKeys = false);
     }
 }

--- a/test/EntityFramework7.SqlServer.Tests/Update/SqlServerModificationCommandBatchFactoryTest.cs
+++ b/test/EntityFramework7.SqlServer.Tests/Update/SqlServerModificationCommandBatchFactoryTest.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.SqlServer.Metadata;
 using Microsoft.Data.Entity.SqlServer.Update;
 using Microsoft.Data.Entity.Storage;
@@ -53,14 +51,6 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Update
 
             Assert.True(factory.AddCommand(batch, new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.SqlServer(), new UntypedValueBufferFactoryFactory())));
             Assert.True(factory.AddCommand(batch, new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.SqlServer(), new UntypedValueBufferFactoryFactory())));
-        }
-
-        private class TestRelationalOptionsExtension : RelationalOptionsExtension
-        {
-            public override void ApplyServices(EntityFrameworkServicesBuilder builder)
-            {
-                throw new NotImplementedException();
-            }
         }
     }
 }

--- a/test/EntityFramework7.Sqlite.Tests/Extensions/SqliteDbContextOptionsBuilderExtensionsTest.cs
+++ b/test/EntityFramework7.Sqlite.Tests/Extensions/SqliteDbContextOptionsBuilderExtensionsTest.cs
@@ -10,6 +10,39 @@ namespace Microsoft.Data.Entity.Sqlite.Extensions
     public class SqliteDbContextOptionsBuilderExtensionsTest
     {
         [Fact]
+        public void Can_add_extension_with_max_batch_size()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder();
+            optionsBuilder.UseSqlite("Database=Crunchie").MaxBatchSize(123);
+
+            var extension = optionsBuilder.Options.Extensions.OfType<SqliteOptionsExtension>().Single();
+
+            Assert.Equal(123, extension.MaxBatchSize);
+        }
+
+        [Fact]
+        public void Can_add_extension_with_command_timeout()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder();
+            optionsBuilder.UseSqlite("Database=Crunchie").CommandTimeout(30);
+
+            var extension = optionsBuilder.Options.Extensions.OfType<SqliteOptionsExtension>().Single();
+
+            Assert.Equal(30, extension.CommandTimeout);
+        }
+
+        [Fact]
+        public void Can_add_extension_with_ambient_transaction_warning_suppressed()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder();
+            optionsBuilder.UseSqlite("Database=Crunchie").SuppressAmbientTransactionWarning();
+
+            var extension = optionsBuilder.Options.Extensions.OfType<SqliteOptionsExtension>().Single();
+
+            Assert.Equal(false, extension.ThrowOnAmbientTransaction);
+        }
+
+        [Fact]
         public void Can_add_extension_with_connection_string()
         {
             var optionsBuilder = new DbContextOptionsBuilder();


### PR DESCRIPTION
These are currently MaxBatchSize, CommandTimeout, SuppressAmbientTransactionWarning, and MigrationsAssembly.