### PR TITLE
DateTime.UtcNow support in LINQ queries for the SQL Server provider

### DIFF
--- a/src/EntityFramework.SqlServer/Query/Methods/DateTimeNowTranslator.cs
+++ b/src/EntityFramework.SqlServer/Query/Methods/DateTimeNowTranslator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -15,10 +15,16 @@ namespace Microsoft.Data.Entity.SqlServer.Query.Methods
         public virtual Expression Translate([NotNull] MemberExpression memberExpression)
         {
             if (memberExpression.Expression == null
-                && memberExpression.Member.DeclaringType == typeof(DateTime)
-                && memberExpression.Member.Name == "Now")
+                && memberExpression.Member.DeclaringType == typeof(DateTime))
             {
-                return new SqlFunctionExpression("GETDATE", Enumerable.Empty<Expression>(), memberExpression.Type);
+                if (memberExpression.Member.Name == "Now")
+                {
+                    return new SqlFunctionExpression("GETDATE", Enumerable.Empty<Expression>(), memberExpression.Type);
+                }
+                else if (memberExpression.Member.Name == "UtcNow")
+                {
+                    return new SqlFunctionExpression("GETUTCDATE", Enumerable.Empty<Expression>(), memberExpression.Type);
+                }
             }
 
             return null;

--- a/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
@@ -881,6 +881,15 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs => cs.Where(c => DateTime.Now != myDatetime),
                 entryCount: 91);
         }
+        
+        [Fact]
+        public virtual void Where_datetime_utcnow()
+        {
+            var myDatetime = new DateTime(2015, 4, 10);
+            AssertQuery<Customer>(
+                cs => cs.Where(c => DateTime.UtcNow != myDatetime),
+                entryCount: 91);
+        }
 
         [Fact]
         public virtual void Where_simple_reversed()


### PR DESCRIPTION
As mentioned in issue [#2872](https://github.com/aspnet/EntityFramework/issues/2872)
This allows use of DateTime.UtcNow in LINQ queries.