### PR TITLE
Avoid using navigation properties for fixup when FK is source of truth

### DIFF
--- a/test/EntityFramework.Core.Tests/ChangeTracking/ChangeTrackerTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/ChangeTrackerTest.cs
@@ -232,9 +232,9 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
                         Id = 1,
                         Products = new List<Product>
                             {
-                                new Product { Id = 1, Details = new ProductDetails { Id = 1 } },
-                                new Product { Id = 2, Details = new ProductDetails { Id = 2 } },
-                                new Product { Id = 3, Details = new ProductDetails { Id = 3 } }
+                                new Product { Id = 1, CategoryId = 1, Details = new ProductDetails { Id = 1 } },
+                                new Product { Id = 2, CategoryId = 1, Details = new ProductDetails { Id = 2 } },
+                                new Product { Id = 3, CategoryId = 1, Details = new ProductDetails { Id = 3 } }
                             }
                     };
 
@@ -259,7 +259,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
                 Assert.Equal(EntityState.Unchanged, context.Entry(category.Products[2].Details).State);
 
                 Assert.Same(category, category.Products[0].Category);
-                Assert.Same(category, category.Products[1].Category);
+                Assert.Null(category.Products[1].Category);
                 Assert.Same(category, category.Products[2].Category);
 
                 Assert.Equal(category.Id, category.Products[0].CategoryId);
@@ -326,9 +326,9 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
                         Id = 77,
                         Products = new List<Product>
                             {
-                                new Product { Id = 77 },
-                                new Product { Id = 0 },
-                                new Product { Id = 78 }
+                                new Product { Id = 77, CategoryId = expectModified ? 0 : 77 },
+                                new Product { Id = 0, CategoryId = expectModified ? 0 : 77 },
+                                new Product { Id = 78, CategoryId = expectModified ? 0 : 77 }
                             }
                     };
 
@@ -369,9 +369,9 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
                         Id = 77,
                         Products = new List<Product>
                             {
-                                new Product { Id = 77 },
-                                new Product { Id = 0 },
-                                new Product { Id = 78 }
+                                new Product { Id = 77, CategoryId = 77 },
+                                new Product { Id = 0, CategoryId = 77 },
+                                new Product { Id = 78, CategoryId = 77 }
                             }
                     };
 

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
@@ -1565,6 +1565,9 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entry = stateManager.GetOrCreateEntry(category);
             entry.SetEntityState(EntityState.Unchanged);
 
+            product1.Category = category;
+            product2.Category = category;
+
             category.Products.Remove(product1);
 
             // DetectChanges still needed here because INotifyCollectionChanged not supported (Issue #445)

--- a/test/EntityFramework.Core.Tests/DbContextTest.cs
+++ b/test/EntityFramework.Core.Tests/DbContextTest.cs
@@ -722,7 +722,7 @@ namespace Microsoft.Data.Entity.Tests
 
                 context.Attach(category);
 
-                Assert.Equal(1, product.CategoryId);
+                Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
                 Assert.Same(category, product.Category);
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
@@ -730,7 +730,7 @@ namespace Microsoft.Data.Entity.Tests
 
                 context.Attach(product);
 
-                Assert.Equal(1, product.CategoryId);
+                Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
                 Assert.Same(category, product.Category);
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
@@ -751,19 +751,19 @@ namespace Microsoft.Data.Entity.Tests
 
                 context.Attach(product);
 
-                Assert.Equal(1, product.CategoryId);
+                Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
                 Assert.Same(category, product.Category);
                 Assert.Equal(EntityState.Detached, context.Entry(category).State);
-                Assert.Equal(EntityState.Modified, context.Entry(product).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
 
                 context.Attach(category);
 
-                Assert.Equal(1, product.CategoryId);
+                Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
                 Assert.Same(category, product.Category);
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
-                Assert.Equal(EntityState.Modified, context.Entry(product).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
             }
         }
 
@@ -786,11 +786,11 @@ namespace Microsoft.Data.Entity.Tests
 
                 context.Attach(product);
 
-                Assert.Equal(1, product.CategoryId);
-                Assert.Same(product, category.Products.Single());
+                Assert.Equal(7, product.CategoryId);
+                Assert.Empty(category.Products);
                 Assert.Same(category, product.Category);
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
-                Assert.Equal(EntityState.Modified, context.Entry(product).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
             }
         }
 
@@ -805,19 +805,19 @@ namespace Microsoft.Data.Entity.Tests
 
                 context.Attach(product);
 
-                Assert.Equal(1, product.CategoryId);
-                Assert.Same(product, category.Products.Single());
+                Assert.Equal(7, product.CategoryId);
+                Assert.Empty(category.Products);
                 Assert.Same(category, product.Category);
                 Assert.Equal(EntityState.Detached, context.Entry(category).State);
-                Assert.Equal(EntityState.Modified, context.Entry(product).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
 
                 context.Attach(category);
 
-                Assert.Equal(1, product.CategoryId);
-                Assert.Same(product, category.Products.Single());
+                Assert.Equal(7, product.CategoryId);
+                Assert.Empty(category.Products);
                 Assert.Same(category, product.Category);
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
-                Assert.Equal(EntityState.Modified, context.Entry(product).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
             }
         }
 
@@ -832,20 +832,18 @@ namespace Microsoft.Data.Entity.Tests
 
                 context.Attach(category);
 
-                Assert.Equal(1, product.CategoryId);
+                Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
-                Assert.Same(category, product.Category);
+                Assert.Null(product.Category);
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
                 Assert.Equal(EntityState.Detached, context.Entry(product).State);
 
                 context.Attach(product);
 
-                Assert.Equal(1, product.CategoryId);
+                Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
-                Assert.Same(category, product.Category);
+                Assert.Null(product.Category);
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
-
-                // Dependent is Unchanged here because the FK change happened before it was attached
                 Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
             }
         }
@@ -869,11 +867,11 @@ namespace Microsoft.Data.Entity.Tests
 
                 context.Attach(category);
 
-                Assert.Equal(1, product.CategoryId);
+                Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
-                Assert.Same(category, product.Category);
+                Assert.Null(product.Category);
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
-                Assert.Equal(EntityState.Modified, context.Entry(product).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
             }
         }
 
@@ -888,7 +886,7 @@ namespace Microsoft.Data.Entity.Tests
 
                 context.Entry(category).State = EntityState.Unchanged;
 
-                Assert.Equal(1, product.CategoryId);
+                Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
                 Assert.Same(category, product.Category);
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
@@ -896,7 +894,7 @@ namespace Microsoft.Data.Entity.Tests
 
                 context.Entry(product).State = EntityState.Unchanged;
 
-                Assert.Equal(1, product.CategoryId);
+                Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
                 Assert.Same(category, product.Category);
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
@@ -917,19 +915,19 @@ namespace Microsoft.Data.Entity.Tests
 
                 context.Entry(product).State = EntityState.Unchanged;
 
-                Assert.Equal(1, product.CategoryId);
+                Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
                 Assert.Same(category, product.Category);
                 Assert.Equal(EntityState.Detached, context.Entry(category).State);
-                Assert.Equal(EntityState.Modified, context.Entry(product).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
 
                 context.Entry(category).State = EntityState.Unchanged;
 
-                Assert.Equal(1, product.CategoryId);
+                Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
                 Assert.Same(category, product.Category);
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
-                Assert.Equal(EntityState.Modified, context.Entry(product).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
             }
         }
 
@@ -952,11 +950,11 @@ namespace Microsoft.Data.Entity.Tests
 
                 context.Entry(product).State = EntityState.Unchanged;
 
-                Assert.Equal(1, product.CategoryId);
-                Assert.Same(product, category.Products.Single());
+                Assert.Equal(7, product.CategoryId);
+                Assert.Empty(category.Products);
                 Assert.Same(category, product.Category);
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
-                Assert.Equal(EntityState.Modified, context.Entry(product).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
             }
         }
 
@@ -971,19 +969,19 @@ namespace Microsoft.Data.Entity.Tests
 
                 context.Entry(product).State = EntityState.Unchanged;
 
-                Assert.Equal(1, product.CategoryId);
-                Assert.Same(product, category.Products.Single());
+                Assert.Equal(7, product.CategoryId);
+                Assert.Empty(category.Products);
                 Assert.Same(category, product.Category);
                 Assert.Equal(EntityState.Detached, context.Entry(category).State);
-                Assert.Equal(EntityState.Modified, context.Entry(product).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
 
                 context.Entry(category).State = EntityState.Unchanged;
 
-                Assert.Equal(1, product.CategoryId);
-                Assert.Same(product, category.Products.Single());
+                Assert.Equal(7, product.CategoryId);
+                Assert.Empty(category.Products);
                 Assert.Same(category, product.Category);
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
-                Assert.Equal(EntityState.Modified, context.Entry(product).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
             }
         }
 
@@ -998,20 +996,18 @@ namespace Microsoft.Data.Entity.Tests
 
                 context.Entry(category).State = EntityState.Unchanged;
 
-                Assert.Equal(1, product.CategoryId);
+                Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
-                Assert.Same(category, product.Category);
+                Assert.Null(product.Category);
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
                 Assert.Equal(EntityState.Detached, context.Entry(product).State);
 
                 context.Entry(product).State = EntityState.Unchanged;
 
-                Assert.Equal(1, product.CategoryId);
+                Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
-                Assert.Same(category, product.Category);
+                Assert.Null(product.Category);
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
-
-                // Dependent is Unchanged here because the FK change happened before it was attached
                 Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
             }
         }
@@ -1035,11 +1031,11 @@ namespace Microsoft.Data.Entity.Tests
 
                 context.Entry(category).State = EntityState.Unchanged;
 
-                Assert.Equal(1, product.CategoryId);
+                Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
-                Assert.Same(category, product.Category);
+                Assert.Null(product.Category);
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
-                Assert.Equal(EntityState.Modified, context.Entry(product).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
             }
         }
 
@@ -1056,7 +1052,7 @@ namespace Microsoft.Data.Entity.Tests
 
                 context.Attach(category);
 
-                Assert.Equal(1, product.CategoryId);
+                Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
                 Assert.Same(category, product.Category);
                 Assert.Empty(category7.Products);
@@ -1065,13 +1061,12 @@ namespace Microsoft.Data.Entity.Tests
 
                 context.Attach(product);
 
-                Assert.Equal(1, product.CategoryId);
+                Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
-                Assert.Same(category, product.Category);
-                Assert.Empty(category7.Products);
+                Assert.Same(category7, product.Category);
+                Assert.Same(product, category7.Products.Single());
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
 
-                // Dependent is Unchanged here because the FK change happened before it was attached
                 Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
             }
         }
@@ -1089,21 +1084,21 @@ namespace Microsoft.Data.Entity.Tests
 
                 context.Attach(product);
 
-                Assert.Equal(1, product.CategoryId);
+                Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
-                Assert.Same(category, product.Category);
-                Assert.Empty(category7.Products);
+                Assert.Same(category7, product.Category);
+                Assert.Same(product, category7.Products.Single());
                 Assert.Equal(EntityState.Detached, context.Entry(category).State);
-                Assert.Equal(EntityState.Modified, context.Entry(product).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
 
                 context.Attach(category);
 
-                Assert.Equal(1, product.CategoryId);
+                Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
-                Assert.Same(category, product.Category);
-                Assert.Empty(category7.Products);
+                Assert.Same(category7, product.Category);
+                Assert.Same(product, category7.Products.Single());
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
-                Assert.Equal(EntityState.Modified, context.Entry(product).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
             }
         }
 
@@ -1129,12 +1124,12 @@ namespace Microsoft.Data.Entity.Tests
 
                 context.Attach(product);
 
-                Assert.Equal(1, product.CategoryId);
-                Assert.Same(product, category.Products.Single());
-                Assert.Same(category, product.Category);
-                Assert.Empty(category7.Products);
+                Assert.Equal(7, product.CategoryId);
+                Assert.Empty(category.Products);
+                Assert.Same(category7, product.Category);
+                Assert.Same(product, category7.Products.Single());
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
-                Assert.Equal(EntityState.Modified, context.Entry(product).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
             }
         }
 
@@ -1151,21 +1146,21 @@ namespace Microsoft.Data.Entity.Tests
 
                 context.Attach(product);
 
-                Assert.Equal(1, product.CategoryId);
-                Assert.Same(product, category.Products.Single());
-                Assert.Same(category, product.Category);
-                Assert.Empty(category7.Products);
+                Assert.Equal(7, product.CategoryId);
+                Assert.Empty(category.Products);
+                Assert.Same(category7, product.Category);
+                Assert.Same(product, category7.Products.Single());
                 Assert.Equal(EntityState.Detached, context.Entry(category).State);
-                Assert.Equal(EntityState.Modified, context.Entry(product).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
 
                 context.Attach(category);
 
-                Assert.Equal(1, product.CategoryId);
-                Assert.Same(product, category.Products.Single());
-                Assert.Same(category, product.Category);
-                Assert.Empty(category7.Products);
+                Assert.Equal(7, product.CategoryId);
+                Assert.Empty(category.Products);
+                Assert.Same(category7, product.Category);
+                Assert.Same(product, category7.Products.Single());
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
-                Assert.Equal(EntityState.Modified, context.Entry(product).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
             }
         }
 
@@ -1182,22 +1177,20 @@ namespace Microsoft.Data.Entity.Tests
 
                 context.Attach(category);
 
-                Assert.Equal(1, product.CategoryId);
+                Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
-                Assert.Same(category, product.Category);
+                Assert.Null(product.Category);
                 Assert.Empty(category7.Products);
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
                 Assert.Equal(EntityState.Detached, context.Entry(product).State);
 
                 context.Attach(product);
 
-                Assert.Equal(1, product.CategoryId);
+                Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
-                Assert.Same(category, product.Category);
-                Assert.Empty(category7.Products);
+                Assert.Same(category7, product.Category);
+                Assert.Same(product, category7.Products.Single());
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
-
-                // Dependent is Unchanged here because the FK change happened before it was attached
                 Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
             }
         }
@@ -1224,12 +1217,12 @@ namespace Microsoft.Data.Entity.Tests
 
                 context.Attach(category);
 
-                Assert.Equal(1, product.CategoryId);
+                Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
-                Assert.Same(category, product.Category);
-                Assert.Empty(category7.Products);
+                Assert.Same(category7, product.Category);
+                Assert.Same(product, category7.Products.Single());
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
-                Assert.Equal(EntityState.Modified, context.Entry(product).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
             }
         }
 
@@ -1246,7 +1239,7 @@ namespace Microsoft.Data.Entity.Tests
 
                 context.Entry(category).State = EntityState.Unchanged;
 
-                Assert.Equal(1, product.CategoryId);
+                Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
                 Assert.Same(category, product.Category);
                 Assert.Empty(category7.Products);
@@ -1255,13 +1248,11 @@ namespace Microsoft.Data.Entity.Tests
 
                 context.Entry(product).State = EntityState.Unchanged;
 
-                Assert.Equal(1, product.CategoryId);
+                Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
-                Assert.Same(category, product.Category);
-                Assert.Empty(category7.Products);
+                Assert.Same(category7, product.Category);
+                Assert.Same(product, category7.Products.Single());
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
-
-                // Dependent is Unchanged here because the FK change happened before it was attached
                 Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
             }
         }
@@ -1279,21 +1270,21 @@ namespace Microsoft.Data.Entity.Tests
 
                 context.Entry(product).State = EntityState.Unchanged;
 
-                Assert.Equal(1, product.CategoryId);
+                Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
-                Assert.Same(category, product.Category);
-                Assert.Empty(category7.Products);
+                Assert.Same(category7, product.Category);
+                Assert.Same(product, category7.Products.Single());
                 Assert.Equal(EntityState.Detached, context.Entry(category).State);
-                Assert.Equal(EntityState.Modified, context.Entry(product).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
 
                 context.Entry(category).State = EntityState.Unchanged;
 
-                Assert.Equal(1, product.CategoryId);
+                Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
-                Assert.Same(category, product.Category);
-                Assert.Empty(category7.Products);
+                Assert.Same(category7, product.Category);
+                Assert.Same(product, category7.Products.Single());
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
-                Assert.Equal(EntityState.Modified, context.Entry(product).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
             }
         }
 
@@ -1319,12 +1310,12 @@ namespace Microsoft.Data.Entity.Tests
 
                 context.Entry(product).State = EntityState.Unchanged;
 
-                Assert.Equal(1, product.CategoryId);
-                Assert.Same(product, category.Products.Single());
-                Assert.Same(category, product.Category);
-                Assert.Empty(category7.Products);
+                Assert.Equal(7, product.CategoryId);
+                Assert.Empty(category.Products);
+                Assert.Same(category7, product.Category);
+                Assert.Same(product, category7.Products.Single());
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
-                Assert.Equal(EntityState.Modified, context.Entry(product).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
             }
         }
 
@@ -1341,21 +1332,21 @@ namespace Microsoft.Data.Entity.Tests
 
                 context.Entry(product).State = EntityState.Unchanged;
 
-                Assert.Equal(1, product.CategoryId);
-                Assert.Same(product, category.Products.Single());
-                Assert.Same(category, product.Category);
-                Assert.Empty(category7.Products);
+                Assert.Equal(7, product.CategoryId);
+                Assert.Empty(category.Products);
+                Assert.Same(category7, product.Category);
+                Assert.Same(product, category7.Products.Single());
                 Assert.Equal(EntityState.Detached, context.Entry(category).State);
-                Assert.Equal(EntityState.Modified, context.Entry(product).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
 
                 context.Entry(category).State = EntityState.Unchanged;
 
-                Assert.Equal(1, product.CategoryId);
-                Assert.Same(product, category.Products.Single());
-                Assert.Same(category, product.Category);
-                Assert.Empty(category7.Products);
+                Assert.Equal(7, product.CategoryId);
+                Assert.Empty(category.Products);
+                Assert.Same(category7, product.Category);
+                Assert.Same(product, category7.Products.Single());
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
-                Assert.Equal(EntityState.Modified, context.Entry(product).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
             }
         }
 
@@ -1372,22 +1363,20 @@ namespace Microsoft.Data.Entity.Tests
 
                 context.Entry(category).State = EntityState.Unchanged;
 
-                Assert.Equal(1, product.CategoryId);
+                Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
-                Assert.Same(category, product.Category);
+                Assert.Null(product.Category);
                 Assert.Empty(category7.Products);
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
                 Assert.Equal(EntityState.Detached, context.Entry(product).State);
 
                 context.Entry(product).State = EntityState.Unchanged;
 
-                Assert.Equal(1, product.CategoryId);
+                Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
-                Assert.Same(category, product.Category);
-                Assert.Empty(category7.Products);
+                Assert.Same(category7, product.Category);
+                Assert.Same(product, category7.Products.Single());
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
-
-                // Dependent is Unchanged here because the FK change happened before it was attached
                 Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
             }
         }
@@ -1414,12 +1403,12 @@ namespace Microsoft.Data.Entity.Tests
 
                 context.Entry(category).State = EntityState.Unchanged;
 
-                Assert.Equal(1, product.CategoryId);
+                Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
-                Assert.Same(category, product.Category);
-                Assert.Empty(category7.Products);
+                Assert.Same(category7, product.Category);
+                Assert.Same(product, category7.Products.Single());
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
-                Assert.Equal(EntityState.Modified, context.Entry(product).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
             }
         }
 


### PR DESCRIPTION
When an entity is queried or attached, the value of the FK property defines the relationship, which means there is no need to scan navigations in order to try to do fixup, thereby improving perf.