### PR TITLE
Fix to 2274 - Chaining multiple Include with ThenInclude throws in some cases when included collections are empty mid-chain

### DIFF
--- a/src/EntityFramework.Relational/Query/AsyncQueryMethodProvider.cs
+++ b/src/EntityFramework.Relational/Query/AsyncQueryMethodProvider.cs
@@ -149,6 +149,7 @@ namespace Microsoft.Data.Entity.Query
                 new AsyncQueryingEnumerable(
                     ((RelationalQueryContext)queryContext),
                     commandBuilder,
+                    /*queryIndex*/ null,
                     queryContext.Logger)
                     .Select(shaper);
         }
@@ -161,12 +162,15 @@ namespace Microsoft.Data.Entity.Query
 
         [UsedImplicitly]
         private static IAsyncEnumerable<ValueBuffer> _Query(
-            QueryContext queryContext, CommandBuilder commandBuilder)
+            QueryContext queryContext, 
+            CommandBuilder commandBuilder,
+            int? queryIndex)
         {
             return
                 new AsyncQueryingEnumerable(
                     ((RelationalQueryContext)queryContext),
                     commandBuilder,
+                    queryIndex,
                     queryContext.Logger);
         }
 

--- a/src/EntityFramework.Relational/Query/AsyncQueryingEnumerable.cs
+++ b/src/EntityFramework.Relational/Query/AsyncQueryingEnumerable.cs
@@ -18,11 +18,13 @@ namespace Microsoft.Data.Entity.Query
     {
         private readonly RelationalQueryContext _relationalQueryContext;
         private readonly CommandBuilder _commandBuilder;
+        private readonly int? _queryIndex;
         private readonly ILogger _logger;
 
         public AsyncQueryingEnumerable(
             [NotNull] RelationalQueryContext relationalQueryContext,
             [NotNull] CommandBuilder commandBuilder,
+            int? queryIndex,
             [NotNull] ILogger logger)
         {
             Check.NotNull(relationalQueryContext, nameof(relationalQueryContext));
@@ -31,6 +33,7 @@ namespace Microsoft.Data.Entity.Query
 
             _relationalQueryContext = relationalQueryContext;
             _commandBuilder = commandBuilder;
+            _queryIndex = queryIndex;
             _logger = logger;
         }
 
@@ -75,7 +78,7 @@ namespace Microsoft.Data.Entity.Query
                             _queryingEnumerable._logger.LogCommand(command);
 
                             await _queryingEnumerable._relationalQueryContext
-                                .RegisterValueBufferCursorAsync(this, cancellationToken);
+                                .RegisterValueBufferCursorAsync(this, _queryingEnumerable._queryIndex, cancellationToken);
 
                             _dataReader = await command.ExecuteReaderAsync(cancellationToken);
 

--- a/src/EntityFramework.Relational/Query/QueryMethodProvider.cs
+++ b/src/EntityFramework.Relational/Query/QueryMethodProvider.cs
@@ -101,6 +101,7 @@ namespace Microsoft.Data.Entity.Query
                 new QueryingEnumerable(
                     ((RelationalQueryContext)queryContext),
                     commandBuilder,
+                    /*queryIndex*/ null,
                     queryContext.Logger)
                     .Select(shaper);
         }
@@ -113,12 +114,15 @@ namespace Microsoft.Data.Entity.Query
 
         [UsedImplicitly]
         private static IEnumerable<ValueBuffer> _Query(
-            QueryContext queryContext, CommandBuilder commandBuilder)
+            QueryContext queryContext, 
+            CommandBuilder commandBuilder,
+            int? queryIndex)
         {
             return
                 new QueryingEnumerable(
                     ((RelationalQueryContext)queryContext),
                     commandBuilder,
+                    queryIndex,
                     queryContext.Logger);
         }
 

--- a/src/EntityFramework.Relational/Query/QueryingEnumerable.cs
+++ b/src/EntityFramework.Relational/Query/QueryingEnumerable.cs
@@ -18,11 +18,13 @@ namespace Microsoft.Data.Entity.Query
     {
         private readonly RelationalQueryContext _relationalQueryContext;
         private readonly CommandBuilder _commandBuilder;
+        private readonly int? _queryIndex;
         private readonly ILogger _logger;
 
         public QueryingEnumerable(
             [NotNull] RelationalQueryContext relationalQueryContext,
             [NotNull] CommandBuilder commandBuilder,
+            int? queryIndex,
             [NotNull] ILogger logger)
         {
             Check.NotNull(relationalQueryContext, nameof(relationalQueryContext));
@@ -31,6 +33,7 @@ namespace Microsoft.Data.Entity.Query
 
             _relationalQueryContext = relationalQueryContext;
             _commandBuilder = commandBuilder;
+            _queryIndex = queryIndex;
             _logger = logger;
         }
 
@@ -68,7 +71,7 @@ namespace Microsoft.Data.Entity.Query
                         {
                             _queryingEnumerable._logger.LogCommand(command);
 
-                            _queryingEnumerable._relationalQueryContext.RegisterValueBufferCursor(this);
+                            _queryingEnumerable._relationalQueryContext.RegisterValueBufferCursor(this, _queryingEnumerable._queryIndex);
 
                             _dataReader = command.ExecuteReader();
 

--- a/src/EntityFramework.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EntityFramework.Relational/Query/RelationalQueryModelVisitor.cs
@@ -168,6 +168,7 @@ namespace Microsoft.Data.Entity.Query
                     {
                         openedNewReader = true;
                         openedReaderCount++;
+                        indexes.Add(openedReaderCount);
                     }
                     else
                     {

--- a/test/EntityFramework.Core.FunctionalTests/ComplexNavigationsQueryFixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/ComplexNavigationsQueryFixtureBase.cs
@@ -59,6 +59,18 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
             modelBuilder.Entity<Level4>().Collection(e => e.OneToMany_Required_Self).InverseReference(e => e.OneToMany_Required_Self_Inverse).Required(true);
             modelBuilder.Entity<Level4>().Collection(e => e.OneToMany_Optional_Self).InverseReference(e => e.OneToMany_Optional_Self_Inverse).Required(false);
+
+            modelBuilder.Entity<ComplexNavigationField>().Key(e => e.Name);
+            modelBuilder.Entity<ComplexNavigationString>().Key(e => e.DefaultText);
+            modelBuilder.Entity<ComplexNavigationGlobalization>().Key(e => e.Text);
+            modelBuilder.Entity<ComplexNavigationLanguage>().Key(e => e.Name);
+
+            modelBuilder.Entity<ComplexNavigationField>().Reference(f => f.Label);
+            modelBuilder.Entity<ComplexNavigationField>().Reference(f => f.Placeholder);
+
+            modelBuilder.Entity<ComplexNavigationString>().Collection(m => m.Globalizations);
+
+            modelBuilder.Entity<ComplexNavigationGlobalization>().Reference(g => g.Language);
         }
     }
 }

--- a/test/EntityFramework.Core.FunctionalTests/ComplexNavigationsQueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/ComplexNavigationsQueryTestBase.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using Microsoft.Data.Entity.FunctionalTests.TestModels.ComplexNavigationsModel;
 using Xunit;
+using System.Collections.Generic;
 
 namespace Microsoft.Data.Entity.FunctionalTests
 {
@@ -27,6 +28,10 @@ namespace Microsoft.Data.Entity.FunctionalTests
         protected TFixture Fixture { get; }
 
         protected TTestStore TestStore { get; }
+
+        protected virtual void ClearLog()
+        {
+        }
 
         public void Dispose()
         {
@@ -143,6 +148,84 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 context.LevelOne
                     .Include(e => e.OneToMany_Optional)
                     .ThenInclude(e => e.OneToMany_Optional_Inverse.OneToOne_Optional_PK.OneToOne_Required_FK_Inverse).ToList();
+            }
+        }
+
+        [Fact]
+        public virtual void Multi_level_include_with_short_circuiting()
+        {
+            var fieldLabels = new Dictionary<string, string>();
+            var fieldPlaceholders = new Dictionary<string, string>();
+            var stringGlobalizations = new Dictionary<string, List<string>>();
+            var globalizationLanguages = new Dictionary<string, string>();
+
+            using (var context = CreateContext())
+            {
+                fieldLabels = context.Fields
+                    .Include(f => f.Label)
+                    .ToDictionary(f => f.Name, f => f.Label?.DefaultText);
+
+                fieldPlaceholders = context.Fields
+                    .Include(f => f.Placeholder)
+                    .ToDictionary(f => f.Name, f => f.Placeholder?.DefaultText);
+
+                stringGlobalizations = context.MultilingualStrings
+                    .Include(s => s.Globalizations)
+                    .ToDictionary(
+                        s => s.DefaultText,
+                        s => s.Globalizations != null
+                            ? s.Globalizations.Select(g => g.Text).ToList()
+                            : new List<string>());
+
+                globalizationLanguages = context.Globalizations
+                    .Include(g => g.Language)
+                    .ToDictionary(g => g.Text, g => g.Language?.Name);
+            }
+
+            ClearLog();
+
+            using (var context = CreateContext())
+            {
+                var query = context.Fields
+                   .Include(x => x.Label.Globalizations)
+                   .ThenInclude(x => x.Language)
+                   .Include(x => x.Placeholder.Globalizations)
+                   .ThenInclude(x => x.Language);
+
+                var result = query.ToList();
+
+                var expectedFieldCount = 2;
+                Assert.Equal(expectedFieldCount, result.Count);
+                Assert.Equal("Field1", result[0].Name);
+                Assert.Equal("Field2", result[1].Name);
+
+                for (int i = 0; i < expectedFieldCount; i++)
+                {
+                    Assert.Equal(fieldLabels[result[i]?.Name], result[i].Label?.DefaultText);
+                    Assert.Equal(fieldPlaceholders[result[i]?.Name], result[i].Placeholder?.DefaultText);
+
+                    var label = result[i].Label;
+                    if (label != null)
+                    {
+                        Assert.Equal(stringGlobalizations[label.DefaultText].Count, label.Globalizations.Count);
+                        foreach (var globalization in label.Globalizations)
+                        {
+                            Assert.True(stringGlobalizations[label.DefaultText].Contains(globalization.Text));
+                            Assert.Equal(globalizationLanguages[globalization.Text], globalization.Language?.Name);
+                        }
+                    }
+
+                    var placeholder = result[i].Placeholder;
+                    if (placeholder != null)
+                    {
+                        Assert.Equal(stringGlobalizations[placeholder.DefaultText].Count, placeholder.Globalizations.Count);
+                        foreach (var globalization in placeholder.Globalizations)
+                        {
+                            Assert.True(stringGlobalizations[placeholder.DefaultText].Contains(globalization.Text));
+                            Assert.Equal(globalizationLanguages[globalization.Text], globalization.Language?.Name);
+                        }
+                    }
+                }
             }
         }
     }

--- a/test/EntityFramework.Core.FunctionalTests/EntityFramework.Core.FunctionalTests.csproj
+++ b/test/EntityFramework.Core.FunctionalTests/EntityFramework.Core.FunctionalTests.csproj
@@ -67,6 +67,10 @@
     <Compile Include="StoreGeneratedTestBase.cs" />
     <Compile Include="TestHelpers.cs" />
     <Compile Include="TestModelSource.cs" />
+    <Compile Include="TestModels\ComplexNavigationsModel\ComplexNavigationField.cs" />
+    <Compile Include="TestModels\ComplexNavigationsModel\ComplexNavigationGlobalization.cs" />
+    <Compile Include="TestModels\ComplexNavigationsModel\ComplexNavigationLanguage.cs" />
+    <Compile Include="TestModels\ComplexNavigationsModel\ComplexNavigationString.cs" />
     <Compile Include="TestModels\ComplexNavigationsModel\ComplexNavigationsContext.cs" />
     <Compile Include="TestModels\ComplexNavigationsModel\ComplexNavigationsModelInitializer.cs" />
     <Compile Include="TestModels\ComplexNavigationsModel\Level1.cs" />

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/ComplexNavigationsModel/ComplexNavigationField.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/ComplexNavigationsModel/ComplexNavigationField.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Data.Entity.FunctionalTests.TestModels.ComplexNavigationsModel
+{
+    public class ComplexNavigationField
+    {
+        public string Name { get; set; }
+        public ComplexNavigationString Label { get; set; }
+        public ComplexNavigationString Placeholder { get; set; }
+    }
+}

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/ComplexNavigationsModel/ComplexNavigationGlobalization.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/ComplexNavigationsModel/ComplexNavigationGlobalization.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Data.Entity.FunctionalTests.TestModels.ComplexNavigationsModel
+{
+    public class ComplexNavigationGlobalization
+    {
+        public string Text { get; set; }
+        public ComplexNavigationLanguage Language { get; set; }
+    }
+}

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/ComplexNavigationsModel/ComplexNavigationLanguage.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/ComplexNavigationsModel/ComplexNavigationLanguage.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Data.Entity.FunctionalTests.TestModels.ComplexNavigationsModel
+{
+    public class ComplexNavigationLanguage
+    {
+        public string Name { get; set; }
+        public string CultureString { get; set; }
+    }
+}

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/ComplexNavigationsModel/ComplexNavigationString.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/ComplexNavigationsModel/ComplexNavigationString.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Data.Entity.FunctionalTests.TestModels.ComplexNavigationsModel
+{
+    public class ComplexNavigationString
+    {
+        public string DefaultText { get; set; }
+        public IList<ComplexNavigationGlobalization> Globalizations { get; set; }
+    }
+}

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/ComplexNavigationsModel/ComplexNavigationsContext.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/ComplexNavigationsModel/ComplexNavigationsContext.cs
@@ -19,5 +19,10 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.ComplexNavigationsMod
         public DbSet<Level2> LevelTwo { get; set; }
         public DbSet<Level3> LevelThree { get; set; }
         public DbSet<Level4> LevelFour { get; set; }
+
+        public DbSet<ComplexNavigationField> Fields { get; set; }
+        public DbSet<ComplexNavigationString> MultilingualStrings { get; set; }
+        public DbSet<ComplexNavigationGlobalization> Globalizations { get; set; }
+        public DbSet<ComplexNavigationLanguage> Languages { get; set; }
     }
 }

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/ComplexNavigationsModel/ComplexNavigationsModelInitializer.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/ComplexNavigationsModel/ComplexNavigationsModelInitializer.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.Data.Entity.FunctionalTests.TestModels.ComplexNavigationsModel
 {
@@ -273,6 +274,41 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.ComplexNavigationsMod
                 l4s[7].OneToMany_Optional_Self = new List<Level4> { l4s[6] };
                 l4s[9].OneToMany_Optional_Self = new List<Level4> { l4s[8] };
 
+                context.SaveChanges();
+
+                for (int i = 0; i < 10; i++)
+                {
+                    var language = new ComplexNavigationLanguage { Name = "Language" + i, CultureString = "Foo" + i };
+                    context.Languages.Add(language);
+                }
+
+                context.SaveChanges();
+
+                int ii = 0;
+                foreach (var l in context.Languages)
+                {
+                    var globalization = new ComplexNavigationGlobalization { Text = "Globalization" + ii, Language = l };
+                    ii++;
+
+                    context.Globalizations.Add(globalization);
+                }
+
+                context.SaveChanges();
+
+                var globalizations = context.Globalizations.ToList();
+
+                var mls1 = new ComplexNavigationString { DefaultText = "MLS1", Globalizations = globalizations.Take(3).ToList() };
+                var mls2 = new ComplexNavigationString { DefaultText = "MLS2", Globalizations = globalizations.Skip(3).Take(3).ToList() };
+                var mls3 = new ComplexNavigationString { DefaultText = "MLS3", Globalizations = globalizations.Skip(6).Take(3).ToList() };
+                var mls4 = new ComplexNavigationString { DefaultText = "MLS4", Globalizations = globalizations.Skip(9).ToList() };
+
+                context.MultilingualStrings.AddRange(new[] { mls1, mls2, mls3, mls4 });
+                context.SaveChanges();
+
+                var field1 = new ComplexNavigationField { Name = "Field1", Label = mls1, Placeholder = null };
+                var field2 = new ComplexNavigationField { Name = "Field2", Label = mls3, Placeholder = mls4 };
+
+                context.Fields.AddRange(new[] { field1, field2 });
                 context.SaveChanges();
             }
         }

--- a/test/EntityFramework.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerFixture.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerFixture.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                     using (var context = new ComplexNavigationsContext(_serviceProvider, optionsBuilder.Options))
                     {
                         // TODO: Delete DB if model changed
-
+                        context.Database.EnsureDeleted();
                         if (context.Database.EnsureCreated())
                         {
                             ComplexNavigationsModelInitializer.Seed(context);

--- a/test/EntityFramework.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -13,6 +13,11 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         {
         }
 
+        protected override void ClearLog()
+        {
+            TestSqlLoggerFactory.Reset();
+        }
+
         public override void Multi_level_include_one_to_many_optional_and_one_to_many_optional_produces_valid_sql()
         {
             base.Multi_level_include_one_to_many_optional_and_one_to_many_optional_produces_valid_sql();
@@ -89,6 +94,39 @@ INNER JOIN (
     INNER JOIN [Level2] AS [l1] ON [l].[OneToMany_Required_InverseId] = [l1].[Id]
 ) AS [l1] ON [l].[OneToMany_Optional_InverseId] = [l1].[Id1]
 ORDER BY [l1].[Id], [l1].[Id0], [l1].[Id1]", Sql);
+        }
+
+        public override void Multi_level_include_with_short_circuiting()
+        {
+            base.Multi_level_include_with_short_circuiting();
+
+            Assert.Equal(
+                @"SELECT [x].[Name], [x].[LabelDefaultText], [x].[PlaceholderDefaultText], [c].[DefaultText], [c0].[DefaultText]
+FROM [ComplexNavigationField] AS [x]
+LEFT JOIN [ComplexNavigationString] AS [c] ON [x].[LabelDefaultText] = [c].[DefaultText]
+LEFT JOIN [ComplexNavigationString] AS [c0] ON [x].[PlaceholderDefaultText] = [c0].[DefaultText]
+ORDER BY [c].[DefaultText], [c0].[DefaultText]
+
+SELECT [c].[Text], [c].[ComplexNavigationStringDefaultText], [c].[LanguageName], [c1].[Name], [c1].[CultureString]
+FROM [ComplexNavigationGlobalization] AS [c]
+INNER JOIN (
+    SELECT DISTINCT [c].[DefaultText]
+    FROM [ComplexNavigationField] AS [x]
+    LEFT JOIN [ComplexNavigationString] AS [c] ON [x].[LabelDefaultText] = [c].[DefaultText]
+) AS [c0] ON [c].[ComplexNavigationStringDefaultText] = [c0].[DefaultText]
+LEFT JOIN [ComplexNavigationLanguage] AS [c1] ON [c].[LanguageName] = [c1].[Name]
+ORDER BY [c0].[DefaultText]
+
+SELECT [c].[Text], [c].[ComplexNavigationStringDefaultText], [c].[LanguageName], [c1].[Name], [c1].[CultureString]
+FROM [ComplexNavigationGlobalization] AS [c]
+INNER JOIN (
+    SELECT DISTINCT [c].[DefaultText], [c0].[DefaultText] AS [DefaultText0]
+    FROM [ComplexNavigationField] AS [x]
+    LEFT JOIN [ComplexNavigationString] AS [c] ON [x].[LabelDefaultText] = [c].[DefaultText]
+    LEFT JOIN [ComplexNavigationString] AS [c0] ON [x].[PlaceholderDefaultText] = [c0].[DefaultText]
+) AS [c0] ON [c].[ComplexNavigationStringDefaultText] = [c0].[DefaultText0]
+LEFT JOIN [ComplexNavigationLanguage] AS [c1] ON [c].[LanguageName] = [c1].[Name]
+ORDER BY [c0].[DefaultText], [c0].[DefaultText0]", Sql);
         }
 
         private static string Sql => TestSqlLoggerFactory.Sql;

--- a/test/EntityFramework.SqlServer.FunctionalTests/QueryLoggingSqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/QueryLoggingSqlServerTest.cs
@@ -183,6 +183,8 @@ WHERE [c].[City] = @__city_0",
                                 FROM ""Customers"" AS ""c""
                             ) AS ""c"" ON ""o"".""CustomerID"" = ""c"".""CustomerID""
                             ORDER BY ""c"".""CustomerID""
+                        , 
+                        queryIndex: 1
                     )
                     , 
                     materializer: (ValueBuffer prm5) => 

--- a/test/EntityFramework.Sqlite.FunctionalTests/ComplexNavigationsQuerySqliteFixture.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/ComplexNavigationsQuerySqliteFixture.cs
@@ -38,6 +38,8 @@ namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
 
                         using (var context = new ComplexNavigationsContext(_serviceProvider, optionsBuilder.Options))
                         {
+                            // TODO: Delete DB if model changed
+                            context.Database.EnsureDeleted();
                             if (context.Database.EnsureCreated())
                             {
                                 ComplexNavigationsModelInitializer.Seed(context);


### PR DESCRIPTION
Problem is that when creating creating query plan for include we statically assign each index for each ReferenceEntity materializer that indicates from which reader the data should be taken, in order to materialize this entity.
However, in some cases, we don't open all the readers that we expect - this can happen if a reader doesn't return any results. We then short circuit the include chain, and don't open any readers that were suppose to follow.

Fix is to introduce a structure that holds active readers for include (on top of the old _activeQueries for all other readers), which we don't fill in like a list, but fill it based on the index that the reader is supposed to have (filling the blanks with nulls temporarily). This way we ensure that reader always land in their place, and are available at the appropriate index, that we introduced in the query plan. This happens whether all of them were opened, or some were short-circuited.

The information about which reader should be placed at which index is also added to the query plan. We do this only for the include-related readers.