### PR TITLE
Add support for InverseProperty

### DIFF
--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -150,8 +150,10 @@
     <Compile Include="Metadata\Builders\ReferenceReferenceBuilder`.cs" />
     <Compile Include="Metadata\Conventions\ConventionSet.cs" />
     <Compile Include="Metadata\Conventions\Internal\INavigationConvention.cs" />
+    <Compile Include="Metadata\Conventions\Internal\InversePropertyAttributeConvention.cs" />
+    <Compile Include="Metadata\Conventions\Internal\NavigationAttributeNavigationConvention.cs" />
     <Compile Include="Metadata\Conventions\Internal\NotMappedPropertyAttributeConvention.cs" />
-    <Compile Include="Metadata\Conventions\Internal\NavigationAttributeConvention.cs" />
+    <Compile Include="Metadata\Conventions\Internal\NavigationAttributeEntityTypeConvention.cs" />
     <Compile Include="Metadata\Conventions\Internal\NotMappedNavigationAttributeConvention.cs" />
     <Compile Include="Metadata\Conventions\Internal\RequiredNavigationAttributeConvention.cs" />
     <Compile Include="Metadata\Conventions\Internal\TimestampAttributeConvention.cs" />

--- a/src/EntityFramework.Core/Extensions/Internal/PropertyInfoExtensions.cs
+++ b/src/EntityFramework.Core/Extensions/Internal/PropertyInfoExtensions.cs
@@ -18,5 +18,27 @@ namespace System.Reflection
                && propertyInfo.GetIndexParameters().Length == 0
                && propertyInfo.CanRead
                && propertyInfo.CanWrite;
+
+        public static Type FindCandidateNavigationPropertyType(this PropertyInfo propertyInfo)
+        {
+            if (!propertyInfo.IsCandidateProperty())
+            {
+                return null;
+            }
+
+            var targetType = propertyInfo.PropertyType;
+            targetType = targetType.TryGetSequenceType() ?? targetType;
+            targetType = targetType.UnwrapNullableType();
+
+            var typeInfo = targetType.GetTypeInfo();
+            if (targetType.IsPrimitive()
+                || typeInfo.IsValueType
+                || typeInfo.IsInterface)
+            {
+                return null;
+            }
+
+            return targetType;
+        }
     }
 }

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
             conventionSet.EntityTypeAddedConventions.Add(new NotMappedEntityTypeAttributeConvention());
             conventionSet.EntityTypeAddedConventions.Add(new PropertyDiscoveryConvention());
             conventionSet.EntityTypeAddedConventions.Add(new KeyDiscoveryConvention());
+            conventionSet.EntityTypeAddedConventions.Add(new NotMappedNavigationAttributeConvention());
+            conventionSet.EntityTypeAddedConventions.Add(new InversePropertyAttributeConvention());
             conventionSet.EntityTypeAddedConventions.Add(new RelationshipDiscoveryConvention());
 
             conventionSet.PropertyAddedConventions.Add(new NotMappedPropertyAttributeConvention());
@@ -34,7 +36,6 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
 
             conventionSet.ModelBuiltConventions.Add(keyAttributeConvention);
 
-            conventionSet.NavigationAddedConventions.Add(new NotMappedNavigationAttributeConvention());
             conventionSet.NavigationAddedConventions.Add(new RequiredNavigationAttributeConvention());
 
             return conventionSet;

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/InversePropertyAttributeConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/InversePropertyAttributeConvention.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Data.Entity.Internal;
+using Microsoft.Data.Entity.Metadata.Internal;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
+{
+    public class InversePropertyAttributeConvention : NavigationAttributeEntityTypeConvention<InversePropertyAttribute>
+    {
+        public override InternalEntityTypeBuilder Apply(InternalEntityTypeBuilder entityTypeBuilder, PropertyInfo navigationPropertyInfo, InversePropertyAttribute attribute)
+        {
+            Check.NotNull(entityTypeBuilder, nameof(entityTypeBuilder));
+            Check.NotNull(navigationPropertyInfo, nameof(navigationPropertyInfo));
+            Check.NotNull(attribute, nameof(attribute));
+
+            if (!entityTypeBuilder.CanAddNavigation(navigationPropertyInfo.Name, ConfigurationSource.DataAnnotation))
+            {
+                return entityTypeBuilder;
+            }
+
+            var targetType = navigationPropertyInfo.FindCandidateNavigationPropertyType();
+            var targetEntityTypeBuilder = entityTypeBuilder.ModelBuilder.Entity(targetType, ConfigurationSource.DataAnnotation);
+            if (targetEntityTypeBuilder == null)
+            {
+                return entityTypeBuilder;
+            }
+
+            // The navigation could have been added when the target entity type was added
+            if (!entityTypeBuilder.CanAddNavigation(navigationPropertyInfo.Name, ConfigurationSource.DataAnnotation))
+            {
+                return entityTypeBuilder;
+            }
+
+            var inverseNavigationPropertyInfo = targetType.GetRuntimeProperties().FirstOrDefault(p => string.Equals(p.Name, attribute.Property, StringComparison.OrdinalIgnoreCase));
+
+            if (inverseNavigationPropertyInfo == null
+                || inverseNavigationPropertyInfo.FindCandidateNavigationPropertyType() != entityTypeBuilder.Metadata.ClrType)
+            {
+                throw new InvalidOperationException(
+                    Strings.InvalidNavigationWithInverseProperty(navigationPropertyInfo.Name, entityTypeBuilder.Metadata.ClrType, attribute.Property, targetType));
+            }
+
+            if (inverseNavigationPropertyInfo == navigationPropertyInfo)
+            {
+                throw new InvalidOperationException(
+                    Strings.SelfReferencingNavigationWithInverseProperty(
+                        navigationPropertyInfo.Name,
+                        entityTypeBuilder.Metadata.ClrType,
+                        navigationPropertyInfo.Name,
+                        entityTypeBuilder.Metadata.ClrType));
+            }
+
+            // Check for InversePropertyAttribute on the inverseNavigation to verify that it matches.
+            var inverseAttribute = inverseNavigationPropertyInfo.GetCustomAttribute<InversePropertyAttribute>(true);
+            if (inverseAttribute != null
+                && inverseAttribute.Property != navigationPropertyInfo.Name)
+            {
+                // TODO: Log error that InversePropertyAttributes are not pointing at each other
+                var inverseNavigation = targetEntityTypeBuilder.Metadata.FindNavigation(inverseNavigationPropertyInfo.Name);
+                if (inverseNavigation != null)
+                {
+                    targetEntityTypeBuilder.RemoveRelationship(inverseNavigation.ForeignKey, ConfigurationSource.DataAnnotation);
+                }
+                return entityTypeBuilder;
+            }
+
+            targetEntityTypeBuilder.Relationship(entityTypeBuilder, navigationPropertyInfo, inverseNavigationPropertyInfo, ConfigurationSource.DataAnnotation);
+
+            return entityTypeBuilder;
+        }
+    }
+}

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/KeyDiscoveryConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/KeyDiscoveryConvention.cs
@@ -35,8 +35,6 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
         {
             Check.NotNull(entityType, nameof(entityType));
 
-            // TODO: Honor [Key]
-            // Issue #213
             var keyProperties = entityType.Properties
                 .Where(p => string.Equals(p.Name, KeySuffix, StringComparison.OrdinalIgnoreCase))
                 .ToList();

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/NavigationAttributeEntityTypeConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/NavigationAttributeEntityTypeConvention.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata.Internal;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
+{
+    public abstract class NavigationAttributeEntityTypeConvention<TAttribute> : IEntityTypeConvention
+        where TAttribute : Attribute
+    {
+        public virtual InternalEntityTypeBuilder Apply(InternalEntityTypeBuilder entityTypeBuilder)
+        {
+            Check.NotNull(entityTypeBuilder, nameof(entityTypeBuilder));
+
+            var entityType = entityTypeBuilder.Metadata;
+
+            if (entityType.HasClrType)
+            {
+                foreach (var navigationPropertyInfo in entityType.ClrType.GetRuntimeProperties().OrderBy(p => p.Name))
+                {
+                    var entityClrType = navigationPropertyInfo.FindCandidateNavigationPropertyType();
+                    if (entityClrType == null)
+                    {
+                        continue;
+                    }
+
+                    var attributes = entityType.ClrType?.GetProperty(navigationPropertyInfo.Name)?.GetCustomAttributes<TAttribute>(true);
+                    if (attributes != null)
+                    {
+                        foreach (var attribute in attributes)
+                        {
+                            var returnValue = Apply(entityTypeBuilder, navigationPropertyInfo, attribute);
+                            if (returnValue == null)
+                            {
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            return entityTypeBuilder;
+        }
+
+        public abstract InternalEntityTypeBuilder Apply([NotNull] InternalEntityTypeBuilder entityTypeBuilder, [NotNull] PropertyInfo navigationPropertyInfo, [NotNull] TAttribute attribute);
+    }
+}

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/NavigationAttributeNavigationConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/NavigationAttributeNavigationConvention.cs
@@ -9,7 +9,7 @@ using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
 {
-    public abstract class NavigationAttributeConvention<TAttribute> : INavigationConvention
+    public abstract class NavigationAttributeNavigationConvention<TAttribute> : INavigationConvention
         where TAttribute : Attribute
     {
         public virtual InternalRelationshipBuilder Apply(InternalRelationshipBuilder relationshipBuilder, Navigation navigation)
@@ -34,6 +34,5 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
         }
 
         public abstract InternalRelationshipBuilder Apply([NotNull] InternalRelationshipBuilder relationshipBuilder, [NotNull] Navigation navigation, [NotNull] TAttribute attribute);
-
     }
 }

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/NotMappedNavigationAttributeConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/NotMappedNavigationAttributeConvention.cs
@@ -1,23 +1,22 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Reflection;
 using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
 {
-    public class NotMappedNavigationAttributeConvention : NavigationAttributeConvention<NotMappedAttribute>
+    public class NotMappedNavigationAttributeConvention : NavigationAttributeEntityTypeConvention<NotMappedAttribute>
     {
-        public override InternalRelationshipBuilder Apply(InternalRelationshipBuilder relationshipBuilder, Navigation navigation, NotMappedAttribute attribute)
+        public override InternalEntityTypeBuilder Apply(InternalEntityTypeBuilder entityTypeBuilder, PropertyInfo navigationPropertyInfo, NotMappedAttribute attribute)
         {
-            Check.NotNull(relationshipBuilder, nameof(relationshipBuilder));
-            Check.NotNull(navigation, nameof(navigation));
+            Check.NotNull(entityTypeBuilder, nameof(entityTypeBuilder));
+            Check.NotNull(navigationPropertyInfo, nameof(navigationPropertyInfo));
             Check.NotNull(attribute, nameof(attribute));
 
-            var entityTypeBuilder = relationshipBuilder.ModelBuilder.Entity(navigation.DeclaringEntityType.Name, ConfigurationSource.Convention);
-            return entityTypeBuilder.Ignore(navigation.Name, ConfigurationSource.DataAnnotation) ? null : relationshipBuilder;
+            return entityTypeBuilder.Ignore(navigationPropertyInfo.Name, ConfigurationSource.DataAnnotation) ? null : entityTypeBuilder;
         }
     }
 }

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/PropertyDiscoveryConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/PropertyDiscoveryConvention.cs
@@ -17,8 +17,6 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
             Check.NotNull(entityTypeBuilder, nameof(entityTypeBuilder));
             var entityType = entityTypeBuilder.Metadata;
 
-            // TODO: Honor [NotMapped]
-            // Issue #107
             if (entityType.HasClrType)
             {
                 var primitiveProperties = entityType.ClrType.GetRuntimeProperties().Where(IsCandidatePrimitiveProperty);

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/RequiredNavigationAttributeConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/RequiredNavigationAttributeConvention.cs
@@ -9,7 +9,7 @@ using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
 {
-    public class RequiredNavigationAttributeConvention : NavigationAttributeConvention<RequiredAttribute>
+    public class RequiredNavigationAttributeConvention : NavigationAttributeNavigationConvention<RequiredAttribute>
     {
         public override InternalRelationshipBuilder Apply(InternalRelationshipBuilder relationshipBuilder, Navigation navigation, RequiredAttribute attribute)
         {

--- a/src/EntityFramework.Core/Properties/Strings.Designer.cs
+++ b/src/EntityFramework.Core/Properties/Strings.Designer.cs
@@ -1108,6 +1108,22 @@ namespace Microsoft.Data.Entity.Internal
             return string.Format(CultureInfo.CurrentCulture, GetString("PropertyWrongEntityClrType", "property", "entityType", "clrType"), property, entityType, clrType);
         }
 
+        /// <summary>
+        /// The InversePropertyAttribute on property '{property}' on type '{entityType}' is not valid. The property '{referencedProperty}' is not a valid navigation property on the related type '{referencedEntityType}'. Ensure that the property exists and is a valid reference or collection navigation property.
+        /// </summary>
+        public static string InvalidNavigationWithInverseProperty([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object referencedProperty, [CanBeNull] object referencedEntityType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("InvalidNavigationWithInverseProperty", "property", "entityType", "referencedProperty", "referencedEntityType"), property, entityType, referencedProperty, referencedEntityType);
+        }
+
+        /// <summary>
+        /// A relationship cannot be established from property '{property}' on type '{entityType}' to property '{referencedProperty}' on type '{referencedEntityType}'. Check the values in the InversePropertyAttribute to ensure relationship definitions are unique and reference from one navigation property to its corresponding inverse navigation property.
+        /// </summary>
+        public static string SelfReferencingNavigationWithInverseProperty([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object referencedProperty, [CanBeNull] object referencedEntityType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("SelfReferencingNavigationWithInverseProperty", "property", "entityType", "referencedProperty", "referencedEntityType"), property, entityType, referencedProperty, referencedEntityType);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EntityFramework.Core/Properties/Strings.resx
+++ b/src/EntityFramework.Core/Properties/Strings.resx
@@ -528,4 +528,10 @@
   <data name="PropertyWrongEntityClrType" xml:space="preserve">
     <value>CLR property '{property}' cannot be added to entity type '{entityType}' because it is declared on the CLR type '{clrType}'.</value>
   </data>
+  <data name="InvalidNavigationWithInverseProperty" xml:space="preserve">
+    <value>The InversePropertyAttribute on property '{property}' on type '{entityType}' is not valid. The property '{referencedProperty}' is not a valid navigation property on the related type '{referencedEntityType}'. Ensure that the property exists and is a valid reference or collection navigation property.</value>
+  </data>
+  <data name="SelfReferencingNavigationWithInverseProperty" xml:space="preserve">
+    <value>A relationship cannot be established from property '{property}' on type '{entityType}' to property '{referencedProperty}' on type '{referencedEntityType}'. Check the values in the InversePropertyAttribute to ensure relationship definitions are unique and reference from one navigation property to its corresponding inverse navigation property.</value>
+  </data>
 </root>

--- a/test/EntityFramework.Core.Tests/EntityFramework.Core.Tests.csproj
+++ b/test/EntityFramework.Core.Tests/EntityFramework.Core.Tests.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Metadata\NavigationExtensionsTest.cs" />
     <Compile Include="Extensions\QueryableExtensionsTest.cs" />
     <Compile Include="Metadata\TypedAnnotationTest.cs" />
+    <Compile Include="ModelBuilderTest\DataAnnotationsTestBase.cs" />
     <Compile Include="ModelBuilderTest\ManyToOneTestBase.cs" />
     <Compile Include="ModelBuilderTest\ModelBuilderGenericRelationshipTypeTest.cs" />
     <Compile Include="ModelBuilderTest\ModelBuilderGenericRelationshipStringTest.cs" />

--- a/test/EntityFramework.Core.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
@@ -1006,11 +1006,11 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
             Assert.True(dependentEntityBuilder.CanAddNavigation(Order.CustomerProperty.Name, ConfigurationSource.Convention));
             Assert.Same(foreignKeyBuilder, dependentEntityBuilder.Navigation(Order.CustomerProperty.Name, foreignKeyBuilder.Metadata, pointsToPrincipal: true, configurationSource: ConfigurationSource.DataAnnotation));
-            Assert.False(dependentEntityBuilder.CanAddNavigation(Order.CustomerProperty.Name, ConfigurationSource.Explicit));
+            Assert.True(dependentEntityBuilder.CanAddNavigation(Order.CustomerProperty.Name, ConfigurationSource.Explicit));
 
             Assert.True(principalEntityBuilder.CanAddNavigation(Customer.OrdersProperty.Name, ConfigurationSource.Convention));
             Assert.Same(foreignKeyBuilder, principalEntityBuilder.Navigation(Customer.OrdersProperty.Name, foreignKeyBuilder.Metadata, pointsToPrincipal: false, configurationSource: ConfigurationSource.DataAnnotation));
-            Assert.False(principalEntityBuilder.CanAddNavigation(Customer.OrdersProperty.Name, ConfigurationSource.Explicit));
+            Assert.True(principalEntityBuilder.CanAddNavigation(Customer.OrdersProperty.Name, ConfigurationSource.Explicit));
 
             Assert.Same(foreignKeyBuilder, dependentEntityBuilder.Navigation(Order.CustomerProperty.Name, foreignKeyBuilder.Metadata, pointsToPrincipal: true, configurationSource: ConfigurationSource.Convention));
             Assert.Same(foreignKeyBuilder, principalEntityBuilder.Navigation(Customer.OrdersProperty.Name, foreignKeyBuilder.Metadata, pointsToPrincipal: false, configurationSource: ConfigurationSource.DataAnnotation));
@@ -1041,10 +1041,10 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                     derivedPrincipalEntityBuilder.Navigation(Customer.OrdersProperty.Name, foreignKeyBuilder.Metadata, pointsToPrincipal: false, configurationSource: ConfigurationSource.DataAnnotation)).Message);
 
             dependentEntityBuilder.Navigation(Order.CustomerProperty.Name, foreignKeyBuilder.Metadata, pointsToPrincipal: true, configurationSource: ConfigurationSource.DataAnnotation);
-            Assert.False(derivedDependentEntityBuilder.CanAddNavigation(Order.CustomerProperty.Name, ConfigurationSource.Explicit));
+            Assert.True(derivedDependentEntityBuilder.CanAddNavigation(Order.CustomerProperty.Name, ConfigurationSource.Explicit));
 
             principalEntityBuilder.Navigation(Customer.OrdersProperty.Name, foreignKeyBuilder.Metadata, pointsToPrincipal: false, configurationSource: ConfigurationSource.DataAnnotation);
-            Assert.False(derivedPrincipalEntityBuilder.CanAddNavigation(Customer.OrdersProperty.Name, ConfigurationSource.Explicit));
+            Assert.True(derivedPrincipalEntityBuilder.CanAddNavigation(Customer.OrdersProperty.Name, ConfigurationSource.Explicit));
 
             Assert.Equal(Strings.DuplicateNavigation(Order.CustomerProperty.Name, typeof(SpecialOrder).FullName),
                 Assert.Throws<InvalidOperationException>(() =>

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/DataAnnotationsTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/DataAnnotationsTestBase.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.Data.Entity.Metadata;
+using Xunit;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Data.Entity.Tests
+{
+    public abstract partial class ModelBuilderTest
+    {
+        public abstract class DataAnnotationsTestBase : ModelBuilderTestBase
+        {
+            [Fact]
+            public virtual void NotMappedAttribute_removes_ambiguity_in_conventional_relationship_building()
+            {
+                var model = new Model();
+                var modelBuilder = CreateModelBuilder(model);
+                modelBuilder.Entity<Book>();
+
+                Assert.Contains("Details", model.GetEntityType(typeof(Book)).Navigations.Select(nav => nav.Name));
+                Assert.Contains("AnotherBook", model.GetEntityType(typeof(BookDetails)).Navigations.Select(nav => nav.Name));
+                Assert.DoesNotContain("Book", model.GetEntityType(typeof(BookDetails)).Navigations.Select(nav => nav.Name));
+            }
+
+            [Fact]
+            public virtual void InversePropertyAttribute_removes_ambiguity_in_conventional_relationalship_building()
+            {
+                var model = new Model();
+                var modelBuilder = CreateModelBuilder(model);
+                modelBuilder.Entity<Book>();
+
+                Assert.Contains("Book", model.GetEntityType(typeof(BookLabel)).Navigations.Select(nav => nav.Name));
+                Assert.Equal("Label", model.GetEntityType(typeof(BookLabel)).FindNavigation("Book").ForeignKey.PrincipalToDependent.Name);
+
+                Assert.Contains("AlternateLabel", model.GetEntityType(typeof(Book)).Navigations.Select(nav => nav.Name));
+                Assert.Null(model.GetEntityType(typeof(Book)).FindNavigation("AlternateLabel").ForeignKey.PrincipalToDependent);
+            }
+        }
+    }
+}

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/InheritanceTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/InheritanceTestBase.cs
@@ -10,7 +10,7 @@ using Xunit;
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Data.Entity.Tests
 {
-    public partial class ModelBuilderTest
+    public abstract partial class ModelBuilderTest
     {
         public abstract class InheritanceTestBase : ModelBuilderTestBase
         {

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderGenericRelationshipStringTest.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderGenericRelationshipStringTest.cs
@@ -14,26 +14,17 @@ namespace Microsoft.Data.Entity.Tests
     {
         public class GenericOneToManyString : OneToManyTestBase
         {
-            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder)
-            {
-                return new GenericStringTestModelBuilder(modelBuilder);
-            }
+            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder) => new GenericStringTestModelBuilder(modelBuilder);
         }
 
         public class GenericManyToOneString : ManyToOneTestBase
         {
-            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder)
-            {
-                return new GenericStringTestModelBuilder(modelBuilder);
-            }
+            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder) => new GenericStringTestModelBuilder(modelBuilder);
         }
 
         public class GenericOneToOneString : OneToOneTestBase
         {
-            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder)
-            {
-                return new GenericStringTestModelBuilder(modelBuilder);
-            }
+            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder) => new GenericStringTestModelBuilder(modelBuilder);
         }
 
         private class GenericStringTestModelBuilder : TestModelBuilder

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderGenericRelationshipTypeTest.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderGenericRelationshipTypeTest.cs
@@ -13,10 +13,7 @@ namespace Microsoft.Data.Entity.Tests
     {
         public class GenericOneToOneType : OneToOneTestBase
         {
-            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder)
-            {
-                return new GenericTypeTestModelBuilder(modelBuilder);
-            }
+            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder) => new GenericTypeTestModelBuilder(modelBuilder);
         }
 
         private class GenericTypeTestModelBuilder : TestModelBuilder

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderGenericTest.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderGenericTest.cs
@@ -67,6 +67,12 @@ namespace Microsoft.Data.Entity.Tests
                 => new GenericTestModelBuilder(modelBuilder);
         }
 
+        public class GenericDataAnnotations : DataAnnotationsTestBase
+        {
+            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder)
+                => new GenericTestModelBuilder(modelBuilder);
+        }
+
         public class GenericInheritance : InheritanceTestBase
         {
             protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder)

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderNonGenericStringTest.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderNonGenericStringTest.cs
@@ -14,26 +14,17 @@ namespace Microsoft.Data.Entity.Tests
     {
         public class NonGenericOneToManyType : OneToManyTestBase
         {
-            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder)
-            {
-                return new NonGenericStringTestModelBuilder(modelBuilder);
-            }
+            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder) => new NonGenericStringTestModelBuilder(modelBuilder);
         }
 
         public class NonGenericManyToOneType : ManyToOneTestBase
         {
-            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder)
-            {
-                return new NonGenericStringTestModelBuilder(modelBuilder);
-            }
+            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder) => new NonGenericStringTestModelBuilder(modelBuilder);
         }
 
         public class NonGenericOneToOneType : OneToOneTestBase
         {
-            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder)
-            {
-                return new NonGenericStringTestModelBuilder(modelBuilder);
-            }
+            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder) => new NonGenericStringTestModelBuilder(modelBuilder);
         }
 
         private class NonGenericStringTestModelBuilder : TestModelBuilder

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderNonGenericTest.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderNonGenericTest.cs
@@ -28,34 +28,22 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Equal("Ro", model.GetAnnotation("Fus").Value);
             }
 
-            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder)
-            {
-                return new NonGenericTestModelBuilder(modelBuilder);
-            }
+            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder) => new NonGenericTestModelBuilder(modelBuilder);
         }
 
         public class NonGenericOneToMany : OneToManyTestBase
         {
-            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder)
-            {
-                return new NonGenericTestModelBuilder(modelBuilder);
-            }
+            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder) => new NonGenericTestModelBuilder(modelBuilder);
         }
 
         public class NonGenericManyToOne : ManyToOneTestBase
         {
-            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder)
-            {
-                return new NonGenericTestModelBuilder(modelBuilder);
-            }
+            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder) => new NonGenericTestModelBuilder(modelBuilder);
         }
 
         public class NonGenericOneToOne : OneToOneTestBase
         {
-            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder)
-            {
-                return new NonGenericTestModelBuilder(modelBuilder);
-            }
+            protected override TestModelBuilder CreateTestModelBuilder(ModelBuilder modelBuilder) => new NonGenericTestModelBuilder(modelBuilder);
         }
 
         private class NonGenericTestModelBuilder : TestModelBuilder

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/TestModel.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/TestModel.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Reflection;
 
 // ReSharper disable once CheckNamespace
@@ -166,6 +167,36 @@ namespace Microsoft.Data.Entity.Tests
             public SelfRef SelfRef1 { get; set; }
             public SelfRef SelfRef2 { get; set; }
             public int SelfRefId { get; set; }
+        }
+
+        private class Book
+        {
+             public int Id { get; set; }
+
+            public BookLabel Label { get; set; }
+
+            public BookLabel AlternateLabel { get; set; }
+
+            public BookDetails Details { get; set; }
+        }
+
+        private class BookDetails
+        {
+            public int Id { get; set; }
+
+            [NotMapped]
+            public Book Book { get; set; }
+
+            public Book AnotherBook { get; set; }
+        }
+
+        private class BookLabel
+        {
+            public int Id { get; set; }
+            public int BookId { get; set; }
+
+            [InverseProperty("Label")]
+            public Book Book { get; set; }
         }
     }
 }


### PR DESCRIPTION
part of #107 

Add support for  `InverseProperty`
Changes to NotMapped for Navigation
Now after `KeyDiscoveryConvention`, `NotMappedNavigationAttributeConvention` will run which will ignore appropriate navigations. After that `InversePropertyAttributeConvention` will run which will create relationships which are defined using `InversePropertyAttribute`. Afterwards `RelationshipDiscoveryConvention` will run which will try to build relationships based on navigations which are not ignored and not already used in relationship with `InversePropertyAttribute`.