### PR TITLE
Fix migration generation

### DIFF
--- a/src/EntityFramework.Commands/Migrations/CSharpMigrationGenerator.cs
+++ b/src/EntityFramework.Commands/Migrations/CSharpMigrationGenerator.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                 .AppendLine("using Microsoft.Data.Entity.Migrations.Builders;")
                 .AppendLine("using Microsoft.Data.Entity.Migrations.Operations;")
                 .AppendLine()
-                .Append("namespace ").AppendLine(_code.Identifier(migrationNamespace))
+                .Append("namespace ").AppendLine(_code.Namespace(migrationNamespace))
                 .AppendLine("{");
             using (builder.Indent())
             {
@@ -109,7 +109,7 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                 .AppendLine("using Microsoft.Data.Entity.Migrations.Infrastructure;")
                 .Append("using ").Append(contextType.Namespace).AppendLine(";")
                 .AppendLine()
-                .Append("namespace ").AppendLine(_code.Identifier(migrationNamespace))
+                .Append("namespace ").AppendLine(_code.Namespace(migrationNamespace))
                 .AppendLine("{");
             using (builder.Indent())
             {
@@ -173,7 +173,7 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                 .AppendLine("using Microsoft.Data.Entity.Migrations.Infrastructure;")
                 .Append("using ").Append(contextType.Namespace).AppendLine(";")
                 .AppendLine()
-                .Append("namespace ").AppendLine(_code.Identifier(modelSnapshotNamespace))
+                .Append("namespace ").AppendLine(_code.Namespace(modelSnapshotNamespace))
                 .AppendLine("{");
             using (builder.Indent())
             {

--- a/src/EntityFramework.Commands/Utilities/CSharpHelper.cs
+++ b/src/EntityFramework.Commands/Utilities/CSharpHelper.cs
@@ -138,7 +138,7 @@ namespace Microsoft.Data.Entity.Commands.Utilities
                 builder.Append(name.Substring(partStart));
             }
 
-            if (!SyntaxFacts.IsIdentifierStartCharacter(builder[0]))
+            if (builder.Length == 0 || !SyntaxFacts.IsIdentifierStartCharacter(builder[0]))
             {
                 builder.Insert(0, "_");
             }
@@ -164,6 +164,23 @@ namespace Microsoft.Data.Entity.Commands.Utilities
             }
 
             return identifier;
+        }
+
+        public virtual string Namespace([NotNull] params string[] name)
+        {
+            Check.NotNull(name, nameof(name));
+
+            var @namespace = new StringBuilder();
+            foreach (var piece in name.Where(p => !string.IsNullOrEmpty(p)).SelectMany(p => p.Split('.')))
+            {
+                var identifier = Identifier(piece);
+                if (!string.IsNullOrEmpty(identifier))
+                {
+                    @namespace.Append(identifier)
+                        .Append('.');
+                }
+            }
+            return (@namespace.Length > 0) ? @namespace.Remove(@namespace.Length - 1, 1).ToString() : "_";
         }
 
         public virtual string Literal([NotNull] string value) =>

--- a/test/EntityFramework.Commands.Tests/Utilities/CSharpHelperTest.cs
+++ b/test/EntityFramework.Commands.Tests/Utilities/CSharpHelperTest.cs
@@ -221,5 +221,32 @@ namespace Microsoft.Data.Entity.Commands.Utilities
         {
             Default
         }
+
+        [Theory]
+        [InlineData("dash-er", "dasher")]
+        [InlineData("params", "@params")]
+        [InlineData("true", "@true")]
+        [InlineData("yield", "@yield")]
+        [InlineData("spac ed", "spaced")]
+        [InlineData("1nders", "_1nders")]
+        [InlineData("name.space", "@namespace")]
+        [InlineData("$", "_")]
+        public void Identifier_works(string input, string expected)
+        {
+            Assert.Equal(expected, new CSharpHelper().Identifier(input));
+        }
+
+        [Theory]
+        [InlineData(new[] { "WebApplication1", "Migration" }, "WebApplication1.Migration")]
+        [InlineData(new[] { "WebApplication1.Migration" }, "WebApplication1.Migration")]
+        [InlineData(new[] { "ef-xplat.namespace" }, "efxplat.@namespace")]
+        [InlineData(new[] { "#", "$" }, "_._")]
+        [InlineData(new[] { "" }, "_")]
+        [InlineData(new string[] { }, "_")]
+        [InlineData(new string[] { null }, "_")]
+        public void Namespace_works(string[] input, string excepted)
+        {
+            Assert.Equal(excepted, new CSharpHelper().Namespace(input));
+        }
     }
 }


### PR DESCRIPTION
Small fix to CSharpHelper. Fixes #2674, which prevents the namespace from generating correctly in Add-Migration.