### PR TITLE
:racehorse: Better cold start benchmarks

### DIFF
--- a/test/EntityFramework.Microbenchmarks.Core/ColdStartSandbox.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/ColdStartSandbox.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if !DNXCORE50
+
+using System;
+
+namespace EntityFramework.Microbenchmarks.Core
+{
+    public class ColdStartSandbox : IDisposable
+    {
+        private AppDomain _domain = AppDomain.CreateDomain(
+                "Cold Start Sandbox",
+                null,
+                new AppDomainSetup { ApplicationBase =  AppDomain.CurrentDomain.BaseDirectory });
+
+        ~ColdStartSandbox()
+        {
+            Dispose(false);
+        }
+
+        public T CreateInstance<T>(params object[] args)
+        {
+            return (T)CreateInstance(typeof(T), args);
+        }
+
+        public object CreateInstance(Type type, params object[] args)
+        {
+            HandleDisposed();
+
+            return _domain.CreateInstanceAndUnwrap(
+                type.Assembly.FullName,
+                type.FullName,
+                ignoreCase: false,
+                bindingAttr: 0,
+                binder: null,
+                args: args,
+                culture: null,
+                activationAttributes: null);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing && _domain != null)
+            {
+                AppDomain.Unload(_domain);
+                _domain = null;
+            }
+        }
+
+        private void HandleDisposed()
+        {
+            if (_domain == null)
+            {
+                throw new ObjectDisposedException(null);
+            }
+        }
+    }
+}
+
+#endif

--- a/test/EntityFramework.Microbenchmarks.Core/EntityFramework.Microbenchmarks.Core.csproj
+++ b/test/EntityFramework.Microbenchmarks.Core/EntityFramework.Microbenchmarks.Core.csproj
@@ -43,6 +43,7 @@
     <Compile Include="BenchmarkTestCaseDiscoverer.cs" />
     <Compile Include="BenchmarkTestCaseRunner.cs" />
     <Compile Include="BenchmarkVariationAttribute.cs" />
+    <Compile Include="ColdStartSandbox.cs" />
     <Compile Include="MetricCollector.cs" />
     <Compile Include="Models\AdventureWorks\Address.cs" />
     <Compile Include="Models\AdventureWorks\AddressType.cs" />

--- a/test/EntityFramework.Microbenchmarks.Core/MetricCollector.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/MetricCollector.cs
@@ -6,7 +6,16 @@ using System.Diagnostics;
 
 namespace EntityFramework.Microbenchmarks.Core
 {
-    public class MetricCollector
+#if !DNXCORE50
+    public partial class MetricCollector : MarshalByRefObject
+    {
+        private partial class Scope : MarshalByRefObject
+        {
+        }
+    }
+#endif
+
+    public partial class MetricCollector 
     {
         private bool _collecting;
         private readonly Scope _scope;
@@ -59,7 +68,7 @@ namespace EntityFramework.Microbenchmarks.Core
             return GC.GetTotalMemory(forceFullCollection: true);
         }
 
-        private class Scope : IDisposable
+        private partial class Scope : IDisposable
         {
             private readonly MetricCollector _collector;
 

--- a/test/EntityFramework.Microbenchmarks.EF6/InitializationTests.cs
+++ b/test/EntityFramework.Microbenchmarks.EF6/InitializationTests.cs
@@ -5,6 +5,7 @@ using EntityFramework.Microbenchmarks.Core;
 using EntityFramework.Microbenchmarks.Core.Models.AdventureWorks;
 using EntityFramework.Microbenchmarks.Core.Models.AdventureWorks.TestHelpers;
 using EntityFramework.Microbenchmarks.EF6.Models.AdventureWorks;
+using System;
 using System.Data.Entity;
 using System.Data.SqlClient;
 using System.Linq;
@@ -14,71 +15,28 @@ namespace EntityFramework.Microbenchmarks.EF6
 {
     public class InitializationTests : IClassFixture<AdventureWorksFixture>
     {
-        private readonly AdventureWorksFixture _fixture;
-
-        public InitializationTests(AdventureWorksFixture fixture)
-        {
-            _fixture = fixture;
-        }
-
         [Benchmark]
-        [BenchmarkVariation("Warm")]
-        public void CreateAndDisposeUnusedContext(MetricCollector collector)
+        [BenchmarkVariation("Cold (1 instance)", true, 1)]
+        [BenchmarkVariation("Warm (100 instances)", false, 100)]
+        public void CreateAndDisposeUnusedContext(MetricCollector collector, bool cold, int count)
         {
-            using (collector.StartCollection())
-            {
-                for (int i = 0; i < 100; i++)
-                {
-                    using (var context = _fixture.CreateContext())
-                    {
-                    }
-                }
-            }
+            RunColdStartEnabledTest(cold, c => c.CreateAndDisposeUnusedContext(collector, count));
         }
 
         [AdventureWorksDatabaseBenchmark]
-        [BenchmarkVariation("Warm")]
-        public void InitializeAndQuery_AdventureWorks(MetricCollector collector)
+        [BenchmarkVariation("Cold (1 instance)", true, 1)]
+        [BenchmarkVariation("Warm (10 instances)", false, 10)]
+        public void InitializeAndQuery_AdventureWorks(MetricCollector collector, bool cold, int count)
         {
-            using (collector.StartCollection())
-            {
-                for (int i = 0; i < 10; i++)
-                {
-                    using (var context = _fixture.CreateContext())
-                    {
-                        context.Department.First();
-                    }
-                }
-            }
+            RunColdStartEnabledTest(cold, c => c.InitializeAndQuery_AdventureWorks(collector, count));
         }
 
         [AdventureWorksDatabaseBenchmark]
-        [BenchmarkVariation("Warm")]
-        public void InitializeAndSaveChanges_AdventureWorks(MetricCollector collector)
+        [BenchmarkVariation("Cold (1 instance)", true, 1)]
+        [BenchmarkVariation("Warm (10 instances)", false, 10)]
+        public void InitializeAndSaveChanges_AdventureWorks(MetricCollector collector, bool cold, int count)
         {
-            using (collector.StartCollection())
-            {
-                for (int i = 0; i < 10; i++)
-                {
-                    using (var context = _fixture.CreateContext())
-                    {
-                        context.Department.Add(new Department
-                        {
-                            Name = "Benchmarking",
-                            GroupName = "Engineering"
-                        });
-
-                        using (context.Database.BeginTransaction())
-                        {
-                            context.SaveChanges();
-
-                            // Don't mesure transaction rollback
-                            collector.StopCollection();
-                        }
-                        collector.StartCollection();
-                    }
-                }
-            }
+            RunColdStartEnabledTest(cold, t => t.InitializeAndSaveChanges_AdventureWorks(collector, count));
         }
 
         [Benchmark]
@@ -93,6 +51,79 @@ namespace EntityFramework.Microbenchmarks.EF6
             collector.StopCollection();
 
             Assert.Equal(67, model.ConceptualModel.EntityTypes.Count());
+        }
+
+        private void RunColdStartEnabledTest(bool cold, Action<ColdStartEnabledTests> test)
+        {
+            if (cold)
+            {
+                using (var sandbox = new ColdStartSandbox())
+                {
+                    var testClass = sandbox.CreateInstance<ColdStartEnabledTests>();
+                    test(testClass);
+                }
+            }
+            else
+            {
+                test(new ColdStartEnabledTests());
+            }
+        }
+
+        private class ColdStartEnabledTests : MarshalByRefObject
+        {
+            public void CreateAndDisposeUnusedContext(MetricCollector collector, int count)
+            {
+                using (collector.StartCollection())
+                {
+                    for (int i = 0; i < count; i++)
+                    {
+                        using (var context = AdventureWorksFixture.CreateContext())
+                        {
+                        }
+                    }
+                }
+            }
+
+            public void InitializeAndQuery_AdventureWorks(MetricCollector collector, int count)
+            {
+                using (collector.StartCollection())
+                {
+                    for (int i = 0; i < count; i++)
+                    {
+                        using (var context = AdventureWorksFixture.CreateContext())
+                        {
+                            context.Department.First();
+                        }
+                    }
+                }
+            }
+
+            public void InitializeAndSaveChanges_AdventureWorks(MetricCollector collector, int count)
+            {
+                using (collector.StartCollection())
+                {
+                    for (int i = 0; i < count; i++)
+                    {
+                        using (var context = AdventureWorksFixture.CreateContext())
+                        {
+                            context.Department.Add(new Department
+                            {
+                                Name = "Benchmarking",
+                                GroupName = "Engineering"
+                            });
+
+                            using (context.Database.BeginTransaction())
+                            {
+                                context.SaveChanges();
+
+                                // Don't mesure transaction rollback
+                                collector.StopCollection();
+                            }
+                            collector.StartCollection();
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/test/EntityFramework.Microbenchmarks.EF6/Models/AdventureWorks/AdventureWorksFixture.cs
+++ b/test/EntityFramework.Microbenchmarks.EF6/Models/AdventureWorks/AdventureWorksFixture.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using EntityFramework.Microbenchmarks.Core;
 using EntityFramework.Microbenchmarks.Core.Models.AdventureWorks.TestHelpers;
 
 namespace EntityFramework.Microbenchmarks.EF6.Models.AdventureWorks
@@ -9,7 +8,7 @@ namespace EntityFramework.Microbenchmarks.EF6.Models.AdventureWorks
     public class AdventureWorksFixture : AdventureWorksFixtureBase
     {
         // This method is called from timed code, be careful when changing it
-        public AdventureWorksContext CreateContext()
+        public static AdventureWorksContext CreateContext()
         {
             return new AdventureWorksContext(ConnectionString);
         }

--- a/test/EntityFramework.Microbenchmarks/CalibrationTests.cs
+++ b/test/EntityFramework.Microbenchmarks/CalibrationTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading;
 using EntityFramework.Microbenchmarks.Core;
 
@@ -27,5 +28,28 @@ namespace EntityFramework.Microbenchmarks
                 Thread.Sleep(100);
             }
         }
+
+#if !DNXCORE50
+        [Benchmark]
+        public void ColdStartSandbox_100ms(MetricCollector collector)
+        {
+            using (var sandbox = new ColdStartSandbox())
+            {
+                var testClass = sandbox.CreateInstance<ColdStartEnabledTests>();
+                testClass.Sleep100ms(collector);
+            }
+        }
+
+        private partial class ColdStartEnabledTests : MarshalByRefObject
+        {
+            public void Sleep100ms(MetricCollector collector)
+            {
+                using (collector.StartCollection())
+                {
+                    Thread.Sleep(100);
+                }
+            }
+        }
+#endif
     }
 }

--- a/test/EntityFramework.Microbenchmarks/Models/AdventureWorks/AdventureWorksFixture.cs
+++ b/test/EntityFramework.Microbenchmarks/Models/AdventureWorks/AdventureWorksFixture.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.Framework.DependencyInjection;
-using Microsoft.Data.Entity.Infrastructure;
 using EntityFramework.Microbenchmarks.Core.Models.AdventureWorks.TestHelpers;
 
 namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
@@ -10,22 +8,9 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
     public class AdventureWorksFixture : AdventureWorksFixtureBase
     {
         // This method is called from timed code, be careful when changing it
-        public AdventureWorksContext CreateContext(bool cold)
+        public static AdventureWorksContext CreateContext()
         {
-            if (cold)
-            {
-                var serviceProvider = new ServiceCollection()
-                    .AddEntityFramework()
-                    .AddSqlServer()
-                    .GetService()
-                    .BuildServiceProvider();
-
-                return new AdventureWorksContext(ConnectionString, serviceProvider);
-            }
-            else
-            {
-                return new AdventureWorksContext(ConnectionString);
-            }
+            return new AdventureWorksContext(ConnectionString);
         }
     }
 }


### PR DESCRIPTION
Exploratory testing shows that creating a fresh ServiceProvider instance isn't a very good simulation of cold start (and there also isn't an equivalent approach that can be used for EF6). Introducing a sandbox helper that uses AppDomains to create a true cold start. This will only ever run on Full .NET since we can't do the AppDomain magic on CoreCLR.