### PR TITLE
[SMALL] Tidy up variations on perf tests

### DIFF
--- a/test/EntityFramework.Microbenchmarks.EF6/ChangeTracker/DbSetOperationTests.cs
+++ b/test/EntityFramework.Microbenchmarks.EF6/ChangeTracker/DbSetOperationTests.cs
@@ -26,13 +26,14 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
         {
             using (var context = _fixture.CreateContext())
             {
+                context.Configuration.AutoDetectChangesEnabled = autoDetectChanges;
+
                 var customers = new Customer[1000];
                 for (var i = 0; i < customers.Length; i++)
                 {
                     customers[i] = new Customer { Name = "Customer " + i };
                 }
 
-                context.Configuration.AutoDetectChangesEnabled = autoDetectChanges;
                 using (collector.StartCollection())
                 {
                     foreach (var customer in customers)
@@ -44,10 +45,14 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
         }
 
         [Benchmark]
-        public void AddCollection(MetricCollector collector)
+        [BenchmarkVariation("AutoDetectChanges On", true)]
+        [BenchmarkVariation("AutoDetectChanges Off", false)]
+        public void AddCollection(MetricCollector collector, bool autoDetectChanges)
         {
             using (var context = _fixture.CreateContext())
             {
+                context.Configuration.AutoDetectChangesEnabled = autoDetectChanges;
+
                 var customers = new Customer[1000];
                 for (var i = 0; i < customers.Length; i++)
                 {
@@ -68,10 +73,11 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
         {
             using (var context = _fixture.CreateContext())
             {
+                context.Configuration.AutoDetectChangesEnabled = autoDetectChanges;
+
                 var customers = GetAllCustomersFromDatabase();
                 Assert.Equal(1000, customers.Length);
-
-                context.Configuration.AutoDetectChangesEnabled = autoDetectChanges;
+                
                 using (collector.StartCollection())
                 {
                     foreach (var customer in customers)
@@ -92,10 +98,11 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
         {
             using (var context = _fixture.CreateContext())
             {
+                context.Configuration.AutoDetectChangesEnabled = autoDetectChanges;
+
                 var customers = context.Customers.ToArray();
                 Assert.Equal(1000, customers.Length);
 
-                context.Configuration.AutoDetectChangesEnabled = autoDetectChanges;
                 using (collector.StartCollection())
                 {
                     foreach (var customer in customers)
@@ -107,10 +114,14 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
         }
 
         [Benchmark]
-        public void RemoveCollection(MetricCollector collector)
+        [BenchmarkVariation("AutoDetectChanges On", true)]
+        [BenchmarkVariation("AutoDetectChanges Off", false)]
+        public void RemoveCollection(MetricCollector collector, bool autoDetectChanges)
         {
             using (var context = _fixture.CreateContext())
             {
+                context.Configuration.AutoDetectChangesEnabled = autoDetectChanges;
+
                 var customers = context.Customers.ToArray();
                 Assert.Equal(1000, customers.Length);
 
@@ -128,10 +139,11 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
         {
             using (var context = _fixture.CreateContext())
             {
+                context.Configuration.AutoDetectChangesEnabled = autoDetectChanges;
+
                 var customers = GetAllCustomersFromDatabase();
                 Assert.Equal(1000, customers.Length);
 
-                context.Configuration.AutoDetectChangesEnabled = autoDetectChanges;
                 using (collector.StartCollection())
                 {
                     foreach (var customer in customers)

--- a/test/EntityFramework.Microbenchmarks.EF6/UpdatePipeline/SimpleUpdatePipelineTests.cs
+++ b/test/EntityFramework.Microbenchmarks.EF6/UpdatePipeline/SimpleUpdatePipelineTests.cs
@@ -19,7 +19,6 @@ namespace EntityFramework.Microbenchmarks.EF6.UpdatePipeline
         }
 
         [Benchmark]
-        [BenchmarkVariation("Batching Off")]
         public void Insert(MetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
@@ -41,7 +40,6 @@ namespace EntityFramework.Microbenchmarks.EF6.UpdatePipeline
         }
 
         [Benchmark]
-        [BenchmarkVariation("Batching Off")]
         public void Update(MetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
@@ -63,7 +61,6 @@ namespace EntityFramework.Microbenchmarks.EF6.UpdatePipeline
         }
 
         [Benchmark]
-        [BenchmarkVariation("Batching Off")]
         public void Delete(MetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
@@ -85,7 +82,6 @@ namespace EntityFramework.Microbenchmarks.EF6.UpdatePipeline
         }
 
         [Benchmark]
-        [BenchmarkVariation("Batching Off")]
         public void Mixed(MetricCollector collector)
         {
             using (var context = _fixture.CreateContext())

--- a/test/EntityFramework.Microbenchmarks/ChangeTracker/DbSetOperationTests.cs
+++ b/test/EntityFramework.Microbenchmarks/ChangeTracker/DbSetOperationTests.cs
@@ -19,11 +19,14 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
         }
 
         [Benchmark]
-        [BenchmarkVariation("AutoDetectChanges Off")]
-        public void Add(MetricCollector collector)
+        [BenchmarkVariation("AutoDetectChanges On", true)]
+        [BenchmarkVariation("AutoDetectChanges Off", false)]
+        public void Add(MetricCollector collector, bool autoDetectChanges)
         {
             using (var context = _fixture.CreateContext())
             {
+                context.ChangeTracker.AutoDetectChangesEnabled = autoDetectChanges;
+
                 var customers = new Customer[1000];
                 for (var i = 0; i < customers.Length; i++)
                 {
@@ -41,10 +44,14 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
         }
 
         [Benchmark]
-        public void AddCollection(MetricCollector collector)
+        [BenchmarkVariation("AutoDetectChanges On", true)]
+        [BenchmarkVariation("AutoDetectChanges Off", false)]
+        public void AddCollection(MetricCollector collector, bool autoDetectChanges)
         {
             using (var context = _fixture.CreateContext())
             {
+                context.ChangeTracker.AutoDetectChangesEnabled = autoDetectChanges;
+
                 var customers = new Customer[1000];
                 for (var i = 0; i < customers.Length; i++)
                 {
@@ -60,11 +67,14 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
         }
 
         [Benchmark]
-        [BenchmarkVariation("AutoDetectChanges Off")]
-        public void Attach(MetricCollector collector)
+        [BenchmarkVariation("AutoDetectChanges On", true)]
+        [BenchmarkVariation("AutoDetectChanges Off", false)]
+        public void Attach(MetricCollector collector, bool autoDetectChanges)
         {
             using (var context = _fixture.CreateContext())
             {
+                context.ChangeTracker.AutoDetectChangesEnabled = autoDetectChanges;
+
                 var customers = GetAllCustomersFromDatabase();
                 Assert.Equal(1000, customers.Length);
 
@@ -80,10 +90,14 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
         }
 
         [Benchmark]
-        public void AttachCollection(MetricCollector collector)
+        [BenchmarkVariation("AutoDetectChanges On", true)]
+        [BenchmarkVariation("AutoDetectChanges Off", false)]
+        public void AttachCollection(MetricCollector collector, bool autoDetectChanges)
         {
             using (var context = _fixture.CreateContext())
             {
+                context.ChangeTracker.AutoDetectChangesEnabled = autoDetectChanges;
+
                 var customers = GetAllCustomersFromDatabase();
                 Assert.Equal(1000, customers.Length);
 
@@ -95,11 +109,14 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
         }
 
         [Benchmark]
-        [BenchmarkVariation("AutoDetectChanges Off")]
-        public void Remove(MetricCollector collector)
+        [BenchmarkVariation("AutoDetectChanges On", true)]
+        [BenchmarkVariation("AutoDetectChanges Off", false)]
+        public void Remove(MetricCollector collector, bool autoDetectChanges)
         {
             using (var context = _fixture.CreateContext())
             {
+                context.ChangeTracker.AutoDetectChangesEnabled = autoDetectChanges;
+
                 var customers = context.Customers.ToArray();
                 Assert.Equal(1000, customers.Length);
 
@@ -114,10 +131,14 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
         }
 
         [Benchmark]
-        public void RemoveCollection(MetricCollector collector)
+        [BenchmarkVariation("AutoDetectChanges On", true)]
+        [BenchmarkVariation("AutoDetectChanges Off", false)]
+        public void RemoveCollection(MetricCollector collector, bool autoDetectChanges)
         {
             using (var context = _fixture.CreateContext())
             {
+                context.ChangeTracker.AutoDetectChangesEnabled = autoDetectChanges;
+
                 var customers = context.Customers.ToArray();
                 Assert.Equal(1000, customers.Length);
 
@@ -129,11 +150,14 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
         }
 
         [Benchmark]
-        [BenchmarkVariation("AutoDetectChanges Off")]
-        public void Update(MetricCollector collector)
+        [BenchmarkVariation("AutoDetectChanges On", true)]
+        [BenchmarkVariation("AutoDetectChanges Off", false)]
+        public void Update(MetricCollector collector, bool autoDetectChanges)
         {
             using (var context = _fixture.CreateContext())
             {
+                context.ChangeTracker.AutoDetectChangesEnabled = autoDetectChanges;
+
                 var customers = GetAllCustomersFromDatabase();
                 Assert.Equal(1000, customers.Length);
 
@@ -148,10 +172,14 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
         }
 
         [Benchmark]
-        public void UpdateCollection(MetricCollector collector)
+        [BenchmarkVariation("AutoDetectChanges On", true)]
+        [BenchmarkVariation("AutoDetectChanges Off", false)]
+        public void UpdateCollection(MetricCollector collector, bool autoDetectChanges)
         {
             using (var context = _fixture.CreateContext())
             {
+                context.ChangeTracker.AutoDetectChangesEnabled = autoDetectChanges;
+
                 var customers = GetAllCustomersFromDatabase();
                 Assert.Equal(1000, customers.Length);
 

--- a/test/EntityFramework.Microbenchmarks/UpdatePipeline/SimpleUpdatePipelineTests.cs
+++ b/test/EntityFramework.Microbenchmarks/UpdatePipeline/SimpleUpdatePipelineTests.cs
@@ -21,7 +21,7 @@ namespace EntityFramework.Microbenchmarks.UpdatePipeline
 
         [Benchmark]
         [BenchmarkVariation("Batching Off", true)]
-        [BenchmarkVariation("Batching On", false)]
+        [BenchmarkVariation("Default", false)]
         public void Insert(MetricCollector collector, bool disableBatching)
         {
             using (var context = _fixture.CreateContext(disableBatching))
@@ -44,7 +44,7 @@ namespace EntityFramework.Microbenchmarks.UpdatePipeline
 
         [Benchmark]
         [BenchmarkVariation("Batching Off", true)]
-        [BenchmarkVariation("Batching On", false)]
+        [BenchmarkVariation("Default", false)]
         public void Update(MetricCollector collector, bool disableBatching)
         {
             using (var context = _fixture.CreateContext(disableBatching))
@@ -67,7 +67,7 @@ namespace EntityFramework.Microbenchmarks.UpdatePipeline
 
         [Benchmark]
         [BenchmarkVariation("Batching Off", true)]
-        [BenchmarkVariation("Batching On", false)]
+        [BenchmarkVariation("Default", false)]
         public void Delete(MetricCollector collector, bool disableBatching)
         {
             using (var context = _fixture.CreateContext(disableBatching))
@@ -90,7 +90,7 @@ namespace EntityFramework.Microbenchmarks.UpdatePipeline
 
         [Benchmark]
         [BenchmarkVariation("Batching Off", true)]
-        [BenchmarkVariation("Batching On", false)]
+        [BenchmarkVariation("Default", false)]
         public void Mixed(MetricCollector collector, bool disableBatching)
         {
             using (var context = _fixture.CreateContext(disableBatching))


### PR DESCRIPTION
* Adjust names of Update Pipeline variations so that the comparisons
better reflect what will happen when you follow best practices (i.e.
there was no batching on EF6 and by default it is on for EF7, so
comparing those numbers gives you the typical perf for each version).
* Standardize on having a DetectChangesOn/Off variation for all DbSet
Operation tests (even for the scenarios where it theoretically makes
little difference).