### PR TITLE
Add environment option to migration apply command

### DIFF
--- a/src/EntityFramework.Commands/ContextTool.cs
+++ b/src/EntityFramework.Commands/ContextTool.cs
@@ -24,12 +24,12 @@ namespace Microsoft.Data.Entity.Commands
             _services = services;
         }
 
-        public virtual DbContext CreateContext([NotNull] Type type, [CanBeNull] string startupAssemblyName)
+        public virtual DbContext CreateContext([NotNull] Type type, [CanBeNull] string startupAssemblyName, [CanBeNull] string environmentName)
         {
             Check.NotNull(type, nameof(type));
 
 #if DNX451 || DNXCORE50
-            var context = TryCreateContextFromStartup(type, startupAssemblyName);
+            var context = TryCreateContextFromStartup(type, startupAssemblyName, environmentName);
             if (context != null)
             {
                 return context;
@@ -41,9 +41,13 @@ namespace Microsoft.Data.Entity.Commands
         }
 
 #if DNX451 || DNXCORE50
-        protected virtual DbContext TryCreateContextFromStartup(Type type, string startupAssemblyName)
+        protected virtual DbContext TryCreateContextFromStartup(Type type, string startupAssemblyName, string environmentName)
         {
             var hostBuilder = new WebHostBuilder(_services);
+			if (environmentName != null)
+            {
+                hostBuilder.UseEnvironment(environmentName);
+            }
             if (startupAssemblyName != null)
             {
                 hostBuilder.UseStartup(startupAssemblyName);

--- a/src/EntityFramework.Commands/MigrationTool.cs
+++ b/src/EntityFramework.Commands/MigrationTool.cs
@@ -99,10 +99,11 @@ namespace Microsoft.Data.Entity.Commands
         public virtual void ApplyMigration(
             [CanBeNull] string migrationName,
             [CanBeNull] string contextTypeName,
-            [CanBeNull] string startupAssemblyName)
+            [CanBeNull] string startupAssemblyName,
+            [CanBeNull] string environmentName = null)
         {
             var contextType = GetContextType(contextTypeName);
-            using (var context = CreateContext(contextType, startupAssemblyName))
+            using (var context = CreateContext(contextType, startupAssemblyName, environmentName))
             {
                 var services = ((IAccessor<IServiceProvider>)context).Service;
                 var migrator = services.GetRequiredService<IMigrator>();
@@ -152,9 +153,9 @@ namespace Microsoft.Data.Entity.Commands
                         .Where(t => t != null))
                 .Distinct();
 
-        protected virtual DbContext CreateContext(Type type, string startupAssemblyName)
+        protected virtual DbContext CreateContext(Type type, string startupAssemblyName, string environmentName = null)
         {
-            var context = new ContextTool(_services).CreateContext(type, startupAssemblyName);
+            var context = new ContextTool(_services).CreateContext(type, startupAssemblyName, environmentName);
             var services = ((IAccessor<IServiceProvider>)context).Service;
 
             var loggerFactory = services.GetRequiredService<ILoggerFactory>();

--- a/src/EntityFramework.Commands/Program.cs
+++ b/src/EntityFramework.Commands/Program.cs
@@ -100,8 +100,12 @@ namespace Microsoft.Data.Entity.Commands
                             var startupProject = update.Option(
                                 "-s|--startupProject <project>",
                                 "The start-up project to use. If omitted, the current project is used");
+							var environment = apply.Option(
+                                "-e|--environment <environment>",
+                                "The environment to use",
+                                CommandOptionType.SingleValue);
                             update.HelpOption("-?|-h|--help");
-                            update.OnExecute(() => ApplyMigration(migrationName.Value, context.Value(), startupProject.Value()));
+                            update.OnExecute(() => ApplyMigration(migrationName.Value, context.Value(), startupProject.Value(), environment.Value()));
                         });
                 });
             app.Command(
@@ -336,13 +340,14 @@ namespace Microsoft.Data.Entity.Commands
         public virtual void ApplyMigration(
             [CanBeNull] string migration,
             [CanBeNull] string context,
-            [CanBeNull] string startupProject)
+            [CanBeNull] string startupProject,
+			[CanBeNull] string environment)
         {
             Execute(
                 startupProject,
                 () =>
                 {
-                    _migrationTool.ApplyMigration(migration, context, startupProject);
+                    _migrationTool.ApplyMigration(migration, context, startupProject, environment);
                 });
         }
 


### PR DESCRIPTION
The Entity Framework migration command currently does not support applying migrations to an alternative connection string. This PR will add an "environment" option to the apply command as shown below:

```
Usage: ef migration apply [arguments] [options]

Arguments:
  [migration]  The migration to apply. Use '0' to unapply all migrations

Options:
  -c|--context <context>                The context class to use
  -s|--startupProject <startupProject>  The start-up project to use
  -e|--environment <environment>        The environment to use
  -h|--help                             Show help information
```

The idea being your model uses either "Startup*Environment*" classes or makes use of "config.*Environment*.json" files, as per http://docs.asp.net/en/latest/fundamentals/environments.html.

You can then run a command like `dnx . ef migration apply -e Staging` which will pass the environment option to `WebHostBuilder` and call your project startup with the correct `IHostingEnvironment`.

Please let me know if any chances are required for a merge, or if the team already has a different direction for this. 