### PR TITLE
Make Add/Attach/Update methods add dependents by default

### DIFF
--- a/src/EntityFramework.Core/ChangeTracking/EntityEntryGraphNode.cs
+++ b/src/EntityFramework.Core/ChangeTracking/EntityEntryGraphNode.cs
@@ -1,0 +1,40 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.ChangeTracking.Internal;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.ChangeTracking
+{
+    public class EntityEntryGraphNode : EntityGraphNodeBase<EntityEntryGraphNode>
+    {
+        public EntityEntryGraphNode(
+            [NotNull] DbContext context,
+            [NotNull] InternalEntityEntry internalEntityEntry,
+            [CanBeNull] INavigation inboundNavigation)
+            : base(internalEntityEntry, inboundNavigation)
+        {
+            Check.NotNull(context, nameof(context));
+
+            Context = context;
+            Entry = new EntityEntry(context, internalEntityEntry);
+        }
+
+        public virtual DbContext Context { get; }
+        public new virtual EntityEntry Entry { get; }
+
+        public override EntityEntryGraphNode CreateNode(
+            EntityEntryGraphNode currentNode,
+            InternalEntityEntry internalEntityEntry,
+            INavigation reachedVia)
+            => new EntityEntryGraphNode(
+                Context,
+                Check.NotNull(internalEntityEntry, nameof(internalEntityEntry)),
+                Check.NotNull(reachedVia, nameof(reachedVia)))
+                {
+                    NodeState = Check.NotNull(currentNode, nameof(currentNode)).NodeState
+                };
+    }
+}

--- a/src/EntityFramework.Core/ChangeTracking/EntityGraphNodeBase.cs
+++ b/src/EntityFramework.Core/ChangeTracking/EntityGraphNodeBase.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.ChangeTracking.Internal;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.ChangeTracking
+{
+    public abstract class EntityGraphNodeBase<TNode>
+        where TNode : EntityGraphNodeBase<TNode>
+    {
+        protected EntityGraphNodeBase(
+            [NotNull] InternalEntityEntry internalEntityEntry, 
+            [CanBeNull] INavigation inboundNavigation)
+        {
+            Check.NotNull(internalEntityEntry, nameof(internalEntityEntry));
+
+            Entry = internalEntityEntry;
+            InboundNavigation = inboundNavigation;
+        }
+
+        public virtual INavigation InboundNavigation { get; }
+
+        public virtual InternalEntityEntry Entry { get; }
+
+        public virtual object NodeState { get; [param: CanBeNull] set; }
+
+        public abstract TNode CreateNode(
+            [NotNull] TNode currentNode, 
+            [NotNull] InternalEntityEntry internalEntityEntry, 
+            [NotNull] INavigation reachedVia);
+    }
+}

--- a/src/EntityFramework.Core/ChangeTracking/Internal/EntityEntryGraphIterator.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/EntityEntryGraphIterator.cs
@@ -1,66 +1,45 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections;
-using System.Collections.Generic;
-using JetBrains.Annotations;
-using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 
 namespace Microsoft.Data.Entity.ChangeTracking.Internal
 {
     public class EntityEntryGraphIterator : IEntityEntryGraphIterator
     {
-        private readonly DbContext _context;
-        private readonly IStateManager _stateManager;
-
-        public EntityEntryGraphIterator(
-            [NotNull] DbContext context,
-            [NotNull] IStateManager stateManager)
+        public virtual void TraverseGraph<TNode>(TNode node, Func<TNode, bool> handleNode)
+            where TNode : EntityGraphNodeBase<TNode>
         {
-            _context = context;
-            _stateManager = stateManager;
-        }
-
-        public virtual IEnumerable<EntityEntry> TraverseGraph(object entity)
-        {
-            var entry = new EntityEntry(_context, _stateManager.GetOrCreateEntry(entity));
-
-            if (entry.State != EntityState.Detached)
+            if (!handleNode(node))
             {
-                yield break;
+                return;
             }
 
-            yield return entry;
+            var navigations = node.Entry.EntityType.GetNavigations();
+            var stateManager = node.Entry.StateManager;
 
-            if (entry.State != EntityState.Detached)
+            foreach (var navigation in navigations)
             {
-                var internalEntry = entry.GetService();
-                var navigations = internalEntry.EntityType.GetNavigations();
+                var navigationValue = node.Entry[navigation];
 
-                foreach (var navigation in navigations)
+                if (navigationValue != null)
                 {
-                    var navigationValue = internalEntry[navigation];
-
-                    if (navigationValue != null)
+                    if (navigation.IsCollection())
                     {
-                        if (navigation.IsCollection())
+                        foreach (var relatedEntity in (IEnumerable)navigationValue)
                         {
-                            foreach (var relatedEntity in (IEnumerable)navigationValue)
-                            {
-                                foreach (var relatedEntry in TraverseGraph(relatedEntity))
-                                {
-                                    yield return relatedEntry;
-                                }
-                            }
+                            TraverseGraph(
+                                node.CreateNode(node, stateManager.GetOrCreateEntry(relatedEntity), navigation),
+                                handleNode);
                         }
-                        else
-                        {
-                            foreach (var relatedEntry in TraverseGraph(navigationValue))
-                            {
-                                yield return relatedEntry;
-                            }
-                        }
+                    }
+                    else
+                    {
+                        TraverseGraph(
+                            node.CreateNode(node, stateManager.GetOrCreateEntry(navigationValue), navigation),
+                            handleNode);
                     }
                 }
             }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/EntityGraphAttacher.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/EntityGraphAttacher.cs
@@ -1,0 +1,56 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+
+namespace Microsoft.Data.Entity.ChangeTracking.Internal
+{
+    public class EntityGraphAttacher : IEntityGraphAttacher
+    {
+        private readonly IEntityEntryGraphIterator _graphIterator;
+
+        public EntityGraphAttacher([NotNull] IEntityEntryGraphIterator graphIterator)
+        {
+            _graphIterator = graphIterator;
+        }
+
+        public virtual void AttachGraph(InternalEntityEntry rootEntry, EntityState entityState)
+            => _graphIterator.TraverseGraph(
+                new InternalEntityEntryGraphNode(rootEntry, null)
+                    {
+                        NodeState = entityState
+                    },
+                PaintAction);
+
+        private static bool PaintAction(InternalEntityEntryGraphNode n)
+        {
+            if (n.Entry.EntityState != EntityState.Detached
+                || (n.InboundNavigation != null && n.InboundNavigation.PointsToPrincipal()))
+            {
+                return false;
+            }
+
+            if (!n.Entry.IsKeySet)
+            {
+                n.NodeState = EntityState.Added;
+            }
+
+            n.Entry.SetEntityState((EntityState)n.NodeState, acceptChanges: true);
+
+            return true;
+        }
+
+        private class InternalEntityEntryGraphNode : EntityGraphNodeBase<InternalEntityEntryGraphNode>
+        {
+            public InternalEntityEntryGraphNode(InternalEntityEntry internalEntityEntry, INavigation reachedVia)
+                : base(internalEntityEntry, reachedVia)
+            {
+            }
+
+            public override InternalEntityEntryGraphNode CreateNode(
+                InternalEntityEntryGraphNode currentNode, InternalEntityEntry internalEntityEntry, INavigation reachedVia)
+                => new InternalEntityEntryGraphNode(internalEntityEntry, reachedVia) { NodeState = currentNode.NodeState };
+        }
+    }
+}

--- a/src/EntityFramework.Core/ChangeTracking/Internal/GraphAttacher.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/GraphAttacher.cs
@@ -1,0 +1,60 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+
+namespace Microsoft.Data.Entity.ChangeTracking.Internal
+{
+    public class GraphAttacher : IGraphAttacher
+    {
+        private readonly IStateManager _stateManager;
+        private readonly IEntityEntryGraphIterator _graphIterator;
+
+        public GraphAttacher(
+            [NotNull] IStateManager stateManager, 
+            [NotNull] IEntityEntryGraphIterator graphIterator)
+        {
+            _stateManager = stateManager;
+            _graphIterator = graphIterator;
+        }
+
+        public virtual void AttachGraph(object rootEntity, EntityState entityState)
+            => _graphIterator.TraverseGraph(
+                new InternalEntityEntryGraphNode(_stateManager.GetOrCreateEntry(rootEntity), null)
+                    {
+                        NodeState = entityState
+                    },
+                PaintAction);
+
+        private static bool PaintAction(InternalEntityEntryGraphNode n)
+        {
+            if (n.Entry.EntityState != EntityState.Detached
+                || (n.ReachedVia != null && n.ReachedVia.PointsToPrincipal()))
+            {
+                return false;
+            }
+
+            if (!n.Entry.IsKeySet)
+            {
+                n.NodeState = EntityState.Added;
+            }
+
+            n.Entry.SetEntityState((EntityState)n.NodeState, acceptChanges: true);
+
+            return true;
+        }
+
+        private class InternalEntityEntryGraphNode : EntityGraphNodeBase<InternalEntityEntryGraphNode>
+        {
+            public InternalEntityEntryGraphNode(InternalEntityEntry internalEntityEntry, INavigation reachedVia)
+                : base(internalEntityEntry, reachedVia)
+            {
+            }
+
+            public override InternalEntityEntryGraphNode NewNode(
+                InternalEntityEntryGraphNode currentNode, InternalEntityEntry internalEntityEntry, INavigation reachedVia)
+                => new InternalEntityEntryGraphNode(internalEntityEntry, reachedVia) { NodeState = currentNode.NodeState };
+        }
+    }
+}

--- a/src/EntityFramework.Core/ChangeTracking/Internal/IEntityGraphAttacher.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/IEntityGraphAttacher.cs
@@ -1,14 +1,12 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using JetBrains.Annotations;
 
 namespace Microsoft.Data.Entity.ChangeTracking.Internal
 {
-    public interface IEntityEntryGraphIterator
+    public interface IEntityGraphAttacher
     {
-        void TraverseGraph<TNode>([NotNull] TNode node, [NotNull] Func<TNode, bool> handleNode)
-            where TNode : EntityGraphNodeBase<TNode>;
+        void AttachGraph([NotNull] InternalEntityEntry rootEntry, EntityState entityState);
     }
 }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/IGraphAttacher.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/IGraphAttacher.cs
@@ -1,14 +1,12 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using JetBrains.Annotations;
 
 namespace Microsoft.Data.Entity.ChangeTracking.Internal
 {
-    public interface IEntityEntryGraphIterator
+    public interface IGraphAttacher
     {
-        void TraverseGraph<TNode>([NotNull] TNode node, [NotNull] Func<TNode, bool> handleNode)
-            where TNode : EntityGraphNodeBase<TNode>;
+        void AttachGraph([NotNull] object rootEntity, EntityState entityState);
     }
 }

--- a/src/EntityFramework.Core/DbContext.cs
+++ b/src/EntityFramework.Core/DbContext.cs
@@ -35,9 +35,8 @@ namespace Microsoft.Data.Entity
     ///     </para>
     ///     <para>
     ///         The model is discovered by running a set of conventions over the entity classes found in the
-    ///         <see cref="DbSet{TEntity}" />
-    ///         properties on the derived context. To further configure the model that is discovered by convention, you can
-    ///         override the <see cref="OnModelCreating(ModelBuilder)" /> method.
+    ///         <see cref="DbSet{TEntity}" /> properties on the derived context. To further configure the model that
+    ///         is discovered by convention, you can override the <see cref="OnModelCreating(ModelBuilder)" /> method.
     ///     </para>
     /// </remarks>
     public class DbContext : IDisposable, IAccessor<IServiceProvider>
@@ -70,17 +69,15 @@ namespace Microsoft.Data.Entity
         ///     </para>
         ///     <para>
         ///         The service provider must contain all the services required by Entity Framework (and the database being
-        ///         used).
-        ///         The Entity Framework services can be registered using the
+        ///         used). The Entity Framework services can be registered using the
         ///         <see cref="EntityFrameworkServiceCollectionExtensions.AddEntityFramework" /> method.
-        ///         Most databases also provide an extension method on <see cref="IServiceCollection" /> to register the services
-        ///         required.
+        ///         Most databases also provide an extension method on <see cref="IServiceCollection" /> to register the
+        ///         services required.
         ///     </para>
         ///     <para>
         ///         If the <see cref="IServiceProvider" /> has a <see cref="DbContextOptions" /> or
-        ///         <see cref="DbContextOptions{TContext}" />
-        ///         registered, then this will be used as the options for this context instance. The <see cref="OnConfiguring" />
-        ///         method
+        ///         <see cref="DbContextOptions{TContext}" /> registered, then this will be used as the options for
+        ///         this context instance. The <see cref="OnConfiguring" /> method
         ///         will still be called to allow further configuration of the options.
         ///     </para>
         /// </summary>
@@ -114,18 +111,16 @@ namespace Microsoft.Data.Entity
         ///     </para>
         ///     <para>
         ///         The service provider must contain all the services required by Entity Framework (and the databases being
-        ///         used).
-        ///         The Entity Framework services can be registered using the
+        ///         used). The Entity Framework services can be registered using the
         ///         <see cref="EntityFrameworkServiceCollectionExtensions.AddEntityFramework" /> method.
-        ///         Most databases also provide an extension method on <see cref="IServiceCollection" /> to register the services
-        ///         required.
+        ///         Most databases also provide an extension method on <see cref="IServiceCollection" /> to register the
+        ///         services required.
         ///     </para>
         ///     <para>
         ///         If the <see cref="IServiceProvider" /> has a <see cref="DbContextOptions" /> or
         ///         <see cref="DbContextOptions{TContext}" />
         ///         registered, then this will be used as the options for this context instance. The <see cref="OnConfiguring" />
-        ///         method
-        ///         will still be called to allow further configuration of the options.
+        ///         method will still be called to allow further configuration of the options.
         ///     </para>
         /// </summary>
         /// <param name="serviceProvider">The service provider to be used.</param>
@@ -211,11 +206,8 @@ namespace Microsoft.Data.Entity
         }
 
         private void InitializeSets(IServiceProvider serviceProvider, DbContextOptions options)
-        {
-            serviceProvider = serviceProvider ?? ServiceProviderCache.Instance.GetOrAdd(options);
-
-            serviceProvider.GetRequiredService<IDbSetInitializer>().InitializeSets(this);
-        }
+            => (serviceProvider ?? ServiceProviderCache.Instance.GetOrAdd(options))
+                .GetRequiredService<IDbSetInitializer>().InitializeSets(this);
 
         /// <summary>
         ///     <para>
@@ -265,9 +257,9 @@ namespace Microsoft.Data.Entity
         ///     Saves all changes made in this context to the underlying database.
         /// </summary>
         /// <remarks>
-        ///     This method will automatically call <see cref="ChangeTracker.DetectChanges" /> to discover any changes
-        ///     to entity instances before saving to the underlying database. This can be disabled via
-        ///     <see cref="ChangeTracker.AutoDetectChangesEnabled" />.
+        ///     This method will automatically call <see cref="ChangeTracking.ChangeTracker.DetectChanges" /> to discover any
+        ///     changes to entity instances before saving to the underlying database. This can be disabled via
+        ///     <see cref="ChangeTracking.ChangeTracker.AutoDetectChangesEnabled" />.
         /// </remarks>
         /// <returns>
         ///     The number of state entries written to the underlying database.
@@ -279,13 +271,13 @@ namespace Microsoft.Data.Entity
         ///     Saves all changes made in this context to the underlying database.
         /// </summary>
         /// <param name="acceptAllChangesOnSuccess">
-        ///     Indicates whether <see cref="ChangeTracker.AcceptAllChanges" /> is called after the changes have been
-        ///     sent succesfully to the database.
+        ///     Indicates whether <see cref="ChangeTracking.ChangeTracker.AcceptAllChanges" /> is called after the changes have
+        ///     been sent succesfully to the database.
         /// </param>
         /// <remarks>
-        ///     This method will automatically call <see cref="ChangeTracker.DetectChanges" /> to discover any changes
-        ///     to entity instances before saving to the underlying database. This can be disabled via
-        ///     <see cref="ChangeTracker.AutoDetectChangesEnabled" />.
+        ///     This method will automatically call <see cref="ChangeTracking.ChangeTracker.DetectChanges" /> to discover any
+        ///     changes to entity instances before saving to the underlying database. This can be disabled via
+        ///     <see cref="ChangeTracking.ChangeTracker.AutoDetectChangesEnabled" />.
         /// </remarks>
         /// <returns>
         ///     The number of state entries written to the underlying database.
@@ -326,9 +318,9 @@ namespace Microsoft.Data.Entity
         /// </summary>
         /// <remarks>
         ///     <para>
-        ///         This method will automatically call <see cref="ChangeTracker.DetectChanges" /> to discover any changes
-        ///         to entity instances before saving to the underlying database. This can be disabled via
-        ///         <see cref="ChangeTracker.AutoDetectChangesEnabled" />.
+        ///         This method will automatically call <see cref="ChangeTracking.ChangeTracker.DetectChanges" /> to discover any
+        ///         changes to entity instances before saving to the underlying database. This can be disabled via
+        ///         <see cref="ChangeTracking.ChangeTracker.AutoDetectChangesEnabled" />.
         ///     </para>
         ///     <para>
         ///         Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
@@ -341,22 +333,21 @@ namespace Microsoft.Data.Entity
         ///     number of state entries written to the underlying database.
         /// </returns>
         public virtual Task<int> SaveChangesAsync(CancellationToken cancellationToken = default(CancellationToken))
-        {
-            return SaveChangesAsync(acceptAllChangesOnSuccess: true, cancellationToken: cancellationToken);
-        }
+            => SaveChangesAsync(acceptAllChangesOnSuccess: true, cancellationToken: cancellationToken);
 
         /// <summary>
         ///     Asynchronously saves all changes made in this context to the underlying database.
         /// </summary>
         /// <param name="acceptAllChangesOnSuccess">
-        ///     Indicates whether <see cref="ChangeTracker.AcceptAllChanges" /> is called after the changes have been
+        ///     Indicates whether <see cref="ChangeTracking.ChangeTracker.AcceptAllChanges" /> is called after the changes have
+        ///     been
         ///     sent succesfully to the database.
         /// </param>
         /// <remarks>
         ///     <para>
-        ///         This method will automatically call <see cref="ChangeTracker.DetectChanges" /> to discover any changes
-        ///         to entity instances before saving to the underlying database. This can be disabled via
-        ///         <see cref="ChangeTracker.AutoDetectChangesEnabled" />.
+        ///         This method will automatically call <see cref="ChangeTracking.ChangeTracker.DetectChanges" /> to discover any
+        ///         changes to entity instances before saving to the underlying database. This can be disabled via
+        ///         <see cref="ChangeTracking.ChangeTracker.AutoDetectChangesEnabled" />.
         ///     </para>
         ///     <para>
         ///         Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
@@ -422,12 +413,8 @@ namespace Microsoft.Data.Entity
             return EntryWithoutDetectChanges(entity);
         }
 
-        private EntityEntry<TEntity> EntryWithoutDetectChanges<TEntity>([NotNull] TEntity entity) where TEntity : class
-        {
-            Check.NotNull(entity, nameof(entity));
-
-            return new EntityEntry<TEntity>(this, GetStateManager().GetOrCreateEntry(entity));
-        }
+        private EntityEntry<TEntity> EntryWithoutDetectChanges<TEntity>(TEntity entity) where TEntity : class
+            => new EntityEntry<TEntity>(this, GetStateManager().GetOrCreateEntry(entity));
 
         /// <summary>
         ///     <para>
@@ -451,11 +438,20 @@ namespace Microsoft.Data.Entity
             return EntryWithoutDetectChanges(entity);
         }
 
-        private EntityEntry EntryWithoutDetectChanges([NotNull] object entity)
-        {
-            Check.NotNull(entity, nameof(entity));
+        private EntityEntry EntryWithoutDetectChanges(object entity)
+            => new EntityEntry(this, GetStateManager().GetOrCreateEntry(entity));
 
-            return new EntityEntry(this, GetStateManager().GetOrCreateEntry(entity));
+        private void SetEntityState(InternalEntityEntry entry, EntityState entityState, bool includeDependents)
+        {
+            if (includeDependents
+                && entry.EntityState == EntityState.Detached)
+            {
+                ServiceProvider.GetRequiredService<IEntityGraphAttacher>().AttachGraph(entry, entityState);
+            }
+            else
+            {
+                entry.SetEntityState(entityState, acceptChanges: true);
+            }
         }
 
         /// <summary>
@@ -464,17 +460,17 @@ namespace Microsoft.Data.Entity
         /// </summary>
         /// <typeparam name="TEntity"> The type of the entity. </typeparam>
         /// <param name="entity"> The entity to add. </param>
+        /// <param name="includeDependents">
+        ///     If true, then the context will also start tracking all dependent entities reachable from the given entity using
+        ///     the same rules. If false, then only the given entity will be tracked.
+        /// </param>
         /// <returns>
         ///     The <see cref="EntityEntry{TEntity}" /> for the entity. This entry provides access to
         ///     information the context is tracking for the entity and the ability to perform
         ///     actions on the entity.
         /// </returns>
-        public virtual EntityEntry<TEntity> Add<TEntity>([NotNull] TEntity entity) where TEntity : class
-        {
-            Check.NotNull(entity, nameof(entity));
-
-            return SetEntityState(entity, EntityState.Added);
-        }
+        public virtual EntityEntry<TEntity> Add<TEntity>([NotNull] TEntity entity, bool includeDependents = true) where TEntity : class
+            => SetEntityState(Check.NotNull(entity, nameof(entity)), EntityState.Added, includeDependents);
 
         /// <summary>
         ///     Begins tracking the given entity in the <see cref="EntityState.Unchanged" /> state such that no
@@ -482,21 +478,17 @@ namespace Microsoft.Data.Entity
         /// </summary>
         /// <typeparam name="TEntity"> The type of the entity. </typeparam>
         /// <param name="entity"> The entity to attach. </param>
+        /// <param name="includeDependents">
+        ///     If true, then the context will also start tracking all dependent entities reachable from the given entity using
+        ///     the same rules. If false, then only the given entity will be tracked.
+        /// </param>
         /// <returns>
         ///     The <see cref="EntityEntry{TEntity}" /> for the entity. This entry provides access to
         ///     information the context is tracking for the entity and the ability to perform
         ///     actions on the entity.
         /// </returns>
-        public virtual EntityEntry<TEntity> Attach<TEntity>([NotNull] TEntity entity) where TEntity : class
-        {
-            Check.NotNull(entity, nameof(entity));
-
-            var entry = EntryWithoutDetectChanges(entity);
-            var internalEntry = entry.GetService();
-            internalEntry.SetEntityState(EntityState.Unchanged, acceptChanges: true);
-
-            return new EntityEntry<TEntity>(entry.Context, internalEntry);
-        }
+        public virtual EntityEntry<TEntity> Attach<TEntity>([NotNull] TEntity entity, bool includeDependents = true) where TEntity : class
+            => SetEntityState(Check.NotNull(entity, nameof(entity)), EntityState.Unchanged, includeDependents);
 
         /// <summary>
         ///     <para>
@@ -505,24 +497,24 @@ namespace Microsoft.Data.Entity
         ///     </para>
         ///     <para>
         ///         All properties of the entity will be marked as modified. To mark only some properties as modified, use
-        ///         <see cref="Attach{TEntity}(TEntity)" /> to begin tracking the entity in the
+        ///         <see cref="Attach{TEntity}(TEntity, bool)" /> to begin tracking the entity in the
         ///         <see cref="EntityState.Unchanged" />
         ///         state and then use the returned <see cref="EntityEntry{TEntity}" /> to mark the desired properties as modified.
         ///     </para>
         /// </summary>
         /// <typeparam name="TEntity"> The type of the entity. </typeparam>
         /// <param name="entity"> The entity to update. </param>
+        /// <param name="includeDependents">
+        ///     If true, then the context will also start tracking all dependent entities reachable from the given entity using
+        ///     the same rules. If false, then only the given entity will be tracked.
+        /// </param>
         /// <returns>
         ///     The <see cref="EntityEntry{TEntity}" /> for the entity. This entry provides access to
         ///     information the context is tracking for the entity and the ability to perform
         ///     actions on the entity.
         /// </returns>
-        public virtual EntityEntry<TEntity> Update<TEntity>([NotNull] TEntity entity) where TEntity : class
-        {
-            Check.NotNull(entity, nameof(entity));
-
-            return SetEntityState(entity, EntityState.Modified);
-        }
+        public virtual EntityEntry<TEntity> Update<TEntity>([NotNull] TEntity entity, bool includeDependents = true) where TEntity : class
+            => SetEntityState(Check.NotNull(entity, nameof(entity)), EntityState.Modified, includeDependents);
 
         /// <summary>
         ///     Begins tracking the given entity in the <see cref="EntityState.Deleted" /> state such that it will
@@ -544,19 +536,26 @@ namespace Microsoft.Data.Entity
         {
             Check.NotNull(entity, nameof(entity));
 
+            var entry = EntryWithoutDetectChanges(entity);
+
             // An Added entity does not yet exist in the database. If it is then marked as deleted there is
             // nothing to delete because it was not yet inserted, so just make sure it doesn't get inserted.
-            return SetEntityState(
-                entity, EntryWithoutDetectChanges(entity).State == EntityState.Added
+            entry.State =
+                entry.State == EntityState.Added
                     ? EntityState.Detached
-                    : EntityState.Deleted);
+                    : EntityState.Deleted;
+
+            return entry;
         }
 
-        private EntityEntry<TEntity> SetEntityState<TEntity>(TEntity entity, EntityState entityState) where TEntity : class
+        private EntityEntry<TEntity> SetEntityState<TEntity>(
+            TEntity entity,
+            EntityState entityState,
+            bool includeDependents) where TEntity : class
         {
             var entry = EntryWithoutDetectChanges(entity);
 
-            entry.State = entityState;
+            SetEntityState(entry.GetService(), entityState, includeDependents);
 
             return entry;
         }
@@ -566,34 +565,34 @@ namespace Microsoft.Data.Entity
         ///     be inserted into the database when <see cref="SaveChanges()" /> is called.
         /// </summary>
         /// <param name="entity"> The entity to add. </param>
+        /// <param name="includeDependents">
+        ///     If true, then the context will also start tracking all dependent entities reachable from the given entity using
+        ///     the same rules. If false, then only the given entity will be tracked.
+        /// </param>
         /// <returns>
         ///     The <see cref="EntityEntry" /> for the entity. This entry provides access to
         ///     information the context is tracking for the entity and the ability to perform
         ///     actions on the entity.
         /// </returns>
-        public virtual EntityEntry Add([NotNull] object entity)
-        {
-            Check.NotNull(entity, nameof(entity));
-
-            return SetEntityState(entity, EntityState.Added);
-        }
+        public virtual EntityEntry Add([NotNull] object entity, bool includeDependents = true)
+            => SetEntityState(Check.NotNull(entity, nameof(entity)), EntityState.Added, includeDependents);
 
         /// <summary>
         ///     Begins tracking the given entity in the <see cref="EntityState.Unchanged" /> state such that no
         ///     operation will be performed when <see cref="SaveChanges()" /> is called.
         /// </summary>
         /// <param name="entity"> The entity to attach. </param>
+        /// <param name="includeDependents">
+        ///     If true, then the context will also start tracking all dependent entities reachable from the given entity using
+        ///     the same rules. If false, then only the given entity will be tracked.
+        /// </param>
         /// <returns>
         ///     The <see cref="EntityEntry" /> for the entity. This entry provides access to
         ///     information the context is tracking for the entity and the ability to perform
         ///     actions on the entity.
         /// </returns>
-        public virtual EntityEntry Attach([NotNull] object entity)
-        {
-            Check.NotNull(entity, nameof(entity));
-
-            return SetEntityState(entity, EntityState.Unchanged);
-        }
+        public virtual EntityEntry Attach([NotNull] object entity, bool includeDependents = true)
+            => SetEntityState(Check.NotNull(entity, nameof(entity)), EntityState.Unchanged, includeDependents);
 
         /// <summary>
         ///     <para>
@@ -602,22 +601,22 @@ namespace Microsoft.Data.Entity
         ///     </para>
         ///     <para>
         ///         All properties of the entity will be marked as modified. To mark only some properties as modified, use
-        ///         <see cref="Attach(object)" /> to begin tracking the entity in the <see cref="EntityState.Unchanged" />
+        ///         <see cref="Attach(object, bool)" /> to begin tracking the entity in the <see cref="EntityState.Unchanged" />
         ///         state and then use the returned <see cref="EntityEntry" /> to mark the desired properties as modified.
         ///     </para>
         /// </summary>
         /// <param name="entity"> The entity to update. </param>
+        /// <param name="includeDependents">
+        ///     If true, then the context will also start tracking all dependent entities reachable from the given entity using
+        ///     the same rules. If false, then only the given entity will be tracked.
+        /// </param>
         /// <returns>
         ///     The <see cref="EntityEntry" /> for the entity. This entry provides access to
         ///     information the context is tracking for the entity and the ability to perform
         ///     actions on the entity.
         /// </returns>
-        public virtual EntityEntry Update([NotNull] object entity)
-        {
-            Check.NotNull(entity, nameof(entity));
-
-            return SetEntityState(entity, EntityState.Modified);
-        }
+        public virtual EntityEntry Update([NotNull] object entity, bool includeDependents = true)
+            => SetEntityState(Check.NotNull(entity, nameof(entity)), EntityState.Modified, includeDependents);
 
         /// <summary>
         ///     Begins tracking the given entity in the <see cref="EntityState.Deleted" /> state such that it will
@@ -638,31 +637,25 @@ namespace Microsoft.Data.Entity
         {
             Check.NotNull(entity, nameof(entity));
 
-            // An Added entity does not yet exist in the database. If it is then marked as deleted there is
-            // nothing to delete because it was not yet inserted, so just make sure it doesn't get inserted.
-            return SetEntityState(
-                entity, EntryWithoutDetectChanges(entity).State == EntityState.Added
-                    ? EntityState.Detached
-                    : EntityState.Deleted);
-        }
-
-        private EntityEntry SetEntityState(object entity, EntityState entityState)
-        {
             var entry = EntryWithoutDetectChanges(entity);
 
-            entry.State = entityState;
+            // An Added entity does not yet exist in the database. If it is then marked as deleted there is
+            // nothing to delete because it was not yet inserted, so just make sure it doesn't get inserted.
+            entry.State =
+                entry.State == EntityState.Added
+                    ? EntityState.Detached
+                    : EntityState.Deleted;
 
             return entry;
         }
 
-        private void SetEntityStates(object[] entities, EntityState entityState)
+        private EntityEntry SetEntityState(object entity, EntityState entityState, bool includeDependents)
         {
-            var stateManager = GetStateManager();
+            var entry = EntryWithoutDetectChanges(entity);
 
-            foreach (var entity in entities)
-            {
-                stateManager.GetOrCreateEntry(entity).SetEntityState(entityState);
-            }
+            SetEntityState(entry.GetService(), entityState, includeDependents);
+
+            return entry;
         }
 
         /// <summary>
@@ -671,11 +664,7 @@ namespace Microsoft.Data.Entity
         /// </summary>
         /// <param name="entities"> The entities to add. </param>
         public virtual void AddRange([NotNull] params object[] entities)
-        {
-            Check.NotNull(entities, nameof(entities));
-
-            SetEntityStates(entities, EntityState.Added);
-        }
+            => AddRange((IEnumerable<object>)entities);
 
         /// <summary>
         ///     Begins tracking the given entities in the <see cref="EntityState.Unchanged" /> state such that no
@@ -683,11 +672,7 @@ namespace Microsoft.Data.Entity
         /// </summary>
         /// <param name="entities"> The entities to attach. </param>
         public virtual void AttachRange([NotNull] params object[] entities)
-        {
-            Check.NotNull(entities, nameof(entities));
-
-            SetEntityStates(entities, EntityState.Unchanged, acceptChanges: true);
-        }
+            => AttachRange((IEnumerable<object>)entities);
 
         /// <summary>
         ///     <para>
@@ -696,17 +681,13 @@ namespace Microsoft.Data.Entity
         ///     </para>
         ///     <para>
         ///         All properties of the entities will be marked as modified. To mark only some properties as modified, use
-        ///         <see cref="Attach(object)" /> to begin tracking each entity in the <see cref="EntityState.Unchanged" />
+        ///         <see cref="Attach(object, bool)" /> to begin tracking each entity in the <see cref="EntityState.Unchanged" />
         ///         state and then use the returned <see cref="EntityEntry" /> to mark the desired properties as modified.
         ///     </para>
         /// </summary>
         /// <param name="entities"> The entities to update. </param>
         public virtual void UpdateRange([NotNull] params object[] entities)
-        {
-            Check.NotNull(entities, nameof(entities));
-
-            SetEntityStates(entities, EntityState.Modified);
-        }
+            => UpdateRange((IEnumerable<object>)entities);
 
         /// <summary>
         ///     Begins tracking the given entities in the <see cref="EntityState.Deleted" /> state such that they will
@@ -719,19 +700,18 @@ namespace Microsoft.Data.Entity
         /// </remarks>
         /// <param name="entities"> The entities to remove. </param>
         public virtual void RemoveRange([NotNull] params object[] entities)
-        {
-            Check.NotNull(entities, nameof(entities));
+            => RemoveRange((IEnumerable<object>)entities);
 
-            RemoveRange((IEnumerable<object>)entities);
-        }
-
-        private void SetEntityStates(IEnumerable<object> entities, EntityState entityState, bool acceptChanges = false)
+        private void SetEntityStates(
+            IEnumerable<object> entities,
+            EntityState entityState,
+            bool includeDependents)
         {
             var stateManager = GetStateManager();
 
             foreach (var entity in entities)
             {
-                stateManager.GetOrCreateEntry(entity).SetEntityState(entityState, acceptChanges);
+                SetEntityState(stateManager.GetOrCreateEntry(entity), entityState, includeDependents);
             }
         }
 
@@ -740,24 +720,24 @@ namespace Microsoft.Data.Entity
         ///     be inserted into the database when <see cref="SaveChanges()" /> is called.
         /// </summary>
         /// <param name="entities"> The entities to add. </param>
-        public virtual void AddRange([NotNull] IEnumerable<object> entities)
-        {
-            Check.NotNull(entities, nameof(entities));
-
-            SetEntityStates(entities, EntityState.Added);
-        }
+        /// <param name="includeDependents">
+        ///     If true, then the context will also start tracking all dependent entities reachable from the given entities using
+        ///     the same rules. If false, then only the given entities will be tracked.
+        /// </param>
+        public virtual void AddRange([NotNull] IEnumerable<object> entities, bool includeDependents = true)
+            => SetEntityStates(Check.NotNull(entities, nameof(entities)), EntityState.Added, includeDependents);
 
         /// <summary>
         ///     Begins tracking the given entities in the <see cref="EntityState.Unchanged" /> state such that no
         ///     operation will be performed when <see cref="SaveChanges()" /> is called.
         /// </summary>
         /// <param name="entities"> The entities to attach. </param>
-        public virtual void AttachRange([NotNull] IEnumerable<object> entities)
-        {
-            Check.NotNull(entities, nameof(entities));
-
-            SetEntityStates(entities, EntityState.Unchanged, acceptChanges: true);
-        }
+        /// <param name="includeDependents">
+        ///     If true, then the context will also start tracking all dependent entities reachable from the given entities using
+        ///     the same rules. If false, then only the given entities will be tracked.
+        /// </param>
+        public virtual void AttachRange([NotNull] IEnumerable<object> entities, bool includeDependents = true)
+            => SetEntityStates(Check.NotNull(entities, nameof(entities)), EntityState.Unchanged, includeDependents);
 
         /// <summary>
         ///     <para>
@@ -766,17 +746,17 @@ namespace Microsoft.Data.Entity
         ///     </para>
         ///     <para>
         ///         All properties of the entities will be marked as modified. To mark only some properties as modified, use
-        ///         <see cref="Attach(object)" /> to begin tracking each entity in the <see cref="EntityState.Unchanged" />
+        ///         <see cref="Attach(object, bool)" /> to begin tracking each entity in the <see cref="EntityState.Unchanged" />
         ///         state and then use the returned <see cref="EntityEntry" /> to mark the desired properties as modified.
         ///     </para>
         /// </summary>
         /// <param name="entities"> The entities to update. </param>
-        public virtual void UpdateRange([NotNull] IEnumerable<object> entities)
-        {
-            Check.NotNull(entities, nameof(entities));
-
-            SetEntityStates(entities, EntityState.Modified);
-        }
+        /// <param name="includeDependents">
+        ///     If true, then the context will also start tracking all dependent entities reachable from the given entities using
+        ///     the same rules. If false, then only the given entities will be tracked.
+        /// </param>
+        public virtual void UpdateRange([NotNull] IEnumerable<object> entities, bool includeDependents = true)
+            => SetEntityStates(Check.NotNull(entities, nameof(entities)), EntityState.Modified, includeDependents);
 
         /// <summary>
         ///     Begins tracking the given entities in the <see cref="EntityState.Deleted" /> state such that they will

--- a/src/EntityFramework.Core/DbSet`.cs
+++ b/src/EntityFramework.Core/DbSet`.cs
@@ -46,12 +46,16 @@ namespace Microsoft.Data.Entity
         ///     be inserted into the database when <see cref="DbContext.SaveChanges()" /> is called.
         /// </summary>
         /// <param name="entity"> The entity to add. </param>
+        /// <param name="includeDependents">
+        ///     If true, then the context will also start tracking all dependent entities reachable from the given entity using
+        ///     the same rules. If false, then only the given entity will be tracked.
+        /// </param>
         /// <returns>
         ///     The <see cref="EntityEntry{TEntity}" /> for the entity. This entry provides access to
         ///     information the context is tracking for the entity and the ability to perform
         ///     actions on the entity.
         /// </returns>
-        public virtual EntityEntry<TEntity> Add([NotNull] TEntity entity)
+        public virtual EntityEntry<TEntity> Add([NotNull] TEntity entity, bool includeDependents = true)
         {
             throw new NotImplementedException();
         }
@@ -61,12 +65,16 @@ namespace Microsoft.Data.Entity
         ///     operation will be performed when <see cref="DbContext.SaveChanges()" /> is called.
         /// </summary>
         /// <param name="entity"> The entity to attach. </param>
+        /// <param name="includeDependents">
+        ///     If true, then the context will also start tracking all dependent entities reachable from the given entity using
+        ///     the same rules. If false, then only the given entity will be tracked.
+        /// </param>
         /// <returns>
         ///     The <see cref="EntityEntry" /> for the entity. This entry provides access to
         ///     information the context is tracking for the entity and the ability to perform
         ///     actions on the entity.
         /// </returns>
-        public virtual EntityEntry<TEntity> Attach([NotNull] TEntity entity)
+        public virtual EntityEntry<TEntity> Attach([NotNull] TEntity entity, bool includeDependents = true)
         {
             throw new NotImplementedException();
         }
@@ -98,17 +106,21 @@ namespace Microsoft.Data.Entity
         ///     </para>
         ///     <para>
         ///         All properties of the entity will be marked as modified. To mark only some properties as modified, use
-        ///         <see cref="Attach(TEntity)" /> to begin tracking the entity in the <see cref="EntityState.Unchanged" />
+        ///         <see cref="Attach(TEntity, bool)" /> to begin tracking the entity in the <see cref="EntityState.Unchanged" />
         ///         state and then use the returned <see cref="EntityEntry" /> to mark the desired properties as modified.
         ///     </para>
         /// </summary>
         /// <param name="entity"> The entity to update. </param>
+        /// <param name="includeDependents">
+        ///     If true, then the context will also start tracking all dependent entities reachable from the given entity using
+        ///     the same rules. If false, then only the given entity will be tracked.
+        /// </param>
         /// <returns>
         ///     The <see cref="EntityEntry" /> for the entity. This entry provides access to
         ///     information the context is tracking for the entity and the ability to perform
         ///     actions on the entity.
         /// </returns>
-        public virtual EntityEntry<TEntity> Update([NotNull] TEntity entity)
+        public virtual EntityEntry<TEntity> Update([NotNull] TEntity entity, bool includeDependents = true)
         {
             throw new NotImplementedException();
         }
@@ -155,7 +167,7 @@ namespace Microsoft.Data.Entity
         ///     </para>
         ///     <para>
         ///         All properties of the entities will be marked as modified. To mark only some properties as modified, use
-        ///         <see cref="Attach(TEntity)" /> to begin tracking each entity in the <see cref="EntityState.Unchanged" />
+        ///         <see cref="Attach(TEntity, bool)" /> to begin tracking each entity in the <see cref="EntityState.Unchanged" />
         ///         state and then use the returned <see cref="EntityEntry" /> to mark the desired properties as modified.
         ///     </para>
         /// </summary>
@@ -170,7 +182,11 @@ namespace Microsoft.Data.Entity
         ///     be inserted into the database when <see cref="DbContext.SaveChanges()" /> is called.
         /// </summary>
         /// <param name="entities"> The entities to add. </param>
-        public virtual void AddRange([NotNull] IEnumerable<TEntity> entities)
+        /// <param name="includeDependents">
+        ///     If true, then the context will also start tracking all dependent entities reachable from the given entity using
+        ///     the same rules. If false, then only the given entity will be tracked.
+        /// </param>
+        public virtual void AddRange([NotNull] IEnumerable<TEntity> entities, bool includeDependents = true)
         {
             throw new NotImplementedException();
         }
@@ -180,7 +196,11 @@ namespace Microsoft.Data.Entity
         ///     operation will be performed when <see cref="DbContext.SaveChanges()" /> is called.
         /// </summary>
         /// <param name="entities"> The entities to attach. </param>
-        public virtual void AttachRange([NotNull] IEnumerable<TEntity> entities)
+        /// <param name="includeDependents">
+        ///     If true, then the context will also start tracking all dependent entities reachable from the given entity using
+        ///     the same rules. If false, then only the given entity will be tracked.
+        /// </param>
+        public virtual void AttachRange([NotNull] IEnumerable<TEntity> entities, bool includeDependents = true)
         {
             throw new NotImplementedException();
         }
@@ -207,12 +227,16 @@ namespace Microsoft.Data.Entity
         ///     </para>
         ///     <para>
         ///         All properties of the entities will be marked as modified. To mark only some properties as modified, use
-        ///         <see cref="Attach(TEntity)" /> to begin tracking each entity in the <see cref="EntityState.Unchanged" />
+        ///         <see cref="Attach(TEntity, bool)" /> to begin tracking each entity in the <see cref="EntityState.Unchanged" />
         ///         state and then use the returned <see cref="EntityEntry" /> to mark the desired properties as modified.
         ///     </para>
         /// </summary>
         /// <param name="entities"> The entities to update. </param>
-        public virtual void UpdateRange([NotNull] IEnumerable<TEntity> entities)
+        /// <param name="includeDependents">
+        ///     If true, then the context will also start tracking all dependent entities reachable from the given entity using
+        ///     the same rules. If false, then only the given entity will be tracked.
+        /// </param>
+        public virtual void UpdateRange([NotNull] IEnumerable<TEntity> entities, bool includeDependents = true)
         {
             throw new NotImplementedException();
         }

--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -56,7 +56,11 @@
       <Link>Extensions\Internal\LoggingExtensions.cs</Link>
     </Compile>
     <Compile Include="ChangeTracking\ChangeTrackerFactory.cs" />
+    <Compile Include="ChangeTracking\EntityEntryGraphNode.cs" />
+    <Compile Include="ChangeTracking\EntityGraphNodeBase.cs" />
     <Compile Include="ChangeTracking\IChangeTrackerFactory.cs" />
+    <Compile Include="ChangeTracking\Internal\EntityGraphAttacher.cs" />
+    <Compile Include="ChangeTracking\Internal\IEntityGraphAttacher.cs" />
     <Compile Include="ChangeTracking\Internal\SimpleNullSentinelEntityKeyFactory.cs" />
     <Compile Include="ChangeTracking\Internal\ValueBufferOriginalValues.cs" />
     <Compile Include="ChangeTracking\Internal\ValueBufferSidecar.cs" />

--- a/src/EntityFramework.Core/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/EntityFramework.Core/EntityFrameworkServiceCollectionExtensions.cs
@@ -99,6 +99,7 @@ namespace Microsoft.Framework.DependencyInjection
                 .AddScoped<IEntityEntryGraphIterator, EntityEntryGraphIterator>()
                 .AddScoped<IDbContextServices, DbContextServices>()
                 .AddScoped<IDatabaseProviderSelector, DatabaseProviderSelector>()
+                .AddScoped<IEntityGraphAttacher, EntityGraphAttacher>()
                 .AddScoped<ValueGeneratorSelector>()
                 .AddScoped(p => GetContextServices(p).Model)
                 .AddScoped(p => GetContextServices(p).Context)

--- a/src/EntityFramework.Core/Internal/InternalDbSet.cs
+++ b/src/EntityFramework.Core/Internal/InternalDbSet.cs
@@ -43,18 +43,18 @@ namespace Microsoft.Data.Entity.Internal
             _entityQueryable = new LazyRef<EntityQueryable<TEntity>>(() => (EntityQueryable<TEntity>)source);
         }
 
-        public override EntityEntry<TEntity> Add(TEntity entity)
+        public override EntityEntry<TEntity> Add(TEntity entity, bool includeDependents = true)
         {
             Check.NotNull(entity, nameof(entity));
 
-            return _context.Add(entity);
+            return _context.Add(entity, includeDependents);
         }
 
-        public override EntityEntry<TEntity> Attach(TEntity entity)
+        public override EntityEntry<TEntity> Attach(TEntity entity, bool includeDependents = true)
         {
             Check.NotNull(entity, nameof(entity));
 
-            return _context.Attach(entity);
+            return _context.Attach(entity, includeDependents);
         }
 
         public override EntityEntry<TEntity> Remove(TEntity entity)
@@ -64,11 +64,11 @@ namespace Microsoft.Data.Entity.Internal
             return _context.Remove(entity);
         }
 
-        public override EntityEntry<TEntity> Update(TEntity entity)
+        public override EntityEntry<TEntity> Update(TEntity entity, bool includeDependents = true)
         {
             Check.NotNull(entity, nameof(entity));
 
-            return _context.Update(entity);
+            return _context.Update(entity, includeDependents);
         }
 
         public override void AddRange(params TEntity[] entities)
@@ -99,18 +99,18 @@ namespace Microsoft.Data.Entity.Internal
             _context.UpdateRange(entities);
         }
 
-        public override void AddRange(IEnumerable<TEntity> entities)
+        public override void AddRange(IEnumerable<TEntity> entities, bool includeDependents = true)
         {
             Check.NotNull(entities, nameof(entities));
 
-            _context.AddRange(entities);
+            _context.AddRange(entities, includeDependents);
         }
 
-        public override void AttachRange(IEnumerable<TEntity> entities)
+        public override void AttachRange(IEnumerable<TEntity> entities, bool includeDependents = true)
         {
             Check.NotNull(entities, nameof(entities));
 
-            _context.AttachRange(entities);
+            _context.AttachRange(entities, includeDependents);
         }
 
         public override void RemoveRange(IEnumerable<TEntity> entities)
@@ -120,11 +120,11 @@ namespace Microsoft.Data.Entity.Internal
             _context.RemoveRange(entities);
         }
 
-        public override void UpdateRange(IEnumerable<TEntity> entities)
+        public override void UpdateRange(IEnumerable<TEntity> entities, bool includeDependents = true)
         {
             Check.NotNull(entities, nameof(entities));
 
-            _context.UpdateRange(entities);
+            _context.UpdateRange(entities, includeDependents);
         }
 
         IEnumerator<TEntity> IEnumerable<TEntity>.GetEnumerator() => _entityQueryable.Value.GetEnumerator();

--- a/src/EntityFramework.Core/Metadata/NavigationExtensions.cs
+++ b/src/EntityFramework.Core/Metadata/NavigationExtensions.cs
@@ -28,10 +28,8 @@ namespace Microsoft.Data.Entity.Metadata
                 : navigation.ForeignKey.DependentToPrincipal;
         }
 
-        public static Navigation FindInverse([NotNull] this Navigation navigation)
-        {
-            return (Navigation)((INavigation)navigation).FindInverse();
-        }
+        public static Navigation FindInverse([NotNull] this Navigation navigation) 
+            => (Navigation)((INavigation)navigation).FindInverse();
 
         public static IEntityType GetTargetType([NotNull] this INavigation navigation)
         {
@@ -42,10 +40,8 @@ namespace Microsoft.Data.Entity.Metadata
                 : navigation.ForeignKey.DeclaringEntityType;
         }
 
-        public static EntityType GetTargetType([NotNull] this Navigation navigation)
-        {
-            return (EntityType)((INavigation)navigation).GetTargetType();
-        }
+        public static EntityType GetTargetType([NotNull] this Navigation navigation) 
+            => (EntityType)((INavigation)navigation).GetTargetType();
 
         public static bool IsCompatible(
             [NotNull] this Navigation navigation,

--- a/test/EntityFramework.Core.FunctionalTests/ChangeTrackingTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/ChangeTrackingTestBase.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 context.ChangeTracker.DetectChanges();
                 Assert.Equal(EntityState.Modified, firstTrackedEntity.State);
 
-                context.Attach(customer);
+                context.Attach(customer, includeDependents: false);
 
                 Assert.Equal(customer.CustomerID, firstTrackedEntity.Property(c => c.CustomerID).CurrentValue);
                 Assert.Equal(EntityState.Unchanged, firstTrackedEntity.State);
@@ -109,7 +109,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 context.ChangeTracker.DetectChanges();
                 Assert.Equal(EntityState.Modified, firstTrackedEntity.State);
 
-                context.Customers.Attach(customer);
+                context.Customers.Attach(customer, includeDependents: false);
 
                 Assert.Equal(customer.CustomerID, firstTrackedEntity.Property(c => c.CustomerID).CurrentValue);
                 Assert.Equal(EntityState.Unchanged, firstTrackedEntity.State);
@@ -148,7 +148,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 Assert.Equal(EntityState.Modified, trackedEntity0.State);
                 Assert.Equal(EntityState.Modified, trackedEntity1.State);
 
-                context.AttachRange(customers);
+                context.AttachRange(customers, includeDependents: false);
 
                 Assert.Equal(customer0.CustomerID, trackedEntity0.Property(c => c.CustomerID).CurrentValue);
                 Assert.Equal(customer1.CustomerID, trackedEntity1.Property(c => c.CustomerID).CurrentValue);
@@ -191,7 +191,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 Assert.Equal(EntityState.Modified, trackedEntity0.State);
                 Assert.Equal(EntityState.Modified, trackedEntity1.State);
 
-                context.Customers.AttachRange(customers);
+                context.Customers.AttachRange(customers, includeDependents: false);
 
                 Assert.Equal(customer0.CustomerID, trackedEntity0.Property(c => c.CustomerID).CurrentValue);
                 Assert.Equal(customer1.CustomerID, trackedEntity1.Property(c => c.CustomerID).CurrentValue);

--- a/test/EntityFramework.Core.FunctionalTests/GraphUpdatesTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/GraphUpdatesTestBase.cs
@@ -2504,7 +2504,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             {
                 var tracker = new KeyValueEntityTracker();
 
-                context.ChangeTracker.TrackGraph(CreateFullGraph(), e => tracker.TrackEntity(e));
+                context.ChangeTracker.TrackGraph(CreateFullGraph(), e => tracker.TrackEntity(e.Entry));
                 context.SaveChanges();
             }
 

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/MonsterContext`.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/MonsterContext`.cs
@@ -1326,7 +1326,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
 
             foreach (var entity in toAdd.SelectMany(l => l))
             {
-                Add(entity);
+                Add(entity, includeDependents: false);
             }
 
             if (saveChanges)

--- a/test/EntityFramework.Core.Tests/ChangeTracking/AggregatesTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/AggregatesTest.cs
@@ -1,0 +1,383 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Tests.ChangeTracking
+{
+    public class AggregatesTest
+    {
+        [Fact]
+        public void Can_add_aggreate()
+        {
+            using (var context = new AggregateContext())
+            {
+                var comments0 = new[] { new Comment(), new Comment() };
+                var comments1 = new[] { new Comment(), new Comment() };
+                var posts = new[] { new Post { Comments = comments0.ToList() }, new Post { Comments = comments1.ToList() } };
+                var blog = new Blog { Posts = posts.ToList() };
+
+                context.Add(blog);
+
+                Assert.Equal(EntityState.Added, context.Entry(blog).State);
+                Assert.Equal(EntityState.Added, context.Entry(posts[0]).State);
+                Assert.Equal(EntityState.Added, context.Entry(posts[1]).State);
+                Assert.Equal(EntityState.Added, context.Entry(comments0[0]).State);
+                Assert.Equal(EntityState.Added, context.Entry(comments0[1]).State);
+                Assert.Equal(EntityState.Added, context.Entry(comments1[0]).State);
+                Assert.Equal(EntityState.Added, context.Entry(comments1[1]).State);
+            }
+        }
+
+        [Fact]
+        public void Can_add_one_to_one_aggreate()
+        {
+            using (var context = new AggregateContext())
+            {
+                var statistics = new BlogCategoryStatistics();
+                var category = new BlogCategory { Statistics = statistics };
+
+                context.Add(category);
+
+                Assert.Equal(EntityState.Added, context.Entry(category).State);
+                Assert.Equal(EntityState.Added, context.Entry(category.Statistics).State);
+            }
+        }
+
+        [Fact]
+        public void Can_attach_aggreate()
+        {
+            using (var context = new AggregateContext())
+            {
+                var comments0 = new[] { new Comment { Id = 33, PostId = 55 }, new Comment { Id = 34, PostId = 55 } };
+                var comments1 = new[] { new Comment { Id = 44, PostId = 56 }, new Comment { Id = 45, PostId = 56 } };
+                var posts = new[]
+                    {
+                        new Post { Id = 55, BlogId = 66, Comments = comments0.ToList() },
+                        new Post { Id = 56, BlogId = 66, Comments = comments1.ToList() }
+                    };
+                var blog = new Blog { Id = 66, Posts = posts.ToList() };
+
+                context.Attach(blog);
+
+                Assert.Equal(EntityState.Unchanged, context.Entry(blog).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(posts[0]).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(posts[1]).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(comments0[0]).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(comments0[1]).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(comments1[0]).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(comments1[1]).State);
+            }
+        }
+
+        [Fact]
+        public void Can_attach_one_to_one_aggreate()
+        {
+            using (var context = new AggregateContext())
+            {
+                var statistics = new BlogCategoryStatistics { Id = 11, BlogCategoryId = 22 };
+                var category = new BlogCategory { Id = 22, Statistics = statistics };
+
+                context.Attach(category);
+
+                Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(category.Statistics).State);
+            }
+        }
+
+        [Fact]
+        public void Attaching_aggregate_with_no_key_set_adds_it_instead()
+        {
+            using (var context = new AggregateContext())
+            {
+                var comments0 = new[] { new Comment(), new Comment() };
+                var comments1 = new[] { new Comment(), new Comment() };
+                var posts = new[] { new Post { Comments = comments0.ToList() }, new Post { Comments = comments1.ToList() } };
+                var blog = new Blog { Posts = posts.ToList() };
+
+                context.Attach(blog);
+
+                Assert.Equal(EntityState.Added, context.Entry(blog).State);
+                Assert.Equal(EntityState.Added, context.Entry(posts[0]).State);
+                Assert.Equal(EntityState.Added, context.Entry(posts[1]).State);
+                Assert.Equal(EntityState.Added, context.Entry(comments0[0]).State);
+                Assert.Equal(EntityState.Added, context.Entry(comments0[1]).State);
+                Assert.Equal(EntityState.Added, context.Entry(comments1[0]).State);
+                Assert.Equal(EntityState.Added, context.Entry(comments1[1]).State);
+            }
+        }
+
+        [Fact]
+        public void Attaching_one_to_one_aggregate_with_no_key_set_adds_it_instead()
+        {
+            using (var context = new AggregateContext())
+            {
+                var statistics = new BlogCategoryStatistics();
+                var category = new BlogCategory { Statistics = statistics };
+
+                context.Attach(category);
+
+                Assert.Equal(EntityState.Added, context.Entry(category).State);
+                Assert.Equal(EntityState.Added, context.Entry(category.Statistics).State);
+            }
+        }
+
+        [Fact]
+        public void Dependents_with_no_key_set_are_added()
+        {
+            using (var context = new AggregateContext())
+            {
+                var comments0 = new[] { new Comment { Id = 33, PostId = 55 }, new Comment { Id = 34, PostId = 55 } };
+                var comments1 = new[] { new Comment { PostId = 56 }, new Comment { PostId = 56 } };
+                var posts = new[]
+                    {
+                        new Post { Id = 55, BlogId = 66, Comments = comments0.ToList() },
+                        new Post { BlogId = 66, Comments = comments1.ToList() }
+                    };
+                var blog = new Blog { Id = 66, Posts = posts.ToList() };
+
+                context.Attach(blog);
+
+                Assert.Equal(EntityState.Unchanged, context.Entry(blog).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(posts[0]).State);
+                Assert.Equal(EntityState.Added, context.Entry(posts[1]).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(comments0[0]).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(comments0[1]).State);
+                Assert.Equal(EntityState.Added, context.Entry(comments1[0]).State);
+                Assert.Equal(EntityState.Added, context.Entry(comments1[1]).State);
+            }
+        }
+
+        [Fact]
+        public void One_to_one_dependents_with_no_key_set_are_added()
+        {
+            using (var context = new AggregateContext())
+            {
+                var statistics = new BlogCategoryStatistics { BlogCategoryId = 22 };
+                var category = new BlogCategory { Id = 22, Statistics = statistics };
+
+                context.Attach(category);
+
+                Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
+                Assert.Equal(EntityState.Added, context.Entry(category.Statistics).State);
+            }
+        }
+
+        [Fact]
+        public void Can_add_aggregate_with_linked_aggregate_not_added()
+        {
+            using (var context = new AggregateContext())
+            {
+                var reminders = new[] { new Reminder { Id = 11 }, new Reminder { Id = 12 } };
+                var author = new Author { Id = 22, Reminders = reminders.ToList() };
+
+                var comments0 = new[] { new Comment { Id = 33, Author = author }, new Comment { Id = 34, Author = author } };
+                var comments1 = new[] { new Comment { Id = 44, Author = author }, new Comment { Id = 45, Author = author } };
+                var posts = new[]
+                    {
+                        new Post { Id = 55, Author = author, Comments = comments0.ToList() },
+                        new Post { Id = 56, Author = author, Comments = comments1.ToList() }
+                    };
+                var blog = new Blog { Id = 66, Author = author, Posts = posts.ToList() };
+
+                context.Add(blog);
+
+                Assert.Equal(EntityState.Added, context.Entry(blog).State);
+                Assert.Equal(EntityState.Added, context.Entry(posts[0]).State);
+                Assert.Equal(EntityState.Added, context.Entry(posts[1]).State);
+                Assert.Equal(EntityState.Added, context.Entry(comments0[0]).State);
+                Assert.Equal(EntityState.Added, context.Entry(comments0[1]).State);
+                Assert.Equal(EntityState.Added, context.Entry(comments1[0]).State);
+                Assert.Equal(EntityState.Added, context.Entry(comments1[1]).State);
+                Assert.Equal(EntityState.Detached, context.Entry(author).State);
+                Assert.Equal(EntityState.Detached, context.Entry(reminders[0]).State);
+                Assert.Equal(EntityState.Detached, context.Entry(reminders[1]).State);
+            }
+        }
+
+        [Fact]
+        public void Can_add_aggregate_with_other_linked_aggregate_not_attached()
+        {
+            using (var context = new AggregateContext())
+            {
+                var reminders = new[] { new Reminder { Id = 11 }, new Reminder { Id = 12 } };
+                var author = new Author { Id = 22, Reminders = reminders.ToList() };
+
+                var comments0 = new[] { new Comment { Id = 33, Author = author }, new Comment { Id = 34, Author = author } };
+                var comments1 = new[] { new Comment { Id = 44, Author = author }, new Comment { Id = 45, Author = author } };
+                var posts = new[]
+                    {
+                        new Post { Id = 55, Author = author, Comments = comments0.ToList() },
+                        new Post { Id = 56, Author = author, Comments = comments1.ToList() }
+                    };
+                var blog = new Blog { Id = 66, Author = author, Posts = posts.ToList() };
+
+                author.Comments = comments0.Concat(comments1).ToList();
+                comments0[0].Post = posts[0];
+                posts[0].Blog = blog;
+
+                context.Add(author);
+
+                Assert.Equal(EntityState.Detached, context.Entry(blog).State);
+                Assert.Equal(EntityState.Detached, context.Entry(posts[0]).State);
+                Assert.Equal(EntityState.Detached, context.Entry(posts[1]).State);
+                Assert.Equal(EntityState.Added, context.Entry(comments0[0]).State);
+                Assert.Equal(EntityState.Added, context.Entry(comments0[1]).State);
+                Assert.Equal(EntityState.Added, context.Entry(comments1[0]).State);
+                Assert.Equal(EntityState.Added, context.Entry(comments1[1]).State);
+                Assert.Equal(EntityState.Added, context.Entry(author).State);
+                Assert.Equal(EntityState.Added, context.Entry(reminders[0]).State);
+                Assert.Equal(EntityState.Added, context.Entry(reminders[1]).State);
+            }
+        }
+
+        [Fact]
+        public void Can_attach_aggregate_with_linked_aggregate_not_attached()
+        {
+            using (var context = new AggregateContext())
+            {
+                var reminders = new[] { new Reminder { Id = 11 }, new Reminder { Id = 12 } };
+                var author = new Author { Id = 22, Reminders = reminders.ToList() };
+
+                var comments0 = new[] { new Comment { Id = 33, Author = author }, new Comment { Id = 34, Author = author } };
+                var comments1 = new[] { new Comment { Id = 44, Author = author }, new Comment { Id = 45, Author = author } };
+                var posts = new[]
+                    {
+                        new Post { Id = 55, Author = author, Comments = comments0.ToList() },
+                        new Post { Id = 56, Author = author, Comments = comments1.ToList() }
+                    };
+                var blog = new Blog { Id = 66, Author = author, Posts = posts.ToList() };
+
+                context.Attach(blog);
+
+                Assert.Equal(EntityState.Unchanged, context.Entry(blog).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(posts[0]).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(posts[1]).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(comments0[0]).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(comments0[1]).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(comments1[0]).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(comments1[1]).State);
+                Assert.Equal(EntityState.Detached, context.Entry(author).State);
+                Assert.Equal(EntityState.Detached, context.Entry(reminders[0]).State);
+                Assert.Equal(EntityState.Detached, context.Entry(reminders[1]).State);
+            }
+        }
+
+        [Fact]
+        public void Can_add_two_aggregates_linked_down_the_tree()
+        {
+            using (var context = new AggregateContext())
+            {
+                var reminders = new[] { new Reminder { Id = 11 }, new Reminder { Id = 12 } };
+                var author = new Author { Id = 22, Reminders = reminders.ToList() };
+
+                var comments0 = new[] { new Comment { Id = 33, Author = author }, new Comment { Id = 34, Author = author } };
+                var comments1 = new[] { new Comment { Id = 44, Author = author }, new Comment { Id = 45, Author = author } };
+                var posts = new[]
+                    {
+                        new Post { Id = 55, Author = author, Comments = comments0.ToList() },
+                        new Post { Id = 56, Author = author, Comments = comments1.ToList() }
+                    };
+                var blog = new Blog { Id = 66, Author = author, Posts = posts.ToList() };
+
+                context.AddRange(blog, author);
+
+                Assert.Equal(EntityState.Added, context.Entry(blog).State);
+                Assert.Equal(EntityState.Added, context.Entry(posts[0]).State);
+                Assert.Equal(EntityState.Added, context.Entry(posts[1]).State);
+                Assert.Equal(EntityState.Added, context.Entry(comments0[0]).State);
+                Assert.Equal(EntityState.Added, context.Entry(comments0[1]).State);
+                Assert.Equal(EntityState.Added, context.Entry(comments1[0]).State);
+                Assert.Equal(EntityState.Added, context.Entry(comments1[1]).State);
+                Assert.Equal(EntityState.Added, context.Entry(author).State);
+                Assert.Equal(EntityState.Added, context.Entry(reminders[0]).State);
+                Assert.Equal(EntityState.Added, context.Entry(reminders[1]).State);
+            }
+        }
+
+        private class AggregateContext : DbContext
+        {
+            protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder.UseInMemoryDatabase();
+
+            public DbSet<Blog> Blogs { get; set; }
+            public DbSet<Post> Posts { get; set; }
+            public DbSet<Comment> Comments { get; set; }
+            public DbSet<Author> Authors { get; set; }
+        }
+
+        private class BlogCategoryStatistics
+        {
+            public int Id { get; set; }
+
+            public int? BlogCategoryId { get; set; }
+            public BlogCategory BlogCategory { get; set; }
+        }
+
+        private class BlogCategory
+        {
+            public int Id { get; set; }
+
+            public BlogCategoryStatistics Statistics { get; set; }
+
+            public ICollection<Blog> Blogs { get; set; }
+        }
+
+        private class Blog
+        {
+            public int Id { get; set; }
+
+            public int? BlogCategoryId { get; set; }
+            public BlogCategory BlogCategory { get; set; }
+
+            public int? AuthorId { get; set; }
+            public Author Author { get; set; }
+
+            public ICollection<Post> Posts { get; set; }
+        }
+
+        private class Post
+        {
+            public int Id { get; set; }
+
+            public int? AuthorId { get; set; }
+            public Author Author { get; set; }
+
+            public int BlogId { get; set; }
+            public Blog Blog { get; set; }
+
+            public ICollection<Comment> Comments { get; set; }
+        }
+
+        private class Comment
+        {
+            public int Id { get; set; }
+
+            public int? AuthorId { get; set; }
+            public Author Author { get; set; }
+
+            public int PostId { get; set; }
+            public Post Post { get; set; }
+        }
+
+        private class Author
+        {
+            public int Id { get; set; }
+
+            public ICollection<Blog> Blogs { get; set; }
+            public ICollection<Post> Posts { get; set; }
+            public ICollection<Comment> Comments { get; set; }
+            public ICollection<Reminder> Reminders { get; set; }
+        }
+
+        private class Reminder
+        {
+            public int Id { get; set; }
+
+            public int AuthorId { get; set; }
+            public Author Author { get; set; }
+        }
+    }
+}

--- a/test/EntityFramework.Core.Tests/ChangeTracking/ChangeTrackerTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/ChangeTrackerTest.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
                             }
                     };
 
-                context.ChangeTracker.TrackGraph(category, e => e.State = EntityState.Modified);
+                context.ChangeTracker.TrackGraph(category, e => e.Entry.State = EntityState.Modified);
 
                 Assert.Equal(4, context.ChangeTracker.Entries().Count());
 
@@ -113,7 +113,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             {
                 var product = new Product { Id = 1, Category = new Category { Id = 1 } };
 
-                context.ChangeTracker.TrackGraph(product, e => e.State = EntityState.Modified);
+                context.ChangeTracker.TrackGraph(product, e => e.Entry.State = EntityState.Modified);
 
                 Assert.Equal(2, context.ChangeTracker.Entries().Count());
 
@@ -132,7 +132,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             {
                 var product = new Product { Id = 1, Details = new ProductDetails { Id = 1, Tag = new ProductDetailsTag { Id = 1 } } };
 
-                context.ChangeTracker.TrackGraph(product, e => e.State = EntityState.Unchanged);
+                context.ChangeTracker.TrackGraph(product, e => e.Entry.State = EntityState.Unchanged);
 
                 Assert.Equal(3, context.ChangeTracker.Entries().Count());
 
@@ -152,7 +152,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             {
                 var tag = new ProductDetailsTag { Id = 1, Details = new ProductDetails { Id = 1, Product = new Product { Id = 1 } } };
 
-                context.ChangeTracker.TrackGraph(tag, e => e.State = EntityState.Unchanged);
+                context.ChangeTracker.TrackGraph(tag, e => e.Entry.State = EntityState.Unchanged);
 
                 Assert.Equal(3, context.ChangeTracker.Entries().Count());
 
@@ -172,7 +172,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             {
                 var details = new ProductDetails { Id = 1, Product = new Product { Id = 1 }, Tag = new ProductDetailsTag { Id = 1 } };
 
-                context.ChangeTracker.TrackGraph(details, e => e.State = EntityState.Unchanged);
+                context.ChangeTracker.TrackGraph(details, e => e.Entry.State = EntityState.Unchanged);
 
                 Assert.Equal(3, context.ChangeTracker.Entries().Count());
 
@@ -203,7 +203,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
                             }
                     };
 
-                context.ChangeTracker.TrackGraph(category, e => e.State = EntityState.Modified);
+                context.ChangeTracker.TrackGraph(category, e => e.Entry.State = EntityState.Modified);
 
                 Assert.Equal(4, context.ChangeTracker.Entries().Count());
 
@@ -240,11 +240,11 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
                 context.ChangeTracker.TrackGraph(category, e =>
                     {
-                        var product = e.Entity as Product;
+                        var product = e.Entry.Entity as Product;
                         if (product == null
                             || product.Id != 2)
                         {
-                            e.State = EntityState.Unchanged;
+                            e.Entry.State = EntityState.Unchanged;
                         }
                     });
 
@@ -295,8 +295,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
                         category,
                         e =>
                             {
-                                var product = e.Entity as Product;
-                                e.State = product != null && product.Id == 0 ? EntityState.Added : EntityState.Unchanged;
+                                var product = e.Entry.Entity as Product;
+                                e.Entry.State = product != null && product.Id == 0 ? EntityState.Added : EntityState.Unchanged;
                             });
                 });
         }
@@ -926,7 +926,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
                 changeDetector.DetectChangesCalled = false;
 
-                context.ChangeTracker.TrackGraph(CreateSimpleGraph(2), e => e.State = EntityState.Unchanged);
+                context.ChangeTracker.TrackGraph(CreateSimpleGraph(2), e => e.Entry.State = EntityState.Unchanged);
 
                 Assert.False(changeDetector.DetectChangesCalled);
 
@@ -1062,7 +1062,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
                     });
             }
 
-            protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder) 
+            protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
                 => optionsBuilder.UseInMemoryDatabase();
         }
 
@@ -1075,8 +1075,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
                 _updateExistingEntities = updateExistingEntities;
             }
 
-            public virtual void TrackEntity(EntityEntry entry)
-                => entry.GetService().SetEntityState(DetermineState(entry), acceptChanges: true);
+            public virtual void TrackEntity(EntityEntryGraphNode node)
+                => node.Entry.GetService().SetEntityState(DetermineState(node.Entry), acceptChanges: true);
 
             public virtual EntityState DetermineState(EntityEntry entry)
                 => entry.IsKeySet

--- a/test/EntityFramework.Core.Tests/DbContextTest.cs
+++ b/test/EntityFramework.Core.Tests/DbContextTest.cs
@@ -326,25 +326,43 @@ namespace Microsoft.Data.Entity.Tests
         [Fact]
         public void Can_add_new_entities_to_context()
         {
-            TrackEntitiesTest((c, e) => c.Add(e), (c, e) => c.Add(e), EntityState.Added);
+            TrackEntitiesTest((c, e) => c.Add(e, includeDependents: false), (c, e) => c.Add(e, includeDependents: false), EntityState.Added);
         }
 
         [Fact]
         public void Can_add_existing_entities_to_context_to_be_attached()
         {
-            TrackEntitiesTest((c, e) => c.Attach(e), (c, e) => c.Attach(e), EntityState.Unchanged);
+            TrackEntitiesTest((c, e) => c.Attach(e, includeDependents: false), (c, e) => c.Attach(e, includeDependents: false), EntityState.Unchanged);
         }
 
         [Fact]
         public void Can_add_existing_entities_to_context_to_be_updated()
         {
-            TrackEntitiesTest((c, e) => c.Update(e), (c, e) => c.Update(e), EntityState.Modified);
+            TrackEntitiesTest((c, e) => c.Update(e, includeDependents: false), (c, e) => c.Update(e, includeDependents: false), EntityState.Modified);
         }
 
         [Fact]
         public void Can_add_existing_entities_to_context_to_be_deleted()
         {
             TrackEntitiesTest((c, e) => c.Remove(e), (c, e) => c.Remove(e), EntityState.Deleted);
+        }
+
+        [Fact]
+        public void Can_add_new_entities_to_context_with_graph_method()
+        {
+            TrackEntitiesTest((c, e) => c.Add(e, includeDependents: false), (c, e) => c.Add(e), EntityState.Added);
+        }
+
+        [Fact]
+        public void Can_add_existing_entities_to_context_to_be_attached_with_graph_method()
+        {
+            TrackEntitiesTest((c, e) => c.Attach(e, includeDependents: false), (c, e) => c.Attach(e), EntityState.Unchanged);
+        }
+
+        [Fact]
+        public void Can_add_existing_entities_to_context_to_be_updated_with_graph_method()
+        {
+            TrackEntitiesTest((c, e) => c.Update(e, includeDependents: false), (c, e) => c.Update(e), EntityState.Modified);
         }
 
         private static void TrackEntitiesTest(
@@ -477,25 +495,43 @@ namespace Microsoft.Data.Entity.Tests
         [Fact]
         public void Can_add_new_entities_to_context_non_generic()
         {
-            TrackEntitiesTestNonGeneric((c, e) => c.Add(e), (c, e) => c.Add(e), EntityState.Added);
+            TrackEntitiesTestNonGeneric((c, e) => c.Add(e, includeDependents: false), (c, e) => c.Add(e, includeDependents: false), EntityState.Added);
         }
 
         [Fact]
         public void Can_add_existing_entities_to_context_to_be_attached_non_generic()
         {
-            TrackEntitiesTestNonGeneric((c, e) => c.Attach(e), (c, e) => c.Attach(e), EntityState.Unchanged);
+            TrackEntitiesTestNonGeneric((c, e) => c.Attach(e, includeDependents: false), (c, e) => c.Attach(e, includeDependents: false), EntityState.Unchanged);
         }
 
         [Fact]
         public void Can_add_existing_entities_to_context_to_be_updated_non_generic()
         {
-            TrackEntitiesTestNonGeneric((c, e) => c.Update(e), (c, e) => c.Update(e), EntityState.Modified);
+            TrackEntitiesTestNonGeneric((c, e) => c.Update(e, includeDependents: false), (c, e) => c.Update(e, includeDependents: false), EntityState.Modified);
         }
 
         [Fact]
         public void Can_add_existing_entities_to_context_to_be_deleted_non_generic()
         {
             TrackEntitiesTestNonGeneric((c, e) => c.Remove(e), (c, e) => c.Remove(e), EntityState.Deleted);
+        }
+
+        [Fact]
+        public void Can_add_new_entities_to_context_non_generic_graph()
+        {
+            TrackEntitiesTestNonGeneric((c, e) => c.Add(e, includeDependents: false), (c, e) => c.Add(e), EntityState.Added);
+        }
+
+        [Fact]
+        public void Can_add_existing_entities_to_context_to_be_attached_non_generic_graph()
+        {
+            TrackEntitiesTestNonGeneric((c, e) => c.Attach(e, includeDependents: false), (c, e) => c.Attach(e), EntityState.Unchanged);
+        }
+
+        [Fact]
+        public void Can_add_existing_entities_to_context_to_be_updated_non_generic_graph()
+        {
+            TrackEntitiesTestNonGeneric((c, e) => c.Update(e, includeDependents: false), (c, e) => c.Update(e), EntityState.Modified);
         }
 
         private static void TrackEntitiesTestNonGeneric(
@@ -539,25 +575,43 @@ namespace Microsoft.Data.Entity.Tests
         [Fact]
         public void Can_add_multiple_new_entities_to_context_Enumerable()
         {
-            TrackMultipleEntitiesTestEnumerable((c, e) => c.AddRange(e), (c, e) => c.AddRange(e), EntityState.Added);
+            TrackMultipleEntitiesTestEnumerable((c, e) => c.AddRange(e, includeDependents: false), (c, e) => c.AddRange(e, includeDependents: false), EntityState.Added);
         }
 
         [Fact]
         public void Can_add_multiple_existing_entities_to_context_to_be_attached_Enumerable()
         {
-            TrackMultipleEntitiesTestEnumerable((c, e) => c.AttachRange(e), (c, e) => c.AttachRange(e), EntityState.Unchanged);
+            TrackMultipleEntitiesTestEnumerable((c, e) => c.AttachRange(e, includeDependents: false), (c, e) => c.AttachRange(e, includeDependents: false), EntityState.Unchanged);
         }
 
         [Fact]
         public void Can_add_multiple_existing_entities_to_context_to_be_updated_Enumerable()
         {
-            TrackMultipleEntitiesTestEnumerable((c, e) => c.UpdateRange(e), (c, e) => c.UpdateRange(e), EntityState.Modified);
+            TrackMultipleEntitiesTestEnumerable((c, e) => c.UpdateRange(e, includeDependents: false), (c, e) => c.UpdateRange(e, includeDependents: false), EntityState.Modified);
         }
 
         [Fact]
         public void Can_add_multiple_existing_entities_to_context_to_be_deleted_Enumerable()
         {
             TrackMultipleEntitiesTestEnumerable((c, e) => c.RemoveRange(e), (c, e) => c.RemoveRange(e), EntityState.Deleted);
+        }
+
+        [Fact]
+        public void Can_add_multiple_new_entities_to_context_Enumerable_graph()
+        {
+            TrackMultipleEntitiesTestEnumerable((c, e) => c.AddRange(e, includeDependents: false), (c, e) => c.AddRange(e), EntityState.Added);
+        }
+
+        [Fact]
+        public void Can_add_multiple_existing_entities_to_context_to_be_attached_Enumerable_graph()
+        {
+            TrackMultipleEntitiesTestEnumerable((c, e) => c.AttachRange(e, includeDependents: false), (c, e) => c.AttachRange(e), EntityState.Unchanged);
+        }
+
+        [Fact]
+        public void Can_add_multiple_existing_entities_to_context_to_be_updated_Enumerable_graph()
+        {
+            TrackMultipleEntitiesTestEnumerable((c, e) => c.UpdateRange(e, includeDependents: false), (c, e) => c.UpdateRange(e), EntityState.Modified);
         }
 
         private static void TrackMultipleEntitiesTestEnumerable(
@@ -594,25 +648,43 @@ namespace Microsoft.Data.Entity.Tests
         [Fact]
         public void Can_add_no_new_entities_to_context_Enumerable()
         {
-            TrackNoEntitiesTestEnumerable((c, e) => c.AddRange(e), (c, e) => c.AddRange(e));
+            TrackNoEntitiesTestEnumerable((c, e) => c.AddRange(e, includeDependents: false), (c, e) => c.AddRange(e, includeDependents: false));
         }
 
         [Fact]
         public void Can_add_no_existing_entities_to_context_to_be_attached_Enumerable()
         {
-            TrackNoEntitiesTestEnumerable((c, e) => c.AttachRange(e), (c, e) => c.AttachRange(e));
+            TrackNoEntitiesTestEnumerable((c, e) => c.AttachRange(e, includeDependents: false), (c, e) => c.AttachRange(e, includeDependents: false));
         }
 
         [Fact]
         public void Can_add_no_existing_entities_to_context_to_be_updated_Enumerable()
         {
-            TrackNoEntitiesTestEnumerable((c, e) => c.UpdateRange(e), (c, e) => c.UpdateRange(e));
+            TrackNoEntitiesTestEnumerable((c, e) => c.UpdateRange(e, includeDependents: false), (c, e) => c.UpdateRange(e, includeDependents: false));
         }
 
         [Fact]
         public void Can_add_no_existing_entities_to_context_to_be_deleted_Enumerable()
         {
             TrackNoEntitiesTestEnumerable((c, e) => c.RemoveRange(e), (c, e) => c.RemoveRange(e));
+        }
+
+        [Fact]
+        public void Can_add_no_new_entities_to_context_Enumerable_graph()
+        {
+            TrackNoEntitiesTestEnumerable((c, e) => c.AddRange(e, includeDependents: false), (c, e) => c.AddRange(e));
+        }
+
+        [Fact]
+        public void Can_add_no_existing_entities_to_context_to_be_attached_Enumerable_graph()
+        {
+            TrackNoEntitiesTestEnumerable((c, e) => c.AttachRange(e, includeDependents: false), (c, e) => c.AttachRange(e));
+        }
+
+        [Fact]
+        public void Can_add_no_existing_entities_to_context_to_be_updated_Enumerable_graph()
+        {
+            TrackNoEntitiesTestEnumerable((c, e) => c.UpdateRange(e, includeDependents: false), (c, e) => c.UpdateRange(e));
         }
 
         private static void TrackNoEntitiesTestEnumerable(
@@ -629,6 +701,12 @@ namespace Microsoft.Data.Entity.Tests
 
         [Fact]
         public void Can_add_new_entities_to_context_with_key_generation()
+        {
+            TrackEntitiesWithKeyGenerationTest((c, e) => c.Add(e, includeDependents: false).Entity);
+        }
+
+        [Fact]
+        public void Can_add_new_entities_to_context_with_key_generation_graph()
         {
             TrackEntitiesWithKeyGenerationTest((c, e) => c.Add(e).Entity);
         }
@@ -659,31 +737,31 @@ namespace Microsoft.Data.Entity.Tests
         [Fact]
         public void Can_use_Add_to_change_entity_state()
         {
-            ChangeStateWithMethod((c, e) => c.Add(e), EntityState.Detached, EntityState.Added);
-            ChangeStateWithMethod((c, e) => c.Add(e), EntityState.Unchanged, EntityState.Added);
-            ChangeStateWithMethod((c, e) => c.Add(e), EntityState.Deleted, EntityState.Added);
-            ChangeStateWithMethod((c, e) => c.Add(e), EntityState.Modified, EntityState.Added);
-            ChangeStateWithMethod((c, e) => c.Add(e), EntityState.Added, EntityState.Added);
+            ChangeStateWithMethod((c, e) => c.Add(e, includeDependents: false), EntityState.Detached, EntityState.Added);
+            ChangeStateWithMethod((c, e) => c.Add(e, includeDependents: false), EntityState.Unchanged, EntityState.Added);
+            ChangeStateWithMethod((c, e) => c.Add(e, includeDependents: false), EntityState.Deleted, EntityState.Added);
+            ChangeStateWithMethod((c, e) => c.Add(e, includeDependents: false), EntityState.Modified, EntityState.Added);
+            ChangeStateWithMethod((c, e) => c.Add(e, includeDependents: false), EntityState.Added, EntityState.Added);
         }
 
         [Fact]
         public void Can_use_Attach_to_change_entity_state()
         {
-            ChangeStateWithMethod((c, e) => c.Attach(e), EntityState.Detached, EntityState.Unchanged);
-            ChangeStateWithMethod((c, e) => c.Attach(e), EntityState.Unchanged, EntityState.Unchanged);
-            ChangeStateWithMethod((c, e) => c.Attach(e), EntityState.Deleted, EntityState.Unchanged);
-            ChangeStateWithMethod((c, e) => c.Attach(e), EntityState.Modified, EntityState.Unchanged);
-            ChangeStateWithMethod((c, e) => c.Attach(e), EntityState.Added, EntityState.Unchanged);
+            ChangeStateWithMethod((c, e) => c.Attach(e, includeDependents: false), EntityState.Detached, EntityState.Unchanged);
+            ChangeStateWithMethod((c, e) => c.Attach(e, includeDependents: false), EntityState.Unchanged, EntityState.Unchanged);
+            ChangeStateWithMethod((c, e) => c.Attach(e, includeDependents: false), EntityState.Deleted, EntityState.Unchanged);
+            ChangeStateWithMethod((c, e) => c.Attach(e, includeDependents: false), EntityState.Modified, EntityState.Unchanged);
+            ChangeStateWithMethod((c, e) => c.Attach(e, includeDependents: false), EntityState.Added, EntityState.Unchanged);
         }
 
         [Fact]
         public void Can_use_Update_to_change_entity_state()
         {
-            ChangeStateWithMethod((c, e) => c.Update(e), EntityState.Detached, EntityState.Modified);
-            ChangeStateWithMethod((c, e) => c.Update(e), EntityState.Unchanged, EntityState.Modified);
-            ChangeStateWithMethod((c, e) => c.Update(e), EntityState.Deleted, EntityState.Modified);
-            ChangeStateWithMethod((c, e) => c.Update(e), EntityState.Modified, EntityState.Modified);
-            ChangeStateWithMethod((c, e) => c.Update(e), EntityState.Added, EntityState.Modified);
+            ChangeStateWithMethod((c, e) => c.Update(e, includeDependents: false), EntityState.Detached, EntityState.Modified);
+            ChangeStateWithMethod((c, e) => c.Update(e, includeDependents: false), EntityState.Unchanged, EntityState.Modified);
+            ChangeStateWithMethod((c, e) => c.Update(e, includeDependents: false), EntityState.Deleted, EntityState.Modified);
+            ChangeStateWithMethod((c, e) => c.Update(e, includeDependents: false), EntityState.Modified, EntityState.Modified);
+            ChangeStateWithMethod((c, e) => c.Update(e, includeDependents: false), EntityState.Added, EntityState.Modified);
         }
 
         [Fact]
@@ -694,6 +772,36 @@ namespace Microsoft.Data.Entity.Tests
             ChangeStateWithMethod((c, e) => c.Remove(e), EntityState.Deleted, EntityState.Deleted);
             ChangeStateWithMethod((c, e) => c.Remove(e), EntityState.Modified, EntityState.Deleted);
             ChangeStateWithMethod((c, e) => c.Remove(e), EntityState.Added, EntityState.Detached);
+        }
+
+        [Fact]
+        public void Can_use_graph_Add_to_change_entity_state()
+        {
+            ChangeStateWithMethod((c, e) => c.Add(e), EntityState.Detached, EntityState.Added);
+            ChangeStateWithMethod((c, e) => c.Add(e), EntityState.Unchanged, EntityState.Added);
+            ChangeStateWithMethod((c, e) => c.Add(e), EntityState.Deleted, EntityState.Added);
+            ChangeStateWithMethod((c, e) => c.Add(e), EntityState.Modified, EntityState.Added);
+            ChangeStateWithMethod((c, e) => c.Add(e), EntityState.Added, EntityState.Added);
+        }
+
+        [Fact]
+        public void Can_use_graph_Attach_to_change_entity_state()
+        {
+            ChangeStateWithMethod((c, e) => c.Attach(e), EntityState.Detached, EntityState.Unchanged);
+            ChangeStateWithMethod((c, e) => c.Attach(e), EntityState.Unchanged, EntityState.Unchanged);
+            ChangeStateWithMethod((c, e) => c.Attach(e), EntityState.Deleted, EntityState.Unchanged);
+            ChangeStateWithMethod((c, e) => c.Attach(e), EntityState.Modified, EntityState.Unchanged);
+            ChangeStateWithMethod((c, e) => c.Attach(e), EntityState.Added, EntityState.Unchanged);
+        }
+
+        [Fact]
+        public void Can_use_graph_Update_to_change_entity_state()
+        {
+            ChangeStateWithMethod((c, e) => c.Update(e), EntityState.Detached, EntityState.Modified);
+            ChangeStateWithMethod((c, e) => c.Update(e), EntityState.Unchanged, EntityState.Modified);
+            ChangeStateWithMethod((c, e) => c.Update(e), EntityState.Deleted, EntityState.Modified);
+            ChangeStateWithMethod((c, e) => c.Update(e), EntityState.Modified, EntityState.Modified);
+            ChangeStateWithMethod((c, e) => c.Update(e), EntityState.Added, EntityState.Modified);
         }
 
         private void ChangeStateWithMethod(Action<DbContext, object> action, EntityState initialState, EntityState expectedState)
@@ -720,7 +828,7 @@ namespace Microsoft.Data.Entity.Tests
                 var product = new Product { Id = 1, CategoryId = 7, Name = "Marmite", Category = category };
                 category.Products = new List<Product> { product };
 
-                context.Attach(category);
+                context.Attach(category, includeDependents: false);
 
                 Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
@@ -728,7 +836,7 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
                 Assert.Equal(EntityState.Detached, context.Entry(product).State);
 
-                context.Attach(product);
+                context.Attach(product, includeDependents: false);
 
                 Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
@@ -749,7 +857,7 @@ namespace Microsoft.Data.Entity.Tests
                 var product = new Product { Id = 1, CategoryId = 7, Name = "Marmite", Category = category };
                 category.Products = new List<Product> { product };
 
-                context.Attach(product);
+                context.Attach(product, includeDependents: false);
 
                 Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
@@ -757,7 +865,7 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Equal(EntityState.Detached, context.Entry(category).State);
                 Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
 
-                context.Attach(category);
+                context.Attach(category, includeDependents: false);
 
                 Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
@@ -776,7 +884,7 @@ namespace Microsoft.Data.Entity.Tests
                 var product = new Product { Id = 1, CategoryId = 7, Name = "Marmite", Category = category };
                 category.Products = new List<Product>();
 
-                context.Attach(category);
+                context.Attach(category, includeDependents: false);
 
                 Assert.Equal(7, product.CategoryId);
                 Assert.Empty(category.Products);
@@ -784,7 +892,7 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
                 Assert.Equal(EntityState.Detached, context.Entry(product).State);
 
-                context.Attach(product);
+                context.Attach(product, includeDependents: false);
 
                 Assert.Equal(7, product.CategoryId);
                 Assert.Empty(category.Products);
@@ -803,7 +911,7 @@ namespace Microsoft.Data.Entity.Tests
                 var product = new Product { Id = 1, CategoryId = 7, Name = "Marmite", Category = category };
                 category.Products = new List<Product>();
 
-                context.Attach(product);
+                context.Attach(product, includeDependents: false);
 
                 Assert.Equal(7, product.CategoryId);
                 Assert.Empty(category.Products);
@@ -811,7 +919,7 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Equal(EntityState.Detached, context.Entry(category).State);
                 Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
 
-                context.Attach(category);
+                context.Attach(category, includeDependents: false);
 
                 Assert.Equal(7, product.CategoryId);
                 Assert.Empty(category.Products);
@@ -830,7 +938,7 @@ namespace Microsoft.Data.Entity.Tests
                 var product = new Product { Id = 1, CategoryId = 7, Name = "Marmite" };
                 category.Products = new List<Product> { product };
 
-                context.Attach(category);
+                context.Attach(category, includeDependents: false);
 
                 Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
@@ -838,7 +946,7 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
                 Assert.Equal(EntityState.Detached, context.Entry(product).State);
 
-                context.Attach(product);
+                context.Attach(product, includeDependents: false);
 
                 Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
@@ -857,7 +965,7 @@ namespace Microsoft.Data.Entity.Tests
                 var product = new Product { Id = 1, CategoryId = 7, Name = "Marmite" };
                 category.Products = new List<Product> { product };
 
-                context.Attach(product);
+                context.Attach(product, includeDependents: false);
 
                 Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
@@ -865,7 +973,7 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Equal(EntityState.Detached, context.Entry(category).State);
                 Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
 
-                context.Attach(category);
+                context.Attach(category, includeDependents: false);
 
                 Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
@@ -1044,13 +1152,13 @@ namespace Microsoft.Data.Entity.Tests
         {
             using (var context = new EarlyLearningCenter(TestHelpers.Instance.CreateServiceProvider()))
             {
-                var category7 = context.Attach(new Category { Id = 7, Products = new List<Product>() }).Entity;
+                var category7 = context.Attach(new Category { Id = 7, Products = new List<Product>() }, includeDependents: false).Entity;
 
                 var category = new Category { Id = 1, Name = "Beverages" };
                 var product = new Product { Id = 1, CategoryId = 7, Name = "Marmite", Category = category };
                 category.Products = new List<Product> { product };
 
-                context.Attach(category);
+                context.Attach(category, includeDependents: false);
 
                 Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
@@ -1059,7 +1167,7 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
                 Assert.Equal(EntityState.Detached, context.Entry(product).State);
 
-                context.Attach(product);
+                context.Attach(product, includeDependents: false);
 
                 Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
@@ -1076,13 +1184,13 @@ namespace Microsoft.Data.Entity.Tests
         {
             using (var context = new EarlyLearningCenter(TestHelpers.Instance.CreateServiceProvider()))
             {
-                var category7 = context.Attach(new Category { Id = 7, Products = new List<Product>() }).Entity;
+                var category7 = context.Attach(new Category { Id = 7, Products = new List<Product>() }, includeDependents: false).Entity;
 
                 var category = new Category { Id = 1, Name = "Beverages" };
                 var product = new Product { Id = 1, CategoryId = 7, Name = "Marmite", Category = category };
                 category.Products = new List<Product> { product };
 
-                context.Attach(product);
+                context.Attach(product, includeDependents: false);
 
                 Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
@@ -1091,7 +1199,7 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Equal(EntityState.Detached, context.Entry(category).State);
                 Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
 
-                context.Attach(category);
+                context.Attach(category, includeDependents: false);
 
                 Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
@@ -1107,13 +1215,13 @@ namespace Microsoft.Data.Entity.Tests
         {
             using (var context = new EarlyLearningCenter(TestHelpers.Instance.CreateServiceProvider()))
             {
-                var category7 = context.Attach(new Category { Id = 7, Products = new List<Product>() }).Entity;
+                var category7 = context.Attach(new Category { Id = 7, Products = new List<Product>() }, includeDependents: false).Entity;
 
                 var category = new Category { Id = 1, Name = "Beverages" };
                 var product = new Product { Id = 1, CategoryId = 7, Name = "Marmite", Category = category };
                 category.Products = new List<Product>();
 
-                context.Attach(category);
+                context.Attach(category, includeDependents: false);
 
                 Assert.Equal(7, product.CategoryId);
                 Assert.Empty(category.Products);
@@ -1122,7 +1230,7 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
                 Assert.Equal(EntityState.Detached, context.Entry(product).State);
 
-                context.Attach(product);
+                context.Attach(product, includeDependents: false);
 
                 Assert.Equal(7, product.CategoryId);
                 Assert.Empty(category.Products);
@@ -1138,13 +1246,13 @@ namespace Microsoft.Data.Entity.Tests
         {
             using (var context = new EarlyLearningCenter(TestHelpers.Instance.CreateServiceProvider()))
             {
-                var category7 = context.Attach(new Category { Id = 7, Products = new List<Product>() }).Entity;
+                var category7 = context.Attach(new Category { Id = 7, Products = new List<Product>() }, includeDependents: false).Entity;
 
                 var category = new Category { Id = 1, Name = "Beverages" };
                 var product = new Product { Id = 1, CategoryId = 7, Name = "Marmite", Category = category };
                 category.Products = new List<Product>();
 
-                context.Attach(product);
+                context.Attach(product, includeDependents: false);
 
                 Assert.Equal(7, product.CategoryId);
                 Assert.Empty(category.Products);
@@ -1153,7 +1261,7 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Equal(EntityState.Detached, context.Entry(category).State);
                 Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
 
-                context.Attach(category);
+                context.Attach(category, includeDependents: false);
 
                 Assert.Equal(7, product.CategoryId);
                 Assert.Empty(category.Products);
@@ -1169,13 +1277,13 @@ namespace Microsoft.Data.Entity.Tests
         {
             using (var context = new EarlyLearningCenter(TestHelpers.Instance.CreateServiceProvider()))
             {
-                var category7 = context.Attach(new Category { Id = 7, Products = new List<Product>() }).Entity;
+                var category7 = context.Attach(new Category { Id = 7, Products = new List<Product>() }, includeDependents: false).Entity;
 
                 var category = new Category { Id = 1, Name = "Beverages" };
                 var product = new Product { Id = 1, CategoryId = 7, Name = "Marmite" };
                 category.Products = new List<Product> { product };
 
-                context.Attach(category);
+                context.Attach(category, includeDependents: false);
 
                 Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
@@ -1184,7 +1292,7 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
                 Assert.Equal(EntityState.Detached, context.Entry(product).State);
 
-                context.Attach(product);
+                context.Attach(product, includeDependents: false);
 
                 Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
@@ -1200,13 +1308,13 @@ namespace Microsoft.Data.Entity.Tests
         {
             using (var context = new EarlyLearningCenter(TestHelpers.Instance.CreateServiceProvider()))
             {
-                var category7 = context.Attach(new Category { Id = 7, Products = new List<Product>() }).Entity;
+                var category7 = context.Attach(new Category { Id = 7, Products = new List<Product>() }, includeDependents: false).Entity;
 
                 var category = new Category { Id = 1, Name = "Beverages" };
                 var product = new Product { Id = 1, CategoryId = 7, Name = "Marmite" };
                 category.Products = new List<Product> { product };
 
-                context.Attach(product);
+                context.Attach(product, includeDependents: false);
 
                 Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
@@ -1215,7 +1323,7 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Equal(EntityState.Detached, context.Entry(category).State);
                 Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
 
-                context.Attach(category);
+                context.Attach(category, includeDependents: false);
 
                 Assert.Equal(7, product.CategoryId);
                 Assert.Same(product, category.Products.Single());
@@ -1231,7 +1339,7 @@ namespace Microsoft.Data.Entity.Tests
         {
             using (var context = new EarlyLearningCenter(TestHelpers.Instance.CreateServiceProvider()))
             {
-                var category7 = context.Attach(new Category { Id = 7, Products = new List<Product>() }).Entity;
+                var category7 = context.Attach(new Category { Id = 7, Products = new List<Product>() }, includeDependents: false).Entity;
 
                 var category = new Category { Id = 1, Name = "Beverages" };
                 var product = new Product { Id = 1, CategoryId = 7, Name = "Marmite", Category = category };
@@ -1262,7 +1370,7 @@ namespace Microsoft.Data.Entity.Tests
         {
             using (var context = new EarlyLearningCenter(TestHelpers.Instance.CreateServiceProvider()))
             {
-                var category7 = context.Attach(new Category { Id = 7, Products = new List<Product>() }).Entity;
+                var category7 = context.Attach(new Category { Id = 7, Products = new List<Product>() }, includeDependents: false).Entity;
 
                 var category = new Category { Id = 1, Name = "Beverages" };
                 var product = new Product { Id = 1, CategoryId = 7, Name = "Marmite", Category = category };
@@ -1293,7 +1401,7 @@ namespace Microsoft.Data.Entity.Tests
         {
             using (var context = new EarlyLearningCenter(TestHelpers.Instance.CreateServiceProvider()))
             {
-                var category7 = context.Attach(new Category { Id = 7, Products = new List<Product>() }).Entity;
+                var category7 = context.Attach(new Category { Id = 7, Products = new List<Product>() }, includeDependents: false).Entity;
 
                 var category = new Category { Id = 1, Name = "Beverages" };
                 var product = new Product { Id = 1, CategoryId = 7, Name = "Marmite", Category = category };
@@ -1324,7 +1432,7 @@ namespace Microsoft.Data.Entity.Tests
         {
             using (var context = new EarlyLearningCenter(TestHelpers.Instance.CreateServiceProvider()))
             {
-                var category7 = context.Attach(new Category { Id = 7, Products = new List<Product>() }).Entity;
+                var category7 = context.Attach(new Category { Id = 7, Products = new List<Product>() }, includeDependents: false).Entity;
 
                 var category = new Category { Id = 1, Name = "Beverages" };
                 var product = new Product { Id = 1, CategoryId = 7, Name = "Marmite", Category = category };
@@ -1355,7 +1463,7 @@ namespace Microsoft.Data.Entity.Tests
         {
             using (var context = new EarlyLearningCenter(TestHelpers.Instance.CreateServiceProvider()))
             {
-                var category7 = context.Attach(new Category { Id = 7, Products = new List<Product>() }).Entity;
+                var category7 = context.Attach(new Category { Id = 7, Products = new List<Product>() }, includeDependents: false).Entity;
 
                 var category = new Category { Id = 1, Name = "Beverages" };
                 var product = new Product { Id = 1, CategoryId = 7, Name = "Marmite" };
@@ -1386,7 +1494,7 @@ namespace Microsoft.Data.Entity.Tests
         {
             using (var context = new EarlyLearningCenter(TestHelpers.Instance.CreateServiceProvider()))
             {
-                var category7 = context.Attach(new Category { Id = 7, Products = new List<Product>() }).Entity;
+                var category7 = context.Attach(new Category { Id = 7, Products = new List<Product>() }, includeDependents: false).Entity;
 
                 var category = new Category { Id = 1, Name = "Beverages" };
                 var product = new Product { Id = 1, CategoryId = 7, Name = "Marmite" };
@@ -2191,7 +2299,7 @@ namespace Microsoft.Data.Entity.Tests
             {
                 Assert.True(context.ChangeTracker.AutoDetectChangesEnabled);
 
-                var product = context.Attach(new Product { Id = 1, Name = "Little Hedgehogs" }).Entity;
+                var product = context.Attach(new Product { Id = 1, Name = "Little Hedgehogs" }, includeDependents: false).Entity;
 
                 product.Name = "Cracked Cookies";
 
@@ -2223,7 +2331,7 @@ namespace Microsoft.Data.Entity.Tests
                 context.ChangeTracker.AutoDetectChangesEnabled = false;
                 Assert.False(context.ChangeTracker.AutoDetectChangesEnabled);
 
-                var product = context.Attach(new Product { Id = 1, Name = "Little Hedgehogs" }).Entity;
+                var product = context.Attach(new Product { Id = 1, Name = "Little Hedgehogs" }, includeDependents: false).Entity;
 
                 product.Name = "Cracked Cookies";
 
@@ -2265,7 +2373,7 @@ namespace Microsoft.Data.Entity.Tests
         {
             using (var context = new ButTheHedgehogContext(TestHelpers.Instance.CreateServiceProvider()))
             {
-                var entry = context.Attach(new Product { Id = 1, Name = "Little Hedgehogs" });
+                var entry = context.Attach(new Product { Id = 1, Name = "Little Hedgehogs" }, includeDependents: false);
 
                 entry.Entity.Name = "Cracked Cookies";
 
@@ -2293,7 +2401,7 @@ namespace Microsoft.Data.Entity.Tests
             {
                 context.ChangeTracker.AutoDetectChangesEnabled = false;
 
-                var entry = context.Attach(new Product { Id = 1, Name = "Little Hedgehogs" });
+                var entry = context.Attach(new Product { Id = 1, Name = "Little Hedgehogs" }, includeDependents: false);
 
                 entry.Entity.Name = "Cracked Cookies";
 
@@ -2320,34 +2428,46 @@ namespace Microsoft.Data.Entity.Tests
             {
                 var changeDetector = (ChangeDetectorProxy)context.GetService<IChangeDetector>();
 
-                var entity = new Product { Id = 1, Name = "Little Hedgehogs" };
+                var id = 1;
 
                 changeDetector.DetectChangesCalled = false;
 
-                context.Add(entity);
-                context.Add((object)entity);
-                context.AddRange(entity);
-                context.AddRange(entity);
-                context.AddRange(new List<Product> { entity });
-                context.AddRange(new List<object> { entity });
-                context.Attach(entity);
-                context.Attach((object)entity);
-                context.AttachRange(entity);
-                context.AttachRange(entity);
-                context.AttachRange(new List<Product> { entity });
-                context.AttachRange(new List<object> { entity });
-                context.Update(entity);
-                context.Update((object)entity);
-                context.UpdateRange(entity);
-                context.UpdateRange(entity);
-                context.UpdateRange(new List<Product> { entity });
-                context.UpdateRange(new List<object> { entity });
-                context.Remove(entity);
-                context.Remove((object)entity);
-                context.RemoveRange(entity);
-                context.RemoveRange(entity);
-                context.RemoveRange(new List<Product> { entity });
-                context.RemoveRange(new List<object> { entity });
+                context.Add(new Product { Id = id++, Name = "Little Hedgehogs" });
+                context.Add((object)new Product { Id = id++, Name = "Little Hedgehogs" });
+                context.AddRange(new Product { Id = id++, Name = "Little Hedgehogs" });
+                context.AddRange(new Product { Id = id++, Name = "Little Hedgehogs" });
+                context.AddRange(new List<Product> { new Product { Id = id++, Name = "Little Hedgehogs" } });
+                context.AddRange(new List<object> { new Product { Id = id++, Name = "Little Hedgehogs" } });
+                context.Attach(new Product { Id = id++, Name = "Little Hedgehogs" });
+                context.Attach((object)new Product { Id = id++, Name = "Little Hedgehogs" });
+                context.AttachRange(new Product { Id = id++, Name = "Little Hedgehogs" });
+                context.AttachRange(new Product { Id = id++, Name = "Little Hedgehogs" });
+                context.AttachRange(new List<Product> { new Product { Id = id++, Name = "Little Hedgehogs" } });
+                context.AttachRange(new List<object> { new Product { Id = id++, Name = "Little Hedgehogs" } });
+                context.Update(new Product { Id = id++, Name = "Little Hedgehogs" });
+                context.Update((object)new Product { Id = id++, Name = "Little Hedgehogs" });
+                context.UpdateRange(new Product { Id = id++, Name = "Little Hedgehogs" });
+                context.UpdateRange(new Product { Id = id++, Name = "Little Hedgehogs" });
+                context.UpdateRange(new List<Product> { new Product { Id = id++, Name = "Little Hedgehogs" } });
+                context.UpdateRange(new List<object> { new Product { Id = id++, Name = "Little Hedgehogs" } });
+                context.Remove(new Product { Id = id++, Name = "Little Hedgehogs" });
+                context.Remove((object)new Product { Id = id++, Name = "Little Hedgehogs" });
+                context.RemoveRange(new Product { Id = id++, Name = "Little Hedgehogs" });
+                context.RemoveRange(new Product { Id = id++, Name = "Little Hedgehogs" });
+                context.RemoveRange(new List<Product> { new Product { Id = id++, Name = "Little Hedgehogs" } });
+                context.RemoveRange(new List<object> { new Product { Id = id++, Name = "Little Hedgehogs" } });
+                context.Add(new Product { Id = id++, Name = "Little Hedgehogs" }, includeDependents: false);
+                context.Add((object)new Product { Id = id++, Name = "Little Hedgehogs" }, includeDependents: false);
+                context.AddRange(new List<Product> { new Product { Id = id++, Name = "Little Hedgehogs" } }, includeDependents: false);
+                context.AddRange(new List<object> { new Product { Id = id++, Name = "Little Hedgehogs" } }, includeDependents: false);
+                context.Attach(new Product { Id = id++, Name = "Little Hedgehogs" }, includeDependents: false);
+                context.Attach((object)new Product { Id = id++, Name = "Little Hedgehogs" }, includeDependents: false);
+                context.AttachRange(new List<Product> { new Product { Id = id++, Name = "Little Hedgehogs" } }, includeDependents: false);
+                context.AttachRange(new List<object> { new Product { Id = id++, Name = "Little Hedgehogs" } }, includeDependents: false);
+                context.Update(new Product { Id = id++, Name = "Little Hedgehogs" }, includeDependents: false);
+                context.Update((object)new Product { Id = id++, Name = "Little Hedgehogs" }, includeDependents: false);
+                context.UpdateRange(new List<Product> { new Product { Id = id++, Name = "Little Hedgehogs" } }, includeDependents: false);
+                context.UpdateRange(new List<object> { new Product { Id = id++, Name = "Little Hedgehogs" } }, includeDependents: false);
 
                 Assert.False(changeDetector.DetectChangesCalled);
 

--- a/test/EntityFramework.Core.Tests/DbSetTest.cs
+++ b/test/EntityFramework.Core.Tests/DbSetTest.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using Microsoft.Data.Entity.ChangeTracking;
-using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Internal;
 using Xunit;
@@ -17,25 +16,43 @@ namespace Microsoft.Data.Entity.Tests
         [Fact]
         public void Can_add_new_entities_to_context()
         {
-            TrackEntitiesTest((c, e) => c.Add(e), (c, e) => c.Add(e), EntityState.Added);
+            TrackEntitiesTest((c, e) => c.Add(e, includeDependents: false), (c, e) => c.Add(e, includeDependents: false), EntityState.Added);
         }
 
         [Fact]
         public void Can_add_existing_entities_to_context_to_be_attached()
         {
-            TrackEntitiesTest((c, e) => c.Attach(e), (c, e) => c.Attach(e), EntityState.Unchanged);
+            TrackEntitiesTest((c, e) => c.Attach(e, includeDependents: false), (c, e) => c.Attach(e, includeDependents: false), EntityState.Unchanged);
         }
 
         [Fact]
         public void Can_add_existing_entities_to_context_to_be_updated()
         {
-            TrackEntitiesTest((c, e) => c.Update(e), (c, e) => c.Update(e), EntityState.Modified);
+            TrackEntitiesTest((c, e) => c.Update(e, includeDependents: false), (c, e) => c.Update(e, includeDependents: false), EntityState.Modified);
         }
 
         [Fact]
         public void Can_add_existing_entities_to_context_to_be_deleted()
         {
             TrackEntitiesTest((c, e) => c.Remove(e), (c, e) => c.Remove(e), EntityState.Deleted);
+        }
+
+        [Fact]
+        public void Can_add_new_entities_to_context_graph()
+        {
+            TrackEntitiesTest((c, e) => c.Add(e), (c, e) => c.Add(e), EntityState.Added);
+        }
+
+        [Fact]
+        public void Can_add_existing_entities_to_context_to_be_attached_graph()
+        {
+            TrackEntitiesTest((c, e) => c.Attach(e), (c, e) => c.Attach(e), EntityState.Unchanged);
+        }
+
+        [Fact]
+        public void Can_add_existing_entities_to_context_to_be_updated_graph()
+        {
+            TrackEntitiesTest((c, e) => c.Update(e), (c, e) => c.Update(e), EntityState.Modified);
         }
 
         private static void TrackEntitiesTest(
@@ -168,25 +185,43 @@ namespace Microsoft.Data.Entity.Tests
         [Fact]
         public void Can_add_multiple_new_entities_to_set_Enumerable()
         {
-            TrackMultipleEntitiesTestEnumerable((c, e) => c.Categories.AddRange(e), (c, e) => c.Products.AddRange(e), EntityState.Added);
+            TrackMultipleEntitiesTestEnumerable((c, e) => c.Categories.AddRange(e, includeDependents: false), (c, e) => c.Products.AddRange(e, includeDependents: false), EntityState.Added);
         }
 
         [Fact]
         public void Can_add_multiple_existing_entities_to_set_to_be_attached_Enumerable()
         {
-            TrackMultipleEntitiesTestEnumerable((c, e) => c.Categories.AttachRange(e), (c, e) => c.Products.AttachRange(e), EntityState.Unchanged);
+            TrackMultipleEntitiesTestEnumerable((c, e) => c.Categories.AttachRange(e, includeDependents: false), (c, e) => c.Products.AttachRange(e, includeDependents: false), EntityState.Unchanged);
         }
 
         [Fact]
         public void Can_add_multiple_existing_entities_to_set_to_be_updated_Enumerable()
         {
-            TrackMultipleEntitiesTestEnumerable((c, e) => c.Categories.UpdateRange(e), (c, e) => c.Products.UpdateRange(e), EntityState.Modified);
+            TrackMultipleEntitiesTestEnumerable((c, e) => c.Categories.UpdateRange(e, includeDependents: false), (c, e) => c.Products.UpdateRange(e, includeDependents: false), EntityState.Modified);
         }
 
         [Fact]
         public void Can_add_multiple_existing_entities_to_set_to_be_deleted_Enumerable()
         {
             TrackMultipleEntitiesTestEnumerable((c, e) => c.Categories.RemoveRange(e), (c, e) => c.Products.RemoveRange(e), EntityState.Deleted);
+        }
+
+        [Fact]
+        public void Can_add_multiple_new_entities_to_set_Enumerable_graph()
+        {
+            TrackMultipleEntitiesTestEnumerable((c, e) => c.Categories.AddRange(e), (c, e) => c.Products.AddRange(e), EntityState.Added);
+        }
+
+        [Fact]
+        public void Can_add_multiple_existing_entities_to_set_to_be_attached_Enumerable_graph()
+        {
+            TrackMultipleEntitiesTestEnumerable((c, e) => c.Categories.AttachRange(e), (c, e) => c.Products.AttachRange(e), EntityState.Unchanged);
+        }
+
+        [Fact]
+        public void Can_add_multiple_existing_entities_to_set_to_be_updated_Enumerable_graph()
+        {
+            TrackMultipleEntitiesTestEnumerable((c, e) => c.Categories.UpdateRange(e), (c, e) => c.Products.UpdateRange(e), EntityState.Modified);
         }
 
         private static void TrackMultipleEntitiesTestEnumerable(
@@ -223,25 +258,43 @@ namespace Microsoft.Data.Entity.Tests
         [Fact]
         public void Can_add_no_new_entities_to_set_Enumerable()
         {
-            TrackNoEntitiesTestEnumerable((c, e) => c.Categories.AddRange(e), (c, e) => c.Products.AddRange(e));
+            TrackNoEntitiesTestEnumerable((c, e) => c.Categories.AddRange(e, includeDependents: false), (c, e) => c.Products.AddRange(e, includeDependents: false));
         }
 
         [Fact]
         public void Can_add_no_existing_entities_to_set_to_be_attached_Enumerable()
         {
-            TrackNoEntitiesTestEnumerable((c, e) => c.Categories.AttachRange(e), (c, e) => c.Products.AttachRange(e));
+            TrackNoEntitiesTestEnumerable((c, e) => c.Categories.AttachRange(e, includeDependents: false), (c, e) => c.Products.AttachRange(e, includeDependents: false));
         }
 
         [Fact]
         public void Can_add_no_existing_entities_to_set_to_be_updated_Enumerable()
         {
-            TrackNoEntitiesTestEnumerable((c, e) => c.Categories.UpdateRange(e), (c, e) => c.Products.UpdateRange(e));
+            TrackNoEntitiesTestEnumerable((c, e) => c.Categories.UpdateRange(e, includeDependents: false), (c, e) => c.Products.UpdateRange(e, includeDependents: false));
         }
 
         [Fact]
         public void Can_add_no_existing_entities_to_set_to_be_deleted_Enumerable()
         {
             TrackNoEntitiesTestEnumerable((c, e) => c.Categories.RemoveRange(e), (c, e) => c.Products.RemoveRange(e));
+        }
+
+        [Fact]
+        public void Can_add_no_new_entities_to_set_Enumerable_graph()
+        {
+            TrackNoEntitiesTestEnumerable((c, e) => c.Categories.AddRange(e), (c, e) => c.Products.AddRange(e));
+        }
+
+        [Fact]
+        public void Can_add_no_existing_entities_to_set_to_be_attached_Enumerable_graph()
+        {
+            TrackNoEntitiesTestEnumerable((c, e) => c.Categories.AttachRange(e), (c, e) => c.Products.AttachRange(e));
+        }
+
+        [Fact]
+        public void Can_add_no_existing_entities_to_set_to_be_updated_Enumerable_graph()
+        {
+            TrackNoEntitiesTestEnumerable((c, e) => c.Categories.UpdateRange(e), (c, e) => c.Products.UpdateRange(e));
         }
 
         private static void TrackNoEntitiesTestEnumerable(
@@ -259,31 +312,31 @@ namespace Microsoft.Data.Entity.Tests
         [Fact]
         public void Can_use_Add_to_change_entity_state()
         {
-            ChangeStateWithMethod((c, e) => c.Categories.Add(e), EntityState.Detached, EntityState.Added);
-            ChangeStateWithMethod((c, e) => c.Categories.Add(e), EntityState.Unchanged, EntityState.Added);
-            ChangeStateWithMethod((c, e) => c.Categories.Add(e), EntityState.Deleted, EntityState.Added);
-            ChangeStateWithMethod((c, e) => c.Categories.Add(e), EntityState.Modified, EntityState.Added);
-            ChangeStateWithMethod((c, e) => c.Categories.Add(e), EntityState.Added, EntityState.Added);
+            ChangeStateWithMethod((c, e) => c.Categories.Add(e, includeDependents: false), EntityState.Detached, EntityState.Added);
+            ChangeStateWithMethod((c, e) => c.Categories.Add(e, includeDependents: false), EntityState.Unchanged, EntityState.Added);
+            ChangeStateWithMethod((c, e) => c.Categories.Add(e, includeDependents: false), EntityState.Deleted, EntityState.Added);
+            ChangeStateWithMethod((c, e) => c.Categories.Add(e, includeDependents: false), EntityState.Modified, EntityState.Added);
+            ChangeStateWithMethod((c, e) => c.Categories.Add(e, includeDependents: false), EntityState.Added, EntityState.Added);
         }
 
         [Fact]
         public void Can_use_Attach_to_change_entity_state()
         {
-            ChangeStateWithMethod((c, e) => c.Categories.Attach(e), EntityState.Detached, EntityState.Unchanged);
-            ChangeStateWithMethod((c, e) => c.Categories.Attach(e), EntityState.Unchanged, EntityState.Unchanged);
-            ChangeStateWithMethod((c, e) => c.Categories.Attach(e), EntityState.Deleted, EntityState.Unchanged);
-            ChangeStateWithMethod((c, e) => c.Categories.Attach(e), EntityState.Modified, EntityState.Unchanged);
-            ChangeStateWithMethod((c, e) => c.Categories.Attach(e), EntityState.Added, EntityState.Unchanged);
+            ChangeStateWithMethod((c, e) => c.Categories.Attach(e, includeDependents: false), EntityState.Detached, EntityState.Unchanged);
+            ChangeStateWithMethod((c, e) => c.Categories.Attach(e, includeDependents: false), EntityState.Unchanged, EntityState.Unchanged);
+            ChangeStateWithMethod((c, e) => c.Categories.Attach(e, includeDependents: false), EntityState.Deleted, EntityState.Unchanged);
+            ChangeStateWithMethod((c, e) => c.Categories.Attach(e, includeDependents: false), EntityState.Modified, EntityState.Unchanged);
+            ChangeStateWithMethod((c, e) => c.Categories.Attach(e, includeDependents: false), EntityState.Added, EntityState.Unchanged);
         }
 
         [Fact]
         public void Can_use_Update_to_change_entity_state()
         {
-            ChangeStateWithMethod((c, e) => c.Categories.Update(e), EntityState.Detached, EntityState.Modified);
-            ChangeStateWithMethod((c, e) => c.Categories.Update(e), EntityState.Unchanged, EntityState.Modified);
-            ChangeStateWithMethod((c, e) => c.Categories.Update(e), EntityState.Deleted, EntityState.Modified);
-            ChangeStateWithMethod((c, e) => c.Categories.Update(e), EntityState.Modified, EntityState.Modified);
-            ChangeStateWithMethod((c, e) => c.Categories.Update(e), EntityState.Added, EntityState.Modified);
+            ChangeStateWithMethod((c, e) => c.Categories.Update(e, includeDependents: false), EntityState.Detached, EntityState.Modified);
+            ChangeStateWithMethod((c, e) => c.Categories.Update(e, includeDependents: false), EntityState.Unchanged, EntityState.Modified);
+            ChangeStateWithMethod((c, e) => c.Categories.Update(e, includeDependents: false), EntityState.Deleted, EntityState.Modified);
+            ChangeStateWithMethod((c, e) => c.Categories.Update(e, includeDependents: false), EntityState.Modified, EntityState.Modified);
+            ChangeStateWithMethod((c, e) => c.Categories.Update(e, includeDependents: false), EntityState.Added, EntityState.Modified);
         }
 
         [Fact]

--- a/test/EntityFramework.Core.Tests/EntityFramework.Core.Tests.csproj
+++ b/test/EntityFramework.Core.Tests/EntityFramework.Core.Tests.csproj
@@ -37,6 +37,7 @@
   <ItemGroup>
     <Compile Include="ApiConsistencyTest.cs" />
     <Compile Include="ApiConsistencyTestBase.cs" />
+    <Compile Include="ChangeTracking\AggregatesTest.cs" />
     <Compile Include="ChangeTracking\Internal\ChangeDetectorTest.cs" />
     <Compile Include="ChangeTracking\Internal\KeyPropagatorTest.cs" />
     <Compile Include="ChangeTracking\Internal\InternalClrEntityEntryTest.cs" />


### PR DESCRIPTION
This gives them a limited form of graph behavior, as discussed in the design meeting. Passing includeDependents: false reverts to the single object behavior.

Note that the params sugar methods for AddRange, etc. do not have the flag (because there is no good place to put it with this signature) and always do the default graph behavior. If the single object behavior is needed, then it can be obtained by using the IEnumerable overload instead of the params overload.

Also, we need to decide whether calling Add/Attach/Update with graph behavior on an already tracked entity causes the state of that entity to change, and, if so, whether the state of dependents should also change. Currently if the entity is already tracked, then its state is not changed (because this is the simplest code) until we decide to do differently.

The behavior of DetectChanges has not yet been updated.