### PR TITLE
Perf test improvements

### DIFF
--- a/test/EntityFramework.Microbenchmarks.Core/SqlServerBenchmarkResultProcessor.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/SqlServerBenchmarkResultProcessor.cs
@@ -1,13 +1,86 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.Data.Entity;
+using System;
+using System.Data.SqlClient;
+using System.Data;
 
 namespace EntityFramework.Microbenchmarks.Core
 {
     public class SqlServerBenchmarkResultProcessor
     {
         private readonly string _connectionString;
+        private static readonly string _insertCommand =
+            @"INSERT INTO [dbo].[Runs]
+           ([TestClassFullName]
+            ,[TestClass]
+            ,[TestMethod]
+            ,[Variation]
+            ,[MachineName]
+            ,[ProductReportingVersion]
+            ,[Framework]
+            ,[CustomData]
+            ,[RunStarted]
+            ,[WarmupIterations]
+            ,[Iterations]
+            ,[TimeElapsedAverage]
+            ,[TimeElapsedPercentile99]
+            ,[TimeElapsedPercentile95]
+            ,[TimeElapsedPercentile90]
+            ,[TimeElapsedStandardDeviation]
+            ,[MemoryDeltaAverage]
+            ,[MemoryDeltaPercentile99]
+            ,[MemoryDeltaPercentile95]
+            ,[MemoryDeltaPercentile90]
+            ,[MemoryDeltaStandardDeviation])
+     VALUES
+           (@TestClassFullName
+           ,@TestClass
+           ,@TestMethod
+           ,@Variation
+           ,@MachineName
+           ,@ProductReportingVersion
+           ,@Framework
+           ,@CustomData
+           ,@RunStarted
+           ,@WarmupIterations
+           ,@Iterations
+           ,@TimeElapsedAverage
+           ,@TimeElapsedPercentile99
+           ,@TimeElapsedPercentile95
+           ,@TimeElapsedPercentile90
+           ,@TimeElapsedStandardDeviation
+           ,@MemoryDeltaAverage
+           ,@MemoryDeltaPercentile99
+           ,@MemoryDeltaPercentile95
+           ,@MemoryDeltaPercentile90
+           ,@MemoryDeltaStandardDeviation)";
+
+        private static readonly string _tableCreationCommand =
+@"IF NOT EXISTS (SELECT * FROM sysobjects WHERE name='runs' and xtype='U')
+	CREATE TABLE [dbo].[Runs](
+		[Id] [int] IDENTITY(1,1) NOT NULL PRIMARY KEY,
+		[TestClassFullName] [nvarchar](max) NULL,
+		[TestClass] [nvarchar](max) NULL,
+		[TestMethod] [nvarchar](max) NULL,
+		[Variation] [nvarchar](max) NULL,
+		[MachineName] [nvarchar](max) NULL,
+		[ProductReportingVersion] [nvarchar](max) NULL,
+		[Framework] [nvarchar](max) NULL,
+		[CustomData] [nvarchar](max) NULL,
+		[RunStarted] [datetime2](7) NOT NULL,
+		[WarmupIterations] [int] NOT NULL,
+		[Iterations] [int] NOT NULL,
+		[TimeElapsedAverage] [bigint] NOT NULL,
+		[TimeElapsedPercentile90] [bigint] NOT NULL,
+		[TimeElapsedPercentile95] [bigint] NOT NULL,
+		[TimeElapsedPercentile99] [bigint] NOT NULL,
+		[TimeElapsedStandardDeviation] [float] NOT NULL,
+		[MemoryDeltaAverage] [bigint] NOT NULL,
+		[MemoryDeltaPercentile90] [bigint] NOT NULL,
+		[MemoryDeltaPercentile95] [bigint] NOT NULL,
+		[MemoryDeltaPercentile99] [bigint] NOT NULL,
+		[MemoryDeltaStandardDeviation] [float] NOT NULL)";
 
         public SqlServerBenchmarkResultProcessor(string connectionString)
         {
@@ -16,42 +89,48 @@ namespace EntityFramework.Microbenchmarks.Core
 
         public void SaveSummary(BenchmarkRunSummary summary)
         {
-            using (var db = new BenchmarkContext(_connectionString))
+            using (var conn = new SqlConnection(_connectionString))
             {
-                db.Database.EnsureCreated();
-
-                db.RunSummaries.Add(summary);
-                db.SaveChanges();
+                conn.Open();
+                EnsureRunsTableCreated(conn);
+                WriteSummaryRecord(summary, conn);
             }
         }
 
-        private class BenchmarkContext : DbContext
+        private void EnsureRunsTableCreated(SqlConnection conn)
         {
-            private readonly string _connectionString;
+            var cmd = conn.CreateCommand();
+            cmd.CommandText = _tableCreationCommand;
+            cmd.ExecuteNonQuery();
+        }
 
-            public BenchmarkContext(string connectionString)
-            {
-                _connectionString = connectionString;
-            }
+        private static void WriteSummaryRecord(BenchmarkRunSummary summary, SqlConnection conn)
+        {
+            var cmd = conn.CreateCommand();
+            cmd.CommandText = _insertCommand;
+            cmd.Parameters.AddWithValue("@TestClassFullName", summary.TestClassFullName);
+            cmd.Parameters.AddWithValue("@TestClass", summary.TestClass);
+            cmd.Parameters.AddWithValue("@TestMethod", summary.TestMethod);
+            cmd.Parameters.AddWithValue("@Variation", summary.Variation);
+            cmd.Parameters.AddWithValue("@MachineName", summary.MachineName);
+            cmd.Parameters.AddWithValue("@ProductReportingVersion", summary.ProductReportingVersion);
+            cmd.Parameters.AddWithValue("@Framework", summary.Framework);
+            cmd.Parameters.Add("@CustomData", SqlDbType.NVarChar).Value = (object)summary.CustomData ?? DBNull.Value;
+            cmd.Parameters.AddWithValue("@RunStarted", summary.RunStarted);
+            cmd.Parameters.AddWithValue("@WarmupIterations", summary.WarmupIterations);
+            cmd.Parameters.AddWithValue("@Iterations", summary.Iterations);
+            cmd.Parameters.AddWithValue("@TimeElapsedAverage", summary.TimeElapsedAverage);
+            cmd.Parameters.AddWithValue("@TimeElapsedPercentile99", summary.TimeElapsedPercentile99);
+            cmd.Parameters.AddWithValue("@TimeElapsedPercentile95", summary.TimeElapsedPercentile95);
+            cmd.Parameters.AddWithValue("@TimeElapsedPercentile90", summary.TimeElapsedPercentile90);
+            cmd.Parameters.AddWithValue("@TimeElapsedStandardDeviation", summary.TimeElapsedStandardDeviation);
+            cmd.Parameters.AddWithValue("@MemoryDeltaAverage", summary.MemoryDeltaAverage);
+            cmd.Parameters.AddWithValue("@MemoryDeltaPercentile99", summary.MemoryDeltaPercentile99);
+            cmd.Parameters.AddWithValue("@MemoryDeltaPercentile95", summary.MemoryDeltaPercentile95);
+            cmd.Parameters.AddWithValue("@MemoryDeltaPercentile90", summary.MemoryDeltaPercentile90);
+            cmd.Parameters.AddWithValue("@MemoryDeltaStandardDeviation", summary.MemoryDeltaStandardDeviation);
 
-            public DbSet<BenchmarkRunSummary> RunSummaries { get; set; }
-
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-            {
-                optionsBuilder.UseSqlServer(_connectionString);
-            }
-
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-            {
-                modelBuilder.Entity<BenchmarkRunSummary>()
-                    .ToSqlServerTable("Runs");
-
-                modelBuilder.Entity<BenchmarkRunSummary>()
-                    .Property<int>("Id");
-
-                modelBuilder.Entity<BenchmarkRunSummary>()
-                    .Key("Id");
-            }
+            cmd.ExecuteNonQuery();
         }
     }
 }

--- a/test/EntityFramework.Microbenchmarks.Core/project.json
+++ b/test/EntityFramework.Microbenchmarks.Core/project.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "EntityFramework.SqlServer": "7.0.0-*",
     "Microsoft.Framework.Configuration.Json": "1.0.0-*",
     "Microsoft.Framework.Configuration.EnvironmentVariables": "1.0.0-*"
   },

--- a/test/EntityFramework.Microbenchmarks.EF6/EntityFramework.Microbenchmarks.EF6.csproj
+++ b/test/EntityFramework.Microbenchmarks.EF6/EntityFramework.Microbenchmarks.EF6.csproj
@@ -36,6 +36,7 @@
   <ItemGroup>
     <Compile Include="ChangeTracker\DbSetOperationTests.cs" />
     <Compile Include="ChangeTracker\FixupTests.cs" />
+    <Compile Include="Extensions.cs" />
     <Compile Include="Models\Orders\OrdersContext.cs" />
     <Compile Include="Models\Orders\OrdersFixture.cs" />
     <Compile Include="Models\Orders\OrdersSeedData.cs" />

--- a/test/EntityFramework.Microbenchmarks.EF6/Extensions.cs
+++ b/test/EntityFramework.Microbenchmarks.EF6/Extensions.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Data.Entity;
+using System.Linq;
+
+namespace EntityFramework.Microbenchmarks.EF6
+{
+    public static class Extensions
+    {
+        public static IQueryable<TEntity> ApplyTracking<TEntity>(this IQueryable<TEntity> query, bool tracking)
+       where TEntity : class
+        {
+            return tracking
+                    ? query
+                    : query.AsNoTracking();
+        }
+    }
+}

--- a/test/EntityFramework.Microbenchmarks.EF6/UpdatePipeline/SimpleUpdatePipelineTests.cs
+++ b/test/EntityFramework.Microbenchmarks.EF6/UpdatePipeline/SimpleUpdatePipelineTests.cs
@@ -19,6 +19,7 @@ namespace EntityFramework.Microbenchmarks.EF6.UpdatePipeline
         }
 
         [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [BenchmarkVariation("Batching Off")]
         public void Insert(MetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
@@ -40,6 +41,7 @@ namespace EntityFramework.Microbenchmarks.EF6.UpdatePipeline
         }
 
         [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [BenchmarkVariation("Batching Off")]
         public void Update(MetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
@@ -61,6 +63,7 @@ namespace EntityFramework.Microbenchmarks.EF6.UpdatePipeline
         }
 
         [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [BenchmarkVariation("Batching Off")]
         public void Delete(MetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
@@ -82,6 +85,7 @@ namespace EntityFramework.Microbenchmarks.EF6.UpdatePipeline
         }
 
         [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [BenchmarkVariation("Batching Off")]
         public void Mixed(MetricCollector collector)
         {
             using (var context = _fixture.CreateContext())

--- a/test/EntityFramework.Microbenchmarks/ChangeTracker/DbSetOperationTests.cs
+++ b/test/EntityFramework.Microbenchmarks/ChangeTracker/DbSetOperationTests.cs
@@ -19,6 +19,7 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
         }
 
         [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [BenchmarkVariation("AutoDetectChanges Off")]
         public void Add(MetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
@@ -59,6 +60,7 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
         }
 
         [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [BenchmarkVariation("AutoDetectChanges Off")]
         public void Attach(MetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
@@ -93,6 +95,7 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
         }
 
         [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [BenchmarkVariation("AutoDetectChanges Off")]
         public void Remove(MetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
@@ -126,6 +129,7 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
         }
 
         [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [BenchmarkVariation("AutoDetectChanges Off")]
         public void Update(MetricCollector collector)
         {
             using (var context = _fixture.CreateContext())

--- a/test/EntityFramework.Microbenchmarks/EntityFramework.Microbenchmarks.csproj
+++ b/test/EntityFramework.Microbenchmarks/EntityFramework.Microbenchmarks.csproj
@@ -37,6 +37,7 @@
   <ItemGroup>
     <Compile Include="ChangeTracker\DbSetOperationTests.cs" />
     <Compile Include="ChangeTracker\FixupTests.cs" />
+    <Compile Include="Extensions.cs" />
     <Compile Include="Models\Orders\OrdersContext.cs" />
     <Compile Include="Models\Orders\OrdersSeedData.cs" />
     <Compile Include="Models\Orders\OrdersFixture.cs" />

--- a/test/EntityFramework.Microbenchmarks/Extensions.cs
+++ b/test/EntityFramework.Microbenchmarks/Extensions.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.Data.Entity;
+
+namespace EntityFramework.Microbenchmarks
+{
+    public static class Extensions
+    {
+        public static IQueryable<TEntity> ApplyTracking<TEntity>(this IQueryable<TEntity> query, bool tracking)
+       where TEntity : class
+        {
+            return tracking
+                    ? query
+                    : query.AsNoTracking();
+        }
+    }
+}

--- a/test/EntityFramework.Microbenchmarks/Query/SimpleQueryTests.cs
+++ b/test/EntityFramework.Microbenchmarks/Query/SimpleQueryTests.cs
@@ -20,36 +20,52 @@ namespace EntityFramework.Microbenchmarks.Query
         }
 
         [Benchmark(Iterations = 100, WarmupIterations = 5)]
-        public void LoadAll(MetricCollector collector)
+        [BenchmarkVariation("Tracking On", true)]
+        [BenchmarkVariation("Tracking Off", false)]
+        public void LoadAll(MetricCollector collector, bool tracking)
         {
             using (var context = _fixture.CreateContext())
             {
+                var query = context.Products.ApplyTracking(tracking);
+
                 collector.StartCollection();
-                var result = context.Products.ToList();
+                var result = query.ToList();
                 collector.StopCollection();
                 Assert.Equal(1000, result.Count);
             }
         }
 
         [Benchmark(Iterations = 100, WarmupIterations = 5)]
-        public void Where(MetricCollector collector)
+        [BenchmarkVariation("Tracking On", true)]
+        [BenchmarkVariation("Tracking Off", false)]
+        public void Where(MetricCollector collector, bool tracking)
         {
             using (var context = _fixture.CreateContext())
             {
+                var query = context.Products
+                    .ApplyTracking(tracking)
+                    .Where(p => p.Retail < 15);
+
                 collector.StartCollection();
-                var result = context.Products.Where(p => p.Retail < 15).ToList();
+                var result = query.ToList();
                 collector.StopCollection();
                 Assert.Equal(500, result.Count);
             }
         }
 
         [Benchmark(Iterations = 100, WarmupIterations = 5)]
-        public void OrderBy(MetricCollector collector)
+        [BenchmarkVariation("Tracking On", true)]
+        [BenchmarkVariation("Tracking Off", false)]
+        public void OrderBy(MetricCollector collector, bool tracking)
         {
             using (var context = _fixture.CreateContext())
             {
+                var query = context.Products
+                    .ApplyTracking(tracking)
+                    .OrderBy(p => p.Retail);
+
                 collector.StartCollection();
-                var result = context.Products.OrderBy(p => p.Retail).ToList();
+                var result = query.ToList();
                 collector.StopCollection();
                 Assert.Equal(1000, result.Count);
             }
@@ -60,24 +76,29 @@ namespace EntityFramework.Microbenchmarks.Query
         {
             using (var context = _fixture.CreateContext())
             {
+                var query = context.Products;
+
                 collector.StartCollection();
-                var result = context.Products.Count();
+                var result = query.Count();
                 collector.StopCollection();
                 Assert.Equal(1000, result);
             }
         }
 
         [Benchmark(Iterations = 100, WarmupIterations = 5)]
-        public void SkipTake(MetricCollector collector)
+        [BenchmarkVariation("Tracking On", true)]
+        [BenchmarkVariation("Tracking Off", false)]
+        public void SkipTake(MetricCollector collector, bool tracking)
         {
             using (var context = _fixture.CreateContext())
             {
-                collector.StartCollection();
-                var result = context.Products
+                var query = context.Products
+                    .ApplyTracking(tracking)
                     .OrderBy(p => p.ProductId)
-                    .Skip(500).Take(500)
-                    .ToList();
+                    .Skip(500).Take(500);
 
+                collector.StartCollection();
+                var result = query.ToList();
                 collector.StopCollection();
                 Assert.Equal(500, result.Count);
             }
@@ -88,16 +109,16 @@ namespace EntityFramework.Microbenchmarks.Query
         {
             using (var context = _fixture.CreateContext())
             {
-                collector.StartCollection();
-                var result = context.Products
+                var query = context.Products
                     .GroupBy(p => p.Retail)
                     .Select(g => new
                     {
                         Retail = g.Key,
                         Products = g
-                    })
-                    .ToList();
+                    });
 
+                collector.StartCollection();
+                var result = query.ToList();
                 collector.StopCollection();
                 Assert.Equal(10, result.Count);
                 Assert.All(result, g => Assert.Equal(100, g.Products.Count()));
@@ -105,12 +126,18 @@ namespace EntityFramework.Microbenchmarks.Query
         }
 
         [Benchmark(Iterations = 2, WarmupIterations = 1)]
-        public void Include(MetricCollector collector)
+        [BenchmarkVariation("Tracking On", true)]
+        [BenchmarkVariation("Tracking Off", false)]
+        public void Include(MetricCollector collector, bool tracking)
         {
             using (var context = _fixture.CreateContext())
             {
+                var query = context.Customers
+                    .ApplyTracking(tracking)
+                    .Include(c => c.Orders);
+
                 collector.StartCollection();
-                var result = context.Customers.Include(c => c.Orders).ToList();
+                var result = query.ToList();
                 collector.StopCollection();
                 Assert.Equal(1000, result.Count);
                 Assert.Equal(2000, result.SelectMany(c => c.Orders).Count());
@@ -122,8 +149,11 @@ namespace EntityFramework.Microbenchmarks.Query
         {
             using (var context = _fixture.CreateContext())
             {
+                var query = context.Products
+                    .Select(p => new { p.Name, p.Retail });
+
                 collector.StartCollection();
-                var result = context.Products.Select(p => new { p.Name, p.Retail }).ToList();
+                var result = query.ToList();
                 collector.StopCollection();
                 Assert.Equal(1000, result.Count);
             }
@@ -134,29 +164,17 @@ namespace EntityFramework.Microbenchmarks.Query
         {
             using (var context = _fixture.CreateContext())
             {
-                collector.StartCollection();
                 // TODO Use navigation for projection when supported (#325)
-                var result = context.Orders.Join(
-                context.Customers,
-                o => o.CustomerId,
-                c => c.CustomerId,
-                (o, c) => new { CustomerName = c.Name, OrderDate = o.Date })
-                .ToList();
+                var query = context.Orders.Join(
+                    context.Customers,
+                    o => o.CustomerId,
+                    c => c.CustomerId,
+                    (o, c) => new { CustomerName = c.Name, OrderDate = o.Date });
 
+                collector.StartCollection();
+                var result = query.ToList();
                 collector.StopCollection();
                 Assert.Equal(2000, result.Count);
-            }
-        }
-
-        [Benchmark(Iterations = 100, WarmupIterations = 5)]
-        public void NoTracking(MetricCollector collector)
-        {
-            using (var context = _fixture.CreateContext())
-            {
-                collector.StartCollection();
-                var result = context.Products.AsNoTracking().ToList();
-                collector.StopCollection();
-                Assert.Equal(1000, result.Count);
             }
         }
 


### PR DESCRIPTION
* Tracking and NoTracking variations for query tests - also moved query
creation to be outside timing so that only execution is timed
* Altered variation name on some tests so that EF6/EF7 scenarios align
(makes it easier to compare figured in reports, pivot table, etc)
* Swapped to SQL Client for result saving :-1:  - we reverted the name
changes that allowed EF7 and EF6 side-by-side so the EF6 results were
failing to save (because we were using EF7 to save them)