### PR TITLE
Migrations: Compare values (not references) when diffing Property.DefaultValue

### DIFF
--- a/src/EntityFramework.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EntityFramework.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -423,7 +423,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
             if (isNullableChanged
                 || columnTypeChanged
                 || sourceAnnotations.GeneratedValueSql != targetAnnotations.GeneratedValueSql
-                || sourceAnnotations.DefaultValue != targetAnnotations.DefaultValue
+                || !Equals(sourceAnnotations.DefaultValue, targetAnnotations.DefaultValue)
                 || HasDifferences(MigrationsAnnotations.For(source), targetMigrationsAnnotations))
             {
                 var isDestructiveChange = (isNullableChanged && isSourceColumnNullable)

--- a/test/EntityFramework.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
+++ b/test/EntityFramework.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
@@ -3400,5 +3400,28 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     Assert.Equal("FK_MountAnimal_Person_RiderId", operation.Name);
                 });
         }
+
+        [Fact] // See #2802
+        public void Diff_IProperty_compares_values_not_references()
+        {
+            Execute(
+                source => source.Entity(
+                    "Stork",
+                    x =>
+                    {
+                        x.Property<int>("Id");
+                        x.Key("Id");
+                        x.Property<bool>("Value").HasDefaultValue(true);
+                    }),
+                 target => target.Entity(
+                    "Stork",
+                    x =>
+                    {
+                        x.Property<int>("Id");
+                        x.Key("Id");
+                        x.Property<bool>("Value").HasDefaultValue(true);
+                    }),
+                 Assert.Empty);
+        }
     }
 }


### PR DESCRIPTION
Fixes #2802