### PR TITLE
Query: Relational: CROSS APPLY and refactorings:

### DIFF
--- a/src/EntityFramework.Relational/EntityFramework.Relational.csproj
+++ b/src/EntityFramework.Relational/EntityFramework.Relational.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Metadata\RelationalModelExtensions.cs" />
     <Compile Include="Metadata\RelationalPropertyExtensions.cs" />
     <Compile Include="Migrations\Infrastructure\ModelDifferContext.cs" />
+    <Compile Include="Query\Expressions\CrossApplyExpression.cs" />
     <Compile Include="Query\Internal\RelationalExpressionPrinter.cs" />
     <Compile Include="RelationalReferenceReferenceBuilderExtensions.cs" />
     <Compile Include="Migrations\Builders\ColumnsBuilder.cs" />

--- a/src/EntityFramework.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
@@ -47,15 +47,6 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
 
             queryModelVisitor.VisitQueryModel(subQueryExpression.QueryModel);
 
-            if (queryModelVisitor.Queries.Count == 1
-                && !queryModelVisitor.RequiresClientFilter
-                && !queryModelVisitor.RequiresClientSelectMany
-                && !queryModelVisitor.RequiresClientProjection
-                && !queryModelVisitor.RequiresClientResultOperator)
-            {
-                QueryModelVisitor.AddSubquery(_querySource, queryModelVisitor.Queries.First());
-            }
-
             QueryModelVisitor.RegisterSubQueryVisitor(_querySource, queryModelVisitor);
 
             return queryModelVisitor.Expression;
@@ -168,13 +159,13 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
 
             var queryMethodArguments
                 = new List<Expression>
-                {
-                    Expression.Constant(_querySource),
-                    EntityQueryModelVisitor.QueryContextParameter,
-                    EntityQueryModelVisitor.QueryResultScopeParameter,
-                    _valueBufferParameter,
-                    Expression.Constant(0)
-                };
+                    {
+                        Expression.Constant(_querySource),
+                        EntityQueryModelVisitor.QueryContextParameter,
+                        EntityQueryModelVisitor.QueryResultScopeParameter,
+                        _valueBufferParameter,
+                        Expression.Constant(0)
+                    };
 
             if (QueryModelVisitor.QueryCompilationContext
                 .QuerySourceRequiresMaterialization(_querySource)
@@ -204,13 +195,13 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
 
                 queryMethodArguments.AddRange(
                     new[]
-                    {
-                        Expression.Constant(entityType),
-                        Expression.Constant(QueryModelVisitor.QuerySourceRequiresTracking(_querySource)),
-                        Expression.Constant(keyFactory),
-                        Expression.Constant(entityType.GetPrimaryKey().Properties),
-                        materializer
-                    });
+                        {
+                            Expression.Constant(entityType),
+                            Expression.Constant(QueryModelVisitor.QuerySourceRequiresTracking(_querySource)),
+                            Expression.Constant(keyFactory),
+                            Expression.Constant(entityType.GetPrimaryKey().Properties),
+                            materializer
+                        });
             }
 
             Func<ISqlQueryGenerator> sqlQueryGeneratorFactory;
@@ -250,12 +241,10 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
             QueryResultScope parentQueryResultScope,
             ValueBuffer valueBuffer,
             int valueBufferOffset)
-        {
-            return new QueryResultScope<ValueBuffer>(
+            => new QueryResultScope<ValueBuffer>(
                 querySource,
                 valueBuffer.WithOffset(valueBufferOffset),
                 parentQueryResultScope);
-        }
 
         public static readonly MethodInfo CreateEntityMethodInfo
             = typeof(RelationalEntityQueryableExpressionVisitor).GetTypeInfo()

--- a/src/EntityFramework.Relational/Query/ExpressionVisitors/RelationalProjectionExpressionVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionVisitors/RelationalProjectionExpressionVisitor.cs
@@ -18,8 +18,6 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
         private readonly RelationalQueryModelVisitor _queryModelVisitor;
         private readonly IQuerySource _querySource;
 
-        private bool _requiresClientEval;
-
         public RelationalProjectionExpressionVisitor(
             [NotNull] RelationalQueryModelVisitor queryModelVisitor,
             [NotNull] IQuerySource querySource)
@@ -33,8 +31,6 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
 
         private new RelationalQueryModelVisitor QueryModelVisitor
             => (RelationalQueryModelVisitor)base.QueryModelVisitor;
-
-        public virtual bool RequiresClientEval => _requiresClientEval;
 
         protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
         {
@@ -109,7 +105,7 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
                 {
                     if (!(expression is QuerySourceReferenceExpression))
                     {
-                        _requiresClientEval = true;
+                        _queryModelVisitor.RequiresClientProjection = true;
                     }
                 }
                 else

--- a/src/EntityFramework.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
 
         public SqlTranslatingExpressionVisitor(
             [NotNull] RelationalQueryModelVisitor queryModelVisitor,
-            [CanBeNull] SelectExpression targetSelectExpression,
+            [CanBeNull] SelectExpression targetSelectExpression = null,
             [CanBeNull] Expression topLevelPredicate = null,
             bool bindParentQueries = false,
             bool inProjection = false)
@@ -353,13 +353,11 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
 
         private AliasExpression CreateAliasedColumnExpressionCore(
             IProperty property, IQuerySource querySource, SelectExpression selectExpression)
-        {
-            return new AliasExpression(
+            => new AliasExpression(
                 new ColumnExpression(
                     _queryModelVisitor.QueryCompilationContext.RelationalExtensions.For(property).ColumnName,
                     property,
                     selectExpression.GetTableForQuerySource(querySource)));
-        }
 
         protected override Expression VisitUnary(UnaryExpression expression)
         {

--- a/src/EntityFramework.Relational/Query/Expressions/CrossJoinExpression.cs
+++ b/src/EntityFramework.Relational/Query/Expressions/CrossJoinExpression.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Data.Entity.Query.Expressions
 
         public virtual TableExpressionBase TableExpression => _tableExpression;
 
-        protected override Expression Accept([NotNull] ExpressionVisitor visitor)
+        protected override Expression Accept(ExpressionVisitor visitor)
         {
             Check.NotNull(visitor, nameof(visitor));
 
@@ -34,5 +34,12 @@ namespace Microsoft.Data.Entity.Query.Expressions
         }
 
         public override string ToString() => "CROSS JOIN " + _tableExpression;
+
+        protected override Expression VisitChildren(ExpressionVisitor visitor)
+        {
+            visitor.Visit(_tableExpression);
+
+            return this;
+        }
     }
 }

--- a/src/EntityFramework.Relational/Query/Expressions/InnerJoinExpression.cs
+++ b/src/EntityFramework.Relational/Query/Expressions/InnerJoinExpression.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Data.Entity.Query.Expressions
         {
         }
 
-        protected override Expression Accept([NotNull] ExpressionVisitor visitor)
+        protected override Expression Accept(ExpressionVisitor visitor)
         {
             Check.NotNull(visitor, nameof(visitor));
 

--- a/src/EntityFramework.Relational/Query/Expressions/LeftOuterJoinExpression.cs
+++ b/src/EntityFramework.Relational/Query/Expressions/LeftOuterJoinExpression.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Data.Entity.Query.Expressions
         {
         }
 
-        protected override Expression Accept([NotNull] ExpressionVisitor visitor)
+        protected override Expression Accept(ExpressionVisitor visitor)
         {
             Check.NotNull(visitor, nameof(visitor));
 

--- a/src/EntityFramework.Relational/Query/Expressions/RawSqlDerivedTableExpression.cs
+++ b/src/EntityFramework.Relational/Query/Expressions/RawSqlDerivedTableExpression.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Data.Entity.Query.Expressions
 
         public virtual object[] Parameters { get; }
 
-        protected override Expression Accept([NotNull] ExpressionVisitor visitor)
+        protected override Expression Accept(ExpressionVisitor visitor)
         {
             Check.NotNull(visitor, nameof(visitor));
 

--- a/src/EntityFramework.Relational/Query/Expressions/TableExpression.cs
+++ b/src/EntityFramework.Relational/Query/Expressions/TableExpression.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Data.Entity.Query.Expressions
 
         public virtual string Schema { get; }
 
-        protected override Expression Accept([NotNull] ExpressionVisitor visitor)
+        protected override Expression Accept(ExpressionVisitor visitor)
         {
             Check.NotNull(visitor, nameof(visitor));
 

--- a/src/EntityFramework.Relational/Query/QueryMethodProvider.cs
+++ b/src/EntityFramework.Relational/Query/QueryMethodProvider.cs
@@ -96,15 +96,12 @@ namespace Microsoft.Data.Entity.Query
         [UsedImplicitly]
         private static IEnumerable<T> _ShapedQuery<T>(
             QueryContext queryContext, CommandBuilder commandBuilder, Func<ValueBuffer, T> shaper)
-        {
-            return
-                new QueryingEnumerable(
+            => new QueryingEnumerable(
                     ((RelationalQueryContext)queryContext),
                     commandBuilder,
                     /*queryIndex*/ null,
                     queryContext.Logger)
                     .Select(shaper);
-        }
 
         public virtual MethodInfo QueryMethod => _queryMethodInfo;
 

--- a/src/EntityFramework.Relational/Query/RelationalQueryCompilationContext.cs
+++ b/src/EntityFramework.Relational/Query/RelationalQueryCompilationContext.cs
@@ -75,10 +75,9 @@ namespace Microsoft.Data.Entity.Query
             return relationalQueryModelVisitor;
         }
 
-        public override IExpressionPrinter CreateExpressionPrinter()
-        {
-            return new RelationalExpressionPrinter();
-        }
+        public override IExpressionPrinter CreateExpressionPrinter() => new RelationalExpressionPrinter();
+
+        public virtual bool IsCrossApplySupported => false;
 
         public virtual SelectExpression FindSelectExpression([NotNull] IQuerySource querySource)
         {

--- a/src/EntityFramework.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/EntityFramework.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -308,6 +308,17 @@ namespace Microsoft.Data.Entity.Query.Sql
             return crossJoinExpression;
         }
 
+        public virtual Expression VisitCrossApply(CrossApplyExpression crossApplyExpression)
+        {
+            Check.NotNull(crossApplyExpression, nameof(crossApplyExpression));
+
+            _sql.Append("CROSS APPLY ");
+
+            Visit(crossApplyExpression.TableExpression);
+
+            return crossApplyExpression;
+        }
+
         public virtual Expression VisitCount(CountExpression countExpression)
         {
             Check.NotNull(countExpression, nameof(countExpression));

--- a/src/EntityFramework.Relational/Query/Sql/ISqlExpressionVisitor.cs
+++ b/src/EntityFramework.Relational/Query/Sql/ISqlExpressionVisitor.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Data.Entity.Query.Sql
         Expression VisitTable([NotNull] TableExpression tableExpression);
         Expression VisitRawSqlDerivedTable([NotNull] RawSqlDerivedTableExpression rawSqlDerivedTableExpression);
         Expression VisitCrossJoin([NotNull] CrossJoinExpression crossJoinExpression);
+        Expression VisitCrossApply([NotNull] CrossApplyExpression crossApplyExpression);
         Expression VisitInnerJoin([NotNull] InnerJoinExpression innerJoinExpression);
         Expression VisitOuterJoin([NotNull] LeftOuterJoinExpression leftOuterJoinExpression);
         Expression VisitExists([NotNull] ExistsExpression existsExpression);

--- a/src/EntityFramework.SqlServer/Query/SqlServerQueryCompilationContext.cs
+++ b/src/EntityFramework.SqlServer/Query/SqlServerQueryCompilationContext.cs
@@ -50,5 +50,7 @@ namespace Microsoft.Data.Entity.SqlServer.Query
 
         public override ISqlQueryGenerator CreateSqlQueryGenerator(SelectExpression selectExpression)
             => new SqlServerQuerySqlGenerator(Check.NotNull(selectExpression, nameof(selectExpression)), TypeMapper);
+
+        public override bool IsCrossApplySupported => true;
     }
 }

--- a/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
@@ -3630,6 +3630,15 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
+        public virtual void SelectMany_Joined_Take()
+        {
+            AssertQuery<Customer, Order>((cs, os) =>
+                from c in cs
+                from o in os.Where(o => o.CustomerID == c.CustomerID).Take(1000)
+                select new { c.ContactName, o });
+        }
+
+        [Fact]
         public virtual void SelectMany_Joined_DefaultIfEmpty2()
         {
             AssertQuery<Customer, Order>((cs, os) =>

--- a/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -2182,6 +2182,21 @@ FROM [Orders] AS [o]",
                 Sql);
         }
 
+        public override void SelectMany_Joined_Take()
+        {
+            base.SelectMany_Joined_Take();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [c].[ContactName]
+FROM [Customers] AS [c]
+CROSS APPLY (
+    SELECT TOP(1000) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    FROM [Orders] AS [o]
+    WHERE [o].[CustomerID] = [c].[CustomerID]
+) AS [t0]",
+                Sql);
+        }
+
         public override void Take_with_single()
         {
             base.Take_with_single();

--- a/test/EntityFramework.Sqlite.FunctionalTests/QuerySqliteTest.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/QuerySqliteTest.cs
@@ -1448,6 +1448,19 @@ CROSS JOIN ""Employees"" AS ""e3""",
                 Sql);
         }
 
+        public override void SelectMany_Joined_Take()
+        {
+            base.SelectMany_Joined_Take();
+
+            Assert.StartsWith(
+                @"SELECT ""c"".""CustomerID"", ""c"".""ContactName""
+FROM ""Customers"" AS ""c""
+
+SELECT ""o"".""OrderID"", ""o"".""CustomerID"", ""o"".""EmployeeID"", ""o"".""OrderDate""
+FROM ""Orders"" AS ""o""",
+                Sql);
+        }
+
         public override void SelectMany_projection1()
         {
             base.SelectMany_projection1();


### PR DESCRIPTION
- Introduces CROSS APPLY support (provider must opt-in).
- Refactoring of sub-query lifting and client eval flags.
- Made SelectExpression visitable.