### PR TITLE
Sequence API and behavioral consistency with core metadata

### DIFF
--- a/src/EntityFramework7.Relational/Metadata/IRelationalModelAnnotations.cs
+++ b/src/EntityFramework7.Relational/Metadata/IRelationalModelAnnotations.cs
@@ -8,8 +8,8 @@ namespace Microsoft.Data.Entity.Metadata
 {
     public interface IRelationalModelAnnotations
     {
-        Sequence TryGetSequence([NotNull] string name, [CanBeNull] string schema = null);
+        ISequence FindSequence([NotNull] string name, [CanBeNull] string schema = null);
 
-        IReadOnlyList<Sequence> Sequences { get; }
+        IReadOnlyList<ISequence> Sequences { get; }
     }
 }

--- a/src/EntityFramework7.Relational/Metadata/ReadOnlyRelationalModelAnnotations.cs
+++ b/src/EntityFramework7.Relational/Metadata/ReadOnlyRelationalModelAnnotations.cs
@@ -10,8 +10,6 @@ namespace Microsoft.Data.Entity.Metadata
 {
     public class ReadOnlyRelationalModelAnnotations : IRelationalModelAnnotations
     {
-        protected const string RelationalSequenceAnnotation = RelationalAnnotationNames.Prefix + RelationalAnnotationNames.Sequence;
-
         private readonly IModel _model;
 
         public ReadOnlyRelationalModelAnnotations([NotNull] IModel model)
@@ -23,31 +21,10 @@ namespace Microsoft.Data.Entity.Metadata
 
         protected virtual IModel Model => _model;
 
-        public virtual IReadOnlyList<Sequence> Sequences => (
-            from a in _model.Annotations
-            where a.Name.StartsWith(RelationalSequenceAnnotation)
-            select Sequence.Deserialize((string)a.Value))
-            .ToList();
+        public virtual IReadOnlyList<ISequence> Sequences
+            => Sequence.GetSequences(_model, RelationalAnnotationNames.Prefix).ToList();
 
-        public virtual Sequence TryGetSequence(string name, string schema = null)
-            => FindSequence(
-                RelationalSequenceAnnotation + Check.NullButNotEmpty(schema, nameof(schema))
-                + "."
-                + Check.NotEmpty(name, nameof(name)));
-
-        protected virtual Sequence FindSequence([NotNull] string annotationName)
-        {
-            Check.NotEmpty(annotationName, nameof(annotationName));
-
-            var value = Model[annotationName];
-            if (value == null)
-            {
-                return null;
-            }
-
-            var sequence = Sequence.Deserialize((string)value);
-            sequence.Model = _model;
-            return sequence;
-        }
+        public virtual ISequence FindSequence(string name, string schema = null)
+            => Sequence.FindSequence(_model, RelationalAnnotationNames.Prefix, name, schema);
     }
 }

--- a/src/EntityFramework7.Relational/Metadata/RelationalModelAnnotations.cs
+++ b/src/EntityFramework7.Relational/Metadata/RelationalModelAnnotations.cs
@@ -13,26 +13,12 @@ namespace Microsoft.Data.Entity.Metadata
         {
         }
 
-        public virtual Sequence AddOrReplaceSequence([NotNull] Sequence sequence)
-        {
-            Check.NotNull(sequence, nameof(sequence));
+        public virtual Sequence GetOrAddSequence([CanBeNull] string name, [CanBeNull] string schema = null) 
+            => new Sequence(
+                (Model)Model, 
+                RelationalAnnotationNames.Prefix, 
+                Check.NotEmpty(name, nameof(name)), 
+                Check.NullButNotEmpty(schema, nameof(schema)));
 
-            var model = (Model)Model;
-            sequence.Model = model;
-            model[RelationalSequenceAnnotation + sequence.Schema + "." + sequence.Name] = sequence.Serialize();
-
-            return sequence;
-        }
-
-        public virtual Sequence GetOrAddSequence([CanBeNull] string name = null, [CanBeNull] string schema = null)
-        {
-            Check.NullButNotEmpty(name, nameof(name));
-            Check.NullButNotEmpty(schema, nameof(schema));
-
-            name = name ?? Sequence.DefaultName;
-
-            return ((Model)Model).Relational().TryGetSequence(name, schema)
-                   ?? AddOrReplaceSequence(new Sequence(name, schema));
-        }
     }
 }

--- a/src/EntityFramework7.Relational/Metadata/RelationalSequenceBuilder.cs
+++ b/src/EntityFramework7.Relational/Metadata/RelationalSequenceBuilder.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Utilities;
 
@@ -9,120 +8,48 @@ namespace Microsoft.Data.Entity.Metadata
 {
     public class RelationalSequenceBuilder
     {
-        private Sequence _sequence;
-        private readonly Action<Sequence> _updateAction;
+        private readonly Sequence _sequence;
 
-        public RelationalSequenceBuilder(
-            [NotNull] Sequence sequence,
-            [NotNull] Action<Sequence> updateAction)
+        public RelationalSequenceBuilder([NotNull] Sequence sequence)
         {
             Check.NotNull(sequence, nameof(sequence));
-            Check.NotNull(updateAction, nameof(updateAction));
 
             _sequence = sequence;
-            _updateAction = updateAction;
         }
 
         public virtual Sequence Metadata => _sequence;
 
         public virtual RelationalSequenceBuilder IncrementsBy(int increment)
         {
-            _sequence = new Sequence(
-                _sequence.Name,
-                _sequence.Schema,
-                _sequence.StartValue,
-                increment,
-                _sequence.MinValue,
-                _sequence.MaxValue,
-                _sequence.ClrType,
-                _sequence.IsCyclic);
-
-            _updateAction(_sequence);
+            _sequence.IncrementBy = increment;
 
             return this;
         }
 
         public virtual RelationalSequenceBuilder StartsAt(long startValue)
         {
-            _sequence = new Sequence(
-                _sequence.Name,
-                _sequence.Schema,
-                startValue,
-                _sequence.IncrementBy,
-                _sequence.MinValue,
-                _sequence.MaxValue,
-                _sequence.ClrType,
-                _sequence.IsCyclic);
-
-            _updateAction(_sequence);
-
-            return this;
-        }
-
-        public virtual RelationalSequenceBuilder Type<T>()
-        {
-            _sequence = new Sequence(
-                _sequence.Name,
-                _sequence.Schema,
-                _sequence.StartValue,
-                _sequence.IncrementBy,
-                _sequence.MinValue,
-                _sequence.MaxValue,
-                typeof(T),
-                _sequence.IsCyclic);
-
-            _updateAction(_sequence);
+            _sequence.StartValue = startValue;
 
             return this;
         }
 
         public virtual RelationalSequenceBuilder HasMax(long maximum)
         {
-            _sequence = new Sequence(
-                _sequence.Name,
-                _sequence.Schema,
-                _sequence.StartValue,
-                _sequence.IncrementBy,
-                _sequence.MinValue,
-                maximum,
-                _sequence.ClrType,
-                _sequence.IsCyclic);
-
-            _updateAction(_sequence);
+            _sequence.MaxValue = maximum;
 
             return this;
         }
 
         public virtual RelationalSequenceBuilder HasMin(long minimum)
         {
-            _sequence = new Sequence(
-                _sequence.Name,
-                _sequence.Schema,
-                _sequence.StartValue,
-                _sequence.IncrementBy,
-                minimum,
-                _sequence.MaxValue,
-                _sequence.ClrType,
-                _sequence.IsCyclic);
-
-            _updateAction(_sequence);
+            _sequence.MinValue = minimum;
 
             return this;
         }
 
         public virtual RelationalSequenceBuilder IsCyclic(bool isCyclic = true)
         {
-            _sequence = new Sequence(
-                _sequence.Name,
-                _sequence.Schema,
-                _sequence.StartValue,
-                _sequence.IncrementBy,
-                _sequence.MinValue,
-                _sequence.MaxValue,
-                _sequence.ClrType,
-                isCyclic);
-
-            _updateAction(_sequence);
+            _sequence.IsCyclic = isCyclic;
 
             return this;
         }

--- a/src/EntityFramework7.Relational/RelationalModelBuilderExtensions.cs
+++ b/src/EntityFramework7.Relational/RelationalModelBuilderExtensions.cs
@@ -22,8 +22,7 @@ namespace Microsoft.Data.Entity
             Check.NullButNotEmpty(schema, nameof(schema));
 
             return new RelationalSequenceBuilder(
-                modelBuilder.Model.Relational().GetOrAddSequence(name, schema),
-                s => modelBuilder.Model.Relational().AddOrReplaceSequence(s));
+                modelBuilder.Model.Relational().GetOrAddSequence(name, schema));
         }
 
         public static ModelBuilder Sequence(
@@ -44,6 +43,85 @@ namespace Microsoft.Data.Entity
             Check.NotNull(builderAction, nameof(builderAction));
 
             builderAction(Sequence(modelBuilder, name, schema));
+
+            return modelBuilder;
+        }
+
+        public static RelationalSequenceBuilder Sequence(
+            [NotNull] this ModelBuilder modelBuilder,
+            [NotNull] Type clrType,
+            [NotNull] string name,
+            [CanBeNull] string schema = null)
+        {
+            Check.NotNull(clrType, nameof(clrType));
+            Check.NotNull(modelBuilder, nameof(modelBuilder));
+            Check.NotEmpty(name, nameof(name));
+            Check.NullButNotEmpty(schema, nameof(schema));
+
+            var sequence = modelBuilder.Model.Relational().GetOrAddSequence(name, schema);
+            sequence.ClrType = clrType;
+
+            return new RelationalSequenceBuilder(sequence);
+        }
+
+        public static ModelBuilder Sequence(
+            [NotNull] this ModelBuilder modelBuilder,
+            [NotNull] Type clrType,
+            [NotNull] string name,
+            [NotNull] Action<RelationalSequenceBuilder> builderAction)
+            => modelBuilder.Sequence(clrType, name, null, builderAction);
+
+        public static ModelBuilder Sequence(
+            [NotNull] this ModelBuilder modelBuilder,
+            [NotNull] Type clrType,
+            [NotNull] string name,
+            [CanBeNull] string schema,
+            [NotNull] Action<RelationalSequenceBuilder> builderAction)
+        {
+            Check.NotNull(clrType, nameof(clrType));
+            Check.NotNull(modelBuilder, nameof(modelBuilder));
+            Check.NotEmpty(name, nameof(name));
+            Check.NullButNotEmpty(schema, nameof(schema));
+            Check.NotNull(builderAction, nameof(builderAction));
+
+            builderAction(Sequence(modelBuilder, clrType, name, schema));
+
+            return modelBuilder;
+        }
+
+        public static RelationalSequenceBuilder Sequence<T>(
+            [NotNull] this ModelBuilder modelBuilder,
+            [NotNull] string name,
+            [CanBeNull] string schema = null)
+        {
+            Check.NotNull(modelBuilder, nameof(modelBuilder));
+            Check.NotEmpty(name, nameof(name));
+            Check.NullButNotEmpty(schema, nameof(schema));
+
+            var sequence = modelBuilder.Model.Relational().GetOrAddSequence(name, schema);
+            sequence.ClrType = typeof(T);
+
+            return new RelationalSequenceBuilder(sequence);
+        }
+
+        public static ModelBuilder Sequence<T>(
+            [NotNull] this ModelBuilder modelBuilder,
+            [NotNull] string name,
+            [NotNull] Action<RelationalSequenceBuilder> builderAction)
+            => modelBuilder.Sequence<T>(name, null, builderAction);
+
+        public static ModelBuilder Sequence<T>(
+            [NotNull] this ModelBuilder modelBuilder,
+            [NotNull] string name,
+            [CanBeNull] string schema,
+            [NotNull] Action<RelationalSequenceBuilder> builderAction)
+        {
+            Check.NotNull(modelBuilder, nameof(modelBuilder));
+            Check.NotEmpty(name, nameof(name));
+            Check.NullButNotEmpty(schema, nameof(schema));
+            Check.NotNull(builderAction, nameof(builderAction));
+
+            builderAction(Sequence<T>(modelBuilder, name, schema));
 
             return modelBuilder;
         }

--- a/src/EntityFramework7.SqlServer/Metadata/ISqlServerPropertyAnnotations.cs
+++ b/src/EntityFramework7.SqlServer/Metadata/ISqlServerPropertyAnnotations.cs
@@ -11,6 +11,6 @@ namespace Microsoft.Data.Entity.SqlServer.Metadata
         string HiLoSequenceName { get; }
         string HiLoSequenceSchema { get; }
         int? HiLoSequencePoolSize { get; }
-        Sequence TryGetHiLoSequence();
+        ISequence FindHiLoSequence();
     }
 }

--- a/src/EntityFramework7.SqlServer/Metadata/ReadOnlySqlServerPropertyAnnotations.cs
+++ b/src/EntityFramework7.SqlServer/Metadata/ReadOnlySqlServerPropertyAnnotations.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Data.Entity.SqlServer.Metadata
         public virtual string HiLoSequenceSchema => Property[SqlServerHiLoSequenceSchemaAnnotation] as string;
         public virtual int? HiLoSequencePoolSize => Property[SqlServerHiLoSequencePoolSizeAnnotation] as int?;
 
-        public virtual Sequence TryGetHiLoSequence()
+        public virtual ISequence FindHiLoSequence()
         {
             var modelExtensions = Property.DeclaringEntityType.Model.SqlServer();
 
@@ -79,13 +79,12 @@ namespace Microsoft.Data.Entity.SqlServer.Metadata
 
             var sequenceName = HiLoSequenceName
                                ?? modelExtensions.HiLoSequenceName
-                               ?? Sequence.DefaultName;
+                               ?? SqlServerAnnotationNames.DefaultHiLoSequenceName;
 
             var sequenceSchema = HiLoSequenceSchema
                                  ?? modelExtensions.HiLoSequenceSchema;
 
-            return modelExtensions.TryGetSequence(sequenceName, sequenceSchema)
-                   ?? new Sequence(Sequence.DefaultName);
+            return modelExtensions.FindSequence(sequenceName, sequenceSchema);
         }
     }
 }

--- a/src/EntityFramework7.SqlServer/Metadata/SqlServerAnnotationNames.cs
+++ b/src/EntityFramework7.SqlServer/Metadata/SqlServerAnnotationNames.cs
@@ -11,5 +11,7 @@ namespace Microsoft.Data.Entity.SqlServer.Metadata
         public const string HiLoSequenceName = "HiLoSequenceName";
         public const string HiLoSequenceSchema = "HiLoSequenceSchema";
         public const string HiLoSequencePoolSize = "HiLoSequencePoolSize";
+
+        public const string DefaultHiLoSequenceName = "DefaultSequence";
     }
 }

--- a/src/EntityFramework7.SqlServer/Metadata/SqlServerModelAnnotations.cs
+++ b/src/EntityFramework7.SqlServer/Metadata/SqlServerModelAnnotations.cs
@@ -65,47 +65,11 @@ namespace Microsoft.Data.Entity.SqlServer.Metadata
                 ((Model)Model)[SqlServerHiLoSequencePoolSizeAnnotation] = value;
             }
         }
-
-        public virtual Sequence AddOrReplaceSequence([NotNull] Sequence sequence)
-        {
-            Check.NotNull(sequence, nameof(sequence));
-
-            var model = (Model)Model;
-            sequence.Model = model;
-            model[SqlServerSequenceAnnotation + sequence.Schema + "." + sequence.Name] = sequence.Serialize();
-
-            return sequence;
-        }
-
-        public virtual Sequence GetOrAddSequence([CanBeNull] string name = null, [CanBeNull] string schema = null)
-        {
-            Check.NullButNotEmpty(name, nameof(name));
-            Check.NullButNotEmpty(schema, nameof(schema));
-
-            name = name ?? Sequence.DefaultName;
-
-            return ((Model)Model).SqlServer().TryGetSequence(name, schema)
-                   ?? AddOrReplaceSequence(new Sequence(name, schema));
-        }
-
-        public virtual void RemoveSequence([NotNull] Sequence sequence)
-        {
-            Check.NotNull(sequence, nameof(sequence));
-
-            var model = (Model)Model;
-            model[SqlServerSequenceAnnotation + sequence.Schema + "." + sequence.Name] = null;
-        }
-
-        public virtual void RemoveSequence([CanBeNull] string name = null, [CanBeNull] string schema = null)
-        {
-            Check.NullButNotEmpty(name, nameof(name));
-            Check.NullButNotEmpty(schema, nameof(schema));
-
-            name = name ?? HiLoSequenceName;
-            schema = schema ?? HiLoSequenceSchema;
-
-            var model = (Model)Model;
-            model[SqlServerSequenceAnnotation + schema + "." + name] = null;
-        }
+        public virtual Sequence GetOrAddSequence([CanBeNull] string name, [CanBeNull] string schema = null)
+            => new Sequence(
+                (Model)Model,
+                SqlServerAnnotationNames.Prefix,
+                Check.NotEmpty(name, nameof(name)),
+                Check.NullButNotEmpty(schema, nameof(schema)));
     }
 }

--- a/src/EntityFramework7.SqlServer/SqlServerPropertyBuilderExtensions.cs
+++ b/src/EntityFramework7.SqlServer/SqlServerPropertyBuilderExtensions.cs
@@ -110,16 +110,13 @@ namespace Microsoft.Data.Entity
 
             var property = propertyBuilder.Metadata;
 
-            name = name ?? Sequence.DefaultName;
+            name = name ?? SqlServerAnnotationNames.DefaultHiLoSequenceName;
 
-            var sqlServerModel = property.DeclaringEntityType.Model.SqlServer();
+            var model = property.DeclaringEntityType.Model;
 
             var sequence =
-                sqlServerModel.TryGetSequence(name, schema) ??
-                new RelationalSequenceBuilder(
-                    sqlServerModel.GetOrAddSequence(name, schema),
-                    s => sqlServerModel.AddOrReplaceSequence(s))
-                    .IncrementsBy(10).Metadata;
+                model.SqlServer().FindSequence(name, schema) ??
+                new Sequence(model, SqlServerAnnotationNames.Prefix, name, schema) { IncrementBy = 10};
 
             property.SqlServer().IdentityStrategy = SqlServerIdentityStrategy.SequenceHiLo;
             property.ValueGenerated = ValueGenerated.OnAdd;

--- a/src/EntityFramework7.SqlServer/ValueGeneration/SqlServerValueGeneratorCache.cs
+++ b/src/EntityFramework7.SqlServer/ValueGeneration/SqlServerValueGeneratorCache.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Diagnostics;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
@@ -18,7 +19,9 @@ namespace Microsoft.Data.Entity.SqlServer.ValueGeneration
         {
             Check.NotNull(property, nameof(property));
 
-            var sequence = property.SqlServer().TryGetHiLoSequence();
+            var sequence = property.SqlServer().FindHiLoSequence();
+
+            Debug.Assert(sequence != null);
 
             return _sequenceGeneratorCache.GetOrAdd(
                 GetSequenceName(sequence),

--- a/src/EntityFramework7.Sqlite/Metadata/ReadOnlySqliteModelAnnotations.cs
+++ b/src/EntityFramework7.Sqlite/Metadata/ReadOnlySqliteModelAnnotations.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Data.Entity.Sqlite.Metadata
         {
         }
 
-        public override Sequence TryGetSequence(string name, string schema = null) => null;
-        public override IReadOnlyList<Sequence> Sequences => new Sequence[0];
+        public override ISequence FindSequence(string name, string schema = null) => null;
+        public override IReadOnlyList<ISequence> Sequences => new Sequence[0];
     }
 }

--- a/test/EntityFramework7.Relational.Tests/Metadata/RelationalMetadataExtensionsTest.cs
+++ b/test/EntityFramework7.Relational.Tests/Metadata/RelationalMetadataExtensionsTest.cs
@@ -242,13 +242,13 @@ namespace Microsoft.Data.Entity.Metadata.Tests
             var model = modelBuilder.Model;
             var extensions = model.Relational();
 
-            Assert.Null(extensions.TryGetSequence("Foo"));
-            Assert.Null(((IModel)model).Relational().TryGetSequence("Foo"));
+            Assert.Null(extensions.FindSequence("Foo"));
+            Assert.Null(((IModel)model).Relational().FindSequence("Foo"));
 
             var sequence = extensions.GetOrAddSequence("Foo");
 
-            Assert.Equal("Foo", extensions.TryGetSequence("Foo").Name);
-            Assert.Equal("Foo", ((IModel)model).Relational().TryGetSequence("Foo").Name);
+            Assert.Equal("Foo", extensions.FindSequence("Foo").Name);
+            Assert.Equal("Foo", ((IModel)model).Relational().FindSequence("Foo").Name);
 
             Assert.Equal("Foo", sequence.Name);
             Assert.Null(sequence.Schema);
@@ -258,9 +258,13 @@ namespace Microsoft.Data.Entity.Metadata.Tests
             Assert.Null(sequence.MaxValue);
             Assert.Same(typeof(long), sequence.ClrType);
 
-            extensions.AddOrReplaceSequence(new Sequence("Foo", null, 1729, 11, 2001, 2010, typeof(int)));
+            var sequence2 = extensions.GetOrAddSequence("Foo");
 
-            sequence = extensions.GetOrAddSequence("Foo");
+            sequence.StartValue = 1729;
+            sequence.IncrementBy = 11;
+            sequence.MinValue = 2001;
+            sequence.MaxValue = 2010;
+            sequence.ClrType = typeof(int);
 
             Assert.Equal("Foo", sequence.Name);
             Assert.Null(sequence.Schema);
@@ -269,6 +273,14 @@ namespace Microsoft.Data.Entity.Metadata.Tests
             Assert.Equal(2001, sequence.MinValue);
             Assert.Equal(2010, sequence.MaxValue);
             Assert.Same(typeof(int), sequence.ClrType);
+
+            Assert.Equal(sequence2.Name, sequence.Name);
+            Assert.Equal(sequence2.Schema, sequence.Schema);
+            Assert.Equal(sequence2.IncrementBy, sequence.IncrementBy);
+            Assert.Equal(sequence2.StartValue, sequence.StartValue);
+            Assert.Equal(sequence2.MinValue, sequence.MinValue);
+            Assert.Equal(sequence2.MaxValue, sequence.MaxValue);
+            Assert.Same(sequence2.ClrType, sequence.ClrType);
         }
 
         [Fact]
@@ -278,13 +290,13 @@ namespace Microsoft.Data.Entity.Metadata.Tests
             var model = modelBuilder.Model;
             var extensions = model.Relational();
 
-            Assert.Null(extensions.TryGetSequence("Foo", "Smoo"));
-            Assert.Null(((IModel)model).Relational().TryGetSequence("Foo", "Smoo"));
+            Assert.Null(extensions.FindSequence("Foo", "Smoo"));
+            Assert.Null(((IModel)model).Relational().FindSequence("Foo", "Smoo"));
 
             var sequence = extensions.GetOrAddSequence("Foo", "Smoo");
 
-            Assert.Equal("Foo", extensions.TryGetSequence("Foo", "Smoo").Name);
-            Assert.Equal("Foo", ((IModel)model).Relational().TryGetSequence("Foo", "Smoo").Name);
+            Assert.Equal("Foo", extensions.FindSequence("Foo", "Smoo").Name);
+            Assert.Equal("Foo", ((IModel)model).Relational().FindSequence("Foo", "Smoo").Name);
 
             Assert.Equal("Foo", sequence.Name);
             Assert.Equal("Smoo", sequence.Schema);
@@ -294,79 +306,13 @@ namespace Microsoft.Data.Entity.Metadata.Tests
             Assert.Null(sequence.MaxValue);
             Assert.Same(typeof(long), sequence.ClrType);
 
-            extensions.AddOrReplaceSequence(new Sequence("Foo", "Smoo", 1729, 11, 2001, 2010, typeof(int)));
+            var sequence2 = extensions.GetOrAddSequence("Foo", "Smoo");
 
-            sequence = extensions.GetOrAddSequence("Foo", "Smoo");
-
-            Assert.Equal("Foo", sequence.Name);
-            Assert.Equal("Smoo", sequence.Schema);
-            Assert.Equal(11, sequence.IncrementBy);
-            Assert.Equal(1729, sequence.StartValue);
-            Assert.Equal(2001, sequence.MinValue);
-            Assert.Equal(2010, sequence.MaxValue);
-            Assert.Same(typeof(int), sequence.ClrType);
-        }
-
-        [Fact]
-        public void Can_add_and_replace_sequence()
-        {
-            var modelBuilder = new ModelBuilder(new ConventionSet());
-            var model = modelBuilder.Model;
-            var extensions = model.Relational();
-
-            extensions.AddOrReplaceSequence(new Sequence("Foo"));
-
-            Assert.Equal("Foo", extensions.TryGetSequence("Foo").Name);
-            Assert.Equal("Foo", ((IModel)model).Relational().TryGetSequence("Foo").Name);
-
-            var sequence = extensions.TryGetSequence("Foo");
-
-            Assert.Equal("Foo", sequence.Name);
-            Assert.Null(sequence.Schema);
-            Assert.Equal(1, sequence.IncrementBy);
-            Assert.Equal(1, sequence.StartValue);
-            Assert.Null(sequence.MinValue);
-            Assert.Null(sequence.MaxValue);
-            Assert.Same(typeof(long), sequence.ClrType);
-
-            extensions.AddOrReplaceSequence(new Sequence("Foo", null, 1729, 11, 2001, 2010, typeof(int)));
-
-            sequence = extensions.TryGetSequence("Foo");
-
-            Assert.Equal("Foo", sequence.Name);
-            Assert.Null(sequence.Schema);
-            Assert.Equal(11, sequence.IncrementBy);
-            Assert.Equal(1729, sequence.StartValue);
-            Assert.Equal(2001, sequence.MinValue);
-            Assert.Equal(2010, sequence.MaxValue);
-            Assert.Same(typeof(int), sequence.ClrType);
-        }
-
-        [Fact]
-        public void Can_add_and_replace_sequence_with_schema_name()
-        {
-            var modelBuilder = new ModelBuilder(new ConventionSet());
-            var model = modelBuilder.Model;
-            var extensions = model.Relational();
-
-            extensions.AddOrReplaceSequence(new Sequence("Foo", "Smoo"));
-
-            Assert.Equal("Foo", extensions.TryGetSequence("Foo", "Smoo").Name);
-            Assert.Equal("Foo", ((IModel)model).Relational().TryGetSequence("Foo", "Smoo").Name);
-
-            var sequence = extensions.TryGetSequence("Foo", "Smoo");
-
-            Assert.Equal("Foo", sequence.Name);
-            Assert.Equal("Smoo", sequence.Schema);
-            Assert.Equal(1, sequence.IncrementBy);
-            Assert.Equal(1, sequence.StartValue);
-            Assert.Null(sequence.MinValue);
-            Assert.Null(sequence.MaxValue);
-            Assert.Same(typeof(long), sequence.ClrType);
-
-            extensions.AddOrReplaceSequence(new Sequence("Foo", "Smoo", 1729, 11, 2001, 2010, typeof(int)));
-
-            sequence = extensions.TryGetSequence("Foo", "Smoo");
+            sequence.StartValue = 1729;
+            sequence.IncrementBy = 11;
+            sequence.MinValue = 2001;
+            sequence.MaxValue = 2010;
+            sequence.ClrType = typeof(int);
 
             Assert.Equal("Foo", sequence.Name);
             Assert.Equal("Smoo", sequence.Schema);
@@ -375,7 +321,16 @@ namespace Microsoft.Data.Entity.Metadata.Tests
             Assert.Equal(2001, sequence.MinValue);
             Assert.Equal(2010, sequence.MaxValue);
             Assert.Same(typeof(int), sequence.ClrType);
+
+            Assert.Equal(sequence2.Name, sequence.Name);
+            Assert.Equal(sequence2.Schema, sequence.Schema);
+            Assert.Equal(sequence2.IncrementBy, sequence.IncrementBy);
+            Assert.Equal(sequence2.StartValue, sequence.StartValue);
+            Assert.Equal(sequence2.MinValue, sequence.MinValue);
+            Assert.Equal(sequence2.MaxValue, sequence.MaxValue);
+            Assert.Same(sequence2.ClrType, sequence.ClrType);
         }
+
 
         [Fact]
         public void Can_get_multiple_sequences()
@@ -384,8 +339,8 @@ namespace Microsoft.Data.Entity.Metadata.Tests
             var model = modelBuilder.Model;
             var extensions = model.Relational();
 
-            extensions.AddOrReplaceSequence(new Sequence("Fibonacci"));
-            extensions.AddOrReplaceSequence(new Sequence("Golomb"));
+            extensions.GetOrAddSequence("Fibonacci");
+            extensions.GetOrAddSequence("Golomb");
 
             var sequences = model.Relational().Sequences;
 

--- a/test/EntityFramework7.Relational.Tests/Metadata/SequenceTest.cs
+++ b/test/EntityFramework7.Relational.Tests/Metadata/SequenceTest.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Data.Entity.Metadata.Tests
         [Fact]
         public void Can_be_created_with_default_values()
         {
-            var sequence = new Sequence("Foo");
+            var sequence = new Sequence(new Model(), RelationalAnnotationNames.Prefix, "Foo");
 
             Assert.Equal("Foo", sequence.Name);
             Assert.Null(sequence.Schema);
@@ -26,7 +26,14 @@ namespace Microsoft.Data.Entity.Metadata.Tests
         [Fact]
         public void Can_be_created_with_specified_values()
         {
-            var sequence = new Sequence("Foo", "Smoo", 1729, 11, 2001, 2010, typeof(int));
+            var sequence = new Sequence(new Model(), RelationalAnnotationNames.Prefix, "Foo", "Smoo")
+            {
+                StartValue = 1729,
+                IncrementBy = 11,
+                MinValue = 2001,
+                MaxValue = 2010,
+                ClrType = typeof(int)
+            };
 
             Assert.Equal("Foo", sequence.Name);
             Assert.Equal("Smoo", sequence.Schema);
@@ -40,30 +47,41 @@ namespace Microsoft.Data.Entity.Metadata.Tests
         [Fact]
         public void Can_only_be_created_for_byte_short_int_and_long()
         {
-            Assert.Same(typeof(byte), new Sequence("Foo", null, 11, 1729, null, null, typeof(byte)).ClrType);
-            Assert.Same(typeof(short), new Sequence("Foo", null, 11, 1729, null, null, typeof(short)).ClrType);
-            Assert.Same(typeof(int), new Sequence("Foo", null, 11, 1729, null, null, typeof(int)).ClrType);
-            Assert.Same(typeof(long), new Sequence("Foo", null, 11, 1729, null, null, typeof(long)).ClrType);
+            Assert.Same(typeof(byte), new Sequence(new Model(), RelationalAnnotationNames.Prefix, "Foo") { ClrType = typeof(byte) }.ClrType);
+            Assert.Same(typeof(short), new Sequence(new Model(), RelationalAnnotationNames.Prefix, "Foo") { ClrType = typeof(short) }.ClrType);
+            Assert.Same(typeof(int), new Sequence(new Model(), RelationalAnnotationNames.Prefix, "Foo") { ClrType = typeof(int) }.ClrType);
+            Assert.Same(typeof(long), new Sequence(new Model(), RelationalAnnotationNames.Prefix, "Foo") { ClrType = typeof(long) }.ClrType);
 
             Assert.Equal(
                 Strings.BadSequenceType,
-                Assert.Throws<ArgumentException>(() => new Sequence("Foo", null, 11, 1729, null, null, typeof(decimal))).Message);
+                Assert.Throws<ArgumentException>(
+                    () => new Sequence(new Model(), RelationalAnnotationNames.Prefix, "Foo") { ClrType = typeof(decimal) }).Message);
         }
 
         [Fact]
-        public void Can_set_model()
+        public void Can_get_model()
         {
-            var sequence = new Sequence("Foo");
-
             var model = new Model();
-            sequence.Model = model;
+
+            var sequence = new Sequence(model, RelationalAnnotationNames.Prefix, "Foo");
+
             Assert.Same(model, sequence.Model);
         }
 
         [Fact]
         public void Can_serialize_and_deserialize()
         {
-            var sequence = Sequence.Deserialize(new Sequence("Foo", "Smoo", 1729, 11, 2001, 2010, typeof(int)).Serialize());
+            var model = new Model();
+            new Sequence(model, RelationalAnnotationNames.Prefix, "Foo", "Smoo")
+            {
+                StartValue = 1729,
+                IncrementBy = 11,
+                MinValue = 2001,
+                MaxValue = 2010,
+                ClrType = typeof(int)
+            };
+
+            var sequence = new Sequence(model, RelationalAnnotationNames.Prefix, "Foo", "Smoo");
 
             Assert.Equal("Foo", sequence.Name);
             Assert.Equal("Smoo", sequence.Schema);
@@ -77,8 +95,10 @@ namespace Microsoft.Data.Entity.Metadata.Tests
         [Fact]
         public void Can_serialize_and_deserialize_with_defaults()
         {
-            var serialize = new Sequence("Foo").Serialize();
-            var sequence = Sequence.Deserialize(serialize);
+            var model = new Model();
+            new Sequence(model, RelationalAnnotationNames.Prefix, "Foo");
+
+            var sequence = new Sequence(model, RelationalAnnotationNames.Prefix, "Foo");
 
             Assert.Equal("Foo", sequence.Name);
             Assert.Null(sequence.Schema);
@@ -92,7 +112,15 @@ namespace Microsoft.Data.Entity.Metadata.Tests
         [Fact]
         public void Can_serialize_and_deserialize_with_funky_names()
         {
-            var sequence = Sequence.Deserialize(new Sequence("'Foo'", "''S'''m'oo'''", 1729, 11, null, null, typeof(int)).Serialize());
+            var model = new Model();
+            new Sequence(model, RelationalAnnotationNames.Prefix, "'Foo'", "''S'''m'oo'''")
+            {
+                StartValue = 1729,
+                IncrementBy = 11,
+                ClrType = typeof(int)
+            };
+
+            var sequence = new Sequence(model, RelationalAnnotationNames.Prefix, "'Foo'", "''S'''m'oo'''");
 
             Assert.Equal("'Foo'", sequence.Name);
             Assert.Equal("''S'''m'oo'''", sequence.Schema);
@@ -106,11 +134,24 @@ namespace Microsoft.Data.Entity.Metadata.Tests
         [Fact]
         public void Throws_on_bad_serialized_form()
         {
-            var badString = new Sequence("Foo", "Smoo", 1729, 11, 2001, 2010, typeof(int)).Serialize().Replace("1", "Z");
+            var model = new Model();
+            new Sequence(model, RelationalAnnotationNames.Prefix, "Foo", "Smoo")
+            {
+                StartValue = 1729,
+                IncrementBy = 11,
+                MinValue = 2001,
+                MaxValue = 2010,
+                ClrType = typeof(int)
+            };
+
+            var annotationName = RelationalAnnotationNames.Prefix + RelationalAnnotationNames.Sequence + "Smoo.Foo";
+
+            model[annotationName] = ((string)model[annotationName]).Replace("1", "Z");
 
             Assert.Equal(
                 Strings.BadSequenceString,
-                Assert.Throws<ArgumentException>(() => Sequence.Deserialize(badString)).Message);
+                Assert.Throws<ArgumentException>(
+                    () => new Sequence(model, RelationalAnnotationNames.Prefix, "Foo", "Smoo").ClrType).Message);
         }
     }
 }

--- a/test/EntityFramework7.Relational.Tests/Migrations/Infrastructure/ModelDifferTest.cs
+++ b/test/EntityFramework7.Relational.Tests/Migrations/Infrastructure/ModelDifferTest.cs
@@ -1335,8 +1335,7 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
         {
             Execute(
                 _ => { },
-                modelBuilder => modelBuilder.Sequence("Tango", "dbo")
-                    .Type<int>()
+                modelBuilder => modelBuilder.Sequence<int>("Tango", "dbo")
                     .StartsAt(2)
                     .IncrementsBy(3)
                     .HasMin(1)
@@ -1414,15 +1413,13 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
         public void Alter_sequence_increment_by()
         {
             Execute(
-                source => source.Sequence("Alpha", "dbo")
-                    .Type<int>()
+                source => source.Sequence<int>("Alpha", "dbo")
                     .StartsAt(2)
                     .IncrementsBy(3)
                     .HasMin(1)
                     .HasMax(4)
                     .IsCyclic(),
-                source => source.Sequence("Alpha", "dbo")
-                    .Type<int>()
+                source => source.Sequence<int>("Alpha", "dbo")
                     .StartsAt(2)
                     .IncrementsBy(5)
                     .HasMin(1)
@@ -1446,15 +1443,13 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
         public void Alter_sequence_max_value()
         {
             Execute(
-                source => source.Sequence("Echo", "dbo")
-                    .Type<int>()
+                source => source.Sequence<int>("Echo", "dbo")
                     .StartsAt(2)
                     .IncrementsBy(3)
                     .HasMin(1)
                     .HasMax(4)
                     .IsCyclic(),
-                source => source.Sequence("Echo", "dbo")
-                    .Type<int>()
+                source => source.Sequence<int>("Echo", "dbo")
                     .StartsAt(2)
                     .IncrementsBy(3)
                     .HasMin(1)
@@ -1478,15 +1473,13 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
         public void Alter_sequence_min_value()
         {
             Execute(
-                source => source.Sequence("Delta", "dbo")
-                    .Type<int>()
+                source => source.Sequence<int>("Delta", "dbo")
                     .StartsAt(2)
                     .IncrementsBy(3)
                     .HasMin(1)
                     .HasMax(4)
                     .IsCyclic(),
-                source => source.Sequence("Delta", "dbo")
-                    .Type<int>()
+                source => source.Sequence<int>("Delta", "dbo")
                     .StartsAt(2)
                     .IncrementsBy(3)
                     .HasMin(5)
@@ -1510,15 +1503,13 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
         public void Alter_sequence_cycle()
         {
             Execute(
-                source => source.Sequence("Foxtrot", "dbo")
-                    .Type<int>()
+                source => source.Sequence<int>("Foxtrot", "dbo")
                     .StartsAt(2)
                     .IncrementsBy(3)
                     .HasMin(1)
                     .HasMax(4)
                     .IsCyclic(true),
-                source => source.Sequence("Foxtrot", "dbo")
-                    .Type<int>()
+                source => source.Sequence<int>("Foxtrot", "dbo")
                     .StartsAt(2)
                     .IncrementsBy(3)
                     .HasMin(1)
@@ -1542,15 +1533,13 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
         public void Alter_sequence_type()
         {
             Execute(
-                source => source.Sequence("Hotel", "dbo")
-                    .Type<int>()
+                source => source.Sequence<int>("Hotel", "dbo")
                     .StartsAt(2)
                     .IncrementsBy(3)
                     .HasMin(1)
                     .HasMax(4)
                     .IsCyclic(),
-                source => source.Sequence("Hotel", "dbo")
-                    .Type<long>()
+                source => source.Sequence<long>("Hotel", "dbo")
                     .StartsAt(2)
                     .IncrementsBy(3)
                     .HasMin(1)
@@ -1580,15 +1569,13 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
         public void Alter_sequence_start()
         {
             Execute(
-                source => source.Sequence("Golf", "dbo")
-                    .Type<int>()
+                source => source.Sequence<int>("Golf", "dbo")
                     .StartsAt(2)
                     .IncrementsBy(3)
                     .HasMin(1)
                     .HasMax(4)
                     .IsCyclic(),
-                source => source.Sequence("Golf", "dbo")
-                    .Type<int>()
+                source => source.Sequence<int>("Golf", "dbo")
                     .StartsAt(5)
                     .IncrementsBy(3)
                     .HasMin(1)

--- a/test/EntityFramework7.SqlServer.FunctionalTests/SqlServerValueGenerationScenariosTest.cs
+++ b/test/EntityFramework7.SqlServer.FunctionalTests/SqlServerValueGenerationScenariosTest.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             }
         }
 
-        public class SequencehHiLo : TestBase<SequencehHiLo.BlogContext>
+        public class SequenceHiLo : TestBase<SequenceHiLo.BlogContext>
         {
             [Fact]
             public void Insert_with_sequence_HiLo()

--- a/test/EntityFramework7.SqlServer.Tests/Metadata/ModelConventions/SqlServerIdentityStrategyConventionTest.cs
+++ b/test/EntityFramework7.SqlServer.Tests/Metadata/ModelConventions/SqlServerIdentityStrategyConventionTest.cs
@@ -33,15 +33,15 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata.Conventions
             Assert.Equal(3, annotations.Count());
 
             Assert.Equal(SqlServerAnnotationNames.Prefix + SqlServerAnnotationNames.HiLoSequenceName, annotations.ElementAt(0).Name);
-            Assert.Equal(Sequence.DefaultName, annotations.ElementAt(0).Value);
+            Assert.Equal(SqlServerAnnotationNames.DefaultHiLoSequenceName, annotations.ElementAt(0).Value);
 
             Assert.Equal(
                 SqlServerAnnotationNames.Prefix +
                 RelationalAnnotationNames.Sequence +
                 "." +
-                Sequence.DefaultName,
+                SqlServerAnnotationNames.DefaultHiLoSequenceName,
                 annotations.ElementAt(1).Name);
-            Assert.Equal(new Sequence(Sequence.DefaultName, null, 1, 10).Serialize(), annotations.ElementAt(1).Value);
+            Assert.NotNull(annotations.ElementAt(1).Value);
 
             Assert.Equal(SqlServerAnnotationNames.Prefix + SqlServerAnnotationNames.ValueGenerationStrategy, annotations.ElementAt(2).Name);
             Assert.Equal(SqlServerIdentityStrategy.SequenceHiLo.ToString(), annotations.ElementAt(2).Value);

--- a/test/EntityFramework7.SqlServer.Tests/Metadata/SqlServerBuilderExtensionsTest.cs
+++ b/test/EntityFramework7.SqlServer.Tests/Metadata/SqlServerBuilderExtensionsTest.cs
@@ -394,11 +394,11 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             var sqlServerExtensions = modelBuilder.Model.SqlServer();
 
             Assert.Equal(SqlServerIdentityStrategy.SequenceHiLo, sqlServerExtensions.IdentityStrategy);
-            Assert.Same(Sequence.DefaultName, sqlServerExtensions.HiLoSequenceName);
+            Assert.Equal(SqlServerAnnotationNames.DefaultHiLoSequenceName, sqlServerExtensions.HiLoSequenceName);
             Assert.Null(sqlServerExtensions.HiLoSequenceSchema);
 
-            Assert.Null(relationalExtensions.TryGetSequence(Sequence.DefaultName));
-            Assert.NotNull(sqlServerExtensions.TryGetSequence(Sequence.DefaultName));
+            Assert.Null(relationalExtensions.FindSequence(SqlServerAnnotationNames.DefaultHiLoSequenceName));
+            Assert.NotNull(sqlServerExtensions.FindSequence(SqlServerAnnotationNames.DefaultHiLoSequenceName));
 
             Assert.Null(sqlServerExtensions.HiLoSequencePoolSize);
         }
@@ -414,11 +414,11 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             var sqlServerExtensions = modelBuilder.Model.SqlServer();
 
             Assert.Equal(SqlServerIdentityStrategy.SequenceHiLo, sqlServerExtensions.IdentityStrategy);
-            Assert.Same(Sequence.DefaultName, sqlServerExtensions.HiLoSequenceName);
+            Assert.Equal(SqlServerAnnotationNames.DefaultHiLoSequenceName, sqlServerExtensions.HiLoSequenceName);
             Assert.Null(sqlServerExtensions.HiLoSequenceSchema);
 
-            Assert.Null(relationalExtensions.TryGetSequence(Sequence.DefaultName));
-            Assert.NotNull(sqlServerExtensions.TryGetSequence(Sequence.DefaultName));
+            Assert.Null(relationalExtensions.FindSequence(SqlServerAnnotationNames.DefaultHiLoSequenceName));
+            Assert.NotNull(sqlServerExtensions.FindSequence(SqlServerAnnotationNames.DefaultHiLoSequenceName));
 
             Assert.Equal(7, sqlServerExtensions.HiLoSequencePoolSize);
         }
@@ -438,17 +438,17 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             Assert.Null(sqlServerExtensions.HiLoSequenceSchema);
             Assert.Null(sqlServerExtensions.HiLoSequencePoolSize);
 
-            Assert.Null(relationalExtensions.TryGetSequence("Snook"));
+            Assert.Null(relationalExtensions.FindSequence("Snook"));
 
-            var sequence = sqlServerExtensions.TryGetSequence("Snook");
+            var sequence = sqlServerExtensions.FindSequence("Snook");
 
             Assert.Equal("Snook", sequence.Name);
             Assert.Null(sequence.Schema);
             Assert.Equal(10, sequence.IncrementBy);
-            Assert.Equal(Sequence.DefaultStartValue, sequence.StartValue);
+            Assert.Equal(1, sequence.StartValue);
             Assert.Null(sequence.MinValue);
             Assert.Null(sequence.MaxValue);
-            Assert.Same(Sequence.DefaultType, sequence.ClrType);
+            Assert.Same(typeof(long), sequence.ClrType);
         }
 
         [Fact]
@@ -466,17 +466,17 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             Assert.Null(sqlServerExtensions.HiLoSequenceSchema);
             Assert.Equal(7, sqlServerExtensions.HiLoSequencePoolSize);
 
-            Assert.Null(relationalExtensions.TryGetSequence("Snook"));
+            Assert.Null(relationalExtensions.FindSequence("Snook"));
 
-            var sequence = sqlServerExtensions.TryGetSequence("Snook");
+            var sequence = sqlServerExtensions.FindSequence("Snook");
 
             Assert.Equal("Snook", sequence.Name);
             Assert.Null(sequence.Schema);
             Assert.Equal(10, sequence.IncrementBy);
-            Assert.Equal(Sequence.DefaultStartValue, sequence.StartValue);
+            Assert.Equal(1, sequence.StartValue);
             Assert.Null(sequence.MinValue);
             Assert.Null(sequence.MaxValue);
-            Assert.Same(Sequence.DefaultType, sequence.ClrType);
+            Assert.Same(typeof(long), sequence.ClrType);
         }
 
         [Fact]
@@ -493,16 +493,16 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             Assert.Equal("Snook", sqlServerExtensions.HiLoSequenceName);
             Assert.Equal("Tasty", sqlServerExtensions.HiLoSequenceSchema);
 
-            Assert.Null(relationalExtensions.TryGetSequence("Snook", "Tasty"));
+            Assert.Null(relationalExtensions.FindSequence("Snook", "Tasty"));
 
-            var sequence = sqlServerExtensions.TryGetSequence("Snook", "Tasty");
+            var sequence = sqlServerExtensions.FindSequence("Snook", "Tasty");
             Assert.Equal("Snook", sequence.Name);
             Assert.Equal("Tasty", sequence.Schema);
             Assert.Equal(10, sequence.IncrementBy);
-            Assert.Equal(Sequence.DefaultStartValue, sequence.StartValue);
+            Assert.Equal(1, sequence.StartValue);
             Assert.Null(sequence.MinValue);
             Assert.Null(sequence.MaxValue);
-            Assert.Same(Sequence.DefaultType, sequence.ClrType);
+            Assert.Same(typeof(long), sequence.ClrType);
         }
 
         [Fact]
@@ -511,12 +511,11 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             var modelBuilder = CreateConventionModelBuilder();
 
             modelBuilder
-                .Sequence("Snook", "Tasty")
+                .Sequence<int>("Snook", "Tasty")
                 .IncrementsBy(11)
                 .StartsAt(1729)
                 .HasMin(111)
-                .HasMax(2222)
-                .Type<int>();
+                .HasMax(2222);
 
             modelBuilder.UseSqlServerSequenceHiLo("Snook", "Tasty");
 
@@ -527,8 +526,8 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             Assert.Equal("Snook", sqlServerExtensions.HiLoSequenceName);
             Assert.Equal("Tasty", sqlServerExtensions.HiLoSequenceSchema);
 
-            ValidateSchemaNamedSpecificSequence(relationalExtensions.TryGetSequence("Snook", "Tasty"));
-            ValidateSchemaNamedSpecificSequence(sqlServerExtensions.TryGetSequence("Snook", "Tasty"));
+            ValidateSchemaNamedSpecificSequence(relationalExtensions.FindSequence("Snook", "Tasty"));
+            ValidateSchemaNamedSpecificSequence(sqlServerExtensions.FindSequence("Snook", "Tasty"));
         }
 
         [Fact]
@@ -537,12 +536,11 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             var modelBuilder = CreateConventionModelBuilder();
 
             modelBuilder
-                .SqlServerSequence("Snook", "Tasty")
+                .SqlServerSequence<int>("Snook", "Tasty")
                 .IncrementsBy(11)
                 .StartsAt(1729)
                 .HasMin(111)
-                .HasMax(2222)
-                .Type<int>();
+                .HasMax(2222);
 
             modelBuilder.UseSqlServerSequenceHiLo("Snook", "Tasty");
 
@@ -553,11 +551,11 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             Assert.Equal("Snook", sqlServerExtensions.HiLoSequenceName);
             Assert.Equal("Tasty", sqlServerExtensions.HiLoSequenceSchema);
 
-            Assert.Null(relationalExtensions.TryGetSequence("Snook", "Tasty"));
-            ValidateSchemaNamedSpecificSequence(sqlServerExtensions.TryGetSequence("Snook", "Tasty"));
+            Assert.Null(relationalExtensions.FindSequence("Snook", "Tasty"));
+            ValidateSchemaNamedSpecificSequence(sqlServerExtensions.FindSequence("Snook", "Tasty"));
         }
 
-        private static void ValidateSchemaNamedSpecificSequence(Sequence sequence)
+        private static void ValidateSchemaNamedSpecificSequence(ISequence sequence)
         {
             Assert.Equal("Snook", sequence.Name);
             Assert.Equal("Tasty", sequence.Schema);
@@ -583,8 +581,8 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             Assert.Null(sqlServerExtensions.HiLoSequenceSchema);
             Assert.Null(sqlServerExtensions.HiLoSequencePoolSize);
 
-            Assert.Null(relationalExtensions.TryGetSequence(Sequence.DefaultName));
-            Assert.Null(sqlServerExtensions.TryGetSequence(Sequence.DefaultName));
+            Assert.Null(relationalExtensions.FindSequence(SqlServerAnnotationNames.DefaultHiLoSequenceName));
+            Assert.Null(sqlServerExtensions.FindSequence(SqlServerAnnotationNames.DefaultHiLoSequenceName));
         }
 
         [Fact]
@@ -602,10 +600,10 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
 
             Assert.Equal(SqlServerIdentityStrategy.SequenceHiLo, property.SqlServer().IdentityStrategy);
             Assert.Equal(ValueGenerated.OnAdd, property.ValueGenerated);
-            Assert.Same(Sequence.DefaultName, property.SqlServer().HiLoSequenceName);
+            Assert.Equal(SqlServerAnnotationNames.DefaultHiLoSequenceName, property.SqlServer().HiLoSequenceName);
 
-            Assert.Null(model.Relational().TryGetSequence(Sequence.DefaultName));
-            Assert.NotNull(model.SqlServer().TryGetSequence(Sequence.DefaultName));
+            Assert.Null(model.Relational().FindSequence(SqlServerAnnotationNames.DefaultHiLoSequenceName));
+            Assert.NotNull(model.SqlServer().FindSequence(SqlServerAnnotationNames.DefaultHiLoSequenceName));
 
             Assert.Null(property.SqlServer().HiLoSequencePoolSize);
         }
@@ -625,10 +623,10 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
 
             Assert.Equal(SqlServerIdentityStrategy.SequenceHiLo, property.SqlServer().IdentityStrategy);
             Assert.Equal(ValueGenerated.OnAdd, property.ValueGenerated);
-            Assert.Same(Sequence.DefaultName, property.SqlServer().HiLoSequenceName);
+            Assert.Equal(SqlServerAnnotationNames.DefaultHiLoSequenceName, property.SqlServer().HiLoSequenceName);
 
-            Assert.Null(model.Relational().TryGetSequence(Sequence.DefaultName));
-            Assert.NotNull(model.SqlServer().TryGetSequence(Sequence.DefaultName));
+            Assert.Null(model.Relational().FindSequence(SqlServerAnnotationNames.DefaultHiLoSequenceName));
+            Assert.NotNull(model.SqlServer().FindSequence(SqlServerAnnotationNames.DefaultHiLoSequenceName));
 
             Assert.Equal(3, property.SqlServer().HiLoSequencePoolSize);
         }
@@ -652,17 +650,17 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             Assert.Null(property.SqlServer().HiLoSequenceSchema);
             Assert.Null(property.SqlServer().HiLoSequencePoolSize);
 
-            Assert.Null(model.Relational().TryGetSequence("Snook"));
+            Assert.Null(model.Relational().FindSequence("Snook"));
 
-            var sequence = model.SqlServer().TryGetSequence("Snook");
+            var sequence = model.SqlServer().FindSequence("Snook");
 
             Assert.Equal("Snook", sequence.Name);
             Assert.Null(sequence.Schema);
             Assert.Equal(10, sequence.IncrementBy);
-            Assert.Equal(Sequence.DefaultStartValue, sequence.StartValue);
+            Assert.Equal(1, sequence.StartValue);
             Assert.Null(sequence.MinValue);
             Assert.Null(sequence.MaxValue);
-            Assert.Same(Sequence.DefaultType, sequence.ClrType);
+            Assert.Same(typeof(long), sequence.ClrType);
         }
 
         [Fact]
@@ -684,16 +682,16 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             Assert.Null(property.SqlServer().HiLoSequenceSchema);
             Assert.Equal(3, property.SqlServer().HiLoSequencePoolSize);
 
-            Assert.Null(model.Relational().TryGetSequence("Snook"));
+            Assert.Null(model.Relational().FindSequence("Snook"));
 
-            var sequence = model.SqlServer().TryGetSequence("Snook");
+            var sequence = model.SqlServer().FindSequence("Snook");
             Assert.Equal("Snook", sequence.Name);
             Assert.Null(sequence.Schema);
             Assert.Equal(10, sequence.IncrementBy);
-            Assert.Equal(Sequence.DefaultStartValue, sequence.StartValue);
+            Assert.Equal(1, sequence.StartValue);
             Assert.Null(sequence.MinValue);
             Assert.Null(sequence.MaxValue);
-            Assert.Same(Sequence.DefaultType, sequence.ClrType);
+            Assert.Same(typeof(long), sequence.ClrType);
         }
 
         [Fact]
@@ -714,16 +712,16 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             Assert.Equal("Snook", property.SqlServer().HiLoSequenceName);
             Assert.Equal("Tasty", property.SqlServer().HiLoSequenceSchema);
 
-            Assert.Null(model.Relational().TryGetSequence("Snook", "Tasty"));
+            Assert.Null(model.Relational().FindSequence("Snook", "Tasty"));
 
-            var sequence = model.SqlServer().TryGetSequence("Snook", "Tasty");
+            var sequence = model.SqlServer().FindSequence("Snook", "Tasty");
             Assert.Equal("Snook", sequence.Name);
             Assert.Equal("Tasty", sequence.Schema);
             Assert.Equal(10, sequence.IncrementBy);
-            Assert.Equal(Sequence.DefaultStartValue, sequence.StartValue);
+            Assert.Equal(1, sequence.StartValue);
             Assert.Null(sequence.MinValue);
             Assert.Null(sequence.MaxValue);
-            Assert.Same(Sequence.DefaultType, sequence.ClrType);
+            Assert.Same(typeof(long), sequence.ClrType);
         }
 
         [Fact]
@@ -732,12 +730,11 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             var modelBuilder = CreateConventionModelBuilder();
 
             modelBuilder
-                .Sequence("Snook", "Tasty")
+                .Sequence<int>("Snook", "Tasty")
                 .IncrementsBy(11)
                 .StartsAt(1729)
                 .HasMin(111)
-                .HasMax(2222)
-                .Type<int>();
+                .HasMax(2222);
 
             modelBuilder
                 .Entity<Customer>()
@@ -752,8 +749,8 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             Assert.Equal("Snook", property.SqlServer().HiLoSequenceName);
             Assert.Equal("Tasty", property.SqlServer().HiLoSequenceSchema);
 
-            ValidateSchemaNamedSpecificSequence(model.Relational().TryGetSequence("Snook", "Tasty"));
-            ValidateSchemaNamedSpecificSequence(model.SqlServer().TryGetSequence("Snook", "Tasty"));
+            ValidateSchemaNamedSpecificSequence(model.Relational().FindSequence("Snook", "Tasty"));
+            ValidateSchemaNamedSpecificSequence(model.SqlServer().FindSequence("Snook", "Tasty"));
         }
 
         [Fact]
@@ -762,7 +759,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             var modelBuilder = CreateConventionModelBuilder();
 
             modelBuilder
-                .Sequence("Snook", "Tasty", b => b.IncrementsBy(11).StartsAt(1729).HasMin(111).HasMax(2222).Type<int>())
+                .Sequence<int>("Snook", "Tasty", b => b.IncrementsBy(11).StartsAt(1729).HasMin(111).HasMax(2222))
                 .Entity<Customer>()
                 .Property(e => e.Id)
                 .UseSqlServerSequenceHiLo("Snook", "Tasty");
@@ -775,8 +772,8 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             Assert.Equal("Snook", property.SqlServer().HiLoSequenceName);
             Assert.Equal("Tasty", property.SqlServer().HiLoSequenceSchema);
 
-            ValidateSchemaNamedSpecificSequence(model.Relational().TryGetSequence("Snook", "Tasty"));
-            ValidateSchemaNamedSpecificSequence(model.SqlServer().TryGetSequence("Snook", "Tasty"));
+            ValidateSchemaNamedSpecificSequence(model.Relational().FindSequence("Snook", "Tasty"));
+            ValidateSchemaNamedSpecificSequence(model.SqlServer().FindSequence("Snook", "Tasty"));
         }
 
         [Fact]
@@ -785,12 +782,11 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             var modelBuilder = CreateConventionModelBuilder();
 
             modelBuilder
-                .SqlServerSequence("Snook", "Tasty")
+                .SqlServerSequence<int>("Snook", "Tasty")
                 .IncrementsBy(11)
                 .StartsAt(1729)
                 .HasMin(111)
-                .HasMax(2222)
-                .Type<int>();
+                .HasMax(2222);
 
             modelBuilder
                 .Entity<Customer>()
@@ -805,8 +801,8 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             Assert.Equal("Snook", property.SqlServer().HiLoSequenceName);
             Assert.Equal("Tasty", property.SqlServer().HiLoSequenceSchema);
 
-            Assert.Null(model.Relational().TryGetSequence("Snook", "Tasty"));
-            ValidateSchemaNamedSpecificSequence(model.SqlServer().TryGetSequence("Snook", "Tasty"));
+            Assert.Null(model.Relational().FindSequence("Snook", "Tasty"));
+            ValidateSchemaNamedSpecificSequence(model.SqlServer().FindSequence("Snook", "Tasty"));
         }
 
         [Fact]
@@ -815,13 +811,12 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             var modelBuilder = CreateConventionModelBuilder();
 
             modelBuilder
-                .SqlServerSequence("Snook", "Tasty", b =>
+                .SqlServerSequence<int>("Snook", "Tasty", b =>
                     {
                         b.IncrementsBy(11)
                             .StartsAt(1729)
                             .HasMin(111)
-                            .HasMax(2222)
-                            .Type<int>();
+                            .HasMax(2222);
                     })
                 .Entity<Customer>()
                 .Property(e => e.Id)
@@ -835,8 +830,8 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             Assert.Equal("Snook", property.SqlServer().HiLoSequenceName);
             Assert.Equal("Tasty", property.SqlServer().HiLoSequenceSchema);
 
-            Assert.Null(model.Relational().TryGetSequence("Snook", "Tasty"));
-            ValidateSchemaNamedSpecificSequence(model.SqlServer().TryGetSequence("Snook", "Tasty"));
+            Assert.Null(model.Relational().FindSequence("Snook", "Tasty"));
+            ValidateSchemaNamedSpecificSequence(model.SqlServer().FindSequence("Snook", "Tasty"));
         }
 
         [Fact]
@@ -857,8 +852,8 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             Assert.Null(property.SqlServer().HiLoSequenceName);
             Assert.Null(property.SqlServer().HiLoSequencePoolSize);
 
-            Assert.Null(model.Relational().TryGetSequence(Sequence.DefaultName));
-            Assert.Null(model.SqlServer().TryGetSequence(Sequence.DefaultName));
+            Assert.Null(model.Relational().FindSequence(SqlServerAnnotationNames.DefaultHiLoSequenceName));
+            Assert.Null(model.SqlServer().FindSequence(SqlServerAnnotationNames.DefaultHiLoSequenceName));
         }
 
         [Fact]
@@ -879,8 +874,8 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             Assert.Null(property.SqlServer().HiLoSequenceName);
             Assert.Null(property.SqlServer().HiLoSequencePoolSize);
 
-            Assert.Null(model.Relational().TryGetSequence(Sequence.DefaultName));
-            Assert.Null(model.SqlServer().TryGetSequence(Sequence.DefaultName));
+            Assert.Null(model.Relational().FindSequence(SqlServerAnnotationNames.DefaultHiLoSequenceName));
+            Assert.Null(model.SqlServer().FindSequence(SqlServerAnnotationNames.DefaultHiLoSequenceName));
         }
 
         [Fact]
@@ -890,16 +885,16 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
 
             modelBuilder.SqlServerSequence("Snook");
 
-            Assert.Null(modelBuilder.Model.Relational().TryGetSequence("Snook"));
-            var sequence = modelBuilder.Model.SqlServer().TryGetSequence("Snook");
+            Assert.Null(modelBuilder.Model.Relational().FindSequence("Snook"));
+            var sequence = modelBuilder.Model.SqlServer().FindSequence("Snook");
 
             Assert.Equal("Snook", sequence.Name);
             Assert.Null(sequence.Schema);
             Assert.Equal(1, sequence.IncrementBy);
-            Assert.Equal(Sequence.DefaultStartValue, sequence.StartValue);
+            Assert.Equal(1, sequence.StartValue);
             Assert.Null(sequence.MinValue);
             Assert.Null(sequence.MaxValue);
-            Assert.Same(Sequence.DefaultType, sequence.ClrType);
+            Assert.Same(typeof(long), sequence.ClrType);
         }
 
         [Fact]
@@ -909,16 +904,16 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
 
             modelBuilder.SqlServerSequence("Snook", "Tasty");
 
-            Assert.Null(modelBuilder.Model.Relational().TryGetSequence("Snook", "Tasty"));
-            var sequence = modelBuilder.Model.SqlServer().TryGetSequence("Snook", "Tasty");
+            Assert.Null(modelBuilder.Model.Relational().FindSequence("Snook", "Tasty"));
+            var sequence = modelBuilder.Model.SqlServer().FindSequence("Snook", "Tasty");
 
             Assert.Equal("Snook", sequence.Name);
             Assert.Equal("Tasty", sequence.Schema);
             Assert.Equal(1, sequence.IncrementBy);
-            Assert.Equal(Sequence.DefaultStartValue, sequence.StartValue);
+            Assert.Equal(1, sequence.StartValue);
             Assert.Null(sequence.MinValue);
             Assert.Null(sequence.MaxValue);
-            Assert.Same(Sequence.DefaultType, sequence.ClrType);
+            Assert.Same(typeof(long), sequence.ClrType);
         }
 
         [Fact]
@@ -927,15 +922,32 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             var modelBuilder = CreateConventionModelBuilder();
 
             modelBuilder
-                .SqlServerSequence("Snook")
+                .SqlServerSequence<int>("Snook")
                 .IncrementsBy(11)
                 .StartsAt(1729)
                 .HasMin(111)
-                .HasMax(2222)
-                .Type<int>();
+                .HasMax(2222);
 
-            Assert.Null(modelBuilder.Model.Relational().TryGetSequence("Snook"));
-            var sequence = modelBuilder.Model.SqlServer().TryGetSequence("Snook");
+            Assert.Null(modelBuilder.Model.Relational().FindSequence("Snook"));
+            var sequence = modelBuilder.Model.SqlServer().FindSequence("Snook");
+
+            ValidateNamedSpecificSequence(sequence);
+        }
+
+        [Fact]
+        public void Can_create_named_sequence_with_specific_facets_non_generic()
+        {
+            var modelBuilder = CreateConventionModelBuilder();
+
+            modelBuilder
+                .SqlServerSequence(typeof(int), "Snook")
+                .IncrementsBy(11)
+                .StartsAt(1729)
+                .HasMin(111)
+                .HasMax(2222);
+
+            Assert.Null(modelBuilder.Model.Relational().FindSequence("Snook"));
+            var sequence = modelBuilder.Model.SqlServer().FindSequence("Snook");
 
             ValidateNamedSpecificSequence(sequence);
         }
@@ -946,22 +958,41 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             var modelBuilder = CreateConventionModelBuilder();
 
             modelBuilder
-                .SqlServerSequence("Snook", b =>
+                .SqlServerSequence<int>("Snook", b =>
                     {
                         b.IncrementsBy(11)
                             .StartsAt(1729)
                             .HasMin(111)
-                            .HasMax(2222)
-                            .Type<int>();
+                            .HasMax(2222);
                     });
 
-            Assert.Null(modelBuilder.Model.Relational().TryGetSequence("Snook"));
-            var sequence = modelBuilder.Model.SqlServer().TryGetSequence("Snook");
+            Assert.Null(modelBuilder.Model.Relational().FindSequence("Snook"));
+            var sequence = modelBuilder.Model.SqlServer().FindSequence("Snook");
 
             ValidateNamedSpecificSequence(sequence);
         }
 
-        private static void ValidateNamedSpecificSequence(Sequence sequence)
+        [Fact]
+        public void Can_create_named_sequence_with_specific_facets_using_nested_closure_non_generic()
+        {
+            var modelBuilder = CreateConventionModelBuilder();
+
+            modelBuilder
+                .SqlServerSequence(typeof(int), "Snook", b =>
+                {
+                    b.IncrementsBy(11)
+                        .StartsAt(1729)
+                        .HasMin(111)
+                        .HasMax(2222);
+                });
+
+            Assert.Null(modelBuilder.Model.Relational().FindSequence("Snook"));
+            var sequence = modelBuilder.Model.SqlServer().FindSequence("Snook");
+
+            ValidateNamedSpecificSequence(sequence);
+        }
+
+        private static void ValidateNamedSpecificSequence(ISequence sequence)
         {
             Assert.Equal("Snook", sequence.Name);
             Assert.Null(sequence.Schema);
@@ -978,15 +1009,32 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             var modelBuilder = CreateConventionModelBuilder();
 
             modelBuilder
-                .SqlServerSequence("Snook", "Tasty")
+                .SqlServerSequence<int>("Snook", "Tasty")
                 .IncrementsBy(11)
                 .StartsAt(1729)
                 .HasMin(111)
-                .HasMax(2222)
-                .Type<int>();
+                .HasMax(2222);
 
-            Assert.Null(modelBuilder.Model.Relational().TryGetSequence("Snook", "Tasty"));
-            var sequence = modelBuilder.Model.SqlServer().TryGetSequence("Snook", "Tasty");
+            Assert.Null(modelBuilder.Model.Relational().FindSequence("Snook", "Tasty"));
+            var sequence = modelBuilder.Model.SqlServer().FindSequence("Snook", "Tasty");
+
+            ValidateSchemaNamedSpecificSequence(sequence);
+        }
+
+        [Fact]
+        public void Can_create_schema_named_sequence_with_specific_facets_non_generic()
+        {
+            var modelBuilder = CreateConventionModelBuilder();
+
+            modelBuilder
+                .SqlServerSequence(typeof(int), "Snook", "Tasty")
+                .IncrementsBy(11)
+                .StartsAt(1729)
+                .HasMin(111)
+                .HasMax(2222);
+
+            Assert.Null(modelBuilder.Model.Relational().FindSequence("Snook", "Tasty"));
+            var sequence = modelBuilder.Model.SqlServer().FindSequence("Snook", "Tasty");
 
             ValidateSchemaNamedSpecificSequence(sequence);
         }
@@ -997,13 +1045,30 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             var modelBuilder = CreateConventionModelBuilder();
 
             modelBuilder
-                .SqlServerSequence("Snook", "Tasty", b =>
+                .SqlServerSequence<int>("Snook", "Tasty", b =>
                     {
-                        b.IncrementsBy(11).StartsAt(1729).HasMin(111).HasMax(2222).Type<int>();
+                        b.IncrementsBy(11).StartsAt(1729).HasMin(111).HasMax(2222);
                     });
 
-            Assert.Null(modelBuilder.Model.Relational().TryGetSequence("Snook", "Tasty"));
-            var sequence = modelBuilder.Model.SqlServer().TryGetSequence("Snook", "Tasty");
+            Assert.Null(modelBuilder.Model.Relational().FindSequence("Snook", "Tasty"));
+            var sequence = modelBuilder.Model.SqlServer().FindSequence("Snook", "Tasty");
+
+            ValidateSchemaNamedSpecificSequence(sequence);
+        }
+
+        [Fact]
+        public void Can_create_schema_named_sequence_with_specific_facets_using_nested_closure_non_generic()
+        {
+            var modelBuilder = CreateConventionModelBuilder();
+
+            modelBuilder
+                .SqlServerSequence(typeof(int), "Snook", "Tasty", b =>
+                {
+                    b.IncrementsBy(11).StartsAt(1729).HasMin(111).HasMax(2222);
+                });
+
+            Assert.Null(modelBuilder.Model.Relational().FindSequence("Snook", "Tasty"));
+            var sequence = modelBuilder.Model.SqlServer().FindSequence("Snook", "Tasty");
 
             ValidateSchemaNamedSpecificSequence(sequence);
         }
@@ -1226,7 +1291,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
         private void AssertIsGeneric(ReferenceCollectionBuilder<Customer, Order> _)
         {
         }
-        
+
         private void AssertIsGeneric(ReferenceReferenceBuilder<Order, OrderDetails> _)
         {
         }

--- a/test/EntityFramework7.SqlServer.Tests/Metadata/SqlServerMetadataExtensionsTest.cs
+++ b/test/EntityFramework7.SqlServer.Tests/Metadata/SqlServerMetadataExtensionsTest.cs
@@ -411,17 +411,17 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             var modelBuilder = new ModelBuilder(new ConventionSet());
             var model = modelBuilder.Model;
 
-            Assert.Null(model.Relational().TryGetSequence("Foo"));
-            Assert.Null(((IModel)model).Relational().TryGetSequence("Foo"));
-            Assert.Null(model.SqlServer().TryGetSequence("Foo"));
-            Assert.Null(((IModel)model).SqlServer().TryGetSequence("Foo"));
+            Assert.Null(model.Relational().FindSequence("Foo"));
+            Assert.Null(((IModel)model).Relational().FindSequence("Foo"));
+            Assert.Null(model.SqlServer().FindSequence("Foo"));
+            Assert.Null(((IModel)model).SqlServer().FindSequence("Foo"));
 
             var sequence = model.SqlServer().GetOrAddSequence("Foo");
 
-            Assert.Null(model.Relational().TryGetSequence("Foo"));
-            Assert.Null(((IModel)model).Relational().TryGetSequence("Foo"));
-            Assert.Equal("Foo", model.SqlServer().TryGetSequence("Foo").Name);
-            Assert.Equal("Foo", ((IModel)model).SqlServer().TryGetSequence("Foo").Name);
+            Assert.Null(model.Relational().FindSequence("Foo"));
+            Assert.Null(((IModel)model).Relational().FindSequence("Foo"));
+            Assert.Equal("Foo", model.SqlServer().FindSequence("Foo").Name);
+            Assert.Equal("Foo", ((IModel)model).SqlServer().FindSequence("Foo").Name);
 
             Assert.Equal("Foo", sequence.Name);
             Assert.Null(sequence.Schema);
@@ -431,11 +431,15 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             Assert.Null(sequence.MaxValue);
             Assert.Same(typeof(long), sequence.ClrType);
 
-            model.SqlServer().AddOrReplaceSequence(new Sequence("Foo", null, 1729, 11, 2001, 2010, typeof(int)));
+            Assert.Null(model.Relational().FindSequence("Foo"));
 
-            Assert.Null(model.Relational().TryGetSequence("Foo"));
+            var sequence2 = model.SqlServer().FindSequence("Foo");
 
-            sequence = model.SqlServer().GetOrAddSequence("Foo");
+            sequence.StartValue = 1729;
+            sequence.IncrementBy = 11;
+            sequence.MinValue = 2001;
+            sequence.MaxValue = 2010;
+            sequence.ClrType = typeof(int);
 
             Assert.Equal("Foo", sequence.Name);
             Assert.Null(sequence.Schema);
@@ -444,6 +448,14 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             Assert.Equal(2001, sequence.MinValue);
             Assert.Equal(2010, sequence.MaxValue);
             Assert.Same(typeof(int), sequence.ClrType);
+
+            Assert.Equal(sequence2.Name, sequence.Name);
+            Assert.Equal(sequence2.Schema, sequence.Schema);
+            Assert.Equal(sequence2.IncrementBy, sequence.IncrementBy);
+            Assert.Equal(sequence2.StartValue, sequence.StartValue);
+            Assert.Equal(sequence2.MinValue, sequence.MinValue);
+            Assert.Equal(sequence2.MaxValue, sequence.MaxValue);
+            Assert.Same(sequence2.ClrType, sequence.ClrType);
         }
 
         [Fact]
@@ -452,17 +464,17 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             var modelBuilder = new ModelBuilder(new ConventionSet());
             var model = modelBuilder.Model;
 
-            Assert.Null(model.Relational().TryGetSequence("Foo", "Smoo"));
-            Assert.Null(((IModel)model).Relational().TryGetSequence("Foo", "Smoo"));
-            Assert.Null(model.SqlServer().TryGetSequence("Foo", "Smoo"));
-            Assert.Null(((IModel)model).SqlServer().TryGetSequence("Foo", "Smoo"));
+            Assert.Null(model.Relational().FindSequence("Foo", "Smoo"));
+            Assert.Null(((IModel)model).Relational().FindSequence("Foo", "Smoo"));
+            Assert.Null(model.SqlServer().FindSequence("Foo", "Smoo"));
+            Assert.Null(((IModel)model).SqlServer().FindSequence("Foo", "Smoo"));
 
             var sequence = model.SqlServer().GetOrAddSequence("Foo", "Smoo");
 
-            Assert.Null(model.Relational().TryGetSequence("Foo", "Smoo"));
-            Assert.Null(((IModel)model).Relational().TryGetSequence("Foo", "Smoo"));
-            Assert.Equal("Foo", model.SqlServer().TryGetSequence("Foo", "Smoo").Name);
-            Assert.Equal("Foo", ((IModel)model).SqlServer().TryGetSequence("Foo", "Smoo").Name);
+            Assert.Null(model.Relational().FindSequence("Foo", "Smoo"));
+            Assert.Null(((IModel)model).Relational().FindSequence("Foo", "Smoo"));
+            Assert.Equal("Foo", model.SqlServer().FindSequence("Foo", "Smoo").Name);
+            Assert.Equal("Foo", ((IModel)model).SqlServer().FindSequence("Foo", "Smoo").Name);
 
             Assert.Equal("Foo", sequence.Name);
             Assert.Equal("Smoo", sequence.Schema);
@@ -472,87 +484,15 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             Assert.Null(sequence.MaxValue);
             Assert.Same(typeof(long), sequence.ClrType);
 
-            model.SqlServer().AddOrReplaceSequence(new Sequence("Foo", "Smoo", 1729, 11, 2001, 2010, typeof(int)));
+            Assert.Null(model.Relational().FindSequence("Foo", "Smoo"));
 
-            Assert.Null(model.Relational().TryGetSequence("Foo", "Smoo"));
+            var sequence2 = model.SqlServer().FindSequence("Foo", "Smoo");
 
-            sequence = model.SqlServer().GetOrAddSequence("Foo", "Smoo");
-
-            Assert.Equal("Foo", sequence.Name);
-            Assert.Equal("Smoo", sequence.Schema);
-            Assert.Equal(11, sequence.IncrementBy);
-            Assert.Equal(1729, sequence.StartValue);
-            Assert.Equal(2001, sequence.MinValue);
-            Assert.Equal(2010, sequence.MaxValue);
-            Assert.Same(typeof(int), sequence.ClrType);
-        }
-
-        [Fact]
-        public void Can_add_and_replace_sequence()
-        {
-            var modelBuilder = new ModelBuilder(new ConventionSet());
-            var model = modelBuilder.Model;
-
-            model.SqlServer().AddOrReplaceSequence(new Sequence("Foo"));
-
-            Assert.Null(model.Relational().TryGetSequence("Foo"));
-            Assert.Null(((IModel)model).Relational().TryGetSequence("Foo"));
-            Assert.Equal("Foo", model.SqlServer().TryGetSequence("Foo").Name);
-            Assert.Equal("Foo", ((IModel)model).SqlServer().TryGetSequence("Foo").Name);
-
-            var sequence = model.SqlServer().TryGetSequence("Foo");
-
-            Assert.Equal("Foo", sequence.Name);
-            Assert.Null(sequence.Schema);
-            Assert.Equal(1, sequence.IncrementBy);
-            Assert.Equal(1, sequence.StartValue);
-            Assert.Null(sequence.MinValue);
-            Assert.Null(sequence.MaxValue);
-            Assert.Same(typeof(long), sequence.ClrType);
-
-            model.SqlServer().AddOrReplaceSequence(new Sequence("Foo", null, 1729, 11, 2001, 2010, typeof(int)));
-
-            Assert.Null(model.Relational().TryGetSequence("Foo"));
-
-            sequence = model.SqlServer().TryGetSequence("Foo");
-
-            Assert.Equal("Foo", sequence.Name);
-            Assert.Null(sequence.Schema);
-            Assert.Equal(11, sequence.IncrementBy);
-            Assert.Equal(1729, sequence.StartValue);
-            Assert.Equal(2001, sequence.MinValue);
-            Assert.Equal(2010, sequence.MaxValue);
-            Assert.Same(typeof(int), sequence.ClrType);
-        }
-
-        [Fact]
-        public void Can_add_and_replace_sequence_with_schema_name()
-        {
-            var modelBuilder = new ModelBuilder(new ConventionSet());
-            var model = modelBuilder.Model;
-
-            model.SqlServer().AddOrReplaceSequence(new Sequence("Foo", "Smoo"));
-
-            Assert.Null(model.Relational().TryGetSequence("Foo", "Smoo"));
-            Assert.Null(((IModel)model).Relational().TryGetSequence("Foo", "Smoo"));
-            Assert.Equal("Foo", model.SqlServer().TryGetSequence("Foo", "Smoo").Name);
-            Assert.Equal("Foo", ((IModel)model).SqlServer().TryGetSequence("Foo", "Smoo").Name);
-
-            var sequence = model.SqlServer().TryGetSequence("Foo", "Smoo");
-
-            Assert.Equal("Foo", sequence.Name);
-            Assert.Equal("Smoo", sequence.Schema);
-            Assert.Equal(1, sequence.IncrementBy);
-            Assert.Equal(1, sequence.StartValue);
-            Assert.Null(sequence.MinValue);
-            Assert.Null(sequence.MaxValue);
-            Assert.Same(typeof(long), sequence.ClrType);
-
-            model.SqlServer().AddOrReplaceSequence(new Sequence("Foo", "Smoo", 1729, 11, 2001, 2010, typeof(int)));
-
-            Assert.Null(model.Relational().TryGetSequence("Foo", "Smoo"));
-
-            sequence = model.SqlServer().TryGetSequence("Foo", "Smoo");
+            sequence.StartValue = 1729;
+            sequence.IncrementBy = 11;
+            sequence.MinValue = 2001;
+            sequence.MaxValue = 2010;
+            sequence.ClrType = typeof(int);
 
             Assert.Equal("Foo", sequence.Name);
             Assert.Equal("Smoo", sequence.Schema);
@@ -561,7 +501,16 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             Assert.Equal(2001, sequence.MinValue);
             Assert.Equal(2010, sequence.MaxValue);
             Assert.Same(typeof(int), sequence.ClrType);
+
+            Assert.Equal(sequence2.Name, sequence.Name);
+            Assert.Equal(sequence2.Schema, sequence.Schema);
+            Assert.Equal(sequence2.IncrementBy, sequence.IncrementBy);
+            Assert.Equal(sequence2.StartValue, sequence.StartValue);
+            Assert.Equal(sequence2.MinValue, sequence.MinValue);
+            Assert.Equal(sequence2.MaxValue, sequence.MaxValue);
+            Assert.Same(sequence2.ClrType, sequence.ClrType);
         }
+
 
         [Fact]
         public void Can_get_multiple_sequences()
@@ -569,8 +518,8 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             var modelBuilder = new ModelBuilder(new ConventionSet());
             var model = modelBuilder.Model;
 
-            model.Relational().AddOrReplaceSequence(new Sequence("Fibonacci"));
-            model.SqlServer().AddOrReplaceSequence(new Sequence("Golomb"));
+            model.Relational().GetOrAddSequence("Fibonacci");
+            model.SqlServer().GetOrAddSequence("Golomb");
 
             var sequences = model.SqlServer().Sequences;
 
@@ -585,9 +534,9 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             var modelBuilder = new ModelBuilder(new ConventionSet());
             var model = modelBuilder.Model;
 
-            model.Relational().AddOrReplaceSequence(new Sequence("Fibonacci", startValue: 1));
-            model.SqlServer().AddOrReplaceSequence(new Sequence("Fibonacci", startValue: 3));
-            model.SqlServer().AddOrReplaceSequence(new Sequence("Golomb"));
+            model.Relational().GetOrAddSequence("Fibonacci").StartValue = 1;
+            model.SqlServer().GetOrAddSequence("Fibonacci").StartValue = 3;
+            model.SqlServer().GetOrAddSequence("Golomb");
 
             var sequences = model.SqlServer().Sequences;
 
@@ -883,26 +832,26 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
                 .Property(e => e.Id)
                 .Metadata;
 
-            modelBuilder.Model.SqlServer().AddOrReplaceSequence(new Sequence("DaneelOlivaw"));
+            modelBuilder.Model.SqlServer().GetOrAddSequence("DaneelOlivaw");
 
-            Assert.Null(property.SqlServer().TryGetHiLoSequence());
-            Assert.Null(((IProperty)property).SqlServer().TryGetHiLoSequence());
+            Assert.Null(property.SqlServer().FindHiLoSequence());
+            Assert.Null(((IProperty)property).SqlServer().FindHiLoSequence());
 
             property.SqlServer().HiLoSequenceName = "DaneelOlivaw";
 
-            Assert.Null(property.SqlServer().TryGetHiLoSequence());
-            Assert.Null(((IProperty)property).SqlServer().TryGetHiLoSequence());
+            Assert.Null(property.SqlServer().FindHiLoSequence());
+            Assert.Null(((IProperty)property).SqlServer().FindHiLoSequence());
 
             modelBuilder.Model.SqlServer().IdentityStrategy = SqlServerIdentityStrategy.IdentityColumn;
 
-            Assert.Null(property.SqlServer().TryGetHiLoSequence());
-            Assert.Null(((IProperty)property).SqlServer().TryGetHiLoSequence());
+            Assert.Null(property.SqlServer().FindHiLoSequence());
+            Assert.Null(((IProperty)property).SqlServer().FindHiLoSequence());
 
             modelBuilder.Model.SqlServer().IdentityStrategy = null;
             property.SqlServer().IdentityStrategy = SqlServerIdentityStrategy.IdentityColumn;
 
-            Assert.Null(property.SqlServer().TryGetHiLoSequence());
-            Assert.Null(((IProperty)property).SqlServer().TryGetHiLoSequence());
+            Assert.Null(property.SqlServer().FindHiLoSequence());
+            Assert.Null(((IProperty)property).SqlServer().FindHiLoSequence());
         }
 
         [Fact]
@@ -916,12 +865,12 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
                 .ValueGeneratedOnAdd()
                 .Metadata;
 
-            modelBuilder.Model.SqlServer().AddOrReplaceSequence(new Sequence("DaneelOlivaw"));
+            modelBuilder.Model.SqlServer().GetOrAddSequence("DaneelOlivaw");
             property.SqlServer().HiLoSequenceName = "DaneelOlivaw";
             property.SqlServer().IdentityStrategy = SqlServerIdentityStrategy.SequenceHiLo;
 
-            Assert.Equal("DaneelOlivaw", property.SqlServer().TryGetHiLoSequence().Name);
-            Assert.Equal("DaneelOlivaw", ((IProperty)property).SqlServer().TryGetHiLoSequence().Name);
+            Assert.Equal("DaneelOlivaw", property.SqlServer().FindHiLoSequence().Name);
+            Assert.Equal("DaneelOlivaw", ((IProperty)property).SqlServer().FindHiLoSequence().Name);
         }
 
         [Fact]
@@ -935,12 +884,12 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
                 .ValueGeneratedOnAdd()
                 .Metadata;
 
-            modelBuilder.Model.SqlServer().AddOrReplaceSequence(new Sequence("DaneelOlivaw"));
+            modelBuilder.Model.SqlServer().GetOrAddSequence("DaneelOlivaw");
             modelBuilder.Model.SqlServer().IdentityStrategy = SqlServerIdentityStrategy.SequenceHiLo;
             property.SqlServer().HiLoSequenceName = "DaneelOlivaw";
 
-            Assert.Equal("DaneelOlivaw", property.SqlServer().TryGetHiLoSequence().Name);
-            Assert.Equal("DaneelOlivaw", ((IProperty)property).SqlServer().TryGetHiLoSequence().Name);
+            Assert.Equal("DaneelOlivaw", property.SqlServer().FindHiLoSequence().Name);
+            Assert.Equal("DaneelOlivaw", ((IProperty)property).SqlServer().FindHiLoSequence().Name);
         }
 
         [Fact]
@@ -954,12 +903,12 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
                 .ValueGeneratedOnAdd()
                 .Metadata;
 
-            modelBuilder.Model.SqlServer().AddOrReplaceSequence(new Sequence("DaneelOlivaw"));
+            modelBuilder.Model.SqlServer().GetOrAddSequence("DaneelOlivaw");
             modelBuilder.Model.SqlServer().HiLoSequenceName = "DaneelOlivaw";
             property.SqlServer().IdentityStrategy = SqlServerIdentityStrategy.SequenceHiLo;
 
-            Assert.Equal("DaneelOlivaw", property.SqlServer().TryGetHiLoSequence().Name);
-            Assert.Equal("DaneelOlivaw", ((IProperty)property).SqlServer().TryGetHiLoSequence().Name);
+            Assert.Equal("DaneelOlivaw", property.SqlServer().FindHiLoSequence().Name);
+            Assert.Equal("DaneelOlivaw", ((IProperty)property).SqlServer().FindHiLoSequence().Name);
         }
 
         [Fact]
@@ -973,12 +922,12 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
                 .ValueGeneratedOnAdd()
                 .Metadata;
 
-            modelBuilder.Model.SqlServer().AddOrReplaceSequence(new Sequence("DaneelOlivaw"));
+            modelBuilder.Model.SqlServer().GetOrAddSequence("DaneelOlivaw");
             modelBuilder.Model.SqlServer().IdentityStrategy = SqlServerIdentityStrategy.SequenceHiLo;
             modelBuilder.Model.SqlServer().HiLoSequenceName = "DaneelOlivaw";
 
-            Assert.Equal("DaneelOlivaw", property.SqlServer().TryGetHiLoSequence().Name);
-            Assert.Equal("DaneelOlivaw", ((IProperty)property).SqlServer().TryGetHiLoSequence().Name);
+            Assert.Equal("DaneelOlivaw", property.SqlServer().FindHiLoSequence().Name);
+            Assert.Equal("DaneelOlivaw", ((IProperty)property).SqlServer().FindHiLoSequence().Name);
         }
 
         [Fact]
@@ -992,15 +941,15 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
                 .ValueGeneratedOnAdd()
                 .Metadata;
 
-            modelBuilder.Model.SqlServer().AddOrReplaceSequence(new Sequence("DaneelOlivaw", "R"));
+            modelBuilder.Model.SqlServer().GetOrAddSequence("DaneelOlivaw", "R");
             property.SqlServer().HiLoSequenceName = "DaneelOlivaw";
             property.SqlServer().HiLoSequenceSchema = "R";
             property.SqlServer().IdentityStrategy = SqlServerIdentityStrategy.SequenceHiLo;
 
-            Assert.Equal("DaneelOlivaw", property.SqlServer().TryGetHiLoSequence().Name);
-            Assert.Equal("DaneelOlivaw", ((IProperty)property).SqlServer().TryGetHiLoSequence().Name);
-            Assert.Equal("R", property.SqlServer().TryGetHiLoSequence().Schema);
-            Assert.Equal("R", ((IProperty)property).SqlServer().TryGetHiLoSequence().Schema);
+            Assert.Equal("DaneelOlivaw", property.SqlServer().FindHiLoSequence().Name);
+            Assert.Equal("DaneelOlivaw", ((IProperty)property).SqlServer().FindHiLoSequence().Name);
+            Assert.Equal("R", property.SqlServer().FindHiLoSequence().Schema);
+            Assert.Equal("R", ((IProperty)property).SqlServer().FindHiLoSequence().Schema);
         }
 
         [Fact]
@@ -1014,15 +963,15 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
                 .ValueGeneratedOnAdd()
                 .Metadata;
 
-            modelBuilder.Model.SqlServer().AddOrReplaceSequence(new Sequence("DaneelOlivaw", "R"));
+            modelBuilder.Model.SqlServer().GetOrAddSequence("DaneelOlivaw", "R");
             modelBuilder.Model.SqlServer().IdentityStrategy = SqlServerIdentityStrategy.SequenceHiLo;
             property.SqlServer().HiLoSequenceName = "DaneelOlivaw";
             property.SqlServer().HiLoSequenceSchema = "R";
 
-            Assert.Equal("DaneelOlivaw", property.SqlServer().TryGetHiLoSequence().Name);
-            Assert.Equal("DaneelOlivaw", ((IProperty)property).SqlServer().TryGetHiLoSequence().Name);
-            Assert.Equal("R", property.SqlServer().TryGetHiLoSequence().Schema);
-            Assert.Equal("R", ((IProperty)property).SqlServer().TryGetHiLoSequence().Schema);
+            Assert.Equal("DaneelOlivaw", property.SqlServer().FindHiLoSequence().Name);
+            Assert.Equal("DaneelOlivaw", ((IProperty)property).SqlServer().FindHiLoSequence().Name);
+            Assert.Equal("R", property.SqlServer().FindHiLoSequence().Schema);
+            Assert.Equal("R", ((IProperty)property).SqlServer().FindHiLoSequence().Schema);
         }
 
         [Fact]
@@ -1036,15 +985,15 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
                 .ValueGeneratedOnAdd()
                 .Metadata;
 
-            modelBuilder.Model.SqlServer().AddOrReplaceSequence(new Sequence("DaneelOlivaw", "R"));
+            modelBuilder.Model.SqlServer().GetOrAddSequence("DaneelOlivaw", "R");
             modelBuilder.Model.SqlServer().HiLoSequenceName = "DaneelOlivaw";
             modelBuilder.Model.SqlServer().HiLoSequenceSchema = "R";
             property.SqlServer().IdentityStrategy = SqlServerIdentityStrategy.SequenceHiLo;
 
-            Assert.Equal("DaneelOlivaw", property.SqlServer().TryGetHiLoSequence().Name);
-            Assert.Equal("DaneelOlivaw", ((IProperty)property).SqlServer().TryGetHiLoSequence().Name);
-            Assert.Equal("R", property.SqlServer().TryGetHiLoSequence().Schema);
-            Assert.Equal("R", ((IProperty)property).SqlServer().TryGetHiLoSequence().Schema);
+            Assert.Equal("DaneelOlivaw", property.SqlServer().FindHiLoSequence().Name);
+            Assert.Equal("DaneelOlivaw", ((IProperty)property).SqlServer().FindHiLoSequence().Name);
+            Assert.Equal("R", property.SqlServer().FindHiLoSequence().Schema);
+            Assert.Equal("R", ((IProperty)property).SqlServer().FindHiLoSequence().Schema);
         }
 
         [Fact]
@@ -1058,15 +1007,15 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
                 .ValueGeneratedOnAdd()
                 .Metadata;
 
-            modelBuilder.Model.SqlServer().AddOrReplaceSequence(new Sequence("DaneelOlivaw", "R"));
+            modelBuilder.Model.SqlServer().GetOrAddSequence("DaneelOlivaw", "R");
             modelBuilder.Model.SqlServer().IdentityStrategy = SqlServerIdentityStrategy.SequenceHiLo;
             modelBuilder.Model.SqlServer().HiLoSequenceName = "DaneelOlivaw";
             modelBuilder.Model.SqlServer().HiLoSequenceSchema = "R";
 
-            Assert.Equal("DaneelOlivaw", property.SqlServer().TryGetHiLoSequence().Name);
-            Assert.Equal("DaneelOlivaw", ((IProperty)property).SqlServer().TryGetHiLoSequence().Name);
-            Assert.Equal("R", property.SqlServer().TryGetHiLoSequence().Schema);
-            Assert.Equal("R", ((IProperty)property).SqlServer().TryGetHiLoSequence().Schema);
+            Assert.Equal("DaneelOlivaw", property.SqlServer().FindHiLoSequence().Name);
+            Assert.Equal("DaneelOlivaw", ((IProperty)property).SqlServer().FindHiLoSequence().Name);
+            Assert.Equal("R", property.SqlServer().FindHiLoSequence().Schema);
+            Assert.Equal("R", ((IProperty)property).SqlServer().FindHiLoSequence().Schema);
         }
 
         private class Customer

--- a/test/EntityFramework7.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
+++ b/test/EntityFramework7.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
@@ -75,7 +75,15 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             const int blockSize = 4;
             const int poolSize = 3;
 
-            var state = new SqlServerSequenceValueGeneratorState(new Sequence("Foo", null, 1, blockSize), poolSize);
+            var state = new SqlServerSequenceValueGeneratorState(
+                new Sequence(
+                    new Model(), RelationalAnnotationNames.Prefix, "Foo")
+                {
+                    IncrementBy = blockSize
+                },
+                poolSize);
+
+
             var generator = new SqlServerSequenceValueGenerator<TValue>(
                 new FakeSqlStatementExecutor(blockSize),
                 new SqlServerUpdateSqlGenerator(),
@@ -143,7 +151,15 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             const int blockSize = 10;
 
             var serviceProvider = SqlServerTestHelpers.Instance.CreateServiceProvider();
-            var state = new SqlServerSequenceValueGeneratorState(new Sequence("Foo", null, 1, blockSize), poolSize);
+
+            var state = new SqlServerSequenceValueGeneratorState(
+                new Sequence(
+                    new Model(), RelationalAnnotationNames.Prefix, "Foo")
+                {
+                    IncrementBy = blockSize
+                },
+                poolSize);
+
             var executor = new FakeSqlStatementExecutor(blockSize);
             var sqlGenerator = new SqlServerUpdateSqlGenerator();
 
@@ -173,7 +189,13 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         [Fact]
         public void Does_not_generate_temp_values()
         {
-            var state = new SqlServerSequenceValueGeneratorState(new Sequence("Foo", null, 1, 4), 3);
+            var state = new SqlServerSequenceValueGeneratorState(
+                new Sequence(
+                    new Model(), RelationalAnnotationNames.Prefix, "Foo")
+                {
+                    IncrementBy = 4
+                }, 3);
+
             var generator = new SqlServerSequenceValueGenerator<int>(
                 new FakeSqlStatementExecutor(4),
                 new SqlServerUpdateSqlGenerator(),

--- a/test/EntityFramework7.SqlServer.Tests/SqlServerValueGeneratorSelectorTest.cs
+++ b/test/EntityFramework7.SqlServer.Tests/SqlServerValueGeneratorSelectorTest.cs
@@ -66,6 +66,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         {
             var model = BuildModel();
             model.SqlServer().IdentityStrategy = SqlServerIdentityStrategy.SequenceHiLo;
+            model.SqlServer().GetOrAddSequence(SqlServerAnnotationNames.DefaultHiLoSequenceName);
             var entityType = model.GetEntityType(typeof(AnEntity));
 
             foreach (var property in entityType.Properties)
@@ -118,6 +119,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         {
             var model = SqlServerTestHelpers.Instance.BuildModelFor<AnEntity>();
             model.SqlServer().IdentityStrategy = SqlServerIdentityStrategy.SequenceHiLo;
+            model.SqlServer().GetOrAddSequence(SqlServerAnnotationNames.DefaultHiLoSequenceName);
             var entityType = model.GetEntityType(typeof(AnEntity));
 
             var selector = SqlServerTestHelpers.Instance.CreateContextServices(model).GetRequiredService<IValueGeneratorSelector>();
@@ -128,6 +130,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         private static Model BuildModel(bool generateValues = true)
         {
             var model = SqlServerTestHelpers.Instance.BuildModelFor<AnEntity>();
+            model.SqlServer().GetOrAddSequence(SqlServerAnnotationNames.DefaultHiLoSequenceName);
             var entityType = model.GetEntityType(typeof(AnEntity));
             entityType.AddProperty("Random", typeof(Random));
 

--- a/test/EntityFramework7.Sqlite.Tests/Metadata/SqliteMetadataExtensionsTest.cs
+++ b/test/EntityFramework7.Sqlite.Tests/Metadata/SqliteMetadataExtensionsTest.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Metadata.Conventions;
-using Microsoft.Data.Entity.Metadata.Conventions.Internal;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Sqlite.Metadata
@@ -242,24 +241,21 @@ namespace Microsoft.Data.Entity.Sqlite.Metadata
             var modelBuilder = new ModelBuilder(new ConventionSet());
             var model = modelBuilder.Model;
 
-            Assert.Null(model.Sqlite().TryGetSequence("Foo"));
-            Assert.Null(((IModel)model).Sqlite().TryGetSequence("Foo"));
+            Assert.Null(model.Sqlite().FindSequence("Foo"));
+            Assert.Null(((IModel)model).Sqlite().FindSequence("Foo"));
 
             var sequence = model.Relational().GetOrAddSequence("Foo");
 
-            Assert.Null(model.Sqlite().TryGetSequence("Foo"));
-            Assert.Null(((IModel)model).Sqlite().TryGetSequence("Foo"));
+            Assert.Null(model.Sqlite().FindSequence("Foo"));
+            Assert.Null(((IModel)model).Sqlite().FindSequence("Foo"));
         }
 
         [Fact]
         public void Cant_get_multiple_sequences()
         {
             var modelBuilder = new ModelBuilder(new ConventionSet());
-            var model = modelBuilder.Model;
 
-            model.Relational().AddOrReplaceSequence(new Sequence("Fibonacci"));
-
-            Assert.Empty(model.Sqlite().Sequences);
+            Assert.Empty(modelBuilder.Model.Sqlite().Sequences);
         }
 
         private class Customer


### PR DESCRIPTION
Specifically:
- Sequence objects now becomes a pure facade over their annotations in the model so that they can be mutated like first-class metadata objects.
- Removed default constants
- Pushed use of default name to be a purely HiLo thing
- Added generic fluent and non-generic overload for sequence type
- Restricted use of the annotation to inside the Sequence class implementation
- Renamed TryGetSequence to FindSequence