### PR TITLE
[query] Add support for OFFSET and FETCH on SQL Server 2008

### DIFF
--- a/src/EntityFramework.Core/Query/EntityQueryModelVisitor.cs
+++ b/src/EntityFramework.Core/Query/EntityQueryModelVisitor.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Data.Entity.Query
         public static readonly MethodInfo PropertyMethodInfo
             = typeof(EF).GetTypeInfo().GetDeclaredMethod(nameof(EF.Property));
 
-        private readonly IModel _model;
+        protected virtual IModel Model { get; }
         private readonly IQueryOptimizer _queryOptimizer;
         private readonly INavigationRewritingExpressionVisitorFactory _navigationRewritingExpressionVisitorFactory;
         private readonly ISubQueryMemberPushDownExpressionVisitor _subQueryMemberPushDownExpressionVisitor;
@@ -94,7 +94,7 @@ namespace Microsoft.Data.Entity.Query
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
             Check.NotNull(queryCompilationContext, nameof(queryCompilationContext));
 
-            _model = model;
+            Model = model;
             _queryOptimizer = queryOptimizer;
             _navigationRewritingExpressionVisitorFactory = navigationRewritingExpressionVisitorFactory;
             _subQueryMemberPushDownExpressionVisitor = subQueryMemberPushDownExpressionVisitor;
@@ -129,8 +129,6 @@ namespace Microsoft.Data.Entity.Query
         public virtual ILinqOperatorProvider LinqOperatorProvider => QueryCompilationContext.LinqOperatorProvider;
 
         public virtual StreamedSequenceInfo StreamedSequenceInfo => _streamedSequenceInfo;
-
-        protected virtual IModel Model => _model;
 
         public virtual Func<QueryContext, IEnumerable<TResult>> CreateQueryExecutor<TResult>([NotNull] QueryModel queryModel)
         {
@@ -362,7 +360,7 @@ namespace Microsoft.Data.Entity.Query
                 foreach (
                     var navigation in
                         from propertyInfo in chainedNavigationProperties
-                        let entityType = _model.FindEntityType(propertyInfo.DeclaringType)
+                        let entityType = Model.FindEntityType(propertyInfo.DeclaringType)
                         select entityType?.FindNavigation(propertyInfo.Name))
                 {
                     if (navigation == null)
@@ -1089,7 +1087,7 @@ namespace Microsoft.Data.Entity.Query
 
             while (memberExpression?.Expression != null)
             {
-                var entityType = _model.FindEntityType(memberExpression.Expression.Type);
+                var entityType = Model.FindEntityType(memberExpression.Expression.Type);
 
                 if (entityType == null)
                 {
@@ -1173,7 +1171,7 @@ namespace Microsoft.Data.Entity.Query
                         || querySource == null
                         || querySource == querySourceReferenceExpression.ReferencedQuerySource)
                     {
-                        var entityType = _model.FindEntityType(methodCallExpression.Arguments[0].Type);
+                        var entityType = Model.FindEntityType(methodCallExpression.Arguments[0].Type);
 
                         if (entityType != null)
                         {

--- a/src/EntityFramework.Core/Query/QueryCompiler.cs
+++ b/src/EntityFramework.Core/Query/QueryCompiler.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Data.Entity.Query
     public class QueryCompiler : IQueryCompiler
     {
         private static MethodInfo CompileQueryMethod { get; }
-            = typeof(IDatabase).GetTypeInfo().GetDeclaredMethod("CompileQuery");
+            = typeof(IDatabase).GetTypeInfo().GetDeclaredMethod(nameof(IDatabase.CompileQuery));
 
         private static readonly INodeTypeProvider _nodeTypeProvider = CreateNodeTypeProvider();
         private static readonly IEvaluatableExpressionFilter _evaluatableExpressionFilter = new EvaluatableExpressionFilter();

--- a/src/EntityFramework.Relational/EntityFramework.Relational.csproj
+++ b/src/EntityFramework.Relational/EntityFramework.Relational.csproj
@@ -80,6 +80,7 @@
     <Compile Include="Migrations\Internal\MigrationExtensions.cs" />
     <Compile Include="Migrations\MigrationAttribute.cs" />
     <Compile Include="Migrations\MigrationsAssemblyExtensions.cs" />
+    <Compile Include="Query\Expressions\ColumnExpression.cs" />
     <Compile Include="Query\Expressions\CrossApplyExpression.cs" />
     <Compile Include="Query\Expressions\ISelectExpressionFactory.cs" />
     <Compile Include="Query\Expressions\SelectExpressionFactory.cs" />
@@ -271,7 +272,6 @@
     <Compile Include="Query\ExpressionVisitors\RelationalProjectionExpressionVisitor.cs" />
     <Compile Include="Query\ExpressionVisitors\RelationalEntityQueryableExpressionVisitor.cs" />
     <Compile Include="Query\Sql\ISqlExpressionVisitor.cs" />
-    <Compile Include="Query\Expressions\ColumnExpression.cs" />
     <Compile Include="Query\RelationalQueryCompilationContext.cs" />
     <Compile Include="Query\RelationalQueryModelVisitor.cs" />
     <Compile Include="Query\Sql\ISqlQueryGenerator.cs" />

--- a/src/EntityFramework.Relational/Query/Expressions/ColumnExpression.cs
+++ b/src/EntityFramework.Relational/Query/Expressions/ColumnExpression.cs
@@ -19,12 +19,22 @@ namespace Microsoft.Data.Entity.Query.Expressions
             [NotNull] string name,
             [NotNull] IProperty property,
             [NotNull] TableExpressionBase tableExpression)
+            :this(name, Check.NotNull(property, nameof(property)).ClrType, tableExpression)
+        {
+            _property = property;
+        }
+
+        public ColumnExpression(
+         [NotNull] string name,
+         [NotNull] Type type,
+         [NotNull] TableExpressionBase tableExpression)
         {
             Check.NotEmpty(name, nameof(name));
+            Check.NotNull(type, nameof(type));
             Check.NotNull(tableExpression, nameof(tableExpression));
 
             Name = name;
-            _property = property;
+            Type = type;
             _tableExpression = tableExpression;
         }
 
@@ -40,7 +50,7 @@ namespace Microsoft.Data.Entity.Query.Expressions
 
         public override ExpressionType NodeType => ExpressionType.Extension;
 
-        public override Type Type => _property.ClrType;
+        public override Type Type { get; }
 
         protected override Expression Accept(ExpressionVisitor visitor)
         {

--- a/src/EntityFramework.SqlServer/EntityFramework.SqlServer.csproj
+++ b/src/EntityFramework.SqlServer/EntityFramework.SqlServer.csproj
@@ -47,7 +47,12 @@
     <Compile Include="ISqlServerConnection.cs" />
     <Compile Include="Metadata\Internal\SqlServerIndexBuilderAnnotations.cs" />
     <Compile Include="Metadata\Internal\SqlServerInternalMetadataBuilderExtensions.cs" />
+    <Compile Include="Query\Expressions\RowNumberExpression.cs" />
+    <Compile Include="Query\SqlServerCompiledQueryCacheKeyGenerator.cs" />
     <Compile Include="Query\SqlServerQueryCompilationContextFactory.cs" />
+    <Compile Include="Query\SqlServerQueryModelVisitor.cs" />
+    <Compile Include="Query\SqlServerQueryModelVisitorFactory.cs" />
+    <Compile Include="Query\Sql\ISqlServerExpressionVisitor.cs" />
     <Compile Include="Query\Sql\SqlServerQuerySqlGeneratorFactory.cs" />
     <Compile Include="Metadata\Internal\SqlServerKeyBuilderAnnotations.cs" />
     <Compile Include="Metadata\Internal\SqlServerModelBuilderAnnotations.cs" />

--- a/src/EntityFramework.SqlServer/Extensions/SqlServerDbContextOptionsBuilder.cs
+++ b/src/EntityFramework.SqlServer/Extensions/SqlServerDbContextOptionsBuilder.cs
@@ -15,5 +15,11 @@ namespace Microsoft.Data.Entity.SqlServer.Extensions
 
         protected override SqlServerOptionsExtension CloneExtension()
             => new SqlServerOptionsExtension(OptionsBuilder.Options.GetExtension<SqlServerOptionsExtension>());
+
+        /// <summary>
+        ///     Use a ROW_NUMBER() in queries instead of OFFSET/FETCH. This method is backwards-compatible to SQL Server 2005.
+        /// </summary>
+        public virtual void UseRowNumberForPaging()
+            => SetOption(e => e.RowNumberPaging = true);
     }
 }

--- a/src/EntityFramework.SqlServer/Query/Expressions/RowNumberExpression.cs
+++ b/src/EntityFramework.SqlServer/Query/Expressions/RowNumberExpression.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Query.Sql;
+using Microsoft.Data.Entity.Utilities;
+using Remotion.Linq.Clauses;
+
+namespace Microsoft.Data.Entity.Query.Expressions
+{
+    public class RowNumberExpression : Expression
+    {
+        private readonly List<Ordering> _orderings = new List<Ordering>();
+
+        public RowNumberExpression(
+            [NotNull] ColumnExpression columnExpression,
+            [NotNull] IReadOnlyList<Ordering> orderings)
+        {
+            Check.NotNull(columnExpression, nameof(columnExpression));
+            Check.NotNull(orderings, nameof(orderings));
+
+            ColumnExpression = columnExpression;
+            _orderings.AddRange(orderings);
+        }
+
+        public virtual ColumnExpression ColumnExpression { get; }
+
+        public override ExpressionType NodeType => ExpressionType.Extension;
+        public override bool CanReduce => false;
+        public override Type Type => ColumnExpression.Type;
+
+        public virtual IReadOnlyList<Ordering> Orderings => _orderings;
+
+        protected override Expression Accept(ExpressionVisitor visitor)
+        {
+            Check.NotNull(visitor, nameof(visitor));
+
+            var specificVisitor = visitor as ISqlServerExpressionVisitor;
+
+            return specificVisitor != null
+                ? specificVisitor.VisitRowNumber(this)
+                : base.Accept(visitor);
+        }
+
+        protected override Expression VisitChildren(ExpressionVisitor visitor)
+        {
+            var newColumnExpression = visitor.Visit(ColumnExpression) as ColumnExpression;
+
+            var newOrderings = new List<Ordering>();
+            var recreate = false;
+            foreach (var ordering in _orderings)
+            {
+                var newOrdering = new Ordering(visitor.Visit(ordering.Expression), ordering.OrderingDirection);
+                newOrderings.Add(newOrdering);
+                recreate |= newOrdering.Expression != ordering.Expression;
+            }
+
+            if (recreate ||
+                (newColumnExpression != null && ColumnExpression != newColumnExpression))
+            {
+                return new RowNumberExpression(newColumnExpression, newOrderings);
+            }
+
+            return this;
+        }
+    }
+}

--- a/src/EntityFramework.SqlServer/Query/Sql/ISqlServerExpressionVisitor.cs
+++ b/src/EntityFramework.SqlServer/Query/Sql/ISqlServerExpressionVisitor.cs
@@ -1,0 +1,14 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Query.Expressions;
+
+namespace Microsoft.Data.Entity.Query.Sql
+{
+    public interface ISqlServerExpressionVisitor
+    {
+        Expression VisitRowNumber([NotNull] RowNumberExpression columnExpression);
+    }
+}

--- a/src/EntityFramework.SqlServer/Query/SqlServerCompiledQueryCacheKeyGenerator.cs
+++ b/src/EntityFramework.SqlServer/Query/SqlServerCompiledQueryCacheKeyGenerator.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Query.ExpressionVisitors;
+using Microsoft.Data.Entity.SqlServer;
+using Microsoft.Data.Entity.Storage;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Query
+{
+    public class SqlServerCompiledQueryCacheKeyGenerator : ICompiledQueryCacheKeyGenerator
+    {
+        private readonly IDbContextOptions _dbOptions;
+        private readonly IModel _model;
+
+        public SqlServerCompiledQueryCacheKeyGenerator([NotNull] IModel model, [NotNull] IDbContextOptions dbOptions)
+        {
+            Check.NotNull(model, nameof(_model));
+            Check.NotNull(dbOptions, nameof(dbOptions));
+
+            _model = model;
+            _dbOptions = dbOptions;
+        }
+
+        public virtual object GenerateCacheKey([NotNull] Expression query, IDatabase database, bool async)
+            => new CompiledQueryCacheKey(
+                new ExpressionStringBuilder().Build(Check.NotNull(query, nameof(query))),
+                _model,
+                async,
+                ((RelationalDatabase)database).UseRelationalNulls,
+                _dbOptions.FindExtension<SqlServerOptionsExtension>()?.RowNumberPaging ?? false
+                );
+
+        private struct CompiledQueryCacheKey
+        {
+            private readonly string _query;
+            private readonly IModel _model;
+            private readonly bool _async;
+            private readonly bool _useRelationalNulls;
+            private readonly bool _useRowNumberOffset;
+
+            public CompiledQueryCacheKey(string query, IModel model, bool async, bool useRelationalNulls, bool useRowNumberOffset)
+            {
+                _query = query;
+                _model = model;
+                _async = async;
+                _useRelationalNulls = useRelationalNulls;
+                _useRowNumberOffset = useRowNumberOffset;
+            }
+
+            public override bool Equals(object obj)
+                => !ReferenceEquals(null, obj)
+                   && (obj is CompiledQueryCacheKey && Equals((CompiledQueryCacheKey)obj));
+
+            private bool Equals(CompiledQueryCacheKey other)
+                => string.Equals(_query, other._query)
+                   && _model.Equals(other._model)
+                   && _async == other._async
+                   && _useRelationalNulls == other._useRelationalNulls
+                   && _useRowNumberOffset == other._useRowNumberOffset;
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    var hashCode = _query.GetHashCode();
+                    hashCode = (hashCode * 397) ^ _model.GetHashCode();
+                    hashCode = (hashCode * 397) ^ _async.GetHashCode();
+                    hashCode = (hashCode * 397) ^ _useRelationalNulls.GetHashCode();
+                    hashCode = (hashCode * 397) ^ _useRowNumberOffset.GetHashCode();
+
+                    return hashCode;
+                }
+            }
+        }
+    }
+}

--- a/src/EntityFramework.SqlServer/Query/SqlServerQueryModelVisitor.cs
+++ b/src/EntityFramework.SqlServer/Query/SqlServerQueryModelVisitor.cs
@@ -1,0 +1,201 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Metadata.Internal;
+using Microsoft.Data.Entity.Query.Expressions;
+using Microsoft.Data.Entity.Query.ExpressionVisitors;
+using Microsoft.Data.Entity.Query.Internal;
+using Microsoft.Data.Entity.SqlServer;
+using Microsoft.Data.Entity.Storage;
+using Microsoft.Data.Entity.Utilities;
+using Remotion.Linq;
+using Remotion.Linq.Clauses;
+
+namespace Microsoft.Data.Entity.Query
+{
+    public class SqlServerQueryModelVisitor : RelationalQueryModelVisitor
+    {
+        private const string RowNumberColumnName = "__RowNumber__";
+
+        private readonly bool _useRowNumberPaging;
+
+        public SqlServerQueryModelVisitor(
+            [NotNull] IDbContextOptions options,
+            [NotNull] IModel model,
+            [NotNull] IQueryOptimizer queryOptimizer,
+            [NotNull] INavigationRewritingExpressionVisitorFactory navigationRewritingExpressionVisitorFactory,
+            [NotNull] ISubQueryMemberPushDownExpressionVisitor subQueryMemberPushDownExpressionVisitor,
+            [NotNull] IQuerySourceTracingExpressionVisitorFactory querySourceTracingExpressionVisitorFactory,
+            [NotNull] IEntityResultFindingExpressionVisitorFactory entityResultFindingExpressionVisitorFactory,
+            [NotNull] ITaskBlockingExpressionVisitor taskBlockingExpressionVisitor,
+            [NotNull] IMemberAccessBindingExpressionVisitorFactory memberAccessBindingExpressionVisitorFactory,
+            [NotNull] IOrderingExpressionVisitorFactory orderingExpressionVisitorFactory,
+            [NotNull] IProjectionExpressionVisitorFactory projectionExpressionVisitorFactory,
+            [NotNull] IEntityQueryableExpressionVisitorFactory entityQueryableExpressionVisitorFactory,
+            [NotNull] IQueryAnnotationExtractor queryAnnotationExtractor,
+            [NotNull] IResultOperatorHandler resultOperatorHandler,
+            [NotNull] IEntityMaterializerSource entityMaterializerSource,
+            [NotNull] IExpressionPrinter expressionPrinter,
+            [NotNull] IRelationalMetadataExtensionProvider relationalMetadataExtensionProvider,
+            [NotNull] IIncludeExpressionVisitorFactory includeExpressionVisitorFactory,
+            [NotNull] ISqlTranslatingExpressionVisitorFactory sqlTranslatingExpressionVisitorFactory,
+            [NotNull] ICompositePredicateExpressionVisitorFactory compositePredicateExpressionVisitorFactory,
+            [NotNull] IQueryFlatteningExpressionVisitorFactory queryFlatteningExpressionVisitorFactory,
+            [NotNull] IShapedQueryFindingExpressionVisitorFactory shapedQueryFindingExpressionVisitorFactory,
+            [NotNull] RelationalQueryCompilationContext queryCompilationContext,
+            [NotNull] IDatabase database,
+            [CanBeNull] SqlServerQueryModelVisitor parentQueryModelVisitor)
+            : base(model,
+                queryOptimizer,
+                navigationRewritingExpressionVisitorFactory,
+                subQueryMemberPushDownExpressionVisitor,
+                querySourceTracingExpressionVisitorFactory,
+                entityResultFindingExpressionVisitorFactory,
+                taskBlockingExpressionVisitor,
+                memberAccessBindingExpressionVisitorFactory,
+                orderingExpressionVisitorFactory,
+                projectionExpressionVisitorFactory,
+                entityQueryableExpressionVisitorFactory,
+                queryAnnotationExtractor,
+                resultOperatorHandler,
+                entityMaterializerSource,
+                expressionPrinter,
+                relationalMetadataExtensionProvider,
+                includeExpressionVisitorFactory,
+                sqlTranslatingExpressionVisitorFactory,
+                compositePredicateExpressionVisitorFactory,
+                queryFlatteningExpressionVisitorFactory,
+                shapedQueryFindingExpressionVisitorFactory,
+                queryCompilationContext,
+                database,
+                parentQueryModelVisitor)
+        {
+            Check.NotNull(options, nameof(options));
+
+            var extension = options.FindExtension<SqlServerOptionsExtension>();
+            _useRowNumberPaging = extension?.RowNumberPaging != null
+                                  && extension.RowNumberPaging.Value;
+        }
+
+        public override void VisitQueryModel(QueryModel queryModel)
+        {
+            base.VisitQueryModel(queryModel);
+
+            if (_useRowNumberPaging)
+            {
+                var visitor = new RowNumberPagingExpressionVisitor();
+                SelectExpression mainSelectExpression;
+                if (QueriesBySource.TryGetValue(queryModel.MainFromClause, out mainSelectExpression))
+                {
+                    visitor.Visit(mainSelectExpression);
+                }
+
+                foreach (var additionalSource in queryModel.BodyClauses.OfType<IQuerySource>())
+                {
+                    SelectExpression additionalFromExpression;
+                    if (QueriesBySource.TryGetValue(additionalSource, out additionalFromExpression))
+                    {
+                        visitor.Visit(mainSelectExpression);
+                    }
+                }
+            }
+        }
+
+        private class RowNumberPagingExpressionVisitor : ExpressionVisitorBase
+        {
+            public override Expression Visit(Expression node)
+            {
+                var expression = node as SelectExpression;
+                if (expression != null)
+                {
+                    return VisitSelectExpression(expression);
+                }
+                return base.Visit(node);
+            }
+
+            private bool RequiresRowNumberPaging(SelectExpression selectExpression)
+                => selectExpression.Offset.HasValue
+                   && selectExpression.Offset != 0
+                   && !selectExpression.Projection.Any(p => p is RowNumberExpression);
+
+            private Expression VisitSelectExpression(SelectExpression selectExpression)
+            {
+                base.Visit(selectExpression);
+
+                if (!RequiresRowNumberPaging(selectExpression))
+                {
+                    return selectExpression;
+                }
+
+                var projections = new List<Expression>();
+                projections.AddRange(selectExpression.Projection);
+
+                var subQuery = selectExpression.PushDownSubquery();
+
+                foreach (var projection in projections)
+                {
+                    var alias = projection as AliasExpression;
+                    var column = projection as ColumnExpression;
+                    if (column != null)
+                    {
+                        column = new ColumnExpression(column.Name, column.Property, subQuery);
+                        selectExpression.AddToProjection(column);
+                        continue;
+                    }
+
+                    column = alias?.TryGetColumnExpression();
+
+                    if (column != null)
+                    {
+                        column = new ColumnExpression(column.Name, column.Property, subQuery);
+                        alias = new AliasExpression(alias.Alias, column);
+                        selectExpression.AddToProjection(alias);
+                    }
+                    else
+                    {
+                        selectExpression.AddToProjection(projection);
+                    }
+                }
+
+                if (subQuery.OrderBy.Count == 0)
+                {
+                    subQuery.AddToOrderBy(new Ordering(new SqlFunctionExpression("@@RowCount", typeof(int)), OrderingDirection.Asc));
+                }
+
+                var columnExpression = new ColumnExpression(RowNumberColumnName, typeof(int), subQuery);
+                var rowNumber = new RowNumberExpression(columnExpression, subQuery.OrderBy);
+                subQuery.ClearOrderBy();
+
+                subQuery.ClearProjection();
+                subQuery.AddToProjection(rowNumber);
+                subQuery.IsProjectStar = true;
+
+                Expression predicate = null;
+
+                var offset = subQuery.Offset ?? 0;
+                if (subQuery.Offset.HasValue)
+                {
+                    predicate = Expression.GreaterThan(columnExpression, Expression.Constant(offset));
+                }
+                if (subQuery.Limit.HasValue)
+                {
+                    var exp = Expression.LessThanOrEqual(columnExpression, Expression.Constant(offset + subQuery.Limit.Value));
+                    if (predicate != null)
+                    {
+                        exp = Expression.AndAlso(predicate, exp);
+                    }
+                    predicate = exp;
+                }
+
+                selectExpression.Predicate = predicate;
+                return selectExpression;
+            }
+        }
+    }
+}

--- a/src/EntityFramework.SqlServer/Query/SqlServerQueryModelVisitorFactory.cs
+++ b/src/EntityFramework.SqlServer/Query/SqlServerQueryModelVisitorFactory.cs
@@ -1,0 +1,146 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Metadata.Internal;
+using Microsoft.Data.Entity.Query.ExpressionVisitors;
+using Microsoft.Data.Entity.Query.Internal;
+using Microsoft.Data.Entity.Storage;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Query
+{
+    public class SqlServerQueryModelVisitorFactory : IEntityQueryModelVisitorFactory
+    {
+        private readonly IDbContextOptions _options;
+        private readonly IModel _model;
+        private readonly IQueryOptimizer _queryOptimizer;
+        private readonly INavigationRewritingExpressionVisitorFactory _navigationRewritingExpressionVisitorFactory;
+        private readonly ISubQueryMemberPushDownExpressionVisitor _subQueryMemberPushDownExpressionVisitor;
+        private readonly IQuerySourceTracingExpressionVisitorFactory _querySourceTracingExpressionVisitorFactory;
+        private readonly IEntityResultFindingExpressionVisitorFactory _entityResultFindingExpressionVisitorFactory;
+        private readonly ITaskBlockingExpressionVisitor _taskBlockingExpressionVisitor;
+        private readonly IMemberAccessBindingExpressionVisitorFactory _memberAccessBindingExpressionVisitorFactory;
+        private readonly IOrderingExpressionVisitorFactory _orderingExpressionVisitorFactory;
+        private readonly IProjectionExpressionVisitorFactory _projectionExpressionVisitorFactory;
+        private readonly IEntityQueryableExpressionVisitorFactory _entityQueryableExpressionVisitorFactory;
+        private readonly IQueryAnnotationExtractor _queryAnnotationExtractor;
+        private readonly IResultOperatorHandler _resultOperatorHandler;
+        private readonly IEntityMaterializerSource _entityMaterializerSource;
+        private readonly IExpressionPrinter _expressionPrinter;
+        private readonly IRelationalMetadataExtensionProvider _relationalMetadataExtensionProvider;
+        private readonly IIncludeExpressionVisitorFactory _includeExpressionVisitorFactory;
+        private readonly ISqlTranslatingExpressionVisitorFactory _sqlTranslatingExpressionVisitorFactory;
+        private readonly ICompositePredicateExpressionVisitorFactory _compositePredicateExpressionVisitorFactory;
+        private readonly IQueryFlatteningExpressionVisitorFactory _queryFlatteningExpressionVisitorFactory;
+        private readonly IShapedQueryFindingExpressionVisitorFactory _shapedQueryFindingExpressionVisitorFactory;
+
+        public SqlServerQueryModelVisitorFactory(
+            [NotNull] IDbContextOptions options,
+            [NotNull] IModel model,
+            [NotNull] IQueryOptimizer queryOptimizer,
+            [NotNull] INavigationRewritingExpressionVisitorFactory navigationRewritingExpressionVisitorFactory,
+            [NotNull] ISubQueryMemberPushDownExpressionVisitor subQueryMemberPushDownExpressionVisitor,
+            [NotNull] IQuerySourceTracingExpressionVisitorFactory querySourceTracingExpressionVisitorFactory,
+            [NotNull] IEntityResultFindingExpressionVisitorFactory entityResultFindingExpressionVisitorFactory,
+            [NotNull] ITaskBlockingExpressionVisitor taskBlockingExpressionVisitor,
+            [NotNull] IMemberAccessBindingExpressionVisitorFactory memberAccessBindingExpressionVisitorFactory,
+            [NotNull] IOrderingExpressionVisitorFactory orderingExpressionVisitorFactory,
+            [NotNull] IProjectionExpressionVisitorFactory projectionExpressionVisitorFactory,
+            [NotNull] IEntityQueryableExpressionVisitorFactory entityQueryableExpressionVisitorFactory,
+            [NotNull] IQueryAnnotationExtractor queryAnnotationExtractor,
+            [NotNull] IResultOperatorHandler resultOperatorHandler,
+            [NotNull] IEntityMaterializerSource entityMaterializerSource,
+            [NotNull] IExpressionPrinter expressionPrinter,
+            [NotNull] IRelationalMetadataExtensionProvider relationalMetadataExtensionProvider,
+            [NotNull] IIncludeExpressionVisitorFactory includeExpressionVisitorFactory,
+            [NotNull] ISqlTranslatingExpressionVisitorFactory sqlTranslatingExpressionVisitorFactory,
+            [NotNull] ICompositePredicateExpressionVisitorFactory compositePredicateExpressionVisitorFactory,
+            [NotNull] IQueryFlatteningExpressionVisitorFactory queryFlatteningExpressionVisitorFactory,
+            [NotNull] IShapedQueryFindingExpressionVisitorFactory shapedQueryFindingExpressionVisitorFactory)
+        {
+            Check.NotNull(options, nameof(options));
+            Check.NotNull(model, nameof(model));
+            Check.NotNull(queryOptimizer, nameof(queryOptimizer));
+            Check.NotNull(navigationRewritingExpressionVisitorFactory, nameof(navigationRewritingExpressionVisitorFactory));
+            Check.NotNull(subQueryMemberPushDownExpressionVisitor, nameof(subQueryMemberPushDownExpressionVisitor));
+            Check.NotNull(querySourceTracingExpressionVisitorFactory, nameof(querySourceTracingExpressionVisitorFactory));
+            Check.NotNull(entityResultFindingExpressionVisitorFactory, nameof(entityResultFindingExpressionVisitorFactory));
+            Check.NotNull(taskBlockingExpressionVisitor, nameof(taskBlockingExpressionVisitor));
+            Check.NotNull(memberAccessBindingExpressionVisitorFactory, nameof(memberAccessBindingExpressionVisitorFactory));
+            Check.NotNull(orderingExpressionVisitorFactory, nameof(orderingExpressionVisitorFactory));
+            Check.NotNull(projectionExpressionVisitorFactory, nameof(projectionExpressionVisitorFactory));
+            Check.NotNull(entityQueryableExpressionVisitorFactory, nameof(entityQueryableExpressionVisitorFactory));
+            Check.NotNull(queryAnnotationExtractor, nameof(queryAnnotationExtractor));
+            Check.NotNull(resultOperatorHandler, nameof(resultOperatorHandler));
+            Check.NotNull(entityMaterializerSource, nameof(entityMaterializerSource));
+            Check.NotNull(expressionPrinter, nameof(expressionPrinter));
+            Check.NotNull(relationalMetadataExtensionProvider, nameof(relationalMetadataExtensionProvider));
+            Check.NotNull(includeExpressionVisitorFactory, nameof(includeExpressionVisitorFactory));
+            Check.NotNull(sqlTranslatingExpressionVisitorFactory, nameof(sqlTranslatingExpressionVisitorFactory));
+            Check.NotNull(compositePredicateExpressionVisitorFactory, nameof(compositePredicateExpressionVisitorFactory));
+            Check.NotNull(queryFlatteningExpressionVisitorFactory, nameof(queryFlatteningExpressionVisitorFactory));
+            Check.NotNull(shapedQueryFindingExpressionVisitorFactory, nameof(shapedQueryFindingExpressionVisitorFactory));
+
+            _options = options;
+            _model = model;
+            _queryOptimizer = queryOptimizer;
+            _navigationRewritingExpressionVisitorFactory = navigationRewritingExpressionVisitorFactory;
+            _subQueryMemberPushDownExpressionVisitor = subQueryMemberPushDownExpressionVisitor;
+            _querySourceTracingExpressionVisitorFactory = querySourceTracingExpressionVisitorFactory;
+            _entityResultFindingExpressionVisitorFactory = entityResultFindingExpressionVisitorFactory;
+            _taskBlockingExpressionVisitor = taskBlockingExpressionVisitor;
+            _memberAccessBindingExpressionVisitorFactory = memberAccessBindingExpressionVisitorFactory;
+            _orderingExpressionVisitorFactory = orderingExpressionVisitorFactory;
+            _projectionExpressionVisitorFactory = projectionExpressionVisitorFactory;
+            _entityQueryableExpressionVisitorFactory = entityQueryableExpressionVisitorFactory;
+            _queryAnnotationExtractor = queryAnnotationExtractor;
+            _resultOperatorHandler = resultOperatorHandler;
+            _entityMaterializerSource = entityMaterializerSource;
+            _expressionPrinter = expressionPrinter;
+            _relationalMetadataExtensionProvider = relationalMetadataExtensionProvider;
+            _includeExpressionVisitorFactory = includeExpressionVisitorFactory;
+            _sqlTranslatingExpressionVisitorFactory = sqlTranslatingExpressionVisitorFactory;
+            _compositePredicateExpressionVisitorFactory = compositePredicateExpressionVisitorFactory;
+            _queryFlatteningExpressionVisitorFactory = queryFlatteningExpressionVisitorFactory;
+            _shapedQueryFindingExpressionVisitorFactory = shapedQueryFindingExpressionVisitorFactory;
+        }
+
+        public virtual EntityQueryModelVisitor Create([NotNull] QueryCompilationContext queryCompilationContext, [NotNull] IDatabase database)
+            => Create(queryCompilationContext, database, null);
+
+        public virtual EntityQueryModelVisitor Create(
+            [NotNull] QueryCompilationContext queryCompilationContext,
+            [NotNull] IDatabase database,
+            [CanBeNull] EntityQueryModelVisitor parentEntityQueryModelVisitor)
+            =>
+                new SqlServerQueryModelVisitor(
+                    _options,
+                    _model,
+                    _queryOptimizer,
+                    _navigationRewritingExpressionVisitorFactory,
+                    _subQueryMemberPushDownExpressionVisitor,
+                    _querySourceTracingExpressionVisitorFactory,
+                    _entityResultFindingExpressionVisitorFactory,
+                    _taskBlockingExpressionVisitor,
+                    _memberAccessBindingExpressionVisitorFactory,
+                    _orderingExpressionVisitorFactory,
+                    _projectionExpressionVisitorFactory,
+                    _entityQueryableExpressionVisitorFactory,
+                    _queryAnnotationExtractor,
+                    _resultOperatorHandler,
+                    _entityMaterializerSource,
+                    _expressionPrinter,
+                    _relationalMetadataExtensionProvider,
+                    _includeExpressionVisitorFactory,
+                    _sqlTranslatingExpressionVisitorFactory,
+                    _compositePredicateExpressionVisitorFactory,
+                    _queryFlatteningExpressionVisitorFactory,
+                    _shapedQueryFindingExpressionVisitorFactory,
+                    (RelationalQueryCompilationContext)Check.NotNull(queryCompilationContext, nameof(queryCompilationContext)),
+                    database,
+                    (SqlServerQueryModelVisitor)parentEntityQueryModelVisitor);
+    }
+}

--- a/src/EntityFramework.SqlServer/SqlServerDatabaseProviderServices.cs
+++ b/src/EntityFramework.SqlServer/SqlServerDatabaseProviderServices.cs
@@ -49,5 +49,7 @@ namespace Microsoft.Data.Entity.SqlServer
         public override IExpressionFragmentTranslator CompositeExpressionFragmentTranslator => GetService<SqlServerCompositeExpressionFragmentTranslator>();
         public override IQueryCompilationContextFactory QueryCompilationContextFactory => GetService<SqlServerQueryCompilationContextFactory>();
         public override ISqlQueryGeneratorFactory SqlQueryGeneratorFactory => GetService<SqlServerQuerySqlGeneratorFactory>();
+        public override IEntityQueryModelVisitorFactory EntityQueryModelVisitorFactory => GetService<SqlServerQueryModelVisitorFactory>();
+        public override ICompiledQueryCacheKeyGenerator CompiledQueryCacheKeyGenerator => GetService<SqlServerCompiledQueryCacheKeyGenerator>();
     }
 }

--- a/src/EntityFramework.SqlServer/SqlServerEntityFrameworkServicesBuilderExtensions.cs
+++ b/src/EntityFramework.SqlServer/SqlServerEntityFrameworkServicesBuilderExtensions.cs
@@ -47,6 +47,8 @@ namespace Microsoft.Framework.DependencyInjection
                     .AddScoped<SqlServerMigrationsSqlGenerator>()
                     .AddScoped<SqlServerDatabaseCreator>()
                     .AddScoped<SqlServerHistoryRepository>()
+                    .AddScoped<SqlServerQueryModelVisitorFactory>()
+                    .AddScoped<SqlServerCompiledQueryCacheKeyGenerator>()
                     .AddQuery());
 
             return builder;

--- a/src/EntityFramework.SqlServer/SqlServerOptionsExtension.cs
+++ b/src/EntityFramework.SqlServer/SqlServerOptionsExtension.cs
@@ -19,6 +19,8 @@ namespace Microsoft.Data.Entity.SqlServer
         {
         }
 
+        public virtual bool? RowNumberPaging { get; set; }
+
         public override void ApplyServices(EntityFrameworkServicesBuilder builder)
             => Check.NotNull(builder, nameof(builder)).AddSqlServer();
     }

--- a/test/EntityFramework.SqlServer.FunctionalTests/CompiledQueryCacheKeyGeneratorTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/CompiledQueryCacheKeyGeneratorTest.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Internal;
+using Microsoft.Framework.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
+{
+    public class CompiledQueryCacheKeyGeneratorTest
+    {
+        [Fact]
+        public void It_creates_unique_query_cache_key()
+        {
+            object key1, key2;
+            Expression query;
+            using (var context1 = new QueryKeyCacheContext(rowNumberPaging: true))
+            {
+                var services = ((IAccessor<IServiceProvider>)context1).Service.GetService<IDbContextServices>().DatabaseProviderServices;
+                query = context1.Set<Poco1>().Skip(4).Take(10).Expression;
+                var generator = services.CompiledQueryCacheKeyGenerator;
+                key1 = generator.GenerateCacheKey(query, services.Database, false);
+            }
+
+            using (var context2 = new QueryKeyCacheContext(rowNumberPaging: false))
+            {
+                var services = ((IAccessor<IServiceProvider>)context2).Service.GetService<IDbContextServices>().DatabaseProviderServices;
+                var generator = services.CompiledQueryCacheKeyGenerator;
+                key2 = generator.GenerateCacheKey(query, services.Database, false);
+            }
+
+            Assert.NotEqual(key1, key2);
+        }
+
+        public class QueryKeyCacheContext : DbContext
+        {
+            private bool _rowNumberPaging;
+
+            public QueryKeyCacheContext(bool rowNumberPaging)
+            {
+                _rowNumberPaging = rowNumberPaging;
+            }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<Poco1>();
+            }
+
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            {
+                var optionBuilder = optionsBuilder.UseSqlServer(SqlServerTestStore.CreateScratch().Connection);
+                if (_rowNumberPaging)
+                {
+                    optionBuilder.UseRowNumberForPaging();
+                }
+            }
+        }
+
+        private class Poco1
+        {
+            public int Id { get; set; }
+        }
+    }
+}

--- a/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
+++ b/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
@@ -38,6 +38,7 @@
     <Compile Include="AsyncFromSqlQuerySqlServerTest.cs" />
     <Compile Include="AsyncFromSqlSprocQuerySqlServerTest.cs" />
     <Compile Include="CommandConfigurationTest.cs" />
+    <Compile Include="CompiledQueryCacheKeyGeneratorTest.cs" />
     <Compile Include="ComputedColumnTest.cs" />
     <Compile Include="DataAnnotationSqlServerFixture.cs" />
     <Compile Include="DataAnnotationSqlServerTest.cs" />
@@ -46,6 +47,7 @@
     <Compile Include="GraphUpdatesWithSequenceSqlServerTest.cs" />
     <Compile Include="MigrationsSqlServerFixture.cs" />
     <Compile Include="MigrationsSqlServerTest.cs" />
+    <Compile Include="NorthwindRowNumberPagingQuerySqlServerFixture.cs" />
     <Compile Include="NorthwindSprocQuerySqlServerFixture.cs" />
     <Compile Include="FromSqlQuerySqlServerTest.cs" />
     <Compile Include="NavigationTest.cs" />
@@ -67,6 +69,7 @@
     <Compile Include="ComplexNavigationsQuerySqlServerTest.cs" />
     <Compile Include="F1SqlServerFixture.cs" />
     <Compile Include="QueryNavigationsSqlServerTest.cs" />
+    <Compile Include="RowNumberPagingTest.cs" />
     <Compile Include="SqlServerFixture.cs" />
     <Compile Include="GearsOfWarQuerySqlServerFixture.cs" />
     <Compile Include="GearsOfWarQuerySqlServerTest.cs" />

--- a/test/EntityFramework.SqlServer.FunctionalTests/NorthwindQuerySqlServerFixture.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/NorthwindQuerySqlServerFixture.cs
@@ -29,13 +29,18 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 .AddInstance<ILoggerFactory>(new TestSqlLoggerFactory())
                 .BuildServiceProvider();
 
+            _options = ConfigureOptions();
+
+            _serviceProvider.GetRequiredService<ILoggerFactory>().MinimumLevel = LogLevel.Debug;
+        }
+
+        protected virtual DbContextOptions ConfigureOptions()
+        {
             var optionsBuilder = new DbContextOptionsBuilder();
 
             optionsBuilder.UseSqlServer(_testStore.Connection.ConnectionString);
 
-            _options = optionsBuilder.Options;
-
-            _serviceProvider.GetRequiredService<ILoggerFactory>().MinimumLevel = LogLevel.Debug;
+            return optionsBuilder.Options;
         }
 
         public override NorthwindContext CreateContext()

--- a/test/EntityFramework.SqlServer.FunctionalTests/NorthwindRowNumberPagingQuerySqlServerFixture.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/NorthwindRowNumberPagingQuerySqlServerFixture.cs
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.SqlServer.Extensions;
+
+namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
+{
+    public class NorthwindRowNumberPagingQuerySqlServerFixture : NorthwindQuerySqlServerFixture
+    {
+        protected override DbContextOptions ConfigureOptions()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder(base.ConfigureOptions());
+            new SqlServerDbContextOptionsBuilder(optionsBuilder).UseRowNumberForPaging();
+            return optionsBuilder.Options;
+        }
+    }
+}

--- a/test/EntityFramework.SqlServer.FunctionalTests/RowNumberPagingTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/RowNumberPagingTest.cs
@@ -1,0 +1,149 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Data.Entity.FunctionalTests;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
+{
+    public class RowNumberPagingTest : QueryTestBase<NorthwindRowNumberPagingQuerySqlServerFixture>, IDisposable
+    {
+        public RowNumberPagingTest(NorthwindRowNumberPagingQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
+            : base(fixture)
+        {
+            //TestSqlLoggerFactory.CaptureOutput(testOutputHelper);
+        }
+
+        public void Dispose()
+        {
+            //Assert for all tests that OFFSET or FETCH is never used
+            Assert.DoesNotContain("OFFSET ", Sql);
+            Assert.DoesNotContain("FETCH ", Sql);
+        }
+
+        public override void Skip()
+        {
+            base.Skip();
+
+            Assert.Equal(
+               @"SELECT [t0].[CustomerID], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
+FROM (
+    SELECT [c].*, ROW_NUMBER() OVER(ORDER BY [c].[CustomerID]) AS [__RowNumber__]
+    FROM [Customers] AS [c]
+) AS [t0]
+WHERE [t0].[__RowNumber__] > 5",
+               Sql);
+        }
+
+        public override void Skip_no_orderby()
+        {
+            base.Skip_no_orderby();
+
+            Assert.EndsWith(
+                @"SELECT [t0].[CustomerID], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
+FROM (
+    SELECT [c].*, ROW_NUMBER() OVER(ORDER BY @@RowCount) AS [__RowNumber__]
+    FROM [Customers] AS [c]
+) AS [t0]
+WHERE [t0].[__RowNumber__] > 5",
+                Sql);
+        }
+
+        public override void Skip_Take()
+        {
+            base.Skip_Take();
+
+            Assert.Equal(
+                @"SELECT [t0].[CustomerID], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
+FROM (
+    SELECT [c].*, ROW_NUMBER() OVER(ORDER BY [c].[ContactName]) AS [__RowNumber__]
+    FROM [Customers] AS [c]
+) AS [t0]
+WHERE ([t0].[__RowNumber__] > 5) AND ([t0].[__RowNumber__] <= 15)",
+                Sql);
+        }
+
+        public override void Take_Skip()
+        {
+            base.Take_Skip();
+
+            Assert.Equal(@"SELECT [t1].*
+FROM (
+    SELECT [t0].*, ROW_NUMBER() OVER(ORDER BY [t0].[ContactName]) AS [__RowNumber__]
+    FROM (
+        SELECT TOP(10) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+        FROM [Customers] AS [c]
+        ORDER BY [c].[ContactName]
+    ) AS [t0]
+) AS [t1]
+WHERE [t1].[__RowNumber__] > 5",
+                Sql);
+        }
+
+        public override void Take_Skip_Distinct()
+        {
+            base.Take_Skip_Distinct();
+
+            Assert.Equal(
+                @"SELECT DISTINCT [t1].*
+FROM (
+    SELECT [t2].*
+    FROM (
+        SELECT [t0].*, ROW_NUMBER() OVER(ORDER BY [t0].[ContactName]) AS [__RowNumber__]
+        FROM (
+            SELECT TOP(10) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+            FROM [Customers] AS [c]
+            ORDER BY [c].[ContactName]
+        ) AS [t0]
+    ) AS [t2]
+    WHERE [t2].[__RowNumber__] > 5
+) AS [t1]",
+                Sql);
+        }
+
+        public override void Take_skip_null_coalesce_operator()
+        {
+            base.Take_skip_null_coalesce_operator();
+
+            Assert.Equal(@"SELECT DISTINCT [t1].*
+FROM (
+    SELECT [t2].*
+    FROM (
+        SELECT [t0].*, ROW_NUMBER() OVER(ORDER BY COALESCE([t0].[Region], 'ZZ')) AS [__RowNumber__]
+        FROM (
+            SELECT TOP(10) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+            FROM [Customers] AS [c]
+            ORDER BY COALESCE([c].[Region], 'ZZ')
+        ) AS [t0]
+    ) AS [t2]
+    WHERE [t2].[__RowNumber__] > 5
+) AS [t1]", Sql);
+        }
+
+        public override void Select_take_skip_null_coalesce_operator()
+        {
+            base.Select_take_skip_null_coalesce_operator();
+
+            Assert.Equal(@"SELECT [t1].*
+FROM (
+    SELECT [t0].*, ROW_NUMBER() OVER(ORDER BY [Coalesce]) AS [__RowNumber__]
+    FROM (
+        SELECT TOP(10) [c].[CustomerID], [c].[CompanyName], COALESCE([c].[Region], 'ZZ') AS [Coalesce]
+        FROM [Customers] AS [c]
+        ORDER BY [Coalesce]
+    ) AS [t0]
+) AS [t1]
+WHERE [t1].[__RowNumber__] > 5", Sql);
+        }
+
+        public override void String_Contains_Literal()
+        {
+            // skip. This is covered in QuerySqlServerTest
+            // base.String_Contains_Literal()
+        }
+
+        private static string Sql => TestSqlLoggerFactory.Sql;
+    }
+}

--- a/test/EntityFramework.SqlServer.Tests/SqlServerDbContextOptionsExtensionsTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerDbContextOptionsExtensionsTest.cs
@@ -93,5 +93,18 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             Assert.Same(connection, extension.Connection);
             Assert.Null(extension.ConnectionString);
         }
+
+        [Fact]
+        public void Can_add_extension_with_legacy_paging()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder<DbContext>();
+
+            optionsBuilder.UseSqlServer("Database=Kilimanjaro").UseRowNumberForPaging();
+
+            var extension = optionsBuilder.Options.Extensions.OfType<SqlServerOptionsExtension>().Single();
+
+            Assert.True(extension.RowNumberPaging.HasValue);
+            Assert.True(extension.RowNumberPaging.Value);
+        }
     }
 }


### PR DESCRIPTION
Modifies the query structure to include the ROW_NUMBER workaround for limited support of OFFSET and FETCH on SQL 2008,

Add legacy paging extension to options builder.

```c#
options.UseSqlServer("Database=Kilimanjaro2008").UseRowNumberForPaging()
```

Fix #2180 