### PR TITLE
Make non-contract methods on UpdateSqlGenerator protected

### DIFF
--- a/src/EntityFramework7.Relational/Update/UpdateSqlGenerator.cs
+++ b/src/EntityFramework7.Relational/Update/UpdateSqlGenerator.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Data.Entity.Update
             AppendSelectAffectedCountCommand(commandStringBuilder, name, schema);
         }
 
-        public virtual void AppendInsertCommand(
+        protected virtual void AppendInsertCommand(
             [NotNull] StringBuilder commandStringBuilder,
             [NotNull] string name,
             [CanBeNull] string schema,
@@ -96,7 +96,7 @@ namespace Microsoft.Data.Entity.Update
             commandStringBuilder.Append(BatchCommandSeparator).AppendLine();
         }
 
-        public virtual void AppendUpdateCommand(
+        protected virtual void AppendUpdateCommand(
             [NotNull] StringBuilder commandStringBuilder,
             [NotNull] string name,
             [CanBeNull] string schema,
@@ -113,7 +113,7 @@ namespace Microsoft.Data.Entity.Update
             commandStringBuilder.Append(BatchCommandSeparator).AppendLine();
         }
 
-        public virtual void AppendDeleteCommand(
+        protected virtual void AppendDeleteCommand(
             [NotNull] StringBuilder commandStringBuilder,
             [NotNull] string name,
             [CanBeNull] string schema,
@@ -128,14 +128,14 @@ namespace Microsoft.Data.Entity.Update
             commandStringBuilder.Append(BatchCommandSeparator).AppendLine();
         }
 
-        public virtual void AppendSelectAffectedCountCommand(
+        protected virtual void AppendSelectAffectedCountCommand(
             [NotNull] StringBuilder commandStringBuilder,
             [NotNull] string name,
             [CanBeNull] string schema)
         {
         }
 
-        public virtual void AppendSelectAffectedCommand(
+        protected virtual void AppendSelectAffectedCommand(
             [NotNull] StringBuilder commandStringBuilder,
             [NotNull] string name,
             [CanBeNull] string schema,
@@ -354,7 +354,7 @@ namespace Microsoft.Data.Entity.Update
         public virtual string DelimitIdentifier(string identifier)
             => "\"" + EscapeIdentifier(Check.NotEmpty(identifier, nameof(identifier))) + "\"";
 
-        public virtual string EscapeIdentifier([NotNull] string identifier)
+        protected virtual string EscapeIdentifier([NotNull] string identifier)
             => Check.NotEmpty(identifier, nameof(identifier)).Replace("\"", "\"\"");
 
         public virtual string GenerateLiteral(string literal)

--- a/src/EntityFramework7.SqlServer/Update/SqlServerUpdateSqlGenerator.cs
+++ b/src/EntityFramework7.SqlServer/Update/SqlServerUpdateSqlGenerator.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Data.Entity.Update
                 .Append("OUTPUT ")
                 .AppendJoin(operations.Select(c => "INSERTED." + DelimitIdentifier(c.ColumnName)));
 
-        public override void AppendSelectAffectedCountCommand(StringBuilder commandStringBuilder, string name, string schema)
+        protected override void AppendSelectAffectedCountCommand(StringBuilder commandStringBuilder, string name, string schema)
             => Check.NotNull(commandStringBuilder, nameof(commandStringBuilder))
                 .Append("SELECT @@ROWCOUNT")
                 .Append(BatchCommandSeparator).AppendLine();
@@ -134,7 +134,7 @@ namespace Microsoft.Data.Entity.Update
         public override string DelimitIdentifier(string identifier)
             => "[" + EscapeIdentifier(Check.NotEmpty(identifier, nameof(identifier))) + "]";
 
-        public override string EscapeIdentifier(string identifier)
+        protected override string EscapeIdentifier(string identifier)
             => Check.NotEmpty(identifier, nameof(identifier)).Replace("]", "]]");
 
         public override string GenerateLiteral(byte[] literal)

--- a/src/EntityFramework7.Sqlite/Update/SqliteUpdateSqlGenerator.cs
+++ b/src/EntityFramework7.Sqlite/Update/SqliteUpdateSqlGenerator.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Data.Entity.Update
                 .Append("last_insert_rowid()");
         }
 
-        public override void AppendSelectAffectedCountCommand(StringBuilder builder, string name, string schema)
+        protected override void AppendSelectAffectedCountCommand(StringBuilder builder, string name, string schema)
         {
             Check.NotNull(builder, nameof(builder));
             Check.NotEmpty(name, nameof(name));

--- a/test/EntityFramework7.Relational.Tests/SqlGeneratorTest.cs
+++ b/test/EntityFramework7.Relational.Tests/SqlGeneratorTest.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Data.Entity.Tests
                     .Append("provider_specific_identity()");
             }
 
-            public override void AppendSelectAffectedCountCommand(StringBuilder commandStringBuilder, string name, string schema)
+            protected override void AppendSelectAffectedCountCommand(StringBuilder commandStringBuilder, string name, string schema)
             {
                 commandStringBuilder
                     .Append("SELECT provider_specific_rowcount();" + Environment.NewLine);

--- a/test/EntityFramework7.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
+++ b/test/EntityFramework7.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Data.Entity.Tests.Update
                 base.AppendBatchHeader(commandStringBuilder);
             }
 
-            public override void AppendSelectAffectedCountCommand(StringBuilder commandStringBuilder, string name, string schema)
+            protected override void AppendSelectAffectedCountCommand(StringBuilder commandStringBuilder, string name, string schema)
             {
             }
 


### PR DESCRIPTION
These methods were public on the abstract class even though they do not exist on the IUpdateSqlGenerator contract interface, through which all public access should go. I decided to make them protected to provide full flexibility for provider-specific derivations of the abstract class.