### PR TITLE
Migrations: Use an attribute for migration ID

### DIFF
--- a/src/EntityFramework.Commands/Executor.cs
+++ b/src/EntityFramework.Commands/Executor.cs
@@ -248,7 +248,7 @@ namespace Microsoft.Data.Entity.Commands
 
         public virtual IEnumerable<IDictionary> GetMigrationsImpl([CanBeNull] string contextTypeName) =>
             CreateMigrationTool().GetMigrations(contextTypeName, _startupAssemblyName).Select(
-                m => new Hashtable { ["MigrationId"] = m.Id, ["MigrationName"] = m.Id, ["SafeName"] = m.Id });
+                id => new Hashtable {["MigrationId"] = id,["MigrationName"] = id,["SafeName"] = id });
 
         public class ReverseEngineer : OperationBase
         {

--- a/src/EntityFramework.Commands/MigrationTool.cs
+++ b/src/EntityFramework.Commands/MigrationTool.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Data.Entity.Commands
             }
         }
 
-        public virtual IEnumerable<Migration> GetMigrations(
+        public virtual IEnumerable<string> GetMigrations(
             [CanBeNull] string contextTypeName,
             [CanBeNull] string startupAssemblyName)
         {
@@ -74,7 +74,7 @@ namespace Microsoft.Data.Entity.Commands
                 var services = new DesignTimeServices(((IAccessor<IServiceProvider>)context).Service);
                 var migrationsAssembly = services.GetRequiredService<IMigrationsAssembly>();
 
-                return migrationsAssembly.Migrations;
+                return migrationsAssembly.Migrations.Keys;
             }
         }
 

--- a/src/EntityFramework.Commands/Migrations/CSharpMigrationGenerator.cs
+++ b/src/EntityFramework.Commands/Migrations/CSharpMigrationGenerator.cs
@@ -136,20 +136,12 @@ namespace Microsoft.Data.Entity.Commands.Migrations
             {
                 builder
                     .Append("[DbContext(typeof(").Append(_code.Reference(contextType)).AppendLine("))]")
+                    .Append("[Migration(").Append(_code.Literal(migrationId)).AppendLine(")]")
                     .Append("partial class ").AppendLine(_code.Identifier(migrationName))
                     .AppendLine("{");
                 using (builder.Indent())
                 {
                     builder
-                        .AppendLine("public override string Id")
-                        .AppendLine("{");
-                    using (builder.Indent())
-                    {
-                        builder.Append("get { return ").Append(_code.Literal(migrationId)).AppendLine("; }");
-                    }
-                    builder
-                        .AppendLine("}")
-                        .AppendLine()
                         .AppendLine("protected override void BuildTargetModel(ModelBuilder modelBuilder)")
                         .AppendLine("{");
                     using (builder.Indent())

--- a/src/EntityFramework.Commands/Program.cs
+++ b/src/EntityFramework.Commands/Program.cs
@@ -12,9 +12,9 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Commands.Utilities;
 using Microsoft.Data.Entity.Utilities;
-using Microsoft.Framework.Logging;
 using Microsoft.Dnx.Runtime;
 using Microsoft.Dnx.Runtime.Common.CommandLine;
+using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.Commands
 {
@@ -358,7 +358,7 @@ namespace Microsoft.Data.Entity.Commands
                     var any = false;
                     foreach (var migration in migrations)
                     {
-                        _logger.LogInformation(migration.Id);
+                        _logger.LogInformation(migration);
                         any = true;
                     }
 

--- a/src/EntityFramework.Core/Infrastructure/DbContextAttribute.cs
+++ b/src/EntityFramework.Core/Infrastructure/DbContextAttribute.cs
@@ -8,7 +8,7 @@ using Microsoft.Data.Entity.Utilities;
 namespace Microsoft.Data.Entity.Infrastructure
 {
     [AttributeUsage(AttributeTargets.Class)]
-    public class DbContextAttribute : Attribute
+    public sealed class DbContextAttribute : Attribute
     {
         public DbContextAttribute([NotNull] Type contextType)
         {
@@ -17,6 +17,6 @@ namespace Microsoft.Data.Entity.Infrastructure
             ContextType = contextType;
         }
 
-        public virtual Type ContextType { get; }
+        public Type ContextType { get; }
     }
 }

--- a/src/EntityFramework.Core/Query/QueryAnnotationMethodAttribute.cs
+++ b/src/EntityFramework.Core/Query/QueryAnnotationMethodAttribute.cs
@@ -5,7 +5,8 @@ using System;
 
 namespace Microsoft.Data.Entity.Query
 {
-    public class QueryAnnotationMethodAttribute : Attribute
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class QueryAnnotationMethodAttribute : Attribute
     {
     }
 }

--- a/src/EntityFramework.Relational/EntityFramework.Relational.csproj
+++ b/src/EntityFramework.Relational/EntityFramework.Relational.csproj
@@ -77,6 +77,8 @@
     <Compile Include="Metadata\RelationalEntityTypeExtensions.cs" />
     <Compile Include="Metadata\RelationalModelExtensions.cs" />
     <Compile Include="Metadata\RelationalPropertyExtensions.cs" />
+    <Compile Include="Migrations\Internal\MigrationExtensions.cs" />
+    <Compile Include="Migrations\MigrationAttribute.cs" />
     <Compile Include="Migrations\MigrationsAssemblyExtensions.cs" />
     <Compile Include="Query\Expressions\CrossApplyExpression.cs" />
     <Compile Include="Query\Internal\RelationalExpressionPrinter.cs" />

--- a/src/EntityFramework.Relational/Migrations/IMigrationsAssembly.cs
+++ b/src/EntityFramework.Relational/Migrations/IMigrationsAssembly.cs
@@ -2,14 +2,16 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Reflection;
 using JetBrains.Annotations;
 
 namespace Microsoft.Data.Entity.Migrations
 {
     public interface IMigrationsAssembly
     {
-        IReadOnlyList<Migration> Migrations { get; }
+        IReadOnlyDictionary<string, TypeInfo> Migrations { get; }
         ModelSnapshot ModelSnapshot { get; }
-        Migration FindMigration([NotNull] string nameOrId);
+        string FindMigrationId([NotNull] string nameOrId);
+        Migration CreateMigration([NotNull] TypeInfo migrationClass);
     }
 }

--- a/src/EntityFramework.Relational/Migrations/Internal/MigrationExtensions.cs
+++ b/src/EntityFramework.Relational/Migrations/Internal/MigrationExtensions.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+using JetBrains.Annotations;
+
+namespace Microsoft.Data.Entity.Migrations.Internal
+{
+    public static class MigrationExtensions
+    {
+        public static string GetId([NotNull] this Migration migration)
+            => migration.GetType().GetTypeInfo().GetCustomAttribute<MigrationAttribute>()?.Id;
+    }
+}

--- a/src/EntityFramework.Relational/Migrations/Migration.cs
+++ b/src/EntityFramework.Relational/Migrations/Migration.cs
@@ -33,8 +33,6 @@ namespace Microsoft.Data.Entity.Migrations
             _downOperations = new LazyRef<List<MigrationOperation>>(() => BuildOperations(Down));
         }
 
-        public abstract string Id { get; }
-
         public virtual IModel TargetModel => _targetModel.Value;
         public virtual IReadOnlyList<MigrationOperation> UpOperations => _upOperations.Value;
         public virtual IReadOnlyList<MigrationOperation> DownOperations => _downOperations.Value;

--- a/src/EntityFramework.Relational/Migrations/MigrationAttribute.cs
+++ b/src/EntityFramework.Relational/Migrations/MigrationAttribute.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Migrations
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public sealed class MigrationAttribute : Attribute
+    {
+        public MigrationAttribute([NotNull] string id)
+        {
+            Check.NotEmpty(id, nameof(id));
+
+            Id = id;
+        }
+
+        public string Id { get; }
+    }
+}

--- a/src/EntityFramework.Relational/Migrations/MigrationsAssemblyExtensions.cs
+++ b/src/EntityFramework.Relational/Migrations/MigrationsAssemblyExtensions.cs
@@ -10,18 +10,18 @@ namespace Microsoft.Data.Entity.Migrations
 {
     public static class MigrationsAssemblyExtensions
     {
-        public static Migration GetMigration([NotNull] this IMigrationsAssembly assembly, [NotNull] string nameOrId)
+        public static string GetMigrationId([NotNull] this IMigrationsAssembly assembly, [NotNull] string nameOrId)
         {
             Check.NotNull(assembly, nameof(assembly));
             Check.NotEmpty(nameOrId, nameof(nameOrId));
 
-            var migration = assembly.FindMigration(nameOrId);
-            if (migration == null)
+            var id = assembly.FindMigrationId(nameOrId);
+            if (id == null)
             {
                 throw new InvalidOperationException(Strings.MigrationNotFound(nameOrId));
             }
 
-            return migration;
+            return id;
         }
     }
 }

--- a/src/EntityFramework.Relational/Storage/ProviderDesignTimeServicesAttribute.cs
+++ b/src/EntityFramework.Relational/Storage/ProviderDesignTimeServicesAttribute.cs
@@ -7,24 +7,20 @@ using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Storage
 {
-    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false)]
-    public class ProviderDesignTimeServicesAttribute : Attribute
+    [AttributeUsage(AttributeTargets.Assembly)]
+    public sealed class ProviderDesignTimeServicesAttribute : Attribute
     {
-        public ProviderDesignTimeServicesAttribute([NotNull] string typeName)
-            : this(typeName, null)
-        {
-        }
-
         public ProviderDesignTimeServicesAttribute(
-            [NotNull] string typeName, [CanBeNull] string assemblyName)
+            [NotNull] string typeName, [NotNull] string assemblyName)
         {
-            Check.NotNull(typeName, nameof(typeName));
+            Check.NotEmpty(typeName, nameof(typeName));
+            Check.NotEmpty(assemblyName, nameof(assemblyName));
 
             TypeName = typeName;
             AssemblyName = assemblyName;
         }
 
-        public virtual string TypeName { get; }
-        public virtual string AssemblyName { get; }
+        public string TypeName { get; }
+        public string AssemblyName { get; }
     }
 }

--- a/test/EntityFramework.Commands.FunctionalTests/ExecutorTest.cs
+++ b/test/EntityFramework.Commands.FunctionalTests/ExecutorTest.cs
@@ -89,10 +89,9 @@ namespace Microsoft.Data.Entity.Commands
                                 namespace Migrations
                                 {
                                     [DbContext(typeof(SimpleContext))]
+                                    [Migration(""201410102227260_InitialCreate"")]
                                     public class InitialCreate : Migration
                                     {
-                                        public override string Id => ""201410102227260_InitialCreate"";
-
                                         protected override void Up(MigrationBuilder migrationBuilder)
                                         {
                                         }
@@ -172,10 +171,9 @@ namespace Microsoft.Data.Entity.Commands
                                 namespace Context1Migrations
                                 {
                                     [DbContext(typeof(Context1))]
+                                    [Migration(""000000000000000_Context1Migration"")]
                                     public class Context1Migration : Migration
                                     {
-                                        public override string Id => ""000000000000000_Context1Migration"";
-
                                         protected override void Up(MigrationBuilder migrationBuilder)
                                         {
                                         }
@@ -185,10 +183,9 @@ namespace Microsoft.Data.Entity.Commands
                                 namespace Context2Migrations
                                 {
                                     [DbContext(typeof(Context2))]
+                                    [Migration(""000000000000000_Context2Migration"")]
                                     public class Context2Migration : Migration
                                     {
-                                        public override string Id => ""000000000000000_Context2Migration"";
-
                                         protected override void Up(MigrationBuilder migrationBuilder)
                                         {
                                         }
@@ -267,10 +264,9 @@ namespace Microsoft.Data.Entity.Commands
                                 namespace Context1Migrations
                                 {
                                     [DbContext(typeof(Context1))]
+                                    [Migration(""000000000000000_Context1Migration"")]
                                     public class Context1Migration : Migration
                                     {
-                                        public override string Id => ""000000000000000_Context1Migration"";
-
                                         protected override void Up(MigrationBuilder migrationBuilder)
                                         {
                                         }
@@ -280,10 +276,9 @@ namespace Microsoft.Data.Entity.Commands
                                 namespace Context2Migrations
                                 {
                                     [DbContext(typeof(Context2))]
+                                    [Migration(""000000000000000_Context2Migration"")]
                                     public class Context2Migration : Migration
                                     {
-                                        public override string Id => ""000000000000000_Context2Migration"";
-
                                         protected override void Up(MigrationBuilder migrationBuilder)
                                         {
                                         }

--- a/test/EntityFramework.Commands.FunctionalTests/Migrations/CodeCompilationTest.cs
+++ b/test/EntityFramework.Commands.FunctionalTests/Migrations/CodeCompilationTest.cs
@@ -9,6 +9,7 @@ using Microsoft.Data.Entity.Commands.Utilities;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Migrations;
+using Microsoft.Data.Entity.Migrations.Internal;
 using Microsoft.Data.Entity.Migrations.Operations;
 using Xunit;
 
@@ -78,13 +79,9 @@ using System.Text.RegularExpressions;
 namespace MyNamespace
 {
     [DbContext(typeof(CodeCompilationTest.MyContext))]
+    [Migration(""20150511161616_MyMigration"")]
     partial class MyMigration
     {
-        public override string Id
-        {
-            get { return ""20150511161616_MyMigration""; }
-        }
-
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
             modelBuilder
@@ -122,7 +119,7 @@ namespace MyNamespace
 
             var migration = (Migration)Activator.CreateInstance(migrationType);
 
-            Assert.Equal("20150511161616_MyMigration", migration.Id);
+            Assert.Equal("20150511161616_MyMigration", migration.GetId());
 
             Assert.Equal(1, migration.UpOperations.Count);
             Assert.Empty(migration.DownOperations);

--- a/test/EntityFramework.Relational.FunctionalTests/MigrationsFixtureBase.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/MigrationsFixtureBase.cs
@@ -47,10 +47,9 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [DbContext(typeof(MigrationsContext))]
+        [Migration("00000000000001_Migration1")]
         private class Migration1 : Migration
         {
-            public override string Id => "00000000000001_Migration1";
-
             protected override void Up(MigrationBuilder migrationBuilder)
             {
                 migrationBuilder
@@ -72,10 +71,9 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [DbContext(typeof(MigrationsContext))]
+        [Migration("00000000000002_Migration2")]
         private class Migration2 : Migration
         {
-            public override string Id => "00000000000002_Migration2";
-
             protected override void Up(MigrationBuilder migrationBuilder)
             {
                 migrationBuilder.RenameTable(

--- a/test/EntityFramework.Relational.Tests/Migrations/Internal/MigrationsAssemblyTest.cs
+++ b/test/EntityFramework.Relational.Tests/Migrations/Internal/MigrationsAssemblyTest.cs
@@ -12,31 +12,27 @@ namespace Microsoft.Data.Entity.Migrations.Internal
     public class MigrationsAssemblyTest
     {
         [Fact]
-        public void FindMigration_matches_id_when_exact_case()
-            => Assert.IsType<Migration2>(CreateMigrationsAssembly().FindMigration("20150302103100_FLUTTER"));
+        public void FindMigrationId_returns_first_candidate_when_id()
+            => Assert.Equal(
+                "20150302103100_Flutter",
+                CreateMigrationsAssembly().FindMigrationId("20150302103100_FLUTTER"));
 
         [Fact]
-        public void FindMigration_returns_first_candidate_migration()
-            => Assert.IsType<Migration1>(CreateMigrationsAssembly().FindMigration("20150302103100_flutter"));
+        public void FindMigrationId_returns_first_candidate_when_name()
+            => Assert.Equal(
+                "20150302103100_Flutter",
+                CreateMigrationsAssembly().FindMigrationId("FLUTTER"));
 
         [Fact]
-        public void FindMigration_matches_name_when_exact_case()
-            => Assert.IsType<Migration2>(CreateMigrationsAssembly().FindMigration("FLUTTER"));
+        public void FindMigrationId_returns_null_when_no_match()
+            => Assert.Null(CreateMigrationsAssembly().FindMigrationId("Spike"));
 
         [Fact]
-        public void FindMigration_returns_migration_of_first_candidate_name()
-            => Assert.IsType<Migration1>(CreateMigrationsAssembly().FindMigration("flutter"));
-
-        [Fact]
-        public void FindMigration_returns_null_when_no_match()
-            => Assert.Null(CreateMigrationsAssembly().FindMigration("Spike"));
-
-        [Fact]
-        public void GetMigration_throws_when_no_match()
+        public void GetMigrationId_throws_when_no_match()
             => Assert.Equal(
                 Strings.MigrationNotFound("Spike"),
                 Assert.Throws<InvalidOperationException>(
-                        () => CreateMigrationsAssembly().GetMigration("Spike"))
+                        () => CreateMigrationsAssembly().GetMigrationId("Spike"))
                     .Message);
 
         private IMigrationsAssembly CreateMigrationsAssembly()
@@ -54,20 +50,18 @@ namespace Microsoft.Data.Entity.Migrations.Internal
         }
 
         [DbContext(typeof(Context))]
+        [Migration("20150302103100_Flutter")]
         private class Migration1 : Migration
         {
-            public override string Id { get; } = "20150302103100_Flutter";
-
             protected override void Up(MigrationBuilder migrationBuilder)
             {
             }
         }
 
         [DbContext(typeof(Context))]
+        [Migration("20150302103100_FLUTTER")]
         private class Migration2 : Migration
         {
-            public override string Id { get; } = "20150302103100_FLUTTER";
-
             protected override void Up(MigrationBuilder migrationBuilder)
             {
             }

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerMigrationsTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerMigrationsTest.cs
@@ -60,13 +60,12 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         }
 
         [DbContext(typeof(BloggingContext))]
+        [Migration("00000000000000_Empty")]
         public class EmptyMigration : Migration
         {
             protected override void Up(MigrationBuilder migrationBuilder)
             {
             }
-
-            public override string Id => "Empty";
         }
     }
 }


### PR DESCRIPTION
Also avoids instantiating `Migration` classes unnecessarily.

Resolves #2832