### PR TITLE
Allow to set Property.ClrType

### DIFF
--- a/src/EntityFramework.Core/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/NavigationFixer.cs
@@ -278,7 +278,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
                 }
             }
 
-            foreach (var foreignKey in _model.GetReferencingForeignKeys(entityType))
+            foreach (var foreignKey in _model.FindReferencingForeignKeys(entityType))
             {
                 var dependents = entry.StateManager.GetDependents(entry, foreignKey).ToArray();
                 if (dependents.Length > 0)

--- a/src/EntityFramework.Core/Internal/ModelForeignKeyUndirectedGraphAdapter.cs
+++ b/src/EntityFramework.Core/Internal/ModelForeignKeyUndirectedGraphAdapter.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Data.Entity.Internal
 
         public override IEnumerable<EntityType> GetOutgoingNeighbours(EntityType from)
             => @from.GetForeignKeys().Select(fk => fk.PrincipalEntityType)
-                .Union(_model.GetReferencingForeignKeys(@from).Select(fk => fk.DeclaringEntityType));
+                .Union(_model.FindReferencingForeignKeys(@from).Select(fk => fk.DeclaringEntityType));
 
         public override IEnumerable<EntityType> GetIncomingNeighbours(EntityType to)
             => GetOutgoingNeighbours(to);

--- a/src/EntityFramework.Core/Internal/ModelNavigationsGraphAdapter.cs
+++ b/src/EntityFramework.Core/Internal/ModelNavigationsGraphAdapter.cs
@@ -21,10 +21,10 @@ namespace Microsoft.Data.Entity.Internal
 
         public override IEnumerable<EntityType> GetOutgoingNeighbours(EntityType from)
             => @from.GetForeignKeys().Where(fk => fk.DependentToPrincipal != null).Select(fk => fk.PrincipalEntityType)
-                .Union(_model.GetReferencingForeignKeys(@from).Where(fk => fk.PrincipalToDependent != null).Select(fk => fk.DeclaringEntityType));
+                .Union(_model.FindReferencingForeignKeys(@from).Where(fk => fk.PrincipalToDependent != null).Select(fk => fk.DeclaringEntityType));
 
         public override IEnumerable<EntityType> GetIncomingNeighbours(EntityType to)
             => to.GetForeignKeys().Where(fk => fk.PrincipalToDependent != null).Select(fk => fk.PrincipalEntityType)
-                .Union(_model.GetReferencingForeignKeys(to).Where(fk => fk.DependentToPrincipal != null).Select(fk => fk.DeclaringEntityType));
+                .Union(_model.FindReferencingForeignKeys(to).Where(fk => fk.DependentToPrincipal != null).Select(fk => fk.DeclaringEntityType));
     }
 }

--- a/src/EntityFramework.Core/Metadata/Builders/EntityTypeBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Builders/EntityTypeBuilder.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Infrastructure;
@@ -132,11 +133,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         /// <param name="propertyName"> The name of the property to be configured. </param>
         /// <returns> An object that can be used to configure the property. </returns>
         public virtual PropertyBuilder<TProperty> Property<TProperty>([NotNull] string propertyName)
-        {
-            Check.NotEmpty(propertyName, nameof(propertyName));
-
-            return new PropertyBuilder<TProperty>(Builder.Property(typeof(TProperty), propertyName, ConfigurationSource.Explicit));
-        }
+            => new PropertyBuilder<TProperty>(PropertyBuilder(typeof(TProperty), propertyName));
 
         /// <summary>
         ///     <para>
@@ -155,12 +152,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         /// <param name="propertyName"> The name of the property to be configured. </param>
         /// <returns> An object that can be used to configure the property. </returns>
         public virtual PropertyBuilder Property([NotNull] Type propertyType, [NotNull] string propertyName)
-        {
-            Check.NotNull(propertyType, nameof(propertyType));
-            Check.NotEmpty(propertyName, nameof(propertyName));
-
-            return new PropertyBuilder(Builder.Property(propertyType, propertyName, ConfigurationSource.Explicit));
-        }
+            => new PropertyBuilder(PropertyBuilder(propertyType, propertyName));
 
         /// <summary>
         ///     Excludes the given property from the entity type. This method is typically used to remove properties
@@ -334,5 +326,16 @@ namespace Microsoft.Data.Entity.Metadata.Builders
                 navigationToDependentName: navigationName ?? "",
                 configurationSource: ConfigurationSource.Explicit,
                 isUnique: false);
+        
+        protected virtual InternalPropertyBuilder PropertyBuilder([NotNull] Type propertyType, string propertyName)
+        {
+            Check.NotNull(propertyType, nameof(propertyType));
+            Check.NotEmpty(propertyName, nameof(propertyName));
+
+            var builder = Builder.Property(propertyName, ConfigurationSource.Explicit);
+            var clrTypeSet = builder.ClrType(propertyType, ConfigurationSource.Explicit);
+            Debug.Assert(clrTypeSet);
+            return builder;
+        }
     }
 }

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/ConcurrencyCheckAttributeConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/ConcurrencyCheckAttributeConvention.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.ComponentModel.DataAnnotations;
+using System.Reflection;
 using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Utilities;
 
@@ -9,7 +10,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
 {
     public class ConcurrencyCheckAttributeConvention : PropertyAttributeConvention<ConcurrencyCheckAttribute>
     {
-        public override InternalPropertyBuilder Apply(InternalPropertyBuilder propertyBuilder, ConcurrencyCheckAttribute attribute)
+        public override InternalPropertyBuilder Apply(InternalPropertyBuilder propertyBuilder, ConcurrencyCheckAttribute attribute, PropertyInfo clrProperty)
         {
             Check.NotNull(propertyBuilder, nameof(propertyBuilder));
             Check.NotNull(attribute, nameof(attribute));

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/DatabaseGeneratedAttributeConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/DatabaseGeneratedAttributeConvention.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Reflection;
 using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Utilities;
 
@@ -9,7 +10,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
 {
     public class DatabaseGeneratedAttributeConvention : PropertyAttributeConvention<DatabaseGeneratedAttribute>
     {
-        public override InternalPropertyBuilder Apply(InternalPropertyBuilder propertyBuilder, DatabaseGeneratedAttribute attribute)
+        public override InternalPropertyBuilder Apply(InternalPropertyBuilder propertyBuilder, DatabaseGeneratedAttribute attribute, PropertyInfo clrProperty)
         {
             Check.NotNull(propertyBuilder, nameof(propertyBuilder));
             Check.NotNull(attribute, nameof(attribute));

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/EntityTypeAttributeConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/EntityTypeAttributeConvention.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/KeyAttributeConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/KeyAttributeConvention.cs
@@ -1,10 +1,11 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using System.Reflection;
 using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Utilities;
@@ -13,7 +14,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
 {
     public class KeyAttributeConvention : PropertyAttributeConvention<KeyAttribute>, IModelConvention
     {
-        public override InternalPropertyBuilder Apply(InternalPropertyBuilder propertyBuilder, KeyAttribute attribute)
+        public override InternalPropertyBuilder Apply(InternalPropertyBuilder propertyBuilder, KeyAttribute attribute, PropertyInfo clrProperty)
         {
             Check.NotNull(propertyBuilder, nameof(propertyBuilder));
             Check.NotNull(attribute, nameof(attribute));

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/MaxLengthAttributeConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/MaxLengthAttributeConvention.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.ComponentModel.DataAnnotations;
+using System.Reflection;
 using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Utilities;
 
@@ -9,7 +10,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
 {
     public class MaxLengthAttributeConvention : PropertyAttributeConvention<MaxLengthAttribute>
     {
-        public override InternalPropertyBuilder Apply(InternalPropertyBuilder propertyBuilder, MaxLengthAttribute attribute)
+        public override InternalPropertyBuilder Apply(InternalPropertyBuilder propertyBuilder, MaxLengthAttribute attribute, PropertyInfo clrProperty)
         {
             Check.NotNull(propertyBuilder, nameof(propertyBuilder));
             Check.NotNull(attribute, nameof(attribute));

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/NavigationAttributeNavigationConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/NavigationAttributeNavigationConvention.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/NotMappedEntityTypeAttributeConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/NotMappedEntityTypeAttributeConvention.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.ComponentModel.DataAnnotations.Schema;

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/NotMappedNavigationAttributeConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/NotMappedNavigationAttributeConvention.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.ComponentModel.DataAnnotations.Schema;

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/NotMappedPropertyAttributeConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/NotMappedPropertyAttributeConvention.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Reflection;
 using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Utilities;
 
@@ -9,7 +10,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
 {
     public class NotMappedPropertyAttributeConvention : PropertyAttributeConvention<NotMappedAttribute>
     {
-        public override InternalPropertyBuilder Apply(InternalPropertyBuilder propertyBuilder, NotMappedAttribute attribute)
+        public override InternalPropertyBuilder Apply(InternalPropertyBuilder propertyBuilder, NotMappedAttribute attribute, PropertyInfo clrProperty)
         {
             Check.NotNull(propertyBuilder, nameof(propertyBuilder));
             Check.NotNull(attribute, nameof(attribute));

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/PropertyAttributeConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/PropertyAttributeConvention.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -19,12 +19,13 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
             var clrType = propertyBuilder.Metadata.DeclaringEntityType.ClrType;
             var propertyName = propertyBuilder.Metadata.Name;
 
-            var attributes = clrType?.GetProperty(propertyName)?.GetCustomAttributes<TAttribute>(true);
+            var clrProperty = clrType?.GetProperty(propertyName);
+            var attributes = clrProperty?.GetCustomAttributes<TAttribute>(true);
             if (attributes != null)
             {
                 foreach (var attribute in attributes)
                 {
-                    propertyBuilder = Apply(propertyBuilder, attribute);
+                    propertyBuilder = Apply(propertyBuilder, attribute, clrProperty);
                     if (propertyBuilder == null)
                     {
                         break;
@@ -34,6 +35,6 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
             return propertyBuilder;
         }
 
-        public abstract InternalPropertyBuilder Apply([NotNull] InternalPropertyBuilder propertyBuilder, [NotNull] TAttribute attribute);
+        public abstract InternalPropertyBuilder Apply([NotNull] InternalPropertyBuilder propertyBuilder, [NotNull] TAttribute attribute, [NotNull] PropertyInfo clrProperty);
     }
 }

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/RequiredNavigationAttributeConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/RequiredNavigationAttributeConvention.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/RequiredPropertyAttributeConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/RequiredPropertyAttributeConvention.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.ComponentModel.DataAnnotations;
+using System.Reflection;
 using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Utilities;
 
@@ -9,7 +10,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
 {
     public class RequiredPropertyAttributeConvention : PropertyAttributeConvention<RequiredAttribute>
     {
-        public override InternalPropertyBuilder Apply(InternalPropertyBuilder propertyBuilder, RequiredAttribute attribute)
+        public override InternalPropertyBuilder Apply(InternalPropertyBuilder propertyBuilder, RequiredAttribute attribute, PropertyInfo clrProperty)
         {
             Check.NotNull(propertyBuilder, nameof(propertyBuilder));
             Check.NotNull(attribute, nameof(attribute));

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/StringLengthAttributeConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/StringLengthAttributeConvention.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.ComponentModel.DataAnnotations;
+using System.Reflection;
 using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Utilities;
 
@@ -9,7 +10,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
 {
     public class StringLengthAttributeConvention : PropertyAttributeConvention<StringLengthAttribute>
     {
-        public override InternalPropertyBuilder Apply(InternalPropertyBuilder propertyBuilder, StringLengthAttribute attribute)
+        public override InternalPropertyBuilder Apply(InternalPropertyBuilder propertyBuilder, StringLengthAttribute attribute, PropertyInfo clrProperty)
         {
             Check.NotNull(propertyBuilder, nameof(propertyBuilder));
             Check.NotNull(attribute, nameof(attribute));

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/TimestampAttributeConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/TimestampAttributeConvention.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.ComponentModel.DataAnnotations;
+using System.Reflection;
 using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Utilities;
@@ -11,16 +12,18 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
 {
     public class TimestampAttributeConvention : PropertyAttributeConvention<TimestampAttribute>
     {
-        public override InternalPropertyBuilder Apply(InternalPropertyBuilder propertyBuilder, TimestampAttribute attribute)
+        public override InternalPropertyBuilder Apply(InternalPropertyBuilder propertyBuilder, TimestampAttribute attribute, PropertyInfo clrProperty)
         {
             Check.NotNull(propertyBuilder, nameof(propertyBuilder));
             Check.NotNull(attribute, nameof(attribute));
+            Check.NotNull(clrProperty, nameof(clrProperty));
 
-            if (propertyBuilder.Metadata.ClrType != typeof(byte[]))
+            if (clrProperty.PropertyType != typeof(byte[]))
             {
                 throw new InvalidOperationException(Strings.TimestampAttributeOnNonBinary(propertyBuilder.Metadata.Name));
             }
 
+            propertyBuilder.ClrType(typeof(byte[]), ConfigurationSource.DataAnnotation);
             propertyBuilder.ValueGenerated(ValueGenerated.OnAddOrUpdate, ConfigurationSource.DataAnnotation);
             propertyBuilder.ConcurrencyToken(true, ConfigurationSource.DataAnnotation);
 

--- a/src/EntityFramework.Core/Metadata/EntityTypeExtensions.cs
+++ b/src/EntityFramework.Core/Metadata/EntityTypeExtensions.cs
@@ -195,7 +195,7 @@ namespace Microsoft.Data.Entity.Metadata
         {
             Check.NotNull(entityType, nameof(entityType));
 
-            return entityType.Model.GetReferencingForeignKeys(entityType);
+            return entityType.Model.FindReferencingForeignKeys(entityType);
         }
 
         public static bool HasPropertyChangingNotifications([NotNull] this IEntityType entityType)

--- a/src/EntityFramework.Core/Metadata/ForeignKey.cs
+++ b/src/EntityFramework.Core/Metadata/ForeignKey.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Data.Entity.Metadata
                 if (value.HasValue
                     && !value.Value)
                 {
-                    var nullableTypeProperties = Properties.Where(p => p.ClrType.IsNullableType()).ToList();
+                    var nullableTypeProperties = Properties.Where(p => ((IProperty)p).ClrType.IsNullableType()).ToList();
                     if (nullableTypeProperties.Any())
                     {
                         properties = nullableTypeProperties;

--- a/src/EntityFramework.Core/Metadata/IModel.cs
+++ b/src/EntityFramework.Core/Metadata/IModel.cs
@@ -19,11 +19,5 @@ namespace Microsoft.Data.Entity.Metadata
         IEntityType FindEntityType([NotNull] string name);
 
         IEntityType GetEntityType([NotNull] string name);
-
-        IEnumerable<IForeignKey> GetReferencingForeignKeys([NotNull] IEntityType entityType);
-
-        IEnumerable<IForeignKey> GetReferencingForeignKeys([NotNull] IKey key);
-
-        IEnumerable<IForeignKey> GetReferencingForeignKeys([NotNull] IProperty property);
     }
 }

--- a/src/EntityFramework.Core/Metadata/Internal/InternalModelBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/InternalModelBuilder.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 Debug.Assert(removed.HasValue);
             }
 
-            foreach (var foreignKey in Metadata.GetReferencingForeignKeys(entityType).ToList())
+            foreach (var foreignKey in Metadata.FindReferencingForeignKeys(entityType).ToList())
             {
                 var removed = entityTypeBuilder.RemoveRelationship(foreignKey, configurationSource);
                 Debug.Assert(removed.HasValue);

--- a/src/EntityFramework.Core/Metadata/Internal/InternalPropertyBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/InternalPropertyBuilder.cs
@@ -1,26 +1,24 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using JetBrains.Annotations;
 
 namespace Microsoft.Data.Entity.Metadata.Internal
 {
     public class InternalPropertyBuilder : InternalMetadataItemBuilder<Property>
     {
+        private ConfigurationSource? _clrTypeConfigurationSource;
         private ConfigurationSource? _isRequiredConfigurationSource;
-        private ConfigurationSource? _maxLengthConfigurationSource;
         private ConfigurationSource? _isConcurrencyTokenConfigurationSource;
-        private ConfigurationSource _isShadowPropertyConfigurationSource;
+        private ConfigurationSource? _isShadowPropertyConfigurationSource;
+        private ConfigurationSource? _maxLengthConfigurationSource;
         private ConfigurationSource? _requiresValueGeneratorConfigurationSource;
         private ConfigurationSource? _valueGeneratedConfigurationSource;
 
-        public InternalPropertyBuilder(
-            [NotNull] Property property,
-            [NotNull] InternalModelBuilder modelBuilder,
-            ConfigurationSource configurationSource)
+        public InternalPropertyBuilder([NotNull] Property property, [NotNull] InternalModelBuilder modelBuilder)
             : base(property, modelBuilder)
         {
-            _isShadowPropertyConfigurationSource = configurationSource;
         }
 
         public virtual bool Required(bool? isRequired, ConfigurationSource configurationSource)
@@ -92,14 +90,44 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             return false;
         }
 
-        public virtual bool Shadow(bool isShadowProperty, ConfigurationSource configurationSource)
+        public virtual bool Shadow(bool? isShadowProperty, ConfigurationSource configurationSource)
         {
-            if (configurationSource.CanSet(_isShadowPropertyConfigurationSource, true)
+            if (configurationSource.CanSet(_isShadowPropertyConfigurationSource, Metadata.IsShadowProperty.HasValue)
                 || Metadata.IsShadowProperty == isShadowProperty)
             {
-                _isShadowPropertyConfigurationSource = configurationSource.Max(_isShadowPropertyConfigurationSource);
+                if (_isShadowPropertyConfigurationSource == null
+                    && Metadata.IsShadowProperty != null)
+                {
+                    _isShadowPropertyConfigurationSource = ConfigurationSource.Explicit;
+                }
+                else
+                {
+                    _isShadowPropertyConfigurationSource = configurationSource.Max(_isShadowPropertyConfigurationSource);
+                }
 
                 Metadata.IsShadowProperty = isShadowProperty;
+                return true;
+            }
+
+            return false;
+        }
+
+        public virtual bool ClrType([CanBeNull] Type propertyType, ConfigurationSource configurationSource)
+        {
+            if (configurationSource.CanSet(_clrTypeConfigurationSource, Metadata.ClrType != null)
+                || Metadata.ClrType == propertyType)
+            {
+                if (_clrTypeConfigurationSource == null
+                    && Metadata.ClrType != null)
+                {
+                    _clrTypeConfigurationSource = ConfigurationSource.Explicit;
+                }
+                else
+                {
+                    _clrTypeConfigurationSource = configurationSource.Max(_clrTypeConfigurationSource);
+                }
+
+                Metadata.ClrType = propertyType;
                 return true;
             }
 

--- a/src/EntityFramework.Core/Metadata/Internal/InternalRelationshipBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/InternalRelationshipBuilder.cs
@@ -258,7 +258,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             return newForeignKey;
         }
 
-        public virtual bool CanSetForeignKey([NotNull] IReadOnlyList<Property> properties, ConfigurationSource configurationSource)
+        public virtual bool CanSetForeignKey([NotNull] IReadOnlyList<IProperty> properties, ConfigurationSource configurationSource)
         {
             if (_foreignKeyPropertiesConfigurationSource.HasValue
                 && !configurationSource.Overrides(_foreignKeyPropertiesConfigurationSource.Value))
@@ -286,7 +286,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
         public virtual bool CanSetRequired(bool isRequired, ConfigurationSource configurationSource)
             => CanSetRequired(Metadata.Properties, isRequired, configurationSource);
 
-        private bool CanSetRequired([NotNull] IReadOnlyList<Property> properties, bool isRequired, ConfigurationSource configurationSource)
+        private bool CanSetRequired([NotNull] IReadOnlyList<IProperty> properties, bool isRequired, ConfigurationSource configurationSource)
         {
             var nullableProperties = properties.Where(p => p.ClrType.IsNullableType()).ToList();
             if (!nullableProperties.Any()
@@ -299,11 +299,11 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             return isRequired
                 ? nullableProperties.All(property =>
                     ModelBuilder.Entity(property.DeclaringEntityType.Name, ConfigurationSource.Convention)
-                        .Property(property.ClrType, property.Name, ConfigurationSource.Convention)
+                        .Property(property.Name, ConfigurationSource.Convention)
                         .CanSetRequired(true, configurationSource))
                 : nullableProperties.Any(property =>
                     ModelBuilder.Entity(property.DeclaringEntityType.Name, ConfigurationSource.Convention)
-                        .Property(property.ClrType, property.Name, ConfigurationSource.Convention)
+                        .Property(property.Name, ConfigurationSource.Convention)
                         .CanSetRequired(false, configurationSource));
         }
 

--- a/src/EntityFramework.Core/Metadata/Model.cs
+++ b/src/EntityFramework.Core/Metadata/Model.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Data.Entity.Metadata
         {
             Check.NotNull(entityType, nameof(entityType));
 
-            if (GetReferencingForeignKeys(entityType).Any())
+            if (FindReferencingForeignKeys(entityType).Any())
             {
                 throw new InvalidOperationException(Strings.EntityTypeInUse(entityType.Name));
             }
@@ -121,37 +121,14 @@ namespace Microsoft.Data.Entity.Metadata
 
         public virtual IReadOnlyList<EntityType> EntityTypes => _entities;
 
-        public virtual IReadOnlyList<ForeignKey> GetReferencingForeignKeys([NotNull] IEntityType entityType)
-        {
-            Check.NotNull(entityType, nameof(entityType));
+        public virtual IEnumerable<ForeignKey> FindReferencingForeignKeys([NotNull] EntityType entityType)
+            => ((IModel)this).FindReferencingForeignKeys(entityType).Cast<ForeignKey>();
 
-            // TODO: Perf: Add additional indexes so that this isn't a linear lookup
-            // Issue #1179
-            return EntityTypes.SelectMany(et => et.GetForeignKeys())
-                .Where(fk => fk.PrincipalEntityType.IsAssignableFrom(entityType))
-                .ToList();
-        }
+        public virtual IEnumerable<ForeignKey> FindReferencingForeignKeys([NotNull] Key key)
+            => ((IModel)this).FindReferencingForeignKeys(key).Cast<ForeignKey>();
 
-        public virtual IReadOnlyList<ForeignKey> GetReferencingForeignKeys([NotNull] IKey key)
-        {
-            Check.NotNull(key, nameof(key));
-
-            // TODO: Perf: Add additional indexes so that this isn't a linear lookup
-            // Issue #1179
-            return EntityTypes.SelectMany(e => e.GetForeignKeys()).Where(fk => fk.PrincipalKey == key).ToList();
-        }
-
-        public virtual IReadOnlyList<ForeignKey> GetReferencingForeignKeys([NotNull] IProperty property)
-        {
-            Check.NotNull(property, nameof(property));
-
-            // TODO: Perf: Add additional indexes so that this isn't a linear lookup
-            // Issue #1179
-            return EntityTypes
-                .SelectMany(e => e.GetForeignKeys()
-                    .Where(f => f.PrincipalKey.Properties.Contains(property)))
-                .ToList();
-        }
+        public virtual IEnumerable<ForeignKey> FindReferencingForeignKeys([NotNull] Property property)
+            => ((IModel)this).FindReferencingForeignKeys(property).Cast<ForeignKey>();
 
         public virtual string StorageName { get; [param: CanBeNull] set; }
 
@@ -164,14 +141,5 @@ namespace Microsoft.Data.Entity.Metadata
         IEntityType IModel.GetEntityType(string name) => GetEntityType(name);
 
         IReadOnlyList<IEntityType> IModel.EntityTypes => EntityTypes;
-
-        IEnumerable<IForeignKey> IModel.GetReferencingForeignKeys(IEntityType entityType)
-            => GetReferencingForeignKeys(entityType);
-
-        IEnumerable<IForeignKey> IModel.GetReferencingForeignKeys(IKey key)
-            => GetReferencingForeignKeys(key);
-
-        IEnumerable<IForeignKey> IModel.GetReferencingForeignKeys(IProperty property)
-            => GetReferencingForeignKeys(property);
     }
 }

--- a/src/EntityFramework.Core/Metadata/ModelExtensions.cs
+++ b/src/EntityFramework.Core/Metadata/ModelExtensions.cs
@@ -10,19 +10,61 @@ namespace Microsoft.Data.Entity.Metadata
 {
     public static class ModelExtensions
     {
-        // TODO: Perf: consider not needing to do a full scan here
         public static IEnumerable<INavigation> GetNavigations(
             [NotNull] this IModel model, [NotNull] IForeignKey foreignKey)
-            => model.EntityTypes.SelectMany(e => e.GetNavigations()).Where(n => n.ForeignKey == foreignKey);
+        {
+            Check.NotNull(model, nameof(model));
+
+            // TODO: Perf: consider not needing to do a full scan here
+            return model.EntityTypes.SelectMany(e => e.GetNavigations()).Where(n => n.ForeignKey == foreignKey);
+        }
 
         public static string GetProductVersion([NotNull] this IModel model)
-            => model[CoreAnnotationNames.ProductVersionAnnotation] as string;
+        {
+            Check.NotNull(model, nameof(model));
+
+            return model[CoreAnnotationNames.ProductVersionAnnotation] as string;
+        }
 
         public static void SetProductVersion([NotNull] this Model model, [NotNull] string value)
         {
+            Check.NotNull(model, nameof(model));
             Check.NotEmpty(value, nameof(value));
 
             model[CoreAnnotationNames.ProductVersionAnnotation] = value;
+        }
+        
+        public static IEnumerable<IForeignKey> FindReferencingForeignKeys([NotNull] this IModel model, [NotNull] IEntityType entityType)
+        {
+            Check.NotNull(model, nameof(model));
+            Check.NotNull(entityType, nameof(entityType));
+
+            // TODO: Perf: Add additional indexes so that this isn't a linear lookup
+            // Issue #1179
+            return model.EntityTypes.SelectMany(et => et.GetDeclaredForeignKeys())
+                .Where(fk => fk.PrincipalEntityType.IsAssignableFrom(entityType));
+        }
+
+        public static IEnumerable<IForeignKey> FindReferencingForeignKeys([NotNull] this IModel model, [NotNull] IKey key)
+        {
+            Check.NotNull(model, nameof(model));
+            Check.NotNull(key, nameof(key));
+
+            // TODO: Perf: Add additional indexes so that this isn't a linear lookup
+            // Issue #1179
+            return model.EntityTypes.SelectMany(e => e.GetDeclaredForeignKeys()).Where(fk => fk.PrincipalKey == key);
+        }
+
+        public static IEnumerable<IForeignKey> FindReferencingForeignKeys([NotNull] this IModel model, [NotNull] IProperty property)
+        {
+            Check.NotNull(model, nameof(model));
+            Check.NotNull(property, nameof(property));
+
+            // TODO: Perf: Add additional indexes so that this isn't a linear lookup
+            // Issue #1179
+            return model.EntityTypes
+                .SelectMany(e => e.GetDeclaredForeignKeys()
+                    .Where(f => f.PrincipalKey.Properties.Contains(property)));
         }
     }
 }

--- a/src/EntityFramework.Core/Metadata/PropertyExtensions.cs
+++ b/src/EntityFramework.Core/Metadata/PropertyExtensions.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Data.Entity.Metadata
             Check.NotNull(property, nameof(property));
 
             if (index < 0
-                || !property.IsShadowProperty)
+                || !((IProperty)property).IsShadowProperty)
             {
                 throw new ArgumentOutOfRangeException(nameof(index));
             }
@@ -83,19 +83,13 @@ namespace Microsoft.Data.Entity.Metadata
         }
 
         public static bool IsForeignKey([NotNull] this IProperty property, [NotNull] IEntityType entityType)
-        {
-            return FindContainingForeignKeys(property, entityType).Any();
-        }
+            => FindContainingForeignKeys(property, entityType).Any();
 
         public static bool IsPrimaryKey([NotNull] this IProperty property)
-        {
-            return FindContainingPrimaryKey(property) != null;
-        }
+            => FindContainingPrimaryKey(property) != null;
 
         public static bool IsKey([NotNull] this IProperty property)
-        {
-            return FindContainingKeys(property).Any();
-        }
+            => FindContainingKeys(property).Any();
 
         public static bool IsSentinelValue([NotNull] this IProperty property, [CanBeNull] object value)
         {
@@ -129,9 +123,7 @@ namespace Microsoft.Data.Entity.Metadata
         }
 
         public static IEnumerable<ForeignKey> FindContainingForeignKeys([NotNull] this Property property, [NotNull] EntityType entityType)
-        {
-            return ((IProperty)property).FindContainingForeignKeys(entityType).Cast<ForeignKey>();
-        }
+            => ((IProperty)property).FindContainingForeignKeys(entityType).Cast<ForeignKey>();
 
         public static IKey FindContainingPrimaryKey([NotNull] this IProperty property)
         {
@@ -149,9 +141,7 @@ namespace Microsoft.Data.Entity.Metadata
         }
 
         public static Key FindContainingPrimaryKey([NotNull] this Property property)
-        {
-            return (Key)((IProperty)property).FindContainingPrimaryKey();
-        }
+            => (Key)((IProperty)property).FindContainingPrimaryKey();
 
         public static IEnumerable<IKey> FindContainingKeys([NotNull] this IProperty property)
         {
@@ -160,11 +150,15 @@ namespace Microsoft.Data.Entity.Metadata
             // TODO: Perf: make it fast to check if a property is part of a key
             return property.DeclaringEntityType.GetKeys().Where(e => e.Properties.Contains(property));
         }
+        
+        public static IEnumerable<IForeignKey> FindReferencingForeignKeys([NotNull] this IProperty property)
+            => property.DeclaringEntityType.Model.FindReferencingForeignKeys(property);
+        
+        public static IEnumerable<ForeignKey> FindReferencingForeignKeys([NotNull] this Property property)
+            => property.DeclaringEntityType.Model.FindReferencingForeignKeys(property);
 
         public static IEnumerable<Key> FindContainingKeys([NotNull] this Property property)
-        {
-            return ((IProperty)property).FindContainingKeys().Cast<Key>();
-        }
+            => ((IProperty)property).FindContainingKeys().Cast<Key>();
 
         public static IProperty GetGenerationProperty([NotNull] this IProperty property)
         {

--- a/src/EntityFramework.Core/Properties/Strings.Designer.cs
+++ b/src/EntityFramework.Core/Properties/Strings.Designer.cs
@@ -285,11 +285,11 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
-        /// The '{propertyName}' on entity type '{entityType}' does not have a value set and no value generator is available for properties of type '{propertyType}'. Either set a value for the property before adding the entity or configure a value generator for properties of type '{propertyType}'.
+        /// The '{property}' on entity type '{entityType}' does not have a value set and no value generator is available for properties of type '{propertyType}'. Either set a value for the property before adding the entity or configure a value generator for properties of type '{propertyType}'.
         /// </summary>
-        public static string NoValueGenerator([CanBeNull] object propertyName, [CanBeNull] object entityType, [CanBeNull] object propertyType)
+        public static string NoValueGenerator([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object propertyType)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("NoValueGenerator", "propertyName", "entityType", "propertyType"), propertyName, entityType, propertyType);
+            return string.Format(CultureInfo.CurrentCulture, GetString("NoValueGenerator", "property", "entityType", "propertyType"), property, entityType, propertyType);
         }
 
         /// <summary>
@@ -949,11 +949,11 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
-        /// Property '{propertyName}' on entity type '{entityType}' is of type '{actualType}' but the generic type provided is of type '{genericType}'.
+        /// Property '{property}' on entity type '{entityType}' is of type '{actualType}' but the generic type provided is of type '{genericType}'.
         /// </summary>
-        public static string WrongGenericPropertyType([CanBeNull] object propertyName, [CanBeNull] object entityType, [CanBeNull] object actualType, [CanBeNull] object genericType)
+        public static string WrongGenericPropertyType([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object actualType, [CanBeNull] object genericType)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("WrongGenericPropertyType", "propertyName", "entityType", "actualType", "genericType"), propertyName, entityType, actualType, genericType);
+            return string.Format(CultureInfo.CurrentCulture, GetString("WrongGenericPropertyType", "property", "entityType", "actualType", "genericType"), property, entityType, actualType, genericType);
         }
 
         /// <summary>
@@ -1106,6 +1106,14 @@ namespace Microsoft.Data.Entity.Internal
         public static string PropertyWrongEntityClrType([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object clrType)
         {
             return string.Format(CultureInfo.CurrentCulture, GetString("PropertyWrongEntityClrType", "property", "entityType", "clrType"), property, entityType, clrType);
+        }
+
+        /// <summary>
+        /// The CLR type for property '{property}' cannot be changed because it is referenced by the foreign key {foreignKey} from entity type '{entityType}'.
+        /// </summary>
+        public static string PropertyClrTypeCannotBeChangedWhenReferenced([CanBeNull] object property, [CanBeNull] object foreignKey, [CanBeNull] object entityType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("PropertyClrTypeCannotBeChangedWhenReferenced", "property", "foreignKey", "entityType"), property, foreignKey, entityType);
         }
 
         /// <summary>

--- a/src/EntityFramework.Core/Properties/Strings.resx
+++ b/src/EntityFramework.Core/Properties/Strings.resx
@@ -220,7 +220,7 @@
     <value>Multiple potential primary key properties named '{property}' but differing only by case were found on entity type '{entityType}'. Configure the primary key explicitly using the SetKey fluent API.</value>
   </data>
   <data name="NoValueGenerator" xml:space="preserve">
-    <value>The '{propertyName}' on entity type '{entityType}' does not have a value set and no value generator is available for properties of type '{propertyType}'. Either set a value for the property before adding the entity or configure a value generator for properties of type '{propertyType}'.</value>
+    <value>The '{property}' on entity type '{entityType}' does not have a value set and no value generator is available for properties of type '{propertyType}'. Either set a value for the property before adding the entity or configure a value generator for properties of type '{propertyType}'.</value>
   </data>
   <data name="TempValuePersists" xml:space="preserve">
     <value>The property '{property}' on entity type '{entityType}' has a temporary value while attempting to change the entity's state to '{state}'. Either set a permanent value explicitly or ensure that the database is configured to generate values for this property.</value>
@@ -469,7 +469,7 @@
     <value>{debug} level logging is enabled. At this level, Entity Framework will log sensitive application data such as SQL parameter values. To hide this information configure {minimumLevel} to {recommendedLevel}</value>
   </data>
   <data name="WrongGenericPropertyType" xml:space="preserve">
-    <value>Property '{propertyName}' on entity type '{entityType}' is of type '{actualType}' but the generic type provided is of type '{genericType}'.</value>
+    <value>Property '{property}' on entity type '{entityType}' is of type '{actualType}' but the generic type provided is of type '{genericType}'.</value>
   </data>
   <data name="NonGenericOptions" xml:space="preserve">
     <value>The DbContextOptions object registered in the service provider must be a DbContextOptions&lt;TContext&gt; where TContext is the type of the DbContext being used.</value>
@@ -527,6 +527,9 @@
   </data>
   <data name="PropertyWrongEntityClrType" xml:space="preserve">
     <value>CLR property '{property}' cannot be added to entity type '{entityType}' because it is declared on the CLR type '{clrType}'.</value>
+  </data>
+  <data name="PropertyClrTypeCannotBeChangedWhenReferenced" xml:space="preserve">
+    <value>The CLR type for property '{property}' cannot be changed because it is referenced by the foreign key {foreignKey} from entity type '{entityType}'.</value>
   </data>
   <data name="InvalidNavigationWithInverseProperty" xml:space="preserve">
     <value>The InversePropertyAttribute on property '{property}' on type '{entityType}' is not valid. The property '{referencedProperty}' is not a valid navigation property on the related type '{referencedEntityType}'. Ensure that the property exists and is a valid reference or collection navigation property.</value>

--- a/src/EntityFramework.Relational.Design/ReverseEngineering/ReverseEngineeringMetadataModelProvider.cs
+++ b/src/EntityFramework.Relational.Design/ReverseEngineering/ReverseEngineeringMetadataModelProvider.cs
@@ -153,8 +153,7 @@ namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering
                 {
                     var codeGenProperty = codeGenEntityType.AddProperty(
                         nameMapper.PropertyToPropertyNameMap[relationalProperty],
-                        relationalProperty.ClrType,
-                        shadowProperty: true);
+                        ((IProperty)relationalProperty).ClrType);
                     _relationalToCodeGenPropertyMap[relationalProperty] = codeGenProperty;
                     CopyPropertyFacets(relationalProperty, codeGenProperty);
                 }

--- a/src/EntityFramework.Relational/Metadata/Conventions/Internal/RelationalColumnAttributeConvention.cs
+++ b/src/EntityFramework.Relational/Metadata/Conventions/Internal/RelationalColumnAttributeConvention.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Reflection;
 using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Utilities;
 
@@ -9,7 +10,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
 {
     public class RelationalColumnAttributeConvention : PropertyAttributeConvention<ColumnAttribute>
     {
-        public override InternalPropertyBuilder Apply(InternalPropertyBuilder propertyBuilder, ColumnAttribute attribute)
+        public override InternalPropertyBuilder Apply(InternalPropertyBuilder propertyBuilder, ColumnAttribute attribute, PropertyInfo clrProperty)
         {
             Check.NotNull(propertyBuilder, nameof(propertyBuilder));
             Check.NotNull(attribute, nameof(attribute));

--- a/src/EntityFramework.SqlServer.Design/ReverseEngineering/SqlServerMetadataModelProvider.cs
+++ b/src/EntityFramework.SqlServer.Design/ReverseEngineering/SqlServerMetadataModelProvider.cs
@@ -212,9 +212,8 @@ namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering
                         Strings.CannotFindTableForColumn(tc.Id, tc.TableId));
                     continue;
                 }
-
-                // IModel will not allow Properties to be created without a Type, so map to CLR type here.
-                // This means if we come across a column with a SQL Server type which we can't map we will ignore it.
+                
+                // If we come across a column with a SQL Server type which we can't map we will ignore it.
                 // Note: foreign key properties appear just like any other property in the relational model.
                 Type clrPropertyType;
                 if (!SqlServerTypeMapping._sqlTypeToClrTypeMap.TryGetValue(tc.DataType, out clrPropertyType))
@@ -229,7 +228,7 @@ namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering
                     clrPropertyType = clrPropertyType.MakeNullable();
                 }
 
-                var property = entityType.AddProperty(tc.Id, clrPropertyType, shadowProperty: true);
+                var property = entityType.AddProperty(tc.Id, clrPropertyType);
                 property.Relational().ColumnName = _tableColumns[tc.Id].ColumnName;
                 _columnIdToProperty[tc.Id] = property;
                 AddFacetsOnProperty(property, _tableColumns[tc.Id]);
@@ -412,7 +411,7 @@ namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering
                 var defaultExpressionOrValue =
                     _sqlServerLiteralUtilities
                         .ConvertSqlServerDefaultValue(
-                            property.ClrType, tableColumn.DefaultValue);
+                            ((IProperty)property).ClrType, tableColumn.DefaultValue);
                 if (defaultExpressionOrValue != null
                     && defaultExpressionOrValue.DefaultExpression != null)
                 {
@@ -428,7 +427,7 @@ namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering
                     Logger.LogWarning(
                         Strings.UnableToConvertDefaultValue(
                             tableColumn.Id, tableColumn.DefaultValue,
-                            property.ClrType, property.Name, property.DeclaringEntityType.Name));
+                            ((IProperty)property).ClrType, property.Name, property.DeclaringEntityType.Name));
                 }
             }
         }

--- a/test/EntityFramework.Core.FunctionalTests/GraphUpdatesTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/GraphUpdatesTestBase.cs
@@ -8,6 +8,7 @@ using System.Linq.Expressions;
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Internal;
+using Microsoft.Data.Entity.Metadata;
 using Xunit;
 
 namespace Microsoft.Data.Entity.FunctionalTests
@@ -2485,7 +2486,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             protected static void SetSentinelValues(ModelBuilder modelBuilder, int intSentinel)
             {
                 foreach (var property in modelBuilder.Model.EntityTypes.SelectMany(e => e.Properties)
-                    .Where(p => p.ClrType == typeof(int) || p.ClrType == typeof(int?)))
+                    .Where(p => ((IProperty)p).ClrType == typeof(int) || ((IProperty)p).ClrType == typeof(int?)))
                 {
                     property.SentinelValue = intSentinel;
                 }
@@ -2493,7 +2494,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 var sentinelGuid = new Guid("{71334AF2-51DE-4015-9CC1-10CE02D151BB}");
 
                 foreach (var property in modelBuilder.Model.EntityTypes.SelectMany(e => e.Properties)
-                    .Where(p => p.ClrType == typeof(Guid) || p.ClrType == typeof(Guid?)))
+                    .Where(p => ((IProperty)p).ClrType == typeof(Guid) || ((IProperty)p).ClrType == typeof(Guid?)))
                 {
                     property.SentinelValue = sentinelGuid;
                 }

--- a/test/EntityFramework.Core.FunctionalTests/InheritanceFixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/InheritanceFixtureBase.cs
@@ -1,7 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.Data.Entity.FunctionalTests.TestModels.Inheritance;
+using Microsoft.Data.Entity.Metadata;
 
 namespace Microsoft.Data.Entity.FunctionalTests
 {
@@ -15,46 +17,61 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
             var country = model.AddEntityType(typeof(Country));
             var countryIdProperty = country.AddProperty("Id", typeof(int));
+            countryIdProperty.IsShadowProperty = false;
             countryIdProperty.RequiresValueGenerator = true;
             var countryKey = country.SetPrimaryKey(countryIdProperty);
-            country.AddProperty("Name", typeof(string));
+            var property1 = country.AddProperty("Name", typeof(string));
+            property1.IsShadowProperty = false;
 
             var animal = model.AddEntityType(typeof(Animal));
             var animalSpeciesProperty = animal.AddProperty("Species", typeof(string));
+            animalSpeciesProperty.IsShadowProperty = false;
             animalSpeciesProperty.RequiresValueGenerator = true;
             var animalKey = animal.SetPrimaryKey(animalSpeciesProperty);
-            animal.AddProperty("Name", typeof(string));
-            var countryFk = animal.AddForeignKey(animal.AddProperty("CountryId", typeof(int)), countryKey, country);
+            var property3 = animal.AddProperty("Name", typeof(string));
+            property3.IsShadowProperty = false;
+            var property4 = animal.AddProperty("CountryId", typeof(int));
+            property4.IsShadowProperty = false;
+            var countryFk = animal.AddForeignKey(property4, countryKey, country);
 
             var bird = model.AddEntityType(typeof(Bird));
             bird.BaseType = animal;
-            bird.AddProperty("IsFlightless", typeof(bool));
+            var property5 = bird.AddProperty("IsFlightless", typeof(bool));
+            property5.IsShadowProperty = false;
 
             var kiwi = model.AddEntityType(typeof(Kiwi));
             kiwi.BaseType = bird;
-            kiwi.AddProperty("FoundOn", typeof(Island));
+            var property6 = kiwi.AddProperty("FoundOn", typeof(Island));
+            property6.IsShadowProperty = false;
 
             var eagle = model.AddEntityType(typeof(Eagle));
             eagle.BaseType = bird;
-            eagle.AddProperty("Group", typeof(EagleGroup));
+            var property7 = eagle.AddProperty("Group", typeof(EagleGroup));
+            property7.IsShadowProperty = false;
 
             var plant = model.AddEntityType(typeof(Plant));
-            var plantSpeciesProperty = plant.AddProperty("Species", typeof(string));
+            var property8 = plant.AddProperty("Species", typeof(string));
+            property8.IsShadowProperty = false;
+            var plantSpeciesProperty = property8;
             plantSpeciesProperty.RequiresValueGenerator = true;
-            var plantKey = plant.SetPrimaryKey(plantSpeciesProperty);
-            plant.AddProperty("Name", typeof(string));
+            plant.SetPrimaryKey(plantSpeciesProperty);
+            var property9 = plant.AddProperty("Name", typeof(string));
+            property9.IsShadowProperty = false;
 
             var flower = model.AddEntityType(typeof(Flower));
             flower.BaseType = plant;
 
             var rose = model.AddEntityType(typeof(Rose));
             rose.BaseType = flower;
-            rose.AddProperty("HasThorns", typeof(bool));
+            var property10 = rose.AddProperty("HasThorns", typeof(bool));
+            property10.IsShadowProperty = false;
 
             var daisy = model.AddEntityType(typeof(Daisy));
             daisy.BaseType = flower;
 
-            var eagleFk = bird.AddForeignKey(bird.AddProperty("EagleId", typeof(string)), animalKey, eagle);
+            var property11 = bird.AddProperty("EagleId", typeof(string));
+            property11.IsShadowProperty = false;
+            var eagleFk = bird.AddForeignKey(property11, animalKey, eagle);
 
             country.AddNavigation("Animals", countryFk, false);
             eagle.AddNavigation("Prey", eagleFk, false);

--- a/test/EntityFramework.Core.FunctionalTests/TestUtilities/Extensions.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestUtilities/Extensions.cs
@@ -81,7 +81,9 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             foreach (var property in sourceEntityType.GetDeclaredProperties())
             {
-                var clonedProperty = targetEntityType.AddProperty(property.Name, property.ClrType, property.IsShadowProperty);
+                var clonedProperty = targetEntityType.AddProperty(property.Name);
+                clonedProperty.ClrType = property.ClrType;
+                clonedProperty.IsShadowProperty = property.IsShadowProperty;
                 clonedProperty.IsNullable = property.IsNullable;
                 clonedProperty.IsConcurrencyToken = property.IsConcurrencyToken;
                 clonedProperty.RequiresValueGenerator = property.RequiresValueGenerator;

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/CompositeEntityKeyFactoryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/CompositeEntityKeyFactoryTest.cs
@@ -205,23 +205,29 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var model = new Model();
 
             var entityType = model.AddEntityType(typeof(Banana));
-            var property1 = entityType.GetOrAddProperty("P1", typeof(int));
-            var property2 = entityType.GetOrAddProperty("P2", typeof(string));
-            var property3 = entityType.GetOrAddProperty("P3", typeof(Random));
-            var property4 = entityType.GetOrAddProperty("P4", typeof(int));
-            var property5 = entityType.GetOrAddProperty("P5", typeof(string));
-            var property6 = entityType.GetOrAddProperty("P6", typeof(Random));
+            var property1 = entityType.AddProperty("P1", typeof(int));
+            property1.IsShadowProperty = false;
+            var property2 = entityType.AddProperty("P2", typeof(string));
+            property2.IsShadowProperty = false;
+            var property3 = entityType.AddProperty("P3", typeof(Random));
+            property3.IsShadowProperty = false;
+            var property4 = entityType.AddProperty("P4", typeof(int));
+            property4.IsShadowProperty = false;
+            var property5 = entityType.AddProperty("P5", typeof(string));
+            property5.IsShadowProperty = false;
+            var property6 = entityType.AddProperty("P6", typeof(Random));
+            property6.IsShadowProperty = false;
 
             entityType.GetOrSetPrimaryKey(new[] { property1, property2, property3 });
             entityType.GetOrAddForeignKey(new[] { property4, property5, property6 }, entityType.GetPrimaryKey(), entityType);
 
             entityType = model.AddEntityType(typeof(SentinelBanana));
-            property1 = entityType.GetOrAddProperty("P1", typeof(int));
-            property2 = entityType.GetOrAddProperty("P2", typeof(string));
-            property3 = entityType.GetOrAddProperty("P3", typeof(Random));
-            property4 = entityType.GetOrAddProperty("P4", typeof(int));
-            property5 = entityType.GetOrAddProperty("P5", typeof(string));
-            property6 = entityType.GetOrAddProperty("P6", typeof(Random));
+            property1 = entityType.AddProperty("P1", typeof(int));
+            property2 = entityType.AddProperty("P2", typeof(string));
+            property3 = entityType.AddProperty("P3", typeof(Random));
+            property4 = entityType.AddProperty("P4", typeof(int));
+            property5 = entityType.AddProperty("P5", typeof(string));
+            property6 = entityType.AddProperty("P6", typeof(Random));
 
             entityType.GetOrSetPrimaryKey(new[] { property1, property2, property3 });
             entityType.GetOrAddForeignKey(new[] { property4, property5, property6 }, entityType.GetPrimaryKey(), entityType);

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntityEntryFactoryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntityEntryFactoryTest.cs
@@ -9,15 +9,15 @@ using Xunit;
 
 namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 {
-    public class InteranlEntryEntryFactoryTest
+    public class InternalEntityEntryFactoryTest
     {
         [Fact]
         public void Creates_shadow_state_only_entry_when_entity_is_fully_shadow_state()
         {
             var model = new Model();
             var entityType = model.AddEntityType("RedHook");
-            entityType.GetOrAddProperty("Long", typeof(int), shadowProperty: true);
-            entityType.GetOrAddProperty("Hammer", typeof(string), shadowProperty: true);
+            entityType.AddProperty("Long", typeof(int));
+            entityType.AddProperty("Hammer", typeof(string));
 
             var contextServices = TestHelpers.Instance.CreateContextServices(model);
             var stateManager = contextServices.GetRequiredService<IStateManager>();
@@ -37,8 +37,10 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         {
             var model = new Model();
             var entityType = model.AddEntityType(typeof(RedHook));
-            entityType.GetOrAddProperty("Long", typeof(int));
-            entityType.GetOrAddProperty("Hammer", typeof(string));
+            var property = entityType.AddProperty("Long", typeof(int));
+            property.IsShadowProperty = false;
+            var property1 = entityType.AddProperty("Hammer", typeof(string));
+            property1.IsShadowProperty = false;
 
             var contextServices = TestHelpers.Instance.CreateContextServices(model);
             var stateManager = contextServices.GetRequiredService<IStateManager>();
@@ -59,8 +61,9 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         {
             var model = new Model();
             var entityType = model.AddEntityType(typeof(RedHook));
-            entityType.GetOrAddProperty("Long", typeof(int));
-            entityType.GetOrAddProperty("Hammer", typeof(string), shadowProperty: true);
+            var property1 = entityType.AddProperty("Long", typeof(int));
+            property1.IsShadowProperty = false;
+            entityType.AddProperty("Hammer", typeof(string));
 
             var contextServices = TestHelpers.Instance.CreateContextServices(model);
             var stateManager = contextServices.GetRequiredService<IStateManager>();

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntityEntryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntityEntryTest.cs
@@ -352,7 +352,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var model = BuildModel();
             var entityType = model.GetEntityType(typeof(SomeEntity).FullName);
-            var keyProperty = entityType.GetProperty("Id");
+            var keyProperty = (IProperty)entityType.GetProperty("Id");
             var configuration = TestHelpers.Instance.CreateContextServices(model);
 
             var entry = CreateInternalEntry(configuration, entityType, new SomeEntity());
@@ -436,7 +436,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var entityType = model.GetEntityType(typeof(SomeDependentEntity).FullName);
             var keyProperties = new[] { entityType.GetProperty("Id1"), entityType.GetProperty("Id2") };
             var fkProperty = entityType.GetProperty("SomeEntityId");
-            var property = entityType.GetProperty("JustAProperty");
+            var property = (IProperty)entityType.GetProperty("JustAProperty");
             var configuration = TestHelpers.Instance.CreateContextServices(model);
 
             var entry = CreateInternalEntry(configuration, entityType, new SomeDependentEntity());
@@ -1518,38 +1518,55 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var model = new Model();
 
             var someSimpleEntityType = model.AddEntityType(typeof(SomeSimpleEntityBase));
-            var simpleKeyProperty = someSimpleEntityType.GetOrAddProperty("Id", typeof(int));
+            var simpleKeyProperty = someSimpleEntityType.AddProperty("Id", typeof(int));
+            simpleKeyProperty.IsShadowProperty = false;
             simpleKeyProperty.RequiresValueGenerator = true;
             someSimpleEntityType.GetOrSetPrimaryKey(simpleKeyProperty);
 
             var someCompositeEntityType = model.AddEntityType(typeof(SomeCompositeEntityBase));
-            var compositeKeyProperty1 = someCompositeEntityType.GetOrAddProperty("Id1", typeof(int));
-            var compositeKeyProperty2 = someCompositeEntityType.GetOrAddProperty("Id2", typeof(string));
+            var compositeKeyProperty1 = someCompositeEntityType.AddProperty("Id1", typeof(int));
+            compositeKeyProperty1.IsShadowProperty = false;
+            var compositeKeyProperty2 = someCompositeEntityType.AddProperty("Id2", typeof(string));
+            compositeKeyProperty2.IsShadowProperty = false;
             someCompositeEntityType.GetOrSetPrimaryKey(new[] { compositeKeyProperty1, compositeKeyProperty2 });
 
             var entityType1 = model.AddEntityType(typeof(SomeEntity));
             entityType1.BaseType = someSimpleEntityType;
-            entityType1.GetOrAddProperty("Name", typeof(string)).IsConcurrencyToken = true;
+            var property3 = entityType1.AddProperty("Name", typeof(string));
+            property3.IsShadowProperty = false;
+            property3.IsConcurrencyToken = true;
 
             var entityType2 = model.AddEntityType(typeof(SomeDependentEntity));
             entityType2.BaseType = someCompositeEntityType;
-            var fk = entityType2.GetOrAddProperty("SomeEntityId", typeof(int));
+            var fk = entityType2.AddProperty("SomeEntityId", typeof(int));
+            fk.IsShadowProperty = false;
             entityType2.GetOrAddForeignKey(new[] { fk }, entityType1.GetPrimaryKey(), entityType1);
-            var justAProperty = entityType2.GetOrAddProperty("JustAProperty", typeof(int));
+            var justAProperty = entityType2.AddProperty("JustAProperty", typeof(int));
+            justAProperty.IsShadowProperty = false;
             justAProperty.RequiresValueGenerator = true;
 
             var entityType3 = model.AddEntityType(typeof(FullNotificationEntity));
-            entityType3.GetOrSetPrimaryKey(entityType3.GetOrAddProperty("Id", typeof(int)));
-            entityType3.GetOrAddProperty("Name", typeof(string)).IsConcurrencyToken = true;
+            var property6 = entityType3.AddProperty("Id", typeof(int));
+            property6.IsShadowProperty = false;
+            entityType3.GetOrSetPrimaryKey(property6);
+            var property7 = entityType3.AddProperty("Name", typeof(string));
+            property7.IsShadowProperty = false;
+            property7.IsConcurrencyToken = true;
 
             var entityType4 = model.AddEntityType(typeof(ChangedOnlyEntity));
-            entityType4.GetOrSetPrimaryKey(entityType4.GetOrAddProperty("Id", typeof(int)));
-            entityType4.GetOrAddProperty("Name", typeof(string)).IsConcurrencyToken = true;
+            var property8 = entityType4.AddProperty("Id", typeof(int));
+            property8.IsShadowProperty = false;
+            entityType4.GetOrSetPrimaryKey(property8);
+            var property9 = entityType4.AddProperty("Name", typeof(string));
+            property9.IsShadowProperty = false;
+            property9.IsConcurrencyToken = true;
 
             var entityType5 = model.AddEntityType(typeof(SomeMoreDependentEntity));
             entityType5.BaseType = someSimpleEntityType;
-            var fk5a = entityType5.GetOrAddProperty("Fk1", typeof(int));
-            var fk5b = entityType5.GetOrAddProperty("Fk2", typeof(string));
+            var fk5a = entityType5.AddProperty("Fk1", typeof(int));
+            fk5a.IsShadowProperty = false;
+            var fk5b = entityType5.AddProperty("Fk2", typeof(string));
+            fk5b.IsShadowProperty = false;
             entityType5.GetOrAddForeignKey(new[] { fk5a, fk5b }, entityType2.GetPrimaryKey(), entityType2);
 
             return model;

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalMixedEntityEntryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalMixedEntityEntryTest.cs
@@ -122,15 +122,10 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         protected override Model BuildModel()
         {
             var model = base.BuildModel();
-
-            var someSimpleEntityType = model.GetEntityType(typeof(SomeSimpleEntityBase));
-            someSimpleEntityType.GetProperty("Id").IsShadowProperty = true;
-
-            var entityType1 = model.GetEntityType(typeof(SomeEntity));
-            entityType1.GetOrAddProperty("Name", typeof(string)).IsConcurrencyToken = false;
-
-            var entityType2 = model.GetEntityType(typeof(SomeDependentEntity));
-            entityType2.GetProperty("SomeEntityId").IsShadowProperty = true;
+            
+            model.GetEntityType(typeof(SomeSimpleEntityBase)).GetProperty("Id").IsShadowProperty = true;
+            model.GetEntityType(typeof(SomeEntity)).GetProperty("Name").IsConcurrencyToken = false;
+            model.GetEntityType(typeof(SomeDependentEntity)).GetProperty("SomeEntityId").IsShadowProperty = true;
 
             return model;
         }

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalShadowEntityEntryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalShadowEntityEntryTest.cs
@@ -50,38 +50,41 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var model = new Model();
 
             var someSimpleEntityType = model.AddEntityType(typeof(SomeSimpleEntityBase).FullName);
-            var simpleKeyProperty = someSimpleEntityType.GetOrAddProperty("Id", typeof(int), shadowProperty: true);
+            var simpleKeyProperty = someSimpleEntityType.AddProperty("Id", typeof(int));
             simpleKeyProperty.RequiresValueGenerator = true;
             someSimpleEntityType.GetOrSetPrimaryKey(simpleKeyProperty);
 
             var someCompositeEntityType = model.AddEntityType(typeof(SomeCompositeEntityBase).FullName);
-            var compositeKeyProperty1 = someCompositeEntityType.GetOrAddProperty("Id1", typeof(int), shadowProperty: true);
-            var compositeKeyProperty2 = someCompositeEntityType.GetOrAddProperty("Id2", typeof(string), shadowProperty: true);
+            var compositeKeyProperty1 = someCompositeEntityType.AddProperty("Id1", typeof(int));
+            var compositeKeyProperty2 = someCompositeEntityType.AddProperty("Id2", typeof(string));
             someCompositeEntityType.GetOrSetPrimaryKey(new[] { compositeKeyProperty1, compositeKeyProperty2 });
 
             var entityType1 = model.AddEntityType(typeof(SomeEntity).FullName);
             entityType1.BaseType = someSimpleEntityType;
-            entityType1.GetOrAddProperty("Name", typeof(string), shadowProperty: true).IsConcurrencyToken = true;
+            var property3 = entityType1.AddProperty("Name", typeof(string));
+            property3.IsConcurrencyToken = true;
 
             var entityType2 = model.AddEntityType(typeof(SomeDependentEntity).FullName);
             entityType2.BaseType = someCompositeEntityType;
-            var fk = entityType2.GetOrAddProperty("SomeEntityId", typeof(int), shadowProperty: true);
+            var fk = entityType2.AddProperty("SomeEntityId", typeof(int));
             entityType2.GetOrAddForeignKey(new[] { fk }, entityType1.GetPrimaryKey(), entityType1);
-            var justAProperty = entityType2.GetOrAddProperty("JustAProperty", typeof(int), shadowProperty: true);
+            var justAProperty = entityType2.AddProperty("JustAProperty", typeof(int));
             justAProperty.RequiresValueGenerator = true;
 
             var entityType3 = model.AddEntityType(typeof(FullNotificationEntity));
-            entityType3.GetOrSetPrimaryKey(entityType3.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
-            entityType3.GetOrAddProperty("Name", typeof(string), shadowProperty: true).IsConcurrencyToken = true;
+            entityType3.GetOrSetPrimaryKey(entityType3.AddProperty("Id", typeof(int)));
+            var property6 = entityType3.AddProperty("Name", typeof(string));
+            property6.IsConcurrencyToken = true;
 
             var entityType4 = model.AddEntityType(typeof(ChangedOnlyEntity));
-            entityType4.GetOrSetPrimaryKey(entityType4.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
-            entityType4.GetOrAddProperty("Name", typeof(string), shadowProperty: true).IsConcurrencyToken = true;
+            entityType4.GetOrSetPrimaryKey(entityType4.AddProperty("Id", typeof(int)));
+            var property8 = entityType4.AddProperty("Name", typeof(string));
+            property8.IsConcurrencyToken = true;
 
             var entityType5 = model.AddEntityType(typeof(SomeMoreDependentEntity).FullName);
             entityType5.BaseType = someSimpleEntityType;
-            var fk5a = entityType5.GetOrAddProperty("Fk1", typeof(int), shadowProperty: true);
-            var fk5b = entityType5.GetOrAddProperty("Fk2", typeof(string), shadowProperty: true);
+            var fk5a = entityType5.AddProperty("Fk1", typeof(int));
+            var fk5b = entityType5.AddProperty("Fk2", typeof(string));
             entityType5.GetOrAddForeignKey(new[] { fk5a, fk5b }, entityType2.GetPrimaryKey(), entityType2);
 
             return model;

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/RelationshipsSnapshotTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/RelationshipsSnapshotTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -296,13 +297,15 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var model = new Model();
 
             var entityType = model.AddEntityType(typeof(Banana));
-            var pkProperty = entityType.GetOrAddProperty("Id", typeof(int));
-            var fkProperty = entityType.GetOrAddProperty("Fk", typeof(int));
+            var pkProperty = entityType.AddProperty("Id", typeof(int));
+            pkProperty.IsShadowProperty = false;
+            var fkProperty = entityType.AddProperty("Fk", typeof(int));
+            fkProperty.IsShadowProperty = false;
 
             entityType.GetOrSetPrimaryKey(pkProperty);
             var fk = entityType.GetOrAddForeignKey(fkProperty, entityType.GetPrimaryKey(), entityType);
 
-            entityType.GetOrAddProperty("Name", typeof(string));
+            entityType.AddProperty("Name", typeof(string)).IsShadowProperty = false;
 
             entityType.AddNavigation("LesserBananas", fk, pointsToPrincipal: false);
             entityType.AddNavigation("TopBanana", fk, pointsToPrincipal: true);
@@ -310,35 +313,17 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             return model;
         }
 
-        protected IProperty IdProperty
-        {
-            get { return _model.GetEntityType(typeof(Banana)).GetProperty("Id"); }
-        }
+        protected IProperty IdProperty => _model.GetEntityType(typeof(Banana)).GetProperty("Id");
 
-        protected IProperty FkProperty
-        {
-            get { return _model.GetEntityType(typeof(Banana)).GetProperty("Fk"); }
-        }
+        protected IProperty FkProperty => _model.GetEntityType(typeof(Banana)).GetProperty("Fk");
 
-        protected IProperty NameProperty
-        {
-            get { return _model.GetEntityType(typeof(Banana)).GetProperty("Name"); }
-        }
+        protected IProperty NameProperty => _model.GetEntityType(typeof(Banana)).GetProperty("Name");
 
-        protected INavigation CollectionNavigation
-        {
-            get { return _model.GetNavigations(ForeignKey).Single(n => n.Name == "LesserBananas"); }
-        }
+        protected INavigation CollectionNavigation => _model.GetNavigations(ForeignKey).Single(n => n.Name == "LesserBananas");
 
-        protected INavigation ReferenceNavigation
-        {
-            get { return _model.GetNavigations(ForeignKey).Single(n => n.Name == "TopBanana"); }
-        }
+        protected INavigation ReferenceNavigation => _model.GetNavigations(ForeignKey).Single(n => n.Name == "TopBanana");
 
-        private ForeignKey ForeignKey
-        {
-            get { return _model.GetEntityType(typeof(Banana)).GetForeignKeys().Single(); }
-        }
+        private ForeignKey ForeignKey => _model.GetEntityType(typeof(Banana)).GetForeignKeys().Single();
 
         protected class Banana : INotifyPropertyChanged, INotifyPropertyChanging
         {

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/SidecarTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/SidecarTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.ComponentModel;
 using System.Linq;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
@@ -391,51 +392,53 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             var entityType = model.AddEntityType(typeof(Banana));
 
-            var idProperty = entityType.GetOrAddProperty("Id", typeof(int));
+            var idProperty = entityType.AddProperty("Id", typeof(int));
+            idProperty.IsShadowProperty = false;
             idProperty.IsConcurrencyToken = true;
             idProperty.RequiresValueGenerator = true;
             var key = entityType.GetOrSetPrimaryKey(idProperty);
 
-            entityType.GetOrAddProperty("Name", typeof(string));
-            entityType.GetOrAddProperty("State", typeof(string)).IsConcurrencyToken = true;
+            entityType.AddProperty("Name", typeof(string)).IsShadowProperty = false;
+            var property2 = entityType.AddProperty("State", typeof(string));
+            property2.IsShadowProperty = false;
+            property2.IsConcurrencyToken = true;
 
-            var fkProperty = entityType.GetOrAddProperty("Fk", typeof(int?));
+            var fkProperty = entityType.AddProperty("Fk", typeof(int?));
+            fkProperty.IsShadowProperty = false;
             fkProperty.IsConcurrencyToken = true;
             entityType.GetOrAddForeignKey(fkProperty, key, entityType);
 
             var entityType2 = model.AddEntityType(typeof(SomeDependentEntity));
-            var key2A = entityType2.GetOrAddProperty("Id1", typeof(int));
-            var key2B = entityType2.GetOrAddProperty("Id2", typeof(string));
+            var key2A = entityType2.AddProperty("Id1", typeof(int));
+            key2A.IsShadowProperty = false;
+            var key2B = entityType2.AddProperty("Id2", typeof(string));
+            key2B.IsShadowProperty = false;
             entityType2.GetOrSetPrimaryKey(new[] { key2A, key2B });
-            var fk = entityType2.GetOrAddProperty("SomeEntityId", typeof(int));
+            var fk = entityType2.AddProperty("SomeEntityId", typeof(int));
+            fk.IsShadowProperty = false;
             entityType2.GetOrAddForeignKey(new[] { fk }, key, entityType);
-            var justAProperty = entityType2.GetOrAddProperty("JustAProperty", typeof(int));
+            var justAProperty = entityType2.AddProperty("JustAProperty", typeof(int));
+            justAProperty.IsShadowProperty = false;
             justAProperty.RequiresValueGenerator = true;
 
             var entityType5 = model.AddEntityType(typeof(SomeMoreDependentEntity));
-            var key5 = entityType5.GetOrAddProperty("Id", typeof(int));
+            var key5 = entityType5.AddProperty("Id", typeof(int));
+            key5.IsShadowProperty = false;
             entityType5.GetOrSetPrimaryKey(key5);
-            var fk5A = entityType5.GetOrAddProperty("Fk1", typeof(int));
-            var fk5B = entityType5.GetOrAddProperty("Fk2", typeof(string));
+            var fk5A = entityType5.AddProperty("Fk1", typeof(int));
+            fk5A.IsShadowProperty = false;
+            var fk5B = entityType5.AddProperty("Fk2", typeof(string));
+            fk5B.IsShadowProperty = false;
             entityType5.GetOrAddForeignKey(new[] { fk5A, fk5B }, entityType2.GetPrimaryKey(), entityType2);
 
             return model;
         }
 
-        protected IProperty IdProperty
-        {
-            get { return _model.GetEntityType(typeof(Banana)).GetProperty("Id"); }
-        }
+        protected IProperty IdProperty => _model.GetEntityType(typeof(Banana)).GetProperty("Id");
 
-        protected IProperty NameProperty
-        {
-            get { return _model.GetEntityType(typeof(Banana)).GetProperty("Name"); }
-        }
+        protected IProperty NameProperty => _model.GetEntityType(typeof(Banana)).GetProperty("Name");
 
-        protected IProperty FkProperty
-        {
-            get { return _model.GetEntityType(typeof(Banana)).GetProperty("Fk"); }
-        }
+        protected IProperty FkProperty => _model.GetEntityType(typeof(Banana)).GetProperty("Fk");
 
         protected class Banana : INotifyPropertyChanged, INotifyPropertyChanging
         {

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/SimpleEntityKeyFactoryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/SimpleEntityKeyFactoryTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
@@ -272,18 +273,22 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var model = new Model();
 
             var entityType = model.AddEntityType(typeof(Banana));
-            var property1 = entityType.GetOrAddProperty("P1", typeof(int));
-            var property2 = entityType.GetOrAddProperty("P2", typeof(int?));
+            var property1 = entityType.AddProperty("P1", typeof(int));
+            property1.IsShadowProperty = false;
+            var property2 = entityType.AddProperty("P2", typeof(int?));
+            property2.IsShadowProperty = false;
 
             entityType.GetOrSetPrimaryKey(property1);
             entityType.GetOrAddForeignKey(property2, entityType.GetPrimaryKey(), entityType);
 
             entityType = model.AddEntityType(typeof(Kiwi));
-            property1 = entityType.GetOrAddProperty("P1", typeof(string));
-            property2 = entityType.GetOrAddProperty("P2", typeof(string));
+            var property3 = entityType.AddProperty("P1", typeof(string));
+            property3.IsShadowProperty = false;
+            var property4 = entityType.AddProperty("P2", typeof(string));
+            property4.IsShadowProperty = false;
 
-            entityType.GetOrSetPrimaryKey(property1);
-            entityType.GetOrAddForeignKey(property2, entityType.GetPrimaryKey(), entityType);
+            entityType.GetOrSetPrimaryKey(property3);
+            entityType.GetOrAddForeignKey(property4, entityType.GetPrimaryKey(), entityType);
 
             return model;
         }

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/SimpleNullableEntityKeyFactoryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/SimpleNullableEntityKeyFactoryTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
@@ -107,8 +108,10 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var model = new Model();
 
             var entityType = model.AddEntityType(typeof(Banana));
-            var property1 = entityType.GetOrAddProperty("P1", typeof(int));
-            var property2 = entityType.GetOrAddProperty("P2", typeof(int?));
+            var property1 = entityType.AddProperty("P1", typeof(int));
+            property1.IsShadowProperty = false;
+            var property2 = entityType.AddProperty("P2", typeof(int?));
+            property2.IsShadowProperty = false;
 
             entityType.GetOrSetPrimaryKey(property1);
             entityType.GetOrAddForeignKey(property2, entityType.GetPrimaryKey(), entityType);

--- a/test/EntityFramework.Core.Tests/EntityFramework.Core.Tests.csproj
+++ b/test/EntityFramework.Core.Tests/EntityFramework.Core.Tests.csproj
@@ -54,7 +54,7 @@
     <Compile Include="ChangeTracking\Internal\SimpleEntityKeyTest.cs" />
     <Compile Include="ChangeTracking\Internal\SimpleNullableEntityKeyFactoryTest.cs" />
     <Compile Include="ChangeTracking\Internal\StateDataTest.cs" />
-    <Compile Include="ChangeTracking\Internal\InteranlEntryEntryFactoryTest.cs" />
+    <Compile Include="ChangeTracking\Internal\InternalEntityEntryFactoryTest.cs" />
     <Compile Include="ChangeTracking\Internal\InternalEntryEntrySubscriberTest.cs" />
     <Compile Include="ChangeTracking\Internal\InternalEntityEntryTest.cs" />
     <Compile Include="ChangeTracking\Internal\StateManagerTest.cs" />

--- a/test/EntityFramework.Core.Tests/Extensions/PropertyExtensionsTest.cs
+++ b/test/EntityFramework.Core.Tests/Extensions/PropertyExtensionsTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Data.Entity.Metadata;
@@ -16,7 +17,7 @@ namespace Microsoft.Data.Entity.Tests
             var model = new Model();
 
             var entityType = new EntityType("Entity", model);
-            var property = entityType.AddProperty("Property", typeof(int), true);
+            var property = entityType.AddProperty("Property", typeof(int));
 
             Assert.Null(property.GetGenerationProperty());
         }
@@ -27,7 +28,7 @@ namespace Microsoft.Data.Entity.Tests
             var model = new Model();
 
             var entityType = new EntityType("Entity", model);
-            var property = entityType.AddProperty("Property", typeof(int), true);
+            var property = entityType.AddProperty("Property", typeof(int));
 
             property.RequiresValueGenerator = true;
 
@@ -40,17 +41,17 @@ namespace Microsoft.Data.Entity.Tests
             var model = new Model();
 
             var firstType = new EntityType("First", model);
-            var firstProperty = firstType.AddProperty("ID", typeof(int), true);
+            var firstProperty = firstType.AddProperty("ID", typeof(int));
             var firstKey = firstType.AddKey(firstProperty);
 
             var secondType = new EntityType("Second", model);
-            var secondProperty = secondType.AddProperty("ID", typeof(int), true);
+            var secondProperty = secondType.AddProperty("ID", typeof(int));
             var secondKey = secondType.AddKey(secondProperty);
-            var secondForeignKey = secondType.AddForeignKey(secondProperty, firstKey, firstType);
+            secondType.AddForeignKey(secondProperty, firstKey, firstType);
 
             var thirdType = new EntityType("Third", model);
-            var thirdProperty = thirdType.AddProperty("ID", typeof(int), true);
-            var thirdForeignKey = thirdType.AddForeignKey(thirdProperty, secondKey, secondType);
+            var thirdProperty = thirdType.AddProperty("ID", typeof(int));
+            thirdType.AddForeignKey(thirdProperty, secondKey, secondType);
 
             firstProperty.RequiresValueGenerator = true;
 
@@ -63,25 +64,25 @@ namespace Microsoft.Data.Entity.Tests
             var model = new Model();
 
             var leftType = new EntityType("Left", model);
-            var leftId = leftType.AddProperty("Id", typeof(int), true);
+            var leftId = leftType.AddProperty("Id", typeof(int));
             var leftKey = leftType.AddKey(leftId);
 
             var rightType = new EntityType("Right", model);
-            var rightId1 = rightType.AddProperty("Id1", typeof(int), true);
-            var rightId2 = rightType.AddProperty("Id2", typeof(int), true);
+            var rightId1 = rightType.AddProperty("Id1", typeof(int));
+            var rightId2 = rightType.AddProperty("Id2", typeof(int));
             var rightKey = rightType.AddKey(new[] { rightId1, rightId2 });
 
             var middleType = new EntityType("Middle", model);
-            var middleProperty1 = middleType.AddProperty("FK1", typeof(int), true);
-            var middleProperty2 = middleType.AddProperty("FK2", typeof(int), true);
+            var middleProperty1 = middleType.AddProperty("FK1", typeof(int));
+            var middleProperty2 = middleType.AddProperty("FK2", typeof(int));
             var middleKey1 = middleType.AddKey(middleProperty1);
-            var middleFK1 = middleType.AddForeignKey(middleProperty1, leftKey, leftType);
-            var middleFK2 = middleType.AddForeignKey(new[] { middleProperty2, middleProperty1 }, rightKey, rightType);
+            middleType.AddForeignKey(middleProperty1, leftKey, leftType);
+            middleType.AddForeignKey(new[] { middleProperty2, middleProperty1 }, rightKey, rightType);
 
             var endType = new EntityType("End", model);
-            var endProperty = endType.AddProperty("FK", typeof(int), true);
+            var endProperty = endType.AddProperty("FK", typeof(int));
 
-            var endFK = endType.AddForeignKey(endProperty, middleKey1, middleType);
+            endType.AddForeignKey(endProperty, middleKey1, middleType);
 
             rightId2.RequiresValueGenerator = true;
 
@@ -94,22 +95,22 @@ namespace Microsoft.Data.Entity.Tests
             var model = new Model();
 
             var leafType = new EntityType("leaf", model);
-            var leafId1 = leafType.AddProperty("Id1", typeof(int), true);
-            var leafId2 = leafType.AddProperty("Id2", typeof(int), true);
+            var leafId1 = leafType.AddProperty("Id1", typeof(int));
+            var leafId2 = leafType.AddProperty("Id2", typeof(int));
             var leafKey = leafType.AddKey(new[] { leafId1, leafId2 });
 
             var firstType = new EntityType("First", model);
-            var firstId = firstType.AddProperty("Id", typeof(int), true);
+            var firstId = firstType.AddProperty("Id", typeof(int));
             var firstKey = firstType.AddKey(firstId);
             
             var secondType = new EntityType("Second", model);
-            var secondId1 = secondType.AddProperty("Id1", typeof(int), true);
-            var secondId2 = secondType.AddProperty("Id2", typeof(int), true);
+            var secondId1 = secondType.AddProperty("Id1", typeof(int));
+            var secondId2 = secondType.AddProperty("Id2", typeof(int));
             var secondKey = secondType.AddKey(secondId1);
 
-            var firstForeignKey = firstType.AddForeignKey(firstId, secondKey, secondType);
-            var secondForeignKey1 = secondType.AddForeignKey(secondId1, firstKey, firstType);
-            var secondForeignKey2 = secondType.AddForeignKey(new[] { secondId1, secondId2 }, leafKey, leafType);
+            firstType.AddForeignKey(firstId, secondKey, secondType);
+            secondType.AddForeignKey(secondId1, firstKey, firstType);
+            secondType.AddForeignKey(new[] { secondId1, secondId2 }, leafKey, leafType);
 
             leafId1.RequiresValueGenerator = true;
 

--- a/test/EntityFramework.Core.Tests/Metadata/ClrCollectionAccessorSourceTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ClrCollectionAccessorSourceTest.cs
@@ -134,8 +134,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var model = new Model();
             var entityType = model.AddEntityType(typeof(MyEntity));
             var otherType = model.AddEntityType(typeof(MyOtherEntity));
-            var foreignKey = otherType.GetOrAddForeignKey(otherType.GetOrAddProperty("MyEntityId", typeof(int), shadowProperty: true),
-                entityType.GetOrSetPrimaryKey(entityType.GetOrAddProperty("Id", typeof(int), shadowProperty: true)),
+            var foreignKey = otherType.GetOrAddForeignKey(otherType.AddProperty("MyEntityId", typeof(int)),
+                entityType.GetOrSetPrimaryKey(entityType.AddProperty("Id", typeof(int))),
                 entityType);
 
             var navigation = entityType.AddNavigation("AsICollection", foreignKey, pointsToPrincipal: false);
@@ -221,8 +221,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var model = new Model();
             var entityType = model.AddEntityType(typeof(MyEntity));
             var otherType = model.AddEntityType(typeof(MyOtherEntity));
-            var foreignKey = otherType.GetOrAddForeignKey(otherType.GetOrAddProperty("MyEntityId", typeof(int), shadowProperty: true),
-                entityType.GetOrSetPrimaryKey(entityType.GetOrAddProperty("Id", typeof(int), shadowProperty: true)),
+            var foreignKey = otherType.GetOrAddForeignKey(otherType.AddProperty("MyEntityId", typeof(int)),
+                entityType.GetOrSetPrimaryKey(entityType.AddProperty("Id", typeof(int))),
                 entityType);
 
             return entityType.AddNavigation(navigationName, foreignKey, pointsToPrincipal: false);

--- a/test/EntityFramework.Core.Tests/Metadata/ClrPropertyGetterSourceTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ClrPropertyGetterSourceTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Metadata.Internal;
 using Moq;
@@ -25,7 +26,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Delegate_getter_is_returned_for_IProperty_property()
         {
             var entityType = new Model().AddEntityType(typeof(Customer));
-            var idProperty = entityType.GetOrAddProperty("Id", typeof(int));
+            var idProperty = entityType.AddProperty("Id", typeof(int));
+            idProperty.IsShadowProperty = false;
 
             Assert.Equal(7, new ClrPropertyGetterSource().GetAccessor(idProperty).GetClrValue(new Customer { Id = 7 }));
         }
@@ -40,7 +42,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Delegate_getter_is_cached_by_type_and_property_name()
         {
             var entityType = new Model().AddEntityType(typeof(Customer));
-            var idProperty = entityType.GetOrAddProperty("Id", typeof(int));
+            var idProperty = entityType.AddProperty("Id", typeof(int));
+            idProperty.IsShadowProperty = false;
 
             var source = new ClrPropertyGetterSource();
 

--- a/test/EntityFramework.Core.Tests/Metadata/ClrPropertySetterSourceTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ClrPropertySetterSourceTest.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Reflection;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Metadata.Internal;
 using Moq;
@@ -25,7 +27,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Delegate_setter_is_returned_for_IProperty_property()
         {
             var entityType = new Model().AddEntityType(typeof(Customer));
-            var idProperty = entityType.GetOrAddProperty("Id", typeof(int));
+            var idProperty = entityType.AddProperty(Customer.IdProperty);
 
             var customer = new Customer { Id = 7 };
 
@@ -48,7 +50,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Delegate_setter_is_cached_by_type_and_property_name()
         {
             var entityType = new Model().AddEntityType(typeof(Customer));
-            var idProperty = entityType.GetOrAddProperty("Id", typeof(int));
+            var idProperty = entityType.AddProperty(Customer.IdProperty);
 
             var source = new ClrPropertySetterSource();
 
@@ -61,7 +63,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Delegate_setter_can_set_value_type_property()
         {
             var entityType = new Model().AddEntityType(typeof(Customer));
-            var idProperty = entityType.GetOrAddProperty("Id", typeof(int));
+            var idProperty = entityType.AddProperty(Customer.IdProperty);
 
             var customer = new Customer { Id = 7 };
 
@@ -74,7 +76,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Delegate_setter_can_set_reference_type_property()
         {
             var entityType = new Model().AddEntityType(typeof(Customer));
-            var idProperty = entityType.GetOrAddProperty("Content", typeof(string));
+            var idProperty = entityType.AddProperty(Customer.ContentProperty);
 
             var customer = new Customer { Id = 7 };
 
@@ -87,7 +89,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Delegate_setter_can_set_nullable_property()
         {
             var entityType = new Model().AddEntityType(typeof(Customer));
-            var idProperty = entityType.GetOrAddProperty("OptionalInt", typeof(int?));
+            var idProperty = entityType.AddProperty(Customer.OptionalIntProperty);
 
             var customer = new Customer { Id = 7 };
 
@@ -100,7 +102,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Delegate_setter_can_set_nullable_property_with_null_value()
         {
             var entityType = new Model().AddEntityType(typeof(Customer));
-            var idProperty = entityType.GetOrAddProperty("OptionalInt", typeof(int?));
+            var idProperty = entityType.AddProperty(Customer.OptionalIntProperty);
 
             var customer = new Customer { Id = 7 };
 
@@ -113,7 +115,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Delegate_setter_can_set_enum_property()
         {
             var entityType = new Model().AddEntityType(typeof(Customer));
-            var idProperty = entityType.GetOrAddProperty("Flag", typeof(Flag));
+            var idProperty = entityType.AddProperty(Customer.FlagProperty);
 
             var customer = new Customer { Id = 7 };
 
@@ -126,7 +128,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Delegate_setter_can_set_nullable_enum_property()
         {
             var entityType = new Model().AddEntityType(typeof(Customer));
-            var idProperty = entityType.GetOrAddProperty("OptionalFlag", typeof(Flag?));
+            var idProperty = entityType.AddProperty(Customer.OptionalFlagProperty);
 
             var customer = new Customer { Id = 7 };
 
@@ -145,11 +147,17 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
         private class Customer
         {
-            internal int Id { get; set; }
-            internal string Content { get; set; }
-            internal int? OptionalInt { get; set; }
-            internal Flag Flag { get; set; }
-            internal Flag? OptionalFlag { get; set; }
+            public readonly static PropertyInfo IdProperty = typeof(Customer).GetProperty("Id");
+            public readonly static PropertyInfo OptionalIntProperty = typeof(Customer).GetProperty("OptionalInt");
+            public readonly static PropertyInfo ContentProperty = typeof(Customer).GetProperty("Content");
+            public readonly static PropertyInfo FlagProperty = typeof(Customer).GetProperty("Flag");
+            public readonly static PropertyInfo OptionalFlagProperty = typeof(Customer).GetProperty("OptionalFlag");
+
+            public int Id { get; set; }
+            public string Content { get; set; }
+            public int? OptionalInt { get; set; }
+            public Flag Flag { get; set; }
+            public Flag? OptionalFlag { get; set; }
         }
 
         #endregion

--- a/test/EntityFramework.Core.Tests/Metadata/EntityMaterializerSourceTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/EntityMaterializerSourceTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq.Expressions;
+using System.Reflection;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Storage;
@@ -33,11 +34,11 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Can_create_materializer_for_entity_with_auto_properties()
         {
             var entityType = new Model().AddEntityType(typeof(SomeEntity));
-            entityType.GetOrAddProperty("Enum", typeof(SomeEnum));
-            entityType.GetOrAddProperty("Foo", typeof(string));
-            entityType.GetOrAddProperty("Goo", typeof(Guid?));
-            entityType.GetOrAddProperty("Id", typeof(int));
-            entityType.GetOrAddProperty("MaybeEnum", typeof(SomeEnum?));
+            entityType.AddProperty(SomeEntity.EnumProperty);
+            entityType.AddProperty(SomeEntity.FooProperty);
+            entityType.AddProperty(SomeEntity.GooProperty);
+            entityType.AddProperty(SomeEntity.IdProperty);
+            entityType.AddProperty(SomeEntity.MaybeEnumProperty);
 
             var factory = GetMaterializer(new EntityMaterializerSource(new MemberMapper(new FieldMatcher())), entityType);
 
@@ -55,11 +56,11 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Can_create_materializer_for_entity_with_fields()
         {
             var entityType = new Model().AddEntityType(typeof(SomeEntityWithFields));
-            entityType.GetOrAddProperty("Enum", typeof(SomeEnum));
-            entityType.GetOrAddProperty("Foo", typeof(string));
-            entityType.GetOrAddProperty("Goo", typeof(Guid?));
-            entityType.GetOrAddProperty("Id", typeof(int));
-            entityType.GetOrAddProperty("MaybeEnum", typeof(SomeEnum?));
+            entityType.AddProperty(SomeEntityWithFields.EnumProperty);
+            entityType.AddProperty(SomeEntityWithFields.FooProperty);
+            entityType.AddProperty(SomeEntityWithFields.GooProperty);
+            entityType.AddProperty(SomeEntityWithFields.IdProperty);
+            entityType.AddProperty(SomeEntityWithFields.MaybeEnumProperty);
 
             var factory = GetMaterializer(new EntityMaterializerSource(new MemberMapper(new FieldMatcher())), entityType);
 
@@ -77,9 +78,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Can_read_nulls()
         {
             var entityType = new Model().AddEntityType(typeof(SomeEntity));
-            entityType.GetOrAddProperty("Id", typeof(int));
-            entityType.GetOrAddProperty("Foo", typeof(string));
-            entityType.GetOrAddProperty("Goo", typeof(Guid?));
+            entityType.AddProperty(SomeEntity.FooProperty);
+            entityType.AddProperty(SomeEntity.GooProperty);
+            entityType.AddProperty(SomeEntity.IdProperty);
 
             var factory = GetMaterializer(new EntityMaterializerSource(new MemberMapper(new FieldMatcher())), entityType);
 
@@ -94,12 +95,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Can_create_materializer_for_entity_ignoring_shadow_fields()
         {
             var entityType = new Model().AddEntityType(typeof(SomeEntity));
-            entityType.GetOrAddProperty("Id", typeof(int));
-            entityType.GetOrAddProperty("IdShadow", typeof(int), shadowProperty: true);
-            entityType.GetOrAddProperty("Foo", typeof(string));
-            entityType.GetOrAddProperty("FooShadow", typeof(string), shadowProperty: true);
-            entityType.GetOrAddProperty("Goo", typeof(Guid?));
-            entityType.GetOrAddProperty("GooShadow", typeof(Guid), shadowProperty: true);
+            entityType.AddProperty(SomeEntity.IdProperty);
+            entityType.AddProperty("IdShadow", typeof(int));
+            entityType.AddProperty(SomeEntity.FooProperty);
+            entityType.AddProperty("FooShadow", typeof(string));
+            entityType.AddProperty(SomeEntity.GooProperty);
+            entityType.AddProperty("GooShadow", typeof(Guid));
 
             var factory = GetMaterializer(new EntityMaterializerSource(new MemberMapper(new FieldMatcher())), entityType);
 
@@ -114,16 +115,19 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         private static readonly ParameterExpression _readerParameter
             = Expression.Parameter(typeof(ValueBuffer), "valueBuffer");
 
-        public virtual Func<ValueBuffer, object> GetMaterializer(IEntityMaterializerSource source, IEntityType entityType)
-        {
-            return Expression.Lambda<Func<ValueBuffer, object>>(
-                source.CreateMaterializeExpression(entityType, _readerParameter),
-                _readerParameter)
-                .Compile();
-        }
+        public virtual Func<ValueBuffer, object> GetMaterializer(IEntityMaterializerSource source, IEntityType entityType) => Expression.Lambda<Func<ValueBuffer, object>>(
+            source.CreateMaterializeExpression(entityType, _readerParameter),
+            _readerParameter)
+            .Compile();
 
         private class SomeEntity
         {
+            public readonly static PropertyInfo IdProperty = typeof(SomeEntity).GetProperty("Id");
+            public readonly static PropertyInfo FooProperty = typeof(SomeEntity).GetProperty("Foo");
+            public readonly static PropertyInfo GooProperty = typeof(SomeEntity).GetProperty("Goo");
+            public readonly static PropertyInfo EnumProperty = typeof(SomeEntity).GetProperty("Enum");
+            public readonly static PropertyInfo MaybeEnumProperty = typeof(SomeEntity).GetProperty("MaybeEnum");
+
             // ReSharper disable UnusedAutoPropertyAccessor.Local
             public int Id { get; set; }
             public string Foo { get; set; }
@@ -135,6 +139,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
         private class SomeEntityWithFields
         {
+            public readonly static PropertyInfo IdProperty = typeof(SomeEntityWithFields).GetProperty("Id");
+            public readonly static PropertyInfo FooProperty = typeof(SomeEntityWithFields).GetProperty("Foo");
+            public readonly static PropertyInfo GooProperty = typeof(SomeEntityWithFields).GetProperty("Goo");
+            public readonly static PropertyInfo EnumProperty = typeof(SomeEntityWithFields).GetProperty("Enum");
+            public readonly static PropertyInfo MaybeEnumProperty = typeof(SomeEntityWithFields).GetProperty("MaybeEnum");
+
 #pragma warning disable 649
             private int _id;
             private string _foo;

--- a/test/EntityFramework.Core.Tests/Metadata/EntityTypeExtensionsTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/EntityTypeExtensionsTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Moq;
@@ -33,11 +34,11 @@ namespace Microsoft.Data.Entity.Metadata.Tests
         {
             var model = new Model();
             var entityType = model.AddEntityType("Customer");
-            var idProperty = entityType.AddProperty("id", typeof(int), shadowProperty: true);
-            var fkProperty = entityType.AddProperty("fk", typeof(int), shadowProperty: true);
+            var idProperty = entityType.AddProperty("id", typeof(int));
+            var fkProperty = entityType.AddProperty("fk", typeof(int));
             var fk = entityType.AddForeignKey(fkProperty, entityType.SetPrimaryKey(idProperty), entityType);
 
-            Assert.Same(fk, entityType.GetReferencingForeignKeys().Single());
+            Assert.Same(fk, entityType.FindReferencingForeignKeys().Single());
         }
 
         [Fact]

--- a/test/EntityFramework.Core.Tests/Metadata/EntityTypeTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/EntityTypeTest.cs
@@ -22,18 +22,27 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
         private class A
         {
+            public static readonly PropertyInfo EProperty = typeof(A).GetProperty("E");
+            public static readonly PropertyInfo GProperty = typeof(A).GetProperty("G");
+
             public string E { get; set; }
             public string G { get; set; }
         }
 
         private class B : A
         {
+            public static readonly PropertyInfo FProperty = typeof(B).GetProperty("F");
+            public static readonly PropertyInfo HProperty = typeof(B).GetProperty("H");
+
             public string F { get; set; }
             public string H { get; set; }
         }
 
         private class C : A
         {
+            public static readonly PropertyInfo FProperty = typeof(C).GetProperty("F");
+            public static readonly PropertyInfo HProperty = typeof(C).GetProperty("H");
+
             public string F { get; set; }
             public string H { get; set; }
         }
@@ -79,7 +88,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Setting_CLR_base_for_shadow_entity_type_should_throw()
         {
             var model = new Model();
-            
+
             var a = model.AddEntityType(typeof(A));
             var b = model.AddEntityType(typeof(B).Name);
 
@@ -124,16 +133,16 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             //  B   C
 
             var a = model.AddEntityType(typeof(A));
-            a.AddProperty("G", typeof(string));
-            a.AddProperty("E", typeof(string));
+            a.AddProperty(A.GProperty);
+            a.AddProperty(A.EProperty);
 
             var b = model.AddEntityType(typeof(B));
-            b.AddProperty("H", typeof(string));
-            b.AddProperty("F", typeof(string));
+            b.AddProperty(B.HProperty);
+            b.AddProperty(B.FProperty);
 
             var c = model.AddEntityType(typeof(C));
-            c.AddProperty("H", typeof(string), true);
-            c.AddProperty("I", typeof(string), true);
+            c.AddProperty(C.HProperty);
+            c.AddProperty("I", typeof(string));
 
             Assert.Equal(new[] { "E", "G" }, a.Properties.Select(p => p.Name).ToArray());
             Assert.Equal(new[] { "F", "H" }, b.Properties.Select(p => p.Name).ToArray());
@@ -147,7 +156,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Equal(new[] { "E", "G", "H", "I" }, c.Properties.Select(p => p.Name).ToArray());
             Assert.Equal(new[] { 0, 1, 2, 3 }, b.Properties.Select(p => p.Index));
             Assert.Equal(new[] { 0, 1, 2, 3 }, c.Properties.Select(p => p.Index));
-            Assert.Same(b.GetOrAddProperty("E", typeof(string)), a.GetOrAddProperty("E", typeof(string)));
+            Assert.Same(b.GetProperty("E"), a.GetProperty("E"));
         }
 
         [Fact]
@@ -166,14 +175,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             b.BaseType = a;
             c.BaseType = a;
 
-            a.AddProperty("G", typeof(string));
-            a.AddProperty("E", typeof(string));
+            a.AddProperty(A.GProperty);
+            a.AddProperty(A.EProperty);
 
-            b.AddProperty("H", typeof(string));
-            b.AddProperty("F", typeof(string));
+            b.AddProperty(B.HProperty);
+            b.AddProperty(B.FProperty);
 
-            c.AddProperty("H", typeof(string), true);
-            c.AddProperty("I", typeof(string), true);
+            c.AddProperty(C.HProperty);
+            c.AddProperty("I", typeof(string));
 
             Assert.Equal(new[] { "E", "G" }, a.Properties.Select(p => p.Name).ToArray());
             Assert.Equal(new[] { "E", "G", "F", "H" }, b.Properties.Select(p => p.Name).ToArray());
@@ -188,12 +197,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var model = new Model();
 
             var c = model.AddEntityType(typeof(C));
-            c.AddProperty("H", typeof(string));
-            c.AddProperty("F", typeof(string));
+            c.AddProperty(C.HProperty);
+            c.AddProperty(C.FProperty);
 
             var d = model.AddEntityType(typeof(D));
-            d.AddProperty("E", typeof(string));
-            d.AddProperty("G", typeof(string));
+            d.AddProperty(A.EProperty);
+            d.AddProperty(A.GProperty);
             d.BaseType = c;
 
             Assert.Equal(new[] { "F", "H" }, c.Properties.Select(p => p.Name).ToArray());
@@ -209,8 +218,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Equal(new[] { 0, 1 }, d.Properties.Select(p => p.Index));
 
             var a = model.AddEntityType(typeof(A));
-            a.AddProperty("E", typeof(string));
-            a.AddProperty("G", typeof(string));
+            a.AddProperty(A.EProperty);
+            a.AddProperty(A.GProperty);
 
             c.BaseType = a;
 
@@ -228,14 +237,13 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var model = new Model();
 
             var a = model.AddEntityType(typeof(A));
-            a.AddProperty("G", typeof(string));
+            a.AddProperty(A.GProperty);
 
             var b = model.AddEntityType(typeof(B));
             b.BaseType = a;
 
-            Assert.Equal(
-                Strings.DuplicateProperty("G", typeof(B).FullName),
-                Assert.Throws<InvalidOperationException>(() => b.AddProperty("G", typeof(string), true)).Message);
+            Assert.Equal(Strings.DuplicateProperty("G", typeof(B).FullName),
+                Assert.Throws<InvalidOperationException>(() => b.AddProperty("G")).Message);
         }
 
         [Fact]
@@ -244,7 +252,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var model = new Model();
 
             var a = model.AddEntityType(typeof(A));
-            a.AddProperty("G", typeof(string));
+            a.AddProperty(A.GProperty);
 
             var c = model.AddEntityType(typeof(C));
             c.BaseType = a;
@@ -254,7 +262,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             Assert.Equal(
                 Strings.DuplicateProperty("G", typeof(D).FullName),
-                Assert.Throws<InvalidOperationException>(() => d.AddProperty("G", typeof(string))).Message);
+                Assert.Throws<InvalidOperationException>(() => d.AddProperty("G")).Message);
         }
 
         [Fact]
@@ -267,11 +275,11 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var b = model.AddEntityType(typeof(B));
             b.BaseType = a;
 
-            b.AddProperty("G", typeof(string));
+            b.AddProperty(A.GProperty);
 
             Assert.Equal(
                 Strings.DuplicateProperty("G", typeof(A).FullName),
-                Assert.Throws<InvalidOperationException>(() => a.AddProperty("G", typeof(string))).Message);
+                Assert.Throws<InvalidOperationException>(() => a.AddProperty(A.GProperty)).Message);
         }
 
         [Fact]
@@ -287,11 +295,11 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var d = model.AddEntityType(typeof(D));
             d.BaseType = c;
 
-            d.AddProperty("G", typeof(string));
+            d.AddProperty(A.GProperty);
 
             Assert.Equal(
                 Strings.DuplicateProperty("G", typeof(A).FullName),
-                Assert.Throws<InvalidOperationException>(() => a.AddProperty("G", typeof(string))).Message);
+                Assert.Throws<InvalidOperationException>(() => a.AddProperty(A.GProperty)).Message);
         }
 
         [Fact]
@@ -300,10 +308,10 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var model = new Model();
 
             var a = model.AddEntityType(typeof(A));
-            a.AddProperty("G", typeof(string));
+            a.AddProperty(A.GProperty);
 
             var b = model.AddEntityType(typeof(B));
-            b.AddProperty("G", typeof(string), true);
+            b.AddProperty(A.GProperty);
 
             Assert.Equal(
                 Strings.DuplicatePropertiesOnBase(typeof(B).FullName, typeof(A).FullName, "G"),
@@ -316,15 +324,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var model = new Model();
 
             var a = model.AddEntityType(typeof(A));
-            a.AddProperty("E", typeof(string));
-            a.AddProperty("G", typeof(string));
+            a.AddProperty(A.EProperty);
+            a.AddProperty(A.GProperty);
 
             var c = model.AddEntityType(typeof(C));
             c.BaseType = a;
 
             var d = model.AddEntityType(typeof(D));
-            d.AddProperty("E", typeof(string));
-            d.AddProperty("G", typeof(string));
+            d.AddProperty(A.EProperty);
+            d.AddProperty(A.GProperty);
 
             Assert.Equal(
                 Strings.DuplicatePropertiesOnBase(typeof(D).FullName, typeof(C).FullName, "E, G"),
@@ -337,14 +345,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var model = new Model();
 
             var a = model.AddEntityType(typeof(A));
-            a.AddProperty("E", typeof(string));
-            a.AddProperty("G", typeof(string));
+            a.AddProperty(A.EProperty);
+            a.AddProperty(A.GProperty);
 
             var c = model.AddEntityType(typeof(C));
 
             var d = model.AddEntityType(typeof(D));
-            d.AddProperty("E", typeof(string));
-            d.AddProperty("G", typeof(string));
+            d.AddProperty(A.EProperty);
+            d.AddProperty(A.GProperty);
             d.BaseType = c;
 
             Assert.Equal(
@@ -358,11 +366,11 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var model = new Model();
 
             var a = model.AddEntityType(typeof(A));
-            var pk = a.SetPrimaryKey(a.AddProperty("G", typeof(string)));
-            a.AddKey(a.AddProperty("E", typeof(string)));
+            var pk = a.SetPrimaryKey(a.AddProperty(A.GProperty));
+            a.AddKey(a.AddProperty(A.EProperty));
 
             var b = model.AddEntityType(typeof(B));
-            b.AddProperty("F", typeof(string));
+            b.AddProperty(B.FProperty);
 
             Assert.Equal(new[] { new[] { "E" }, new[] { "G" } },
                 a.GetKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
@@ -380,9 +388,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Equal(new[] { "G", "E" }, a.Properties.Select(p => p.Name).ToArray());
             Assert.Equal(new[] { "G", "E", "F" }, b.Properties.Select(p => p.Name).ToArray());
             Assert.Equal(new[] { 0, 1, 2 }, b.Properties.Select(p => p.Index));
-            Assert.Same(pk, b.FindPrimaryKey(new[] { b.GetOrAddProperty("G", typeof(string)) }));
-            Assert.Same(b.GetOrAddKey(b.GetOrAddProperty("G", typeof(string))),
-                a.GetOrAddKey(a.GetOrAddProperty("G", typeof(string))));
+            Assert.Same(pk, b.FindPrimaryKey(new[] { b.GetProperty("G") }));
+            Assert.Same(b.GetKey(b.GetProperty("G")), a.GetKey(a.GetProperty("G")));
         }
 
         [Fact]
@@ -391,11 +398,11 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var model = new Model();
 
             var a = model.AddEntityType(typeof(A));
-            a.AddProperty("G", typeof(string));
-            a.AddProperty("E", typeof(string));
+            a.AddProperty(A.GProperty);
+            a.AddProperty(A.EProperty);
 
             var b = model.AddEntityType(typeof(B));
-            b.AddProperty("F", typeof(string));
+            b.AddProperty(B.FProperty);
 
             b.BaseType = a;
 
@@ -416,11 +423,11 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var model = new Model();
 
             var a = model.AddEntityType(typeof(A));
-            a.SetPrimaryKey(a.AddProperty("G", typeof(string)));
-            a.AddKey(a.AddProperty("E", typeof(string)));
+            a.SetPrimaryKey(a.AddProperty(A.GProperty));
+            a.AddKey(a.AddProperty(A.EProperty));
 
             var b = model.AddEntityType(typeof(B));
-            b.AddProperty("F", typeof(string));
+            b.AddProperty(B.FProperty);
             b.BaseType = a;
 
             b.BaseType = null;
@@ -444,10 +451,10 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             Assert.Equal(
                 Strings.DerivedEntityTypeKey(typeof(B).FullName),
-                Assert.Throws<InvalidOperationException>(() => b.SetPrimaryKey(b.AddProperty("G", typeof(string)))).Message);
+                Assert.Throws<InvalidOperationException>(() => b.SetPrimaryKey(b.AddProperty("G"))).Message);
             Assert.Equal(
                 Strings.DerivedEntityTypeKey(typeof(B).FullName),
-                Assert.Throws<InvalidOperationException>(() => b.AddKey(b.AddProperty("E", typeof(string)))).Message);
+                Assert.Throws<InvalidOperationException>(() => b.AddKey(b.AddProperty("E"))).Message);
         }
 
         [Fact]
@@ -457,14 +464,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var a = model.AddEntityType(typeof(A));
             var b = model.AddEntityType(typeof(B));
-            var key = b.AddKey(b.AddProperty("H", typeof(string)));
+            var key = b.AddKey(b.AddProperty(B.HProperty));
 
             Assert.Equal(
                 Strings.DerivedEntityCannotHaveKeys(typeof(B).FullName),
                 Assert.Throws<InvalidOperationException>(() => b.BaseType = a).Message);
 
             b.RemoveKey(key);
-            b.SetPrimaryKey(b.AddProperty("F", typeof(string)));
+            b.SetPrimaryKey(b.AddProperty(B.FProperty));
 
             Assert.Equal(
                 Strings.DerivedEntityCannotHaveKeys(typeof(B).FullName),
@@ -686,7 +693,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var specialCustomerType = model.AddEntityType(typeof(SpecialCustomer));
 
             var derivedForeignKeyProperty = specialOrderType.GetOrAddProperty(Order.IdProperty);
-            var specialCustomerKey = specialCustomerType.GetOrAddKey(specialCustomerType.GetOrAddProperty("AltId", typeof(int), true));
+            var property = specialCustomerType.AddProperty("AltId", typeof(int));
+            var specialCustomerKey = specialCustomerType.GetOrAddKey(property);
             var specialCustomerForeignKey = specialOrderType.GetOrAddForeignKey(derivedForeignKeyProperty, specialCustomerKey, specialCustomerType);
             specialOrderType.AddNavigation("Customer", specialCustomerForeignKey, pointsToPrincipal: true);
 
@@ -714,7 +722,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var verySpecialOrderType = model.AddEntityType(typeof(VerySpecialOrder));
             var derivedForeignKeyProperty = verySpecialOrderType.GetOrAddProperty(Order.IdProperty);
-            var specialCustomerKey = specialCustomerType.GetOrAddKey(specialCustomerType.GetOrAddProperty("AltId", typeof(int), true));
+            var property = specialCustomerType.AddProperty("AltId", typeof(int));
+            var specialCustomerKey = specialCustomerType.GetOrAddKey(property);
             var specialCustomerForeignKey = verySpecialOrderType.GetOrAddForeignKey(derivedForeignKeyProperty, specialCustomerKey, specialCustomerType);
             verySpecialOrderType.AddNavigation("Customer", specialCustomerForeignKey, pointsToPrincipal: true);
             verySpecialOrderType.BaseType = specialOrderType;
@@ -744,7 +753,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var verySpecialOrderType = model.AddEntityType(typeof(VerySpecialOrder));
             var derivedForeignKeyProperty = verySpecialOrderType.GetOrAddProperty(Order.IdProperty);
-            var specialCustomerKey = specialCustomerType.GetOrAddKey(specialCustomerType.GetOrAddProperty("AltId", typeof(int), true));
+            var property = specialCustomerType.AddProperty("AltId", typeof(int));
+            var specialCustomerKey = specialCustomerType.GetOrAddKey(property);
             var specialCustomerForeignKey = verySpecialOrderType.GetOrAddForeignKey(derivedForeignKeyProperty, specialCustomerKey, specialCustomerType);
             verySpecialOrderType.AddNavigation("Customer", specialCustomerForeignKey, pointsToPrincipal: true);
 
@@ -767,7 +777,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
             var derivedForeignKeyProperty = specialOrderType.GetOrAddProperty(Order.IdProperty);
-            var specialCustomerForeignKey = specialOrderType.GetOrAddForeignKey(derivedForeignKeyProperty, customerKey, customerType);
+            specialOrderType.GetOrAddForeignKey(derivedForeignKeyProperty, customerKey, customerType);
 
             Assert.Equal(new[] { new[] { Order.CustomerIdProperty.Name } },
                 orderType.GetForeignKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
@@ -797,7 +807,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
 
             specialOrderType.BaseType = orderType;
-            var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
+            orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
 
             Assert.Equal(new[] { new[] { Order.CustomerIdProperty.Name } },
                 orderType.GetForeignKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
@@ -805,7 +815,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 specialOrderType.GetForeignKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
 
             var derivedForeignKeyProperty = specialOrderType.GetOrAddProperty(Order.IdProperty);
-            var specialCustomerForeignKey = specialOrderType.GetOrAddForeignKey(derivedForeignKeyProperty, customerKey, customerType);
+            specialOrderType.GetOrAddForeignKey(derivedForeignKeyProperty, customerKey, customerType);
 
             Assert.Equal(new[] { new[] { Order.CustomerIdProperty.Name } },
                 orderType.GetForeignKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
@@ -826,10 +836,10 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
             specialOrderType.BaseType = orderType;
             var derivedForeignKeyProperty = specialOrderType.GetOrAddProperty(Order.IdProperty);
-            var specialCustomerForeignKey = specialOrderType.GetOrAddForeignKey(derivedForeignKeyProperty, customerKey, customerType);
+            specialOrderType.GetOrAddForeignKey(derivedForeignKeyProperty, customerKey, customerType);
 
             var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
-            var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
+            orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
 
             specialOrderType.BaseType = null;
 
@@ -1405,9 +1415,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             var model = new Model();
             var customerType = model.AddEntityType(typeof(Customer));
-            var idProperty = customerType.GetOrAddProperty(Customer.IdProperty);
-            var nameProperty = customerType.GetOrAddProperty(Customer.NameProperty);
-            var otherNameProperty = customerType.GetOrAddProperty("OtherNameProperty", typeof(string), shadowProperty: true);
+            var idProperty = customerType.AddProperty(Customer.IdProperty);
+            var nameProperty = customerType.AddProperty(Customer.NameProperty);
+            var otherNameProperty = customerType.AddProperty("OtherNameProperty", typeof(string));
 
             var k2 = customerType.GetOrAddKey(nameProperty);
             var k4 = customerType.GetOrAddKey(new[] { idProperty, otherNameProperty });
@@ -1513,7 +1523,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var customerKey = customerType.GetOrAddKey(idProperty);
             var orderType = model.AddEntityType(typeof(Order));
             var customerFk1 = orderType.GetOrAddProperty(Order.CustomerIdProperty);
-            var customerFk2 = orderType.GetOrAddProperty("IdAgain", typeof(int), shadowProperty: true);
+            var customerFk2 = orderType.AddProperty("IdAgain", typeof(int));
 
             var fk1 = orderType.AddForeignKey(customerFk1, customerKey, customerType);
 
@@ -1567,7 +1577,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var entityType = model.AddEntityType(typeof(Customer));
             var idProperty = entityType.GetOrAddProperty(Customer.IdProperty);
             var key = entityType.GetOrAddKey(idProperty);
-            var fkProperty = entityType.GetOrAddProperty("fk", typeof(int), shadowProperty: true);
+            var fkProperty = entityType.AddProperty("fk", typeof(int));
             entityType.RemoveProperty(fkProperty);
 
             Assert.Equal(
@@ -1583,7 +1593,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var idProperty = entityType.GetOrAddProperty(Customer.IdProperty);
             var key = entityType.GetOrAddKey(idProperty);
             entityType.RemoveKey(key);
-            var fkProperty = entityType.GetOrAddProperty("fk", typeof(int), shadowProperty: true);
+            var fkProperty = entityType.AddProperty("fk", typeof(int));
 
             Assert.Equal(
                 Strings.ForeignKeyReferencedEntityKeyMismatch("{'" + Customer.IdProperty.Name + "'}", typeof(Customer).FullName),
@@ -1612,7 +1622,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var customerKey = customerType.GetOrAddKey(idProperty);
             var orderType = model.AddEntityType(typeof(Order));
             var customerFk1 = orderType.GetOrAddProperty(Order.CustomerIdProperty);
-            var customerFk2 = orderType.GetOrAddProperty("IdAgain", typeof(int), shadowProperty: true);
+            var customerFk2 = orderType.AddProperty("IdAgain", typeof(int));
             var fk1 = orderType.AddForeignKey(customerFk1, customerKey, customerType);
 
             var fk2 = orderType.GetOrAddForeignKey(customerFk2, customerKey, customerType);
@@ -1629,7 +1639,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         [Fact]
         public void TryGetForeignKey_finds_foreign_key_matching_principal_type_name_plus_PK_name()
         {
-            var fkProperty = DependentType.GetOrAddProperty("PrincipalEntityPeEKaY", typeof(int), shadowProperty: true);
+            var fkProperty = DependentType.AddProperty("PrincipalEntityPeEKaY", typeof(int));
 
             var fk = DependentType.GetOrAddForeignKey(fkProperty, PrincipalType.GetPrimaryKey(), PrincipalType);
 
@@ -1645,11 +1655,11 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         [Fact]
         public void TryGetForeignKey_finds_foreign_key_matching_given_properties()
         {
-            DependentType.GetOrAddProperty("SomeNavID", typeof(int), shadowProperty: true);
-            DependentType.GetOrAddProperty("SomeNavPeEKaY", typeof(int), shadowProperty: true);
-            DependentType.GetOrAddProperty("PrincipalEntityID", typeof(int), shadowProperty: true);
-            DependentType.GetOrAddProperty("PrincipalEntityPeEKaY", typeof(int), shadowProperty: true);
-            var fkProperty = DependentType.GetOrAddProperty("HeToldMeYouKilledMyFk", typeof(int), shadowProperty: true);
+            DependentType.AddProperty("SomeNavID", typeof(int));
+            DependentType.AddProperty("SomeNavPeEKaY", typeof(int));
+            DependentType.AddProperty("PrincipalEntityID", typeof(int));
+            DependentType.AddProperty("PrincipalEntityPeEKaY", typeof(int));
+            var fkProperty = DependentType.AddProperty("HeToldMeYouKilledMyFk", typeof(int));
 
             var fk = DependentType.GetOrAddForeignKey(fkProperty, PrincipalType.GetPrimaryKey(), PrincipalType);
 
@@ -1667,18 +1677,18 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         [Fact]
         public void TryGetForeignKey_finds_foreign_key_matching_given_property()
         {
-            DependentType.GetOrAddProperty("SomeNavID", typeof(int), shadowProperty: true);
-            DependentType.GetOrAddProperty("SomeNavPeEKaY", typeof(int), shadowProperty: true);
-            DependentType.GetOrAddProperty("PrincipalEntityID", typeof(int), shadowProperty: true);
-            DependentType.GetOrAddProperty("PrincipalEntityPeEKaY", typeof(int), shadowProperty: true);
-            var fkProperty1 = DependentType.GetOrAddProperty("No", typeof(int), shadowProperty: true);
-            var fkProperty2 = DependentType.GetOrAddProperty("IAmYourFk", typeof(int), shadowProperty: true);
+            DependentType.AddProperty("SomeNavID", typeof(int));
+            DependentType.AddProperty("SomeNavPeEKaY", typeof(int));
+            DependentType.AddProperty("PrincipalEntityID", typeof(int));
+            DependentType.AddProperty("PrincipalEntityPeEKaY", typeof(int));
+            var fkProperty1 = DependentType.AddProperty("No", typeof(int));
+            var fkProperty2 = DependentType.AddProperty("IAmYourFk", typeof(int));
 
             var fk = DependentType.GetOrAddForeignKey(new[] { fkProperty1, fkProperty2 }, PrincipalType.GetOrAddKey(
                 new[]
                     {
-                        PrincipalType.GetOrAddProperty("Id1", typeof(int), shadowProperty: true),
-                        PrincipalType.GetOrAddProperty("Id2", typeof(int), shadowProperty: true)
+                        PrincipalType.AddProperty("Id1", typeof(int)),
+                        PrincipalType.AddProperty("Id2", typeof(int))
                     }),
                 PrincipalType);
 
@@ -1696,10 +1706,10 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         [Fact]
         public void TryGetForeignKey_finds_foreign_key_matching_navigation_plus_Id()
         {
-            var fkProperty = DependentType.GetOrAddProperty("SomeNavID", typeof(int), shadowProperty: true);
-            DependentType.GetOrAddProperty("SomeNavPeEKaY", typeof(int), shadowProperty: true);
-            DependentType.GetOrAddProperty("PrincipalEntityID", typeof(int), shadowProperty: true);
-            DependentType.GetOrAddProperty("PrincipalEntityPeEKaY", typeof(int), shadowProperty: true);
+            var fkProperty = DependentType.AddProperty("SomeNavID", typeof(int));
+            DependentType.AddProperty("SomeNavPeEKaY", typeof(int));
+            DependentType.AddProperty("PrincipalEntityID", typeof(int));
+            DependentType.AddProperty("PrincipalEntityPeEKaY", typeof(int));
 
             var fk = DependentType.GetOrAddForeignKey(fkProperty, PrincipalType.GetPrimaryKey(), PrincipalType);
 
@@ -1717,9 +1727,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         [Fact]
         public void TryGetForeignKey_finds_foreign_key_matching_navigation_plus_PK_name()
         {
-            var fkProperty = DependentType.GetOrAddProperty("SomeNavPeEKaY", typeof(int), shadowProperty: true);
-            DependentType.GetOrAddProperty("PrincipalEntityID", typeof(int), shadowProperty: true);
-            DependentType.GetOrAddProperty("PrincipalEntityPeEKaY", typeof(int), shadowProperty: true);
+            var fkProperty = DependentType.AddProperty("SomeNavPeEKaY", typeof(int));
+            DependentType.AddProperty("PrincipalEntityID", typeof(int));
+            DependentType.AddProperty("PrincipalEntityPeEKaY", typeof(int));
 
             var fk = DependentType.GetOrAddForeignKey(fkProperty, PrincipalType.GetPrimaryKey(), PrincipalType);
 
@@ -1737,8 +1747,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         [Fact]
         public void TryGetForeignKey_finds_foreign_key_matching_principal_type_name_plus_Id()
         {
-            var fkProperty = DependentType.GetOrAddProperty("PrincipalEntityID", typeof(int), shadowProperty: true);
-            DependentType.GetOrAddProperty("PrincipalEntityPeEKaY", typeof(int), shadowProperty: true);
+            var fkProperty = DependentType.AddProperty("PrincipalEntityID", typeof(int));
+            DependentType.AddProperty("PrincipalEntityPeEKaY", typeof(int));
 
             var fk = DependentType.GetOrAddForeignKey(fkProperty, PrincipalType.GetPrimaryKey(), PrincipalType);
 
@@ -1756,7 +1766,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         [Fact]
         public void TryGetForeignKey_does_not_find_existing_FK_if_FK_has_different_navigation_to_principal()
         {
-            var fkProperty = DependentType.GetOrAddProperty("SharedFk", typeof(int), shadowProperty: true);
+            var fkProperty = DependentType.AddProperty("SharedFk", typeof(int));
             var fk = DependentType.GetOrAddForeignKey(fkProperty, PrincipalType.GetPrimaryKey(), PrincipalType);
             DependentType.AddNavigation("AnotherNav", fk, pointsToPrincipal: true);
 
@@ -1774,7 +1784,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         [Fact]
         public void TryGetForeignKey_does_not_find_existing_FK_if_FK_has_different_navigation_to_dependent()
         {
-            var fkProperty = DependentType.GetOrAddProperty("SharedFk", typeof(int), shadowProperty: true);
+            var fkProperty = DependentType.AddProperty("SharedFk", typeof(int));
             var fk = DependentType.GetOrAddForeignKey(fkProperty, PrincipalType.GetPrimaryKey(), PrincipalType);
             PrincipalType.AddNavigation("AnotherNav", fk, pointsToPrincipal: false);
 
@@ -1792,7 +1802,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         [Fact]
         public void TryGetForeignKey_does_not_find_existing_FK_if_FK_has_different_uniqueness()
         {
-            var fkProperty = DependentType.GetOrAddProperty("SharedFk", typeof(int), shadowProperty: true);
+            var fkProperty = DependentType.AddProperty("SharedFk", typeof(int));
             var fk = DependentType.GetOrAddForeignKey(fkProperty, PrincipalType.GetPrimaryKey(), PrincipalType);
             fk.IsUnique = true;
 
@@ -1812,10 +1822,13 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var model = new Model();
 
             var principalType = model.AddEntityType(typeof(PrincipalEntity));
-            principalType.GetOrSetPrimaryKey(principalType.GetOrAddProperty("PeeKay", typeof(int)));
+            var property1 = principalType.AddProperty("PeeKay", typeof(int));
+            property1.IsShadowProperty = false;
+            principalType.GetOrSetPrimaryKey(property1);
 
             var dependentType = model.AddEntityType(typeof(DependentEntity));
-            dependentType.GetOrSetPrimaryKey(dependentType.GetOrAddProperty("KayPee", typeof(int), shadowProperty: true));
+            var property = dependentType.AddProperty("KayPee", typeof(int));
+            dependentType.GetOrSetPrimaryKey(property);
 
             return model;
         }
@@ -1844,7 +1857,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
             var orderType = model.AddEntityType(typeof(Order));
             var customerFk1 = orderType.GetOrAddProperty(Order.CustomerIdProperty);
-            var customerFk2 = orderType.GetOrAddProperty("IdAgain", typeof(int), shadowProperty: true);
+            var customerFk2 = orderType.AddProperty("IdAgain", typeof(int));
 
             Assert.Equal(
                 Strings.ForeignKeyNotFound("{'" + Order.CustomerIdProperty.Name + "'}", typeof(Order).FullName),
@@ -1906,10 +1919,10 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var orderType = model.AddEntityType(typeof(Order));
             var customerFk1 = orderType.GetOrAddProperty(Order.CustomerIdProperty);
-            var customerFk2 = orderType.GetOrAddProperty("IdAgain", typeof(int), shadowProperty: true);
-            var customerFk3A = orderType.GetOrAddProperty("OtherId1", typeof(int), shadowProperty: true);
-            var customerFk3B = orderType.GetOrAddProperty("OtherId2", typeof(string), shadowProperty: true);
-            var customerFk4B = orderType.GetOrAddProperty("OtherId3", typeof(string), shadowProperty: true);
+            var customerFk2 = orderType.AddProperty("IdAgain", typeof(int));
+            var customerFk3A = orderType.AddProperty("OtherId1", typeof(int));
+            var customerFk3B = orderType.AddProperty("OtherId2", typeof(string));
+            var customerFk4B = orderType.AddProperty("OtherId3", typeof(string));
 
             var fk2 = orderType.AddForeignKey(customerFk2, customerKey, customerType);
             var fk4 = orderType.AddForeignKey(new[] { customerFk3A, customerFk4B }, otherCustomerKey, customerType);
@@ -2048,10 +2061,10 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             var model = new Model();
             var customerType = model.AddEntityType(typeof(Customer));
-            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            var customerKey = customerType.GetOrAddKey(customerType.AddProperty("Id", typeof(int)));
 
             var orderType = model.AddEntityType("Order");
-            var foreignKeyProperty = orderType.GetOrAddProperty("CustomerId", typeof(int), shadowProperty: true);
+            var foreignKeyProperty = orderType.AddProperty("CustomerId", typeof(int));
             var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
 
             Assert.Equal(
@@ -2065,10 +2078,10 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             var model = new Model();
             var customerType = model.AddEntityType("Customer");
-            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            var customerKey = customerType.GetOrAddKey(customerType.AddProperty("Id", typeof(int)));
 
             var orderType = model.AddEntityType(typeof(Order));
-            var foreignKeyProperty = orderType.GetOrAddProperty("CustomerId", typeof(int), shadowProperty: true);
+            var foreignKeyProperty = orderType.AddProperty("CustomerId", typeof(int));
             var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
 
             Assert.Equal(
@@ -2229,15 +2242,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             var model = new Model();
             var entityType = model.AddEntityType(typeof(SelfRef));
-            var fkProperty = entityType.AddProperty("ForeignKey", typeof(int));
-            var principalEntityType = entityType;
-            var principalKeyProperty = principalEntityType.AddProperty("Id", typeof(int));
-            var referencedKey = principalEntityType.SetPrimaryKey(principalKeyProperty);
-            var fk = entityType.AddForeignKey(fkProperty, referencedKey, principalEntityType);
+            var fkProperty = entityType.AddProperty(SelfRef.ForeignKeyProperty);
+            var principalKeyProperty = entityType.AddProperty(SelfRef.IdProperty);
+            var referencedKey = entityType.SetPrimaryKey(principalKeyProperty);
+            var fk = entityType.AddForeignKey(fkProperty, referencedKey, entityType);
             fk.IsUnique = true;
 
-            var navigationToDependent = principalEntityType.AddNavigation("SelfRef1", fk, pointsToPrincipal: false);
-            var navigationToPrincipal = principalEntityType.AddNavigation("SelfRef2", fk, pointsToPrincipal: true);
+            var navigationToDependent = entityType.AddNavigation("SelfRef1", fk, pointsToPrincipal: false);
+            var navigationToPrincipal = entityType.AddNavigation("SelfRef2", fk, pointsToPrincipal: true);
 
             Assert.Same(fk.PrincipalToDependent, navigationToDependent);
             Assert.Same(fk.DependentToPrincipal, navigationToPrincipal);
@@ -2248,16 +2260,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             var model = new Model();
             var entityType = model.AddEntityType(typeof(SelfRef));
-            var fkProperty = entityType.AddProperty("ForeignKey", typeof(int));
-            var principalEntityType = entityType;
-            var principalKeyProperty = principalEntityType.AddProperty("Id", typeof(int));
-            var referencedKey = principalEntityType.SetPrimaryKey(principalKeyProperty);
-            var fk = entityType.AddForeignKey(fkProperty, referencedKey, principalEntityType);
+            var fkProperty = entityType.AddProperty(SelfRef.ForeignKeyProperty);
+            var principalKeyProperty = entityType.AddProperty(SelfRef.IdProperty);
+            var referencedKey = entityType.SetPrimaryKey(principalKeyProperty);
+            var fk = entityType.AddForeignKey(fkProperty, referencedKey, entityType);
             fk.IsUnique = true;
 
-            principalEntityType.AddNavigation("SelfRef1", fk, pointsToPrincipal: false);
+            entityType.AddNavigation("SelfRef1", fk, pointsToPrincipal: false);
             Assert.Equal(Strings.DuplicateNavigation("SelfRef1", typeof(SelfRef).FullName),
-                Assert.Throws<InvalidOperationException>(() => principalEntityType.AddNavigation("SelfRef1", fk, pointsToPrincipal: true)).Message);
+                Assert.Throws<InvalidOperationException>(() => entityType.AddNavigation("SelfRef1", fk, pointsToPrincipal: true)).Message);
         }
 
         [Fact]
@@ -2286,8 +2297,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             var model = new Model();
             var entityType = model.AddEntityType(typeof(Order));
-            var property1 = entityType.GetOrAddProperty(Order.IdProperty);
-            var property2 = entityType.GetOrAddProperty(Order.CustomerIdProperty);
+            var property1 = entityType.AddProperty(Order.IdProperty);
+            var property2 = entityType.AddProperty(Order.CustomerIdProperty);
 
             Assert.Equal(0, entityType.Indexes.Count());
             Assert.Null(entityType.RemoveIndex(new Index(new[] { property1 })));
@@ -2328,8 +2339,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var model = new Model();
             var entityType1 = model.AddEntityType(typeof(Customer));
             var entityType2 = model.AddEntityType(typeof(Order));
-            var property1 = entityType1.GetOrAddProperty(Customer.IdProperty);
-            var property2 = entityType1.GetOrAddProperty(Customer.NameProperty);
+            var property1 = entityType1.AddProperty(Customer.IdProperty);
+            var property2 = entityType1.AddProperty(Customer.NameProperty);
 
             Assert.Equal(Strings.IndexPropertiesWrongEntity("{'" + Customer.IdProperty.Name + "', '" + Customer.NameProperty.Name + "'}", typeof(Order).FullName),
                 Assert.Throws<ArgumentException>(
@@ -2341,8 +2352,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             var model = new Model();
             var entityType = model.AddEntityType(typeof(Customer));
-            var property1 = entityType.GetOrAddProperty(Customer.IdProperty);
-            var property2 = entityType.GetOrAddProperty(Customer.NameProperty);
+            var property1 = entityType.AddProperty(Customer.IdProperty);
+            var property2 = entityType.AddProperty(Customer.NameProperty);
             entityType.AddIndex(new[] { property1, property2 });
 
             Assert.Equal(Strings.DuplicateIndex("{'" + Customer.IdProperty.Name + "', '" + Customer.NameProperty.Name + "'}", typeof(Customer).FullName),
@@ -2355,8 +2366,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             var model = new Model();
             var entityType = model.AddEntityType(typeof(Customer));
-            var property1 = entityType.GetOrAddProperty(Customer.IdProperty);
-            var property2 = entityType.GetOrAddProperty(Customer.NameProperty);
+            var property1 = entityType.AddProperty(Customer.IdProperty);
+            var property2 = entityType.AddProperty(Customer.NameProperty);
 
             Assert.Equal(Strings.IndexNotFound("{'" + Customer.IdProperty.Name + "', '" + Customer.NameProperty.Name + "'}", typeof(Customer).FullName),
                 Assert.Throws<ModelItemNotFoundException>(
@@ -2374,9 +2385,10 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             var model = new Model();
             var entityType = model.AddEntityType(typeof(Customer));
-            Assert.Null(entityType.RemoveProperty(new Property("Id", typeof(int), entityType)));
+            Assert.Null(entityType.RemoveProperty(new Property("Id", entityType)));
 
             var property1 = entityType.AddProperty("Id", typeof(int));
+            property1.IsShadowProperty = false;
 
             Assert.False(property1.IsShadowProperty);
             Assert.Equal("Id", property1.Name);
@@ -2385,6 +2397,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(entityType, property1.DeclaringEntityType);
 
             var property2 = entityType.AddProperty("Name", typeof(string));
+            property2.IsShadowProperty = false;
 
             Assert.True(new[] { property1, property2 }.SequenceEqual(entityType.Properties));
 
@@ -2393,7 +2406,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             Assert.True(new[] { property2 }.SequenceEqual(entityType.Properties));
 
-            Assert.Same(property2, entityType.RemoveProperty(new Property("Name", typeof(string), entityType)));
+            Assert.Same(property2, entityType.RemoveProperty(new Property("Name", entityType)));
 
             Assert.Empty(entityType.Properties);
         }
@@ -2404,29 +2417,29 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var model = new Model();
             var entityType = model.AddEntityType(typeof(Customer));
 
-            var idProperty = (IProperty)entityType.GetOrAddProperty("Id", typeof(int));
+            var idProperty = entityType.AddProperty("Id", typeof(int));
+            idProperty.IsShadowProperty = false;
 
             Assert.False(idProperty.IsShadowProperty);
             Assert.Equal("Id", idProperty.Name);
             Assert.Same(typeof(int), idProperty.ClrType);
-            Assert.False(idProperty.IsConcurrencyToken);
             Assert.Same(entityType, idProperty.DeclaringEntityType);
 
             Assert.Same(idProperty, entityType.GetOrAddProperty(Customer.IdProperty));
-            Assert.Same(idProperty, entityType.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            Assert.Same(idProperty, entityType.GetOrAddProperty("Id"));
             Assert.False(idProperty.IsShadowProperty);
 
-            var nameProperty = (IProperty)entityType.GetOrAddProperty("Name", typeof(string), shadowProperty: true);
+            var nameProperty = entityType.GetOrAddProperty("Name");
+            nameProperty.ClrType = typeof(string);
 
-            Assert.True(nameProperty.IsShadowProperty);
+            Assert.True(((IProperty)nameProperty).IsShadowProperty);
             Assert.Equal("Name", nameProperty.Name);
             Assert.Same(typeof(string), nameProperty.ClrType);
-            Assert.False(nameProperty.IsConcurrencyToken);
             Assert.Same(entityType, nameProperty.DeclaringEntityType);
 
             Assert.Same(nameProperty, entityType.GetOrAddProperty(Customer.NameProperty));
-            Assert.Same(nameProperty, entityType.GetOrAddProperty("Name", typeof(string)));
-            Assert.True(nameProperty.IsShadowProperty);
+            Assert.Same(nameProperty, entityType.GetProperty("Name"));
+            Assert.False(nameProperty.IsShadowProperty);
 
             Assert.True(new[] { idProperty, nameProperty }.SequenceEqual(entityType.Properties));
         }
@@ -2507,7 +2520,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var model = new Model();
             var entityType = model.AddEntityType(typeof(Customer));
 
-            var aProperty = entityType.AddProperty("A", typeof(int), true);
+            var aProperty = entityType.AddProperty("A", typeof(int));
             var pkProperty = entityType.AddProperty(Customer.IdProperty);
 
             entityType.SetPrimaryKey(pkProperty);
@@ -2521,9 +2534,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var model = new Model();
             var entityType = model.AddEntityType("CompositeKeyType");
 
-            var aProperty = entityType.AddProperty("A", typeof(int), true);
-            var pkProperty2 = entityType.AddProperty("aPK", typeof(int), true);
-            var pkProperty1 = entityType.AddProperty("bPK", typeof(int), true);
+            var aProperty = entityType.AddProperty("A", typeof(int));
+            var pkProperty2 = entityType.AddProperty("aPK", typeof(int));
+            var pkProperty1 = entityType.AddProperty("bPK", typeof(int));
 
             entityType.SetPrimaryKey(new[] { pkProperty1, pkProperty2 });
 
@@ -2536,12 +2549,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var model = new Model();
 
             var parentType = model.AddEntityType("Parent");
-            var property2 = parentType.AddProperty("D", typeof(int), true);
-            var property1 = parentType.AddProperty("C", typeof(int), true);
+            var property2 = parentType.AddProperty("D", typeof(int));
+            var property1 = parentType.AddProperty("C", typeof(int));
 
             var childType = model.AddEntityType("Child");
-            var property4 = childType.AddProperty("B", typeof(int), true);
-            var property3 = childType.AddProperty("A", typeof(int), true);
+            var property4 = childType.AddProperty("B", typeof(int));
+            var property3 = childType.AddProperty("A", typeof(int));
             childType.BaseType = parentType;
 
             Assert.True(new[] { property1, property2, property3, property4 }.SequenceEqual(childType.Properties));
@@ -2553,8 +2566,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var model = new Model();
             var entityType = model.AddEntityType(typeof(Customer));
 
-            var aProperty = entityType.AddProperty("A", typeof(int), true);
-            var bProperty = entityType.AddProperty("B", typeof(int), true);
+            var aProperty = entityType.AddProperty("A", typeof(int));
+            var bProperty = entityType.AddProperty("B", typeof(int));
 
             entityType.SetPrimaryKey(bProperty);
 
@@ -2591,12 +2604,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var entityType = model.AddEntityType(typeof(Customer));
 
             entityType.GetOrAddProperty(Customer.NameProperty);
-            entityType.GetOrAddProperty("Id", typeof(int));
-            entityType.GetOrAddProperty("Mane", typeof(int), shadowProperty: true);
+            entityType.AddProperty(Customer.IdProperty);
+            entityType.AddProperty("Mane", typeof(int));
 
             Assert.False(entityType.GetProperty("Name").IsShadowProperty);
             Assert.False(entityType.GetProperty("Id").IsShadowProperty);
-            Assert.True(entityType.GetProperty("Mane").IsShadowProperty);
+            Assert.Null(entityType.GetProperty("Mane").IsShadowProperty);
         }
 
         [Fact]
@@ -2604,34 +2617,11 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             var model = new Model();
             var entityType = model.AddEntityType(typeof(Customer));
-
-            entityType.AddProperty("Id", typeof(int));
+            entityType.AddProperty(Customer.IdProperty);
 
             Assert.Equal(
                 Strings.DuplicateProperty("Id", typeof(Customer).FullName),
-                Assert.Throws<InvalidOperationException>(() => entityType.AddProperty("Id", typeof(int))).Message);
-        }
-
-        [Fact]
-        public void Adding_a_CLR_property_to_a_shadow_entity_type_throws()
-        {
-            var model = new Model();
-            var entityType = model.AddEntityType("Hello");
-
-            Assert.Equal(
-                Strings.ClrPropertyOnShadowEntity("Kitty", "Hello"),
-                Assert.Throws<InvalidOperationException>(() => entityType.AddProperty("Kitty", typeof(int))).Message);
-        }
-
-        [Fact]
-        public void Adding_a_CLR_property_that_doesnt_match_a_CLR_property_throws()
-        {
-            var model = new Model();
-            var entityType = model.AddEntityType(typeof(Customer));
-
-            Assert.Equal(
-                Strings.NoClrProperty("Snook", typeof(Customer).FullName),
-                Assert.Throws<InvalidOperationException>(() => entityType.AddProperty("Snook", typeof(int))).Message);
+                Assert.Throws<InvalidOperationException>(() => entityType.AddProperty("Id")).Message);
         }
 
         [Fact]
@@ -2646,43 +2636,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         }
 
         [Fact]
-        public void Adding_a_CLR_property_where_the_type_doesnt_match_the_CLR_type_throws()
-        {
-            var model = new Model();
-            var entityType = model.AddEntityType(typeof(Customer));
-
-            Assert.Equal(
-                Strings.PropertyWrongClrType("Id", typeof(Customer).FullName),
-                Assert.Throws<InvalidOperationException>(() => entityType.AddProperty("Id", typeof(string))).Message);
-        }
-
-        [Fact]
-        public void Making_a_shadow_property_a_non_shadow_property_throws_if_CLR_property_does_not_match()
-        {
-            var model = new Model();
-            var entityType = model.AddEntityType(typeof(Customer));
-
-            var property1 = entityType.AddProperty("Snook", typeof(int), shadowProperty: true);
-            var property2 = entityType.AddProperty("Id", typeof(string), shadowProperty: true);
-
-            Assert.Equal(
-                Strings.NoClrProperty("Snook", typeof(Customer).FullName),
-                Assert.Throws<InvalidOperationException>(() => property1.IsShadowProperty = false).Message);
-
-            Assert.Equal(
-                Strings.PropertyWrongClrType("Id", typeof(Customer).FullName),
-                Assert.Throws<InvalidOperationException>(() => property2.IsShadowProperty = false).Message);
-        }
-
-        [Fact]
         public void Can_get_property_indexes()
         {
             var model = new Model();
             var entityType = model.AddEntityType(typeof(Customer));
 
             entityType.GetOrAddProperty(Customer.NameProperty);
-            entityType.GetOrAddProperty("Id", typeof(int), shadowProperty: true);
-            entityType.GetOrAddProperty("Mane", typeof(int), shadowProperty: true);
+            entityType.AddProperty("Id", typeof(int));
+            entityType.AddProperty("Mane", typeof(int));
 
             Assert.Equal(0, entityType.GetProperty("Id").Index);
             Assert.Equal(1, entityType.GetProperty("Mane").Index);
@@ -2701,8 +2662,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var model = new Model();
             var entityType = model.AddEntityType(typeof(FullNotificationEntity));
 
-            var nameProperty = entityType.GetOrAddProperty("Name", typeof(string));
-            entityType.GetOrAddProperty("Id", typeof(int), shadowProperty: true).IsConcurrencyToken = true;
+            var nameProperty = entityType.AddProperty("Name", typeof(string));
+            nameProperty.IsShadowProperty = false;
+            var property = entityType.AddProperty("Id", typeof(int)).IsConcurrencyToken = true;
 
             Assert.Equal(0, entityType.GetProperty("Id").Index);
             Assert.Equal(1, entityType.GetProperty("Name").Index);
@@ -2716,10 +2678,10 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Equal(1, entityType.ShadowPropertyCount());
             Assert.Equal(1, entityType.OriginalValueCount());
 
-            var gameProperty = entityType.GetOrAddProperty("Game", typeof(int), shadowProperty: true);
+            var gameProperty = entityType.AddProperty("Game", typeof(int));
             gameProperty.IsConcurrencyToken = true;
 
-            var maneProperty = entityType.GetOrAddProperty("Mane", typeof(int), shadowProperty: true);
+            var maneProperty = entityType.AddProperty("Mane", typeof(int));
             maneProperty.IsConcurrencyToken = true;
 
             Assert.Equal(0, entityType.GetProperty("Game").Index);
@@ -2790,7 +2752,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var customerType = model.AddEntityType(typeof(Customer));
             var idProperty = customerType.GetOrAddProperty(Customer.IdProperty);
             var nameProperty = customerType.GetOrAddProperty(Customer.NameProperty);
-            var otherProperty = customerType.GetOrAddProperty("OtherProperty", typeof(string), shadowProperty: true);
+            var otherProperty = customerType.AddProperty("OtherProperty", typeof(string));
 
             var i2 = customerType.AddIndex(nameProperty);
             var i4 = customerType.AddIndex(new[] { idProperty, otherProperty });
@@ -2847,8 +2809,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             var entityType = new EntityType(typeof(FullNotificationEntity), new Model()) { UseEagerSnapshots = true };
 
-            entityType.GetOrAddProperty("Name", typeof(string));
-            entityType.GetOrAddProperty("Id", typeof(int));
+            entityType.AddProperty(FullNotificationEntity.NameProperty);
+            entityType.AddProperty(FullNotificationEntity.IdProperty);
 
             Assert.Equal(0, entityType.GetProperty("Id").GetOriginalValueIndex());
             Assert.Equal(1, entityType.GetProperty("Name").GetOriginalValueIndex());
@@ -2862,8 +2824,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var model = new Model();
             var entityType = model.AddEntityType(typeof(FullNotificationEntity));
 
-            entityType.GetOrAddProperty("Name", typeof(string)).IsConcurrencyToken = true;
-            entityType.GetOrAddProperty("Id", typeof(int));
+            entityType.AddProperty(FullNotificationEntity.NameProperty).IsConcurrencyToken = true;
+            entityType.AddProperty(FullNotificationEntity.IdProperty);
 
             Assert.Equal(-1, entityType.GetProperty("Id").GetOriginalValueIndex());
             Assert.Equal(0, entityType.GetProperty("Name").GetOriginalValueIndex());
@@ -2876,8 +2838,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             var model = new Model();
             var entityType = model.AddEntityType(typeof(FullNotificationEntity));
-            var key = entityType.GetOrSetPrimaryKey(entityType.GetOrAddProperty("Id", typeof(int)));
-            var fkProperty = entityType.GetOrAddProperty("Fk", typeof(int), shadowProperty: true);
+            var key = entityType.GetOrSetPrimaryKey(entityType.AddProperty(FullNotificationEntity.IdProperty));
+            var fkProperty = entityType.AddProperty("Fk", typeof(int));
 
             Assert.Equal(-1, fkProperty.GetOriginalValueIndex());
 
@@ -2938,6 +2900,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
         private class FullNotificationEntity : INotifyPropertyChanging, INotifyPropertyChanged
         {
+            public static readonly PropertyInfo IdProperty = typeof(FullNotificationEntity).GetProperty("Id");
+            public static readonly PropertyInfo NameProperty = typeof(FullNotificationEntity).GetProperty("Name");
+
             private int _id;
             private string _name;
             private int _game;
@@ -3048,6 +3013,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
         private class SelfRef
         {
+            public static readonly PropertyInfo IdProperty = typeof(SelfRef).GetProperty("Id");
+            public static readonly PropertyInfo ForeignKeyProperty = typeof(SelfRef).GetProperty("ForeignKey");
+
             public int Id { get; set; }
             public SelfRef SelfRef1 { get; set; }
             public SelfRef SelfRef2 { get; set; }

--- a/test/EntityFramework.Core.Tests/Metadata/FieldMatcherTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/FieldMatcherTest.cs
@@ -69,7 +69,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         private static void FieldMatchTest(string propertyName, string fieldName)
         {
             var entityType = new Model().AddEntityType(typeof(TheDarkSideOfTheMoon));
-            var property = entityType.GetOrAddProperty(propertyName, typeof(int));
+            var property = entityType.AddProperty(propertyName, typeof(int));
+            property.IsShadowProperty = false;
             var propertyInfo = entityType.ClrType.GetAnyProperty(propertyName);
             var fields = propertyInfo.DeclaringType.GetRuntimeFields().ToDictionary(f => f.Name);
 
@@ -82,7 +83,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void M_underscore_matching_field_is_not_used_if_type_is_not_compatible()
         {
             var entityType = new Model().AddEntityType(typeof(TheDarkSideOfTheMoon));
-            var property = entityType.GetOrAddProperty("SpeakToMe", typeof(int));
+            var property = entityType.AddProperty("SpeakToMe", typeof(int));
+            property.IsShadowProperty = false;
             var propertyInfo = entityType.ClrType.GetAnyProperty("SpeakToMe");
             var fields = propertyInfo.DeclaringType.GetRuntimeFields().ToDictionary(f => f.Name);
 

--- a/test/EntityFramework.Core.Tests/Metadata/ForeignKeyTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ForeignKeyTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Microsoft.Data.Entity.Internal;
 using Xunit;
 
@@ -15,8 +16,8 @@ namespace Microsoft.Data.Entity.Metadata.Tests
         public void Can_create_foreign_key()
         {
             var entityType = new Model().AddEntityType("E");
-            var dependentProp = entityType.GetOrAddProperty("P", typeof(int), shadowProperty: true);
-            var principalProp = entityType.GetOrAddProperty("Id", typeof(int), shadowProperty: true);
+            var dependentProp = entityType.AddProperty("P", typeof(int));
+            var principalProp = entityType.AddProperty("Id", typeof(int));
             entityType.GetOrSetPrimaryKey(principalProp);
 
             var foreignKey
@@ -39,7 +40,7 @@ namespace Microsoft.Data.Entity.Metadata.Tests
 
             var principalEntityType = model.AddEntityType("R");
             var dependentEntityType = model.AddEntityType("D");
-            var fk = dependentEntityType.AddProperty("Fk", typeof(int), shadowProperty: true);
+            var fk = dependentEntityType.AddProperty("Fk", typeof(int));
 
             var principalKey = dependentEntityType.SetPrimaryKey(fk);
 
@@ -54,10 +55,11 @@ namespace Microsoft.Data.Entity.Metadata.Tests
             var dependentType = new Model().AddEntityType("D");
             var principalType = new Model().AddEntityType("P");
 
-            var dependentProperty1 = dependentType.GetOrAddProperty("P1", typeof(int), shadowProperty: true);
-            var dependentProperty2 = dependentType.GetOrAddProperty("P2", typeof(int), shadowProperty: true);
+            var dependentProperty1 = dependentType.AddProperty("P1", typeof(int));
+            var dependentProperty2 = dependentType.AddProperty("P2", typeof(int));
 
-            principalType.GetOrSetPrimaryKey(principalType.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            var idProperty = principalType.AddProperty("Id", typeof(int));
+            principalType.GetOrSetPrimaryKey(idProperty);
 
             Assert.Equal(
                 Strings.ForeignKeyCountMismatch("{'P1', 'P2'}", "D", "{'Id'}", "P"),
@@ -71,13 +73,15 @@ namespace Microsoft.Data.Entity.Metadata.Tests
             var dependentType = new Model().AddEntityType("D");
             var principalType = new Model().AddEntityType("P");
 
-            var dependentProperty1 = dependentType.GetOrAddProperty("P1", typeof(int), shadowProperty: true);
-            var dependentProperty2 = dependentType.GetOrAddProperty("P2", typeof(string), shadowProperty: true);
+            var dependentProperty1 = dependentType.AddProperty("P1", typeof(int));
+            var dependentProperty2 = dependentType.AddProperty("P2", typeof(string));
 
+            var property2 = principalType.AddProperty("Id1", typeof(int));
+            var property3 = principalType.AddProperty("Id2", typeof(int));
             principalType.GetOrSetPrimaryKey(new[]
                 {
-                    principalType.GetOrAddProperty("Id1", typeof(int), shadowProperty: true),
-                    principalType.GetOrAddProperty("Id2", typeof(int), shadowProperty: true)
+                    property2,
+                    property3
                 });
 
             Assert.Equal(
@@ -90,9 +94,9 @@ namespace Microsoft.Data.Entity.Metadata.Tests
         public void Can_create_foreign_key_with_non_pk_principal()
         {
             var entityType = new Model().AddEntityType("E");
-            var keyProp = entityType.GetOrAddProperty("Id", typeof(int), shadowProperty: true);
-            var dependentProp = entityType.GetOrAddProperty("P", typeof(int), shadowProperty: true);
-            var principalProp = entityType.GetOrAddProperty("U", typeof(int), shadowProperty: true);
+            var keyProp = entityType.AddProperty("Id", typeof(int));
+            var dependentProp = entityType.AddProperty("P", typeof(int));
+            var principalProp = entityType.AddProperty("U", typeof(int));
             entityType.GetOrSetPrimaryKey(keyProp);
             var principalKey = entityType.AddKey(principalProp);
 
@@ -113,8 +117,9 @@ namespace Microsoft.Data.Entity.Metadata.Tests
         public void IsRequired_true_when_dependent_property_not_nullable()
         {
             var entityType = new Model().AddEntityType("E");
-            entityType.GetOrSetPrimaryKey(entityType.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
-            var dependentProp = entityType.GetOrAddProperty("P", typeof(int), shadowProperty: true);
+            var property = entityType.AddProperty("Id", typeof(int));
+            entityType.GetOrSetPrimaryKey(property);
+            var dependentProp = entityType.AddProperty("P", typeof(int));
             dependentProp.IsNullable = false;
 
             var foreignKey = new ForeignKey(new[] { dependentProp }, entityType.GetPrimaryKey(), entityType, entityType);
@@ -127,8 +132,9 @@ namespace Microsoft.Data.Entity.Metadata.Tests
         public void IsRequired_false_when_dependent_property_nullable()
         {
             var entityType = new Model().AddEntityType("E");
-            entityType.GetOrSetPrimaryKey(entityType.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
-            var dependentProp = entityType.GetOrAddProperty("P", typeof(int?), shadowProperty: true);
+            var property = entityType.AddProperty("Id", typeof(int));
+            entityType.GetOrSetPrimaryKey(property);
+            var dependentProp = entityType.AddProperty("P", typeof(int?));
             dependentProp.IsNullable = true;
 
             var foreignKey = new ForeignKey(new[] { dependentProp }, entityType.GetPrimaryKey(), entityType, entityType);
@@ -141,8 +147,9 @@ namespace Microsoft.Data.Entity.Metadata.Tests
         public void IsRequired_and_IsUnique_null_when_dependent_property_not_nullable_by_default()
         {
             var entityType = new Model().AddEntityType("E");
-            entityType.GetOrSetPrimaryKey(entityType.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
-            var dependentProp = entityType.GetOrAddProperty("P", typeof(int), shadowProperty: true);
+            var property = entityType.AddProperty("Id", typeof(int));
+            entityType.GetOrSetPrimaryKey(property);
+            var dependentProp = entityType.AddProperty("P", typeof(int));
 
             var foreignKey = new ForeignKey(new[] { dependentProp }, entityType.GetPrimaryKey(), entityType, entityType);
 
@@ -156,8 +163,9 @@ namespace Microsoft.Data.Entity.Metadata.Tests
         public void IsRequired_and_IsUnique_null_when_dependent_property_nullable_by_default()
         {
             var entityType = new Model().AddEntityType("E");
-            entityType.GetOrSetPrimaryKey(entityType.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
-            var dependentProp = entityType.GetOrAddProperty("P", typeof(int?), shadowProperty: true);
+            var property = entityType.AddProperty("Id", typeof(int));
+            entityType.GetOrSetPrimaryKey(property);
+            var dependentProp = entityType.AddProperty("P", typeof(int?));
 
             var foreignKey = new ForeignKey(new[] { dependentProp }, entityType.GetPrimaryKey(), entityType, entityType);
 
@@ -171,14 +179,16 @@ namespace Microsoft.Data.Entity.Metadata.Tests
         public void IsRequired_false_for_composite_FK_by_default()
         {
             var entityType = new Model().AddEntityType("E");
+            var property = entityType.AddProperty("Id1", typeof(int));
+            var property1 = entityType.AddProperty("Id2", typeof(string));
             entityType.GetOrSetPrimaryKey(new[]
                 {
-                    entityType.GetOrAddProperty("Id1", typeof(int), shadowProperty: true),
-                    entityType.GetOrAddProperty("Id2", typeof(string), shadowProperty: true)
+                    property,
+                    property1
                 });
 
-            var dependentProp1 = entityType.GetOrAddProperty("P1", typeof(int), shadowProperty: true);
-            var dependentProp2 = entityType.GetOrAddProperty("P2", typeof(string), shadowProperty: true);
+            var dependentProp1 = entityType.AddProperty("P1", typeof(int));
+            var dependentProp2 = entityType.AddProperty("P2", typeof(string));
 
             var foreignKey = new ForeignKey(new[] { dependentProp1, dependentProp2 }, entityType.GetPrimaryKey(), entityType, entityType);
 
@@ -190,14 +200,16 @@ namespace Microsoft.Data.Entity.Metadata.Tests
         public void IsRequired_false_when_any_part_of_composite_FK_is_nullable()
         {
             var entityType = new Model().AddEntityType("E");
+            var property = entityType.AddProperty("Id1", typeof(int));
+            var property1 = entityType.AddProperty("Id2", typeof(string));
             entityType.GetOrSetPrimaryKey(new[]
                 {
-                    entityType.GetOrAddProperty("Id1", typeof(int), shadowProperty: true),
-                    entityType.GetOrAddProperty("Id2", typeof(string), shadowProperty: true)
+                    property,
+                    property1
                 });
 
-            var dependentProp1 = entityType.GetOrAddProperty("P1", typeof(int), shadowProperty: true);
-            var dependentProp2 = entityType.GetOrAddProperty("P2", typeof(string), shadowProperty: true);
+            var dependentProp1 = entityType.AddProperty("P1", typeof(int));
+            var dependentProp2 = entityType.AddProperty("P2", typeof(string));
             dependentProp2.IsNullable = true;
 
             var foreignKey = new ForeignKey(new[] { dependentProp1, dependentProp2 }, entityType.GetPrimaryKey(), entityType, entityType);
@@ -215,15 +227,17 @@ namespace Microsoft.Data.Entity.Metadata.Tests
         public void Setting_IsRequired_to_true_will_set_all_FK_properties_as_non_nullable()
         {
             var entityType = new Model().AddEntityType("E");
+            var property = entityType.AddProperty("Id1", typeof(int));
+            var property3 = entityType.AddProperty("Id2", typeof(string));
             entityType.GetOrSetPrimaryKey(
                 new[]
                     {
-                        entityType.GetOrAddProperty("Id1", typeof(int), shadowProperty: true),
-                        entityType.GetOrAddProperty("Id2", typeof(string), shadowProperty: true)
+                        property,
+                        property3
                     });
 
-            var dependentProp1 = entityType.GetOrAddProperty("P1", typeof(int), shadowProperty: true);
-            var dependentProp2 = entityType.GetOrAddProperty("P2", typeof(string), shadowProperty: true);
+            var dependentProp1 = entityType.AddProperty("P1", typeof(int));
+            var dependentProp2 = entityType.AddProperty("P2", typeof(string));
 
             var foreignKey = new ForeignKey(new[] { dependentProp1, dependentProp2 }, entityType.GetPrimaryKey(), entityType, entityType)
                 { IsRequired = true };
@@ -237,14 +251,16 @@ namespace Microsoft.Data.Entity.Metadata.Tests
         public void Setting_IsRequired_to_false_will_set_all_FK_properties_as_nullable()
         {
             var entityType = new Model().AddEntityType("E");
+            var property = entityType.AddProperty("Id1", typeof(int));
+            var property1 = entityType.AddProperty("Id2", typeof(string));
             entityType.GetOrSetPrimaryKey(new[]
                 {
-                    entityType.GetOrAddProperty("Id1", typeof(int), shadowProperty: true),
-                    entityType.GetOrAddProperty("Id2", typeof(string), shadowProperty: true)
+                    property,
+                    property1
                 });
 
-            var dependentProp1 = entityType.GetOrAddProperty("P1", typeof(int?), shadowProperty: true);
-            var dependentProp2 = entityType.GetOrAddProperty("P2", typeof(string), shadowProperty: true);
+            var dependentProp1 = entityType.AddProperty("P1", typeof(int?));
+            var dependentProp2 = entityType.AddProperty("P2", typeof(string));
 
             var foreignKey = new ForeignKey(new[] { dependentProp1, dependentProp2 }, entityType.GetPrimaryKey(), entityType, entityType) { IsRequired = false };
 
@@ -382,10 +398,11 @@ namespace Microsoft.Data.Entity.Metadata.Tests
         {
             var model = new Model();
             var principalEntityType = model.AddEntityType(typeof(OneToManyPrincipal));
-            var pk = principalEntityType.GetOrSetPrimaryKey(principalEntityType.GetOrAddProperty("Id", typeof(int)));
+            var property = principalEntityType.AddProperty(NavigationBase.IdProperty);
+            var pk = principalEntityType.GetOrSetPrimaryKey(property);
 
             var dependentEntityType = model.AddEntityType(typeof(OneToManyDependent));
-            var fkProp = dependentEntityType.GetOrAddProperty("Id", typeof(int));
+            var fkProp = dependentEntityType.AddProperty(NavigationBase.IdProperty);
             var fk = dependentEntityType.AddForeignKey(new[] { fkProp }, pk, principalEntityType);
 
             principalEntityType.AddNavigation("OneToManyDependents", fk, pointsToPrincipal: false);
@@ -398,14 +415,15 @@ namespace Microsoft.Data.Entity.Metadata.Tests
             var model = new Model();
 
             var baseEntityType = model.AddEntityType(typeof(NavigationBase));
-            var pk = baseEntityType.GetOrSetPrimaryKey(baseEntityType.GetOrAddProperty("Id", typeof(int)));
+            var property1 = baseEntityType.AddProperty(NavigationBase.IdProperty);
+            var pk = baseEntityType.GetOrSetPrimaryKey(property1);
 
             var principalEntityType = model.AddEntityType(typeof(OneToManyPrincipal));
             principalEntityType.BaseType = baseEntityType;
 
             var dependentEntityType = model.AddEntityType(typeof(OneToManyDependent));
             dependentEntityType.BaseType = baseEntityType;
-            var fkProp = dependentEntityType.GetOrAddProperty("Fk", typeof(int), shadowProperty: true);
+            var fkProp = dependentEntityType.AddProperty("Fk", typeof(int));
             var fk = dependentEntityType.AddForeignKey(new[] { fkProp }, pk, principalEntityType);
 
             principalEntityType.AddNavigation("OneToManyDependents", fk, pointsToPrincipal: false);
@@ -418,11 +436,12 @@ namespace Microsoft.Data.Entity.Metadata.Tests
             var model = new Model();
 
             var baseEntityType = model.AddEntityType(typeof(NavigationBase));
-            var pk = baseEntityType.GetOrSetPrimaryKey(baseEntityType.GetOrAddProperty("Id", typeof(int)));
+            var property1 = baseEntityType.AddProperty(NavigationBase.IdProperty);
+            var pk = baseEntityType.GetOrSetPrimaryKey(property1);
 
             var dependentEntityType = model.AddEntityType(typeof(OneToManyDependent));
             dependentEntityType.BaseType = baseEntityType;
-            var fkProp = dependentEntityType.GetOrAddProperty("Fk", typeof(int), shadowProperty: true);
+            var fkProp = dependentEntityType.AddProperty("Fk", typeof(int));
             var fk = dependentEntityType.AddForeignKey(new[] { fkProp }, pk, baseEntityType);
 
             baseEntityType.AddNavigation("OneToManyDependents", fk, pointsToPrincipal: false);
@@ -431,6 +450,8 @@ namespace Microsoft.Data.Entity.Metadata.Tests
 
         public abstract class NavigationBase
         {
+            public static readonly PropertyInfo IdProperty = typeof(NavigationBase).GetProperty("Id");
+
             public int Id { get; set; }
             public IEnumerable<OneToManyDependent> OneToManyDependents { get; set; }
             public OneToManyPrincipal OneToManyPrincipal { get; set; }
@@ -584,11 +605,12 @@ namespace Microsoft.Data.Entity.Metadata.Tests
         private ForeignKey CreateSelfRefFK(bool useAltKey = false)
         {
             var entityType = new Model().AddEntityType(typeof(SelfRef));
-            var pk = entityType.GetOrSetPrimaryKey(entityType.GetOrAddProperty("Id", typeof(int)));
-            var fkProp = entityType.GetOrAddProperty("SelfRefId", typeof(int?));
+            var pk = entityType.GetOrSetPrimaryKey(entityType.AddProperty(SelfRef.IdProperty));
+            var fkProp = entityType.AddProperty(SelfRef.SelfRefIdProperty);
 
+            var property = entityType.AddProperty("AltId", typeof(int));
             var principalKey = useAltKey
-                ? entityType.GetOrAddKey(entityType.GetOrAddProperty("AltId", typeof(int), shadowProperty: true))
+                ? entityType.GetOrAddKey(property)
                 : pk;
 
             var fk = entityType.AddForeignKey(new[] { fkProp }, principalKey, entityType);
@@ -600,6 +622,9 @@ namespace Microsoft.Data.Entity.Metadata.Tests
 
         private class SelfRef
         {
+            public static readonly PropertyInfo IdProperty = typeof(SelfRef).GetProperty("Id");
+            public static readonly PropertyInfo SelfRefIdProperty = typeof(SelfRef).GetProperty("SelfRefId");
+
             public int Id { get; set; }
             public SelfRef SelfRefPrincipal { get; set; }
             public SelfRef SelfRefDependent { get; set; }

--- a/test/EntityFramework.Core.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
             var key = principalEntityBuilder.PrimaryKey(new[] { Customer.IdProperty, Customer.UniqueProperty }, ConfigurationSource.Explicit);
             var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-            var shadowProperty = dependentEntityBuilder.Property(typeof(Guid), "Shadow", ConfigurationSource.Convention);
+            var shadowProperty = dependentEntityBuilder.Property("Shadow", typeof(Guid), ConfigurationSource.Convention);
 
             var relationshipBuilder = dependentEntityBuilder.Relationship(
                 principalEntityBuilder,
@@ -185,11 +185,11 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             Test_removing_relationship_does_not_remove_contained_shadow_properties_if_referenced_elsewhere(
                 (entityBuilder, property) => entityBuilder.ForeignKey(
                     typeof(Customer).FullName,
-                    new[] { entityBuilder.Property(typeof(int), "Shadow2", ConfigurationSource.Convention).Metadata.Name, property.Name },
+                    new[] { entityBuilder.Property("Shadow2", typeof(int), ConfigurationSource.Convention).Metadata.Name, property.Name },
                     ConfigurationSource.Convention));
 
             Test_removing_relationship_does_not_remove_contained_shadow_properties_if_referenced_elsewhere(
-                (entityBuilder, property) => entityBuilder.Property(typeof(Guid), "Shadow", ConfigurationSource.Explicit));
+                (entityBuilder, property) => entityBuilder.Property("Shadow", typeof(Guid), ConfigurationSource.Explicit));
         }
 
         private void Test_removing_relationship_does_not_remove_contained_shadow_properties_if_referenced_elsewhere(Func<InternalEntityTypeBuilder, Property, object> shadowConfig)
@@ -198,7 +198,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
             var key = principalEntityBuilder.PrimaryKey(new[] { Customer.IdProperty, Customer.UniqueProperty }, ConfigurationSource.Explicit);
             var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-            var shadowProperty = dependentEntityBuilder.Property(typeof(Guid), "Shadow", ConfigurationSource.Convention);
+            var shadowProperty = dependentEntityBuilder.Property("Shadow", typeof(Guid), ConfigurationSource.Convention);
             Assert.NotNull(shadowConfig(dependentEntityBuilder, shadowProperty.Metadata));
 
             var relationshipBuilder = dependentEntityBuilder.Relationship(
@@ -289,7 +289,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
         {
             var modelBuilder = CreateModelBuilder();
             var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-            var shadowProperty = entityBuilder.Property(typeof(Guid), "Shadow", ConfigurationSource.Convention);
+            var shadowProperty = entityBuilder.Property("Shadow", typeof(Guid), ConfigurationSource.Convention);
 
             var index = entityBuilder.Index(new[] { Order.CustomerIdProperty.Name, shadowProperty.Metadata.Name }, ConfigurationSource.Convention);
             Assert.NotNull(index);
@@ -316,7 +316,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                     ConfigurationSource.Convention));
 
             Test_removing_index_does_not_remove_contained_shadow_properties_if_referenced_elsewhere(
-                (entityBuilder, property) => entityBuilder.Property(property.ClrType, property.Name, ConfigurationSource.Explicit));
+                (entityBuilder, property) => entityBuilder.Property(((IProperty)property).Name, property.ClrType, ConfigurationSource.Explicit));
         }
 
         private void Test_removing_index_does_not_remove_contained_shadow_properties_if_referenced_elsewhere(Func<InternalEntityTypeBuilder, Property, object> shadowConfig)
@@ -326,7 +326,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 .Entity(typeof(Customer), ConfigurationSource.Explicit)
                 .PrimaryKey(new[] { Customer.IdProperty, Customer.UniqueProperty }, ConfigurationSource.Explicit);
             var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-            var shadowProperty = entityBuilder.Property(typeof(Guid), "Shadow", ConfigurationSource.Convention);
+            var shadowProperty = entityBuilder.Property("Shadow", typeof(Guid), ConfigurationSource.Convention);
             Assert.NotNull(shadowConfig(entityBuilder, shadowProperty.Metadata));
 
             var index = entityBuilder.Index(new[] { Order.CustomerIdProperty.Name, shadowProperty.Metadata.Name }, ConfigurationSource.Convention);
@@ -360,17 +360,6 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
             Assert.NotNull(keyBuilder);
             Assert.Same(keyBuilder, entityBuilder.Key(new[] { Order.IdProperty, Order.CustomerIdProperty }, ConfigurationSource.DataAnnotation));
-        }
-
-        [Fact]
-        public void Key_throws_for_clr_properties_if_they_do_not_exist()
-        {
-            var modelBuilder = CreateModelBuilder();
-            var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-
-            Assert.Equal(Strings.NoClrProperty(Customer.UniqueProperty.Name, typeof(Order).FullName),
-                Assert.Throws<InvalidOperationException>(() =>
-                    entityBuilder.Key(new[] { Customer.UniqueProperty }, ConfigurationSource.DataAnnotation)).Message);
         }
 
         [Fact]
@@ -415,7 +404,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
         {
             var modelBuilder = CreateModelBuilder();
             var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-            entityBuilder.Property(Order.CustomerIdProperty.PropertyType, Order.CustomerIdProperty.Name, ConfigurationSource.Convention);
+            entityBuilder.Property(Order.CustomerIdProperty.Name, Order.CustomerIdProperty.PropertyType, ConfigurationSource.Convention);
 
             Assert.NotNull(entityBuilder.Key(new[] { Order.CustomerIdProperty.Name }, ConfigurationSource.Convention));
 
@@ -463,7 +452,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
         {
             var modelBuilder = CreateModelBuilder();
             var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-            var shadowProperty = entityBuilder.Property(typeof(Guid), "Shadow", ConfigurationSource.Convention);
+            var shadowProperty = entityBuilder.Property("Shadow", typeof(Guid), ConfigurationSource.Convention);
 
             var key = entityBuilder.Key(new[] { Order.CustomerIdProperty.Name, shadowProperty.Metadata.Name }, ConfigurationSource.Convention);
             Assert.NotNull(key);
@@ -481,7 +470,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 (entityBuilder, property) => entityBuilder.PrimaryKey(
                     new[]
                         {
-                            entityBuilder.Property(typeof(int), "Shadow2", ConfigurationSource.Convention).Metadata.Name,
+                            entityBuilder.Property("Shadow2", typeof(int), ConfigurationSource.Convention).Metadata.Name,
                             property.Name
                         }, ConfigurationSource.Convention));
 
@@ -495,7 +484,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                     ConfigurationSource.Convention));
 
             Test_removing_key_does_not_remove_contained_shadow_properties_if_referenced_elsewhere(
-                (entityBuilder, property) => entityBuilder.Property(typeof(Guid), "Shadow", ConfigurationSource.Explicit));
+                (entityBuilder, property) => entityBuilder.Property("Shadow", typeof(Guid), ConfigurationSource.Explicit));
         }
 
         private void Test_removing_key_does_not_remove_contained_shadow_properties_if_referenced_elsewhere(Func<InternalEntityTypeBuilder, Property, object> shadowConfig)
@@ -505,7 +494,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 .Entity(typeof(Customer), ConfigurationSource.Explicit)
                 .PrimaryKey(new[] { Customer.IdProperty, Customer.UniqueProperty }, ConfigurationSource.Explicit);
             var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-            var shadowProperty = entityBuilder.Property(typeof(Guid), "Shadow", ConfigurationSource.Convention);
+            var shadowProperty = entityBuilder.Property("Shadow", typeof(Guid), ConfigurationSource.Convention);
             Assert.NotNull(shadowConfig(entityBuilder, shadowProperty.Metadata));
 
             var key = entityBuilder.Key(new[] { Order.CustomerIdProperty.Name, shadowProperty.Metadata.Name }, ConfigurationSource.Convention);
@@ -584,17 +573,6 @@ namespace Microsoft.Data.Entity.Metadata.Internal
         }
 
         [Fact]
-        public void PrimaryKey_throws_for_clr_properties_if_they_do_not_exist()
-        {
-            var modelBuilder = CreateModelBuilder();
-            var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-
-            Assert.Equal(Strings.NoClrProperty(Customer.UniqueProperty.Name, typeof(Order).FullName),
-                Assert.Throws<InvalidOperationException>(() =>
-                    entityBuilder.PrimaryKey(new[] { Customer.UniqueProperty }, ConfigurationSource.DataAnnotation)).Message);
-        }
-
-        [Fact]
         public void PrimaryKey_throws_for_property_names_if_they_do_not_exist()
         {
             var modelBuilder = CreateModelBuilder();
@@ -636,7 +614,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
         {
             var modelBuilder = CreateModelBuilder();
             var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-            entityBuilder.Property(Order.CustomerIdProperty.PropertyType, Order.CustomerIdProperty.Name, ConfigurationSource.Convention);
+            entityBuilder.Property(Order.CustomerIdProperty.Name, Order.CustomerIdProperty.PropertyType, ConfigurationSource.Convention);
 
             Assert.NotNull(entityBuilder.PrimaryKey(new[] { Order.CustomerIdProperty.Name }, ConfigurationSource.Convention));
 
@@ -750,7 +728,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var propertyBuilder = entityBuilder.Property(Order.IdProperty, ConfigurationSource.Explicit);
 
             Assert.NotNull(propertyBuilder);
-            Assert.Same(propertyBuilder, entityBuilder.Property(typeof(Order), Order.IdProperty.Name, ConfigurationSource.Explicit));
+            Assert.Same(propertyBuilder, entityBuilder.Property(Order.IdProperty.Name, typeof(Order), ConfigurationSource.Explicit));
         }
 
         [Fact]
@@ -759,7 +737,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var modelBuilder = CreateModelBuilder();
             var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
-            var propertyBuilder = entityBuilder.Property(typeof(Order), Order.IdProperty.Name, ConfigurationSource.DataAnnotation);
+            var propertyBuilder = entityBuilder.Property(Order.IdProperty.Name, typeof(Order), ConfigurationSource.DataAnnotation);
 
             Assert.NotNull(propertyBuilder);
             Assert.Same(propertyBuilder, entityBuilder.Property(Order.IdProperty, ConfigurationSource.DataAnnotation));
@@ -770,14 +748,14 @@ namespace Microsoft.Data.Entity.Metadata.Internal
         {
             var modelBuilder = CreateModelBuilder();
             var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-            var propertyBuilder = entityBuilder.Property(typeof(int), Order.IdProperty.Name, ConfigurationSource.Convention);
+            var propertyBuilder = entityBuilder.Property(Order.IdProperty.Name, typeof(int), ConfigurationSource.Convention);
 
             var derivedEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
             derivedEntityBuilder.BaseType(entityBuilder.Metadata, ConfigurationSource.Convention);
 
             Assert.Equal(Strings.DuplicateProperty(Order.IdProperty.Name, typeof(SpecialOrder).FullName),
                 Assert.Throws<InvalidOperationException>(() =>
-                    derivedEntityBuilder.Property(typeof(int), Order.IdProperty.Name, ConfigurationSource.DataAnnotation)).Message);
+                    derivedEntityBuilder.Property(Order.IdProperty.Name, typeof(int), ConfigurationSource.DataAnnotation)).Message);
         }
 
         [Fact]
@@ -791,11 +769,11 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
             Assert.Null(entityType.FindProperty(Order.IdProperty.Name));
             Assert.True(entityBuilder.Ignore(Order.IdProperty.Name, ConfigurationSource.Explicit));
-            Assert.Null(entityBuilder.Property(typeof(Order), Order.IdProperty.Name, ConfigurationSource.DataAnnotation));
+            Assert.Null(entityBuilder.Property(Order.IdProperty.Name, typeof(Order), ConfigurationSource.DataAnnotation));
 
             Assert.Equal(Strings.PropertyIgnoredExplicitly(Order.IdProperty.Name, typeof(Order).FullName),
                 Assert.Throws<InvalidOperationException>(() =>
-                    entityBuilder.Property(typeof(Order), Order.IdProperty.Name, ConfigurationSource.Explicit)).Message);
+                    entityBuilder.Property(Order.IdProperty.Name, typeof(Order), ConfigurationSource.Explicit)).Message);
         }
 
         [Fact]
@@ -805,25 +783,24 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
             var entityType = entityBuilder.Metadata;
 
-            Assert.NotNull(entityBuilder.Property(typeof(Order), Order.IdProperty.Name, ConfigurationSource.Convention));
+            Assert.NotNull(entityBuilder.Property(Order.IdProperty.Name, typeof(Order), ConfigurationSource.Convention));
             Assert.True(entityBuilder.Ignore(Order.IdProperty.Name, ConfigurationSource.Convention));
             Assert.Null(entityType.FindProperty(Order.IdProperty.Name));
 
-            Assert.NotNull(entityBuilder.Property(typeof(Order), Order.IdProperty.Name, ConfigurationSource.DataAnnotation));
+            Assert.NotNull(entityBuilder.Property(Order.IdProperty.Name, typeof(Order), ConfigurationSource.DataAnnotation));
             Assert.False(entityBuilder.Ignore(Order.IdProperty.Name, ConfigurationSource.Convention));
             Assert.NotNull(entityType.FindProperty(Order.IdProperty.Name));
 
             Assert.True(entityBuilder.Ignore(Order.IdProperty.Name, ConfigurationSource.DataAnnotation));
             Assert.Null(entityType.FindProperty(Order.IdProperty.Name));
 
-            Assert.NotNull(entityBuilder.Property(typeof(Order), Order.IdProperty.Name, ConfigurationSource.Explicit));
+            Assert.NotNull(entityBuilder.Property(Order.IdProperty.Name, typeof(Order), ConfigurationSource.Explicit));
             Assert.False(entityBuilder.Ignore(Order.IdProperty.Name, ConfigurationSource.Convention));
             Assert.False(entityBuilder.Ignore(Order.IdProperty.Name, ConfigurationSource.DataAnnotation));
             Assert.NotNull(entityType.FindProperty(Order.IdProperty.Name));
 
             Assert.True(entityBuilder.Ignore(Order.IdProperty.Name, ConfigurationSource.Explicit));
             Assert.Null(entityType.FindProperty(Order.IdProperty.Name));
-
         }
 
         [Fact]
@@ -833,8 +810,9 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
             var entityType = entityBuilder.Metadata;
             var property = entityType.AddProperty(Order.IdProperty.Name, typeof(int));
+            property.IsShadowProperty = false;
 
-            Assert.Same(property, entityBuilder.Property(typeof(Order), Order.IdProperty.Name, ConfigurationSource.Convention).Metadata);
+            Assert.Same(property, entityBuilder.Property(Order.IdProperty.Name, ConfigurationSource.Convention).Metadata);
             Assert.False(entityBuilder.Ignore(Order.IdProperty.Name, ConfigurationSource.DataAnnotation));
             Assert.NotNull(entityType.FindProperty(Order.IdProperty.Name));
 
@@ -843,7 +821,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
             Assert.Equal(Strings.PropertyIgnoredExplicitly(Order.IdProperty.Name, typeof(Order).FullName),
                 Assert.Throws<InvalidOperationException>(() =>
-                    entityBuilder.Property(typeof(Order), Order.IdProperty.Name, ConfigurationSource.Explicit)).Message);
+                    entityBuilder.Property(Order.IdProperty.Name, typeof(Order), ConfigurationSource.Explicit)).Message);
         }
 
         [Fact]
@@ -1153,11 +1131,15 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
             principalEntityBuilder.PrimaryKey(new[] { Customer.IdProperty, Customer.UniqueProperty }, ConfigurationSource.Explicit);
             var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+            var property1 = dependentEntityBuilder.Metadata.AddProperty(Order.CustomerIdProperty.Name, typeof(int));
+            property1.IsShadowProperty = false;
+            var property2 = dependentEntityBuilder.Metadata.AddProperty(Order.CustomerUniqueProperty.Name, typeof(Guid));
+            property2.IsShadowProperty = false;
             var foreignKey = dependentEntityBuilder.Metadata.AddForeignKey(
                 new[]
                     {
-                        dependentEntityBuilder.Metadata.GetOrAddProperty(Order.CustomerIdProperty.Name, typeof(int)),
-                        dependentEntityBuilder.Metadata.GetOrAddProperty(Order.CustomerUniqueProperty.Name, typeof(Guid))
+                        property1,
+                        property2
                     },
                 principalEntityBuilder.Metadata.GetPrimaryKey(),
                 principalEntityBuilder.Metadata);
@@ -1624,7 +1606,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var modelBuilder = CreateModelBuilder();
             var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
             principalEntityBuilder.PrimaryKey(new[] { Customer.IdProperty }, ConfigurationSource.Explicit);
-            var principalShadowProp = principalEntityBuilder.Property(typeof(int), "ShadowId", ConfigurationSource.Convention);
+            var principalShadowProp = principalEntityBuilder.Property("ShadowId", typeof(int), ConfigurationSource.Convention);
             var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
             dependentEntityBuilder.ForeignKey(typeof(Customer).FullName, new[] { Order.CustomerIdProperty.Name }, ConfigurationSource.DataAnnotation);
 
@@ -1657,7 +1639,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var modelBuilder = CreateModelBuilder();
             var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
             principalEntityBuilder.PrimaryKey(new[] { Customer.IdProperty }, ConfigurationSource.Explicit);
-            var principalShadowProp = principalEntityBuilder.Property(typeof(int), "ShadowId", ConfigurationSource.Convention);
+            var principalShadowProp = principalEntityBuilder.Property("ShadowId", typeof(int), ConfigurationSource.Convention);
             var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
             dependentEntityBuilder.ForeignKey(typeof(Customer).FullName, new[] { Order.CustomerIdProperty.Name }, ConfigurationSource.DataAnnotation);
 
@@ -1710,8 +1692,8 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             Assert.Equal(1, principalEntityBuilder.Metadata.GetDeclaredKeys().Count());
             Assert.Equal(0, derivedPrincipalEntityBuilder.Metadata.GetDeclaredKeys().Count());
             Assert.Equal(0, derivedPrincipalEntityBuilder.Metadata.GetForeignKeys().Count());
-            Assert.Equal(0, principalEntityBuilder.Metadata.GetReferencingForeignKeys().Count());
-            var fk = derivedPrincipalEntityBuilder.Metadata.GetReferencingForeignKeys().Single();
+            Assert.Equal(0, principalEntityBuilder.Metadata.FindReferencingForeignKeys().Count());
+            var fk = derivedPrincipalEntityBuilder.Metadata.FindReferencingForeignKeys().Single();
             Assert.Equal(Order.CustomerProperty.Name, fk.DependentToPrincipal.Name);
             Assert.Equal(Customer.OrdersProperty.Name, fk.PrincipalToDependent.Name);
         }

--- a/test/EntityFramework.Core.Tests/Metadata/Internal/InternalModelBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/Internal/InternalModelBuilderTest.cs
@@ -262,7 +262,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal.Test
 
         private class Product
         {
-            public static readonly PropertyInfo IdProperty = typeof(Order).GetProperty("Id");
+            public static readonly PropertyInfo IdProperty = typeof(Product).GetProperty("Id");
             public int Id { get; set; }
         }
     }

--- a/test/EntityFramework.Core.Tests/Metadata/Internal/InternalPropertyBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/Internal/InternalPropertyBuilderTest.cs
@@ -11,12 +11,51 @@ namespace Microsoft.Data.Entity.Metadata.Internal
     public class InternalPropertyBuilderTest
     {
         [Fact]
-        public void Can_only_override_lower_source_ConcurrencyToken()
+        public void Can_only_override_lower_or_equal_source_ClrType()
         {
             var builder = CreateInternalPropertyBuilder();
             var metadata = builder.Metadata;
 
-            Assert.True(builder.ConcurrencyToken(true, ConfigurationSource.Convention));
+            Assert.True(builder.ClrType(typeof(int), ConfigurationSource.DataAnnotation));
+
+            Assert.Equal(typeof(int), metadata.ClrType);
+
+            Assert.True(builder.ClrType(typeof(string), ConfigurationSource.DataAnnotation));
+
+            Assert.Equal(typeof(string), metadata.ClrType);
+
+            Assert.False(builder.ClrType(typeof(int), ConfigurationSource.Convention));
+
+            Assert.Equal(typeof(string), metadata.ClrType);
+
+            Assert.True(builder.ClrType(typeof(string), ConfigurationSource.Convention));
+        }
+
+        [Fact]
+        public void Can_only_override_existing_ClrType_value_explicitly()
+        {
+            var model = new Model();
+            model.AddEntityType(typeof(Customer)).AddProperty(Customer.NameProperty);
+            var modelBuilder = new InternalModelBuilder(model, new ConventionSet());
+            var entityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
+            var builder = entityBuilder.Property(Customer.NameProperty.Name, ConfigurationSource.Convention);
+
+            Assert.True(builder.ClrType(typeof(string), ConfigurationSource.DataAnnotation));
+            Assert.False(builder.ClrType(typeof(int), ConfigurationSource.DataAnnotation));
+
+            Assert.Equal(typeof(string), builder.Metadata.ClrType);
+
+            Assert.True(builder.ClrType(typeof(int), ConfigurationSource.Explicit));
+            Assert.Equal(typeof(int), builder.Metadata.ClrType);
+        }
+
+        [Fact]
+        public void Can_only_override_lower_or_equal_source_ConcurrencyToken()
+        {
+            var builder = CreateInternalPropertyBuilder();
+            var metadata = builder.Metadata;
+
+            Assert.True(builder.ConcurrencyToken(true, ConfigurationSource.DataAnnotation));
             Assert.True(builder.ConcurrencyToken(false, ConfigurationSource.DataAnnotation));
 
             Assert.False(metadata.IsConcurrencyToken.Value);
@@ -42,12 +81,12 @@ namespace Microsoft.Data.Entity.Metadata.Internal
         }
 
         [Fact]
-        public void Can_only_override_lower_source_UseValueGenerator()
+        public void Can_only_override_lower_or_equal_source_UseValueGenerator()
         {
             var builder = CreateInternalPropertyBuilder();
             var metadata = builder.Metadata;
 
-            Assert.True(builder.UseValueGenerator(true, ConfigurationSource.Convention));
+            Assert.True(builder.UseValueGenerator(true, ConfigurationSource.DataAnnotation));
             Assert.True(builder.UseValueGenerator(false, ConfigurationSource.DataAnnotation));
 
             Assert.Equal(false, metadata.RequiresValueGenerator);
@@ -73,12 +112,12 @@ namespace Microsoft.Data.Entity.Metadata.Internal
         }
 
         [Fact]
-        public void Can_only_override_lower_source_ValueGenerated()
+        public void Can_only_override_lower_or_equal_source_ValueGenerated()
         {
             var builder = CreateInternalPropertyBuilder();
             var metadata = builder.Metadata;
 
-            Assert.True(builder.ValueGenerated(ValueGenerated.OnAddOrUpdate, ConfigurationSource.Convention));
+            Assert.True(builder.ValueGenerated(ValueGenerated.OnAddOrUpdate, ConfigurationSource.DataAnnotation));
             Assert.True(builder.ValueGenerated(ValueGenerated.Never, ConfigurationSource.DataAnnotation));
 
             Assert.Equal(ValueGenerated.Never, metadata.ValueGenerated);
@@ -104,12 +143,12 @@ namespace Microsoft.Data.Entity.Metadata.Internal
         }
 
         [Fact]
-        public void Can_only_override_lower_source_MaxLength()
+        public void Can_only_override_lower_or_equal_source_MaxLength()
         {
             var builder = CreateInternalPropertyBuilder();
             var metadata = builder.Metadata;
 
-            Assert.True(builder.MaxLength(1, ConfigurationSource.Convention));
+            Assert.True(builder.MaxLength(1, ConfigurationSource.DataAnnotation));
             Assert.True(builder.MaxLength(2, ConfigurationSource.DataAnnotation));
 
             Assert.Equal(2, metadata.GetMaxLength().Value);
@@ -135,12 +174,12 @@ namespace Microsoft.Data.Entity.Metadata.Internal
         }
 
         [Fact]
-        public void Can_only_override_lower_source_Required()
+        public void Can_only_override_lower_or_equal_source_Required()
         {
             var builder = CreateInternalPropertyBuilder();
             var metadata = builder.Metadata;
 
-            Assert.True(builder.Required(true, ConfigurationSource.Convention));
+            Assert.True(builder.Required(true, ConfigurationSource.DataAnnotation));
             Assert.True(builder.Required(false, ConfigurationSource.DataAnnotation));
 
             Assert.True(metadata.IsNullable.Value);
@@ -166,12 +205,12 @@ namespace Microsoft.Data.Entity.Metadata.Internal
         }
 
         [Fact]
-        public void Can_only_override_lower_source_Shadow()
+        public void Can_only_override_lower_or_equal_source_Shadow()
         {
             var builder = CreateInternalPropertyBuilder();
             var metadata = builder.Metadata;
 
-            Assert.True(builder.Shadow(true, ConfigurationSource.Convention));
+            Assert.True(builder.Shadow(true, ConfigurationSource.DataAnnotation));
             Assert.True(builder.Shadow(false, ConfigurationSource.DataAnnotation));
 
             Assert.False(metadata.IsShadowProperty);
@@ -183,18 +222,19 @@ namespace Microsoft.Data.Entity.Metadata.Internal
         [Fact]
         public void Can_only_override_existing_Shadow_value_explicitly()
         {
-            var modelBuilder = new InternalModelBuilder(new Model(), new ConventionSet());
+            var model = new Model();
+            model.AddEntityType(typeof(Customer)).AddProperty(Customer.NameProperty);
+            var modelBuilder = new InternalModelBuilder(model, new ConventionSet());
             var entityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-            var builder = entityBuilder.Property(Customer.NameProperty.PropertyType, Customer.NameProperty.Name, ConfigurationSource.Explicit);
-            var metadata = builder.Metadata;
+            var builder = entityBuilder.Property(Customer.NameProperty.Name, ConfigurationSource.Convention);
 
-            Assert.True(builder.Shadow(true, ConfigurationSource.DataAnnotation));
-            Assert.False(builder.Shadow(false, ConfigurationSource.DataAnnotation));
+            Assert.True(builder.Shadow(false, ConfigurationSource.DataAnnotation));
+            Assert.False(builder.Shadow(true, ConfigurationSource.DataAnnotation));
 
-            Assert.True(metadata.IsShadowProperty);
+            Assert.False(builder.Metadata.IsShadowProperty);
 
-            Assert.True(builder.Shadow(false, ConfigurationSource.Explicit));
-            Assert.False(metadata.IsShadowProperty);
+            Assert.True(builder.Shadow(true, ConfigurationSource.Explicit));
+            Assert.True(builder.Metadata.IsShadowProperty);
         }
 
         private InternalPropertyBuilder CreateInternalPropertyBuilder()
@@ -206,7 +246,6 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
         private class Customer
         {
-            public static readonly PropertyInfo IdProperty = typeof(Customer).GetProperty("Id");
             public static readonly PropertyInfo NameProperty = typeof(Customer).GetProperty("Name");
 
             public int Id { get; set; }

--- a/test/EntityFramework.Core.Tests/Metadata/MemberMapperTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/MemberMapperTest.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Annotated_field_name_is_used_if_present()
         {
             var entityType = new Model().AddEntityType(typeof(TheDarkSide));
-            var property = entityType.GetOrAddProperty("SpeakToMe", typeof(int));
+            var property = entityType.AddProperty(TheDarkSide.SpeakToMeProperty);
             property["BackingField"] = "fieldForSpeak";
 
             var mapping = new MemberMapper(new FieldMatcher()).MapPropertiesToMembers(entityType).Single();
@@ -30,7 +30,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Throws_if_annotated_field_name_is_not_found()
         {
             var entityType = new Model().AddEntityType(typeof(TheDarkSide));
-            var property = entityType.GetOrAddProperty("SpeakToMe", typeof(int));
+            var property = entityType.AddProperty(TheDarkSide.SpeakToMeProperty);
             property["BackingField"] = "_speakToMe";
 
             Assert.Equal(
@@ -43,7 +43,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Throws_if_annotated_field_if_types_not_compatible()
         {
             var entityType = new Model().AddEntityType(typeof(TheDarkSide));
-            var property = entityType.GetOrAddProperty("SpeakToMe", typeof(int));
+            var property = entityType.AddProperty(TheDarkSide.SpeakToMeProperty);
             property["BackingField"] = "_badFieldForSpeak";
 
             Assert.Equal(
@@ -56,7 +56,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Field_name_match_is_used_in_preference_to_property_setter()
         {
             var entityType = new Model().AddEntityType(typeof(TheDarkSide));
-            var property = entityType.GetOrAddProperty("Breathe", typeof(int));
+            var property = entityType.AddProperty(TheDarkSide.BreatheProperty);
 
             var mapping = new MemberMapper(new FieldMatcher()).MapPropertiesToMembers(entityType).Single();
 
@@ -69,7 +69,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Property_setter_is_used_if_no_matching_field_is_found()
         {
             var entityType = new Model().AddEntityType(typeof(TheDarkSide));
-            var property = entityType.GetOrAddProperty("OnTheRun", typeof(int));
+            var property = entityType.AddProperty(TheDarkSide.OnTheRunProperty);
 
             var mapping = new MemberMapper(new FieldMatcher()).MapPropertiesToMembers(entityType).Single();
 
@@ -82,7 +82,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Throws_if_no_match_found_and_no_property_setter()
         {
             var entityType = new Model().AddEntityType(typeof(TheDarkSide));
-            entityType.GetOrAddProperty("Time", typeof(int));
+            var property = entityType.AddProperty(TheDarkSide.TimeProperty);
 
             Assert.Equal(
                 Strings.NoFieldOrSetter(typeof(TheDarkSide).FullName, "Time"),
@@ -94,7 +94,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Property_and_field_in_base_type_is_matched()
         {
             var entityType = new Model().AddEntityType(typeof(TheDarkSide));
-            var property = entityType.GetOrAddProperty("TheGreatGigInTheSky", typeof(int));
+            var property = entityType.AddProperty(OfTheMoon.TheGreatGigInTheSkyProperty);
 
             var mapping = new MemberMapper(new FieldMatcher()).MapPropertiesToMembers(entityType).Single();
 
@@ -107,7 +107,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Property_and_field_in_base_type_is_matched_even_when_overridden()
         {
             var entityType = new Model().AddEntityType(typeof(TheDarkSide));
-            var property = entityType.GetOrAddProperty("Money", typeof(int));
+            var property = entityType.AddProperty(TheDarkSide.MoneyProperty);
 
             var mapping = new MemberMapper(new FieldMatcher()).MapPropertiesToMembers(entityType).Single();
 
@@ -120,7 +120,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Private_setter_in_base_class_of_overridden_property_is_used()
         {
             var entityType = new Model().AddEntityType(typeof(TheDarkSide));
-            var property = entityType.GetOrAddProperty("UsAndThem", typeof(int));
+            var property = entityType.AddProperty(TheDarkSide.UsAndThemProperty);
 
             var mapping = new MemberMapper(new FieldMatcher()).MapPropertiesToMembers(entityType).Single();
 
@@ -131,6 +131,13 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
         private class TheDarkSide : OfTheMoon
         {
+            public static readonly PropertyInfo SpeakToMeProperty = typeof(TheDarkSide).GetProperty("SpeakToMe");
+            public static readonly PropertyInfo BreatheProperty = typeof(TheDarkSide).GetProperty("Breathe");
+            public static readonly PropertyInfo OnTheRunProperty = typeof(TheDarkSide).GetProperty("OnTheRun");
+            public static readonly PropertyInfo TimeProperty = typeof(TheDarkSide).GetProperty("Time");
+            public static readonly PropertyInfo MoneyProperty = typeof(TheDarkSide).GetProperty("Money");
+            public static readonly PropertyInfo UsAndThemProperty = typeof(TheDarkSide).GetProperty("UsAndThem");
+
             private int? fieldForSpeak;
 #pragma warning disable 169
             private string _badFieldForSpeak;
@@ -170,6 +177,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
         private class OfTheMoon
         {
+            public static readonly PropertyInfo TheGreatGigInTheSkyProperty = typeof(OfTheMoon).GetProperty("TheGreatGigInTheSky");
+
             private int? _theGreatGigInTheSky;
 
             public int TheGreatGigInTheSky

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/ConventionDispatcherTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/ConventionDispatcherTest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             convention.Setup(c => c.Apply(It.IsAny<InternalPropertyBuilder>())).Returns<InternalPropertyBuilder>(b =>
                 {
                     Assert.NotNull(b);
-                    propertyBuilder = new InternalPropertyBuilder(b.Metadata, b.ModelBuilder, ConfigurationSource.Convention);
+                    propertyBuilder = new InternalPropertyBuilder(b.Metadata, b.ModelBuilder);
                     return propertyBuilder;
                 });
             conventions.PropertyAddedConventions.Add(convention.Object);
@@ -85,7 +85,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             var builder = new InternalModelBuilder(new Model(), conventions);
 
             var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
-            var explicitKeyBuilder = entityBuilder.Property(typeof(int), "OrderId", ConfigurationSource.Convention);
+            var explicitKeyBuilder = entityBuilder.Property("OrderId", typeof(int), ConfigurationSource.Convention);
 
             Assert.Null(explicitKeyBuilder);
             Assert.NotNull(propertyBuilder);
@@ -186,8 +186,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
 
             var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
             var foreignKey = new ForeignKey(
-                new[] { entityBuilder.Property(typeof(int), "FK", ConfigurationSource.Convention).Metadata },
-                entityBuilder.Key(new[] { entityBuilder.Property(typeof(int), "OrderId", ConfigurationSource.Convention).Metadata }, ConfigurationSource.Convention).Metadata,
+                new[] { entityBuilder.Property("FK", typeof(int), ConfigurationSource.Convention).Metadata },
+                entityBuilder.Key(new[] { entityBuilder.Property("OrderId", typeof(int), ConfigurationSource.Convention).Metadata }, ConfigurationSource.Convention).Metadata,
                 entityBuilder.Metadata,
                 entityBuilder.Metadata);
             var conventionDispatcher = new ConventionDispatcher(conventions);

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/ForeignKeyPropertyDiscoveryConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/ForeignKeyPropertyDiscoveryConventionTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             DependentType.Property(DependentEntity.PrincipalEntityPeEKaYProperty, ConfigurationSource.Convention);
             DependentType.Property(DependentEntity.IDProperty, ConfigurationSource.Convention);
             DependentType.Property(DependentEntity.PeEKaYProperty, ConfigurationSource.Convention);
-            var fkProperty = DependentType.Property(typeof(int), "No!No!", ConfigurationSource.Convention).Metadata;
+            var fkProperty = DependentType.Property("No!No!", typeof(int), ConfigurationSource.Convention).Metadata;
 
             var relationshipBuilder = DependentType.Relationship(
                 PrincipalType,
@@ -55,8 +55,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             DependentTypeWithCompositeKey.Property(DependentEntityWithCompositeKey.PrincipalEntityWithCompositeKeyNameProperty, ConfigurationSource.Convention);
             DependentTypeWithCompositeKey.Property(DependentEntityWithCompositeKey.IdProperty, ConfigurationSource.Convention);
             DependentTypeWithCompositeKey.Property(DependentEntityWithCompositeKey.NameProperty, ConfigurationSource.Convention);
-            var fkProperty1 = DependentTypeWithCompositeKey.Property(typeof(int), "No!No!", ConfigurationSource.Convention);
-            var fkProperty2 = DependentTypeWithCompositeKey.Property(typeof(string), "No!No!2", ConfigurationSource.Convention);
+            var fkProperty1 = DependentTypeWithCompositeKey.Property("No!No!", typeof(int), ConfigurationSource.Convention);
+            var fkProperty2 = DependentTypeWithCompositeKey.Property("No!No!2", typeof(string), ConfigurationSource.Convention);
             fkProperty2.Required(true, ConfigurationSource.Convention);
 
             var relationshipBuilder = DependentTypeWithCompositeKey.Relationship(
@@ -927,7 +927,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
 
             var dependentTypeWithCompositeKey = modelBuilder.Entity(typeof(DependentEntityWithCompositeKey), ConfigurationSource.Explicit);
             dependentTypeWithCompositeKey.PrimaryKey(new[] { "NotId", "NotName" }, ConfigurationSource.Explicit);
-            dependentTypeWithCompositeKey.Property(typeof(string), "NotName", ConfigurationSource.Explicit).Required(true, ConfigurationSource.Explicit);
+            dependentTypeWithCompositeKey.Property("NotName", typeof(string), ConfigurationSource.Explicit).Required(true, ConfigurationSource.Explicit);
 
             return modelBuilder;
         }

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/KeyConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/KeyConventionTest.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
 
             var properties = new List<string> { "Id" };
-            entityBuilder.Property(typeof(int), "Id", ConfigurationSource.Convention).UseValueGenerator(false, ConfigurationSource.Explicit);
+            entityBuilder.Property("Id", typeof(int), ConfigurationSource.Convention).UseValueGenerator(false, ConfigurationSource.Explicit);
 
             var keyBuilder = entityBuilder.Key(properties, ConfigurationSource.Convention);
 
@@ -279,15 +279,24 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             var modelBuilder = CreateInternalModelBuilder();
             var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
 
-            var idProperty = entityBuilder.Property(typeof(int), "Id", ConfigurationSource.Convention).Metadata;
-            var numberProperty = entityBuilder.Property(typeof(int), "Number", ConfigurationSource.Convention).Metadata;
+            var idProperty = entityBuilder.Property("Id", typeof(int), ConfigurationSource.Convention).Metadata;
+            var numberProperty = entityBuilder.Property("Number", typeof(int), ConfigurationSource.Convention).Metadata;
+
+            Assert.Same(idProperty, entityBuilder.Metadata.GetProperty("Id"));
+            Assert.Same(numberProperty, entityBuilder.Metadata.GetProperty("Number"));
 
             Assert.Equal(ValueGenerated.OnAdd, idProperty.ValueGenerated);
             Assert.Null(numberProperty.ValueGenerated);
 
             var keyBuilder = entityBuilder.PrimaryKey(new List<string> { "Number" }, ConfigurationSource.Convention);
 
+            Assert.Same(idProperty, entityBuilder.Metadata.GetProperty("Id"));
+            Assert.Same(numberProperty, entityBuilder.Metadata.GetProperty("Number"));
+
             Assert.Same(keyBuilder, new KeyConvention().Apply(keyBuilder));
+
+            Assert.Same(idProperty, entityBuilder.Metadata.GetProperty("Id"));
+            Assert.Same(numberProperty, entityBuilder.Metadata.GetProperty("Number"));
 
             Assert.Null(idProperty.ValueGenerated);
             Assert.Equal(ValueGenerated.OnAdd, numberProperty.ValueGenerated);
@@ -299,7 +308,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             var modelBuilder = CreateInternalModelBuilder();
             var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
 
-            entityBuilder.Property(typeof(int), "Id", ConfigurationSource.Convention)
+            entityBuilder.Property("Id", typeof(int), ConfigurationSource.Convention)
                 .ValueGenerated(ValueGenerated.Never, ConfigurationSource.Explicit);
 
             var keyBuilder = entityBuilder.PrimaryKey(new List<string> { "Id" }, ConfigurationSource.Convention);

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/PropertyAttributeConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/PropertyAttributeConventionTest.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions
         {
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
-            var propertyBuilder = entityTypeBuilder.Property(typeof(Guid), "RowVersion", ConfigurationSource.Explicit);
+            var propertyBuilder = entityTypeBuilder.Property("RowVersion", typeof(Guid), ConfigurationSource.Explicit);
 
             propertyBuilder.ConcurrencyToken(false, ConfigurationSource.Convention);
 
@@ -36,7 +36,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions
         {
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
-            var propertyBuilder = entityTypeBuilder.Property(typeof(Guid), "RowVersion", ConfigurationSource.Explicit);
+            var propertyBuilder = entityTypeBuilder.Property("RowVersion", typeof(Guid), ConfigurationSource.Explicit);
 
             propertyBuilder.ConcurrencyToken(false, ConfigurationSource.Explicit);
 
@@ -63,7 +63,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions
         {
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
-            var propertyBuilder = entityTypeBuilder.Property(typeof(int), "Id", ConfigurationSource.Explicit);
+            var propertyBuilder = entityTypeBuilder.Property("Id", typeof(int), ConfigurationSource.Explicit);
 
             propertyBuilder.ValueGenerated(ValueGenerated.OnAdd, ConfigurationSource.Convention);
 
@@ -77,7 +77,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions
         {
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
-            var propertyBuilder = entityTypeBuilder.Property(typeof(int), "Id", ConfigurationSource.Explicit);
+            var propertyBuilder = entityTypeBuilder.Property("Id", typeof(int), ConfigurationSource.Explicit);
 
             propertyBuilder.ValueGenerated(ValueGenerated.Never, ConfigurationSource.Explicit);
 
@@ -104,7 +104,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions
         {
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
-            var propertyBuilder = entityTypeBuilder.Property(typeof(int), "MyPrimaryKey", ConfigurationSource.Explicit);
+            var propertyBuilder = entityTypeBuilder.Property("MyPrimaryKey", typeof(int), ConfigurationSource.Explicit);
 
             entityTypeBuilder.PrimaryKey(new List<string> { "Id" }, ConfigurationSource.Convention);
 
@@ -118,7 +118,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions
         {
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
-            var propertyBuilder = entityTypeBuilder.Property(typeof(int), "MyPrimaryKey", ConfigurationSource.Explicit);
+            var propertyBuilder = entityTypeBuilder.Property("MyPrimaryKey", typeof(int), ConfigurationSource.Explicit);
 
             entityTypeBuilder.PrimaryKey(new List<string> { "Id" }, ConfigurationSource.Explicit);
 
@@ -171,7 +171,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions
         {
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
-            var propertyBuilder = entityTypeBuilder.Property(typeof(string), "MaxLengthProperty", ConfigurationSource.Explicit);
+            var propertyBuilder = entityTypeBuilder.Property("MaxLengthProperty", typeof(string), ConfigurationSource.Explicit);
 
             propertyBuilder.MaxLength(100, ConfigurationSource.Convention);
 
@@ -185,7 +185,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions
         {
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
-            var propertyBuilder = entityTypeBuilder.Property(typeof(string), "MaxLengthProperty", ConfigurationSource.Explicit);
+            var propertyBuilder = entityTypeBuilder.Property("MaxLengthProperty", typeof(string), ConfigurationSource.Explicit);
 
             propertyBuilder.MaxLength(100, ConfigurationSource.Explicit);
 
@@ -212,7 +212,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions
         {
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
-            var propertyBuilder = entityTypeBuilder.Property(typeof(string), "IgnoredProperty", ConfigurationSource.Convention);
+            var propertyBuilder = entityTypeBuilder.Property("IgnoredProperty", typeof(string), ConfigurationSource.Convention);
 
             new NotMappedPropertyAttributeConvention().Apply(propertyBuilder);
 
@@ -224,7 +224,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions
         {
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
-            var propertyBuilder = entityTypeBuilder.Property(typeof(string), "IgnoredProperty", ConfigurationSource.Explicit);
+            var propertyBuilder = entityTypeBuilder.Property("IgnoredProperty", typeof(string), ConfigurationSource.Explicit);
 
             new NotMappedPropertyAttributeConvention().Apply(propertyBuilder);
 
@@ -249,7 +249,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions
         {
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
-            var propertyBuilder = entityTypeBuilder.Property(typeof(string), "Name", ConfigurationSource.Explicit);
+            var propertyBuilder = entityTypeBuilder.Property("Name", typeof(string), ConfigurationSource.Explicit);
 
             propertyBuilder.Required(false, ConfigurationSource.Convention);
 
@@ -263,7 +263,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions
         {
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
-            var propertyBuilder = entityTypeBuilder.Property(typeof(string), "Name", ConfigurationSource.Explicit);
+            var propertyBuilder = entityTypeBuilder.Property("Name", typeof(string), ConfigurationSource.Explicit);
 
             propertyBuilder.Required(false, ConfigurationSource.Explicit);
 
@@ -290,7 +290,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions
         {
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
-            var propertyBuilder = entityTypeBuilder.Property(typeof(string), "StringLengthProperty", ConfigurationSource.Explicit);
+            var propertyBuilder = entityTypeBuilder.Property("StringLengthProperty", typeof(string), ConfigurationSource.Explicit);
 
             propertyBuilder.MaxLength(100, ConfigurationSource.Convention);
 
@@ -304,7 +304,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions
         {
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
-            var propertyBuilder = entityTypeBuilder.Property(typeof(string), "StringLengthProperty", ConfigurationSource.Explicit);
+            var propertyBuilder = entityTypeBuilder.Property("StringLengthProperty", typeof(string), ConfigurationSource.Explicit);
 
             propertyBuilder.MaxLength(100, ConfigurationSource.Explicit);
 
@@ -331,7 +331,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions
         {
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
-            var propertyBuilder = entityTypeBuilder.Property(typeof(byte[]), "Timestamp", ConfigurationSource.Explicit);
+            var propertyBuilder = entityTypeBuilder.Property("Timestamp", typeof(byte[]), ConfigurationSource.Explicit);
 
             propertyBuilder.ValueGenerated(ValueGenerated.Never, ConfigurationSource.Convention);
             propertyBuilder.ConcurrencyToken(false, ConfigurationSource.Convention);
@@ -347,7 +347,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions
         {
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<A>();
 
-            var propertyBuilder = entityTypeBuilder.Property(typeof(byte[]), "Timestamp", ConfigurationSource.Explicit);
+            var propertyBuilder = entityTypeBuilder.Property("Timestamp", typeof(byte[]), ConfigurationSource.Explicit);
 
             propertyBuilder.ValueGenerated(ValueGenerated.Never, ConfigurationSource.Explicit);
             propertyBuilder.ConcurrencyToken(false, ConfigurationSource.Explicit);
@@ -373,7 +373,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions
         {
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<C>();
 
-            var propertyBuilder = entityTypeBuilder.Property(typeof(string), "Timestamp", ConfigurationSource.Explicit);
+            var propertyBuilder = entityTypeBuilder.Property("Timestamp", typeof(string), ConfigurationSource.Explicit);
 
             Assert.Equal(Strings.TimestampAttributeOnNonBinary("Timestamp"),
                 Assert.Throws<InvalidOperationException>(() => new TimestampAttributeConvention().Apply(propertyBuilder)).Message);

--- a/test/EntityFramework.Core.Tests/Metadata/ModelTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelTest.cs
@@ -146,14 +146,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var model = new Model();
             var entityType1 = model.AddEntityType(typeof(Customer));
             var entityType2 = model.AddEntityType(typeof(Order));
-            var keyProperty = entityType1.AddProperty("Id", typeof(int), shadowProperty: true);
-            var fkProperty = entityType2.AddProperty("CustomerId", typeof(int?), shadowProperty: true);
+            var keyProperty = entityType1.AddProperty("Id", typeof(int));
+            var fkProperty = entityType2.AddProperty("CustomerId", typeof(int?));
             var foreignKey = entityType2.GetOrAddForeignKey(fkProperty, entityType1.AddKey(keyProperty), entityType1);
 
-            var referencingForeignKeys = model.GetReferencingForeignKeys(entityType1);
+            var referencingForeignKeys = model.FindReferencingForeignKeys(entityType1);
 
             Assert.Same(foreignKey, referencingForeignKeys.Single());
-            Assert.Same(foreignKey, entityType1.GetReferencingForeignKeys().Single());
+            Assert.Same(foreignKey, entityType1.FindReferencingForeignKeys().Single());
         }
 
         private class Customer

--- a/test/EntityFramework.Core.Tests/Metadata/NavigationTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/NavigationTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.Data.Entity.Metadata;
 using Xunit;
 
@@ -24,9 +25,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             var model = new Model();
             var entityType = model.AddEntityType("E");
-            var idProperty = entityType.AddProperty("id", typeof(int), shadowProperty: true);
+            var idProperty = entityType.AddProperty("id", typeof(int));
             var key = entityType.SetPrimaryKey(idProperty);
-            var fkProperty = entityType.AddProperty("p", typeof(int), shadowProperty: true);
+            var fkProperty = entityType.AddProperty("p", typeof(int));
             return entityType.AddForeignKey(fkProperty, key, entityType);
         }
     }

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/InheritanceTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/InheritanceTestBase.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Data.Entity.Tests
                 AssertEqual(initialKeys, pickle.GetKeys());
                 AssertEqual(initialIndexes, pickle.Indexes);
                 AssertEqual(initialForeignKey, pickle.GetForeignKeys());
-                AssertEqual(initialReferencingForeignKey, pickle.GetReferencingForeignKeys());
+                AssertEqual(initialReferencingForeignKey, pickle.FindReferencingForeignKeys());
 
                 /*
                 pickleBuilder.BaseEntity(null);

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/ManyToOneTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/ManyToOneTestBase.cs
@@ -353,7 +353,8 @@ namespace Microsoft.Data.Entity.Tests
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
 
-                var fk = dependentType.AddForeignKey(dependentType.GetOrAddProperty("BurgerId", typeof(int)), principalKey, principalType);
+                var property = dependentType.GetOrAddProperty(Ingredient.BurgerIdProperty);
+                var fk = dependentType.AddForeignKey(property, principalKey, principalType);
                 fk.IsUnique = false;
 
                 modelBuilder
@@ -537,7 +538,7 @@ namespace Microsoft.Data.Entity.Tests
                 modelBuilder.Entity<Pickle>().Reference(e => e.BigMak).InverseCollection(e => e.Pickles);
 
                 var fk = dependentType.GetForeignKeys().Single();
-                var fkProperty = fk.Properties.Single();
+                var fkProperty = (IProperty)fk.Properties.Single();
 
                 Assert.Equal("BigMakId", fkProperty.Name);
                 Assert.True(fkProperty.IsShadowProperty);
@@ -575,7 +576,7 @@ namespace Microsoft.Data.Entity.Tests
                 modelBuilder.Entity<Pickle>().Reference(e => e.BigMak).InverseCollection();
 
                 var fk = dependentType.GetForeignKeys().Single();
-                var fkProperty = fk.Properties.Single();
+                var fkProperty = (IProperty)fk.Properties.Single();
 
                 Assert.Equal("BigMakId", fkProperty.Name);
                 Assert.True(fkProperty.IsShadowProperty);
@@ -612,7 +613,7 @@ namespace Microsoft.Data.Entity.Tests
                 modelBuilder.Entity<Pickle>().Reference<BigMak>().InverseCollection(e => e.Pickles);
 
                 var fk = dependentType.GetForeignKeys().Single();
-                var fkProperty = fk.Properties.Single();
+                var fkProperty = (IProperty)fk.Properties.Single();
 
                 Assert.Equal("BigMakId", fkProperty.Name);
                 Assert.True(fkProperty.IsShadowProperty);
@@ -651,7 +652,7 @@ namespace Microsoft.Data.Entity.Tests
                 modelBuilder.Entity<Pickle>().Reference<BigMak>().InverseCollection();
 
                 var newFk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey != fk);
-                var fkProperty = newFk.Properties.Single();
+                var fkProperty = (IProperty)newFk.Properties.Single();
 
                 Assert.True(fkProperty.IsShadowProperty);
                 Assert.Same(typeof(int?), fkProperty.ClrType);
@@ -1370,8 +1371,6 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentType = model.GetEntityType(typeof(Tomato));
                 var principalType = model.GetEntityType(typeof(Whoopper));
 
-                var fkProperty1 = dependentType.GetOrAddProperty("BurgerId1", typeof(int));
-                var fkProperty2 = dependentType.GetOrAddProperty("BurgerId2", typeof(int));
                 var navigationForeignKey = dependentType.GetForeignKeys().SingleOrDefault();
 
                 var expectedPrincipalProperties = principalType.Properties.ToList();
@@ -1384,6 +1383,8 @@ namespace Microsoft.Data.Entity.Tests
                     .Entity<Tomato>().Reference<Whoopper>().InverseCollection()
                     .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
 
+                var fkProperty1 = dependentType.GetProperty("BurgerId1");
+                var fkProperty2 = dependentType.GetProperty("BurgerId2");
                 var newFk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey != navigationForeignKey);
                 Assert.Same(fkProperty1, newFk.Properties[0]);
                 Assert.Same(fkProperty2, newFk.Properties[1]);

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/NonRelationshipTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/NonRelationshipTestBase.cs
@@ -469,7 +469,7 @@ namespace Microsoft.Data.Entity.Tests
                         b.Property<string>("Photon");
                     });
 
-                var entityType = model.GetEntityType(typeof(Quarks));
+                var entityType = (IEntityType)model.GetEntityType(typeof(Quarks));
 
                 Assert.False(entityType.GetProperty("Up").IsShadowProperty);
                 Assert.False(entityType.GetProperty("Charm").IsShadowProperty);

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/OneToManyTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/OneToManyTestBase.cs
@@ -540,7 +540,7 @@ namespace Microsoft.Data.Entity.Tests
                 modelBuilder.Entity<BigMak>().Collection(e => e.Pickles).InverseReference(e => e.BigMak);
 
                 var fk = dependentType.GetForeignKeys().Single();
-                var fkProperty = fk.Properties.Single();
+                var fkProperty = (IProperty)fk.Properties.Single();
 
                 Assert.Equal("BigMakId", fkProperty.Name);
                 Assert.True(fkProperty.IsShadowProperty);
@@ -578,7 +578,7 @@ namespace Microsoft.Data.Entity.Tests
                 modelBuilder.Entity<BigMak>().Collection(e => e.Pickles).InverseReference();
 
                 var fk = dependentType.GetForeignKeys().Single();
-                var fkProperty = fk.Properties.Single();
+                var fkProperty = (IProperty)fk.Properties.Single();
 
                 Assert.Equal("BigMakId", fkProperty.Name);
                 Assert.True(fkProperty.IsShadowProperty);
@@ -615,7 +615,7 @@ namespace Microsoft.Data.Entity.Tests
                 modelBuilder.Entity<BigMak>().Collection<Pickle>().InverseReference(e => e.BigMak);
 
                 var fk = dependentType.GetForeignKeys().Single();
-                var fkProperty = fk.Properties.Single();
+                var fkProperty = (IProperty)fk.Properties.Single();
 
                 Assert.Equal("BigMakId", fkProperty.Name);
                 Assert.True(fkProperty.IsShadowProperty);
@@ -653,7 +653,7 @@ namespace Microsoft.Data.Entity.Tests
                 modelBuilder.Entity<BigMak>().Collection<Pickle>().InverseReference();
 
                 var foreignKey = dependentType.GetForeignKeys().Single(fk => fk != existingFk);
-                var fkProperty = foreignKey.Properties.Single();
+                var fkProperty = (IProperty)foreignKey.Properties.Single();
 
                 Assert.Equal("BigMakId1", fkProperty.Name);
                 Assert.True(fkProperty.IsShadowProperty);
@@ -1114,9 +1114,7 @@ namespace Microsoft.Data.Entity.Tests
 
                 var dependentType = model.GetEntityType(typeof(Pickle));
                 var principalType = model.GetEntityType(typeof(BigMak));
-
-                var fkProperty = dependentType.GetOrAddProperty("BurgerId", typeof(int));
-                var principalProperty = principalType.GetOrAddProperty("AlternateKey", typeof(int));
+                
 
                 var dependentKey = dependentType.GetKeys().SingleOrDefault();
 
@@ -1124,9 +1122,9 @@ namespace Microsoft.Data.Entity.Tests
                 var expectedDependentProperties = dependentType.Properties.ToList();
 
                 modelBuilder.Entity<BigMak>().Key(e => e.AlternateKey);
-
+                
                 var fk = dependentType.GetForeignKeys().Single();
-                Assert.Same(fkProperty, fk.Properties.Single());
+                var principalProperty = principalType.GetProperty("AlternateKey");
 
                 Assert.Equal("BigMak", dependentType.Navigations.Single().Name);
                 Assert.Equal("Pickles", principalType.Navigations.Single().Name);
@@ -1159,8 +1157,6 @@ namespace Microsoft.Data.Entity.Tests
                 var principalType = model.GetEntityType(typeof(BigMak));
 
                 var nonPrimaryPrincipalKey = principalType.GetKeys().Single(k => !k.IsPrimaryKey());
-                var principalProperty = principalType.GetOrAddProperty("AlternateKey", typeof(int));
-
                 var dependentKey = dependentType.GetKeys().SingleOrDefault();
 
                 var expectedPrincipalProperties = principalType.Properties.ToList();
@@ -1168,6 +1164,7 @@ namespace Microsoft.Data.Entity.Tests
 
                 modelBuilder.Entity<BigMak>().Key(e => e.AlternateKey);
 
+                var principalProperty = principalType.GetProperty("AlternateKey");
                 var fk = dependentType.GetForeignKeys().Single();
                 Assert.Equal(2, fk.Properties.Count);
                 Assert.Same(nonPrimaryPrincipalKey, fk.PrincipalKey);
@@ -1203,7 +1200,6 @@ namespace Microsoft.Data.Entity.Tests
                 var principalType = model.GetEntityType(typeof(BigMak));
 
                 var nonPrimaryPrincipalKey = principalType.GetKeys().Single();
-                var principalProperty = principalType.GetOrAddProperty("AlternateKey", typeof(int));
 
                 var dependentKey = dependentType.GetKeys().SingleOrDefault();
 
@@ -1212,6 +1208,7 @@ namespace Microsoft.Data.Entity.Tests
 
                 modelBuilder.Entity<BigMak>().Key(e => e.AlternateKey);
 
+                var principalProperty = principalType.GetProperty("AlternateKey");
                 var fk = dependentType.GetForeignKeys().Single();
                 Assert.Same(nonPrimaryPrincipalKey, fk.PrincipalKey);
 

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/OneToOneTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/OneToOneTestBase.cs
@@ -787,7 +787,7 @@ namespace Microsoft.Data.Entity.Tests
 
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
-                var expectedPrincipalProperties = principalType.Properties.Where(p => !p.IsShadowProperty).ToList();
+                var expectedPrincipalProperties = principalType.Properties.Where(p => !((IProperty)p).IsShadowProperty).ToList();
                 var expectedDependentProperties = dependentType.Properties.ToList();
 
                 modelBuilder
@@ -825,7 +825,7 @@ namespace Microsoft.Data.Entity.Tests
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
                 var expectedPrincipalProperties = principalType.Properties.ToList();
-                var expectedDependentProperties = dependentType.Properties.Where(p => !p.IsShadowProperty).ToList();
+                var expectedDependentProperties = dependentType.Properties.Where(p => !((IProperty)p).IsShadowProperty).ToList();
 
                 modelBuilder
                     .Entity<CustomerDetails>().Reference(e => e.Customer).InverseReference()
@@ -861,7 +861,7 @@ namespace Microsoft.Data.Entity.Tests
 
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
-                var expectedPrincipalProperties = principalType.Properties.Where(p => !p.IsShadowProperty).ToList();
+                var expectedPrincipalProperties = principalType.Properties.Where(p => !((IProperty)p).IsShadowProperty).ToList();
                 var expectedDependentProperties = dependentType.Properties.ToList();
 
                 modelBuilder
@@ -899,7 +899,7 @@ namespace Microsoft.Data.Entity.Tests
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
                 var expectedPrincipalProperties = principalType.Properties.ToList();
-                var expectedDependentProperties = dependentType.Properties.Where(p => !p.IsShadowProperty).ToList();
+                var expectedDependentProperties = dependentType.Properties.Where(p => !((IProperty)p).IsShadowProperty).ToList();
 
                 modelBuilder
                     .Entity<CustomerDetails>().Reference<Customer>().InverseReference(e => e.Details)
@@ -1088,7 +1088,7 @@ namespace Microsoft.Data.Entity.Tests
                 var principalType = model.GetEntityType(typeof(Customer));
                 var principalProperty = principalType.GetProperty("AlternateKey");
                 var expectedPrincipalProperties = principalType.Properties.ToList();
-                var expectedDependentProperties = dependentType.Properties.Where(p => !p.IsShadowProperty).ToList();
+                var expectedDependentProperties = dependentType.Properties.Where(p => !((IProperty)p).IsShadowProperty).ToList();
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
 

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/TestModel.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/TestModel.cs
@@ -24,8 +24,9 @@ namespace Microsoft.Data.Entity.Tests
 
         private class Ingredient
         {
-            public int Id { get; set; }
+            public readonly static PropertyInfo BurgerIdProperty = typeof(Ingredient).GetProperty("BurgerId");
 
+            public int Id { get; set; }
             public int BurgerId { get; set; }
             public BigMak BigMak { get; set; }
         }

--- a/test/EntityFramework.Core.Tests/Utilities/MultigraphTest.cs
+++ b/test/EntityFramework.Core.Tests/Utilities/MultigraphTest.cs
@@ -1,9 +1,12 @@
-﻿using System;
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
-using Microsoft.Data.Entity.Utilities;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Tests.Utilities
@@ -16,48 +19,52 @@ namespace Microsoft.Data.Entity.Tests.Utilities
         {
             public int Id { get; set; }
 
-            public override string ToString()
-            {
-                return Id.ToString();
-            }
+            public override string ToString() => Id.ToString();
         }
 
         private class Edge
         {
             public int Id { get; set; }
 
-            public override string ToString()
-            {
-                return Id.ToString();
-            }
+            public override string ToString() => Id.ToString();
         }
 
         private class A
         {
+            public static readonly PropertyInfo PProperty = typeof(A).GetProperty("P");
+
             public int P { get; set; }
             public int P2 { get; set; }
         }
 
         private class B
         {
+            public static readonly PropertyInfo PProperty = typeof(B).GetProperty("P");
+
             public int P { get; set; }
             public int P2 { get; set; }
         }
 
         private class C
         {
+            public static readonly PropertyInfo PProperty = typeof(C).GetProperty("P");
+
             public int P { get; set; }
             public int P2 { get; set; }
         }
 
         private class D
         {
+            public static readonly PropertyInfo PProperty = typeof(D).GetProperty("P");
+
             public int P { get; set; }
             public int P2 { get; set; }
         }
 
         private class E
         {
+            public static readonly PropertyInfo PProperty = typeof(E).GetProperty("P");
+
             public int P { get; set; }
             public int P2 { get; set; }
         }
@@ -296,9 +303,9 @@ namespace Microsoft.Data.Entity.Tests.Utilities
             Assert.Equal(
                 new[] { vertexOne },
                 graph.TopologicalSort((from, to, edges) =>
-                        from == vertexOne &&
-                        to == vertexOne &&
-                        edges.Intersect(new[] { edgeOne }).Count() == 1).ToArray());
+                    from == vertexOne &&
+                    to == vertexOne &&
+                    edges.Intersect(new[] { edgeOne }).Count() == 1).ToArray());
         }
 
         [Fact]
@@ -365,10 +372,10 @@ namespace Microsoft.Data.Entity.Tests.Utilities
                 new[] { vertexTwo, vertexThree, vertexOne, vertexFour, vertexFive },
                 graph.TopologicalSort(
                     (from, to, edges) =>
-                    {
-                        var edge = edges.Single();
-                        return edge == edgeOne || edge == edgeSix;
-                    }).ToArray());
+                        {
+                            var edge = edges.Single();
+                            return edge == edgeOne || edge == edgeSix;
+                        }).ToArray());
         }
 
         [Fact]
@@ -423,10 +430,10 @@ namespace Microsoft.Data.Entity.Tests.Utilities
             Dictionary<Vertex, Tuple<Vertex, Vertex, IEnumerable<Edge>>> cycleData = null;
 
             Func<IEnumerable<Tuple<Vertex, Vertex, IEnumerable<Edge>>>, string> formatter = data =>
-            {
-                cycleData = data.ToDictionary(entry => entry.Item1);
-                return message;
-            };
+                {
+                    cycleData = data.ToDictionary(entry => entry.Item1);
+                    return message;
+                };
 
             Assert.Equal(
                 Strings.CircularDependency(message),
@@ -443,8 +450,6 @@ namespace Microsoft.Data.Entity.Tests.Utilities
             Assert.Equal(vertexOne, cycleData[vertexThree].Item2);
             Assert.Equal(new[] { edgeThree }, cycleData[vertexThree].Item3);
         }
-
-
 
         [Fact]
         public void BatchingTopologicalSort_throws_with_formatted_message_when_cycle_cannot_be_broken()
@@ -472,10 +477,10 @@ namespace Microsoft.Data.Entity.Tests.Utilities
             Dictionary<Vertex, Tuple<Vertex, Vertex, IEnumerable<Edge>>> cycleData = null;
 
             Func<IEnumerable<Tuple<Vertex, Vertex, IEnumerable<Edge>>>, string> formatter = data =>
-            {
-                cycleData = data.ToDictionary(entry => entry.Item1);
-                return message;
-            };
+                {
+                    cycleData = data.ToDictionary(entry => entry.Item1);
+                    return message;
+                };
 
             Assert.Equal(
                 Strings.CircularDependency(message),
@@ -499,17 +504,17 @@ namespace Microsoft.Data.Entity.Tests.Utilities
             var model = new Model();
 
             var entityTypeA = model.AddEntityType(typeof(A));
-            entityTypeA.GetOrSetPrimaryKey(entityTypeA.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            entityTypeA.GetOrSetPrimaryKey(entityTypeA.AddProperty("Id", typeof(int)));
 
             var entityTypeB = model.AddEntityType(typeof(B));
-            entityTypeB.GetOrSetPrimaryKey(entityTypeB.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            entityTypeB.GetOrSetPrimaryKey(entityTypeB.AddProperty("Id", typeof(int)));
 
             var entityTypeC = model.AddEntityType(typeof(C));
-            entityTypeC.GetOrSetPrimaryKey(entityTypeC.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            entityTypeC.GetOrSetPrimaryKey(entityTypeC.AddProperty("Id", typeof(int)));
 
             // B -> A -> C
-            entityTypeC.GetOrAddForeignKey(entityTypeC.GetOrAddProperty("P", typeof(int)), entityTypeA.GetPrimaryKey(), entityTypeA);
-            entityTypeA.GetOrAddForeignKey(entityTypeA.GetOrAddProperty("P", typeof(int)), entityTypeB.GetPrimaryKey(), entityTypeB);
+            entityTypeC.GetOrAddForeignKey(entityTypeC.AddProperty(C.PProperty), entityTypeA.GetPrimaryKey(), entityTypeA);
+            entityTypeA.GetOrAddForeignKey(entityTypeA.AddProperty(A.PProperty), entityTypeB.GetPrimaryKey(), entityTypeB);
 
             var graph = new EntityTypeGraph();
             graph.Populate(entityTypeA, entityTypeB, entityTypeC);
@@ -525,17 +530,17 @@ namespace Microsoft.Data.Entity.Tests.Utilities
             var model = new Model();
 
             var entityTypeA = model.AddEntityType(typeof(A));
-            entityTypeA.GetOrSetPrimaryKey(entityTypeA.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            entityTypeA.GetOrSetPrimaryKey(entityTypeA.AddProperty("Id", typeof(int)));
 
             var entityTypeB = model.AddEntityType(typeof(B));
-            entityTypeB.GetOrSetPrimaryKey(entityTypeB.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            entityTypeB.GetOrSetPrimaryKey(entityTypeB.AddProperty("Id", typeof(int)));
 
             var entityTypeC = model.AddEntityType(typeof(C));
-            entityTypeC.GetOrSetPrimaryKey(entityTypeC.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            entityTypeC.GetOrSetPrimaryKey(entityTypeC.AddProperty("Id", typeof(int)));
 
             // C -> B -> A
-            entityTypeA.GetOrAddForeignKey(entityTypeA.GetOrAddProperty("P", typeof(int)), entityTypeB.GetPrimaryKey(), entityTypeB);
-            entityTypeB.GetOrAddForeignKey(entityTypeB.GetOrAddProperty("P", typeof(int)), entityTypeC.GetPrimaryKey(), entityTypeC);
+            entityTypeA.GetOrAddForeignKey(entityTypeA.AddProperty(A.PProperty), entityTypeB.GetPrimaryKey(), entityTypeB);
+            entityTypeB.GetOrAddForeignKey(entityTypeB.AddProperty(B.PProperty), entityTypeC.GetPrimaryKey(), entityTypeC);
 
             var graph = new EntityTypeGraph();
             graph.Populate(entityTypeA, entityTypeB, entityTypeC);
@@ -551,17 +556,17 @@ namespace Microsoft.Data.Entity.Tests.Utilities
             var model = new Model();
 
             var entityTypeA = model.AddEntityType(typeof(A));
-            entityTypeA.GetOrSetPrimaryKey(entityTypeA.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            entityTypeA.GetOrSetPrimaryKey(entityTypeA.AddProperty("Id", typeof(int)));
 
             var entityTypeB = model.AddEntityType(typeof(B));
-            entityTypeB.GetOrSetPrimaryKey(entityTypeB.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            entityTypeB.GetOrSetPrimaryKey(entityTypeB.AddProperty("Id", typeof(int)));
 
             var entityTypeC = model.AddEntityType(typeof(C));
-            entityTypeC.GetOrSetPrimaryKey(entityTypeC.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            entityTypeC.GetOrSetPrimaryKey(entityTypeC.AddProperty("Id", typeof(int)));
 
             // B -> A -> C
-            entityTypeC.GetOrAddForeignKey(entityTypeC.GetOrAddProperty("P", typeof(int)), entityTypeA.GetPrimaryKey(), entityTypeA);
-            entityTypeA.GetOrAddForeignKey(entityTypeA.GetOrAddProperty("P", typeof(int)), entityTypeB.GetPrimaryKey(), entityTypeB);
+            entityTypeC.GetOrAddForeignKey(entityTypeC.AddProperty(C.PProperty), entityTypeA.GetPrimaryKey(), entityTypeA);
+            entityTypeA.GetOrAddForeignKey(entityTypeA.AddProperty(A.PProperty), entityTypeB.GetPrimaryKey(), entityTypeB);
 
             var graph = new EntityTypeGraph();
             graph.Populate(entityTypeA, entityTypeB, entityTypeC);
@@ -593,18 +598,18 @@ namespace Microsoft.Data.Entity.Tests.Utilities
             var model = new Model();
 
             var entityTypeA = model.AddEntityType(typeof(A));
-            entityTypeA.GetOrSetPrimaryKey(entityTypeA.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            entityTypeA.GetOrSetPrimaryKey(entityTypeA.AddProperty("Id", typeof(int)));
 
             var entityTypeB = model.AddEntityType(typeof(B));
-            entityTypeB.GetOrSetPrimaryKey(entityTypeB.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            entityTypeB.GetOrSetPrimaryKey(entityTypeB.AddProperty("Id", typeof(int)));
 
             var entityTypeC = model.AddEntityType(typeof(C));
-            entityTypeC.GetOrSetPrimaryKey(entityTypeC.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            entityTypeC.GetOrSetPrimaryKey(entityTypeC.AddProperty("Id", typeof(int)));
 
             // A -> B, A -> C, C -> B
-            entityTypeB.GetOrAddForeignKey(entityTypeB.GetOrAddProperty("P", typeof(int)), entityTypeA.GetPrimaryKey(), entityTypeA);
-            entityTypeC.GetOrAddForeignKey(entityTypeC.GetOrAddProperty("P", typeof(int)), entityTypeA.GetPrimaryKey(), entityTypeA);
-            entityTypeB.GetOrAddForeignKey(entityTypeB.GetOrAddProperty("P2", typeof(int)), entityTypeC.GetPrimaryKey(), entityTypeC);
+            entityTypeB.GetOrAddForeignKey(entityTypeB.AddProperty(B.PProperty), entityTypeA.GetPrimaryKey(), entityTypeA);
+            entityTypeC.GetOrAddForeignKey(entityTypeC.AddProperty(C.PProperty), entityTypeA.GetPrimaryKey(), entityTypeA);
+            entityTypeB.GetOrAddForeignKey(entityTypeB.AddProperty("P2", typeof(int)), entityTypeC.GetPrimaryKey(), entityTypeC);
 
             var graph = new EntityTypeGraph();
             graph.Populate(entityTypeA, entityTypeB, entityTypeC);
@@ -620,13 +625,13 @@ namespace Microsoft.Data.Entity.Tests.Utilities
             var model = new Model();
 
             var entityTypeA = model.AddEntityType(typeof(A));
-            entityTypeA.GetOrSetPrimaryKey(entityTypeA.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            entityTypeA.GetOrSetPrimaryKey(entityTypeA.AddProperty("Id", typeof(int)));
 
             var entityTypeB = model.AddEntityType(typeof(B));
-            entityTypeB.GetOrSetPrimaryKey(entityTypeB.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            entityTypeB.GetOrSetPrimaryKey(entityTypeB.AddProperty("Id", typeof(int)));
 
             var entityTypeC = model.AddEntityType(typeof(C));
-            entityTypeC.GetOrSetPrimaryKey(entityTypeC.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            entityTypeC.GetOrSetPrimaryKey(entityTypeC.AddProperty("Id", typeof(int)));
 
             // A B C
             var graph = new EntityTypeGraph();
@@ -643,10 +648,11 @@ namespace Microsoft.Data.Entity.Tests.Utilities
             var model = new Model();
 
             var entityTypeA = model.AddEntityType(typeof(A));
-            entityTypeA.GetOrSetPrimaryKey(entityTypeA.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            var property = entityTypeA.AddProperty("Id", typeof(int));
+            entityTypeA.GetOrSetPrimaryKey(property);
 
             // A -> A
-            entityTypeA.GetOrAddForeignKey(entityTypeA.GetOrAddProperty("P", typeof(int)), entityTypeA.GetPrimaryKey(), entityTypeA);
+            entityTypeA.GetOrAddForeignKey(entityTypeA.AddProperty(A.PProperty), entityTypeA.GetPrimaryKey(), entityTypeA);
 
             var graph = new EntityTypeGraph();
             graph.Populate(entityTypeA);
@@ -662,17 +668,17 @@ namespace Microsoft.Data.Entity.Tests.Utilities
             var model = new Model();
 
             var entityTypeA = model.AddEntityType(typeof(A));
-            entityTypeA.GetOrSetPrimaryKey(entityTypeA.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            entityTypeA.GetOrSetPrimaryKey(entityTypeA.AddProperty("Id", typeof(int)));
 
             var entityTypeB = model.AddEntityType(typeof(B));
-            entityTypeB.GetOrSetPrimaryKey(entityTypeB.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            entityTypeB.GetOrSetPrimaryKey(entityTypeB.AddProperty("Id", typeof(int)));
 
             var entityTypeC = model.AddEntityType(typeof(C));
-            entityTypeC.GetOrSetPrimaryKey(entityTypeC.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            entityTypeC.GetOrSetPrimaryKey(entityTypeC.AddProperty("Id", typeof(int)));
 
             // C, A -> B -> A
-            entityTypeA.GetOrAddForeignKey(entityTypeA.GetOrAddProperty("P", typeof(int)), entityTypeB.GetPrimaryKey(), entityTypeB);
-            entityTypeB.GetOrAddForeignKey(entityTypeB.GetOrAddProperty("P", typeof(int)), entityTypeA.GetPrimaryKey(), entityTypeA);
+            entityTypeA.GetOrAddForeignKey(entityTypeA.AddProperty(A.PProperty), entityTypeB.GetPrimaryKey(), entityTypeB);
+            entityTypeB.GetOrAddForeignKey(entityTypeB.AddProperty(B.PProperty), entityTypeA.GetPrimaryKey(), entityTypeA);
 
             var graph = new EntityTypeGraph();
             graph.Populate(entityTypeC, entityTypeA, entityTypeB);
@@ -688,18 +694,18 @@ namespace Microsoft.Data.Entity.Tests.Utilities
             var model = new Model();
 
             var entityTypeA = model.AddEntityType(typeof(A));
-            entityTypeA.GetOrSetPrimaryKey(entityTypeA.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            entityTypeA.GetOrSetPrimaryKey(entityTypeA.AddProperty("Id", typeof(int)));
 
             var entityTypeB = model.AddEntityType(typeof(B));
-            entityTypeB.GetOrSetPrimaryKey(entityTypeB.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            entityTypeB.GetOrSetPrimaryKey(entityTypeB.AddProperty("Id", typeof(int)));
 
             var entityTypeC = model.AddEntityType(typeof(C));
-            entityTypeC.GetOrSetPrimaryKey(entityTypeC.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            entityTypeC.GetOrSetPrimaryKey(entityTypeC.AddProperty("Id", typeof(int)));
 
             // A -> C -> B -> A
-            entityTypeA.GetOrAddForeignKey(entityTypeA.GetOrAddProperty("P", typeof(int)), entityTypeB.GetPrimaryKey(), entityTypeB);
-            entityTypeB.GetOrAddForeignKey(entityTypeB.GetOrAddProperty("P", typeof(int)), entityTypeC.GetPrimaryKey(), entityTypeC);
-            entityTypeC.GetOrAddForeignKey(entityTypeC.GetOrAddProperty("P", typeof(int)), entityTypeA.GetPrimaryKey(), entityTypeA);
+            entityTypeA.GetOrAddForeignKey(entityTypeA.AddProperty(A.PProperty), entityTypeB.GetPrimaryKey(), entityTypeB);
+            entityTypeB.GetOrAddForeignKey(entityTypeB.AddProperty(B.PProperty), entityTypeC.GetPrimaryKey(), entityTypeC);
+            entityTypeC.GetOrAddForeignKey(entityTypeC.AddProperty(C.PProperty), entityTypeA.GetPrimaryKey(), entityTypeA);
 
             var graph = new EntityTypeGraph();
             graph.Populate(entityTypeA, entityTypeB, entityTypeC);
@@ -715,29 +721,29 @@ namespace Microsoft.Data.Entity.Tests.Utilities
             var model = new Model();
 
             var entityTypeA = model.AddEntityType(typeof(A));
-            entityTypeA.GetOrSetPrimaryKey(entityTypeA.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            entityTypeA.GetOrSetPrimaryKey(entityTypeA.AddProperty("Id", typeof(int)));
 
             var entityTypeB = model.AddEntityType(typeof(B));
-            entityTypeB.GetOrSetPrimaryKey(entityTypeB.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            entityTypeB.GetOrSetPrimaryKey(entityTypeB.AddProperty("Id", typeof(int)));
 
             var entityTypeC = model.AddEntityType(typeof(C));
-            entityTypeC.GetOrSetPrimaryKey(entityTypeC.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            entityTypeC.GetOrSetPrimaryKey(entityTypeC.AddProperty("Id", typeof(int)));
 
             var entityTypeD = model.AddEntityType(typeof(D));
-            entityTypeD.GetOrSetPrimaryKey(entityTypeD.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            entityTypeD.GetOrSetPrimaryKey(entityTypeD.AddProperty("Id", typeof(int)));
 
             var entityTypeE = model.AddEntityType(typeof(E));
-            entityTypeE.GetOrSetPrimaryKey(entityTypeE.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            entityTypeE.GetOrSetPrimaryKey(entityTypeE.AddProperty("Id", typeof(int)));
 
             // A -> C -> B -> A
-            entityTypeA.GetOrAddForeignKey(entityTypeA.GetOrAddProperty("P", typeof(int)), entityTypeB.GetPrimaryKey(), entityTypeB);
-            entityTypeB.GetOrAddForeignKey(entityTypeB.GetOrAddProperty("P", typeof(int)), entityTypeC.GetPrimaryKey(), entityTypeC);
-            entityTypeC.GetOrAddForeignKey(entityTypeC.GetOrAddProperty("P", typeof(int)), entityTypeA.GetPrimaryKey(), entityTypeA);
+            entityTypeA.GetOrAddForeignKey(entityTypeA.AddProperty(A.PProperty), entityTypeB.GetPrimaryKey(), entityTypeB);
+            entityTypeB.GetOrAddForeignKey(entityTypeB.AddProperty(B.PProperty), entityTypeC.GetPrimaryKey(), entityTypeC);
+            entityTypeC.GetOrAddForeignKey(entityTypeC.AddProperty(C.PProperty), entityTypeA.GetPrimaryKey(), entityTypeA);
 
             // A -> E -> D -> A
-            entityTypeA.GetOrAddForeignKey(entityTypeA.GetOrAddProperty("P2", typeof(int)), entityTypeD.GetPrimaryKey(), entityTypeD);
-            entityTypeD.GetOrAddForeignKey(entityTypeD.GetOrAddProperty("P2", typeof(int)), entityTypeE.GetPrimaryKey(), entityTypeE);
-            entityTypeE.GetOrAddForeignKey(entityTypeE.GetOrAddProperty("P2", typeof(int)), entityTypeA.GetPrimaryKey(), entityTypeA);
+            entityTypeA.GetOrAddForeignKey(entityTypeA.AddProperty("P2", typeof(int)), entityTypeD.GetPrimaryKey(), entityTypeD);
+            entityTypeD.GetOrAddForeignKey(entityTypeD.AddProperty("P2", typeof(int)), entityTypeE.GetPrimaryKey(), entityTypeE);
+            entityTypeE.GetOrAddForeignKey(entityTypeE.AddProperty("P2", typeof(int)), entityTypeA.GetPrimaryKey(), entityTypeA);
 
             var graph = new EntityTypeGraph();
             graph.Populate(entityTypeA, entityTypeB, entityTypeC, entityTypeD, entityTypeE);
@@ -753,18 +759,18 @@ namespace Microsoft.Data.Entity.Tests.Utilities
             var model = new Model();
 
             var entityTypeA = model.AddEntityType(typeof(A));
-            entityTypeA.GetOrSetPrimaryKey(entityTypeA.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            entityTypeA.GetOrSetPrimaryKey(entityTypeA.AddProperty("Id", typeof(int)));
 
             var entityTypeB = model.AddEntityType(typeof(B));
-            entityTypeB.GetOrSetPrimaryKey(entityTypeB.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            entityTypeB.GetOrSetPrimaryKey(entityTypeB.AddProperty("Id", typeof(int)));
 
             var entityTypeC = model.AddEntityType(typeof(C));
-            entityTypeC.GetOrSetPrimaryKey(entityTypeC.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            entityTypeC.GetOrSetPrimaryKey(entityTypeC.AddProperty("Id", typeof(int)));
 
             // C -> B -> C -> A
-            entityTypeB.GetOrAddForeignKey(entityTypeB.GetOrAddProperty("P", typeof(int)), entityTypeC.GetPrimaryKey(), entityTypeC);
-            entityTypeC.GetOrAddForeignKey(entityTypeC.GetOrAddProperty("P", typeof(int)), entityTypeB.GetPrimaryKey(), entityTypeB);
-            entityTypeA.GetOrAddForeignKey(entityTypeA.GetOrAddProperty("P", typeof(int)), entityTypeC.GetPrimaryKey(), entityTypeC);
+            entityTypeB.GetOrAddForeignKey(entityTypeB.AddProperty(B.PProperty), entityTypeC.GetPrimaryKey(), entityTypeC);
+            entityTypeC.GetOrAddForeignKey(entityTypeC.AddProperty(C.PProperty), entityTypeB.GetPrimaryKey(), entityTypeB);
+            entityTypeA.GetOrAddForeignKey(entityTypeA.AddProperty(A.PProperty), entityTypeC.GetPrimaryKey(), entityTypeC);
 
             var graph = new EntityTypeGraph();
             graph.Populate(entityTypeA, entityTypeB, entityTypeC);

--- a/test/EntityFramework.Core.Tests/ValueGeneration/ValueGeneratorCacheTest.cs
+++ b/test/EntityFramework.Core.Tests/ValueGeneration/ValueGeneratorCacheTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.Data.Entity.InMemory;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.ValueGeneration;
 using Microsoft.Framework.DependencyInjection;
@@ -30,26 +29,14 @@ namespace Microsoft.Data.Entity.Tests.ValueGeneration
             Assert.Same(generator2, cache.GetOrAdd(property2, entityType, (p, et) => new GuidValueGenerator()));
             Assert.NotSame(generator1, generator2);
         }
-
-        private static Property GetProperty1(Model model)
-        {
-            return model.GetEntityType("Led").GetProperty("Zeppelin");
-        }
-
-        private static Property GetProperty2(Model model)
-        {
-            return model.GetEntityType("Led").GetProperty("Stairway");
-        }
-
+        
         private static Model CreateModel(bool generateValues = true)
         {
             var model = new Model();
 
             var entityType = model.AddEntityType("Led");
-            var property1 = entityType.GetOrAddProperty("Zeppelin", typeof(Guid), shadowProperty: true);
-            property1.RequiresValueGenerator = generateValues;
-            var property2 = entityType.GetOrAddProperty("Stairway", typeof(Guid), shadowProperty: true);
-            property2.RequiresValueGenerator = generateValues;
+            entityType.AddProperty("Zeppelin", typeof(Guid));
+            entityType.AddProperty("Stairway", typeof(Guid)).RequiresValueGenerator = generateValues;
 
             return model;
         }

--- a/test/EntityFramework.Core.Tests/ValueGeneration/ValueGeneratorFactoryTest.cs
+++ b/test/EntityFramework.Core.Tests/ValueGeneration/ValueGeneratorFactoryTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Data.Entity.Tests.ValueGeneration
         private static Property CreateProperty()
         {
             var entityType = new Model().AddEntityType("Led");
-            return entityType.GetOrAddProperty("Zeppelin", typeof(Guid), shadowProperty: true);
+            return entityType.AddProperty("Zeppelin", typeof(Guid));
         }
     }
 }

--- a/test/EntityFramework.Core.Tests/ValueGeneration/ValueGeneratorSelectorTest.cs
+++ b/test/EntityFramework.Core.Tests/ValueGeneration/ValueGeneratorSelectorTest.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Data.Entity.Tests.ValueGeneration
         {
             var model = TestHelpers.Instance.BuildModelFor<AnEntity>();
             var entityType = model.GetEntityType(typeof(AnEntity));
-            entityType.AddProperty("Random", typeof(Random));
+            entityType.AddProperty("Random", typeof(Random)).IsShadowProperty = false;
 
             foreach (var property in entityType.Properties)
             {

--- a/test/EntityFramework.InMemory.FunctionalTests/EndToEndTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/EndToEndTest.cs
@@ -11,61 +11,8 @@ using Xunit;
 
 namespace Microsoft.Data.Entity.InMemory.FunctionalTests
 {
-    public class EntityTypeTest : IClassFixture<InMemoryFixture>
+    public class EndToEndTest : IClassFixture<InMemoryFixture>
     {
-        public class Root
-        {
-        }
-
-        public class Leaf : Root
-        {
-        }
-
-        [Fact]
-        public void Original_value_index_maintenance_when_inheritance()
-        {
-            var model = new Model();
-            var root = model.AddEntityType(typeof(Root));
-            var leaf = model.AddEntityType(typeof(Leaf));
-
-            var a = leaf.AddProperty("A", typeof(int), shadowProperty: true);
-
-            leaf.BaseType = root;
-
-            var b = root.AddProperty("B", typeof(int), shadowProperty: true);
-
-            Assert.Equal(0, b.GetOriginalValueIndex());
-            Assert.Equal(1, a.GetOriginalValueIndex());
-        }
-
-        [Fact]
-        public void Introduce_duplicate_property_when_inheritance()
-        {
-            var model = new Model();
-            var root = model.AddEntityType(typeof(Root));
-            var leaf = model.AddEntityType(typeof(Leaf));
-
-            leaf.AddProperty("A", typeof(int), shadowProperty: true);
-
-            leaf.BaseType = root;
-
-            Assert.Throws<InvalidOperationException>(() =>
-                root.AddProperty("A", typeof(int), shadowProperty: true));
-        }
-
-        [Fact]
-        public void Introduce_duplicate_property_when_inheritance2()
-        {
-            var model = new Model();
-            var root = model.AddEntityType(typeof(Root));
-            var leaf = model.AddEntityType(typeof(Leaf));
-
-            leaf.AddProperty("A", typeof(int), shadowProperty: true);
-            root.AddProperty("A", typeof(int), shadowProperty: true);
-            
-            Assert.Throws<InvalidOperationException>(() => leaf.BaseType = root);
-        }
-
         [Fact]
         public void Can_use_different_entity_types_end_to_end()
         {
@@ -86,8 +33,8 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
             var model = new Model();
 
             var entityType = model.AddEntityType(type);
-            var idProperty = entityType.GetOrAddProperty("Id", typeof(int), shadowProperty: true);
-            var nameProperty = entityType.GetOrAddProperty("Name", typeof(string), shadowProperty: true);
+            var idProperty = entityType.AddProperty("Id", typeof(int));
+            var nameProperty = entityType.AddProperty("Name", typeof(string));
             entityType.GetOrSetPrimaryKey(idProperty);
 
             var optionsBuilder = new DbContextOptionsBuilder()
@@ -144,7 +91,7 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
 
         private readonly InMemoryFixture _fixture;
 
-        public EntityTypeTest(InMemoryFixture fixture)
+        public EndToEndTest(InMemoryFixture fixture)
         {
             _fixture = fixture;
         }

--- a/test/EntityFramework.InMemory.FunctionalTests/EntityFramework.InMemory.FunctionalTests.csproj
+++ b/test/EntityFramework.InMemory.FunctionalTests/EntityFramework.InMemory.FunctionalTests.csproj
@@ -33,7 +33,7 @@
   <ItemGroup>
     <Compile Include="DataAnnotationInMemoryFixture.cs" />
     <Compile Include="DataAnnotationInMemoryTest.cs" />
-    <Compile Include="EntityTypeTest.cs" />
+    <Compile Include="EndToEndTest.cs" />
     <Compile Include="AsNoTrackingInMemoryTest.cs" />
     <Compile Include="ChangeTrackingInMemoryTest.cs" />
     <Compile Include="InMemoryFixture.cs" />

--- a/test/EntityFramework.InMemory.FunctionalTests/ShadowStateUpdateTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/ShadowStateUpdateTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
@@ -18,8 +19,8 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
             var model = new Model();
 
             var customerType = model.AddEntityType("Customer");
-            customerType.GetOrSetPrimaryKey(customerType.AddProperty("Id", typeof(int), shadowProperty: true));
-            customerType.GetOrAddProperty("Name", typeof(string), shadowProperty: true);
+            customerType.GetOrSetPrimaryKey(customerType.AddProperty("Id", typeof(int)));
+            customerType.AddProperty("Name", typeof(string));
 
             var optionsBuilder = new DbContextOptionsBuilder()
                 .UseModel(model);
@@ -80,11 +81,12 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
             var model = new Model();
 
             var customerType = model.AddEntityType(typeof(Customer));
-            customerType.GetOrSetPrimaryKey(customerType.GetOrAddProperty("Id", typeof(int)));
-            customerType.GetOrAddProperty("Name", typeof(string), shadowProperty: true);
+            var property1 = customerType.AddProperty("Id", typeof(int));
+            property1.IsShadowProperty = false;
+            customerType.GetOrSetPrimaryKey(property1);
+            customerType.AddProperty("Name", typeof(string));
 
-            var optionsBuilder = new DbContextOptionsBuilder()
-                .UseModel(model);
+            var optionsBuilder = new DbContextOptionsBuilder().UseModel(model);
             optionsBuilder.UseInMemoryDatabase();
 
             var customer = new Customer { Id = 42 };

--- a/test/EntityFramework.InMemory.Tests/InMemoryValueGeneratorSelectorTest.cs
+++ b/test/EntityFramework.InMemory.Tests/InMemoryValueGeneratorSelectorTest.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
         {
             var model = InMemoryTestHelpers.Instance.BuildModelFor<AnEntity>();
             var entityType = model.GetEntityType(typeof(AnEntity));
-            entityType.AddProperty("Random", typeof(Random));
+            entityType.AddProperty("Random", typeof(Random)).IsShadowProperty = false;
 
             foreach (var property in entityType.Properties)
             {

--- a/test/EntityFramework.Relational.FunctionalTests/InheritanceRelationalFixture.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/InheritanceRelationalFixture.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.Data.Entity.FunctionalTests.TestModels.Inheritance;
+using Microsoft.Data.Entity.Metadata;
 
 namespace Microsoft.Data.Entity.FunctionalTests
 {
@@ -15,9 +17,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
             var animal = modelBuilder.Entity<Animal>().Metadata;
 
-            var animalDiscriminatorProperty
-                = animal.AddProperty("Discriminator", typeof(string), shadowProperty: true);
-
+            var animalDiscriminatorProperty = animal.AddProperty("Discriminator", typeof(string));
             animalDiscriminatorProperty.IsNullable = false;
             //animalDiscriminatorProperty.IsReadOnlyBeforeSave = true; // #2132
             animalDiscriminatorProperty.IsReadOnlyAfterSave = true;
@@ -25,11 +25,10 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
             animal.Relational().DiscriminatorProperty = animalDiscriminatorProperty;
 
-
             var plant = modelBuilder.Entity<Plant>().Metadata;
 
-            var plantDiscriminatorProperty
-                = plant.AddProperty("Genus", typeof(PlantGenus));
+            var plantDiscriminatorProperty = plant.AddProperty("Genus", typeof(PlantGenus));
+            plantDiscriminatorProperty.IsShadowProperty = false;
 
             plantDiscriminatorProperty.IsNullable = false;
             //plantDiscriminatorProperty.IsReadOnlyBeforeSave = true; // #2132

--- a/test/EntityFramework.Relational.Tests/Metadata/InternalRelationalMetadataBuilderExtensionsTest.cs
+++ b/test/EntityFramework.Relational.Tests/Metadata/InternalRelationalMetadataBuilderExtensionsTest.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Data.Entity.Metadata
         {
             var propertyBuilder = CreateBuilder()
                 .Entity(typeof(Splot), ConfigurationSource.Convention)
-                .Property(typeof(int), "Id", ConfigurationSource.Convention);
+                .Property("Id", typeof(int), ConfigurationSource.Convention);
 
             propertyBuilder.Relational(ConfigurationSource.Convention).ColumnName = "Splew";
             Assert.Equal("Splew", propertyBuilder.Metadata.Relational().ColumnName);
@@ -59,7 +59,7 @@ namespace Microsoft.Data.Entity.Metadata
         {
             var modelBuilder = CreateBuilder();
             var entityTypeBuilder = modelBuilder.Entity(typeof(Splot), ConfigurationSource.Convention);
-            var property = entityTypeBuilder.Property(typeof(int), "Id", ConfigurationSource.Convention).Metadata;
+            var property = entityTypeBuilder.Property("Id", typeof(int), ConfigurationSource.Convention).Metadata;
             var keyBuilder = entityTypeBuilder.Key(new[] { property }, ConfigurationSource.Convention);
 
             keyBuilder.Relational(ConfigurationSource.Convention).Name = "Splew";
@@ -77,7 +77,7 @@ namespace Microsoft.Data.Entity.Metadata
         {
             var modelBuilder = CreateBuilder();
             var entityTypeBuilder = modelBuilder.Entity(typeof(Splot), ConfigurationSource.Convention);
-            entityTypeBuilder.Property(typeof(int), "Id", ConfigurationSource.Convention);
+            entityTypeBuilder.Property("Id", typeof(int), ConfigurationSource.Convention);
             var indexBuilder = entityTypeBuilder.Index(new[] { "Id" }, ConfigurationSource.Convention);
 
             indexBuilder.Relational(ConfigurationSource.Convention).Name = "Splew";
@@ -95,7 +95,7 @@ namespace Microsoft.Data.Entity.Metadata
         {
             var modelBuilder = CreateBuilder();
             var entityTypeBuilder = modelBuilder.Entity(typeof(Splot), ConfigurationSource.Convention);
-            entityTypeBuilder.Property(typeof(int), "Id", ConfigurationSource.Convention);
+            entityTypeBuilder.Property("Id", typeof(int), ConfigurationSource.Convention);
             var relationshipBuilder = entityTypeBuilder.ForeignKey("Splot", new[] { "Id" }, ConfigurationSource.Convention);
 
             relationshipBuilder.Relational(ConfigurationSource.Convention).Name = "Splew";

--- a/test/EntityFramework.Relational.Tests/Metadata/RelationalPropertyAttributeConventionTest.cs
+++ b/test/EntityFramework.Relational.Tests/Metadata/RelationalPropertyAttributeConventionTest.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Data.Entity.Metadata
         {
             var entityBuilder = CreateInternalEntityTypeBuilder<A>();
 
-            var propertyBuilder = entityBuilder.Property(typeof(string), "Name", ConfigurationSource.Explicit);
+            var propertyBuilder = entityBuilder.Property("Name", typeof(string), ConfigurationSource.Explicit);
 
             propertyBuilder.Annotation(RelationalAnnotationNames.Prefix + RelationalAnnotationNames.ColumnName, "ConventionalName", ConfigurationSource.Convention);
             propertyBuilder.Annotation(RelationalAnnotationNames.Prefix + RelationalAnnotationNames.ColumnType, "BYTE", ConfigurationSource.Convention);
@@ -53,7 +53,7 @@ namespace Microsoft.Data.Entity.Metadata
         {
             var entityBuilder = CreateInternalEntityTypeBuilder<A>();
 
-            var propertyBuilder = entityBuilder.Property(typeof(string), "Name", ConfigurationSource.Explicit);
+            var propertyBuilder = entityBuilder.Property("Name", typeof(string), ConfigurationSource.Explicit);
 
             propertyBuilder.Annotation(RelationalAnnotationNames.Prefix + RelationalAnnotationNames.ColumnName, "ExplicitName", ConfigurationSource.Explicit);
             propertyBuilder.Annotation(RelationalAnnotationNames.Prefix + RelationalAnnotationNames.ColumnType, "BYTE", ConfigurationSource.Explicit);

--- a/test/EntityFramework.Relational.Tests/Model/RelationalTypeMapperTest.cs
+++ b/test/EntityFramework.Relational.Tests/Model/RelationalTypeMapperTest.cs
@@ -77,8 +77,7 @@ namespace Microsoft.Data.Entity.Tests.Model
 
         private static RelationalTypeMapping GetTypeMapping(Type propertyType, int? maxLength = null)
         {
-            var property = CreateEntityType().AddProperty("MyProp", propertyType, shadowProperty: true);
-
+            var property = CreateEntityType().AddProperty("MyProp", propertyType);
             if (maxLength.HasValue)
             {
                 property.SetMaxLength(maxLength);
@@ -125,7 +124,7 @@ namespace Microsoft.Data.Entity.Tests.Model
 
         private static RelationalTypeMapping GetNamedMapping(Type propertyType, string typeName)
         {
-            var property = CreateEntityType().AddProperty("MyProp", propertyType, shadowProperty: true);
+            var property = CreateEntityType().AddProperty("MyProp", propertyType);
             property.Relational().ColumnType = typeName;
 
             return new ConcreteTypeMapper().MapPropertyType(property);

--- a/test/EntityFramework.Relational.Tests/Update/ModificationCommandComparerTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/ModificationCommandComparerTest.cs
@@ -1,8 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Update;
 using Microsoft.Framework.DependencyInjection;
@@ -25,7 +27,7 @@ namespace Microsoft.Data.Entity.Tests.Update
             var contextServices = new DbContext(optionsBuilder.Options).GetService();
             var stateManager = contextServices.GetRequiredService<IStateManager>();
 
-            var key = entityType.GetOrAddProperty("Id", typeof(int), shadowProperty: true);
+            var key = entityType.AddProperty("Id", typeof(int));
             entityType.GetOrSetPrimaryKey(key);
 
             var entry1 = stateManager.GetOrCreateEntry(new object());

--- a/test/EntityFramework.Relational.Tests/Update/ModificationCommandTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/ModificationCommandTest.cs
@@ -370,12 +370,14 @@ namespace Microsoft.Data.Entity.Tests.Update
             var model = new Entity.Metadata.Model();
             var entityType = model.AddEntityType(typeof(T1));
 
-            var key = entityType.GetOrAddProperty("Id", typeof(int));
+            var key = entityType.AddProperty("Id", typeof(int));
+            key.IsShadowProperty = false;
             key.ValueGenerated = generateKeyValues ? ValueGenerated.OnAdd : ValueGenerated.Never;
             key.Relational().ColumnName = "Col1";
             entityType.GetOrSetPrimaryKey(key);
 
-            var nonKey = entityType.GetOrAddProperty("Name", typeof(string));
+            var nonKey = entityType.AddProperty("Name", typeof(string));
+            nonKey.IsShadowProperty = false;
             nonKey.IsConcurrencyToken = computeNonKeyValue;
 
             nonKey.Relational().ColumnName = "Col2";

--- a/test/EntityFramework.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
@@ -591,12 +591,14 @@ namespace Microsoft.Data.Entity.Tests.Update
 
             var entityType = model.AddEntityType(typeof(T1));
 
-            var key = entityType.GetOrAddProperty("Id", typeof(int));
+            var key = entityType.AddProperty("Id", typeof(int));
+            key.IsShadowProperty = false;
             key.ValueGenerated = generateKeyValues ? ValueGenerated.OnAdd : ValueGenerated.Never;
             key.Relational().ColumnName = "Col1";
             entityType.GetOrSetPrimaryKey(key);
 
-            var nonKey = entityType.GetOrAddProperty("Name", typeof(string));
+            var nonKey = entityType.AddProperty("Name", typeof(string));
+            nonKey.IsShadowProperty = false;
             nonKey.Relational().ColumnName = "Col2";
             nonKey.ValueGenerated = computeNonKeyValue ? ValueGenerated.OnAddOrUpdate : ValueGenerated.Never;
 

--- a/test/EntityFramework.SqlServer.Tests/Metadata/InternalSqlServerMetadataBuilderExtensionsTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/Metadata/InternalSqlServerMetadataBuilderExtensionsTest.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
         {
             var propertyBuilder = CreateBuilder()
                 .Entity(typeof(Splot), ConfigurationSource.Convention)
-                .Property(typeof(int), "Id", ConfigurationSource.Convention);
+                .Property("Id", typeof(int), ConfigurationSource.Convention);
 
             propertyBuilder.SqlServer(ConfigurationSource.Convention).HiLoSequenceName = "Splew";
             Assert.Equal("Splew", propertyBuilder.Metadata.SqlServer().HiLoSequenceName);
@@ -78,7 +78,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
         {
             var modelBuilder = CreateBuilder();
             var entityTypeBuilder = modelBuilder.Entity(typeof(Splot), ConfigurationSource.Convention);
-            var property = entityTypeBuilder.Property(typeof(int), "Id", ConfigurationSource.Convention).Metadata;
+            var property = entityTypeBuilder.Property("Id", typeof(int), ConfigurationSource.Convention).Metadata;
             var keyBuilder = entityTypeBuilder.Key(new[] { property }, ConfigurationSource.Convention);
 
             keyBuilder.SqlServer(ConfigurationSource.Convention).IsClustered = true;
@@ -99,7 +99,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
         {
             var modelBuilder = CreateBuilder();
             var entityTypeBuilder = modelBuilder.Entity(typeof(Splot), ConfigurationSource.Convention);
-            entityTypeBuilder.Property(typeof(int), "Id", ConfigurationSource.Convention);
+            entityTypeBuilder.Property("Id", typeof(int), ConfigurationSource.Convention);
             var indexBuilder = entityTypeBuilder.Index(new[] { "Id" }, ConfigurationSource.Convention);
 
             indexBuilder.SqlServer(ConfigurationSource.Convention).IsClustered = true;
@@ -120,7 +120,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
         {
             var modelBuilder = CreateBuilder();
             var entityTypeBuilder = modelBuilder.Entity(typeof(Splot), ConfigurationSource.Convention);
-            entityTypeBuilder.Property(typeof(int), "Id", ConfigurationSource.Convention);
+            entityTypeBuilder.Property("Id", typeof(int), ConfigurationSource.Convention);
             var relationshipBuilder = entityTypeBuilder.ForeignKey("Splot", new[] { "Id" }, ConfigurationSource.Convention);
 
             relationshipBuilder.SqlServer(ConfigurationSource.Convention).Name = "Splew";

--- a/test/EntityFramework.SqlServer.Tests/SqlServerTypeMapperTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerTypeMapperTest.cs
@@ -209,7 +209,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         [Fact]
         public void Does_key_SQL_Server_string_mapping()
         {
-            var property = CreateEntityType().AddProperty("MyProp", typeof(string), shadowProperty: true);
+            var property = CreateEntityType().AddProperty("MyProp", typeof(string));
             property.DeclaringEntityType.SetPrimaryKey(property);
             property.IsNullable = false;
 
@@ -223,8 +223,8 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         [Fact]
         public void Does_foreign_key_SQL_Server_string_mapping()
         {
-            var property = CreateEntityType().AddProperty("MyProp", typeof(string), shadowProperty: true);
-            var fkProperty = property.DeclaringEntityType.AddProperty("FK", typeof(string), shadowProperty: true);
+            var property = CreateEntityType().AddProperty("MyProp", typeof(string));
+            var fkProperty = property.DeclaringEntityType.AddProperty("FK", typeof(string));
             var pk = property.DeclaringEntityType.SetPrimaryKey(property);
             property.DeclaringEntityType.AddForeignKey(fkProperty, pk, property.DeclaringEntityType);
 
@@ -238,8 +238,8 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         [Fact]
         public void Does_required_foreign_key_SQL_Server_string_mapping()
         {
-            var property = CreateEntityType().AddProperty("MyProp", typeof(string), shadowProperty: true);
-            var fkProperty = property.DeclaringEntityType.AddProperty("FK", typeof(string), shadowProperty: true);
+            var property = CreateEntityType().AddProperty("MyProp", typeof(string));
+            var fkProperty = property.DeclaringEntityType.AddProperty("FK", typeof(string));
             var pk = property.DeclaringEntityType.SetPrimaryKey(property);
             property.DeclaringEntityType.AddForeignKey(fkProperty, pk, property.DeclaringEntityType);
             fkProperty.IsNullable = false;
@@ -304,7 +304,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         [Fact]
         public void Does_key_SQL_Server_binary_mapping()
         {
-            var property = CreateEntityType().AddProperty("MyProp", typeof(byte[]), shadowProperty: true);
+            var property = CreateEntityType().AddProperty("MyProp", typeof(byte[]));
             property.DeclaringEntityType.SetPrimaryKey(property);
             property.IsNullable = false;
 
@@ -318,8 +318,8 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         [Fact]
         public void Does_foreign_key_SQL_Server_binary_mapping()
         {
-            var property = CreateEntityType().AddProperty("MyProp", typeof(byte[]), shadowProperty: true);
-            var fkProperty = property.DeclaringEntityType.AddProperty("FK", typeof(byte[]), shadowProperty: true);
+            var property = CreateEntityType().AddProperty("MyProp", typeof(byte[]));
+            var fkProperty = property.DeclaringEntityType.AddProperty("FK", typeof(byte[]));
             var pk = property.DeclaringEntityType.SetPrimaryKey(property);
             property.DeclaringEntityType.AddForeignKey(fkProperty, pk, property.DeclaringEntityType);
 
@@ -333,8 +333,8 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         [Fact]
         public void Does_required_foreign_key_SQL_Server_binary_mapping()
         {
-            var property = CreateEntityType().AddProperty("MyProp", typeof(byte[]), shadowProperty: true);
-            var fkProperty = property.DeclaringEntityType.AddProperty("FK", typeof(byte[]), shadowProperty: true);
+            var property = CreateEntityType().AddProperty("MyProp", typeof(byte[]));
+            var fkProperty = property.DeclaringEntityType.AddProperty("FK", typeof(byte[]));
             var pk = property.DeclaringEntityType.SetPrimaryKey(property);
             property.DeclaringEntityType.AddForeignKey(fkProperty, pk, property.DeclaringEntityType);
             fkProperty.IsNullable = false;
@@ -349,7 +349,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         [Fact]
         public void Does_non_key_SQL_Server_rowversion_mapping()
         {
-            var property = CreateEntityType().AddProperty("MyProp", typeof(byte[]), shadowProperty: true);
+            var property = CreateEntityType().AddProperty("MyProp", typeof(byte[]));
             property.IsConcurrencyToken = true;
             property.ValueGenerated = ValueGenerated.OnAddOrUpdate;
 
@@ -364,7 +364,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         [Fact]
         public void Does_non_key_SQL_Server_required_rowversion_mapping()
         {
-            var property = CreateEntityType().AddProperty("MyProp", typeof(byte[]), shadowProperty: true);
+            var property = CreateEntityType().AddProperty("MyProp", typeof(byte[]));
             property.IsConcurrencyToken = true;
             property.ValueGenerated = ValueGenerated.OnAddOrUpdate;
             property.IsNullable = false;
@@ -380,7 +380,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         [Fact]
         public void Does_not_do_rowversion_mapping_for_non_computed_concurrency_tokens()
         {
-            var property = CreateEntityType().AddProperty("MyProp", typeof(byte[]), shadowProperty: true);
+            var property = CreateEntityType().AddProperty("MyProp", typeof(byte[]));
             property.IsConcurrencyToken = true;
 
             var typeMapping = (SqlServerMaxLengthMapping)new SqlServerTypeMapper().MapPropertyType(property);
@@ -391,7 +391,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
 
         private static RelationalTypeMapping GetTypeMapping(Type propertyType, bool? isNullable = null, int? maxLength = null)
         {
-            var property = CreateEntityType().AddProperty("MyProp", propertyType, shadowProperty: true);
+            var property = CreateEntityType().AddProperty("MyProp", propertyType);
 
             if (isNullable.HasValue)
             {

--- a/test/EntityFramework.SqlServer.Tests/SqlServerValueGeneratorCacheTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerValueGeneratorCacheTest.cs
@@ -359,15 +359,12 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                 Assert.Throws<ArgumentOutOfRangeException>(() => cache.GetOrAddSequenceState(property)).Message);
         }
 
-        protected virtual ModelBuilder CreateConventionModelBuilder()
-        {
-            return SqlServerTestHelpers.Instance.CreateConventionBuilder();
-        }
+        protected virtual ModelBuilder CreateConventionModelBuilder() => SqlServerTestHelpers.Instance.CreateConventionBuilder();
 
         private static Property CreateProperty()
         {
             var entityType = new Model().AddEntityType("MyType");
-            var property = entityType.GetOrAddProperty("MyProperty", typeof(string), shadowProperty: true);
+            var property = entityType.AddProperty("MyProperty", typeof(string));
             entityType.SqlServer().TableName = "MyTable";
 
             return property;

--- a/test/EntityFramework.SqlServer.Tests/SqlServerValueGeneratorSelectorTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerValueGeneratorSelectorTest.cs
@@ -132,7 +132,8 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             var model = SqlServerTestHelpers.Instance.BuildModelFor<AnEntity>();
             model.SqlServer().GetOrAddSequence(SqlServerAnnotationNames.DefaultHiLoSequenceName);
             var entityType = model.GetEntityType(typeof(AnEntity));
-            entityType.AddProperty("Random", typeof(Random));
+            var property1 = entityType.AddProperty("Random", typeof(Random));
+            property1.IsShadowProperty = false;
 
             foreach (var property in entityType.Properties)
             {

--- a/test/EntityFramework.Sqlite.Tests/Metadata/InternalSqliteMetadataBuilderExtensionsTest.cs
+++ b/test/EntityFramework.Sqlite.Tests/Metadata/InternalSqliteMetadataBuilderExtensionsTest.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Data.Entity.Sqlite.Metadata
         {
             var propertyBuilder = CreateBuilder()
                 .Entity(typeof(Splot), ConfigurationSource.Convention)
-                .Property(typeof(int), "Id", ConfigurationSource.Convention);
+                .Property("Id", typeof(int), ConfigurationSource.Convention);
 
             propertyBuilder.Sqlite(ConfigurationSource.Convention).ColumnName = "Splew";
             Assert.Equal("Splew", propertyBuilder.Metadata.Sqlite().ColumnName);
@@ -72,7 +72,7 @@ namespace Microsoft.Data.Entity.Sqlite.Metadata
         {
             var modelBuilder = CreateBuilder();
             var entityTypeBuilder = modelBuilder.Entity(typeof(Splot), ConfigurationSource.Convention);
-            var property = entityTypeBuilder.Property(typeof(int), "Id", ConfigurationSource.Convention).Metadata;
+            var property = entityTypeBuilder.Property("Id", typeof(int), ConfigurationSource.Convention).Metadata;
             var keyBuilder = entityTypeBuilder.Key(new[] { property }, ConfigurationSource.Convention);
 
             keyBuilder.Sqlite(ConfigurationSource.Convention).Name = "Splew";
@@ -93,7 +93,7 @@ namespace Microsoft.Data.Entity.Sqlite.Metadata
         {
             var modelBuilder = CreateBuilder();
             var entityTypeBuilder = modelBuilder.Entity(typeof(Splot), ConfigurationSource.Convention);
-            entityTypeBuilder.Property(typeof(int), "Id", ConfigurationSource.Convention);
+            entityTypeBuilder.Property("Id", typeof(int), ConfigurationSource.Convention);
             var indexBuilder = entityTypeBuilder.Index(new[] { "Id" }, ConfigurationSource.Convention);
 
             indexBuilder.Sqlite(ConfigurationSource.Convention).Name = "Splew";
@@ -114,7 +114,7 @@ namespace Microsoft.Data.Entity.Sqlite.Metadata
         {
             var modelBuilder = CreateBuilder();
             var entityTypeBuilder = modelBuilder.Entity(typeof(Splot), ConfigurationSource.Convention);
-            entityTypeBuilder.Property(typeof(int), "Id", ConfigurationSource.Convention);
+            entityTypeBuilder.Property("Id", typeof(int), ConfigurationSource.Convention);
             var relationshipBuilder = entityTypeBuilder.ForeignKey("Splot", new[] { "Id" }, ConfigurationSource.Convention);
 
             relationshipBuilder.Sqlite(ConfigurationSource.Convention).Name = "Splew";


### PR DESCRIPTION
Remove ClrType and IsShadowProperty from the Property constructor
Move CLR type validation to ModelValidator
Make IModel.GetReferencingForeignKeys extension methods and rename to FindReferencingForeignKeys