### PR TITLE
Improve perf for snapshotting original values

### DIFF
--- a/src/EntityFramework.Core/ChangeTracking/Internal/ArraySidecar.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/ArraySidecar.cs
@@ -24,10 +24,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
         protected override object ReadValue(IPropertyBase property) => _values[IndexChecked(property)];
 
-        protected override void WriteValue(IPropertyBase property, object value)
-        {
-            _values[IndexChecked(property)] = value;
-        }
+        protected override void WriteValue(IPropertyBase property, object value) => _values[IndexChecked(property)] = value;
 
         private int IndexChecked(IPropertyBase property)
         {

--- a/src/EntityFramework.Core/ChangeTracking/Internal/IInternalEntityEntrySubscriber.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/IInternalEntityEntrySubscriber.cs
@@ -2,11 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Storage;
 
 namespace Microsoft.Data.Entity.ChangeTracking.Internal
 {
     public interface IInternalEntityEntrySubscriber
     {
-        InternalEntityEntry SnapshotAndSubscribe([NotNull] InternalEntityEntry entry);
+        InternalEntityEntry SnapshotAndSubscribe([NotNull] InternalEntityEntry entry, ValueBuffer? values);
     }
 }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -36,8 +36,15 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
         protected virtual IEntityEntryMetadataServices MetadataServices { get; }
 
-        public virtual Sidecar OriginalValues => TryGetSidecar(Sidecar.WellKnownNames.OriginalValues)
-                                                 ?? AddSidecar(MetadataServices.CreateOriginalValues(this));
+        public virtual Sidecar OriginalValues
+        {
+            get
+            {
+                return TryGetSidecar(Sidecar.WellKnownNames.OriginalValues)
+                       ?? AddSidecar(MetadataServices.CreateOriginalValues(this));
+            }
+            [param: NotNull] set { AddSidecar(value); }
+        }
 
         public virtual Sidecar RelationshipsSnapshot => TryGetSidecar(Sidecar.WellKnownNames.RelationshipsSnapshot)
                                                         ?? AddSidecar(MetadataServices.CreateRelationshipSnapshot(this));

--- a/src/EntityFramework.Core/ChangeTracking/Internal/StateManager.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/StateManager.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
             // Issue #240
             var entity = entityType.HasClrType() ? Activator.CreateInstance(entityType.ClrType) : null;
 
-            return _subscriber.SnapshotAndSubscribe(_factory.Create(this, entityType, entity));
+            return _subscriber.SnapshotAndSubscribe(_factory.Create(this, entityType, entity), null);
         }
 
         public virtual InternalEntityEntry GetOrCreateEntry(object entity)
@@ -86,7 +86,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
                 var entityType = _model.GetEntityType(entity.GetType());
 
-                entry = _subscriber.SnapshotAndSubscribe(_factory.Create(this, entityType, entity));
+                entry = _subscriber.SnapshotAndSubscribe(_factory.Create(this, entityType, entity), null);
 
                 _detachedEntityReferenceMap[entity] = new WeakReference<InternalEntityEntry>(entry);
             }
@@ -112,7 +112,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
                 return existingEntry;
             }
 
-            var newEntry = _subscriber.SnapshotAndSubscribe(_factory.Create(this, entityType, entity, valueBuffer));
+            var newEntry = _subscriber.SnapshotAndSubscribe(_factory.Create(this, entityType, entity, valueBuffer), valueBuffer);
 
             AddToIdentityMap(entityType, entityKey, newEntry);
 

--- a/src/EntityFramework.Core/ChangeTracking/Internal/ValueBufferOriginalValues.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/ValueBufferOriginalValues.cs
@@ -1,0 +1,24 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Storage;
+
+namespace Microsoft.Data.Entity.ChangeTracking.Internal
+{
+    public class ValueBufferOriginalValues : ValueBufferSidecar
+    {
+        public ValueBufferOriginalValues([NotNull] InternalEntityEntry entry, ValueBuffer values)
+            : base(entry, values)
+        {
+        }
+
+        public override string Name => WellKnownNames.OriginalValues;
+
+        public override bool TransparentRead => false;
+
+        public override bool TransparentWrite => false;
+
+        public override bool AutoCommit => false;
+    }
+}

--- a/src/EntityFramework.Core/ChangeTracking/Internal/ValueBufferSidecar.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/ValueBufferSidecar.cs
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Storage;
+
+namespace Microsoft.Data.Entity.ChangeTracking.Internal
+{
+    public abstract class ValueBufferSidecar : Sidecar
+    {
+        private ValueBuffer _values;
+
+        protected ValueBufferSidecar([NotNull] InternalEntityEntry entry, ValueBuffer values)
+            : base(entry)
+        {
+            _values = values;
+        }
+
+        public override bool CanStoreValue(IPropertyBase property)
+            => property is IProperty;
+
+        protected override object ReadValue(IPropertyBase property)
+            => _values[((IProperty)property).Index] ?? NullSentinel.Value;
+
+        protected override void WriteValue(IPropertyBase property, object value)
+            => _values[((IProperty)property).Index] = value;
+    }
+}

--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -58,6 +58,8 @@
     <Compile Include="ChangeTracking\ChangeTrackerFactory.cs" />
     <Compile Include="ChangeTracking\IChangeTrackerFactory.cs" />
     <Compile Include="ChangeTracking\Internal\SimpleNullSentinelEntityKeyFactory.cs" />
+    <Compile Include="ChangeTracking\Internal\ValueBufferOriginalValues.cs" />
+    <Compile Include="ChangeTracking\Internal\ValueBufferSidecar.cs" />
     <Compile Include="DbUpdateConcurrencyException.cs" />
     <Compile Include="DbUpdateException.cs" />
     <Compile Include="Extensions\Internal\ExpressionExtensions.cs" />

--- a/src/EntityFramework.Core/Metadata/Internal/EntityMaterializerSource.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/EntityMaterializerSource.cs
@@ -24,30 +24,8 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             _memberMapper = memberMapper;
         }
 
-        public virtual Expression CreateReadValueExpression(Expression valueBuffer, Type type, int index)
-        {
-            Expression expression = Expression.Call(valueBuffer, _readValue, Expression.Constant(index));
-
-            if (type.IsNullableType())
-            {
-                var underlyingType = type.UnwrapNullableType();
-                if (underlyingType.GetTypeInfo().IsEnum)
-                {
-                    return Expression.Condition(
-                        Expression.ReferenceEqual(
-                            expression,
-                            Expression.Constant(null)),
-                        Expression.Constant(null, type),
-                        Expression.Convert(
-                            Expression.Convert(
-                                expression,
-                                underlyingType.UnwrapEnumType()),
-                            type));
-                }
-            }
-
-            return Expression.Convert(expression, type);
-        }
+        public virtual Expression CreateReadValueExpression(Expression valueBuffer, Type type, int index) 
+            => Expression.Convert(Expression.Call(valueBuffer, _readValue, Expression.Constant(index)), type);
 
         public virtual Expression CreateMaterializeExpression(
             IEntityType entityType,

--- a/src/EntityFramework.Core/Storage/ValueBuffer.cs
+++ b/src/EntityFramework.Core/Storage/ValueBuffer.cs
@@ -11,15 +11,15 @@ namespace Microsoft.Data.Entity.Storage
     {
         public static readonly ValueBuffer Empty = new ValueBuffer();
 
-        private readonly IReadOnlyList<object> _values;
+        private readonly IList<object> _values;
         private readonly int _offset;
 
-        public ValueBuffer([NotNull] IReadOnlyList<object> values)
+        public ValueBuffer([NotNull] IList<object> values)
             : this(values, 0)
         {
         }
 
-        public ValueBuffer([NotNull] IReadOnlyList<object> values, int offset)
+        public ValueBuffer([NotNull] IList<object> values, int offset)
         {
             Debug.Assert(values != null);
             Debug.Assert(offset >= 0);
@@ -28,7 +28,11 @@ namespace Microsoft.Data.Entity.Storage
             _offset = offset;
         }
 
-        public object this[int index] => _values[_offset + index];
+        public object this[int index]
+        {
+            get { return _values[_offset + index]; }
+            [param: CanBeNull] set { _values[_offset + index] = value; }
+        }
 
         public int Count => _values.Count - _offset;
 

--- a/src/EntityFramework.Relational/Storage/IRelationalValueBufferFactoryFactory.cs
+++ b/src/EntityFramework.Relational/Storage/IRelationalValueBufferFactoryFactory.cs
@@ -10,6 +10,6 @@ namespace Microsoft.Data.Entity.Storage
     public interface IRelationalValueBufferFactoryFactory
     {
         IRelationalValueBufferFactory Create(
-            [NotNull] IReadOnlyCollection<Type> valueTypes, [CanBeNull] IReadOnlyList<int> indexMap);
+            [NotNull] IReadOnlyList<Type> valueTypes, [CanBeNull] IReadOnlyList<int> indexMap);
     }
 }

--- a/src/EntityFramework.Relational/Storage/RemappingUntypedRelationalValueBufferFactory.cs
+++ b/src/EntityFramework.Relational/Storage/RemappingUntypedRelationalValueBufferFactory.cs
@@ -13,12 +13,16 @@ namespace Microsoft.Data.Entity.Storage
     public class RemappingUntypedRelationalValueBufferFactory : IRelationalValueBufferFactory
     {
         private readonly IReadOnlyList<int> _indexMap;
+        private readonly Action<object[]> _processValuesAction;
 
-        public RemappingUntypedRelationalValueBufferFactory([NotNull] IReadOnlyList<int> indexMap)
+        public RemappingUntypedRelationalValueBufferFactory(
+            [NotNull] IReadOnlyList<int> indexMap, 
+            [CanBeNull] Action<object[]> processValuesAction)
         {
             Check.NotNull(indexMap, nameof(indexMap));
 
             _indexMap = indexMap;
+            _processValuesAction = processValuesAction;
         }
 
         public virtual ValueBuffer Create(DbDataReader dataReader)
@@ -34,6 +38,8 @@ namespace Microsoft.Data.Entity.Storage
             var values = new object[dataReader.FieldCount];
 
             dataReader.GetValues(values);
+
+            _processValuesAction?.Invoke(values);
 
             var remappedValues = new object[_indexMap.Count];
 

--- a/src/EntityFramework.Relational/Storage/TypedValueBufferFactoryFactory.cs
+++ b/src/EntityFramework.Relational/Storage/TypedValueBufferFactoryFactory.cs
@@ -22,13 +22,13 @@ namespace Microsoft.Data.Entity.Storage
 
         private struct CacheKey
         {
-            public CacheKey(IReadOnlyCollection<Type> valueTypes, IReadOnlyList<int> indexMap)
+            public CacheKey(IReadOnlyList<Type> valueTypes, IReadOnlyList<int> indexMap)
             {
                 ValueTypes = valueTypes;
                 IndexMap = indexMap;
             }
 
-            public IReadOnlyCollection<Type> ValueTypes { get; }
+            public IReadOnlyList<Type> ValueTypes { get; }
             public IReadOnlyList<int> IndexMap { get; }
 
             private bool Equals(CacheKey other)
@@ -62,7 +62,7 @@ namespace Microsoft.Data.Entity.Storage
             = new ThreadSafeDictionaryCache<CacheKey, Func<DbDataReader, object[]>>();
 
         public virtual IRelationalValueBufferFactory Create(
-            IReadOnlyCollection<Type> valueTypes, IReadOnlyList<int> indexMap)
+            IReadOnlyList<Type> valueTypes, IReadOnlyList<int> indexMap)
         {
             Check.NotNull(valueTypes, nameof(valueTypes));
 

--- a/src/EntityFramework.Relational/Storage/UntypedRelationalValueBufferFactory.cs
+++ b/src/EntityFramework.Relational/Storage/UntypedRelationalValueBufferFactory.cs
@@ -4,11 +4,20 @@
 using System;
 using System.Data.Common;
 using System.Diagnostics;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Storage
 {
     public class UntypedRelationalValueBufferFactory : IRelationalValueBufferFactory
     {
+        private readonly Action<object[]> _processValuesAction;
+
+        public UntypedRelationalValueBufferFactory([CanBeNull] Action<object[]> processValuesAction)
+        {
+            _processValuesAction = processValuesAction;
+        }
+
         public virtual ValueBuffer Create(DbDataReader dataReader)
         {
             Debug.Assert(dataReader != null); // hot path
@@ -23,6 +32,8 @@ namespace Microsoft.Data.Entity.Storage
             var values = new object[fieldCount];
 
             dataReader.GetValues(values);
+
+            _processValuesAction?.Invoke(values);
 
             for (var i = 0; i < fieldCount; i++)
             {

--- a/src/EntityFramework.Relational/Storage/UntypedValueBufferFactoryFactory.cs
+++ b/src/EntityFramework.Relational/Storage/UntypedValueBufferFactoryFactory.cs
@@ -3,15 +3,101 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.Data.Entity.Internal;
 
 namespace Microsoft.Data.Entity.Storage
 {
     public class UntypedValueBufferFactoryFactory : IRelationalValueBufferFactoryFactory
     {
+        private struct CacheKey
+        {
+            public CacheKey(IReadOnlyList<Type> valueTypes)
+            {
+                ValueTypes = valueTypes;
+            }
+
+            public IReadOnlyList<Type> ValueTypes { get; }
+
+            private bool Equals(CacheKey other) => ValueTypes.SequenceEqual(other.ValueTypes);
+
+            public override bool Equals(object obj)
+                => !ReferenceEquals(null, obj)
+                   && (obj is CacheKey
+                       && Equals((CacheKey)obj));
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    return ValueTypes.Aggregate(0, (t, v) => (t * 397) ^ v.GetHashCode());
+                }
+            }
+        }
+
+        private readonly ThreadSafeDictionaryCache<CacheKey, Action<object[]>> _cache
+            = new ThreadSafeDictionaryCache<CacheKey, Action<object[]>>();
+
         public virtual IRelationalValueBufferFactory Create(
-            IReadOnlyCollection<Type> _, IReadOnlyList<int> indexMap)
-            => indexMap == null
-                ? (IRelationalValueBufferFactory)new UntypedRelationalValueBufferFactory()
-                : new RemappingUntypedRelationalValueBufferFactory(indexMap);
+            IReadOnlyList<Type> valueTypes, IReadOnlyList<int> indexMap)
+        {
+            var processValuesAction = _cache.GetOrAdd(new CacheKey(valueTypes.ToArray()), CreateValueProcessor);
+
+            return indexMap == null
+                ? (IRelationalValueBufferFactory)new UntypedRelationalValueBufferFactory(processValuesAction)
+                : new RemappingUntypedRelationalValueBufferFactory(indexMap, processValuesAction);
+        }
+
+        private static Action<object[]> CreateValueProcessor(CacheKey cacheKey)
+        {
+            var valuesParam = Expression.Parameter(typeof(object[]), "values");
+
+            var conversions = new List<Expression>();
+            var valueTypes = cacheKey.ValueTypes;
+
+            var valueVariable = Expression.Variable(typeof(object), "value");
+
+            for (var i = 0; i < valueTypes.Count; i++)
+            {
+                var type = valueTypes[i];
+
+                if (type.UnwrapNullableType().GetTypeInfo().IsEnum)
+                {
+                    var arrayAccess = Expression.ArrayAccess(valuesParam, Expression.Constant(i));
+
+                    conversions.Add(Expression.Assign(valueVariable, arrayAccess));
+
+                    conversions.Add(
+                        Expression.IfThen(
+                            Expression.IsFalse(
+                                Expression.ReferenceEqual(
+                                    valueVariable,
+                                    Expression.Constant(DBNull.Value))),
+                            Expression.Assign(
+                                arrayAccess,
+                                Expression.Convert(
+                                    Expression.Convert(
+                                        Expression.Convert(
+                                            valueVariable,
+                                            type.UnwrapEnumType()),
+                                        type),
+                                    typeof(object)))));
+                }
+            }
+
+            if (conversions.Count == 0)
+            {
+                return null;
+            }
+
+            return Expression.Lambda<Action<object[]>>(
+                Expression.Block(
+                    new[] { valueVariable },
+                    conversions),
+                valuesParam)
+                .Compile();
+        }
     }
 }

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntityEntryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntityEntryTest.cs
@@ -1498,20 +1498,16 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         }
 
         protected virtual InternalEntityEntry CreateInternalEntry(IServiceProvider contextServices, IEntityType entityType, object entity)
-        {
-            return contextServices.GetRequiredService<IInternalEntityEntrySubscriber>().SnapshotAndSubscribe(
+            => contextServices.GetRequiredService<IInternalEntityEntrySubscriber>().SnapshotAndSubscribe(
                 new InternalEntityEntryFactory(
                     contextServices.GetRequiredService<IEntityEntryMetadataServices>())
-                    .Create(contextServices.GetRequiredService<IStateManager>(), entityType, entity));
-        }
+                    .Create(contextServices.GetRequiredService<IStateManager>(), entityType, entity), null);
 
         protected virtual InternalEntityEntry CreateInternalEntry(IServiceProvider contextServices, IEntityType entityType, object entity, ValueBuffer valueBuffer)
-        {
-            return contextServices.GetRequiredService<IInternalEntityEntrySubscriber>().SnapshotAndSubscribe(
+            => contextServices.GetRequiredService<IInternalEntityEntrySubscriber>().SnapshotAndSubscribe(
                 new InternalEntityEntryFactory(
                     contextServices.GetRequiredService<IEntityEntryMetadataServices>())
-                    .Create(contextServices.GetRequiredService<IStateManager>(), entityType, entity, valueBuffer));
-        }
+                    .Create(contextServices.GetRequiredService<IStateManager>(), entityType, entity, valueBuffer), null);
 
         protected virtual Model BuildModel()
         {


### PR DESCRIPTION
In the common case where original values are tracked eagerly for all properties this change takes the query value buffer and uses it directly as the original values store. This essentially eliminates the cost of creating the original values snapshot, although snapshot of relationship state still takes time.

In doing this work it became apparent that sometimes values in the ValueBuffer are not of the correct type--notably for enum values. This caused problems for DetectChanges since the values were of different types and therefore were flagged as different even when no change had been made. To fix this the ValueBuffer obtained from GetValues is now post-processed to convert values as necessary. Currently this is only for enums, but in the future it could be used for any type conversion. Since values in the ValueBufferare now always of the correct type even when GetValues is used it means that the conversion code in the materializer can be removed.