### PR TITLE
Fix for RevEng EntityType Templates producing error CS0656

### DIFF
--- a/src/EntityFramework.Relational.Design/ReverseEngineering/Templates/EntityTypeTemplate.cshtml
+++ b/src/EntityFramework.Relational.Design/ReverseEngineering/Templates/EntityTypeTemplate.cshtml
@@ -41,7 +41,7 @@ if (useAttributesOverFluentApi) {
     {
         if (useAttributesOverFluentApi)
         {
-            var propertyConfiguration = Model.FindPropertyConfiguration(property);
+            PropertyConfiguration propertyConfiguration = Model.FindPropertyConfiguration(property);
             if (propertyConfiguration != null)
             {
                 foreach (var attrConfig in propertyConfiguration.AttributeConfigurations)


### PR DESCRIPTION
@bricelam This should fix the Sqlite test failures you were seeing:

      System.InvalidOperationException : There was an error running the EntityType template. Message: Template Processing Failed: At
 line 3626. Message: (45,17): error CS0656: Missing compiler required member 'Microsoft.CSharp.RuntimeBinder.Binder.BinaryOperation'