### PR TITLE
Update Remotion.Linq to v2.0.0-beta.2

### DIFF
--- a/src/EntityFramework7.Core/Query/ExpressionVisitors/ParameterExtractingExpressionVisitor.cs
+++ b/src/EntityFramework7.Core/Query/ExpressionVisitors/ParameterExtractingExpressionVisitor.cs
@@ -15,10 +15,11 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
     {
         public static Expression ExtractParameters(
             [NotNull] Expression expressionTree,
-            [NotNull] QueryContext queryContext)
+            [NotNull] QueryContext queryContext,
+            [NotNull] IEvaluatableExpressionFilter evaluatableExpressionFilter)
         {
             var functionEvaluationDisabledExpression = new FunctionEvaluationDisablingVisitor().Visit(expressionTree);
-            var partialEvaluationInfo = EvaluatableTreeFindingExpressionVisitor.Analyze(functionEvaluationDisabledExpression);
+            var partialEvaluationInfo = EvaluatableTreeFindingExpressionVisitor.Analyze(functionEvaluationDisabledExpression, evaluatableExpressionFilter);
             var visitor = new ParameterExtractingExpressionVisitor(partialEvaluationInfo, queryContext);
 
             return visitor.Visit(functionEvaluationDisabledExpression);

--- a/src/EntityFramework7.Core/Query/Expressions/MethodCallEvaluationPreventingExpression.cs
+++ b/src/EntityFramework7.Core/Query/Expressions/MethodCallEvaluationPreventingExpression.cs
@@ -25,16 +25,6 @@ namespace Microsoft.Data.Entity.Query.Expressions
 
         public override Type Type => _methodCall.Type;
 
-        public override bool CanReduce
-        {
-            get { return true; }
-        }
-
-        public override Expression Reduce()
-        {
-            return MethodCall;
-        }
-
         protected override Expression VisitChildren(ExpressionVisitor visitor)
         {
             var newObject = visitor.Visit(MethodCall.Object);

--- a/src/EntityFramework7.Core/Query/Expressions/PropertyEvaluationPreventingExpression.cs
+++ b/src/EntityFramework7.Core/Query/Expressions/PropertyEvaluationPreventingExpression.cs
@@ -22,16 +22,6 @@ namespace Microsoft.Data.Entity.Query.Expressions
 
         public override Type Type => _memberExpression.Type;
 
-        public override bool CanReduce
-        {
-            get { return true; }
-        }
-
-        public override Expression Reduce()
-        {
-            return MemberExpression;
-        }
-
         protected override Expression VisitChildren(ExpressionVisitor visitor)
         {
             var newExpression = visitor.Visit(MemberExpression.Expression);

--- a/src/EntityFramework7.Core/Query/ResultOperators/ThenIncludeExpressionNode.cs
+++ b/src/EntityFramework7.Core/Query/ResultOperators/ThenIncludeExpressionNode.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Data.Entity.Query.ResultOperators
             _navigationPropertyPathLambda = navigationPropertyPathLambda;
         }
 
-        protected override QueryModel ApplyNodeSpecificSemantics(QueryModel queryModel, ClauseGenerationContext clauseGenerationContext)
+        protected override void ApplyNodeSpecificSemantics(QueryModel queryModel, ClauseGenerationContext clauseGenerationContext)
         {
             var queryAnnotationResultOperator
                 = (QueryAnnotationResultOperator)clauseGenerationContext.GetContextInfo(Source);
@@ -41,8 +41,6 @@ namespace Microsoft.Data.Entity.Query.ResultOperators
                 .AppendToNavigationPath(_navigationPropertyPathLambda.GetComplexPropertyAccess());
 
             clauseGenerationContext.AddContextInfo(this, queryAnnotationResultOperator);
-
-            return queryModel;
         }
 
         protected override ResultOperatorBase CreateResultOperator(ClauseGenerationContext clauseGenerationContext) => null;

--- a/src/EntityFramework7.Core/project.json
+++ b/src/EntityFramework7.Core/project.json
@@ -17,7 +17,7 @@
     "Microsoft.Framework.Logging": "1.0.0-*",
     "Microsoft.Framework.Logging.Abstractions": "1.0.0-*",
     "Microsoft.Framework.OptionsModel": "1.0.0-*",
-    "Remotion.Linq": "2.0.0-alpha-004",
+    "Remotion.Linq": "2.0.0-beta-002",
     "System.Collections.Immutable": "1.1.37-*"
   },
   "compile": "..\\Shared\\*.cs",


### PR DESCRIPTION
* Updated dependency.
* Updated API changes:
 * Injected stub-implementation for EvaluatableExpressionFilterBase into PartialEvaluatingExpressionTreeProcessor. This can later be changed to exclude specific method/property calls (e.g. DateTime.Now) from partial evaluation.
 * ReferenceReplacingExpressionVisitor is no longer available as extension point. Usages have been replaced with equivalent semantics.
 * FromClause no longer exposes settable properties. The QueryOptimizer has been changed to use a stub object for transferring the values during sub-query flattening.
 *  Changed MethodCallEvaluationPreventingExpression and PropertyEvaluationPreventingExpression to non-reducible to work with updated partial evaluation behavior.

Note: #2667 already contains a short description for refactoring the support for DateTime.Now and Guid.NewGuid() via a custom EvaluatableExpressionFilterBase. 