### PR TITLE
Bugfixes in relationshipbuilder

### DIFF
--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/NotMappedEntityTypeAttributeConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/NotMappedEntityTypeAttributeConvention.cs
@@ -14,9 +14,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
             Check.NotNull(entityTypeBuilder, nameof(entityTypeBuilder));
             Check.NotNull(attribute, nameof(attribute));
 
-            entityTypeBuilder.ModelBuilder.Ignore(entityTypeBuilder.Metadata.Name, ConfigurationSource.DataAnnotation);
-
-            return null;
+            return entityTypeBuilder.ModelBuilder.Ignore(entityTypeBuilder.Metadata.Name, ConfigurationSource.DataAnnotation) ? null : entityTypeBuilder;
         }
     }
 }

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/NotMappedNavigationAttributeConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/NotMappedNavigationAttributeConvention.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
             Check.NotNull(navigation, nameof(navigation));
             Check.NotNull(attribute, nameof(attribute));
 
-            var entityTypeBuilder = relationshipBuilder.ModelBuilder.Entity(navigation.DeclaringEntityType.Name, ConfigurationSource.DataAnnotation);
+            var entityTypeBuilder = relationshipBuilder.ModelBuilder.Entity(navigation.DeclaringEntityType.Name, ConfigurationSource.Convention);
             return entityTypeBuilder.Ignore(navigation.Name, ConfigurationSource.DataAnnotation) ? null : relationshipBuilder;
         }
     }

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/NotMappedPropertyAttributeConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/NotMappedPropertyAttributeConvention.cs
@@ -15,9 +15,8 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
             Check.NotNull(attribute, nameof(attribute));
 
             var entityTypeBuilder = propertyBuilder.ModelBuilder.Entity(propertyBuilder.Metadata.DeclaringEntityType.Name, ConfigurationSource.DataAnnotation);
-            var ignored = entityTypeBuilder.Ignore(propertyBuilder.Metadata.Name, ConfigurationSource.DataAnnotation);
 
-            return ignored ? null : propertyBuilder;
+            return entityTypeBuilder.Ignore(propertyBuilder.Metadata.Name, ConfigurationSource.DataAnnotation) ? null : propertyBuilder;
         }
     }
 }

--- a/src/EntityFramework.Core/Metadata/Internal/InternalModelBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/InternalModelBuilder.cs
@@ -39,19 +39,21 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                     () => Metadata.AddEntityType(name),
                     entityType => new InternalEntityTypeBuilder(entityType, ModelBuilder),
                     ConventionDispatcher.OnEntityTypeAdded,
+                    ConfigurationSource.DataAnnotation,
                     configurationSource);
         }
 
         public virtual InternalEntityTypeBuilder Entity([NotNull] Type type, ConfigurationSource configurationSource)
         {
             return !CanAdd(type.FullName, configurationSource)
-                ? null
-                : _entityTypeBuilders.GetOrAdd(
-                    () => Metadata.FindEntityType(type),
-                    () => Metadata.AddEntityType(type),
-                    entityType => new InternalEntityTypeBuilder(entityType, ModelBuilder),
-                    ConventionDispatcher.OnEntityTypeAdded,
-                    configurationSource);
+                 ? null
+                 : _entityTypeBuilders.GetOrAdd(
+                     () => Metadata.FindEntityType(type),
+                     () => Metadata.AddEntityType(type),
+                     entityType => new InternalEntityTypeBuilder(entityType, ModelBuilder),
+                     ConventionDispatcher.OnEntityTypeAdded,
+                     ConfigurationSource.DataAnnotation,
+                     configurationSource);
         }
 
         private bool CanAdd(string name, ConfigurationSource configurationSource)
@@ -93,13 +95,8 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var entityType = Metadata.FindEntityType(name);
             if (entityType != null)
             {
-                if (!Remove(entityType, configurationSource, canOverrideSameSource: false))
+                if (!Remove(entityType, configurationSource, canOverrideSameSource: true))
                 {
-                    if (configurationSource == ConfigurationSource.Explicit)
-                    {
-                        throw new InvalidOperationException(Strings.EntityAddedExplicitly(entityType.Name));
-                    }
-
                     return false;
                 }
 

--- a/src/EntityFramework.Core/Properties/Strings.Designer.cs
+++ b/src/EntityFramework.Core/Properties/Strings.Designer.cs
@@ -741,27 +741,11 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
-        /// The property '{property}' on entity type '{entityType}' could not be ignored because it has been explicitly added or is part of a key, foreign key or index that has been explicitly defined.
-        /// </summary>
-        public static string PropertyAddedExplicitly([CanBeNull] object property, [CanBeNull] object entityType)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("PropertyAddedExplicitly", "property", "entityType"), property, entityType);
-        }
-
-        /// <summary>
         /// The property '{property}' cannot be added to entity type '{entityType}' because it has been explicitly ignored.
         /// </summary>
         public static string PropertyIgnoredExplicitly([CanBeNull] object property, [CanBeNull] object entityType)
         {
             return string.Format(CultureInfo.CurrentCulture, GetString("PropertyIgnoredExplicitly", "property", "entityType"), property, entityType);
-        }
-
-        /// <summary>
-        /// The  entity type '{entityType}' could not be ignored because it has been explicitly added or is referenced from a foreign key that has been explicitly defined.
-        /// </summary>
-        public static string EntityAddedExplicitly([CanBeNull] object entityType)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("EntityAddedExplicitly", "entityType"), entityType);
         }
 
         /// <summary>
@@ -802,14 +786,6 @@ namespace Microsoft.Data.Entity.Internal
         public static string RelationshipCannotBeInverted
         {
             get { return GetString("RelationshipCannotBeInverted"); }
-        }
-
-        /// <summary>
-        /// The navigation property '{navigation}' on entity type '{entityType}' could not be ignored because it has been explicitly added.
-        /// </summary>
-        public static string NavigationAddedExplicitly([CanBeNull] object navigation, [CanBeNull] object entityType)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("NavigationAddedExplicitly", "navigation", "entityType"), navigation, entityType);
         }
 
         /// <summary>

--- a/src/EntityFramework.Core/Properties/Strings.resx
+++ b/src/EntityFramework.Core/Properties/Strings.resx
@@ -390,14 +390,8 @@
   <data name="RecursiveOnConfiguring" xml:space="preserve">
     <value>An attempt was made to use the context while it is being configured. A DbContext instance cannot be used inside OnConfiguring since it is still being configured at this point.</value>
   </data>
-  <data name="PropertyAddedExplicitly" xml:space="preserve">
-    <value>The property '{property}' on entity type '{entityType}' could not be ignored because it has been explicitly added or is part of a key, foreign key or index that has been explicitly defined.</value>
-  </data>
   <data name="PropertyIgnoredExplicitly" xml:space="preserve">
     <value>The property '{property}' cannot be added to entity type '{entityType}' because it has been explicitly ignored.</value>
-  </data>
-  <data name="EntityAddedExplicitly" xml:space="preserve">
-    <value>The  entity type '{entityType}' could not be ignored because it has been explicitly added or is referenced from a foreign key that has been explicitly defined.</value>
   </data>
   <data name="EntityIgnoredExplicitly" xml:space="preserve">
     <value>The entity type '{entityType}' could not be added because it has been explicitly ignored.</value>
@@ -413,9 +407,6 @@
   </data>
   <data name="RelationshipCannotBeInverted" xml:space="preserve">
     <value>The principal and dependent ends of the relationship cannot be flipped once foreign key or principal key properties have been specified.</value>
-  </data>
-  <data name="NavigationAddedExplicitly" xml:space="preserve">
-    <value>The navigation property '{navigation}' on entity type '{entityType}' could not be ignored because it has been explicitly added.</value>
   </data>
   <data name="InvalidEntityType" xml:space="preserve">
     <value>The entity type '{type}' provided for the argument '{argumentName}' must be a reference type.</value>

--- a/test/EntityFramework.Core.FunctionalTests/DataAnnotationFixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/DataAnnotationFixtureBase.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         public DbSet<Two> Twos { get; set; }
 
         public DbSet<Book> Books { get; set; }
+
         public DbSet<BookDetail> BookDetails { get; set; }
 
     }
@@ -83,10 +84,10 @@ namespace Microsoft.Data.Entity.FunctionalTests
     {
         public string Id { get; set; }
 
-        public virtual BookDetail OrderDetail { get; set; }
+        public virtual BookDetail BookDetail { get; set; }
 
         [NotMapped]
-        public virtual UselessBookDetails UselessOrderDetails { get; set; }
+        public virtual UselessBookDetails UselessBookDetails { get; set; }
     }
 
     public class BookDetail

--- a/test/EntityFramework.Core.Tests/Metadata/Internal/InternalModelBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/Internal/InternalModelBuilderTest.cs
@@ -102,41 +102,40 @@ namespace Microsoft.Data.Entity.Metadata.Internal.Test
         }
 
         [Fact]
-        public void Cannot_ignore_existing_entity_type_using_entity_clr_type()
+        public void Can_ignore_existing_entity_type_using_entity_clr_type_explicitly()
         {
             var model = new Model();
             var entityType = model.AddEntityType(typeof(Customer));
             var modelBuilder = CreateModelBuilder(model);
             Assert.Same(entityType, modelBuilder.Entity(typeof(Customer), ConfigurationSource.Convention).Metadata);
-
-            Assert.False(modelBuilder.Ignore(typeof(Customer), ConfigurationSource.DataAnnotation));
-
-            Assert.Same(entityType, modelBuilder.Entity(typeof(Customer), ConfigurationSource.Convention).Metadata);
             Assert.False(modelBuilder.Ignore(typeof(Customer), ConfigurationSource.DataAnnotation));
             Assert.NotNull(model.FindEntityType(typeof(Customer)));
 
-            Assert.Equal(Strings.EntityAddedExplicitly(typeof(Customer).FullName),
+            Assert.True(modelBuilder.Ignore(typeof(Customer), ConfigurationSource.Explicit));
+            Assert.Null(model.FindEntityType(typeof(Customer)));
+
+            Assert.Equal(Strings.EntityIgnoredExplicitly(typeof(Customer).FullName),
                 Assert.Throws<InvalidOperationException>(() =>
-                    Assert.False(modelBuilder.Ignore(typeof(Customer), ConfigurationSource.Explicit))).Message);
+                    modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit)).Message);
         }
 
         [Fact]
-        public void Cannot_ignore_existing_entity_type_using_entity_type_name()
+        public void Can_ignore_existing_entity_type_using_entity_type_name_explicitly()
         {
             var model = new Model();
             var entityType = model.AddEntityType(typeof(Customer).FullName);
             var modelBuilder = CreateModelBuilder(model);
-            Assert.Same(entityType, modelBuilder.Entity(typeof(Customer).FullName, ConfigurationSource.Convention).Metadata);
-
-            Assert.False(modelBuilder.Ignore(typeof(Customer).FullName, ConfigurationSource.DataAnnotation));
 
             Assert.Same(entityType, modelBuilder.Entity(typeof(Customer).FullName, ConfigurationSource.Convention).Metadata);
             Assert.False(modelBuilder.Ignore(typeof(Customer).FullName, ConfigurationSource.DataAnnotation));
             Assert.NotNull(model.FindEntityType(typeof(Customer).FullName));
 
-            Assert.Equal(Strings.EntityAddedExplicitly(typeof(Customer).FullName),
+            Assert.True(modelBuilder.Ignore(typeof(Customer).FullName, ConfigurationSource.Explicit));
+            Assert.Null(model.FindEntityType(typeof(Customer).FullName));
+
+            Assert.Equal(Strings.EntityIgnoredExplicitly(typeof(Customer).FullName),
                 Assert.Throws<InvalidOperationException>(() =>
-                    Assert.False(modelBuilder.Ignore(typeof(Customer).FullName, ConfigurationSource.Explicit))).Message);
+                    modelBuilder.Entity(typeof(Customer).FullName, ConfigurationSource.Explicit)).Message);
         }
 
         [Fact]

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/RelationshipDiscoveryConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/RelationshipDiscoveryConventionTest.cs
@@ -153,8 +153,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
 
             Assert.Empty(entityBuilder.Metadata.GetForeignKeys());
             Assert.Empty(entityBuilder.Metadata.Navigations);
-            // TODO: remove discovered entity types if no relationship discovered
-            Assert.Equal(2, entityBuilder.Metadata.Model.EntityTypes.Count);
+            Assert.Equal(1, entityBuilder.Metadata.Model.EntityTypes.Count);
         }
 
         [Fact]
@@ -386,7 +385,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
                 conventions.EntityTypeAddedConventions.Add(new TestModelChangeListener(onEntityAdded));
             }
             var modelBuilder = new InternalModelBuilder(new Model(), conventions);
-            var entityBuilder = modelBuilder.Entity(typeof(T), ConfigurationSource.Convention);
+            var entityBuilder = modelBuilder.Entity(typeof(T), ConfigurationSource.DataAnnotation);
 
             return entityBuilder;
         }

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/NonRelationshipTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/NonRelationshipTestBase.cs
@@ -310,33 +310,29 @@ namespace Microsoft.Data.Entity.Tests
             }
 
             [Fact]
-            public virtual void Ignoring_a_property_that_is_part_of_explicit_entity_key_throws()
+            public virtual void Can_ignore_a_property_that_is_part_of_explicit_entity_key()
             {
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
 
-                Assert.Equal(Strings.PropertyAddedExplicitly(Customer.IdProperty.Name, typeof(Customer).FullName),
-                    Assert.Throws<InvalidOperationException>(() =>
-                        modelBuilder.Entity<Customer>(b =>
-                            {
-                                b.Key(e => e.Id);
-                                b.Ignore(e => e.Id);
-                            })).Message);
+                Assert.NotNull(modelBuilder.Entity<Customer>(b =>
+                    {
+                        b.Key(e => e.Id);
+                        b.Ignore(e => e.Id);
+                    }));
             }
 
             [Fact]
-            public virtual void Ignoring_shadow_properties_when_they_have_been_added_throws()
+            public virtual void Can_ignore_shadow_properties_when_they_have_been_added_explicitly()
             {
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
 
-                Assert.Equal(Strings.PropertyAddedExplicitly("Shadow", typeof(Customer).FullName),
-                    Assert.Throws<InvalidOperationException>(() =>
-                        modelBuilder.Entity<Customer>(b =>
-                            {
-                                b.Property<string>("Shadow");
-                                b.Ignore("Shadow");
-                            })).Message);
+                Assert.NotNull(modelBuilder.Entity<Customer>(b =>
+                    {
+                        b.Property<string>("Shadow");
+                        b.Ignore("Shadow");
+                    }));
             }
 
             [Fact]


### PR DESCRIPTION
Problem:
Previously all the modifications to relationshipbuilder was possible after navigations are added therefore preserving all the information provided to `Relationship()`. With the addition of OnNavigationAdded Conventions, the relationshipbuilder can be mutated before it is built fully which causes missing relationship information, upgrading ConfigurationSource for relationshipbuilder at wrong times, Removing entityTypes which are still exploring relationship (but not built them yet).

Solution:
`ReplaceForeignKey` preserves the configurationSource unless defining properties of foreignkey changed.
EntityTypes will be added with ConfigurationSource.DataAnnotation or higher and will be changed to the original configuration source once it finishes configuring it by conventions. (this stops entityTypes being removed which hasn't explored the relationships yet)
This requires behavior of Ignore to be changed allowing to remove the model item added with same source.

Build status:
Working