### PR TITLE
Query: First round of nav prop translation.

### DIFF
--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -223,6 +223,7 @@
     <Compile Include="Query\ExpressionVisitors\ExpressionStringBuilder.cs" />
     <Compile Include="Query\ExpressionVisitors\ExpressionVisitorBase.cs" />
     <Compile Include="Query\ExpressionVisitors\FunctionEvaluationDisablingVisitor.cs" />
+    <Compile Include="Query\ExpressionVisitors\NavigationRewritingExpressionVisitor.cs" />
     <Compile Include="Query\ExpressionVisitors\ParameterExtractingExpressionVisitor.cs" />
     <Compile Include="Query\ExpressionVisitors\QueryAnnotatingExpressionVisitor.cs" />
     <Compile Include="Query\ExpressionVisitors\ReducingExpressionVisitor.cs" />

--- a/src/EntityFramework.Core/Query/EntityQueryProvider.cs
+++ b/src/EntityFramework.Core/Query/EntityQueryProvider.cs
@@ -42,14 +42,14 @@ namespace Microsoft.Data.Entity.Query
             _queryContextFactory = queryContextFactory;
         }
 
-        public virtual IQueryable<TElement> CreateQuery<TElement>([NotNull] Expression expression)
+        public virtual IQueryable<TElement> CreateQuery<TElement>(Expression expression)
         {
             Check.NotNull(expression, nameof(expression));
 
             return new EntityQueryable<TElement>(this, expression);
         }
 
-        public virtual IQueryable CreateQuery([NotNull] Expression expression)
+        public virtual IQueryable CreateQuery(Expression expression)
         {
             Check.NotNull(expression, nameof(expression));
 
@@ -60,7 +60,7 @@ namespace Microsoft.Data.Entity.Query
                 .Invoke(this, new object[] { expression });
         }
 
-        public virtual TResult Execute<TResult>([NotNull] Expression expression)
+        public virtual TResult Execute<TResult>(Expression expression)
         {
             Check.NotNull(expression, nameof(expression));
 
@@ -71,7 +71,7 @@ namespace Microsoft.Data.Entity.Query
             return _compiledQueryCache.Execute<TResult>(expression, _database, queryContext);
         }
 
-        public virtual object Execute([NotNull] Expression expression)
+        public virtual object Execute(Expression expression)
         {
             Check.NotNull(expression, nameof(expression));
 

--- a/src/EntityFramework.Core/Query/ExpressionVisitors/DefaultQueryExpressionVisitor.cs
+++ b/src/EntityFramework.Core/Query/ExpressionVisitors/DefaultQueryExpressionVisitor.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
@@ -40,7 +41,7 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
         protected override Expression VisitParameter(ParameterExpression parameterExpression)
         {
             if (parameterExpression.Name
-                .StartsWith(CompiledQueryCache.CompiledQueryParameterPrefix))
+                .StartsWith(CompiledQueryCache.CompiledQueryParameterPrefix, StringComparison.Ordinal))
             {
                 return Expression.Call(
                     _getParameterValueMethodInfo.MakeGenericMethod(parameterExpression.Type),

--- a/src/EntityFramework.Core/Query/ExpressionVisitors/NavigationRewritingExpressionVisitor.cs
+++ b/src/EntityFramework.Core/Query/ExpressionVisitors/NavigationRewritingExpressionVisitor.cs
@@ -1,0 +1,215 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Utilities;
+using Remotion.Linq;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.Expressions;
+using Remotion.Linq.Parsing;
+
+namespace Microsoft.Data.Entity.Query.ExpressionVisitors
+{
+    public class NavigationRewritingExpressionVisitor : RelinqExpressionVisitor
+    {
+        private readonly EntityQueryModelVisitor _queryModelVisitor;
+
+        private readonly List<NavigationJoin> _navigationJoins = new List<NavigationJoin>();
+
+        private class NavigationJoin
+        {
+            public NavigationJoin(
+                IQuerySource querySource,
+                INavigation navigation,
+                JoinClause joinClause,
+                QuerySourceReferenceExpression querySourceReferenceExpression)
+            {
+                QuerySource = querySource;
+                Navigation = navigation;
+                JoinClause = joinClause;
+                QuerySourceReferenceExpression = querySourceReferenceExpression;
+            }
+
+            public IQuerySource QuerySource { get; }
+            public INavigation Navigation { get; }
+            public JoinClause JoinClause { get; }
+            public QuerySourceReferenceExpression QuerySourceReferenceExpression { get; }
+            public readonly List<NavigationJoin> NavigationJoins = new List<NavigationJoin>();
+
+            public IEnumerable<NavigationJoin> Iterate()
+            {
+                yield return this;
+
+                foreach (var navigationJoin in NavigationJoins.SelectMany(nj => nj.Iterate()))
+                {
+                    yield return navigationJoin;
+                }
+            }
+        }
+
+        private IEntityQueryProvider _entityQueryProvider;
+
+        public NavigationRewritingExpressionVisitor(
+            [NotNull] EntityQueryModelVisitor queryModelVisitor)
+        {
+            Check.NotNull(queryModelVisitor, nameof(queryModelVisitor));
+
+            _queryModelVisitor = queryModelVisitor;
+        }
+
+        public virtual void Rewrite([NotNull] QueryModel queryModel)
+        {
+            Check.NotNull(queryModel, nameof(queryModel));
+
+            queryModel.TransformExpressions(Visit);
+
+            var insertionIndex = 0;
+
+            foreach (var navigationJoin in _navigationJoins)
+            {
+                var bodyClause = navigationJoin.QuerySource as IBodyClause;
+
+                if (bodyClause != null)
+                {
+                    insertionIndex = queryModel.BodyClauses.IndexOf(bodyClause) + 1;
+                }
+
+                var i = insertionIndex;
+
+                foreach (var nj in navigationJoin.Iterate())
+                {
+                    queryModel.BodyClauses.Insert(i++, nj.JoinClause);
+                }
+            }
+        }
+
+        protected override Expression VisitConstant(ConstantExpression constantExpression)
+        {
+            if (_entityQueryProvider == null)
+            {
+                _entityQueryProvider
+                    = (constantExpression.Value as IQueryable)?.Provider as IEntityQueryProvider;
+            }
+
+            return constantExpression;
+        }
+
+        protected override Expression VisitMember(MemberExpression memberExpression)
+        {
+            Check.NotNull(memberExpression, nameof(memberExpression));
+
+            return
+                _queryModelVisitor.BindNavigationPathMemberExpression(
+                    memberExpression,
+                    (ps, qs) =>
+                        {
+                            var properties = ps.ToList();
+                            var navigations = properties.OfType<INavigation>().ToList();
+
+                            if (navigations.Any())
+                            {
+                                var outerQuerySourceReferenceExpression = new QuerySourceReferenceExpression(qs);
+
+                                var innerQuerySourceReferenceExpression
+                                    = CreateJoinsForNavigations(outerQuerySourceReferenceExpression, navigations);
+
+                                return properties.Count == navigations.Count
+                                    ? innerQuerySourceReferenceExpression
+                                    : Expression.MakeMemberAccess(innerQuerySourceReferenceExpression, memberExpression.Member);
+                            }
+
+                            return default(Expression);
+                        })
+                ?? base.VisitMember(memberExpression);
+        }
+
+        private Expression CreateJoinsForNavigations(
+            QuerySourceReferenceExpression outerQuerySourceReferenceExpression,
+            IEnumerable<INavigation> navigations)
+        {
+            var querySourceReferenceExpression = outerQuerySourceReferenceExpression;
+            var navigationJoins = _navigationJoins;
+
+            foreach (var navigation in navigations)
+            {
+                var navigationJoin
+                    = navigationJoins
+                        .FirstOrDefault(nj =>
+                            nj.QuerySource == querySourceReferenceExpression.ReferencedQuerySource
+                            && nj.Navigation == navigation);
+
+                if (navigationJoin == null)
+                {
+                    var targetEntityType = navigation.GetTargetType();
+
+                    var joinClause
+                        = new JoinClause(
+                            $"{querySourceReferenceExpression.ReferencedQuerySource.ItemName}.{navigation.Name}",
+                            targetEntityType.ClrType,
+                            Expression.Constant(
+                                _createEntityQueryableMethod
+                                    .MakeGenericMethod(targetEntityType.ClrType)
+                                    .Invoke(null, new object[]
+                                        {
+                                            _entityQueryProvider
+                                        })),
+                            CreatePropertyCallExpression(
+                                querySourceReferenceExpression,
+                                navigation.ForeignKey.Properties.Single()),
+                            Expression.Constant(null));
+
+                    var innerQuerySourceReferenceExpression
+                        = new QuerySourceReferenceExpression(joinClause);
+
+                    Expression innerKeySelector
+                        = CreatePropertyCallExpression(
+                            innerQuerySourceReferenceExpression,
+                            targetEntityType.GetPrimaryKey().Properties.Single());
+
+                    if (innerKeySelector.Type != joinClause.OuterKeySelector.Type)
+                    {
+                        innerKeySelector
+                            = Expression.Convert(
+                                innerKeySelector,
+                                joinClause.OuterKeySelector.Type);
+                    }
+
+                    joinClause.InnerKeySelector = innerKeySelector;
+                    
+                    navigationJoins.Add(
+                        navigationJoin
+                            = new NavigationJoin(
+                                querySourceReferenceExpression.ReferencedQuerySource,
+                                navigation,
+                                joinClause,
+                                innerQuerySourceReferenceExpression));
+                }
+
+                querySourceReferenceExpression = navigationJoin.QuerySourceReferenceExpression;
+                navigationJoins = navigationJoin.NavigationJoins;
+            }
+
+            return querySourceReferenceExpression;
+        }
+
+        private static MethodCallExpression CreatePropertyCallExpression(Expression target, IProperty property)
+            => Expression.Call(
+                null,
+                EntityQueryModelVisitor.PropertyMethodInfo.MakeGenericMethod(property.ClrType),
+                target,
+                Expression.Constant(property.Name));
+
+        private static readonly MethodInfo _createEntityQueryableMethod
+            = typeof(NavigationRewritingExpressionVisitor)
+                .GetTypeInfo().GetDeclaredMethod(nameof(_CreateEntityQueryable));
+
+        [UsedImplicitly]
+        private static EntityQueryable<TResult> _CreateEntityQueryable<TResult>(IEntityQueryProvider entityQueryProvider)
+            => new EntityQueryable<TResult>(entityQueryProvider);
+    }
+}

--- a/src/EntityFramework.InMemory/Query/InMemoryQueryCompilationContext.cs
+++ b/src/EntityFramework.InMemory/Query/InMemoryQueryCompilationContext.cs
@@ -28,7 +28,6 @@ namespace Microsoft.Data.Entity.InMemory.Query
                 Check.NotNull(entityKeyFactorySource, nameof(entityKeyFactorySource)),
                 Check.NotNull(clrPropertyGetterSource, nameof(clrPropertyGetterSource)))
         {
-            Check.NotNull(entityKeyFactorySource, nameof(entityKeyFactorySource));
         }
 
         public override EntityQueryModelVisitor CreateQueryModelVisitor(EntityQueryModelVisitor parentEntityQueryModelVisitor)

--- a/src/EntityFramework.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EntityFramework.Relational/Query/RelationalQueryModelVisitor.cs
@@ -579,7 +579,9 @@ namespace Microsoft.Data.Entity.Query
 
                         return BindReadValueMethod(methodCallExpression.Type, expression, projectionIndex);
                     },
-                bindSubQueries: true);
+                bindSubQueries: true)
+                   ?? ParentQueryModelVisitor?
+                       .BindMethodCallToValueBuffer(methodCallExpression, expression); 
         }
 
         public virtual TResult BindMemberExpression<TResult>(

--- a/src/EntityFramework.Relational/Storage/RelationalDatabase.cs
+++ b/src/EntityFramework.Relational/Storage/RelationalDatabase.cs
@@ -61,6 +61,7 @@ namespace Microsoft.Data.Entity.Storage
             EntityKeyFactorySource = entityKeyFactorySource;
             EntityMaterializerSource = entityMaterializerSource;
             ClrPropertyGetterSource = clrPropertyGetterSource;
+
             _batchPreparer = batchPreparer;
             _batchExecutor = batchExecutor;
             _connection = connection;

--- a/test/EntityFramework.Core.FunctionalTests/EntityFramework.Core.FunctionalTests.csproj
+++ b/test/EntityFramework.Core.FunctionalTests/EntityFramework.Core.FunctionalTests.csproj
@@ -61,6 +61,7 @@
     <Compile Include="NorthwindQueryFixtureBase.cs" />
     <Compile Include="AsyncQueryTestBase.cs" />
     <Compile Include="F1FixtureBase.cs" />
+    <Compile Include="QueryNavigationsTestBase.cs" />
     <Compile Include="QueryTestBase.cs" />
     <Compile Include="OptimisticConcurrencyTestBase.cs" />
     <Compile Include="StoreGeneratedTestBase.cs" />

--- a/test/EntityFramework.Core.FunctionalTests/IncludeTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/IncludeTestBase.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using Microsoft.Data.Entity.FunctionalTests.TestModels.Northwind;
 using Microsoft.Data.Entity.Internal;
@@ -21,6 +22,21 @@ namespace Microsoft.Data.Entity.FunctionalTests
         protected NorthwindContext CreateContext()
         {
             return Fixture.CreateContext();
+        }
+
+        [Fact]
+        public virtual void Include_reference_invalid()
+        {
+            Assert.Throws<InvalidOperationException>(
+                () =>
+                {
+                    using (var context = CreateContext())
+                    {
+                        return context.Set<Order>()
+                            .Include(o => o.Customer.CustomerID)
+                            .ToList();
+                    }
+                });
         }
 
         [Fact]

--- a/test/EntityFramework.Core.FunctionalTests/NorthwindQueryFixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/NorthwindQueryFixtureBase.cs
@@ -25,6 +25,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     e.Ignore(em => em.PostalCode);
                     e.Ignore(em => em.Region);
                     e.Ignore(em => em.TitleOfCourtesy);
+
+                    e.Reference(e1 => e1.Manager).InverseCollection().ForeignKey(e1 => e1.ReportsTo);
                 });
 
             modelBuilder.Entity<Product>(e =>

--- a/test/EntityFramework.Core.FunctionalTests/QueryNavigationsTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/QueryNavigationsTestBase.cs
@@ -1,0 +1,269 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.Data.Entity.FunctionalTests.TestModels.Northwind;
+using Xunit;
+
+namespace Microsoft.Data.Entity.FunctionalTests
+{
+    public abstract class QueryNavigationsTestBase<TFixture> : IClassFixture<TFixture>
+        where TFixture : NorthwindQueryFixtureBase, new()
+    {
+        // TODO:
+        // - Composite keys
+        // - o1.Customer == o2.Customer
+        // - o1.Customer.Name == foo.Customer.Name
+        // - Collections, sub-queries (Any etc.).
+        // - Deep paths
+        // - One to ones
+        // - Client eval
+        // - Async
+
+        [Fact]
+        public virtual void Select_Where_Navigation()
+        {
+            using (var context = CreateContext())
+            {
+                var orders
+                    = (from o in context.Set<Order>()
+                        where o.Customer.City == "Seattle"
+                        select o).ToList();
+
+                Assert.Equal(14, orders.Count);
+            }
+        }
+
+        [Fact]
+        public virtual void Select_Where_Navigation_Scalar_Equals_Navigation_Scalar()
+        {
+            using (var context = CreateContext())
+            {
+                var orders
+                    = (from o1 in context.Set<Order>()
+                       from o2 in context.Set<Order>()
+                       where o1.Customer.City == o2.Customer.City
+                       select new { o1, o2 }).ToList();
+
+                Assert.Equal(14786, orders.Count);
+            }
+        }
+
+        [Fact]
+        public virtual void Select_Where_Navigation_Scalar_Equals_Navigation_Scalar_Projected()
+        {
+            using (var context = CreateContext())
+            {
+                var orders
+                    = (from o1 in context.Set<Order>()
+                       from o2 in context.Set<Order>()
+                       where o1.Customer.City == o2.Customer.City
+                       select new { o1.CustomerID, C2 = o2.CustomerID }).ToList();
+
+                Assert.Equal(14786, orders.Count);
+            }
+        }
+
+        [Fact]
+        public virtual void Select_Where_Navigation_Client()
+        {
+            using (var context = CreateContext())
+            {
+                var orders
+                    = (from o in context.Set<Order>()
+                       where o.Customer.IsLondon
+                       select o).ToList();
+
+                Assert.Equal(46, orders.Count);
+            }
+        }
+
+        [Fact]
+        public virtual void Select_Where_Navigation_Deep()
+        {
+            using (var context = CreateContext())
+            {
+                var orderDetails
+                    = (from od in context.Set<OrderDetail>()
+                        where od.Order.Customer.City == "Seattle"
+                        select od).Take(1).ToList();
+
+                Assert.Equal(1, orderDetails.Count);
+            }
+        }
+
+        // TODO: Nav-prop to key comparison semantics
+
+//        [Fact]
+//        public virtual void Select_Where_Navigation_Null()
+//        {
+//            using (var context = CreateContext())
+//            {
+//                var employees
+//                    = (from e in context.Set<Employee>()
+//                        where e.Manager == null
+//                        select e).ToList();
+//
+//                Assert.Equal(1, employees.Count);
+//            }
+//        }
+//
+//        [Fact]
+//        public virtual void Select_Where_Navigation_Null_Reverse()
+//        {
+//            using (var context = CreateContext())
+//            {
+//                var employees
+//                    = (from e in context.Set<Employee>()
+//                        where null == e.Manager
+//                        select e).ToList();
+//
+//                Assert.Equal(1, employees.Count);
+//            }
+//        }
+//
+//        [Fact]
+//        public virtual void Select_Where_Navigation_Null_Deep()
+//        {
+//            using (var context = CreateContext())
+//            {
+//                var employees
+//                    = (from e in context.Set<Employee>()
+//                        where e.Manager.Manager == null
+//                        select e).ToList();
+//
+//                Assert.Equal(3, employees.Count);
+//            }
+//        }
+
+        [Fact]
+        public virtual void Select_Where_Navigation_Included()
+        {
+            using (var context = CreateContext())
+            {
+                var orders
+                    = (from o in context.Set<Order>().Include(o => o.Customer)
+                        where o.Customer.City == "Seattle"
+                        select o).ToList();
+
+                Assert.Equal(14, orders.Count);
+                Assert.True(orders.All(o => o.Customer != null));
+            }
+        }
+
+        [Fact]
+        public virtual void Singleton_Navigation_With_Member_Access()
+        {
+            using (var context = CreateContext())
+            {
+                var orders
+                    = (from o in context.Set<Order>()
+                       where o.Customer.City == "Seattle"
+                       where o.Customer.Phone != "555 555 5555"
+                       select new { B = o.Customer.City }).ToList();
+
+                Assert.Equal(14, orders.Count);
+                Assert.True(orders.All(o => o.B != null));
+            }
+        }
+
+        [Fact]
+        public virtual void Select_Singleton_Navigation_With_Member_Access()
+        {
+            using (var context = CreateContext())
+            {
+                var orders
+                    = (from o in context.Set<Order>()
+                        where o.Customer.City == "Seattle"
+                        where o.Customer.Phone != "555 555 5555"
+                        select new { A = o.Customer, B = o.Customer.City }).ToList();
+
+                Assert.Equal(14, orders.Count);
+                Assert.True(orders.All(o => o.A != null && o.B != null));
+            }
+        }
+
+        [Fact]
+        public virtual void Select_Where_Navigations()
+        {
+            using (var context = CreateContext())
+            {
+                var orders
+                    = (from o in context.Set<Order>()
+                        where o.Customer.City == "Seattle"
+                              && o.Customer.Phone != "555 555 5555"
+                        select o).ToList();
+
+                Assert.Equal(14, orders.Count);
+            }
+        }
+
+        [Fact]
+        public virtual void Select_Where_Navigation_Multiple_Access()
+        {
+            using (var context = CreateContext())
+            {
+                var orders
+                    = (from o in context.Set<Order>()
+                        where o.Customer.City == "Seattle"
+                              && o.Customer.Phone != "555 555 5555"
+                        select o).ToList();
+
+                Assert.Equal(14, orders.Count);
+            }
+        }
+
+        [Fact]
+        public virtual void Select_Navigation()
+        {
+            using (var context = CreateContext())
+            {
+                var orders
+                    = (from o in context.Set<Order>()
+                        select o.Customer).ToList();
+
+                Assert.Equal(830, orders.Count);
+                Assert.True(orders.All(o => o != null));
+            }
+        }
+
+        [Fact]
+        public virtual void Select_Navigations()
+        {
+            using (var context = CreateContext())
+            {
+                var orders
+                    = (from o in context.Set<Order>()
+                        select new { A = o.Customer, B = o.Customer }).ToList();
+
+                Assert.Equal(830, orders.Count);
+                Assert.True(orders.All(o => o.A != null && o.B != null));
+            }
+        }
+
+        [Fact]
+        public virtual void Select_Navigations_Where_Navigations()
+        {
+            using (var context = CreateContext())
+            {
+                var orders
+                    = (from o in context.Set<Order>()
+                        where o.Customer.City == "Seattle"
+                        where o.Customer.Phone != "555 555 5555"
+                        select new { A = o.Customer, B = o.Customer }).ToList();
+
+                Assert.Equal(14, orders.Count);
+                Assert.True(orders.All(o => o.A != null && o.B != null));
+            }
+        }
+
+        protected QueryNavigationsTestBase(TFixture fixture)
+        {
+            Fixture = fixture;
+        }
+
+        protected TFixture Fixture { get; }
+
+        protected NorthwindContext CreateContext() => Fixture.CreateContext();
+    }
+}

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/Northwind/Employee.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/Northwind/Employee.cs
@@ -26,6 +26,8 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.Northwind
         public int? ReportsTo { get; set; }
         public string PhotoPath { get; set; }
 
+        public Employee Manager { get; set; }
+
         protected bool Equals(Employee other)
         {
             return EmployeeID == other.EmployeeID;

--- a/test/EntityFramework.InMemory.FunctionalTests/EntityFramework.InMemory.FunctionalTests.csproj
+++ b/test/EntityFramework.InMemory.FunctionalTests/EntityFramework.InMemory.FunctionalTests.csproj
@@ -43,6 +43,7 @@
     <Compile Include="NullKeysInMemoryTest.cs" />
     <Compile Include="GraphUpdatesInMemoryTestBase.cs" />
     <Compile Include="InheritanceInMemoryTest.cs" />
+    <Compile Include="QueryNavigationsInMemoryTest.cs" />
     <Compile Include="SentinelGraphUpdatesInMemoryTest.cs" />
     <Compile Include="InMemoryTestStore.cs" />
     <Compile Include="BuiltInDataTypesInMemoryFixture.cs" />

--- a/test/EntityFramework.InMemory.FunctionalTests/QueryNavigationsInMemoryTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/QueryNavigationsInMemoryTest.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.FunctionalTests;
+
+namespace Microsoft.Data.Entity.InMemory.FunctionalTests
+{
+    public class QueryNavigationsInMemoryTest : QueryNavigationsTestBase<NorthwindQueryInMemoryFixture>
+    {
+        public QueryNavigationsInMemoryTest(NorthwindQueryInMemoryFixture fixture)
+            : base(fixture)
+        {
+        }
+    }
+}

--- a/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
+++ b/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
@@ -67,6 +67,7 @@
     <Compile Include="ComplexNavigationsQuerySqlServerFixture.cs" />
     <Compile Include="ComplexNavigationsQuerySqlServerTest.cs" />
     <Compile Include="F1SqlServerFixture.cs" />
+    <Compile Include="QueryNavigationsSqlServerTest.cs" />
     <Compile Include="SqlServerFixture.cs" />
     <Compile Include="GearsOfWarQuerySqlServerFixture.cs" />
     <Compile Include="GearsOfWarQuerySqlServerTest.cs" />

--- a/test/EntityFramework.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
@@ -1,0 +1,163 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.FunctionalTests;
+using Xunit;
+
+namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
+{
+    public class QueryNavigationsSqlServerTest : QueryNavigationsTestBase<NorthwindQuerySqlServerFixture>
+    {
+        public override void Select_Where_Navigation()
+        {
+            base.Select_Where_Navigation();
+
+            Assert.Equal(
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+INNER JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
+WHERE [o.Customer].[City] = 'Seattle'",
+                Sql);
+        }
+
+        public override void Select_Where_Navigation_Deep()
+        {
+            base.Select_Where_Navigation_Deep();
+
+            Assert.StartsWith(
+                @"SELECT TOP(1) [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice]
+FROM [Order Details] AS [od]
+INNER JOIN [Orders] AS [od.Order] ON [od].[OrderID] = [od.Order].[OrderID]
+INNER JOIN [Customers] AS [od.Order.Customer] ON [od.Order].[CustomerID] = [od.Order.Customer].[CustomerID]
+WHERE [od.Order.Customer].[City] = 'Seattle'",
+                Sql);
+        }
+
+        public override void Select_Where_Navigation_Included()
+        {
+            base.Select_Where_Navigation_Included();
+
+            Assert.Equal(
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Orders] AS [o]
+INNER JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+WHERE [o.Customer].[City] = 'Seattle'",
+                Sql);
+        }
+
+        public override void Select_Navigation()
+        {
+            base.Select_Navigation();
+
+            Assert.StartsWith(
+                @"SELECT [o.Customer].[CustomerID], [o.Customer].[Address], [o.Customer].[City], [o.Customer].[CompanyName], [o.Customer].[ContactName], [o.Customer].[ContactTitle], [o.Customer].[Country], [o.Customer].[Fax], [o.Customer].[Phone], [o.Customer].[PostalCode], [o.Customer].[Region]
+FROM [Orders] AS [o]
+INNER JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]",
+                Sql);
+        }
+
+        public override void Select_Navigations()
+        {
+            base.Select_Navigations();
+
+            Assert.Equal(
+                @"SELECT [o.Customer].[CustomerID], [o.Customer].[Address], [o.Customer].[City], [o.Customer].[CompanyName], [o.Customer].[ContactName], [o.Customer].[ContactTitle], [o.Customer].[Country], [o.Customer].[Fax], [o.Customer].[Phone], [o.Customer].[PostalCode], [o.Customer].[Region]
+FROM [Orders] AS [o]
+INNER JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]",
+                Sql);
+        }
+
+        public override void Select_Where_Navigations()
+        {
+            base.Select_Where_Navigations();
+
+            Assert.Equal(
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+INNER JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
+WHERE (([o.Customer].[City] = 'Seattle' AND [o.Customer].[City] IS NOT NULL) AND ([o.Customer].[Phone] <> '555 555 5555' OR [o.Customer].[Phone] IS NULL))",
+                Sql);
+        }
+
+        public override void Select_Where_Navigation_Multiple_Access()
+        {
+            base.Select_Where_Navigation_Multiple_Access();
+
+            Assert.Equal(
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+INNER JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
+WHERE (([o.Customer].[City] = 'Seattle' AND [o.Customer].[City] IS NOT NULL) AND ([o.Customer].[Phone] <> '555 555 5555' OR [o.Customer].[Phone] IS NULL))",
+                Sql);
+        }
+
+        public override void Select_Navigations_Where_Navigations()
+        {
+            base.Select_Navigations_Where_Navigations();
+
+            Assert.Equal(
+                @"SELECT [o.Customer].[CustomerID], [o.Customer].[Address], [o.Customer].[City], [o.Customer].[CompanyName], [o.Customer].[ContactName], [o.Customer].[ContactTitle], [o.Customer].[Country], [o.Customer].[Fax], [o.Customer].[Phone], [o.Customer].[PostalCode], [o.Customer].[Region]
+FROM [Orders] AS [o]
+INNER JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
+WHERE (([o.Customer].[City] = 'Seattle' AND [o.Customer].[City] IS NOT NULL) AND ([o.Customer].[Phone] <> '555 555 5555' OR [o.Customer].[Phone] IS NULL))",
+                Sql);
+        }
+
+        public override void Select_Where_Navigation_Client()
+        {
+            base.Select_Where_Navigation_Client();
+
+            Assert.Equal(
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [o.Customer].[CustomerID], [o.Customer].[Address], [o.Customer].[City], [o.Customer].[CompanyName], [o.Customer].[ContactName], [o.Customer].[ContactTitle], [o.Customer].[Country], [o.Customer].[Fax], [o.Customer].[Phone], [o.Customer].[PostalCode], [o.Customer].[Region]
+FROM [Orders] AS [o]
+INNER JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]",
+                Sql);
+        }
+
+        public override void Select_Singleton_Navigation_With_Member_Access()
+        {
+            base.Select_Singleton_Navigation_With_Member_Access();
+
+            Assert.Equal(
+                @"SELECT [o.Customer].[CustomerID], [o.Customer].[Address], [o.Customer].[City], [o.Customer].[CompanyName], [o.Customer].[ContactName], [o.Customer].[ContactTitle], [o.Customer].[Country], [o.Customer].[Fax], [o.Customer].[Phone], [o.Customer].[PostalCode], [o.Customer].[Region]
+FROM [Orders] AS [o]
+INNER JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
+WHERE (([o.Customer].[City] = 'Seattle' AND [o.Customer].[City] IS NOT NULL) AND ([o.Customer].[Phone] <> '555 555 5555' OR [o.Customer].[Phone] IS NULL))",
+                Sql);
+        }
+
+        public override void Singleton_Navigation_With_Member_Access()
+        {
+            base.Singleton_Navigation_With_Member_Access();
+
+            Assert.Equal(
+                @"SELECT [o.Customer].[City]
+FROM [Orders] AS [o]
+INNER JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
+WHERE (([o.Customer].[City] = 'Seattle' AND [o.Customer].[City] IS NOT NULL) AND ([o.Customer].[Phone] <> '555 555 5555' OR [o.Customer].[Phone] IS NULL))",
+                Sql);
+        }
+
+        public override void Select_Where_Navigation_Scalar_Equals_Navigation_Scalar()
+        {
+            base.Select_Where_Navigation_Scalar_Equals_Navigation_Scalar();
+
+            Assert.Equal(
+                @"SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate], [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate]
+FROM [Orders] AS [o1]
+INNER JOIN [Customers] AS [o1.Customer] ON [o1].[CustomerID] = [o1.Customer].[CustomerID]
+CROSS JOIN [Orders] AS [o2]
+INNER JOIN [Customers] AS [o2.Customer] ON [o2].[CustomerID] = [o2.Customer].[CustomerID]
+WHERE ([o1.Customer].[City] = [o2.Customer].[City] OR ([o1.Customer].[City] IS NULL AND [o2.Customer].[City] IS NULL))",
+                Sql);
+        }
+
+        private static string Sql => TestSqlLoggerFactory.Sql;
+
+        public QueryNavigationsSqlServerTest(NorthwindQuerySqlServerFixture fixture)
+            : base(fixture)
+        {
+        }
+    }
+}


### PR DESCRIPTION
- Adds support for translating navigation property entity scalar property access. E.g. o.Customer.City == 'London'