### PR TITLE
Remove unnecessary dependency

### DIFF
--- a/test/EntityFramework.Microbenchmarks.Core/EntityFramework.Microbenchmarks.Core.csproj
+++ b/test/EntityFramework.Microbenchmarks.Core/EntityFramework.Microbenchmarks.Core.csproj
@@ -125,16 +125,6 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\EntityFramework.Core\EntityFramework.Core.csproj">
-      <Project>{71415cec-8111-4c73-8751-512d22f10602}</Project>
-      <Name>EntityFramework.Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\src\EntityFramework.SqlServer\EntityFramework.SqlServer.csproj">
-      <Project>{04e6620b-5b41-45fe-981a-f40eb7686b0e}</Project>
-      <Name>EntityFramework.SqlServer</Name>
-    </ProjectReference>
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/Address.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/Address.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/AddressType.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/AddressType.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/BillOfMaterials.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/BillOfMaterials.cs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/BusinessEntity.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/BusinessEntity.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/BusinessEntityAddress.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/BusinessEntityAddress.cs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/BusinessEntityContact.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/BusinessEntityContact.cs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/ContactType.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/ContactType.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/CountryRegion.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/CountryRegion.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/CountryRegionCurrency.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/CountryRegionCurrency.cs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/CreditCard.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/CreditCard.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/Culture.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/Culture.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/Currency.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/Currency.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/CurrencyRate.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/CurrencyRate.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/Customer.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/Customer.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/Department.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/Department.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/EmailAddress.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/EmailAddress.cs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/Employee.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/Employee.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/EmployeeDepartmentHistory.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/EmployeeDepartmentHistory.cs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/EmployeePayHistory.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/EmployeePayHistory.cs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/Illustration.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/Illustration.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/JobCandidate.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/JobCandidate.cs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/Location.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/Location.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/Password.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/Password.cs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/Person.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/Person.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/PersonCreditCard.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/PersonCreditCard.cs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/PersonPhone.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/PersonPhone.cs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/PhoneNumberType.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/PhoneNumberType.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/Product.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/Product.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/ProductCategory.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/ProductCategory.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/ProductCostHistory.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/ProductCostHistory.cs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/ProductDescription.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/ProductDescription.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/ProductDocument.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/ProductDocument.cs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/ProductInventory.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/ProductInventory.cs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/ProductListPriceHistory.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/ProductListPriceHistory.cs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/ProductModel.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/ProductModel.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/ProductModelIllustration.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/ProductModelIllustration.cs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/ProductModelProductDescriptionCulture.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/ProductModelProductDescriptionCulture.cs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/ProductPhoto.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/ProductPhoto.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/ProductProductPhoto.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/ProductProductPhoto.cs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/ProductReview.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/ProductReview.cs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/ProductSubcategory.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/ProductSubcategory.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/ProductVendor.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/ProductVendor.cs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/PurchaseOrderDetail.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/PurchaseOrderDetail.cs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/PurchaseOrderHeader.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/PurchaseOrderHeader.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/SalesOrderDetail.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/SalesOrderDetail.cs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/SalesOrderHeader.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/SalesOrderHeader.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/SalesOrderHeaderSalesReason.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/SalesOrderHeaderSalesReason.cs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/SalesPerson.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/SalesPerson.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/SalesPersonQuotaHistory.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/SalesPersonQuotaHistory.cs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/SalesReason.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/SalesReason.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/SalesTaxRate.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/SalesTaxRate.cs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/SalesTerritory.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/SalesTerritory.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/SalesTerritoryHistory.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/SalesTerritoryHistory.cs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/ScrapReason.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/ScrapReason.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/Shift.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/Shift.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/ShipMethod.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/ShipMethod.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/ShoppingCartItem.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/ShoppingCartItem.cs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/SpecialOffer.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/SpecialOffer.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/SpecialOfferProduct.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/SpecialOfferProduct.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/StateProvince.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/StateProvince.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/Store.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/Store.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/TransactionHistory.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/TransactionHistory.cs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/TransactionHistoryArchive.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/TransactionHistoryArchive.cs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/UnitMeasure.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/UnitMeasure.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/Vendor.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/Vendor.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/WorkOrder.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/WorkOrder.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/WorkOrderRouting.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/Models/AdventureWorks/WorkOrderRouting.cs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 
 namespace EntityFramework.Microbenchmarks.Core.Models.AdventureWorks
 {

--- a/test/EntityFramework.Microbenchmarks.Core/project.json
+++ b/test/EntityFramework.Microbenchmarks.Core/project.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "EntityFramework.SqlServer": "7.0.0-*",
     "Microsoft.Framework.Configuration.Json": "1.0.0-*",
     "Microsoft.Framework.Configuration.EnvironmentVariables": "1.0.0-*"
   },


### PR DESCRIPTION
I unblocked the build with e79118a558cf217950b4388bcd806bfaf1dccb98, but it wasn't the right change. @rowanmiller Were these added by Reverse Engineer? If so, why are they needed in entity class files, @lajones?