### PR TITLE
SQL Server: Create unique indices using WHERE..IS NOT NULL

### DIFF
--- a/src/EntityFramework.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EntityFramework.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -186,6 +186,28 @@ namespace Microsoft.Data.Entity.Migrations
             }
         }
 
+        protected override void Generate([NotNull] CreateIndexOperation operation, [CanBeNull] IModel model, [NotNull] SqlBatchBuilder builder)
+        {
+            base.Generate(operation, model, builder);
+
+            var clustered = operation[SqlServerAnnotationNames.Prefix + SqlServerAnnotationNames.Clustered] as bool?;
+            if (operation.IsUnique && clustered != true)
+            {
+                builder.Append(" WHERE ");
+                for (var i = 0; i < operation.Columns.Length; i++)
+                {
+                    if (i != 0)
+                    {
+                        builder.Append(" AND ");
+                    }
+
+                    builder
+                        .Append(base.Sql.DelimitIdentifier(operation.Columns[i]))
+                        .Append(" IS NOT NULL");
+                }
+            }
+        }
+
         protected override void Generate(EnsureSchemaOperation operation, IModel model, SqlBatchBuilder builder)
         {
             Check.NotNull(operation, nameof(operation));

--- a/test/EntityFramework.SqlServer.Tests/Migrations/SqlServerMigrationSqlGeneratorTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/Migrations/SqlServerMigrationSqlGeneratorTest.cs
@@ -157,6 +157,24 @@ namespace Microsoft.Data.Entity.Migrations
                 Sql);
         }
 
+        public override void CreateIndexOperation_nonunique()
+        {
+            base.CreateIndexOperation_nonunique();
+
+            Assert.Equal(
+                "CREATE INDEX [IX_People_Name] ON [People] ([Name]);" + EOL,
+                Sql);
+        }
+
+        public override void CreateIndexOperation_unique()
+        {
+            base.CreateIndexOperation_unique();
+
+            Assert.Equal(
+                "CREATE UNIQUE INDEX [IX_People_Name] ON [dbo].[People] ([FirstName], [LastName]) WHERE [FirstName] IS NOT NULL AND [LastName] IS NOT NULL;" + EOL,
+                Sql);
+        }
+
         [Fact]
         public virtual void CreateIndexOperation_clustered()
         {
@@ -171,6 +189,42 @@ namespace Microsoft.Data.Entity.Migrations
 
             Assert.Equal(
                 "CREATE CLUSTERED INDEX [IX_People_Name] ON [People] ([Name]);" + EOL,
+                Sql);
+        }
+
+        [Fact]
+        public virtual void CreateIndexOperation_unique_clustered()
+        {
+            Generate(
+                new CreateIndexOperation
+                {
+                    Name = "IX_People_Name",
+                    Table = "People",
+                    Columns = new[] { "Name" },
+                    IsUnique = true,
+                    [SqlServerAnnotationNames.Prefix + SqlServerAnnotationNames.Clustered] = true
+                });
+
+            Assert.Equal(
+                "CREATE UNIQUE CLUSTERED INDEX [IX_People_Name] ON [People] ([Name]);" + EOL,
+                Sql);
+        }
+
+        [Fact]
+        public virtual void CreateIndexOperation_unique_nonclustered()
+        {
+            Generate(
+                new CreateIndexOperation
+                {
+                    Name = "IX_People_Name",
+                    Table = "People",
+                    Columns = new[] { "Name" },
+                    IsUnique = true,
+                    [SqlServerAnnotationNames.Prefix + SqlServerAnnotationNames.Clustered] = false
+                });
+
+            Assert.Equal(
+                "CREATE UNIQUE NONCLUSTERED INDEX [IX_People_Name] ON [People] ([Name]) WHERE [Name] IS NOT NULL;" + EOL,
                 Sql);
         }
 


### PR DESCRIPTION
This is to support 0..1:0..1 relationships.

Resolves #1711