### PR TITLE
Migrations: Deffer type mapping until SQL generation

### DIFF
--- a/src/EntityFramework.Commands/Migrations/CSharpMigrationOperationGenerator.cs
+++ b/src/EntityFramework.Commands/Migrations/CSharpMigrationOperationGenerator.cs
@@ -54,7 +54,10 @@ namespace Microsoft.Data.Entity.Commands.Migrations
             Check.NotNull(operation, nameof(operation));
             Check.NotNull(builder, nameof(builder));
 
-            builder.AppendLine(".AddColumn(");
+            builder
+                .Append(".AddColumn<")
+                .Append(_code.Reference(operation.ClrType))
+                .AppendLine(">(");
 
             using (builder.Indent())
             {
@@ -73,11 +76,17 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                 builder
                     .AppendLine(",")
                     .Append("table: ")
-                    .Append(_code.Literal(operation.Table))
-                    .AppendLine(",")
-                    .Append("type: ")
-                    .Append(_code.Literal(operation.Type))
-                    .AppendLine(",")
+                    .Append(_code.Literal(operation.Table));
+
+                if (operation.ColumnType != null)
+                {
+                    builder
+                        .AppendLine(",")
+                        .Append("type: ")
+                        .Append(_code.Literal(operation.ColumnType));
+                }
+
+                builder.AppendLine(",")
                     .Append("nullable: ")
                     .Append(_code.Literal(operation.IsNullable));
 
@@ -266,7 +275,10 @@ namespace Microsoft.Data.Entity.Commands.Migrations
             Check.NotNull(operation, nameof(operation));
             Check.NotNull(builder, nameof(builder));
 
-            builder.AppendLine(".AlterColumn(");
+            builder
+                .Append(".AlterColumn<")
+                .Append(_code.Reference(operation.ClrType))
+                .AppendLine(">(");
 
             using (builder.Indent())
             {
@@ -285,11 +297,16 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                 builder
                     .AppendLine(",")
                     .Append("table: ")
-                    .Append(_code.Literal(operation.Table))
-                    .AppendLine(",")
-                    .Append("type: ")
-                    .Append(_code.Literal(operation.Type))
-                    .AppendLine(",")
+                    .Append(_code.Literal(operation.Table));
+
+                if (operation.ColumnType != null)
+                {
+                    builder.AppendLine(",")
+                        .Append("type: ")
+                        .Append(_code.Literal(operation.ColumnType));
+                }
+
+                builder.AppendLine(",")
                     .Append("nullable: ")
                     .Append(_code.Literal(operation.IsNullable));
 
@@ -445,7 +462,17 @@ namespace Microsoft.Data.Entity.Commands.Migrations
             Check.NotNull(operation, nameof(operation));
             Check.NotNull(builder, nameof(builder));
 
-            builder.AppendLine(".CreateSequence(");
+            builder.Append(".CreateSequence");
+
+            if (operation.ClrType != typeof(long))
+            {
+                builder
+                    .Append("<")
+                    .Append(_code.Reference(operation.ClrType))
+                    .Append(">");
+            }
+
+            builder.AppendLine("(");
 
             using (builder.Indent())
             {
@@ -459,14 +486,6 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                         .AppendLine(",")
                         .Append("schema: ")
                         .Append(_code.Literal(operation.Schema));
-                }
-
-                if (operation.Type != null)
-                {
-                    builder
-                        .AppendLine(",")
-                        .Append("type: ")
-                        .Append(_code.Literal(operation.Type));
                 }
 
                 if (operation.StartWith.HasValue)
@@ -552,7 +571,9 @@ namespace Microsoft.Data.Entity.Commands.Migrations
 
                         builder
                             .Append(propertyName)
-                            .Append(" = table.Column(");
+                            .Append(" = table.Column<")
+                            .Append(_code.Reference(column.ClrType))
+                            .Append(">(");
 
                         if (propertyName != column.Name)
                         {
@@ -562,10 +583,15 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                                 .Append(", ");
                         }
 
-                        builder
-                            .Append("type: ")
-                            .Append(_code.Literal(column.Type))
-                            .Append(", nullable: ")
+                        if (column.ColumnType != null)
+                        {
+                            builder
+                                .Append("type: ")
+                                .Append(_code.Literal(column.ColumnType))
+                                .Append(", ");
+                        }
+
+                        builder.Append("nullable: ")
                             .Append(_code.Literal(column.IsNullable));
 
                         if (column.DefaultValueSql != null)

--- a/src/EntityFramework.Relational/Migrations/Builders/ColumnsBuilder.cs
+++ b/src/EntityFramework.Relational/Migrations/Builders/ColumnsBuilder.cs
@@ -18,22 +18,21 @@ namespace Microsoft.Data.Entity.Migrations.Builders
             _createTableOperation = createTableOperation;
         }
 
-        public virtual OperationBuilder<AddColumnOperation> Column(
-            [NotNull] string type,
+        public virtual OperationBuilder<AddColumnOperation> Column<T>(
+            [CanBeNull] string type = null,
             [CanBeNull] string name = null,
             bool nullable = false,
             [CanBeNull] object defaultValue = null,
             [CanBeNull] string defaultValueSql = null,
             [CanBeNull] string computedColumnSql = null)
         {
-            Check.NotEmpty(type, nameof(type));
-
             var operation = new AddColumnOperation
             {
                 Schema = _createTableOperation.Schema,
                 Table = _createTableOperation.Name,
                 Name = name,
-                Type = type,
+                ClrType = typeof(T),
+                ColumnType = type,
                 IsNullable = nullable,
                 DefaultValue = defaultValue,
                 DefaultValueSql = defaultValueSql,

--- a/src/EntityFramework.Relational/Migrations/Builders/MigrationBuilder.cs
+++ b/src/EntityFramework.Relational/Migrations/Builders/MigrationBuilder.cs
@@ -15,10 +15,10 @@ namespace Microsoft.Data.Entity.Migrations.Builders
     {
         public virtual ICollection<MigrationOperation> Operations { get; } = new List<MigrationOperation>();
 
-        public virtual OperationBuilder<AddColumnOperation> AddColumn(
+        public virtual OperationBuilder<AddColumnOperation> AddColumn<T>(
             [NotNull] string name,
             [NotNull] string table,
-            [NotNull] string type,
+            [CanBeNull] string type = null,
             [CanBeNull] string schema = null,
             bool nullable = false,
             [CanBeNull] object defaultValue = null,
@@ -27,14 +27,14 @@ namespace Microsoft.Data.Entity.Migrations.Builders
         {
             Check.NotEmpty(name, nameof(name));
             Check.NotEmpty(table, nameof(table));
-            Check.NotEmpty(type, nameof(type));
 
             var operation = new AddColumnOperation
             {
                 Schema = schema,
                 Table = table,
                 Name = name,
-                Type = type,
+                ClrType = typeof(T),
+                ColumnType = type,
                 IsNullable = nullable,
                 DefaultValue = defaultValue,
                 DefaultValueSql = defaultValueSql,
@@ -165,10 +165,10 @@ namespace Microsoft.Data.Entity.Migrations.Builders
             return new OperationBuilder<AddUniqueConstraintOperation>(operation);
         }
 
-        public virtual OperationBuilder<AlterColumnOperation> AlterColumn(
+        public virtual OperationBuilder<AlterColumnOperation> AlterColumn<T>(
             [NotNull] string name,
             [NotNull] string table,
-            [NotNull] string type,
+            [CanBeNull] string type = null,
             [CanBeNull] string schema = null,
             bool nullable = false,
             [CanBeNull] object defaultValue = null,
@@ -183,7 +183,8 @@ namespace Microsoft.Data.Entity.Migrations.Builders
                 Schema = schema,
                 Table = table,
                 Name = name,
-                Type = type,
+                ClrType = typeof(T),
+                ColumnType = type,
                 IsNullable = nullable,
                 DefaultValue = defaultValue,
                 DefaultValueSql = defaultValueSql,
@@ -272,7 +273,16 @@ namespace Microsoft.Data.Entity.Migrations.Builders
         public virtual OperationBuilder<CreateSequenceOperation> CreateSequence(
             [NotNull] string name,
             [CanBeNull] string schema = null,
-            [CanBeNull] string type = null,
+            [CanBeNull] long? startWith = null,
+            [CanBeNull] int? incrementBy = null,
+            [CanBeNull] long? minValue = null,
+            [CanBeNull] long? maxValue = null,
+            bool cycle = false)
+            => CreateSequence<long>(name, schema, startWith, incrementBy, minValue, maxValue, cycle);
+
+        public virtual OperationBuilder<CreateSequenceOperation> CreateSequence<T>(
+            [NotNull] string name,
+            [CanBeNull] string schema = null,
             [CanBeNull] long? startWith = null,
             [CanBeNull] int? incrementBy = null,
             [CanBeNull] long? minValue = null,
@@ -285,7 +295,7 @@ namespace Microsoft.Data.Entity.Migrations.Builders
             {
                 Schema = schema,
                 Name = name,
-                Type = type,
+                ClrType = typeof(T),
                 StartWith = startWith,
                 IncrementBy = incrementBy,
                 MinValue = minValue,

--- a/src/EntityFramework.Relational/Migrations/History/HistoryRepository.cs
+++ b/src/EntityFramework.Relational/Migrations/History/HistoryRepository.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Data.Entity.Migrations.History
         public virtual string GetCreateScript()
         {
             var operations = _modelDiffer.GetDifferences(null, _model.Value);
-            var batches = _migrationSqlGenerator.Generate(operations);
+            var batches = _migrationSqlGenerator.Generate(operations, _model.Value);
             if (batches.Count != 1 || batches[0].SuppressTransaction)
             {
                 throw new InvalidOperationException(Strings.InvalidCreateScript);

--- a/src/EntityFramework.Relational/Migrations/Operations/AddColumnOperation.cs
+++ b/src/EntityFramework.Relational/Migrations/Operations/AddColumnOperation.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using JetBrains.Annotations;
 
 namespace Microsoft.Data.Entity.Migrations.Operations
@@ -10,7 +11,8 @@ namespace Microsoft.Data.Entity.Migrations.Operations
         public virtual string Name { get; [param: NotNull] set; }
         public virtual string Schema { get; [param: CanBeNull] set; }
         public virtual string Table { get; [param: NotNull] set; }
-        public virtual string Type { get; [param: NotNull] set; }
+        public virtual Type ClrType { get; [param: NotNull] set; }
+        public virtual string ColumnType { get; [param: CanBeNull] set; }
         public virtual bool IsNullable { get; set; }
         public virtual object DefaultValue { get; [param: CanBeNull] set; }
         public virtual string DefaultValueSql { get; [param: CanBeNull] set; }

--- a/src/EntityFramework.Relational/Migrations/Operations/AlterColumnOperation.cs
+++ b/src/EntityFramework.Relational/Migrations/Operations/AlterColumnOperation.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using JetBrains.Annotations;
 
 namespace Microsoft.Data.Entity.Migrations.Operations
@@ -10,7 +11,8 @@ namespace Microsoft.Data.Entity.Migrations.Operations
         public virtual string Schema { get; [param: CanBeNull] set; }
         public virtual string Table { get; [param: NotNull] set; }
         public virtual string Name { get; [param: NotNull] set; }
-        public virtual string Type { get; [param: NotNull] set; }
+        public virtual Type ClrType { get; [param: NotNull] set; }
+        public virtual string ColumnType { get; [param: CanBeNull] set; }
         public virtual bool IsNullable { get; set; }
         public virtual object DefaultValue { get; [param: CanBeNull] set; }
         public virtual string DefaultValueSql { get; [param: CanBeNull] set; }

--- a/src/EntityFramework.Relational/Migrations/Operations/CreateSequenceOperation.cs
+++ b/src/EntityFramework.Relational/Migrations/Operations/CreateSequenceOperation.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using JetBrains.Annotations;
 
 namespace Microsoft.Data.Entity.Migrations.Operations
@@ -9,7 +10,7 @@ namespace Microsoft.Data.Entity.Migrations.Operations
     {
         public virtual string Schema { get; [param: CanBeNull] set; }
         public virtual string Name { get; [param: NotNull] set; }
-        public virtual string Type { get; [param: CanBeNull] set; }
+        public virtual Type ClrType { get; [param: NotNull] set; }
         public virtual long? StartWith { get; [param: CanBeNull] set; }
         public virtual int? IncrementBy { get; [param: CanBeNull] set; }
         public virtual long? MaxValue { get; [param: CanBeNull] set; }

--- a/src/EntityFramework.SqlServer/Migrations/SqlServerMigrationSqlGenerator.cs
+++ b/src/EntityFramework.SqlServer/Migrations/SqlServerMigrationSqlGenerator.cs
@@ -19,8 +19,11 @@ namespace Microsoft.Data.Entity.SqlServer
     {
         private readonly ISqlServerUpdateSqlGenerator _sql;
 
-        public SqlServerMigrationSqlGenerator([NotNull] ISqlServerUpdateSqlGenerator sqlGenerator)
-            : base(Check.NotNull(sqlGenerator, nameof(sqlGenerator)))
+        public SqlServerMigrationSqlGenerator(
+            [NotNull] ISqlServerUpdateSqlGenerator sqlGenerator,
+            [NotNull] SqlServerTypeMapper typeMapper,
+            [NotNull] SqlServerMetadataExtensionProvider annotations)
+            : base(sqlGenerator, typeMapper, annotations)
         {
             _sql = sqlGenerator;
         }
@@ -234,6 +237,7 @@ namespace Microsoft.Data.Entity.SqlServer
             string schema,
             string table,
             string name,
+            Type clrType,
             string type,
             bool nullable,
             object defaultValue,
@@ -244,7 +248,7 @@ namespace Microsoft.Data.Entity.SqlServer
             SqlBatchBuilder builder)
         {
             Check.NotEmpty(name, nameof(name));
-            Check.NotEmpty(type, nameof(type));
+            Check.NotNull(clrType, nameof(clrType));
             Check.NotNull(annotatable, nameof(annotatable));
             Check.NotNull(builder, nameof(builder));
 
@@ -262,6 +266,7 @@ namespace Microsoft.Data.Entity.SqlServer
                 schema,
                 table,
                 name,
+                clrType,
                 type,
                 nullable,
                 defaultValue,
@@ -334,7 +339,8 @@ namespace Microsoft.Data.Entity.SqlServer
                     operation.Schema,
                     operation.Table,
                     operation.Name,
-                    operation.Type,
+                    operation.ClrType,
+                    operation.ColumnType,
                     operation.IsNullable,
                     operation.DefaultValue,
                     operation.DefaultValueSql,

--- a/src/EntityFramework.Sqlite/Migrations/SqliteMigrationSqlGenerator.cs
+++ b/src/EntityFramework.Sqlite/Migrations/SqliteMigrationSqlGenerator.cs
@@ -18,8 +18,11 @@ namespace Microsoft.Data.Entity.Sqlite.Migrations
     {
         private readonly IUpdateSqlGenerator _sql;
 
-        public SqliteMigrationSqlGenerator([NotNull] IUpdateSqlGenerator sqlGenerator)
-            : base(sqlGenerator)
+        public SqliteMigrationSqlGenerator(
+            [NotNull] SqliteUpdateSqlGenerator sqlGenerator,
+            [NotNull] SqliteTypeMapper typeMapper,
+            [NotNull] SqliteMetadataExtensionProvider annotations)
+            : base(sqlGenerator, typeMapper, annotations)
         {
             _sql = sqlGenerator;
         }
@@ -71,20 +74,21 @@ namespace Microsoft.Data.Entity.Sqlite.Migrations
         }
 
         public override void ColumnDefinition(
-            string schema, 
-            string table, 
-            string name, 
-            string type, 
-            bool nullable, 
-            object defaultValue, 
+            string schema,
+            string table,
+            string name,
+            Type clrType,
+            string type,
+            bool nullable,
+            object defaultValue,
             string defaultValueSql,
-            string computedColumnSql, 
-            IAnnotatable annotatable, 
-            IModel model, 
+            string computedColumnSql,
+            IAnnotatable annotatable,
+            IModel model,
             SqlBatchBuilder builder)
         {
             base.ColumnDefinition(
-                schema, table, name, type, nullable, 
+                schema, table, name, clrType, type, nullable,
                 defaultValue, defaultValueSql, computedColumnSql, annotatable, model, builder);
 
             var columnAnnotation = annotatable as Annotatable;

--- a/test/EntityFramework.Commands.FunctionalTests/Migrations/OperationCompilationTest.cs
+++ b/test/EntityFramework.Commands.FunctionalTests/Migrations/OperationCompilationTest.cs
@@ -25,18 +25,17 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                 {
                     Name = "Id",
                     Table = "Post",
-                    Type = "int",
+                    ClrType = typeof(int),
                 },
-                "mb.AddColumn(" + EOL +
+                "mb.AddColumn<int>(" + EOL +
                 "    name: \"Id\"," + EOL +
                 "    table: \"Post\"," + EOL +
-                "    type: \"int\"," + EOL +
                 "    nullable: false);" + EOL,
                 o =>
                 {
                     Assert.Equal("Id", o.Name);
                     Assert.Equal("Post", o.Table);
-                    Assert.Equal("int", o.Type);
+                    Assert.Equal(typeof(int), o.ClrType);
                 });
         }
 
@@ -49,11 +48,12 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                     Name = "Id",
                     Schema = "dbo",
                     Table = "Post",
-                    Type = "int",
+                    ClrType = typeof(int),
+                    ColumnType = "int",
                     IsNullable = true,
                     DefaultValue = 1
                 },
-                "mb.AddColumn(" + EOL +
+                "mb.AddColumn<int>(" + EOL +
                 "    name: \"Id\"," + EOL +
                 "    schema: \"dbo\"," + EOL +
                 "    table: \"Post\"," + EOL +
@@ -65,7 +65,8 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                     Assert.Equal("Id", o.Name);
                     Assert.Equal("dbo", o.Schema);
                     Assert.Equal("Post", o.Table);
-                    Assert.Equal("int", o.Type);
+                    Assert.Equal(typeof(int), o.ClrType);
+                    Assert.Equal("int", o.ColumnType);
                     Assert.True(o.IsNullable);
                     Assert.Equal(1, o.DefaultValue);
                 });
@@ -79,20 +80,19 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                 {
                     Name = "Id",
                     Table = "Post",
-                    Type = "int",
+                    ClrType = typeof(int),
                     DefaultValueSql = "1"
                 },
-                "mb.AddColumn(" + EOL +
+                "mb.AddColumn<int>(" + EOL +
                 "    name: \"Id\"," + EOL +
                 "    table: \"Post\"," + EOL +
-                "    type: \"int\"," + EOL +
                 "    nullable: false," + EOL +
                 "    defaultValueSql: \"1\");" + EOL,
                 o =>
                 {
                     Assert.Equal("Id", o.Name);
                     Assert.Equal("Post", o.Table);
-                    Assert.Equal("int", o.Type);
+                    Assert.Equal(typeof(int), o.ClrType);
                     Assert.Equal("1", o.DefaultValueSql);
                 });
         }
@@ -105,20 +105,19 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                 {
                     Name = "Id",
                     Table = "Post",
-                    Type = "int",
+                    ClrType = typeof(int),
                     ComputedColumnSql = "1"
                 },
-                "mb.AddColumn(" + EOL +
+                "mb.AddColumn<int>(" + EOL +
                 "    name: \"Id\"," + EOL +
                 "    table: \"Post\"," + EOL +
-                "    type: \"int\"," + EOL +
                 "    nullable: false," + EOL +
                 "    computedColumnSql: \"1\");" + EOL,
                 o =>
                 {
                     Assert.Equal("Id", o.Name);
                     Assert.Equal("Post", o.Table);
-                    Assert.Equal("int", o.Type);
+                    Assert.Equal(typeof(int), o.ClrType);
                     Assert.Equal("1", o.ComputedColumnSql);
                 });
         }
@@ -361,18 +360,17 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                 {
                     Name = "Id",
                     Table = "Post",
-                    Type = "int"
+                    ClrType = typeof(int)
                 },
-                "mb.AlterColumn(" + EOL +
+                "mb.AlterColumn<int>(" + EOL +
                 "    name: \"Id\"," + EOL +
                 "    table: \"Post\"," + EOL +
-                "    type: \"int\"," + EOL +
                 "    nullable: false);" + EOL,
                 o =>
                 {
                     Assert.Equal("Id", o.Name);
                     Assert.Equal("Post", o.Table);
-                    Assert.Equal("int", o.Type);
+                    Assert.Equal(typeof(int), o.ClrType);
                 });
         }
 
@@ -385,11 +383,12 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                     Name = "Id",
                     Schema = "dbo",
                     Table = "Post",
-                    Type = "int",
+                    ClrType = typeof(int),
+                    ColumnType = "int",
                     IsNullable = true,
                     DefaultValue = 1
                 },
-                "mb.AlterColumn(" + EOL +
+                "mb.AlterColumn<int>(" + EOL +
                 "    name: \"Id\"," + EOL +
                 "    schema: \"dbo\"," + EOL +
                 "    table: \"Post\"," + EOL +
@@ -401,7 +400,8 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                     Assert.Equal("Id", o.Name);
                     Assert.Equal("dbo", o.Schema);
                     Assert.Equal("Post", o.Table);
-                    Assert.Equal("int", o.Type);
+                    Assert.Equal(typeof(int), o.ClrType);
+                    Assert.Equal("int", o.ColumnType);
                     Assert.True(o.IsNullable);
                     Assert.Equal(1, o.DefaultValue);
                 });
@@ -415,13 +415,12 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                 {
                     Name = "Id",
                     Table = "Post",
-                    Type = "int",
+                    ClrType = typeof(int),
                     DefaultValueSql = "1"
                 },
-                "mb.AlterColumn(" + EOL +
+                "mb.AlterColumn<int>(" + EOL +
                 "    name: \"Id\"," + EOL +
                 "    table: \"Post\"," + EOL +
-                "    type: \"int\"," + EOL +
                 "    nullable: false," + EOL +
                 "    defaultValueSql: \"1\");" + EOL,
                 o =>
@@ -440,13 +439,12 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                 {
                     Name = "Id",
                     Table = "Post",
-                    Type = "int",
+                    ClrType = typeof(int),
                     ComputedColumnSql = "1"
                 },
-                "mb.AlterColumn(" + EOL +
+                "mb.AlterColumn<int>(" + EOL +
                 "    name: \"Id\"," + EOL +
                 "    table: \"Post\"," + EOL +
-                "    type: \"int\"," + EOL +
                 "    nullable: false," + EOL +
                 "    computedColumnSql: \"1\");" + EOL,
                 o =>
@@ -583,10 +581,36 @@ namespace Microsoft.Data.Entity.Commands.Migrations
         public void CreateSequenceOperation_required_args()
         {
             Test(
-                new CreateSequenceOperation { Name = "DefaultSequence" },
+                new CreateSequenceOperation
+                {
+                    Name = "DefaultSequence",
+                    ClrType = typeof(long)
+                },
                 "mb.CreateSequence(" + EOL +
                 "    name: \"DefaultSequence\");" + EOL,
-                o => Assert.Equal("DefaultSequence", o.Name));
+                o =>
+                {
+                    Assert.Equal("DefaultSequence", o.Name);
+                    Assert.Equal(typeof(long), o.ClrType);
+                });
+        }
+
+        [Fact]
+        public void CreateSequenceOperation_required_args_not_long()
+        {
+            Test(
+                new CreateSequenceOperation
+                {
+                    Name = "DefaultSequence",
+                    ClrType = typeof(int)
+                },
+                "mb.CreateSequence<int>(" + EOL +
+                "    name: \"DefaultSequence\");" + EOL,
+                o =>
+                {
+                    Assert.Equal("DefaultSequence", o.Name);
+                    Assert.Equal(typeof(int), o.ClrType);
+                });
         }
 
         [Fact]
@@ -597,7 +621,7 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                 {
                     Name = "DefaultSequence",
                     Schema = "dbo",
-                    Type = "bigint",
+                    ClrType = typeof(long),
                     StartWith = 3,
                     IncrementBy = 1,
                     MinValue = 2,
@@ -607,7 +631,6 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                 "mb.CreateSequence(" + EOL +
                 "    name: \"DefaultSequence\"," + EOL +
                 "    schema: \"dbo\"," + EOL +
-                "    type: \"bigint\"," + EOL +
                 "    startWith: 3L," + EOL +
                 "    incrementBy: 1," + EOL +
                 "    minValue: 2L," + EOL +
@@ -617,7 +640,43 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                 {
                     Assert.Equal("DefaultSequence", o.Name);
                     Assert.Equal("dbo", o.Schema);
-                    Assert.Equal("bigint", o.Type);
+                    Assert.Equal(typeof(long), o.ClrType);
+                    Assert.Equal(3, o.StartWith);
+                    Assert.Equal(1, o.IncrementBy);
+                    Assert.Equal(2, o.MinValue);
+                    Assert.Equal(4, o.MaxValue);
+                    Assert.True(o.Cycle);
+                });
+        }
+
+        [Fact]
+        public void CreateSequenceOperation_all_args_not_long()
+        {
+            Test(
+                new CreateSequenceOperation
+                {
+                    Name = "DefaultSequence",
+                    Schema = "dbo",
+                    ClrType = typeof(int),
+                    StartWith = 3,
+                    IncrementBy = 1,
+                    MinValue = 2,
+                    MaxValue = 4,
+                    Cycle = true
+                },
+                "mb.CreateSequence<int>(" + EOL +
+                "    name: \"DefaultSequence\"," + EOL +
+                "    schema: \"dbo\"," + EOL +
+                "    startWith: 3L," + EOL +
+                "    incrementBy: 1," + EOL +
+                "    minValue: 2L," + EOL +
+                "    maxValue: 4L," + EOL +
+                "    cycle: true);" + EOL,
+                o =>
+                {
+                    Assert.Equal("DefaultSequence", o.Name);
+                    Assert.Equal("dbo", o.Schema);
+                    Assert.Equal(typeof(int), o.ClrType);
                     Assert.Equal(3, o.StartWith);
                     Assert.Equal(1, o.IncrementBy);
                     Assert.Equal(2, o.MinValue);
@@ -639,7 +698,7 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                         {
                             Name = "Id",
                             Table = "Post",
-                            Type = "int"
+                            ClrType= typeof(int)
                         }
                     }
                 },
@@ -647,7 +706,7 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                 "    name: \"Post\"," + EOL +
                 "    columns: table => new" + EOL +
                 "    {" + EOL +
-                "        Id = table.Column(type: \"int\", nullable: false)" + EOL +
+                "        Id = table.Column<int>(nullable: false)" + EOL +
                 "    }," + EOL +
                 "    constraints: table =>" + EOL +
                 "    {" + EOL +
@@ -659,7 +718,7 @@ namespace Microsoft.Data.Entity.Commands.Migrations
 
                     Assert.Equal("Id", o.Columns[0].Name);
                     Assert.Equal("Post", o.Columns[0].Table);
-                    Assert.Equal("int", o.Columns[0].Type);
+                    Assert.Equal(typeof(int), o.Columns[0].ClrType);
                 });
         }
 
@@ -678,7 +737,8 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                             Name = "Post Id",
                             Schema = "dbo",
                             Table = "Post",
-                            Type = "int",
+                            ClrType= typeof(int),
+                            ColumnType = "int",
                             IsNullable = true,
                             DefaultValue = 1
                         }
@@ -689,7 +749,7 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                 "    schema: \"dbo\"," + EOL +
                 "    columns: table => new" + EOL +
                 "    {" + EOL +
-                "        PostId = table.Column(name: \"Post Id\", type: \"int\", nullable: true, defaultValue: 1)" + EOL +
+                "        PostId = table.Column<int>(name: \"Post Id\", type: \"int\", nullable: true, defaultValue: 1)" + EOL +
                 "    }," + EOL +
                 "    constraints: table =>" + EOL +
                 "    {" + EOL +
@@ -703,7 +763,8 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                     Assert.Equal("Post Id", o.Columns[0].Name);
                     Assert.Equal("dbo", o.Columns[0].Schema);
                     Assert.Equal("Post", o.Columns[0].Table);
-                    Assert.Equal("int", o.Columns[0].Type);
+                    Assert.Equal(typeof(int), o.Columns[0].ClrType);
+                    Assert.Equal("int", o.Columns[0].ColumnType);
                     Assert.True(o.Columns[0].IsNullable);
                     Assert.Equal(1, o.Columns[0].DefaultValue);
                 });
@@ -722,7 +783,7 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                         {
                             Name = "Id",
                             Table = "Post",
-                            Type = "int",
+                            ClrType = typeof(int),
                             DefaultValueSql = "1"
                         }
                     }
@@ -731,7 +792,7 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                 "    name: \"Post\"," + EOL +
                 "    columns: table => new" + EOL +
                 "    {" + EOL +
-                "        Id = table.Column(type: \"int\", nullable: false, defaultValueSql: \"1\")" + EOL +
+                "        Id = table.Column<int>(nullable: false, defaultValueSql: \"1\")" + EOL +
                 "    }," + EOL +
                 "    constraints: table =>" + EOL +
                 "    {" + EOL +
@@ -742,7 +803,7 @@ namespace Microsoft.Data.Entity.Commands.Migrations
 
                     Assert.Equal("Id", o.Columns[0].Name);
                     Assert.Equal("Post", o.Columns[0].Table);
-                    Assert.Equal("int", o.Columns[0].Type);
+                    Assert.Equal(typeof(int), o.Columns[0].ClrType);
                     Assert.Equal("1", o.Columns[0].DefaultValueSql);
                 });
         }
@@ -760,7 +821,7 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                         {
                             Name = "Id",
                             Table = "Post",
-                            Type = "int",
+                            ClrType = typeof(int),
                             ComputedColumnSql = "1"
                         }
                     }
@@ -769,7 +830,7 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                 "    name: \"Post\"," + EOL +
                 "    columns: table => new" + EOL +
                 "    {" + EOL +
-                "        Id = table.Column(type: \"int\", nullable: false, computedColumnSql: \"1\")" + EOL +
+                "        Id = table.Column<int>(nullable: false, computedColumnSql: \"1\")" + EOL +
                 "    }," + EOL +
                 "    constraints: table =>" + EOL +
                 "    {" + EOL +
@@ -780,7 +841,7 @@ namespace Microsoft.Data.Entity.Commands.Migrations
 
                     Assert.Equal("Id", o.Columns[0].Name);
                     Assert.Equal("Post", o.Columns[0].Table);
-                    Assert.Equal("int", o.Columns[0].Type);
+                    Assert.Equal(typeof(int), o.Columns[0].ClrType);
                     Assert.Equal("1", o.Columns[0].ComputedColumnSql);
                 });
         }
@@ -794,7 +855,7 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                     Name = "Post",
                     Columns =
                     {
-                        new AddColumnOperation { Name = "BlogId", Type = "int" }
+                        new AddColumnOperation { Name = "BlogId", ClrType = typeof(int) }
                     },
                     ForeignKeys =
                     {
@@ -811,7 +872,7 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                 "    name: \"Post\"," + EOL +
                 "    columns: table => new" + EOL +
                 "    {" + EOL +
-                "        BlogId = table.Column(type: \"int\", nullable: false)" + EOL +
+                "        BlogId = table.Column<int>(nullable: false)" + EOL +
                 "    }," + EOL +
                 "    constraints: table =>" + EOL +
                 "    {" + EOL +
@@ -842,7 +903,7 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                     Name = "Post",
                     Columns =
                     {
-                        new AddColumnOperation { Name = "BlogId", Type = "int" }
+                        new AddColumnOperation { Name = "BlogId", ClrType = typeof(int) }
                     },
                     ForeignKeys =
                     {
@@ -865,7 +926,7 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                 "    schema: \"dbo\"," + EOL +
                 "    columns: table => new" + EOL +
                 "    {" + EOL +
-                "        BlogId = table.Column(type: \"int\", nullable: false)" + EOL +
+                "        BlogId = table.Column<int>(nullable: false)" + EOL +
                 "    }," + EOL +
                 "    constraints: table =>" + EOL +
                 "    {" + EOL +
@@ -904,8 +965,8 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                     Name = "Post",
                     Columns =
                     {
-                        new AddColumnOperation { Name = "BlogId1", Type = "int" },
-                        new AddColumnOperation { Name = "BlogId2", Type = "int" }
+                        new AddColumnOperation { Name = "BlogId1", ClrType = typeof(int) },
+                        new AddColumnOperation { Name = "BlogId2", ClrType = typeof(int) }
                     },
                     ForeignKeys =
                     {
@@ -923,8 +984,8 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                 "    name: \"Post\"," + EOL +
                 "    columns: table => new" + EOL +
                 "    {" + EOL +
-                "        BlogId1 = table.Column(type: \"int\", nullable: false)," + EOL +
-                "        BlogId2 = table.Column(type: \"int\", nullable: false)" + EOL +
+                "        BlogId1 = table.Column<int>(nullable: false)," + EOL +
+                "        BlogId2 = table.Column<int>(nullable: false)" + EOL +
                 "    }," + EOL +
                 "    constraints: table =>" + EOL +
                 "    {" + EOL +
@@ -955,7 +1016,7 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                     Name = "Post",
                     Columns =
                     {
-                        new AddColumnOperation { Name = "Id", Type = "int" }
+                        new AddColumnOperation { Name = "Id", ClrType = typeof(int) }
                     },
                     PrimaryKey = new AddPrimaryKeyOperation
                     {
@@ -968,7 +1029,7 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                 "    name: \"Post\"," + EOL +
                 "    columns: table => new" + EOL +
                 "    {" + EOL +
-                "        Id = table.Column(type: \"int\", nullable: false)" + EOL +
+                "        Id = table.Column<int>(nullable: false)" + EOL +
                 "    }," + EOL +
                 "    constraints: table =>" + EOL +
                 "    {" + EOL +
@@ -994,7 +1055,7 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                     Schema = "dbo",
                     Columns =
                     {
-                        new AddColumnOperation { Name = "Id", Type = "int" }
+                        new AddColumnOperation { Name = "Id", ClrType = typeof(int) }
                     },
                     PrimaryKey = new AddPrimaryKeyOperation
                     {
@@ -1009,7 +1070,7 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                 "    schema: \"dbo\"," + EOL +
                 "    columns: table => new" + EOL +
                 "    {" + EOL +
-                "        Id = table.Column(type: \"int\", nullable: false)" + EOL +
+                "        Id = table.Column<int>(nullable: false)" + EOL +
                 "    }," + EOL +
                 "    constraints: table =>" + EOL +
                 "    {" + EOL +
@@ -1035,8 +1096,8 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                     Name = "Post",
                     Columns =
                     {
-                        new AddColumnOperation { Name = "Id1", Type = "int" },
-                        new AddColumnOperation { Name = "Id2", Type = "int" }
+                        new AddColumnOperation { Name = "Id1", ClrType = typeof(int) },
+                        new AddColumnOperation { Name = "Id2", ClrType = typeof(int) }
                     },
                     PrimaryKey = new AddPrimaryKeyOperation
                     {
@@ -1049,8 +1110,8 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                 "    name: \"Post\"," + EOL +
                 "    columns: table => new" + EOL +
                 "    {" + EOL +
-                "        Id1 = table.Column(type: \"int\", nullable: false)," + EOL +
-                "        Id2 = table.Column(type: \"int\", nullable: false)" + EOL +
+                "        Id1 = table.Column<int>(nullable: false)," + EOL +
+                "        Id2 = table.Column<int>(nullable: false)" + EOL +
                 "    }," + EOL +
                 "    constraints: table =>" + EOL +
                 "    {" + EOL +
@@ -1075,7 +1136,7 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                     Name = "Post",
                     Columns =
                     {
-                        new AddColumnOperation { Name = "AltId", Type = "int" }
+                        new AddColumnOperation { Name = "AltId", ClrType = typeof(int) }
                     },
                     UniqueConstraints =
                     {
@@ -1091,7 +1152,7 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                 "    name: \"Post\"," + EOL +
                 "    columns: table => new" + EOL +
                 "    {" + EOL +
-                "        AltId = table.Column(type: \"int\", nullable: false)" + EOL +
+                "        AltId = table.Column<int>(nullable: false)" + EOL +
                 "    }," + EOL +
                 "    constraints: table =>" + EOL +
                 "    {" + EOL +
@@ -1117,7 +1178,7 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                     Schema = "dbo",
                     Columns =
                     {
-                        new AddColumnOperation { Name = "AltId", Type = "int" }
+                        new AddColumnOperation { Name = "AltId", ClrType = typeof(int) }
                     },
                     UniqueConstraints =
                     {
@@ -1135,7 +1196,7 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                 "    schema: \"dbo\"," + EOL +
                 "    columns: table => new" + EOL +
                 "    {" + EOL +
-                "        AltId = table.Column(type: \"int\", nullable: false)" + EOL +
+                "        AltId = table.Column<int>(nullable: false)" + EOL +
                 "    }," + EOL +
                 "    constraints: table =>" + EOL +
                 "    {" + EOL +
@@ -1161,8 +1222,8 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                     Name = "Post",
                     Columns =
                     {
-                        new AddColumnOperation { Name = "AltId1", Type = "int" },
-                        new AddColumnOperation { Name = "AltId2", Type = "int" }
+                        new AddColumnOperation { Name = "AltId1", ClrType = typeof(int) },
+                        new AddColumnOperation { Name = "AltId2", ClrType = typeof(int) }
                     },
                     UniqueConstraints =
                     {
@@ -1178,8 +1239,8 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                 "    name: \"Post\"," + EOL +
                 "    columns: table => new" + EOL +
                 "    {" + EOL +
-                "        AltId1 = table.Column(type: \"int\", nullable: false)," + EOL +
-                "        AltId2 = table.Column(type: \"int\", nullable: false)" + EOL +
+                "        AltId1 = table.Column<int>(nullable: false)," + EOL +
+                "        AltId2 = table.Column<int>(nullable: false)" + EOL +
                 "    }," + EOL +
                 "    constraints: table =>" + EOL +
                 "    {" + EOL +

--- a/test/EntityFramework.Commands.Tests/Migrations/MigrationScaffolderTest.cs
+++ b/test/EntityFramework.Commands.Tests/Migrations/MigrationScaffolderTest.cs
@@ -1,15 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using System.Data;
 using Microsoft.Data.Entity.Commands.Utilities;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Migrations.History;
 using Microsoft.Data.Entity.Migrations.Infrastructure;
-using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Tests;
 using Microsoft.Framework.Logging;
 using Xunit;
@@ -44,7 +41,6 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                     new DbContextOptions<TContext>().WithExtension(new MockRelationalOptionsExtension()),
                     modelFactory),
                 new ModelDiffer(
-                    new ConcreteTypeMapper(),
                     new TestMetadataExtensionProvider(),
                     new MigrationAnnotationProvider()),
                 new MigrationIdGenerator(),
@@ -84,20 +80,6 @@ namespace Microsoft.Data.Entity.Commands.Migrations
             public IReadOnlyList<HistoryRow> GetAppliedMigrations() => null;
             public string GetDeleteScript(string migrationId) => null;
             public string GetInsertScript(HistoryRow row) => null;
-        }
-
-        private class ConcreteTypeMapper : RelationalTypeMapper
-        {
-            protected override string GetColumnType(IProperty property) => property.TestProvider().ColumnType;
-
-            protected override IReadOnlyDictionary<Type, RelationalTypeMapping> SimpleMappings { get; }
-                = new Dictionary<Type, RelationalTypeMapping>
-                {
-                    { typeof(int), new RelationalTypeMapping("int", DbType.String) }
-                };
-
-            protected override IReadOnlyDictionary<string, RelationalTypeMapping> SimpleNameMappings { get; }
-                = new Dictionary<string, RelationalTypeMapping>();
         }
     }
 }

--- a/test/EntityFramework.Relational.FunctionalTests/MigrationsFixtureBase.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/MigrationsFixtureBase.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                         name: "Table1",
                         columns: x => new
                         {
-                            Id = x.Column("int")
+                            Id = x.Column<int>()
                         })
                     .PrimaryKey(
                         name: "PK_Table1",

--- a/test/EntityFramework.Relational.Tests/Migrations/Infrastructure/ModelDifferTest.cs
+++ b/test/EntityFramework.Relational.Tests/Migrations/Infrastructure/ModelDifferTest.cs
@@ -270,7 +270,8 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
                     Assert.Equal("dbo", operation.Schema);
                     Assert.Equal("Dragon", operation.Table);
                     Assert.Equal("Name", operation.Name);
-                    Assert.Equal("nvarchar(30)", operation.Type);
+                    Assert.Equal(typeof(string), operation.ClrType);
+                    Assert.Equal("nvarchar(30)", operation.ColumnType);
                     Assert.False(operation.IsNullable);
                     Assert.Equal("Draco", operation.DefaultValue);
                     Assert.Equal("CreateDragonName()", operation.DefaultValueSql);
@@ -310,7 +311,8 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
                     Assert.Equal("dbo", operation.Schema);
                     Assert.Equal("Dragon", operation.Table);
                     Assert.Equal("Name", operation.Name);
-                    Assert.Equal("nvarchar(30)", operation.Type);
+                    Assert.Equal(typeof(string), operation.ClrType);
+                    Assert.Equal("nvarchar(30)", operation.ColumnType);
                     Assert.False(operation.IsNullable);
                     Assert.Equal("Draco", operation.DefaultValue);
                     Assert.Equal("CreateDragonName()", operation.ComputedColumnSql);
@@ -480,7 +482,8 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
                     Assert.Equal("dbo", operation.Schema);
                     Assert.Equal("Bison", operation.Table);
                     Assert.Equal("Name", operation.Name);
-                    Assert.Equal("nvarchar(30)", operation.Type);
+                    Assert.Equal(typeof(string), operation.ClrType);
+                    Assert.Equal("nvarchar(30)", operation.ColumnType);
                     Assert.True(operation.IsNullable);
                     Assert.Equal("Buffy", operation.DefaultValue);
                     Assert.Equal("CreateBisonName()", operation.DefaultValueSql);
@@ -525,7 +528,8 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
                     Assert.Equal("dbo", operation.Schema);
                     Assert.Equal("Puma", operation.Table);
                     Assert.Equal("Name", operation.Name);
-                    Assert.Equal("nvarchar(450)", operation.Type);
+                    Assert.Equal(typeof(string), operation.ClrType);
+                    Assert.Equal("nvarchar(450)", operation.ColumnType);
                     Assert.False(operation.IsNullable);
                     Assert.Equal("Puff", operation.DefaultValue);
                     Assert.Equal("CreatePumaName()", operation.DefaultValueSql);
@@ -570,7 +574,8 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
                     Assert.Equal("dbo", operation.Schema);
                     Assert.Equal("Cougar", operation.Table);
                     Assert.Equal("Name", operation.Name);
-                    Assert.Equal("nvarchar(30)", operation.Type);
+                    Assert.Equal(typeof(string), operation.ClrType);
+                    Assert.Equal("nvarchar(30)", operation.ColumnType);
                     Assert.False(operation.IsNullable);
                     Assert.Equal("Cosmo", operation.DefaultValue);
                     Assert.Equal("CreateCougarName()", operation.DefaultValueSql);
@@ -615,7 +620,8 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
                     Assert.Equal("dbo", operation.Schema);
                     Assert.Equal("MountainLion", operation.Table);
                     Assert.Equal("Name", operation.Name);
-                    Assert.Equal("nvarchar(30)", operation.Type);
+                    Assert.Equal(typeof(string), operation.ClrType);
+                    Assert.Equal("nvarchar(30)", operation.ColumnType);
                     Assert.False(operation.IsNullable);
                     Assert.Equal("Liam", operation.DefaultValue);
                     Assert.Equal("CreateCatamountName()", operation.DefaultValueSql);
@@ -660,7 +666,8 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
                     Assert.Equal("dbo", operation.Schema);
                     Assert.Equal("MountainLion", operation.Table);
                     Assert.Equal("Name", operation.Name);
-                    Assert.Equal("nvarchar(30)", operation.Type);
+                    Assert.Equal(typeof(string), operation.ClrType);
+                    Assert.Equal("nvarchar(30)", operation.ColumnType);
                     Assert.False(operation.IsNullable);
                     Assert.Equal("Liam", operation.DefaultValue);
                     Assert.Equal("CreateCatamountName()", operation.ComputedColumnSql);
@@ -1348,7 +1355,7 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
                     var operation = Assert.IsType<CreateSequenceOperation>(operations[0]);
                     Assert.Equal("Tango", operation.Name);
                     Assert.Equal("dbo", operation.Schema);
-                    Assert.Equal("int", operation.Type);
+                    Assert.Equal(typeof(int), operation.ClrType);
                     Assert.Equal(2, operation.StartWith);
                     Assert.Equal(3, operation.IncrementBy);
                     Assert.Equal(1, operation.MinValue);
@@ -1556,7 +1563,7 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
                     var createOperation = Assert.IsType<CreateSequenceOperation>(operations[1]);
                     Assert.Equal("Hotel", createOperation.Name);
                     Assert.Equal("dbo", createOperation.Schema);
-                    Assert.Equal("bigint", createOperation.Type);
+                    Assert.Equal(typeof(long), createOperation.ClrType);
                     Assert.Equal(2, createOperation.StartWith);
                     Assert.Equal(3, createOperation.IncrementBy);
                     Assert.Equal(1, createOperation.MinValue);
@@ -2797,7 +2804,7 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
                     Assert.Equal("dbo", operation.Schema);
                     Assert.Equal("Animal", operation.Table);
                     Assert.Equal("Name", operation.Name);
-                    Assert.Equal("varchar(30)", operation.Type);
+                    Assert.Equal("varchar(30)", operation.ColumnType);
                 });
         }
 

--- a/test/EntityFramework.Relational.Tests/Migrations/Infrastructure/ModelDifferTestBase.cs
+++ b/test/EntityFramework.Relational.Tests/Migrations/Infrastructure/ModelDifferTestBase.cs
@@ -3,9 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Migrations.Operations;
-using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Tests;
 
 namespace Microsoft.Data.Entity.Migrations.Infrastructure
@@ -32,23 +30,6 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
 
         protected virtual ModelBuilder CreateModelBuilder() => TestHelpers.Instance.CreateConventionBuilder();
         protected virtual ModelDiffer CreateModelDiffer()
-            => new ModelDiffer(new ConcreteTypeMapper(), new TestMetadataExtensionProvider(), new MigrationAnnotationProvider());
-
-        private class ConcreteTypeMapper : RelationalTypeMapper
-        {
-            protected override IReadOnlyDictionary<Type, RelationalTypeMapping> SimpleMappings { get; }
-                = new Dictionary<Type, RelationalTypeMapping>
-                    {
-                        { typeof(int), new RelationalTypeMapping("int") },
-                        { typeof(long), new RelationalTypeMapping("bigint") },
-                        { typeof(string), new RelationalTypeMapping("nvarchar(4000)") },
-                        { typeof(byte[]), new RelationalTypeMapping("varbinary(8000)") }
-                    };
-
-            protected override string GetColumnType(IProperty property) => property.TestProvider().ColumnType;
-
-            protected override IReadOnlyDictionary<string, RelationalTypeMapping> SimpleNameMappings { get; }
-                = new Dictionary<string, RelationalTypeMapping>();
-        }
+            => new ModelDiffer(new TestMetadataExtensionProvider(), new MigrationAnnotationProvider());
     }
 }

--- a/test/EntityFramework.Relational.Tests/Migrations/Sql/MigrationSqlGeneratorTestBase.cs
+++ b/test/EntityFramework.Relational.Tests/Migrations/Sql/MigrationSqlGeneratorTestBase.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Linq;
 using Microsoft.Data.Entity.Migrations.Operations;
-using Microsoft.Data.Entity.Migrations.Sql;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Migrations.Sql
@@ -26,7 +25,8 @@ namespace Microsoft.Data.Entity.Migrations.Sql
                     Table = "People",
                     Schema = "dbo",
                     Name = "Name",
-                    Type = "varchar(30)",
+                    ClrType = typeof(string),
+                    ColumnType = "varchar(30)",
                     IsNullable = false,
                     DefaultValue = "John Doe"
                 });
@@ -40,7 +40,8 @@ namespace Microsoft.Data.Entity.Migrations.Sql
                 {
                     Table = "People",
                     Name = "Birthday",
-                    Type = "date",
+                    ClrType = typeof(DateTime),
+                    ColumnType = "date",
                     IsNullable = true,
                     DefaultValueSql = "CURRENT_TIMESTAMP"
                 });
@@ -54,9 +55,22 @@ namespace Microsoft.Data.Entity.Migrations.Sql
                 {
                     Table = "People",
                     Name = "Birthday",
-                    Type = "date",
+                    ClrType = typeof(DateTime),
+                    ColumnType = "date",
                     IsNullable = true,
                     ComputedColumnSql = "CURRENT_TIMESTAMP"
+                });
+        }
+
+        [Fact]
+        public virtual void AddColumnOperation_without_column_type()
+        {
+            Generate(
+                new AddColumnOperation
+                {
+                    Table = "People",
+                    Name = "Alias",
+                    ClrType = typeof(string)
                 });
         }
 
@@ -147,9 +161,22 @@ namespace Microsoft.Data.Entity.Migrations.Sql
                     Table = "People",
                     Schema = "dbo",
                     Name = "LuckyNumber",
-                    Type = "int",
+                    ClrType = typeof(int),
+                    ColumnType = "int",
                     IsNullable = false,
                     DefaultValue = 7
+                });
+        }
+
+        [Fact]
+        public virtual void AlterColumnOperation_without_column_type()
+        {
+            Generate(
+                new AlterColumnOperation
+                {
+                    Table = "People",
+                    Name = "LuckyNumber",
+                    ClrType = typeof(int)
                 });
         }
 
@@ -231,7 +258,24 @@ namespace Microsoft.Data.Entity.Migrations.Sql
                     IncrementBy = 1,
                     MinValue = 2,
                     MaxValue = 816,
-                    Type = "bigint",
+                    ClrType = typeof(long),
+                    Cycle = true
+                });
+        }
+
+        [Fact]
+        public virtual void CreateSequenceOperation_with_minValue_and_maxValue_not_long()
+        {
+            Generate(
+                new CreateSequenceOperation
+                {
+                    Name = "DefaultSequence",
+                    Schema = "dbo",
+                    StartWith = 3,
+                    IncrementBy = 1,
+                    MinValue = 2,
+                    MaxValue = 816,
+                    ClrType = typeof(int),
                     Cycle = true
                 });
         }
@@ -243,6 +287,7 @@ namespace Microsoft.Data.Entity.Migrations.Sql
                 new CreateSequenceOperation
                 {
                     Name = "DefaultSequence",
+                    ClrType = typeof(long),
                     StartWith = 3,
                     IncrementBy = 1
                 });
@@ -261,19 +306,20 @@ namespace Microsoft.Data.Entity.Migrations.Sql
                         new AddColumnOperation
                         {
                             Name = "Id",
-                            Type = "int",
+                            ClrType = typeof(int),
                             IsNullable = false
                         },
                         new AddColumnOperation
                         {
                             Name = "EmployerId",
-                            Type = "int",
+                            ClrType = typeof(int),
                             IsNullable = true
                         },
                          new AddColumnOperation
                         {
                             Name = "SSN",
-                            Type = "char(11)",
+                            ClrType = typeof(string),
+                            ColumnType = "char(11)",
                             IsNullable = true
                         }
                     },

--- a/test/EntityFramework.SqlServer.Tests/Migrations/SqlServerHistoryRepositoryTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/Migrations/SqlServerHistoryRepositoryTest.cs
@@ -116,11 +116,12 @@ namespace Microsoft.Data.Entity.SqlServer.Migrations
                         { typeof(SqlServerOptionsExtension), new SqlServerOptionsExtension() }
                     }),
                 new ModelDiffer(
-                    new SqlServerTypeMapper(),
                     annotationsProvider,
                     new SqlServerMigrationAnnotationProvider()),
                 new SqlServerMigrationSqlGenerator(
-                    updateSqlGenerator),
+                    updateSqlGenerator,
+                    new SqlServerTypeMapper(),
+                    annotationsProvider),
                 annotationsProvider,
                 updateSqlGenerator,
                 Mock.Of<IServiceProvider>());

--- a/test/EntityFramework.SqlServer.Tests/Migrations/SqlServerMigrationSqlGeneratorTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/Migrations/SqlServerMigrationSqlGeneratorTest.cs
@@ -12,7 +12,10 @@ namespace Microsoft.Data.Entity.SqlServer.Migrations
     public class SqlServerMigrationSqlGeneratorTest : MigrationSqlGeneratorTestBase
     {
         protected override IMigrationSqlGenerator SqlGenerator =>
-            new SqlServerMigrationSqlGenerator(new SqlServerUpdateSqlGenerator());
+            new SqlServerMigrationSqlGenerator(
+                new SqlServerUpdateSqlGenerator(),
+                new SqlServerTypeMapper(),
+                new SqlServerMetadataExtensionProvider());
 
         [Fact]
         public virtual void AddColumnOperation_with_computedSql()
@@ -22,7 +25,7 @@ namespace Microsoft.Data.Entity.SqlServer.Migrations
                 {
                     Table = "People",
                     Name = "FullName",
-                    Type = "nvarchar(30)",
+                    ClrType = typeof(string),
                     ComputedColumnSql = "FirstName + ' ' + LastName"
                 });
 
@@ -49,7 +52,8 @@ namespace Microsoft.Data.Entity.SqlServer.Migrations
                 {
                     Table = "People",
                     Name = "Id",
-                    Type = "int",
+                    ClrType = typeof(int),
+                    ColumnType = "int",
                     IsNullable = false,
                     [SqlServerAnnotationNames.Prefix + SqlServerAnnotationNames.ValueGenerationStrategy] =
                         SqlServerIdentityStrategy.IdentityColumn
@@ -57,6 +61,15 @@ namespace Microsoft.Data.Entity.SqlServer.Migrations
 
             Assert.Equal(
                 "ALTER TABLE [People] ADD [Id] int NOT NULL IDENTITY;" + EOL,
+                Sql);
+        }
+
+        public override void AddColumnOperation_without_column_type()
+        {
+            base.AddColumnOperation_without_column_type();
+
+            Assert.Equal(
+                "ALTER TABLE [People] ADD [Alias] nvarchar(max) NOT NULL;" + EOL,
                 Sql);
         }
 
@@ -82,6 +95,15 @@ namespace Microsoft.Data.Entity.SqlServer.Migrations
 
             Assert.Equal(
                 "ALTER TABLE [dbo].[People] ALTER COLUMN [LuckyNumber] int NOT NULL DEFAULT 7;" + EOL,
+                Sql);
+        }
+
+        public override void AlterColumnOperation_without_column_type()
+        {
+            base.AlterColumnOperation_without_column_type();
+
+            Assert.Equal(
+                "ALTER TABLE [People] ALTER COLUMN [LuckyNumber] int NOT NULL;" + EOL,
                 Sql);
         }
 

--- a/test/EntityFramework.SqlServer.Tests/Migrations/SqlServerModelDifferTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/Migrations/SqlServerModelDifferTest.cs
@@ -155,7 +155,7 @@ namespace Microsoft.Data.Entity.SqlServer.Migrations
                         var addTableOperation = Assert.IsType<AlterColumnOperation>(operations[0]);
                         Assert.Equal("Person", addTableOperation.Table);
                         Assert.Equal("Value", addTableOperation.Name);
-                        Assert.Equal("varchar(8000)", addTableOperation.Type);
+                        Assert.Equal("varchar(8000)", addTableOperation.ColumnType);
                         Assert.Equal("1 + 1", addTableOperation.DefaultValueSql);
                     });
         }
@@ -695,7 +695,6 @@ namespace Microsoft.Data.Entity.SqlServer.Migrations
 
         protected override ModelDiffer CreateModelDiffer()
             => new ModelDiffer(
-                new SqlServerTypeMapper(),
                 new SqlServerMetadataExtensionProvider(),
                 new SqlServerMigrationAnnotationProvider());
     }

--- a/test/EntityFramework.Sqlite.Tests/Migrations/SqliteHistoryRepositoryTest.cs
+++ b/test/EntityFramework.Sqlite.Tests/Migrations/SqliteHistoryRepositoryTest.cs
@@ -110,11 +110,12 @@ namespace Microsoft.Data.Entity.Sqlite.Migrations
                         { typeof(SqliteOptionsExtension), new SqliteOptionsExtension() }
                     }),
                 new ModelDiffer(
-                    new SqliteTypeMapper(),
                     annotationsProvider,
                     new SqliteMigrationAnnotationProvider()),
                 new SqliteMigrationSqlGenerator(
-                    updateSqlGenerator),
+                    updateSqlGenerator,
+                    new SqliteTypeMapper(),
+                    annotationsProvider),
                 annotationsProvider,
                 updateSqlGenerator,
                 Mock.Of<IServiceProvider>());


### PR DESCRIPTION
Resolves #2421

I did some manual bashing to verify this end-to-end. Migrations is pretty broken at the moment due to #2545 & #2715.