### PR TITLE
Make look up by alternate key faster to help with fixup time

### DIFF
--- a/src/EntityFramework.Core/ChangeTracking/Internal/CompositeEntityKey.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/CompositeEntityKey.cs
@@ -14,9 +14,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
     {
         private readonly object[] _keyValueParts;
 
-        public CompositeEntityKey([NotNull] IEntityType entityType, [NotNull] object[] keyValueParts)
+        public CompositeEntityKey([NotNull] IKey key, [NotNull] object[] keyValueParts)
+            : base(key)
         {
-            EntityType = entityType;
             _keyValueParts = keyValueParts;
         }
 
@@ -26,7 +26,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
         private bool Equals(CompositeEntityKey other)
         {
-            if (EntityType != other.EntityType)
+            if (Key != other.Key)
             {
                 return false;
             }
@@ -65,11 +65,11 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
         public override int GetHashCode()
             => _keyValueParts.Aggregate(
-                EntityType.GetHashCode() * 397,
+                Key.GetHashCode() * 397,
                 (t, v) => (t * 397) ^ (v != null ? StructuralComparisons.StructuralEqualityComparer.GetHashCode(v) : 0));
 
         [UsedImplicitly]
         private string DebuggerDisplay
-            => $"{EntityType.Name}({string.Join(", ", _keyValueParts.Select(k => k.ToString()))})";
+            => $"{string.Join(", ", Key.Properties.Select(p => p.DeclaringEntityType.Name + "." + p.Name))}.({string.Join(", ", _keyValueParts.Select(k => k.ToString()))})";
     }
 }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/EntityEntryMetadataServices.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/EntityEntryMetadataServices.cs
@@ -48,9 +48,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         public virtual Sidecar CreateStoreGeneratedValues(InternalEntityEntry entry, IReadOnlyList<IProperty> properties)
             => _storeGeneratedValuesFactory.Create(entry, properties);
 
-        public virtual EntityKey CreateKey(IEntityType entityType, IReadOnlyList<IProperty> properties, IPropertyAccessor propertyAccessor)
+        public virtual EntityKey CreateKey(IKey key, IReadOnlyList<IProperty> properties, IPropertyAccessor propertyAccessor)
             => _entityKeyFactorySource
-                .GetKeyFactory(properties)
-                .Create(entityType, properties, propertyAccessor);
+                .GetKeyFactory(key)
+                .Create(properties, propertyAccessor);
     }
 }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/EntityKey.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/EntityKey.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using JetBrains.Annotations;
 using Microsoft.Data.Entity.Metadata;
 
 namespace Microsoft.Data.Entity.ChangeTracking.Internal
@@ -9,7 +10,17 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
     {
         public static readonly EntityKey InvalidEntityKey = new InvalidEntityKeySentinel();
 
-        public virtual IEntityType EntityType { get; protected set; }
+        private EntityKey()
+        {
+        }
+
+        protected EntityKey([NotNull] IKey key)
+        {
+            Key = key;
+        }
+
+        public virtual IKey Key { get; }
+
         public virtual object Value => GetValue();
 
         protected abstract object GetValue();

--- a/src/EntityFramework.Core/ChangeTracking/Internal/EntityKeyFactory.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/EntityKeyFactory.cs
@@ -10,13 +10,18 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 {
     public abstract class EntityKeyFactory
     {
+        protected EntityKeyFactory([NotNull] IKey key)
+        {
+            Key = key;
+        }
+
+        public virtual IKey Key { get; }
+
         public abstract EntityKey Create(
-            [NotNull] IEntityType entityType,
             [NotNull] IReadOnlyList<IProperty> properties,
             ValueBuffer valueBuffer);
 
         public abstract EntityKey Create(
-            [NotNull] IEntityType entityType,
             [NotNull] IReadOnlyList<IProperty> properties,
             [NotNull] IPropertyAccessor propertyAccessor);
     }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/IEntityEntryMetadataServices.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/IEntityEntryMetadataServices.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         Sidecar CreateStoreGeneratedValues([NotNull] InternalEntityEntry entry, [NotNull] IReadOnlyList<IProperty> properties);
 
         EntityKey CreateKey(
-            [NotNull] IEntityType entityType,
+            [NotNull] IKey key,
             [NotNull] IReadOnlyList<IProperty> properties,
             [NotNull] IPropertyAccessor propertyAccessor);
     }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/IEntityKeyFactorySource.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/IEntityKeyFactorySource.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Metadata;
 
@@ -9,6 +8,6 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 {
     public interface IEntityKeyFactorySource
     {
-        EntityKeyFactory GetKeyFactory([NotNull] IReadOnlyList<IProperty> keyProperties);
+        EntityKeyFactory GetKeyFactory([NotNull] IKey key);
     }
 }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -320,12 +320,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
         [NotNull]
         public virtual EntityKey CreateKey(
-            [NotNull] IEntityType entityType,
+            [NotNull] IKey key,
             [NotNull] IReadOnlyList<IProperty> properties,
-            [NotNull] IPropertyAccessor propertyAccessor) => MetadataServices.CreateKey(entityType, properties, propertyAccessor);
-
-        public virtual EntityKey GetDependentKeySnapshot([NotNull] IForeignKey foreignKey)
-            => CreateKey(foreignKey.PrincipalEntityType.RootType(), foreignKey.Properties, RelationshipsSnapshot);
+            [NotNull] IPropertyAccessor propertyAccessor) => MetadataServices.CreateKey(key, properties, propertyAccessor);
 
         public virtual object[] GetValueBuffer() => EntityType.GetProperties().Select(p => this[p]).ToArray();
 

--- a/src/EntityFramework.Core/ChangeTracking/Internal/PropertyAccessorExtensions.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/PropertyAccessorExtensions.cs
@@ -10,16 +10,19 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
     {
         public static EntityKey GetDependentKeyValue([NotNull] this IPropertyAccessor propertyAccessor, [NotNull] IForeignKey foreignKey)
             => propertyAccessor.InternalEntityEntry.CreateKey(
-                foreignKey.PrincipalEntityType.RootType(), foreignKey.Properties, propertyAccessor);
+                foreignKey.PrincipalKey, foreignKey.Properties, propertyAccessor);
 
         public static EntityKey GetPrincipalKeyValue([NotNull] this IPropertyAccessor propertyAccessor, [NotNull] IForeignKey foreignKey)
+            => propertyAccessor.GetPrincipalKeyValue(foreignKey.PrincipalKey);
+
+        public static EntityKey GetPrincipalKeyValue([NotNull] this IPropertyAccessor propertyAccessor, [NotNull] IKey key)
             => propertyAccessor.InternalEntityEntry.CreateKey(
-                foreignKey.PrincipalEntityType.RootType(), foreignKey.PrincipalKey.Properties, propertyAccessor);
+                key, key.Properties, propertyAccessor);
 
         public static EntityKey GetPrimaryKeyValue([NotNull] this IPropertyAccessor propertyAccessor)
         {
-            var entityType = propertyAccessor.InternalEntityEntry.EntityType.RootType();
-            return propertyAccessor.InternalEntityEntry.CreateKey(entityType, entityType.GetPrimaryKey().Properties, propertyAccessor);
+            var key = propertyAccessor.InternalEntityEntry.EntityType.GetPrimaryKey();
+            return propertyAccessor.InternalEntityEntry.CreateKey(key, key.Properties, propertyAccessor);
         }
     }
 }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/SimpleEntityKey.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/SimpleEntityKey.cs
@@ -13,14 +13,12 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
     public class SimpleEntityKey<TKey> : EntityKey
     {
         private static readonly IEqualityComparer _equalityComparer = EqualityComparer<TKey>.Default;
-        
+
         private readonly TKey _keyValue;
 
-        public SimpleEntityKey([NotNull] IEntityType entityType, [CanBeNull] TKey keyValue)
+        public SimpleEntityKey([NotNull] IKey key, [CanBeNull] TKey keyValue)
+            : base(key)
         {
-            Debug.Assert(entityType != null); // hot path
-
-            EntityType = entityType;
             _keyValue = keyValue;
         }
 
@@ -35,14 +33,14 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
                        && Equals((SimpleEntityKey<TKey>)obj)));
 
         private bool Equals(SimpleEntityKey<TKey> other)
-            => EntityType == other.EntityType
+            => Key == other.Key
                && _equalityComparer.Equals(_keyValue, other._keyValue);
 
         public override int GetHashCode()
-            => (EntityType.GetHashCode() * 397)
+            => (Key.GetHashCode() * 397)
                ^ _equalityComparer.GetHashCode(_keyValue);
 
         [UsedImplicitly]
-        private string DebuggerDisplay => $"{EntityType.Name}({string.Join(", ", _keyValue)})";
+        private string DebuggerDisplay => $"{Key.EntityType.Name}.{Key.Properties[0].Name}({string.Join(", ", _keyValue)})";
     }
 }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/SimpleEntityKeyFactory.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/SimpleEntityKeyFactory.cs
@@ -12,27 +12,26 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
     {
         private readonly TKey _sentinel;
 
-        public SimpleEntityKeyFactory([CanBeNull] TKey sentinel)
+        public SimpleEntityKeyFactory([NotNull] IKey key, [CanBeNull] TKey sentinel)
+            : base(key)
         {
             _sentinel = sentinel;
         }
 
-        public override EntityKey Create(
-            IEntityType entityType, IReadOnlyList<IProperty> properties, ValueBuffer valueBuffer)
-            => Create(entityType, valueBuffer[properties[0].Index]);
+        public override EntityKey Create(IReadOnlyList<IProperty> properties, ValueBuffer valueBuffer)
+            => Create(valueBuffer[properties[0].Index]);
 
-        public override EntityKey Create(
-            IEntityType entityType, IReadOnlyList<IProperty> properties, IPropertyAccessor propertyAccessor)
-            => Create(entityType, propertyAccessor[properties[0]]);
+        public override EntityKey Create(IReadOnlyList<IProperty> properties, IPropertyAccessor propertyAccessor)
+            => Create(propertyAccessor[properties[0]]);
 
-        private EntityKey Create(IEntityType entityType, object value)
+        private EntityKey Create(object value)
         {
             if (value != null)
             {
                 var typedValue = (TKey)value;
                 if (!EqualityComparer<TKey>.Default.Equals(typedValue, _sentinel))
                 {
-                    return new SimpleEntityKey<TKey>(entityType, typedValue);
+                    return new SimpleEntityKey<TKey>(Key, typedValue);
                 }
             }
 

--- a/src/EntityFramework.Core/ChangeTracking/Internal/SimpleNullSentinelEntityKeyFactory.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/SimpleNullSentinelEntityKeyFactory.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using JetBrains.Annotations;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
 
@@ -9,19 +10,22 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 {
     public class SimpleNullSentinelEntityKeyFactory<TKey> : EntityKeyFactory
     {
-        public override EntityKey Create(
-            IEntityType entityType, IReadOnlyList<IProperty> properties, ValueBuffer valueBuffer)
-            => Create(entityType, valueBuffer[properties[0].Index]);
-
-        public override EntityKey Create(
-            IEntityType entityType, IReadOnlyList<IProperty> properties, IPropertyAccessor propertyAccessor)
-            => Create(entityType, propertyAccessor[properties[0]]);
-
-        private EntityKey Create(IEntityType entityType, object value)
+        public SimpleNullSentinelEntityKeyFactory([NotNull] IKey key)
+            : base(key)
         {
-            return value != null
-                ? new SimpleEntityKey<TKey>(entityType, (TKey)value)
-                : EntityKey.InvalidEntityKey;
         }
+
+        public override EntityKey Create(
+            IReadOnlyList<IProperty> properties, ValueBuffer valueBuffer)
+            => Create(valueBuffer[properties[0].Index]);
+
+        public override EntityKey Create(
+            IReadOnlyList<IProperty> properties, IPropertyAccessor propertyAccessor)
+            => Create(propertyAccessor[properties[0]]);
+
+        private EntityKey Create(object value)
+            => value != null
+                ? new SimpleEntityKey<TKey>(Key, (TKey)value)
+                : EntityKey.InvalidEntityKey;
     }
 }

--- a/src/EntityFramework.Core/Query/EntityTrackingInfo.cs
+++ b/src/EntityFramework.Core/Query/EntityTrackingInfo.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Data.Entity.Query
 
             _entityKeyFactory
                 = queryCompilationContext.EntityKeyFactorySource
-                    .GetKeyFactory(_entityKeyProperties);
+                    .GetKeyFactory(_entityType.GetPrimaryKey());
 
             _includedNavigationPaths
                 = _queryCompilationContext
@@ -59,14 +59,14 @@ namespace Microsoft.Data.Entity.Query
                     if (!_includedEntityTrackingInfos.ContainsKey(navigation))
                     {
                         var targetEntityType = navigation.GetTargetType();
-                        var entityKeyProperties = targetEntityType.GetPrimaryKey().Properties;
+                        var targetKey = targetEntityType.GetPrimaryKey();
 
                         _includedEntityTrackingInfos.Add(
                             navigation,
                             new IncludedEntityTrackingInfo(
                                 targetEntityType,
-                                _queryCompilationContext.EntityKeyFactorySource.GetKeyFactory(entityKeyProperties),
-                                entityKeyProperties));
+                                _queryCompilationContext.EntityKeyFactorySource.GetKeyFactory(targetKey),
+                                targetKey.Properties));
                     }
                 }
             }
@@ -83,7 +83,7 @@ namespace Microsoft.Data.Entity.Query
 
             stateManager.StartTracking(
                 _entityType,
-                _entityKeyFactory.Create(_entityType.RootType(), _entityKeyProperties, valueBuffer),
+                _entityKeyFactory.Create(_entityKeyProperties, valueBuffer),
                 entity,
                 valueBuffer);
         }
@@ -109,10 +109,8 @@ namespace Microsoft.Data.Entity.Query
             private EntityKeyFactory EntityKeyFactory { get; }
             private IReadOnlyList<IProperty> EntityKeyProperties { get; }
 
-            public virtual EntityKey CreateEntityKey(ValueBuffer valueBuffer)
-            {
-                return EntityKeyFactory.Create(EntityType.RootType(), EntityKeyProperties, valueBuffer);
-            }
+            public virtual EntityKey CreateEntityKey(ValueBuffer valueBuffer) 
+                => EntityKeyFactory.Create(EntityKeyProperties, valueBuffer);
         }
 
         public struct IncludedEntity

--- a/src/EntityFramework.Core/Query/QueryBuffer.cs
+++ b/src/EntityFramework.Core/Query/QueryBuffer.cs
@@ -213,7 +213,7 @@ namespace Microsoft.Data.Entity.Query
 
             var entityKeyFactory
                 = _entityKeyFactorySource
-                    .GetKeyFactory(keyProperties);
+                    .GetKeyFactory(targetEntityType.GetPrimaryKey());
 
             LoadNavigationProperties(
                 entity,
@@ -224,7 +224,7 @@ namespace Microsoft.Data.Entity.Query
                         {
                             var entityKey
                                 = entityKeyFactory
-                                    .Create(targetEntityType.RootType(), keyProperties, eli.ValueBuffer);
+                                    .Create(keyProperties, eli.ValueBuffer);
 
                             object targetEntity = null;
 
@@ -293,7 +293,7 @@ namespace Microsoft.Data.Entity.Query
 
             var entityKeyFactory
                 = _entityKeyFactorySource
-                    .GetKeyFactory(keyProperties);
+                    .GetKeyFactory(targetEntityType.GetPrimaryKey());
 
             LoadNavigationProperties(
                 entity,
@@ -304,7 +304,7 @@ namespace Microsoft.Data.Entity.Query
                     {
                         var entityKey
                             = entityKeyFactory
-                                .Create(targetEntityType.RootType(), keyProperties, eli.ValueBuffer);
+                                .Create(keyProperties, eli.ValueBuffer);
 
                         object targetEntity = null;
 
@@ -338,13 +338,9 @@ namespace Microsoft.Data.Entity.Query
             out EntityKey primaryKey,
             out Func<ValueBuffer, EntityKey> relatedKeyFactory)
         {
-            var primaryKeyFactory
+            var keyFactory
                 = _entityKeyFactorySource
-                    .GetKeyFactory(navigation.ForeignKey.PrincipalKey.Properties);
-
-            var foreignKeyFactory
-                = _entityKeyFactorySource
-                    .GetKeyFactory(navigation.ForeignKey.Properties);
+                    .GetKeyFactory(navigation.ForeignKey.PrincipalKey);
 
             var targetEntityType = navigation.GetTargetType();
 
@@ -357,21 +353,19 @@ namespace Microsoft.Data.Entity.Query
 
                 primaryKey
                     = navigation.PointsToPrincipal()
-                        ? entry.GetDependentKeySnapshot(navigation.ForeignKey)
+                        ? entry.GetDependentKeyValue(navigation.ForeignKey)
                         : entry.GetPrimaryKeyValue();
             }
             else
             {
                 primaryKey
                     = navigation.PointsToPrincipal()
-                        ? foreignKeyFactory
+                        ? keyFactory
                             .Create(
-                                targetEntityType.RootType(),
                                 navigation.ForeignKey.Properties,
                                 (ValueBuffer)boxedValueBuffer)
-                        : primaryKeyFactory
+                        : keyFactory
                             .Create(
-                                navigation.DeclaringEntityType.RootType(),
                                 navigation.ForeignKey.PrincipalKey.Properties,
                                 (ValueBuffer)boxedValueBuffer);
             }
@@ -380,9 +374,8 @@ namespace Microsoft.Data.Entity.Query
             {
                 relatedKeyFactory
                     = valueBuffer =>
-                        primaryKeyFactory
+                        keyFactory
                             .Create(
-                                targetEntityType.RootType(),
                                 navigation.ForeignKey.PrincipalKey.Properties,
                                 valueBuffer);
             }
@@ -390,9 +383,8 @@ namespace Microsoft.Data.Entity.Query
             {
                 relatedKeyFactory
                     = valueBuffer =>
-                        foreignKeyFactory
+                        keyFactory
                             .Create(
-                                navigation.DeclaringEntityType.RootType(),
                                 navigation.ForeignKey.Properties,
                                 valueBuffer);
             }

--- a/src/EntityFramework.InMemory/Query/InMemoryQueryModelVisitor.cs
+++ b/src/EntityFramework.InMemory/Query/InMemoryQueryModelVisitor.cs
@@ -199,10 +199,10 @@ namespace Microsoft.Data.Entity.InMemory.Query
                 var keyFactory
                     = QueryModelVisitor
                         .QueryCompilationContext
-                        .EntityKeyFactorySource.GetKeyFactory(keyProperties);
+                        .EntityKeyFactorySource.GetKeyFactory(entityType.GetPrimaryKey());
 
                 Func<ValueBuffer, EntityKey> entityKeyFactory
-                    = vr => keyFactory.Create(entityType.RootType(), keyProperties, vr);
+                    = vr => keyFactory.Create(keyProperties, vr);
 
                 if (QueryModelVisitor.QueryCompilationContext
                     .QuerySourceRequiresMaterialization(_querySource))

--- a/src/EntityFramework.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
@@ -198,12 +198,9 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
                 queryMethodInfo
                     = CreateEntityMethodInfo.MakeGenericMethod(elementType);
 
-                var keyProperties
-                    = entityType.GetPrimaryKey().Properties;
-
                 var keyFactory
                     = relationalQueryCompilationContext.EntityKeyFactorySource
-                        .GetKeyFactory(keyProperties);
+                        .GetKeyFactory(entityType.GetPrimaryKey());
 
                 queryMethodArguments.AddRange(
                     new[]
@@ -211,7 +208,7 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
                         Expression.Constant(entityType),
                         Expression.Constant(QueryModelVisitor.QuerySourceRequiresTracking(_querySource)),
                         Expression.Constant(keyFactory),
-                        Expression.Constant(keyProperties),
+                        Expression.Constant(entityType.GetPrimaryKey().Properties),
                         materializer
                     });
             }
@@ -281,7 +278,7 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
             valueBuffer = valueBuffer.WithOffset(valueBufferOffset);
 
             var entityKey
-                = entityKeyFactory.Create(entityType.RootType(), keyProperties, valueBuffer);
+                = entityKeyFactory.Create(keyProperties, valueBuffer);
 
             return new QueryResultScope<TEntity>(
                 querySource,

--- a/test/EntityFramework.Core.FunctionalTests/FixupTest.cs
+++ b/test/EntityFramework.Core.FunctionalTests/FixupTest.cs
@@ -60,30 +60,30 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
                 var stateManager = context.ChangeTracker.GetService();
 
-                stateManager.StartTracking(categoryType, new SimpleEntityKey<int>(categoryType, 11), new Category { Id = 11 }, new ValueBuffer(new object[] { 11 }));
-                stateManager.StartTracking(categoryType, new SimpleEntityKey<int>(categoryType, 12), new Category { Id = 12 }, new ValueBuffer(new object[] { 12 }));
-                stateManager.StartTracking(categoryType, new SimpleEntityKey<int>(categoryType, 13), new Category { Id = 13 }, new ValueBuffer(new object[] { 13 }));
+                stateManager.StartTracking(categoryType, new SimpleEntityKey<int>(categoryType.FindPrimaryKey(), 11), new Category { Id = 11 }, new ValueBuffer(new object[] { 11 }));
+                stateManager.StartTracking(categoryType, new SimpleEntityKey<int>(categoryType.FindPrimaryKey(), 12), new Category { Id = 12 }, new ValueBuffer(new object[] { 12 }));
+                stateManager.StartTracking(categoryType, new SimpleEntityKey<int>(categoryType.FindPrimaryKey(), 13), new Category { Id = 13 }, new ValueBuffer(new object[] { 13 }));
 
-                stateManager.StartTracking(productType, new SimpleEntityKey<int>(productType, 21), new Product { Id = 21, CategoryId = 11 }, new ValueBuffer(new object[] { 21, 11 }));
+                stateManager.StartTracking(productType, new SimpleEntityKey<int>(productType.FindPrimaryKey(), 21), new Product { Id = 21, CategoryId = 11 }, new ValueBuffer(new object[] { 21, 11 }));
                 AssertAllFixedUp(context);
-                stateManager.StartTracking(productType, new SimpleEntityKey<int>(productType, 22), new Product { Id = 22, CategoryId = 11 }, new ValueBuffer(new object[] { 22, 11 }));
+                stateManager.StartTracking(productType, new SimpleEntityKey<int>(productType.FindPrimaryKey(), 22), new Product { Id = 22, CategoryId = 11 }, new ValueBuffer(new object[] { 22, 11 }));
                 AssertAllFixedUp(context);
-                stateManager.StartTracking(productType, new SimpleEntityKey<int>(productType, 23), new Product { Id = 23, CategoryId = 11 }, new ValueBuffer(new object[] { 23, 11 }));
+                stateManager.StartTracking(productType, new SimpleEntityKey<int>(productType.FindPrimaryKey(), 23), new Product { Id = 23, CategoryId = 11 }, new ValueBuffer(new object[] { 23, 11 }));
                 AssertAllFixedUp(context);
-                stateManager.StartTracking(productType, new SimpleEntityKey<int>(productType, 24), new Product { Id = 24, CategoryId = 12 }, new ValueBuffer(new object[] { 24, 12 }));
+                stateManager.StartTracking(productType, new SimpleEntityKey<int>(productType.FindPrimaryKey(), 24), new Product { Id = 24, CategoryId = 12 }, new ValueBuffer(new object[] { 24, 12 }));
                 AssertAllFixedUp(context);
-                stateManager.StartTracking(productType, new SimpleEntityKey<int>(productType, 25), new Product { Id = 25, CategoryId = 12 }, new ValueBuffer(new object[] { 25, 12 }));
+                stateManager.StartTracking(productType, new SimpleEntityKey<int>(productType.FindPrimaryKey(), 25), new Product { Id = 25, CategoryId = 12 }, new ValueBuffer(new object[] { 25, 12 }));
                 AssertAllFixedUp(context);
 
-                stateManager.StartTracking(offerType, new SimpleEntityKey<int>(offerType, 31), new SpecialOffer { Id = 31, ProductId = 22 }, new ValueBuffer(new object[] { 31, 22 }));
+                stateManager.StartTracking(offerType, new SimpleEntityKey<int>(offerType.FindPrimaryKey(), 31), new SpecialOffer { Id = 31, ProductId = 22 }, new ValueBuffer(new object[] { 31, 22 }));
                 AssertAllFixedUp(context);
-                stateManager.StartTracking(offerType, new SimpleEntityKey<int>(offerType, 32), new SpecialOffer { Id = 32, ProductId = 22 }, new ValueBuffer(new object[] { 32, 22 }));
+                stateManager.StartTracking(offerType, new SimpleEntityKey<int>(offerType.FindPrimaryKey(), 32), new SpecialOffer { Id = 32, ProductId = 22 }, new ValueBuffer(new object[] { 32, 22 }));
                 AssertAllFixedUp(context);
-                stateManager.StartTracking(offerType, new SimpleEntityKey<int>(offerType, 33), new SpecialOffer { Id = 33, ProductId = 24 }, new ValueBuffer(new object[] { 33, 24 }));
+                stateManager.StartTracking(offerType, new SimpleEntityKey<int>(offerType.FindPrimaryKey(), 33), new SpecialOffer { Id = 33, ProductId = 24 }, new ValueBuffer(new object[] { 33, 24 }));
                 AssertAllFixedUp(context);
-                stateManager.StartTracking(offerType, new SimpleEntityKey<int>(offerType, 34), new SpecialOffer { Id = 34, ProductId = 24 }, new ValueBuffer(new object[] { 34, 24 }));
+                stateManager.StartTracking(offerType, new SimpleEntityKey<int>(offerType.FindPrimaryKey(), 34), new SpecialOffer { Id = 34, ProductId = 24 }, new ValueBuffer(new object[] { 34, 24 }));
                 AssertAllFixedUp(context);
-                stateManager.StartTracking(offerType, new SimpleEntityKey<int>(offerType, 35), new SpecialOffer { Id = 35, ProductId = 24 }, new ValueBuffer(new object[] { 35, 24 }));
+                stateManager.StartTracking(offerType, new SimpleEntityKey<int>(offerType.FindPrimaryKey(), 35), new SpecialOffer { Id = 35, ProductId = 24 }, new ValueBuffer(new object[] { 35, 24 }));
 
                 AssertAllFixedUp(context);
 

--- a/test/EntityFramework.Core.FunctionalTests/MonsterFixupTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/MonsterFixupTestBase.cs
@@ -6,7 +6,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.FunctionalTests.TestModels;
 using Microsoft.Data.Entity.Infrastructure;
 using Xunit;

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
@@ -185,14 +185,14 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entry = stateManager.GetOrCreateEntry(category);
             entry.SetEntityState(EntityState.Added);
 
-            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType, -1)));
+            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType.GetPrimaryKey(), -1)));
 
             category.PrincipalId = 78;
 
             changeDetector.DetectChanges(entry);
 
             Assert.Equal(78, entry.RelationshipsSnapshot[entry.EntityType.GetProperty("PrincipalId")]);
-            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType, -1)));
+            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType.GetPrimaryKey(), -1)));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -293,14 +293,14 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entry = stateManager.GetOrCreateEntry(category);
             entry.SetEntityState(EntityState.Added);
 
-            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType, -1)));
+            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType.GetPrimaryKey(), -1)));
 
             category.Id = 78;
 
             changeDetector.DetectChanges(entry);
 
             Assert.Equal(78, entry.RelationshipsSnapshot[entry.EntityType.GetProperty("Id")]);
-            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType, 78)));
+            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType.GetPrimaryKey(), 78)));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -325,7 +325,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entry = stateManager.GetOrCreateEntry(category);
             entry.SetEntityState(EntityState.Added);
 
-            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType, -1)));
+            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType.GetPrimaryKey(), -1)));
 
             var property = entry.EntityType.GetProperty("Id");
             var sidecar = entry.AddSidecar(storeGeneratedValuesFactory.Create(entry, entry.EntityType.GetProperties()));
@@ -337,7 +337,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             Assert.Equal(78, entry.RelationshipsSnapshot[property]);
 
-            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType, 78)));
+            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType.GetPrimaryKey(), 78)));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -361,14 +361,14 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entry = stateManager.GetOrCreateEntry(category);
             entry.SetEntityState(EntityState.Added);
 
-            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType, -1)));
+            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType.GetPrimaryKey(), -1)));
 
             category.PrincipalId = 77;
 
             changeDetector.DetectChanges(entry);
 
             Assert.Equal(77, entry.RelationshipsSnapshot[entry.EntityType.GetProperty("PrincipalId")]);
-            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType, -1)));
+            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType.GetPrimaryKey(), -1)));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -827,14 +827,14 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entry = stateManager.GetOrCreateEntry(product);
             entry.SetEntityState(EntityState.Added);
 
-            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType, 77)));
+            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType.GetPrimaryKey(), 77)));
 
             product.Id = 78;
 
             changeDetector.DetectChanges(entry);
 
             Assert.Equal(77, entry.RelationshipsSnapshot[entry.EntityType.GetProperty("Id")]);
-            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType, 77)));
+            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType.GetPrimaryKey(), 77)));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -1190,12 +1190,12 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entry = stateManager.GetOrCreateEntry(category);
             entry.SetEntityState(EntityState.Added);
 
-            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType, -1)));
+            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType.GetPrimaryKey(), -1)));
 
             category.PrincipalId = 78;
 
             Assert.Equal(78, entry.RelationshipsSnapshot[entry.EntityType.GetProperty("PrincipalId")]);
-            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType, -1)));
+            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType.GetPrimaryKey(), -1)));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -1254,12 +1254,12 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entry = stateManager.GetOrCreateEntry(category);
             entry.SetEntityState(EntityState.Added);
 
-            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType, -1)));
+            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType.GetPrimaryKey(), -1)));
 
             category.Id = 78;
 
             Assert.Equal(78, entry.RelationshipsSnapshot[entry.EntityType.GetProperty("Id")]);
-            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType, 78)));
+            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType.GetPrimaryKey(), 78)));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -1283,12 +1283,12 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entry = stateManager.GetOrCreateEntry(category);
             entry.SetEntityState(EntityState.Added);
 
-            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType, -1)));
+            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType.GetPrimaryKey(), -1)));
 
             category.PrincipalId = 77;
 
             Assert.Equal(77, entry.RelationshipsSnapshot[entry.EntityType.GetProperty("PrincipalId")]);
-            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType, -1)));
+            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType.GetPrimaryKey(), -1)));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/CompositeEntityKeyFactoryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/CompositeEntityKeyFactoryTest.cs
@@ -3,8 +3,6 @@
 
 using System;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
-using Microsoft.Data.Entity.Infrastructure;
-using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Framework.DependencyInjection;
@@ -27,8 +25,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entry = stateManager.GetOrCreateEntry(entity);
 
             var key = (CompositeEntityKey)new CompositeEntityKeyFactory(
-                new object[] { 0, null, null })
-                .Create(type, type.GetPrimaryKey().Properties, entry);
+                type.GetPrimaryKey())
+                .Create(type.GetPrimaryKey().Properties, entry);
 
             Assert.Equal(new object[] { 7, "Ate", random }, key.Value);
         }
@@ -46,8 +44,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entry = stateManager.GetOrCreateEntry(entity);
 
             var key = (CompositeEntityKey)new CompositeEntityKeyFactory(
-                new object[] { null, null })
-                .Create(type, new[] { type.GetProperty("P6"), type.GetProperty("P5") }, entry);
+                type.GetPrimaryKey())
+                .Create(new[] { type.GetProperty("P6"), type.GetProperty("P5") }, entry);
 
             Assert.Equal(new object[] { random, "Ate" }, key.Value);
         }
@@ -68,8 +66,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             sidecar[type.GetProperty("P4")] = 77;
 
             var key = (CompositeEntityKey)new CompositeEntityKeyFactory(
-                new object[] { null, 0, null })
-                .Create(type, new[] { type.GetProperty("P6"), type.GetProperty("P4"), type.GetProperty("P5") }, sidecar);
+                type.GetPrimaryKey())
+                .Create(new[] { type.GetProperty("P6"), type.GetProperty("P4"), type.GetProperty("P5") }, sidecar);
 
             Assert.Equal(new object[] { random, 77, "Ate" }, key.Value);
         }
@@ -89,8 +87,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             Assert.Equal(
                 EntityKey.InvalidEntityKey,
                 new CompositeEntityKeyFactory(
-                    new object[] { 0, null, null })
-                    .Create(type, type.GetPrimaryKey().Properties, entry));
+                    type.GetPrimaryKey())
+                    .Create(type.GetPrimaryKey().Properties, entry));
         }
 
         [Fact]
@@ -107,26 +105,26 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             Assert.Equal(
                 EntityKey.InvalidEntityKey,
                 new CompositeEntityKeyFactory(
-                    new object[] { 0, null, null })
-                    .Create(type, type.GetPrimaryKey().Properties, entry));
+                    type.GetPrimaryKey())
+                    .Create(type.GetPrimaryKey().Properties, entry));
         }
 
         [Fact]
         public void Returns_null_if_any_value_in_the_entry_properties_are_the_set_sentinel()
         {
             var model = BuildModel();
-            var type = model.GetEntityType(typeof(Banana));
+            var type = model.GetEntityType(typeof(SentinelBanana));
             var stateManager = TestHelpers.Instance.CreateContextServices(model).GetRequiredService<IStateManager>();
 
-            var entity = new Banana { P1 = 7, P2 = "Ate", P3 = new Random() };
+            var entity = new SentinelBanana { P1 = 7, P2 = "Ate", P3 = new Random() };
 
             var entry = stateManager.GetOrCreateEntry(entity);
 
             Assert.Equal(
                 EntityKey.InvalidEntityKey,
                 new CompositeEntityKeyFactory(
-                    new object[] { 7, null, null })
-                    .Create(type, type.GetPrimaryKey().Properties, entry));
+                    type.GetPrimaryKey())
+                    .Create(type.GetPrimaryKey().Properties, entry));
         }
 
         [Fact]
@@ -137,20 +135,20 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             Assert.Equal(
                 EntityKey.InvalidEntityKey,
                 new CompositeEntityKeyFactory(
-                    new object[] { 0, null, null })
-                    .Create(type, type.GetPrimaryKey().Properties, new ValueBuffer(new object[] { 0, "Ate", new Random() })));
+                    type.GetPrimaryKey())
+                    .Create(type.GetPrimaryKey().Properties, new ValueBuffer(new object[] { 0, "Ate", new Random() })));
         }
 
         [Fact]
         public void Returns_null_if_any_value_in_the_entry_properties_are_the_set_sentinel_using_value_reader()
         {
-            var type = BuildModel().GetEntityType(typeof(Banana));
+            var type = BuildModel().GetEntityType(typeof(SentinelBanana));
 
             Assert.Equal(
                 EntityKey.InvalidEntityKey,
                 new CompositeEntityKeyFactory(
-                    new object[] { 7, null, null })
-                    .Create(type, type.GetPrimaryKey().Properties, new ValueBuffer(new object[] { 7, "Ate", new Random() })));
+                    type.GetPrimaryKey())
+                    .Create(type.GetPrimaryKey().Properties, new ValueBuffer(new object[] { 7, "Ate", new Random() })));
         }
 
         [Fact]
@@ -162,8 +160,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var random = new Random();
 
             var key = (CompositeEntityKey)new CompositeEntityKeyFactory(
-                new object[] { 0, null, null })
-                .Create(type, type.GetPrimaryKey().Properties, new ValueBuffer(new object[] { 7, "Ate", random }));
+                type.GetPrimaryKey())
+                .Create(type.GetPrimaryKey().Properties, new ValueBuffer(new object[] { 7, "Ate", random }));
 
             Assert.Equal(new object[] { 7, "Ate", random }, key.Value);
         }
@@ -177,9 +175,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var random = new Random();
 
             var key = (CompositeEntityKey)new CompositeEntityKeyFactory(
-                new object[] { null, null })
+                type.GetPrimaryKey())
                 .Create(
-                    type,
                     new[] { type.GetProperty("P6"), type.GetProperty("P5") },
                     new ValueBuffer(new object[] { null, null, null, null, "Ate", random }));
 
@@ -195,9 +192,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var random = new Random();
 
             var key = new CompositeEntityKeyFactory(
-                new object[] { null, null })
+                type.GetPrimaryKey())
                 .Create(
-                    type,
                     new[] { type.GetProperty("P6"), type.GetProperty("P5") },
                     new ValueBuffer(new object[] { 7, "Ate", random, 77, null, random }));
 
@@ -219,10 +215,33 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             entityType.GetOrSetPrimaryKey(new[] { property1, property2, property3 });
             entityType.GetOrAddForeignKey(new[] { property4, property5, property6 }, entityType.GetPrimaryKey(), entityType);
 
+            entityType = model.AddEntityType(typeof(SentinelBanana));
+            property1 = entityType.GetOrAddProperty("P1", typeof(int));
+            property2 = entityType.GetOrAddProperty("P2", typeof(string));
+            property3 = entityType.GetOrAddProperty("P3", typeof(Random));
+            property4 = entityType.GetOrAddProperty("P4", typeof(int));
+            property5 = entityType.GetOrAddProperty("P5", typeof(string));
+            property6 = entityType.GetOrAddProperty("P6", typeof(Random));
+
+            entityType.GetOrSetPrimaryKey(new[] { property1, property2, property3 });
+            entityType.GetOrAddForeignKey(new[] { property4, property5, property6 }, entityType.GetPrimaryKey(), entityType);
+
+            property1.SentinelValue = 7;
+
             return model;
         }
 
         private class Banana
+        {
+            public int P1 { get; set; }
+            public string P2 { get; set; }
+            public Random P3 { get; set; }
+            public int P4 { get; set; }
+            public string P5 { get; set; }
+            public Random P6 { get; set; }
+        }
+
+        private class SentinelBanana
         {
             public int P1 { get; set; }
             public string P2 { get; set; }

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/CompositeEntityKeyTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/CompositeEntityKeyTest.cs
@@ -14,13 +14,13 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Value_property_is_strongly_typed()
         {
-            Assert.IsType<object[]>(new CompositeEntityKey(new Mock<IEntityType>().Object, new object[] { 77, "Kake" }).Value);
+            Assert.IsType<object[]>(new CompositeEntityKey(new Mock<IKey>().Object, new object[] { 77, "Kake" }).Value);
         }
 
         [Fact]
         public void Base_class_value_property_returns_same_as_strongly_typed_value_property()
         {
-            var key = new CompositeEntityKey(new Mock<IEntityType>().Object, new object[] { 77, "Kake" });
+            var key = new CompositeEntityKey(new Mock<IKey>().Object, new object[] { 77, "Kake" });
 
             Assert.Equal(new object[] { 77, "Kake" }, key.Value);
             Assert.Equal(new object[] { 77, "Kake" }, (object[])((EntityKey)key).Value);
@@ -29,50 +29,50 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Only_keys_with_the_same_value_and_entity_type_test_as_equal()
         {
-            var type1 = new Mock<IEntityType>().Object;
-            var type2 = new Mock<IEntityType>().Object;
+            var key1 = new Mock<IKey>().Object;
+            var key2 = new Mock<IKey>().Object;
 
-            Assert.True(new CompositeEntityKey(type1, new object[] { 77, "Kake" }).Equals(new CompositeEntityKey(type1, new object[] { 77, "Kake" })));
-            Assert.False(new CompositeEntityKey(type1, new object[] { 77, "Kake" }).Equals(null));
-            Assert.False(new CompositeEntityKey(type1, new object[] { 77 }).Equals(new SimpleEntityKey<int>(type1, 77)));
-            Assert.False(new CompositeEntityKey(type1, new object[] { 77, "Kake" }).Equals(new CompositeEntityKey(type1, new object[] { 77, "Lie" })));
-            Assert.False(new CompositeEntityKey(type1, new object[] { 77, "Kake" }).Equals(new CompositeEntityKey(type1, new object[] { 77L, "Kake" })));
-            Assert.False(new CompositeEntityKey(type1, new object[] { 77, "Kake" }).Equals(new CompositeEntityKey(type1, new object[] { null, "Kake" })));
-            Assert.False(new CompositeEntityKey(type1, new object[] { 77, "Kake" }).Equals(new CompositeEntityKey(type1, new object[] { 77, "Kake", 42 })));
-            Assert.False(new CompositeEntityKey(type1, new object[] { 77, "Kake" }).Equals(new CompositeEntityKey(type1, new object[] { 88, "Kake" })));
-            Assert.False(new CompositeEntityKey(type1, new object[] { 77, "Kake" }).Equals(new CompositeEntityKey(type2, new object[] { 77, "Kake" })));
+            Assert.True(new CompositeEntityKey(key1, new object[] { 77, "Kake" }).Equals(new CompositeEntityKey(key1, new object[] { 77, "Kake" })));
+            Assert.False(new CompositeEntityKey(key1, new object[] { 77, "Kake" }).Equals(null));
+            Assert.False(new CompositeEntityKey(key1, new object[] { 77 }).Equals(new SimpleEntityKey<int>(key1, 77)));
+            Assert.False(new CompositeEntityKey(key1, new object[] { 77, "Kake" }).Equals(new CompositeEntityKey(key1, new object[] { 77, "Lie" })));
+            Assert.False(new CompositeEntityKey(key1, new object[] { 77, "Kake" }).Equals(new CompositeEntityKey(key1, new object[] { 77L, "Kake" })));
+            Assert.False(new CompositeEntityKey(key1, new object[] { 77, "Kake" }).Equals(new CompositeEntityKey(key1, new object[] { null, "Kake" })));
+            Assert.False(new CompositeEntityKey(key1, new object[] { 77, "Kake" }).Equals(new CompositeEntityKey(key1, new object[] { 77, "Kake", 42 })));
+            Assert.False(new CompositeEntityKey(key1, new object[] { 77, "Kake" }).Equals(new CompositeEntityKey(key1, new object[] { 88, "Kake" })));
+            Assert.False(new CompositeEntityKey(key1, new object[] { 77, "Kake" }).Equals(new CompositeEntityKey(key2, new object[] { 77, "Kake" })));
         }
 
         [Fact]
         public void Only_keys_with_the_same_value_and_type_return_same_hashcode()
         {
-            var type1 = new Mock<IEntityType>().Object;
-            var type2 = new Mock<IEntityType>().Object;
+            var key1 = new Mock<IKey>().Object;
+            var key2 = new Mock<IKey>().Object;
 
-            Assert.Equal(new CompositeEntityKey(type1, new object[] { 77, "Kake" }).GetHashCode(), new CompositeEntityKey(type1, new object[] { 77, "Kake" }).GetHashCode());
-            Assert.NotEqual(new CompositeEntityKey(type1, new object[] { 77, "Kake" }).GetHashCode(), new CompositeEntityKey(type1, new object[] { 77, "Lie" }).GetHashCode());
-            Assert.NotEqual(new CompositeEntityKey(type1, new object[] { 77, "Kake" }).GetHashCode(), new CompositeEntityKey(type1, new object[] { null, "Kake" }).GetHashCode());
-            Assert.NotEqual(new CompositeEntityKey(type1, new object[] { 77, "Kake" }).GetHashCode(), new CompositeEntityKey(type1, new object[] { 77, "Kake", 42 }).GetHashCode());
-            Assert.NotEqual(new CompositeEntityKey(type1, new object[] { 77, "Kake" }).GetHashCode(), new CompositeEntityKey(type1, new object[] { 88, "Kake" }).GetHashCode());
-            Assert.NotEqual(new CompositeEntityKey(type1, new object[] { 77, "Kake" }).GetHashCode(), new CompositeEntityKey(type2, new object[] { 77, "Kake" }).GetHashCode());
+            Assert.Equal(new CompositeEntityKey(key1, new object[] { 77, "Kake" }).GetHashCode(), new CompositeEntityKey(key1, new object[] { 77, "Kake" }).GetHashCode());
+            Assert.NotEqual(new CompositeEntityKey(key1, new object[] { 77, "Kake" }).GetHashCode(), new CompositeEntityKey(key1, new object[] { 77, "Lie" }).GetHashCode());
+            Assert.NotEqual(new CompositeEntityKey(key1, new object[] { 77, "Kake" }).GetHashCode(), new CompositeEntityKey(key1, new object[] { null, "Kake" }).GetHashCode());
+            Assert.NotEqual(new CompositeEntityKey(key1, new object[] { 77, "Kake" }).GetHashCode(), new CompositeEntityKey(key1, new object[] { 77, "Kake", 42 }).GetHashCode());
+            Assert.NotEqual(new CompositeEntityKey(key1, new object[] { 77, "Kake" }).GetHashCode(), new CompositeEntityKey(key1, new object[] { 88, "Kake" }).GetHashCode());
+            Assert.NotEqual(new CompositeEntityKey(key1, new object[] { 77, "Kake" }).GetHashCode(), new CompositeEntityKey(key2, new object[] { 77, "Kake" }).GetHashCode());
         }
 
         [Fact]
         public void Uses_structural_comparisons_for_array_matching()
         {
-            var type = new Mock<IEntityType>().Object;
+            var key = new Mock<IKey>().Object;
 
-            Assert.True(new CompositeEntityKey(type, new object[] { new Byte[] { 1, 2, 3 } }).Equals(new CompositeEntityKey(type, new object[] { new Byte[] { 1, 2, 3 } })));
-            Assert.False(new CompositeEntityKey(type, new object[] { new Byte[] { 1, 2, 3 } }).Equals(new CompositeEntityKey(type, new object[] { new Byte[] { 3, 2, 3 } })));
+            Assert.True(new CompositeEntityKey(key, new object[] { new Byte[] { 1, 2, 3 } }).Equals(new CompositeEntityKey(key, new object[] { new Byte[] { 1, 2, 3 } })));
+            Assert.False(new CompositeEntityKey(key, new object[] { new Byte[] { 1, 2, 3 } }).Equals(new CompositeEntityKey(key, new object[] { new Byte[] { 3, 2, 3 } })));
         }
 
         [Fact]
         public void Uses_structural_comparisons_for_array_hashcode_generation()
         {
-            var type = new Mock<IEntityType>().Object;
+            var key = new Mock<IKey>().Object;
 
-            Assert.Equal(new CompositeEntityKey(type, new object[] { new Byte[] { 1, 2, 3 } }).GetHashCode(), new CompositeEntityKey(type, new object[] { new Byte[] { 1, 2, 3 } }).GetHashCode());
-            Assert.NotEqual(new CompositeEntityKey(type, new object[] { new Byte[] { 1, 2, 3 } }).GetHashCode(), new CompositeEntityKey(type, new object[] { new Byte[] { 3, 2, 3 } }).GetHashCode());
+            Assert.Equal(new CompositeEntityKey(key, new object[] { new Byte[] { 1, 2, 3 } }).GetHashCode(), new CompositeEntityKey(key, new object[] { new Byte[] { 1, 2, 3 } }).GetHashCode());
+            Assert.NotEqual(new CompositeEntityKey(key, new object[] { new Byte[] { 1, 2, 3 } }).GetHashCode(), new CompositeEntityKey(key, new object[] { new Byte[] { 3, 2, 3 } }).GetHashCode());
         }
     }
 }

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/EntityKeyFactorySourceTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/EntityKeyFactorySourceTest.cs
@@ -13,141 +13,141 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Returns_a_simple_entity_key_factory_for_single_property()
         {
-            var property = GetEntityType().GetProperty("Id");
+            var key = GetEntityType().GetPrimaryKey();
 
-            Assert.IsType<SimpleEntityKeyFactory<int>>(CreateKeyFactorySource().GetKeyFactory(new[] { property }));
+            Assert.IsType<SimpleEntityKeyFactory<int>>(CreateKeyFactorySource().GetKeyFactory(key));
         }
 
         [Fact]
         public void Returns_a_null_sentinel_entity_key_factory_for_single_nullable_property()
         {
-            var property = GetEntityType().GetProperty("NullableInt");
+            var entityType = GetEntityType();
+            var key = entityType.GetKey(entityType.GetProperty("NullableInt"));
 
-            Assert.IsType<SimpleNullSentinelEntityKeyFactory<int>>(CreateKeyFactorySource().GetKeyFactory(new[] { property }));
+            Assert.IsType<SimpleNullSentinelEntityKeyFactory<int>>(CreateKeyFactorySource().GetKeyFactory(key));
         }
 
         [Fact]
         public void Returns_a_simple_entity_key_factory_for_single_nullable_property_with_sentinel_set()
         {
-            var property = GetEntityType().GetProperty("NullableSentinelInt");
+            var entityType = GetEntityType();
+            var key = entityType.GetKey(entityType.GetProperty("NullableSentinelInt"));
 
-            Assert.IsType<SimpleEntityKeyFactory<int>>(CreateKeyFactorySource().GetKeyFactory(new[] { property }));
+            Assert.IsType<SimpleEntityKeyFactory<int>>(CreateKeyFactorySource().GetKeyFactory(key));
         }
 
         [Fact]
         public void Returns_different_simple_entity_key_factory_for_different_properties()
         {
             var entityType = GetEntityType();
-            var property1 = entityType.GetProperty("Guid1");
-            var property2 = entityType.GetProperty("Guid2");
+            var key1 = entityType.GetKey(entityType.GetProperty("Guid1"));
+            var key2 = entityType.GetKey(entityType.GetProperty("Guid2"));
 
             var factorySource = CreateKeyFactorySource();
-            Assert.NotSame(factorySource.GetKeyFactory(new[] { property1 }), factorySource.GetKeyFactory(new[] { property2 }));
+            Assert.NotSame(factorySource.GetKeyFactory(key1), factorySource.GetKeyFactory(key2));
         }
 
         [Fact]
         public void Returns_different_simple_nullable_entity_key_factory_for_different_properties()
         {
             var entityType = GetEntityType();
-            var property1 = entityType.GetProperty("NullableGuid1");
-            var property2 = entityType.GetProperty("NullableGuid2");
+            var key1 = entityType.GetKey(entityType.GetProperty("NullableGuid1"));
+            var key2 = entityType.GetKey(entityType.GetProperty("NullableGuid2"));
 
             var factorySource = CreateKeyFactorySource();
-            Assert.NotSame(factorySource.GetKeyFactory(new[] { property1 }), factorySource.GetKeyFactory(new[] { property2 }));
+            Assert.NotSame(factorySource.GetKeyFactory(key1), factorySource.GetKeyFactory(key2));
         }
 
         [Fact]
         public void Returns_same_simple_entity_key_factory_for_same_property()
         {
-            var property = GetEntityType().GetProperty("Guid1");
+            var entityType = GetEntityType();
+            var key = entityType.GetKey(entityType.GetProperty("Guid1"));
 
             var factorySource = CreateKeyFactorySource();
-            Assert.Same(factorySource.GetKeyFactory(new[] { property }), factorySource.GetKeyFactory(new[] { property }));
-        }
-
-        [Fact]
-        public void Returns_same_nullable_simple_entity_key_factory_for_same_property()
-        {
-            var property = GetEntityType().GetProperty("NullableGuid1");
-
-            var factorySource = CreateKeyFactorySource();
-            Assert.Same(factorySource.GetKeyFactory(new[] { property }), factorySource.GetKeyFactory(new[] { property }));
+            Assert.Same(factorySource.GetKeyFactory(key), factorySource.GetKeyFactory(key));
         }
 
         [Fact]
         public void Returns_a_composite_entity_key_factory_for_composite_property_key()
         {
             var entityType = GetEntityType();
-            var property1 = entityType.GetProperty("Id");
-            var property2 = entityType.GetProperty("String");
+            var key = entityType.GetKey(new[] { entityType.GetProperty("Id"), entityType.GetProperty("String") });
 
             Assert.IsType<CompositeEntityKeyFactory>(
-                CreateKeyFactorySource().GetKeyFactory(new[] { property1, property2 }));
+                CreateKeyFactorySource().GetKeyFactory(key));
         }
 
         [Fact]
         public void Returns_same_composite_entity_key_factory_for_same_properties()
         {
             var entityType = GetEntityType();
-            var property1 = entityType.GetProperty("Id");
-            var property2 = entityType.GetProperty("String");
+            var key1 = entityType.GetKey(new[] { entityType.GetProperty("Id"), entityType.GetProperty("String") });
+            var key2 = entityType.GetKey(new[] { entityType.GetProperty("Id"), entityType.GetProperty("String") });
 
             var factorySource = CreateKeyFactorySource();
-            Assert.Same(factorySource.GetKeyFactory(new[] { property1, property2 }), factorySource.GetKeyFactory(new[] { property1, property2 }));
+            Assert.Same(factorySource.GetKeyFactory(key1), factorySource.GetKeyFactory(key2));
         }
 
         [Fact]
         public void Returns_a_null_sentinel_entity_key_factory_for_single_reference_property()
         {
-            var property = GetEntityType().GetProperty("String");
+            var entityType = GetEntityType();
+            var key = entityType.GetKey(entityType.GetProperty("String"));
 
-            Assert.IsType<SimpleNullSentinelEntityKeyFactory<string>>(CreateKeyFactorySource().GetKeyFactory(new[] { property }));
+            Assert.IsType<SimpleNullSentinelEntityKeyFactory<string>>(CreateKeyFactorySource().GetKeyFactory(key));
         }
 
         [Fact]
         public void Returns_a_simple_entity_key_factory_for_single_reference_property_with_sentinel_set()
         {
-            var property = GetEntityType().GetProperty("SentinelString");
+            var entityType = GetEntityType();
+            var key = entityType.GetKey(entityType.GetProperty("SentinelString"));
 
-            Assert.IsType<SimpleEntityKeyFactory<string>>(CreateKeyFactorySource().GetKeyFactory(new[] { property }));
+            Assert.IsType<SimpleEntityKeyFactory<string>>(CreateKeyFactorySource().GetKeyFactory(key));
         }
-
 
         [Fact]
         public void Returns_a_composite_entity_key_factory_for_single_structural_property()
         {
-            var property = GetEntityType().GetProperty("ByteArray");
+            var entityType = GetEntityType();
+            var key = entityType.GetKey(entityType.GetProperty("ByteArray"));
 
-            Assert.IsType<CompositeEntityKeyFactory>(CreateKeyFactorySource().GetKeyFactory(new[] { property }));
+            Assert.IsType<CompositeEntityKeyFactory>(CreateKeyFactorySource().GetKeyFactory(key));
         }
 
         [Fact]
         public void Returns_same_composite_entity_key_factory_for_same_structural_property()
         {
-            var property = GetEntityType().GetProperty("ByteArray");
+            var entityType = GetEntityType();
+            var key = entityType.GetKey(entityType.GetProperty("ByteArray"));
 
             var factorySource = CreateKeyFactorySource();
-            Assert.Same(factorySource.GetKeyFactory(new[] { property }), factorySource.GetKeyFactory(new[] { property }));
+            Assert.Same(factorySource.GetKeyFactory(key), factorySource.GetKeyFactory(key));
         }
 
-        private static IEntityKeyFactorySource CreateKeyFactorySource()
-        {
-            return new EntityKeyFactorySource();
-        }
+        private static IEntityKeyFactorySource CreateKeyFactorySource() => new EntityKeyFactorySource();
 
         private static IEntityType GetEntityType()
         {
             var builder = TestHelpers.Instance.CreateConventionBuilder();
 
-            builder.Entity<ScissorSister>()
-                .Property(e => e.NullableSentinelInt)
-                .Metadata
-                .SentinelValue = -1;
+            builder.Entity<ScissorSister>(b =>
+                {
+                    b.Property(e => e.NullableSentinelInt).Metadata.SentinelValue = -1;
+                    b.Property(e => e.SentinelString).Metadata.SentinelValue = "Excellent!";
 
-            builder.Entity<ScissorSister>()
-                .Property(e => e.SentinelString)
-                .Metadata
-                .SentinelValue = "Excellent!";
+                    b.AlternateKey(e => e.NullableInt);
+                    b.AlternateKey(e => e.NullableSentinelInt);
+                    b.AlternateKey(e => e.Guid1);
+                    b.AlternateKey(e => e.Guid2);
+                    b.AlternateKey(e => e.NullableGuid1);
+                    b.AlternateKey(e => e.NullableGuid2);
+                    b.AlternateKey(e => e.String);
+                    b.AlternateKey(e => e.SentinelString);
+                    b.AlternateKey(e => e.ByteArray);
+                    b.AlternateKey(e => new { e.Id, e.String });
+                });
 
             return builder.Model.GetEntityType(typeof(ScissorSister));
         }

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/EntityKeyTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/EntityKeyTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Data.Entity.ChangeTracking.Internal;
+using Microsoft.Data.Entity.Metadata;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
@@ -11,15 +12,17 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Value_property_calls_template_method()
         {
-            Assert.Equal("Kake", new ConcreteKey().Value);
+            Assert.Equal("Kake", new ConcreteKey(null).Value);
         }
 
         public class ConcreteKey : EntityKey
         {
-            protected override object GetValue()
+            public ConcreteKey(IKey key)
+                : base(key)
             {
-                return "Kake";
             }
+
+            protected override object GetValue() => "Kake";
         }
     }
 }

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntityEntryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntityEntryTest.cs
@@ -473,7 +473,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var keyValue = entry.GetPrimaryKeyValue();
             Assert.IsType<SimpleEntityKey<int>>(keyValue);
             Assert.Equal(77, keyValue.Value);
-            Assert.Same(entityType.BaseType, keyValue.EntityType);
+            Assert.Same(entityType.GetPrimaryKey(), keyValue.Key);
         }
 
         [Fact]
@@ -491,7 +491,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var keyValue = (CompositeEntityKey)entry.GetPrimaryKeyValue();
             Assert.Equal(77, keyValue.Value[0]);
             Assert.Equal("SmokeyBacon", keyValue.Value[1]);
-            Assert.Same(entityType.BaseType, keyValue.EntityType);
+            Assert.Same(entityType.GetPrimaryKey(), keyValue.Key);
         }
 
         [Fact]
@@ -510,7 +510,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var keyValue = entry.GetDependentKeyValue(fk);
             Assert.IsType<SimpleEntityKey<int>>(keyValue);
             Assert.Equal(77, keyValue.Value);
-            Assert.Same(fk.PrincipalEntityType.BaseType, keyValue.EntityType);
+            Assert.Same(fk.PrincipalEntityType.GetPrimaryKey(), keyValue.Key);
         }
 
         [Fact]
@@ -526,10 +526,10 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             entry[fkProperty] = 77;
             entry.RelationshipsSnapshot[fkProperty] = 78;
 
-            var keyValue = entry.GetDependentKeySnapshot(fk);
+            var keyValue = entry.RelationshipsSnapshot.GetDependentKeyValue(fk);
             Assert.IsType<SimpleEntityKey<int>>(keyValue);
             Assert.Equal(78, keyValue.Value);
-            Assert.Same(fk.PrincipalEntityType.BaseType, keyValue.EntityType);
+            Assert.Same(fk.PrincipalEntityType.GetPrimaryKey(), keyValue.Key);
         }
 
         [Fact]
@@ -544,10 +544,10 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var entry = CreateInternalEntry(configuration, entityType, new SomeDependentEntity());
             entry[fkProperty] = 77;
 
-            var keyValue = entry.GetDependentKeySnapshot(fk);
+            var keyValue = entry.RelationshipsSnapshot.GetDependentKeyValue(fk);
             Assert.IsType<SimpleEntityKey<int>>(keyValue);
             Assert.Equal(77, keyValue.Value);
-            Assert.Same(fk.PrincipalEntityType.BaseType, keyValue.EntityType);
+            Assert.Same(fk.PrincipalEntityType.GetPrimaryKey(), keyValue.Key);
         }
 
         [Fact]
@@ -564,7 +564,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             entry[fkProperty] = 79;
 
-            var keyValue = entry.GetDependentKeySnapshot(entityType.GetForeignKeys().Single());
+            var keyValue = entry.RelationshipsSnapshot.GetDependentKeyValue(entityType.GetForeignKeys().Single());
             Assert.IsType<SimpleEntityKey<int>>(keyValue);
             Assert.Equal(79, keyValue.Value);
         }
@@ -583,7 +583,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             entry[fkProperty] = 77;
 
-            var keyValue = entry.GetDependentKeySnapshot(entityType.GetForeignKeys().Single());
+            var keyValue = entry.RelationshipsSnapshot.GetDependentKeyValue(entityType.GetForeignKeys().Single());
             Assert.IsType<SimpleEntityKey<int>>(keyValue);
             Assert.Equal(78, keyValue.Value);
         }
@@ -604,7 +604,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var keyValue = entry.GetPrincipalKeyValue(fk);
             Assert.IsType<SimpleEntityKey<int>>(keyValue);
             Assert.Equal(77, keyValue.Value);
-            Assert.Same(fk.PrincipalEntityType.BaseType, keyValue.EntityType);
+            Assert.Same(fk.PrincipalEntityType.GetPrimaryKey(), keyValue.Key);
         }
 
         [Fact]
@@ -622,7 +622,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var keyValue = (CompositeEntityKey)entry.GetDependentKeyValue(fk);
             Assert.Equal(77, keyValue.Value[0]);
             Assert.Equal("CheeseAndOnion", keyValue.Value[1]);
-            Assert.Same(fk.PrincipalEntityType.BaseType, keyValue.EntityType);
+            Assert.Same(fk.PrincipalEntityType.GetPrimaryKey(), keyValue.Key);
         }
 
         [Fact]
@@ -641,7 +641,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var keyValue = (CompositeEntityKey)entry.GetPrincipalKeyValue(dependentType.GetForeignKeys().Single());
             Assert.Equal(77, keyValue.Value[0]);
             Assert.Equal("PrawnCocktail", keyValue.Value[1]);
-            Assert.Same(principalType.BaseType, keyValue.EntityType);
+            Assert.Same(principalType.GetPrimaryKey(), keyValue.Key);
         }
 
         [Fact]
@@ -660,7 +660,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var fk = dependentType.GetForeignKeys().Single();
             var keyValue = entry.GetPrincipalKeyValue(fk);
             Assert.Same(EntityKey.InvalidEntityKey, keyValue);
-            Assert.Null(keyValue.EntityType);
+            Assert.Null(keyValue.Key);
         }
 
         [Fact]

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/SimpleEntityKeyFactoryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/SimpleEntityKeyFactoryTest.cs
@@ -21,7 +21,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entity = new Banana { P1 = 7, P2 = 8 };
             var entry = stateManager.GetOrCreateEntry(entity);
 
-            var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>(0).Create(type, type.GetPrimaryKey().Properties, entry);
+            var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>(type.GetPrimaryKey(), 0)
+                .Create(type.GetPrimaryKey().Properties, entry);
 
             Assert.Equal(7, key.Value);
         }
@@ -36,8 +37,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entity = new Banana { P1 = 7, P2 = 8 };
             var entry = stateManager.GetOrCreateEntry(entity);
 
-            var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>(0).Create(
-                type, new[] { type.GetProperty("P2") }, entry);
+            var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>(type.GetPrimaryKey(), 0)
+                .Create(new[] { type.GetProperty("P2") }, entry);
 
             Assert.Equal(8, key.Value);
         }
@@ -52,7 +53,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entity = new Banana { P1 = 7, P2 = null };
             var entry = stateManager.GetOrCreateEntry(entity);
 
-            Assert.Equal(EntityKey.InvalidEntityKey, new SimpleEntityKeyFactory<int>(0).Create(type, new[] { type.GetProperty("P2") }, entry));
+            Assert.Equal(EntityKey.InvalidEntityKey, new SimpleEntityKeyFactory<int>(type.GetPrimaryKey(), 0)
+                .Create(new[] { type.GetProperty("P2") }, entry));
         }
 
         [Fact]
@@ -65,7 +67,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entity = new Banana { P1 = 0, P2 = 8 };
             var entry = stateManager.GetOrCreateEntry(entity);
 
-            Assert.Equal(EntityKey.InvalidEntityKey, new SimpleEntityKeyFactory<int>(0).Create(type, new[] { type.GetProperty("P1") }, entry));
+            Assert.Equal(EntityKey.InvalidEntityKey, new SimpleEntityKeyFactory<int>(type.GetPrimaryKey(), 0)
+                .Create(new[] { type.GetProperty("P1") }, entry));
         }
 
         [Fact]
@@ -78,7 +81,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entity = new Banana { P1 = 7, P2 = 0 };
             var entry = stateManager.GetOrCreateEntry(entity);
 
-            Assert.Equal(EntityKey.InvalidEntityKey, new SimpleEntityKeyFactory<int>(0).Create(type, new[] { type.GetProperty("P2") }, entry));
+            Assert.Equal(EntityKey.InvalidEntityKey, new SimpleEntityKeyFactory<int>(type.GetPrimaryKey(), 0)
+                .Create(new[] { type.GetProperty("P2") }, entry));
         }
 
         [Fact]
@@ -91,8 +95,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entity = new Banana { P1 = 7, P2 = 0 };
             var entry = stateManager.GetOrCreateEntry(entity);
 
-            var key = (SimpleEntityKey<int?>)new SimpleEntityKeyFactory<int?>(null).Create(
-                type, new[] { type.GetProperty("P2") }, entry);
+            var key = (SimpleEntityKey<int?>)new SimpleEntityKeyFactory<int?>(type.GetPrimaryKey(), null)
+                .Create(new[] { type.GetProperty("P2") }, entry);
 
             Assert.Equal(0, key.Value);
         }
@@ -107,7 +111,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entity = new Banana { P1 = 7, P2 = 8 };
             var entry = stateManager.GetOrCreateEntry(entity);
 
-            Assert.Equal(EntityKey.InvalidEntityKey, new SimpleEntityKeyFactory<int>(7).Create(type, new[] { type.GetProperty("P1") }, entry));
+            Assert.Equal(EntityKey.InvalidEntityKey, new SimpleEntityKeyFactory<int>(type.GetPrimaryKey(), 7)
+                .Create(new[] { type.GetProperty("P1") }, entry));
         }
 
         [Fact]
@@ -120,8 +125,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entity = new Banana { P1 = 0, P2 = 8 };
             var entry = stateManager.GetOrCreateEntry(entity);
 
-            var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>(7).Create(
-                type, new[] { type.GetProperty("P1") }, entry);
+            var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>(type.GetPrimaryKey(), 7)
+                .Create(new[] { type.GetProperty("P1") }, entry);
 
             Assert.Equal(0, key.Value);
         }
@@ -131,8 +136,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         {
             var type = BuildModel().GetEntityType(typeof(Banana));
 
-            var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>(0).Create(
-                type, type.GetPrimaryKey().Properties, new ValueBuffer(new object[] { 7, "Ate" }));
+            var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>(type.GetPrimaryKey(), 0)
+                .Create(type.GetPrimaryKey().Properties, new ValueBuffer(new object[] { 7, "Ate" }));
 
             Assert.Equal(7, key.Value);
         }
@@ -142,8 +147,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         {
             var type = BuildModel().GetEntityType(typeof(Banana));
 
-            var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>(0).Create(
-                type, new[] { type.GetProperty("P2") }, new ValueBuffer(new object[] { 7, 8 }));
+            var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>(type.GetPrimaryKey(), 0)
+                .Create(new[] { type.GetProperty("P2") }, new ValueBuffer(new object[] { 7, 8 }));
 
             Assert.Equal(8, key.Value);
         }
@@ -153,8 +158,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         {
             var type = BuildModel().GetEntityType(typeof(Kiwi));
 
-            var key = (SimpleEntityKey<string>)new SimpleEntityKeyFactory<string>(null).Create(
-                type, type.GetPrimaryKey().Properties, new ValueBuffer(new object[] { "7", "Ate" }));
+            var key = (SimpleEntityKey<string>)new SimpleEntityKeyFactory<string>(type.GetPrimaryKey(), null)
+                .Create(type.GetPrimaryKey().Properties, new ValueBuffer(new object[] { "7", "Ate" }));
 
             Assert.Equal("7", key.Value);
         }
@@ -164,8 +169,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         {
             var type = BuildModel().GetEntityType(typeof(Kiwi));
 
-            var key = (SimpleEntityKey<string>)new SimpleEntityKeyFactory<string>(null).Create(
-                type, new[] { type.GetProperty("P2") }, new ValueBuffer(new object[] { "7", "Ate" }));
+            var key = (SimpleEntityKey<string>)new SimpleEntityKeyFactory<string>(type.GetPrimaryKey(), null)
+                .Create(new[] { type.GetProperty("P2") }, new ValueBuffer(new object[] { "7", "Ate" }));
 
             Assert.Equal("Ate", key.Value);
         }
@@ -177,7 +182,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             Assert.Equal(
                 EntityKey.InvalidEntityKey,
-                new SimpleEntityKeyFactory<int>(0).Create(type, new[] { type.GetProperty("P1") }, new ValueBuffer(new object[] { 0, 8 })));
+                new SimpleEntityKeyFactory<int>(type.GetPrimaryKey(), 0)
+                .Create(new[] { type.GetProperty("P1") }, new ValueBuffer(new object[] { 0, 8 })));
         }
 
         [Fact]
@@ -187,7 +193,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             Assert.Equal(
                 EntityKey.InvalidEntityKey,
-                new SimpleEntityKeyFactory<int>(0).Create(type, new[] { type.GetProperty("P2") }, new ValueBuffer(new object[] { 7, 0 })));
+                new SimpleEntityKeyFactory<int>(type.GetPrimaryKey(), 0).Create(
+                    new[] { type.GetProperty("P2") }, new ValueBuffer(new object[] { 7, 0 })));
         }
 
         [Fact]
@@ -195,8 +202,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         {
             var type = BuildModel().GetEntityType(typeof(Banana));
 
-            var key = (SimpleEntityKey<int?>)new SimpleEntityKeyFactory<int?>(null).Create(
-                type, new[] { type.GetProperty("P2") }, new ValueBuffer(new object[] { 7, 0 }));
+            var key = (SimpleEntityKey<int?>)new SimpleEntityKeyFactory<int?>(type.GetPrimaryKey(), null)
+                .Create(new[] { type.GetProperty("P2") }, new ValueBuffer(new object[] { 7, 0 }));
 
             Assert.Equal(0, key.Value);
         }
@@ -208,7 +215,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             Assert.Equal(
                 EntityKey.InvalidEntityKey,
-                new SimpleEntityKeyFactory<int>(7).Create(type, new[] { type.GetProperty("P1") }, new ValueBuffer(new object[] { 7, 8 })));
+                new SimpleEntityKeyFactory<int>(type.GetPrimaryKey(), 7)
+                .Create(new[] { type.GetProperty("P1") }, new ValueBuffer(new object[] { 7, 8 })));
         }
 
         [Fact]
@@ -216,8 +224,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         {
             var type = BuildModel().GetEntityType(typeof(Banana));
 
-            var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>(7).Create(
-                type, new[] { type.GetProperty("P1") }, new ValueBuffer(new object[] { 0, 8 }));
+            var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>(type.GetPrimaryKey(), 7)
+                .Create(new[] { type.GetProperty("P1") }, new ValueBuffer(new object[] { 0, 8 }));
 
             Assert.Equal(0, key.Value);
         }
@@ -235,8 +243,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var sidecar = new RelationshipsSnapshot(entry);
             sidecar[type.GetProperty("P2")] = "Eaten";
 
-            var key = (SimpleEntityKey<string>)new SimpleEntityKeyFactory<string>(null).Create(
-                type, new[] { type.GetProperty("P2") }, sidecar);
+            var key = (SimpleEntityKey<string>)new SimpleEntityKeyFactory<string>(type.GetPrimaryKey(), null)
+                .Create(new[] { type.GetProperty("P2") }, sidecar);
 
             Assert.Equal("Eaten", key.Value);
         }
@@ -253,8 +261,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             var sidecar = new RelationshipsSnapshot(entry);
 
-            var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>(0).Create(
-                type, new[] { type.GetProperty("P2") }, sidecar);
+            var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>(type.GetPrimaryKey(), 0)
+                .Create(new[] { type.GetProperty("P2") }, sidecar);
 
             Assert.Equal(8, key.Value);
         }

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/SimpleEntityKeyTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/SimpleEntityKeyTest.cs
@@ -13,13 +13,13 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Value_property_is_strongly_typed()
         {
-            Assert.IsType<int>(new SimpleEntityKey<int>(new Mock<IEntityType>().Object, 77).Value);
+            Assert.IsType<int>(new SimpleEntityKey<int>(new Mock<IKey>().Object, 77).Value);
         }
 
         [Fact]
         public void Base_class_value_property_returns_same_as_strongly_typed_value_property()
         {
-            var key = new SimpleEntityKey<int>(new Mock<IEntityType>().Object, 77);
+            var key = new SimpleEntityKey<int>(new Mock<IKey>().Object, 77);
 
             Assert.Equal(77, key.Value);
             Assert.Equal(77, ((EntityKey)key).Value);
@@ -28,26 +28,26 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Only_keys_with_the_same_value_type_and_entity_type_test_as_equal()
         {
-            var type1 = new Mock<IEntityType>().Object;
-            var type2 = new Mock<IEntityType>().Object;
+            var key1 = new Mock<IKey>().Object;
+            var key2 = new Mock<IKey>().Object;
 
-            Assert.True(new SimpleEntityKey<int>(type1, 77).Equals(new SimpleEntityKey<int>(type1, 77)));
-            Assert.False(new SimpleEntityKey<int>(type1, 77).Equals(null));
-            Assert.False(new SimpleEntityKey<int>(type1, 77).Equals(new CompositeEntityKey(type1, new object[] { 77 })));
-            Assert.False(new SimpleEntityKey<int>(type1, 77).Equals(new SimpleEntityKey<int>(type1, 88)));
-            Assert.False(new SimpleEntityKey<int>(type1, 77).Equals(new SimpleEntityKey<long>(type1, 77)));
-            Assert.False(new SimpleEntityKey<int>(type1, 77).Equals(new SimpleEntityKey<int>(type2, 77)));
+            Assert.True(new SimpleEntityKey<int>(key1, 77).Equals(new SimpleEntityKey<int>(key1, 77)));
+            Assert.False(new SimpleEntityKey<int>(key1, 77).Equals(null));
+            Assert.False(new SimpleEntityKey<int>(key1, 77).Equals(new CompositeEntityKey(key1, new object[] { 77 })));
+            Assert.False(new SimpleEntityKey<int>(key1, 77).Equals(new SimpleEntityKey<int>(key1, 88)));
+            Assert.False(new SimpleEntityKey<int>(key1, 77).Equals(new SimpleEntityKey<long>(key1, 77)));
+            Assert.False(new SimpleEntityKey<int>(key1, 77).Equals(new SimpleEntityKey<int>(key2, 77)));
         }
 
         [Fact]
         public void Only_keys_with_the_same_value_and_type_return_same_hashcode()
         {
-            var type1 = new Mock<IEntityType>().Object;
-            var type2 = new Mock<IEntityType>().Object;
+            var key1 = new Mock<IKey>().Object;
+            var key2 = new Mock<IKey>().Object;
 
-            Assert.Equal(new SimpleEntityKey<int>(type1, 77).GetHashCode(), new SimpleEntityKey<int>(type1, 77).GetHashCode());
-            Assert.NotEqual(new SimpleEntityKey<int>(type1, 77).GetHashCode(), new SimpleEntityKey<int>(type1, 88).GetHashCode());
-            Assert.NotEqual(new SimpleEntityKey<int>(type1, 77).GetHashCode(), new SimpleEntityKey<int>(type2, 77).GetHashCode());
+            Assert.Equal(new SimpleEntityKey<int>(key1, 77).GetHashCode(), new SimpleEntityKey<int>(key1, 77).GetHashCode());
+            Assert.NotEqual(new SimpleEntityKey<int>(key1, 77).GetHashCode(), new SimpleEntityKey<int>(key1, 88).GetHashCode());
+            Assert.NotEqual(new SimpleEntityKey<int>(key1, 77).GetHashCode(), new SimpleEntityKey<int>(key2, 77).GetHashCode());
         }
     }
 }

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/SimpleNullableEntityKeyFactoryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/SimpleNullableEntityKeyFactoryTest.cs
@@ -21,7 +21,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entity = new Banana { P1 = 7 };
             var entry = stateManager.GetOrCreateEntry(entity);
 
-            var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>(0).Create(type, type.GetPrimaryKey().Properties, entry);
+            var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>(type.GetPrimaryKey(), 0)
+                .Create(type.GetPrimaryKey().Properties, entry);
 
             Assert.Equal(7, key.Value);
         }
@@ -36,7 +37,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entity = new Banana { P1 = 7, P2 = null };
             var entry = stateManager.GetOrCreateEntry(entity);
 
-            Assert.Equal(EntityKey.InvalidEntityKey, new SimpleEntityKeyFactory<int>(0).Create(type, new[] { type.GetProperty("P2") }, entry));
+            Assert.Equal(EntityKey.InvalidEntityKey, new SimpleEntityKeyFactory<int>(type.GetPrimaryKey(), 0)
+                .Create(new[] { type.GetProperty("P2") }, entry));
         }
 
         [Fact]
@@ -45,8 +47,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var model = BuildModel();
             var type = model.GetEntityType(typeof(Banana));
 
-            var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>(0).Create(
-                type, new[] { type.GetProperty("P2") }, new ValueBuffer(new object[] { 7, 77 }));
+            var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>(type.GetPrimaryKey(), 0)
+                .Create(new[] { type.GetProperty("P2") }, new ValueBuffer(new object[] { 7, 77 }));
 
             Assert.Equal(77, key.Value);
         }
@@ -59,8 +61,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             Assert.Equal(
                 EntityKey.InvalidEntityKey,
-                new SimpleEntityKeyFactory<int>(0).Create(
-                    type, new[] { type.GetProperty("P2") }, new ValueBuffer(new object[] { 7, null })));
+                new SimpleEntityKeyFactory<int>(type.GetPrimaryKey(), 0)
+                .Create(new[] { type.GetProperty("P2") }, new ValueBuffer(new object[] { 7, null })));
         }
 
         [Fact]
@@ -76,8 +78,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var sidecar = new RelationshipsSnapshot(entry);
             sidecar[type.GetProperty("P2")] = 78;
 
-            var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>(0).Create(
-                type, new[] { type.GetProperty("P2") }, sidecar);
+            var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>(type.GetPrimaryKey(), 0)
+                .Create(new[] { type.GetProperty("P2") }, sidecar);
 
             Assert.Equal(78, key.Value);
         }
@@ -94,8 +96,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             var sidecar = new RelationshipsSnapshot(entry);
 
-            var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>(0).Create(
-                type, new[] { type.GetProperty("P2") }, sidecar);
+            var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>(type.GetPrimaryKey(), 0)
+                .Create(new[] { type.GetProperty("P2") }, sidecar);
 
             Assert.Equal(77, key.Value);
         }


### PR DESCRIPTION
Changes the identity map to keep track of entities by any principal key, thereby allowing fast lookup of entities at the principal end of a relationship. Also, slight change to tracking of entries created for entities that are not yet tracked. These are now tracked as weak references so that in the case where an application is looping over many detached entities without actually tracking most of them the memory use will be bounded.