### PR TITLE
:art: Defaults for benchmark Iterations

### DIFF
--- a/test/EntityFramework.Microbenchmarks.Core/BenchmarkAttribute.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/BenchmarkAttribute.cs
@@ -9,8 +9,8 @@ namespace EntityFramework.Microbenchmarks.Core
     [XunitTestCaseDiscoverer("EntityFramework.Microbenchmarks.Core.BenchmarkTestCaseDiscoverer", "EntityFramework.Microbenchmarks.Core")]
     public class BenchmarkAttribute : FactAttribute
     {
-        public int Iterations { get; set; } = 1;
-        public int WarmupIterations { get; set; } 
+        public int Iterations { get; set; } = 100;
+        public int WarmupIterations { get; set; } = 1;
     }
 
 }

--- a/test/EntityFramework.Microbenchmarks.EF6/ChangeTracker/DbSetOperationTests.cs
+++ b/test/EntityFramework.Microbenchmarks.EF6/ChangeTracker/DbSetOperationTests.cs
@@ -19,7 +19,7 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
             _fixture = fixture;
         }
 
-        [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [Benchmark]
         [BenchmarkVariation("AutoDetectChanges On", true)]
         [BenchmarkVariation("AutoDetectChanges Off", false)]
         public void Add(MetricCollector collector, bool autoDetectChanges)
@@ -43,7 +43,7 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
             }
         }
 
-        [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [Benchmark]
         public void AddCollection(MetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
@@ -61,7 +61,7 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
             }
         }
 
-        [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [Benchmark]
         [BenchmarkVariation("AutoDetectChanges On", true)]
         [BenchmarkVariation("AutoDetectChanges Off", false)]
         public void Attach(MetricCollector collector, bool autoDetectChanges)
@@ -85,7 +85,7 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
         // Note: AttachCollection() not implemented because there is no
         //       API for bulk attach in EF6.x
 
-        [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [Benchmark]
         [BenchmarkVariation("AutoDetectChanges On", true)]
         [BenchmarkVariation("AutoDetectChanges Off", false)]
         public void Remove(MetricCollector collector, bool autoDetectChanges)
@@ -106,7 +106,7 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
             }
         }
 
-        [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [Benchmark]
         public void RemoveCollection(MetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
@@ -121,7 +121,7 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
             }
         }
 
-        [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [Benchmark]
         [BenchmarkVariation("AutoDetectChanges On", true)]
         [BenchmarkVariation("AutoDetectChanges Off", false)]
         public void Update(MetricCollector collector, bool autoDetectChanges)

--- a/test/EntityFramework.Microbenchmarks.EF6/ChangeTracker/FixupTests.cs
+++ b/test/EntityFramework.Microbenchmarks.EF6/ChangeTracker/FixupTests.cs
@@ -19,7 +19,7 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
             _fixture = fixture;
         }
 
-        [Benchmark(Iterations = 10, WarmupIterations = 5)]
+        [Benchmark(Iterations = 10)]
         public void AddChildren(MetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
@@ -44,7 +44,7 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
         // Note: AddParents() not implemented because fixup to added parents 
         //       only happens during SaveChanges for EF6.x (not during Add)
 
-        [Benchmark(Iterations = 10, WarmupIterations = 5)]
+        [Benchmark(Iterations = 10)]
         public void AttachChildren(MetricCollector collector)
         {
             List<Order> orders;
@@ -71,7 +71,7 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
             }
         }
 
-        [Benchmark(Iterations = 10, WarmupIterations = 5)]
+        [Benchmark(Iterations = 10)]
         public void AttachParents(MetricCollector collector)
         {
             List<Customer> customers;
@@ -98,7 +98,7 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
             }
         }
 
-        [Benchmark(Iterations = 10, WarmupIterations = 5)]
+        [Benchmark(Iterations = 10)]
         public void QueryChildren(MetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
@@ -115,7 +115,7 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
             }
         }
 
-        [Benchmark(Iterations = 10, WarmupIterations = 5)]
+        [Benchmark(Iterations = 10)]
         public void QueryParents(MetricCollector collector)
         {
             using (var context = _fixture.CreateContext())

--- a/test/EntityFramework.Microbenchmarks.EF6/Query/FuncletizationTests.cs
+++ b/test/EntityFramework.Microbenchmarks.EF6/Query/FuncletizationTests.cs
@@ -18,7 +18,7 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
             _fixture = fixture;
         }
 
-        [Benchmark(Iterations = 50, WarmupIterations = 5)]
+        [Benchmark]
         public void NewQueryInstance(MetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
@@ -36,7 +36,7 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
             }
         }
 
-        [Benchmark(Iterations = 50, WarmupIterations = 5)]
+        [Benchmark]
         public void SameQueryInstance(MetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
@@ -56,7 +56,7 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
             }
         }
 
-        [Benchmark(Iterations = 50, WarmupIterations = 5)]
+        [Benchmark]
         public void ValueFromObject(MetricCollector collector)
         {
             using (var context = _fixture.CreateContext())

--- a/test/EntityFramework.Microbenchmarks.EF6/Query/SimpleQueryTests.cs
+++ b/test/EntityFramework.Microbenchmarks.EF6/Query/SimpleQueryTests.cs
@@ -18,7 +18,7 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
             _fixture = fixture;
         }
 
-        [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [Benchmark]
         [BenchmarkVariation("Tracking On", true)]
         [BenchmarkVariation("Tracking Off", false)]
         public void LoadAll(MetricCollector collector, bool tracking)
@@ -34,7 +34,7 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
             }
         }
 
-        [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [Benchmark]
         [BenchmarkVariation("Tracking On", true)]
         [BenchmarkVariation("Tracking Off", false)]
         public void Where(MetricCollector collector, bool tracking)
@@ -52,7 +52,7 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
             }
         }
 
-        [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [Benchmark]
         [BenchmarkVariation("Tracking On", true)]
         [BenchmarkVariation("Tracking Off", false)]
         public void OrderBy(MetricCollector collector, bool tracking)
@@ -70,7 +70,7 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
             }
         }
 
-        [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [Benchmark]
         public void Count(MetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
@@ -84,7 +84,7 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
             }
         }
 
-        [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [Benchmark]
         [BenchmarkVariation("Tracking On", true)]
         [BenchmarkVariation("Tracking Off", false)]
         public void SkipTake(MetricCollector collector, bool tracking)
@@ -103,7 +103,7 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
             }
         }
 
-        [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [Benchmark]
         public void GroupBy(MetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
@@ -124,7 +124,7 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
             }
         }
 
-        [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [Benchmark]
         [BenchmarkVariation("Tracking On", true)]
         [BenchmarkVariation("Tracking Off", false)]
         public void Include(MetricCollector collector, bool tracking)
@@ -143,7 +143,7 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
             }
         }
 
-        [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [Benchmark]
         public void Projection(MetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
@@ -158,7 +158,7 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
             }
         }
 
-        [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [Benchmark]
         public void ProjectionAcrossNavigation(MetricCollector collector)
         {
             using (var context = _fixture.CreateContext())

--- a/test/EntityFramework.Microbenchmarks.EF6/UpdatePipeline/SimpleUpdatePipelineTests.cs
+++ b/test/EntityFramework.Microbenchmarks.EF6/UpdatePipeline/SimpleUpdatePipelineTests.cs
@@ -18,7 +18,7 @@ namespace EntityFramework.Microbenchmarks.EF6.UpdatePipeline
             _fixture = fixture;
         }
 
-        [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [Benchmark]
         [BenchmarkVariation("Batching Off")]
         public void Insert(MetricCollector collector)
         {
@@ -40,7 +40,7 @@ namespace EntityFramework.Microbenchmarks.EF6.UpdatePipeline
             }
         }
 
-        [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [Benchmark]
         [BenchmarkVariation("Batching Off")]
         public void Update(MetricCollector collector)
         {
@@ -62,7 +62,7 @@ namespace EntityFramework.Microbenchmarks.EF6.UpdatePipeline
             }
         }
 
-        [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [Benchmark]
         [BenchmarkVariation("Batching Off")]
         public void Delete(MetricCollector collector)
         {
@@ -84,7 +84,7 @@ namespace EntityFramework.Microbenchmarks.EF6.UpdatePipeline
             }
         }
 
-        [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [Benchmark]
         [BenchmarkVariation("Batching Off")]
         public void Mixed(MetricCollector collector)
         {

--- a/test/EntityFramework.Microbenchmarks/CalibrationTests.cs
+++ b/test/EntityFramework.Microbenchmarks/CalibrationTests.cs
@@ -8,7 +8,7 @@ namespace EntityFramework.Microbenchmarks
 {
     public class CalibrationTests
     {
-        [Benchmark(Iterations = 10)]
+        [Benchmark]
         public void Calibration_100ms(MetricCollector collector)
         {
             using (collector.StartCollection())
@@ -17,7 +17,7 @@ namespace EntityFramework.Microbenchmarks
             }
         }
 
-        [Benchmark(Iterations = 10)]
+        [Benchmark]
         public void Calibration_100ms_controlled(MetricCollector collector)
         {
 

--- a/test/EntityFramework.Microbenchmarks/ChangeTracker/DbSetOperationTests.cs
+++ b/test/EntityFramework.Microbenchmarks/ChangeTracker/DbSetOperationTests.cs
@@ -18,7 +18,7 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
             _fixture = fixture;
         }
 
-        [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [Benchmark]
         [BenchmarkVariation("AutoDetectChanges Off")]
         public void Add(MetricCollector collector)
         {
@@ -40,7 +40,7 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
             }
         }
 
-        [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [Benchmark]
         public void AddCollection(MetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
@@ -59,7 +59,7 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
 
         }
 
-        [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [Benchmark]
         [BenchmarkVariation("AutoDetectChanges Off")]
         public void Attach(MetricCollector collector)
         {
@@ -79,7 +79,7 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
 
         }
 
-        [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [Benchmark]
         public void AttachCollection(MetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
@@ -94,7 +94,7 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
             }
         }
 
-        [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [Benchmark]
         [BenchmarkVariation("AutoDetectChanges Off")]
         public void Remove(MetricCollector collector)
         {
@@ -113,7 +113,7 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
             }
         }
 
-        [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [Benchmark]
         public void RemoveCollection(MetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
@@ -128,7 +128,7 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
             }
         }
 
-        [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [Benchmark]
         [BenchmarkVariation("AutoDetectChanges Off")]
         public void Update(MetricCollector collector)
         {
@@ -147,7 +147,7 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
             }
         }
 
-        [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [Benchmark]
         public void UpdateCollection(MetricCollector collector)
         {
             using (var context = _fixture.CreateContext())

--- a/test/EntityFramework.Microbenchmarks/ChangeTracker/FixupTests.cs
+++ b/test/EntityFramework.Microbenchmarks/ChangeTracker/FixupTests.cs
@@ -19,7 +19,7 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
             _fixture = fixture;
         }
 
-        [Benchmark(Iterations = 10, WarmupIterations = 5)]
+        [Benchmark(Iterations = 10)]
         public void AddChildren(MetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
@@ -41,7 +41,7 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
             }
         }
 
-        [Benchmark(Iterations = 10, WarmupIterations = 5)]
+        [Benchmark(Iterations = 10)]
         public void AddParents(MetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
@@ -65,7 +65,7 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
             }
         }
 
-        [Benchmark(Iterations = 10, WarmupIterations = 5)]
+        [Benchmark(Iterations = 10)]
         public void AttachChildren(MetricCollector collector)
         {
             List<Order> orders;
@@ -92,7 +92,7 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
             }
         }
 
-        [Benchmark(Iterations = 10, WarmupIterations = 5)]
+        [Benchmark(Iterations = 10)]
         public void AttachParents(MetricCollector collector)
         {
             List<Customer> customers;
@@ -119,7 +119,7 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
             }
         }
 
-        [Benchmark(Iterations = 10, WarmupIterations = 5)]
+        [Benchmark(Iterations = 10)]
         public void QueryChildren(MetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
@@ -136,7 +136,7 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
             }
         }
 
-        [Benchmark(Iterations = 10, WarmupIterations = 5)]
+        [Benchmark(Iterations = 10)]
         public void QueryParents(MetricCollector collector)
         {
             using (var context = _fixture.CreateContext())

--- a/test/EntityFramework.Microbenchmarks/Query/FuncletizationTests.cs
+++ b/test/EntityFramework.Microbenchmarks/Query/FuncletizationTests.cs
@@ -19,7 +19,7 @@ namespace EntityFramework.Microbenchmarks.Query
             _fixture = fixture;
         }
 
-        [Benchmark(Iterations = 50, WarmupIterations = 5)]
+        [Benchmark]
         public void NewQueryInstance(MetricCollector collector)
         {
 
@@ -38,7 +38,7 @@ namespace EntityFramework.Microbenchmarks.Query
             }
         }
 
-        [Benchmark(Iterations = 50, WarmupIterations = 5)]
+        [Benchmark]
         public void SameQueryInstance(MetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
@@ -58,7 +58,7 @@ namespace EntityFramework.Microbenchmarks.Query
             }
         }
 
-        [Benchmark(Iterations = 50, WarmupIterations = 5)]
+        [Benchmark]
         public void ValueFromObject(MetricCollector collector)
         {
             using (var context = _fixture.CreateContext())

--- a/test/EntityFramework.Microbenchmarks/Query/SimpleQueryTests.cs
+++ b/test/EntityFramework.Microbenchmarks/Query/SimpleQueryTests.cs
@@ -19,7 +19,7 @@ namespace EntityFramework.Microbenchmarks.Query
             _fixture = fixture;
         }
 
-        [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [Benchmark]
         [BenchmarkVariation("Tracking On", true)]
         [BenchmarkVariation("Tracking Off", false)]
         public void LoadAll(MetricCollector collector, bool tracking)
@@ -35,7 +35,7 @@ namespace EntityFramework.Microbenchmarks.Query
             }
         }
 
-        [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [Benchmark]
         [BenchmarkVariation("Tracking On", true)]
         [BenchmarkVariation("Tracking Off", false)]
         public void Where(MetricCollector collector, bool tracking)
@@ -53,7 +53,7 @@ namespace EntityFramework.Microbenchmarks.Query
             }
         }
 
-        [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [Benchmark]
         [BenchmarkVariation("Tracking On", true)]
         [BenchmarkVariation("Tracking Off", false)]
         public void OrderBy(MetricCollector collector, bool tracking)
@@ -71,7 +71,7 @@ namespace EntityFramework.Microbenchmarks.Query
             }
         }
 
-        [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [Benchmark]
         public void Count(MetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
@@ -85,7 +85,7 @@ namespace EntityFramework.Microbenchmarks.Query
             }
         }
 
-        [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [Benchmark]
         [BenchmarkVariation("Tracking On", true)]
         [BenchmarkVariation("Tracking Off", false)]
         public void SkipTake(MetricCollector collector, bool tracking)
@@ -104,7 +104,7 @@ namespace EntityFramework.Microbenchmarks.Query
             }
         }
 
-        [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [Benchmark]
         public void GroupBy(MetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
@@ -125,7 +125,7 @@ namespace EntityFramework.Microbenchmarks.Query
             }
         }
 
-        [Benchmark(Iterations = 2, WarmupIterations = 1)]
+        [Benchmark(Iterations = 2)]
         [BenchmarkVariation("Tracking On", true)]
         [BenchmarkVariation("Tracking Off", false)]
         public void Include(MetricCollector collector, bool tracking)
@@ -144,7 +144,7 @@ namespace EntityFramework.Microbenchmarks.Query
             }
         }
 
-        [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [Benchmark]
         public void Projection(MetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
@@ -159,7 +159,7 @@ namespace EntityFramework.Microbenchmarks.Query
             }
         }
 
-        [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [Benchmark]
         public void ProjectionAcrossNavigation(MetricCollector collector)
         {
             using (var context = _fixture.CreateContext())

--- a/test/EntityFramework.Microbenchmarks/UpdatePipeline/SimpleUpdatePipelineTests.cs
+++ b/test/EntityFramework.Microbenchmarks/UpdatePipeline/SimpleUpdatePipelineTests.cs
@@ -19,7 +19,7 @@ namespace EntityFramework.Microbenchmarks.UpdatePipeline
             _fixture = fixture;
         }
 
-        [Benchmark(Iterations = 10, WarmupIterations = 5)]
+        [Benchmark]
         [BenchmarkVariation("Batching Off", true)]
         [BenchmarkVariation("Batching On", false)]
         public void Insert(MetricCollector collector, bool disableBatching)
@@ -42,7 +42,7 @@ namespace EntityFramework.Microbenchmarks.UpdatePipeline
             }
         }
 
-        [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [Benchmark]
         [BenchmarkVariation("Batching Off", true)]
         [BenchmarkVariation("Batching On", false)]
         public void Update(MetricCollector collector, bool disableBatching)
@@ -65,7 +65,7 @@ namespace EntityFramework.Microbenchmarks.UpdatePipeline
             }
         }
 
-        [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [Benchmark]
         [BenchmarkVariation("Batching Off", true)]
         [BenchmarkVariation("Batching On", false)]
         public void Delete(MetricCollector collector, bool disableBatching)
@@ -88,7 +88,7 @@ namespace EntityFramework.Microbenchmarks.UpdatePipeline
             }
         }
 
-        [Benchmark(Iterations = 100, WarmupIterations = 5)]
+        [Benchmark]
         [BenchmarkVariation("Batching Off", true)]
         [BenchmarkVariation("Batching On", false)]
         public void Mixed(MetricCollector collector, bool disableBatching)


### PR DESCRIPTION
Standardizing on a 100 iterations and 1 warmup iteration for benchmarks.
Moving them to be default values and only overriding where text
execution time make 100 iterations prohibitive.