### PR TITLE
[SQLite] Fix bug in timestamp literals. Add more testing.

### DIFF
--- a/src/EntityFramework7.Sqlite/Update/SqliteUpdateSqlGenerator.cs
+++ b/src/EntityFramework7.Sqlite/Update/SqliteUpdateSqlGenerator.cs
@@ -1,7 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Text;
+using Microsoft.Data.Entity.Sqlite;
 using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Update
@@ -38,6 +40,14 @@ namespace Microsoft.Data.Entity.Update
             Check.NotNull(builder, nameof(builder));
 
             builder.Append("changes() = " + expectedRowsAffected);
+        }
+
+        public override string GenerateLiteral(DateTime literal) => "'" + literal.ToString(@"yyyy\-MM\-dd HH\:mm\:ss.FFFFFFF") + "'";
+        public override string GenerateLiteral(DateTimeOffset literal) => "'" + literal.ToString(@"yyyy\-MM\-dd HH\:mm\:ss.FFFFFFFzzz") + "'";
+
+        public override string GenerateNextSequenceValueOperation(string name, string schema)
+        {
+            throw new NotSupportedException(Strings.SequencesNotSupported);
         }
     }
 }

--- a/test/EntityFramework7.Sqlite.FunctionalTests/CommandConfigurationTest.cs
+++ b/test/EntityFramework7.Sqlite.FunctionalTests/CommandConfigurationTest.cs
@@ -1,0 +1,246 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Linq;
+using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Query;
+using Microsoft.Data.Entity.Query.Expressions;
+using Microsoft.Data.Entity.Query.Sql;
+using Microsoft.Data.Entity.Sqlite.Update;
+using Microsoft.Data.Entity.Storage;
+using Microsoft.Data.Entity.Update;
+using Microsoft.Data.Sqlite;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.Logging;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
+{
+    public class CommandConfigurationTest : IClassFixture<CommandConfigurationTest.CommandConfigurationTestFixture>
+    {
+        private const string DatabaseName = "NotKettleChips";
+
+        private readonly CommandConfigurationTestFixture _fixture;
+
+        public CommandConfigurationTest(CommandConfigurationTestFixture fixture)
+        {
+            _fixture = fixture;
+            _fixture.CreateDatabase();
+        }
+
+        public class CommandConfigurationTestFixture : IDisposable
+        {
+            private SqliteTestStore _store;
+
+            public IServiceProvider ServiceProvider { get; } = new ServiceCollection()
+                .AddEntityFramework()
+                .AddSqlite()
+                .ServiceCollection()
+                .BuildServiceProvider();
+
+            public virtual void CreateDatabase()
+            {
+                _store = SqliteTestStore.GetOrCreateShared(DatabaseName, () =>
+                {
+                    using (var context = new ChipsContext(ServiceProvider))
+                    {
+                        context.Database.EnsureDeleted();
+                        context.Database.EnsureCreated();
+                    }
+                });
+            }
+
+            public void Dispose()
+            {
+                _store.Dispose();
+            }
+        }
+
+        [Fact]
+        public void Constructed_select_query_uses_default_when_CommandTimeout_not_configured_and_can_be_changed()
+        {
+            using (var context = new ChipsContext(_fixture.ServiceProvider))
+            {
+                var commandBuilder = SetupCommandBuilder();
+
+                var command = commandBuilder.Build(context.GetService<IRelationalConnection>(), new Dictionary<string, object>());
+
+                Assert.Equal(new SqliteCommand().CommandTimeout, command.CommandTimeout);
+
+                context.Database.SetCommandTimeout(77);
+                var command2 = commandBuilder.Build(context.GetService<IRelationalConnection>(), new Dictionary<string, object>());
+
+                Assert.Equal(77, command2.CommandTimeout);
+            }
+        }
+
+        [Fact]
+        public void Constructed_select_query_honors_latest_configured_CommandTimeout_configured_in_context()
+        {
+            using (var context = new ConfiguredChipsContext(_fixture.ServiceProvider))
+            {
+                var commandBuilder = SetupCommandBuilder();
+
+                context.Database.SetCommandTimeout(88);
+                var command = commandBuilder.Build(context.GetService<IRelationalConnection>(), new Dictionary<string, object>());
+
+                Assert.Equal(88, command.CommandTimeout);
+
+                context.Database.SetCommandTimeout(99);
+                var command2 = commandBuilder.Build(context.GetService<IRelationalConnection>(), new Dictionary<string, object>());
+
+                Assert.Equal(99, command2.CommandTimeout);
+            }
+        }
+
+        [Fact]
+        public void Constructed_select_query_CommandBuilder_throws_when_negative_CommandTimeout_is_used()
+        {
+            using (var context = new ConfiguredChipsContext(_fixture.ServiceProvider))
+            {
+                Assert.Throws<ArgumentException>(() => context.Database.SetCommandTimeout(-5));
+            }
+        }
+
+        [Fact]
+        public void Constructed_select_query_CommandBuilder_uses_default_when_null()
+        {
+            using (var context = new ConfiguredChipsContext(_fixture.ServiceProvider))
+            {
+                var commandBuilder = SetupCommandBuilder();
+
+                context.Database.SetCommandTimeout(null);
+                var command = commandBuilder.Build(context.GetService<IRelationalConnection>(), new Dictionary<string, object>());
+
+                Assert.Equal(new SqliteCommand().CommandTimeout, command.CommandTimeout);
+            }
+        }
+
+        private CommandBuilder SetupCommandBuilder()
+        {
+            var selectExpression = new SelectExpression();
+
+            return new CommandBuilder(
+                () => new DefaultQuerySqlGenerator(selectExpression, new SqliteTypeMapper()), new UntypedValueBufferFactoryFactory());
+        }
+
+        [Fact]
+        public void Constructed_update_statement_uses_default_when_CommandTimeout_not_configured()
+        {
+            var serviceProvider = new ServiceCollection()
+                .AddEntityFramework()
+                .AddSqlite()
+                .ServiceCollection()
+                .AddScoped<SqliteModificationCommandBatchFactory, TestSqliteModificationCommandBatchFactory>()
+                .BuildServiceProvider();
+
+            using (var context = new ChipsContext(serviceProvider))
+            {
+                context.Database.EnsureCreated();
+
+                context.Chips.Add(new KettleChips { BestBuyDate = DateTime.Now, Name = "Doritos Locos Tacos" });
+                context.SaveChanges();
+                Assert.Null(GlobalCommandTimeout);
+            }
+        }
+
+        [Fact]
+        public async void Constructed_update_statement_uses_default_CommandTimeout_can_override()
+        {
+            var serviceProvider = new ServiceCollection()
+                .AddEntityFramework()
+                .AddSqlite()
+                .ServiceCollection()
+                .AddScoped<SqliteModificationCommandBatchFactory, TestSqliteModificationCommandBatchFactory>()
+                .BuildServiceProvider();
+
+            using (var context = new ChipsContext(serviceProvider))
+            {
+                context.Database.EnsureCreated();
+
+                context.Chips.Add(new KettleChips { BestBuyDate = DateTime.Now, Name = "Doritos Locos Tacos" });
+                await context.SaveChangesAsync();
+                Assert.Null(GlobalCommandTimeout);
+
+                context.Database.SetCommandTimeout(88);
+
+                context.Chips.Add(new KettleChips { BestBuyDate = DateTime.Now, Name = "Doritos Locos Tacos" });
+                await context.SaveChangesAsync();
+                Assert.Equal(88, GlobalCommandTimeout);
+            }
+        }
+
+        public static int? GlobalCommandTimeout;
+
+        public class TestSqliteModificationCommandBatch : SingularModificationCommandBatch
+        {
+            protected override DbCommand CreateStoreCommand(string commandText, DbTransaction transaction, IRelationalTypeMapper typeMapper, int? commandTimeout)
+            {
+                GlobalCommandTimeout = commandTimeout;
+                return base.CreateStoreCommand(commandText, transaction, typeMapper, commandTimeout);
+            }
+
+            public TestSqliteModificationCommandBatch(IUpdateSqlGenerator sqlGenerator)
+                : base(sqlGenerator)
+            {
+            }
+        }
+
+        public class TestSqliteModificationCommandBatchFactory : SqliteModificationCommandBatchFactory
+        {
+            public TestSqliteModificationCommandBatchFactory(
+                IUpdateSqlGenerator sqlGenerator)
+                : base(sqlGenerator)
+            {
+            }
+
+            public override ModificationCommandBatch Create(
+                IDbContextOptions options,
+                IRelationalMetadataExtensionProvider metadataExtensionProvider) => new TestSqliteModificationCommandBatch(UpdateSqlGenerator);
+        }
+
+        private class ChipsContext : DbContext
+        {
+            public ChipsContext(IServiceProvider serviceProvider)
+                : base(serviceProvider)
+            {
+            }
+
+            public DbSet<KettleChips> Chips { get; set; }
+
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            {
+                optionsBuilder.UseSqlite(SqliteTestStore.CreateConnectionString(DatabaseName));
+            }
+        }
+
+        private class KettleChips
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public DateTime BestBuyDate { get; set; }
+        }
+
+        private class ConfiguredChipsContext : ChipsContext
+        {
+            public ConfiguredChipsContext(IServiceProvider serviceProvider)
+                : base(serviceProvider)
+            {
+            }
+
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            {
+                optionsBuilder.UseSqlite($"Data Source=./{DatabaseName}.db");
+
+                base.OnConfiguring(optionsBuilder);
+            }
+        }
+
+        private static string Sql => TestSqlLoggerFactory.Sql;
+    }
+}

--- a/test/EntityFramework7.Sqlite.FunctionalTests/CompositeKeyEndToEndTest.cs
+++ b/test/EntityFramework7.Sqlite.FunctionalTests/CompositeKeyEndToEndTest.cs
@@ -1,0 +1,166 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Framework.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
+{
+    public class CompositeKeyEndToEndTest
+    {
+        [Fact]
+        public async Task Can_use_two_non_generated_integers_as_composite_key_end_to_end()
+        {
+            var serviceProvider = new ServiceCollection()
+                .AddEntityFramework()
+                .AddSqlite()
+                .ServiceCollection()
+                .BuildServiceProvider();
+
+            var ticks = DateTime.UtcNow.Ticks;
+
+            using (var context = new BronieContext(serviceProvider, "CompositePegasuses"))
+            {
+                context.Database.EnsureCreated();
+
+                context.Add(new Pegasus { Id1 = ticks, Id2 = ticks + 1, Name = "Rainbow Dash" });
+                await context.SaveChangesAsync();
+            }
+
+            using (var context = new BronieContext(serviceProvider, "CompositePegasuses"))
+            {
+                var pegasus = context.Pegasuses.Single(e => e.Id1 == ticks && e.Id2 == ticks + 1);
+
+                pegasus.Name = "Rainbow Crash";
+
+                await context.SaveChangesAsync();
+            }
+
+            using (var context = new BronieContext(serviceProvider, "CompositePegasuses"))
+            {
+                var pegasus = context.Pegasuses.Single(e => e.Id1 == ticks && e.Id2 == ticks + 1);
+
+                Assert.Equal("Rainbow Crash", pegasus.Name);
+
+                context.Pegasuses.Remove(pegasus);
+
+                await context.SaveChangesAsync();
+            }
+
+            using (var context = new BronieContext(serviceProvider, "CompositePegasuses"))
+            {
+                Assert.Equal(0, context.Pegasuses.Count(e => e.Id1 == ticks && e.Id2 == ticks + 1));
+            }
+        }
+
+        [Fact]
+        public async Task Only_one_part_of_a_composite_key_needs_to_vary_for_uniqueness()
+        {
+            var serviceProvider = new ServiceCollection()
+                .AddEntityFramework()
+                .AddSqlite()
+                .ServiceCollection()
+                .BuildServiceProvider();
+
+            var ids = new int[3];
+
+            using (var context = new BronieContext(serviceProvider, "CompositeEarthPonies"))
+            {
+                context.Database.EnsureCreated();
+
+                var pony1 = context.Add(new EarthPony { Id1 = 1, Id2 = 7, Name = "Apple Jack 1" }).Entity;
+                var pony2 = context.Add(new EarthPony { Id1 = 2, Id2 = 7, Name = "Apple Jack 2" }).Entity;
+                var pony3 = context.Add(new EarthPony { Id1 = 3, Id2 = 7, Name = "Apple Jack 3" }).Entity;
+
+                await context.SaveChangesAsync();
+
+                ids[0] = pony1.Id1;
+                ids[1] = pony2.Id1;
+                ids[2] = pony3.Id1;
+            }
+
+            using (var context = new BronieContext(serviceProvider, "CompositeEarthPonies"))
+            {
+                var ponies = context.EarthPonies.ToList();
+                Assert.Equal(ponies.Count, ponies.Count(e => e.Name == "Apple Jack 1") * 3);
+
+                Assert.Equal("Apple Jack 1", ponies.Single(e => e.Id1 == ids[0]).Name);
+                Assert.Equal("Apple Jack 2", ponies.Single(e => e.Id1 == ids[1]).Name);
+                Assert.Equal("Apple Jack 3", ponies.Single(e => e.Id1 == ids[2]).Name);
+
+                ponies.Single(e => e.Id1 == ids[1]).Name = "Pinky Pie 2";
+
+                await context.SaveChangesAsync();
+            }
+
+            using (var context = new BronieContext(serviceProvider, "CompositeEarthPonies"))
+            {
+                var ponies = context.EarthPonies.ToArray();
+                Assert.Equal(ponies.Length, ponies.Count(e => e.Name == "Apple Jack 1") * 3);
+
+                Assert.Equal("Apple Jack 1", ponies.Single(e => e.Id1 == ids[0]).Name);
+                Assert.Equal("Pinky Pie 2", ponies.Single(e => e.Id1 == ids[1]).Name);
+                Assert.Equal("Apple Jack 3", ponies.Single(e => e.Id1 == ids[2]).Name);
+
+                context.EarthPonies.RemoveRange(ponies);
+
+                await context.SaveChangesAsync();
+            }
+
+            using (var context = new BronieContext(serviceProvider, "CompositeEarthPonies"))
+            {
+                Assert.Equal(0, context.EarthPonies.Count());
+            }
+        }
+
+        private class BronieContext : DbContext
+        {
+            private readonly string _databaseName;
+
+            public BronieContext(IServiceProvider serviceProvider, string databaseName)
+                : base(serviceProvider)
+            {
+                _databaseName = databaseName;
+            }
+
+            public DbSet<Pegasus> Pegasuses { get; set; }
+            public DbSet<EarthPony> EarthPonies { get; set; }
+
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            {
+                optionsBuilder.UseSqlite(SqliteTestStore.CreateConnectionString(_databaseName));
+            }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<Pegasus>().Key(e => new { e.Id1, e.Id2 });
+
+                modelBuilder.Entity<EarthPony>(b =>
+                {
+                    b.Key(e => new { e.Id1, e.Id2});
+                    b.Property(e => e.Id1);
+                });
+            }
+        }
+
+        private class Pegasus
+        {
+            public long Id1 { get; set; }
+            public long Id2 { get; set; }
+            public string Name { get; set; }
+        }
+
+
+        private class EarthPony
+        {
+            public int Id1 { get; set; }
+            public int Id2 { get; set; }
+            public string Name { get; set; }
+        }
+    }
+}

--- a/test/EntityFramework7.Sqlite.FunctionalTests/DefaultValuesTest.cs
+++ b/test/EntityFramework7.Sqlite.FunctionalTests/DefaultValuesTest.cs
@@ -1,0 +1,85 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Framework.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
+{
+    public class DefaultValuesTest : IDisposable
+    {
+        private readonly IServiceProvider _serviceProvider = new ServiceCollection()
+            .AddEntityFramework()
+            .AddSqlite()
+            .ServiceCollection()
+            .BuildServiceProvider();
+
+        [Fact]
+        public void Can_use_SQLite_default_values()
+        {
+            using (var context = new ChipsContext(_serviceProvider, "DefaultKettleChips"))
+            {
+                context.Database.EnsureDeleted();
+                context.Database.EnsureCreated();
+
+                var honeyDijon = context.Add(new KettleChips { Name = "Honey Dijon" }).Entity;
+                var buffaloBleu = context.Add(new KettleChips { Name = "Buffalo Bleu", BestBuyDate = new DateTime(2111, 1, 11) }).Entity;
+
+                context.SaveChanges();
+
+                Assert.Equal(new DateTime(2035, 9, 25), honeyDijon.BestBuyDate);
+                Assert.Equal(new DateTime(2111, 1, 11), buffaloBleu.BestBuyDate);
+            }
+
+            using (var context = new ChipsContext(_serviceProvider, "DefaultKettleChips"))
+            {
+                Assert.Equal(new DateTime(2035, 9, 25), context.Chips.Single(c => c.Name == "Honey Dijon").BestBuyDate);
+                Assert.Equal(new DateTime(2111, 1, 11), context.Chips.Single(c => c.Name == "Buffalo Bleu").BestBuyDate);
+            }
+        }
+
+        public void Dispose()
+        {
+            using (var context = new ChipsContext(_serviceProvider, "DefaultKettleChips"))
+            {
+                context.Database.EnsureDeleted();
+            }
+        }
+
+        private class ChipsContext : DbContext
+        {
+            private readonly string _databaseName;
+
+            public ChipsContext(IServiceProvider serviceProvider, string databaseName)
+                : base(serviceProvider)
+            {
+                _databaseName = databaseName;
+            }
+
+            public DbSet<KettleChips> Chips { get; set; }
+
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            {
+                optionsBuilder.UseSqlite(SqliteTestStore.CreateConnectionString(_databaseName));
+            }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<KettleChips>()
+                    .Property(e => e.BestBuyDate)
+                    .ValueGeneratedOnAdd()
+                    .HasDefaultValue(new DateTime(2035, 9, 25));
+            }
+        }
+
+        private class KettleChips
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public DateTime BestBuyDate { get; set; }
+        }
+    }
+}

--- a/test/EntityFramework7.Sqlite.FunctionalTests/EntityFramework7.Sqlite.FunctionalTests.csproj
+++ b/test/EntityFramework7.Sqlite.FunctionalTests/EntityFramework7.Sqlite.FunctionalTests.csproj
@@ -42,10 +42,13 @@
     <Compile Include="BuiltInDataTypesSqliteFixture.cs" />
     <Compile Include="BuiltInDataTypesSqliteTest.cs" />
     <Compile Include="ChangeTrackingSqliteTest.cs" />
+    <Compile Include="CommandConfigurationTest.cs" />
     <Compile Include="ComplexNavigationsQuerySqliteFixture.cs" />
     <Compile Include="ComplexNavigationsQuerySqliteTest.cs" />
+    <Compile Include="CompositeKeyEndToEndTest.cs" />
     <Compile Include="DataAnnotationSqliteFixture.cs" />
     <Compile Include="DataAnnotationSqliteTest.cs" />
+    <Compile Include="DefaultValuesTest.cs" />
     <Compile Include="F1SqliteFixture.cs" />
     <Compile Include="ForeignKeyTest.cs" />
     <Compile Include="FromSqlQuerySqliteTest.cs" />

--- a/test/EntityFramework7.Sqlite.Tests/Migrations/SqliteMigrationSqlGeneratorTest.cs
+++ b/test/EntityFramework7.Sqlite.Tests/Migrations/SqliteMigrationSqlGeneratorTest.cs
@@ -14,6 +14,28 @@ namespace Microsoft.Data.Entity.Sqlite.Migrations
     {
         protected override IMigrationSqlGenerator SqlGenerator => new SqliteMigrationSqlGenerator(new SqliteUpdateSqlGenerator());
 
+        [Fact]
+        public virtual void DefaultValue_formats_literal_correctly()
+        {
+            Generate(new CreateTableOperation
+            {
+                Name = "History",
+                Columns =
+                {
+                    new AddColumnOperation
+                    {
+                        Name = "Event",
+                        Type = "TEXT",
+                        DefaultValue = new DateTime(2015, 4, 12, 17, 5, 0)
+                    }
+                }
+            });
+
+            Assert.Equal(@"CREATE TABLE ""History"" (
+    ""Event"" TEXT NOT NULL DEFAULT '2015-04-12 17:05:00'
+);" + EOL, Sql);
+        }
+
         [Theory]
         [InlineData(true)]
         [InlineData(false)]

--- a/test/EntityFramework7.Sqlite.Tests/SqliteSqlGeneratorTest.cs
+++ b/test/EntityFramework7.Sqlite.Tests/SqliteSqlGeneratorTest.cs
@@ -1,9 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.Data.Entity.Infrastructure;
+using System;
 using Microsoft.Data.Entity.Tests;
 using Microsoft.Data.Entity.Update;
+using Xunit;
 
 namespace Microsoft.Data.Entity.Sqlite
 {
@@ -13,5 +14,31 @@ namespace Microsoft.Data.Entity.Sqlite
         protected override string RowsAffected => "changes()";
         protected override string Identity => "last_insert_rowid()";
         protected override string Schema => null;
+
+        public override void GenerateNextSequenceValueOperation_correctly_handles_schemas()
+        {
+            var ex = Assert.Throws<NotSupportedException>(() => base.GenerateNextSequenceValueOperation_correctly_handles_schemas());
+            Assert.Equal(Strings.SequencesNotSupported, ex.Message);
+        }
+
+        public override void GenerateNextSequenceValueOperation_returns_statement_with_sanatized_sequence()
+        {
+            var ex = Assert.Throws<NotSupportedException>(() => base.GenerateNextSequenceValueOperation_returns_statement_with_sanatized_sequence());
+            Assert.Equal(Strings.SequencesNotSupported, ex.Message);
+        }
+
+        public override void GenerateLiteral_returns_DateTimeOffset_literal()
+        {
+            var value = new DateTimeOffset(2015, 3, 12, 13, 36, 37, 371, new TimeSpan(-7, 0, 0));
+            var literal = CreateSqlGenerator().GenerateLiteral(value);
+            Assert.Equal("'2015-03-12 13:36:37.371-07:00'", literal);
+        }
+
+        public override void GenerateLiteral_returns_DateTime_literal()
+        {
+            var value = new DateTime(2015, 3, 12, 13, 36, 37, 371);
+            var literal = CreateSqlGenerator().GenerateLiteral(value);
+            Assert.Equal("'2015-03-12 13:36:37.371'", literal);
+        }
     }
 }


### PR DESCRIPTION
Test composite keys, default values, and command timeout on SQLite. 

Fix bug in SQLite timestamp literals.