### PR TITLE
RevEng: When is Required required?

### DIFF
--- a/src/EntityFramework.Relational.Design/ReverseEngineering/Configuration/ModelConfiguration.cs
+++ b/src/EntityFramework.Relational.Design/ReverseEngineering/Configuration/ModelConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
@@ -230,7 +231,8 @@ namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering.Configurati
         {
             Check.NotNull(propertyConfiguration, nameof(propertyConfiguration));
 
-            if (!propertyConfiguration.Property.IsNullable)
+            if (!propertyConfiguration.Property.IsNullable
+                && propertyConfiguration.Property.ClrType.IsNullableType())
             {
                 var entityKeyProperties =
                     ((EntityType)propertyConfiguration.EntityConfiguration.EntityType)

--- a/test/EntityFramework.SqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/SqlServerReverseEngineerTestE2EContext.expected
+++ b/test/EntityFramework.SqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/SqlServerReverseEngineerTestE2EContext.expected
@@ -14,35 +14,13 @@ namespace E2ETest.Namespace
         {
             modelBuilder.Entity<AllDataTypes>(entity =>
             {
-                entity.Property(e => e.bigintColumn).Required();
-
-                entity.Property(e => e.bitColumn).Required();
-
-                entity.Property(e => e.dateColumn).Required();
-
                 entity.Property(e => e.datetime2Column).HasColumnType("datetime2(7)");
 
-                entity.Property(e => e.decimalColumn)
-                    .Required()
-                    .HasColumnType("decimal(18, 0)");
+                entity.Property(e => e.decimalColumn).HasColumnType("decimal(18, 0)");
 
-                entity.Property(e => e.floatColumn).Required();
-
-                entity.Property(e => e.intColumn).Required();
-
-                entity.Property(e => e.moneyColumn).Required();
-
-                entity.Property(e => e.numericColumn)
-                    .Required()
-                    .HasColumnType("numeric(18, 0)");
-
-                entity.Property(e => e.smallintColumn).Required();
-
-                entity.Property(e => e.smallmoneyColumn).Required();
+                entity.Property(e => e.numericColumn).HasColumnType("numeric(18, 0)");
 
                 entity.Property(e => e.timestampColumn).ValueGeneratedOnAddOrUpdate();
-
-                entity.Property(e => e.tinyintColumn).Required();
             });
 
             modelBuilder.Entity<OneToManyDependent>(entity =>
@@ -97,10 +75,6 @@ namespace E2ETest.Namespace
             {
                 entity.Property(e => e.PropertyConfigurationID).ValueGeneratedNever();
 
-                entity.Property(e => e.A).Required();
-
-                entity.Property(e => e.B).Required();
-
                 entity.Property(e => e.RowversionColumn)
                     .Required()
                     .ValueGeneratedOnAddOrUpdate();
@@ -108,21 +82,14 @@ namespace E2ETest.Namespace
                 entity.Property(e => e.SumOfAAndB).ValueGeneratedOnAddOrUpdate();
 
                 entity.Property(e => e.WithDateDefaultExpression)
-                    .Required()
                     .HasColumnType("datetime2(7)")
                     .HasDefaultValueSql("getdate()");
 
-                entity.Property(e => e.WithDefaultValue)
-                    .Required()
-                    .HasDefaultValue(-1);
+                entity.Property(e => e.WithDefaultValue).HasDefaultValue(-1);
 
-                entity.Property(e => e.WithGuidDefaultExpression)
-                    .Required()
-                    .HasDefaultValueSql("newsequentialid()");
+                entity.Property(e => e.WithGuidDefaultExpression).HasDefaultValueSql("newsequentialid()");
 
-                entity.Property(e => e.WithMoneyDefaultValue)
-                    .Required()
-                    .HasDefaultValue(0.00m);
+                entity.Property(e => e.WithMoneyDefaultValue).HasDefaultValue(0.00m);
             });
 
             modelBuilder.Entity<ReferredToByTableWithUnmappablePrimaryKeyColumn>(entity =>
@@ -131,9 +98,7 @@ namespace E2ETest.Namespace
 
                 entity.Property(e => e.AColumn).Required();
 
-                entity.Property(e => e.ValueGeneratedOnAddColumn)
-                    .Required()
-                    .ValueGeneratedOnAdd();
+                entity.Property(e => e.ValueGeneratedOnAddColumn).ValueGeneratedOnAdd();
             });
 
             modelBuilder.Entity<SelfReferencing>(entity =>
@@ -155,37 +120,27 @@ namespace E2ETest.Namespace
                     .HasColumnName("Test Spaces Keywords TableID")
                     .ValueGeneratedNever();
 
-                entity.Property(e => e.@Multiple_At_Symbols_In_Column)
-                    .Required()
-                    .HasColumnName("@Multiple@At@Symbols@In@Column");
+                entity.Property(e => e.@Multiple_At_Symbols_In_Column).HasColumnName("@Multiple@At@Symbols@In@Column");
 
-                entity.Property(e => e._abstract)
-                    .Required()
-                    .HasColumnName("abstract");
+                entity.Property(e => e._abstract).HasColumnName("abstract");
 
                 entity.Property(e => e._Backslashes_In_Column).HasColumnName("\\Backslashes\\In\\Column");
 
                 entity.Property(e => e._class).HasColumnName("class");
 
-                entity.Property(e => e._Dollar_Sign_Column)
-                    .Required()
-                    .HasColumnName("$Dollar$Sign$Column");
+                entity.Property(e => e._Dollar_Sign_Column).HasColumnName("$Dollar$Sign$Column");
 
                 entity.Property(e => e._Double_Quotes_Column).HasColumnName("\"Double\"Quotes\"Column");
 
                 entity.Property(e => e._Exclamation_Mark_Column).HasColumnName("!Exclamation!Mark!Column");
 
-                entity.Property(e => e._volatile)
-                    .Required()
-                    .HasColumnName("volatile");
+                entity.Property(e => e._volatile).HasColumnName("volatile");
 
                 entity.Property(e => e.Commas_In_Column).HasColumnName("Commas,In,Column");
 
                 entity.Property(e => e.Spaces_In_Column).HasColumnName("Spaces In Column");
 
-                entity.Property(e => e.Tabs_In_Column)
-                    .Required()
-                    .HasColumnName("Tabs\tIn\tColumn");
+                entity.Property(e => e.Tabs_In_Column).HasColumnName("Tabs\tIn\tColumn");
             });
         }
 

--- a/test/EntityFramework.SqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/AllDataTypes.expected
+++ b/test/EntityFramework.SqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/AllDataTypes.expected
@@ -10,41 +10,30 @@ namespace E2ETest.Namespace
     public class AllDataTypes
     {
         public int AllDataTypesID { get; set; }
-        [Required]
         public long bigintColumn { get; set; }
         public byte[] binaryColumn { get; set; }
-        [Required]
         public bool bitColumn { get; set; }
         public string charColumn { get; set; }
-        [Required]
         public DateTime dateColumn { get; set; }
         public DateTime? datetime2Column { get; set; }
         public DateTime? datetimeColumn { get; set; }
         public DateTimeOffset? datetimeoffsetColumn { get; set; }
-        [Required]
         public decimal decimalColumn { get; set; }
-        [Required]
         public double floatColumn { get; set; }
         public byte[] imageColumn { get; set; }
-        [Required]
         public int intColumn { get; set; }
-        [Required]
         public decimal moneyColumn { get; set; }
         public string ncharColumn { get; set; }
         public string ntextColumn { get; set; }
-        [Required]
         public decimal numericColumn { get; set; }
         public string nvarcharColumn { get; set; }
         public float? realColumn { get; set; }
         public DateTime? smalldatetimeColumn { get; set; }
-        [Required]
         public short smallintColumn { get; set; }
-        [Required]
         public decimal smallmoneyColumn { get; set; }
         public string textColumn { get; set; }
         public DateTime? timeColumn { get; set; }
         public byte[] timestampColumn { get; set; }
-        [Required]
         public byte tinyintColumn { get; set; }
         public Guid? uniqueidentifierColumn { get; set; }
         public byte[] varbinaryColumn { get; set; }

--- a/test/EntityFramework.SqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/PropertyConfiguration.expected
+++ b/test/EntityFramework.SqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/PropertyConfiguration.expected
@@ -10,20 +10,14 @@ namespace E2ETest.Namespace
     public class PropertyConfiguration
     {
         public byte PropertyConfigurationID { get; set; }
-        [Required]
         public int A { get; set; }
-        [Required]
         public int B { get; set; }
         [Required]
         public byte[] RowversionColumn { get; set; }
         public int? SumOfAAndB { get; set; }
-        [Required]
         public DateTime WithDateDefaultExpression { get; set; }
-        [Required]
         public int WithDefaultValue { get; set; }
-        [Required]
         public Guid WithGuidDefaultExpression { get; set; }
-        [Required]
         public decimal WithMoneyDefaultValue { get; set; }
     }
 }

--- a/test/EntityFramework.SqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/ReferredToByTableWithUnmappablePrimaryKeyColumn.expected
+++ b/test/EntityFramework.SqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/ReferredToByTableWithUnmappablePrimaryKeyColumn.expected
@@ -12,7 +12,6 @@ namespace E2ETest.Namespace
         public int ReferredToByTableWithUnmappablePrimaryKeyColumnID { get; set; }
         [Required]
         public string AColumn { get; set; }
-        [Required]
         public int ValueGeneratedOnAddColumn { get; set; }
 
         // Unable to add a Navigation Property referencing type TableWithUnmappablePrimaryKeyColumn because of errors generating that EntityType.

--- a/test/EntityFramework.SqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/Test_Spaces_Keywords_Table.expected
+++ b/test/EntityFramework.SqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/Test_Spaces_Keywords_Table.expected
@@ -13,31 +13,26 @@ namespace E2ETest.Namespace
         [Column("Test Spaces Keywords TableID")]
         public int Test_Spaces_Keywords_TableID { get; set; }
         public int? @AtSymbolAtStartOfColumn { get; set; }
-        [Required]
         [Column("@Multiple@At@Symbols@In@Column")]
         public int @Multiple_At_Symbols_In_Column { get; set; }
-        [Required]
         [Column("abstract")]
         public int _abstract { get; set; }
         [Column("\\Backslashes\\In\\Column")]
         public int? _Backslashes_In_Column { get; set; }
         [Column("class")]
         public int? _class { get; set; }
-        [Required]
         [Column("$Dollar$Sign$Column")]
         public int _Dollar_Sign_Column { get; set; }
         [Column("\"Double\"Quotes\"Column")]
         public int? _Double_Quotes_Column { get; set; }
         [Column("!Exclamation!Mark!Column")]
         public int? _Exclamation_Mark_Column { get; set; }
-        [Required]
         [Column("volatile")]
         public int _volatile { get; set; }
         [Column("Commas,In,Column")]
         public int? Commas_In_Column { get; set; }
         [Column("Spaces In Column")]
         public int? Spaces_In_Column { get; set; }
-        [Required]
         [Column("Tabs\tIn\tColumn")]
         public int Tabs_In_Column { get; set; }
     }

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/OneToOne/ModelContext.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/OneToOne/ModelContext.expected
@@ -16,9 +16,7 @@ namespace E2E.Sqlite
             {
                 entity.Property(e => e.Id).HasColumnType("INT");
 
-                entity.Property(e => e.PrincipalId)
-                    .Required()
-                    .HasColumnType("INT");
+                entity.Property(e => e.PrincipalId).HasColumnType("INT");
 
                 entity.Reference(d => d.Principal).InverseReference(p => p.Dependent).ForeignKey<Dependent>(d => d.PrincipalId);
             });

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/OneToOne/Dependent.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/OneToOne/Dependent.expected
@@ -10,7 +10,6 @@ namespace E2E.Sqlite
     public class Dependent
     {
         public long Id { get; set; }
-        [Required]
         public long PrincipalId { get; set; }
 
         [ForeignKey("PrincipalId")]


### PR DESCRIPTION
Only output the Required fluent API or attribute when property is a nullable type.

@smitpatel Addressing your comment in https://github.com/aspnet/EntityFramework/pull/2957