### PR TITLE
Update DetectChanges to bring in all detected dependents

### DIFF
--- a/src/EntityFramework.Core/ChangeTracking/Internal/ChangeDetector.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/ChangeDetector.cs
@@ -12,11 +12,11 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 {
     public class ChangeDetector : IChangeDetector
     {
-        private readonly IModel _model;
+        private readonly IEntityGraphAttacher _attacher;
 
-        public ChangeDetector([NotNull] IModel model)
+        public ChangeDetector([NotNull] IEntityGraphAttacher attacher)
         {
-            _model = model;
+            _attacher = attacher;
         }
 
         public virtual void PropertyChanged(InternalEntityEntry entry, IPropertyBase propertyBase)
@@ -247,7 +247,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
                 var addedEntry = stateManager.GetOrCreateEntry(addedEntity);
                 if (addedEntry.EntityState == EntityState.Detached)
                 {
-                    addedEntry.SetEntityState(EntityState.Added);
+                    _attacher.AttachGraph(addedEntry, EntityState.Added);
                 }
             }
         }

--- a/test/EntityFramework.Core.Tests/ChangeTracking/ChangeTrackerTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/ChangeTrackerTest.cs
@@ -936,15 +936,13 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             }
         }
 
-        private static Product CreateSimpleGraph(int id)
-        {
-            return new Product { Id = id, Category = new Category { Id = id } };
-        }
+        private static Product CreateSimpleGraph(int id) 
+            => new Product { Id = id, Category = new Category { Id = id } };
 
         private class ChangeDetectorProxy : ChangeDetector
         {
-            public ChangeDetectorProxy(IModel model)
-                : base(model)
+            public ChangeDetectorProxy(IEntityGraphAttacher attacher)
+                : base(attacher)
             {
             }
 

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
@@ -1029,11 +1029,11 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             Assert.Equal(EntityState.Added, stateManager.GetOrCreateEntry(newCategory).EntityState);
 
-            Assert.Equal(EntityState.Detached, stateManager.GetOrCreateEntry(newCategory.Tag).EntityState);
+            Assert.Equal(EntityState.Added, stateManager.GetOrCreateEntry(newCategory.Tag).EntityState);
 
             changeDetector.DetectChanges(stateManager);
 
-            Assert.Equal(EntityState.Detached, stateManager.GetOrCreateEntry(newCategory.Tag).EntityState);
+            Assert.Equal(EntityState.Added, stateManager.GetOrCreateEntry(newCategory.Tag).EntityState);
         }
 
         [Fact]
@@ -1119,11 +1119,11 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             Assert.Equal(EntityState.Added, stateManager.GetOrCreateEntry(product3).EntityState);
 
-            Assert.Equal(EntityState.Detached, stateManager.GetOrCreateEntry(product3.Tag).EntityState);
+            Assert.Equal(EntityState.Added, stateManager.GetOrCreateEntry(product3.Tag).EntityState);
 
             changeDetector.DetectChanges(stateManager);
 
-            Assert.Equal(EntityState.Detached, stateManager.GetOrCreateEntry(product3.Tag).EntityState);
+            Assert.Equal(EntityState.Added, stateManager.GetOrCreateEntry(product3.Tag).EntityState);
         }
 
         [Fact]
@@ -1626,7 +1626,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             Assert.Empty(originalCategory.Products);
 
             Assert.Equal(EntityState.Added, stateManager.GetOrCreateEntry(newCategory).EntityState);
-            Assert.Equal(EntityState.Detached, stateManager.GetOrCreateEntry(newCategory.Tag).EntityState);
+            Assert.Equal(EntityState.Added, stateManager.GetOrCreateEntry(newCategory.Tag).EntityState);
         }
 
         [Fact]
@@ -1706,7 +1706,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             Assert.Equal(new[] { product1, product2, product3 }.OrderBy(e => e.Id), category.Products.OrderBy(e => e.Id).ToArray());
 
             Assert.Equal(EntityState.Added, stateManager.GetOrCreateEntry(product3).EntityState);
-            Assert.Equal(EntityState.Detached, stateManager.GetOrCreateEntry(product3.Tag).EntityState);
+            Assert.Equal(EntityState.Added, stateManager.GetOrCreateEntry(product3.Tag).EntityState);
         }
 
         [Fact]

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/StateManagerTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/StateManagerTest.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
@@ -372,8 +371,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
         internal class ChangeDetectorProxy : ChangeDetector
         {
-            public ChangeDetectorProxy([NotNull] IModel model)
-                : base(model)
+            public ChangeDetectorProxy(IEntityGraphAttacher attacher)
+                : base(attacher)
             {
             }
 

--- a/test/EntityFramework.Core.Tests/DbContextTest.cs
+++ b/test/EntityFramework.Core.Tests/DbContextTest.cs
@@ -2479,8 +2479,8 @@ namespace Microsoft.Data.Entity.Tests
 
         private class ChangeDetectorProxy : ChangeDetector
         {
-            public ChangeDetectorProxy(IModel model)
-                : base(model)
+            public ChangeDetectorProxy(IEntityGraphAttacher attacher)
+                : base(attacher)
             {
             }
 


### PR DESCRIPTION
This matches the semantics of Add making the behavior more consistent across the stack and, based on our design meeting discussion, more likely to be what is expected.