### PR TITLE
Commands: Version handler interfaces

### DIFF
--- a/src/EntityFramework.Commands/Utilities/CommandLogger.cs
+++ b/src/EntityFramework.Commands/Utilities/CommandLogger.cs
@@ -74,6 +74,9 @@ namespace Microsoft.Data.Entity.Commands.Utilities
 
             switch (logLevel)
             {
+                case LogLevel.Error:
+                    WriteError(message.ToString());
+                    break;
                 case LogLevel.Warning:
                     WriteWarning(message.ToString());
                     break;
@@ -83,16 +86,22 @@ namespace Microsoft.Data.Entity.Commands.Utilities
                 case LogLevel.Verbose:
                     WriteVerbose(message.ToString());
                     break;
+                case LogLevel.Debug:
+                    WriteDebug(message.ToString());
+                    break;
                 default:
-                    Debug.Fail("Unexpected event type.");
+                    Debug.Fail("Unexpected event type: " + logLevel);
+                    WriteVerbose(message.ToString());
                     break;
             }
         }
 
         public virtual IDisposable BeginScopeImpl(object state) => null;
 
+        protected abstract void WriteError([NotNull] string message);
         protected abstract void WriteWarning([NotNull] string message);
         protected abstract void WriteInformation([NotNull] string message);
         protected abstract void WriteVerbose([NotNull] string message);
+        protected abstract void WriteDebug([NotNull] string message);
     }
 }

--- a/src/EntityFramework.Commands/Utilities/CommandLoggerAdapter.cs
+++ b/src/EntityFramework.Commands/Utilities/CommandLoggerAdapter.cs
@@ -18,8 +18,10 @@ namespace Microsoft.Data.Entity.Commands.Utilities
             _logHandler = logHandler;
         }
 
+        protected override void WriteError(string message) => _logHandler.WriteError(message);
         protected override void WriteInformation(string message) => _logHandler.WriteInformation(message);
         protected override void WriteVerbose(string message) => _logHandler.WriteVerbose(message);
         protected override void WriteWarning(string message) => _logHandler.WriteWarning(message);
+        protected override void WriteDebug(string message) => _logHandler.WriteDebug(message);
     }
 }

--- a/src/EntityFramework.Commands/Utilities/ConsoleCommandLogger.cs
+++ b/src/EntityFramework.Commands/Utilities/ConsoleCommandLogger.cs
@@ -19,7 +19,18 @@ namespace Microsoft.Data.Entity.Commands.Utilities
         }
 
         public override bool IsEnabled(LogLevel logLevel) =>
-            base.IsEnabled(logLevel) && (logLevel != LogLevel.Verbose || _verbose);
+            base.IsEnabled(logLevel) && (logLevel > LogLevel.Verbose || _verbose);
+
+        protected override void WriteError(string message)
+        {
+            lock (_sync)
+            {
+                using (new ColorScope(ConsoleColor.Red))
+                {
+                    Console.WriteLine(message);
+                }
+            }
+        }
 
         protected override void WriteWarning(string message)
         {
@@ -53,5 +64,7 @@ namespace Microsoft.Data.Entity.Commands.Utilities
                 }
             }
         }
+
+        protected override void WriteDebug(string message) => WriteVerbose(message);
     }
 }

--- a/src/EntityFramework.Commands/tools/EntityFramework.psm1
+++ b/src/EntityFramework.Commands/tools/EntityFramework.psm1
@@ -98,7 +98,7 @@ function Add-Migration {
     $DTE.ItemOperations.OpenFile($artifacts[0]) | Out-Null
     ShowConsole
 
-    Write-Host 'To undo this action, use Remove-Migration.'
+    Write-Output 'To undo this action, use Remove-Migration.'
 }
 
 #
@@ -511,9 +511,11 @@ function InvokeOperation($project, $operation, $arguments = @{}, $startupProject
     }
 
     $logHandler = New-Object Microsoft.Data.Entity.Commands.LogHandler @(
+        { param ($message) Write-Error $message }
         { param ($message) Write-Warning $message }
-        { param ($message) Write-Host $message }
+        { param ($message) Write-Output $message }
         { param ($message) Write-Verbose $message }
+        { param ($message) Write-Debug $message }
     )
 
     $outputPath = GetProperty $project.ConfigurationManager.ActiveConfiguration.Properties OutputPath

--- a/test/EntityFramework.Commands.Tests/HandlerTest.cs
+++ b/test/EntityFramework.Commands.Tests/HandlerTest.cs
@@ -8,6 +8,12 @@ namespace Microsoft.Data.Entity.Commands.Tests
     public class HandlerTest
     {
         [Fact]
+        public void Result_Version_is_zero()
+        {
+            Assert.Equal(0, new ResultHandler().Version);
+        }
+
+        [Fact]
         public void HasResult_defaults_to_false()
         {
             Assert.False(new ResultHandler().HasResult);
@@ -47,13 +53,33 @@ namespace Microsoft.Data.Entity.Commands.Tests
         }
 
         [Fact]
+        public void Log_Version_is_zero()
+        {
+            Assert.Equal(0, new LogHandler().Version);
+        }
+
+        [Fact]
         public void Write_methods_are_noops_when_null()
         {
             var handler = new LogHandler();
 
+            handler.WriteError("Princess Celestia does not exist.");
             handler.WriteWarning("Princess Celestia is in danger.");
             handler.WriteInformation("Princess Celestia is on her way.");
             handler.WriteVerbose("Princess Celestia is an alicorn.");
+            handler.WriteDebug("Princess Celestia is a princess.");
+        }
+
+        [Fact]
+        public void WriteError_works()
+        {
+            string result = null;
+            var handler = new LogHandler(writeError: m => result = m);
+            var message = "Princess Celestia does not exist.";
+
+            handler.WriteError(message);
+
+            Assert.Equal(message, result);
         }
 
         [Fact]
@@ -88,6 +114,18 @@ namespace Microsoft.Data.Entity.Commands.Tests
             var message = "Princess Celestia is an alicorn.";
 
             handler.WriteVerbose(message);
+
+            Assert.Equal(message, result);
+        }
+
+        [Fact]
+        public void WriteDebug_works()
+        {
+            string result = null;
+            var handler = new LogHandler(writeDebug: m => result = m);
+            var message = "Princess Celestia is a princess.";
+
+            handler.WriteDebug(message);
 
             Assert.Equal(message, result);
         }

--- a/test/EntityFramework.Relational.Design.FunctionalTests/ReverseEngineering/InMemoryCommandLogger.cs
+++ b/test/EntityFramework.Relational.Design.FunctionalTests/ReverseEngineering/InMemoryCommandLogger.cs
@@ -18,6 +18,11 @@ namespace Microsoft.Data.Entity.Relational.Design.FunctionalTests.ReverseEnginee
 
         public override bool IsEnabled(LogLevel logLevel) => true;
 
+        protected override void WriteError(string message)
+        {
+            Messages.Error.Add(message);
+        }
+
         protected override void WriteWarning(string message)
         {
             Messages.Warn.Add(message);
@@ -32,12 +37,19 @@ namespace Microsoft.Data.Entity.Relational.Design.FunctionalTests.ReverseEnginee
         {
             Messages.Verbose.Add(message);
         }
+
+        protected override void WriteDebug(string message)
+        {
+            Messages.Debug.Add(message);
+        }
     }
 
     public class LoggerMessages
     {
+        public List<string> Error = new List<string>();
         public List<string> Warn = new List<string>();
         public List<string> Info = new List<string>();
         public List<string> Verbose = new List<string>();
+        public List<string> Debug = new List<string>();
     }
 }


### PR DESCRIPTION
This allows us to add additional, unforeseen members to them in the future while maintaining backwards-compatibility. This would be needed after upgrading but before restarting VS, or in a solution that contains multiple versions of EF.

Resolves #2512 (other cases already accounted for)