### PR TITLE
:racehorse: Multiple benchmark result databases

### DIFF
--- a/test/EntityFramework.Microbenchmarks.Core/BenchmarkConfig.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/BenchmarkConfig.cs
@@ -3,6 +3,8 @@
 
 using Microsoft.Framework.Configuration;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace EntityFramework.Microbenchmarks.Core
 {
@@ -15,10 +17,12 @@ namespace EntityFramework.Microbenchmarks.Core
                 .AddEnvironmentVariables()
                 .Build();
 
+            var resultDatabasesSection = config.GetConfigurationSection("benchmarks:resultDatabases");
+
             return new BenchmarkConfig
             {
                 RunIterations = bool.Parse(config.Get("benchmarks:runIterations")),
-                ResultsDatabase = config.Get("benchmarks:resultsDatabase"),
+                ResultDatabases = resultDatabasesSection.GetConfigurationSections().Select(s => resultDatabasesSection.Get(s.Key)).ToArray(),
                 BenchmarkDatabaseInstance = config.Get("benchmarks:benchmarkDatabaseInstance"),
                 ProductReportingVersion = config.Get("benchmarks:productReportingVersion"),
                 CustomData = config.Get("benchmarks:customData")
@@ -34,7 +38,7 @@ namespace EntityFramework.Microbenchmarks.Core
         }
 
         public bool RunIterations { get; private set; }
-        public string ResultsDatabase { get; private set; }
+        public IEnumerable<string> ResultDatabases { get; private set; }
         public string BenchmarkDatabaseInstance { get; private set; }
         public string ProductReportingVersion { get; private set; }
         public string CustomData { get; private set; }

--- a/test/EntityFramework.Microbenchmarks.Core/BenchmarkTestCaseRunner.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/BenchmarkTestCaseRunner.cs
@@ -86,9 +86,9 @@ namespace EntityFramework.Microbenchmarks.Core
             runSummary.PopulateMetrics();
             _diagnosticMessageSink.OnMessage(new XunitDiagnosticMessage(runSummary.ToString()));
 
-            if (BenchmarkConfig.Instance.ResultsDatabase != null)
+            foreach (var database in BenchmarkConfig.Instance.ResultDatabases)
             {
-                new SqlServerBenchmarkResultProcessor(BenchmarkConfig.Instance.ResultsDatabase).SaveSummary(runSummary);
+                new SqlServerBenchmarkResultProcessor(database).SaveSummary(runSummary);
             }
 
             return runSummary;

--- a/test/EntityFramework.Microbenchmarks.EF6/config.json
+++ b/test/EntityFramework.Microbenchmarks.EF6/config.json
@@ -1,8 +1,10 @@
 ﻿{
   "benchmarks": {
     "runIterations": false,
-    "resultsDatabase": "Server=(localdb)\\mssqllocaldb;Database=Benchmarks;Trusted_Connection=True;",
+    "resultDatabases": {
+      "local": "Server=(localdb)\\mssqllocaldb;Database=Benchmarks;Trusted_Connection=True;"
+    },
     "benchmarkDatabaseInstance": "(localdb)\\mssqllocaldb",
-    "productReportingVersion":  "EF6"
+    "productReportingVersion": "EF6"
   }
 }

--- a/test/EntityFramework.Microbenchmarks/config.json
+++ b/test/EntityFramework.Microbenchmarks/config.json
@@ -1,8 +1,10 @@
 ﻿{
   "benchmarks": {
     "runIterations": false,
-    "resultsDatabase": "Server=(localdb)\\mssqllocaldb;Database=Benchmarks;Trusted_Connection=True;",
+    "resultDatabases": {
+      "local": "Server=(localdb)\\mssqllocaldb;Database=Benchmarks;Trusted_Connection=True;"
+    },
     "benchmarkDatabaseInstance": "(localdb)\\mssqllocaldb",
-    "productReportingVersion":  "EF7"
+    "productReportingVersion": "EF7"
   }
 }


### PR DESCRIPTION
This enables results to be stored locally on the perf agent but also
sent up to a remote reporting server.