### PR TITLE
Resolves #2212 Add MigrateAsync (and related async methods)

### DIFF
--- a/src/EntityFramework.Relational/Migrations/IHistoryRepository.cs
+++ b/src/EntityFramework.Relational/Migrations/IHistoryRepository.cs
@@ -3,13 +3,16 @@
 
 using System.Collections.Generic;
 using JetBrains.Annotations;
+using System.Threading.Tasks;
 
 namespace Microsoft.Data.Entity.Migrations
 {
     public interface IHistoryRepository
     {
         bool Exists();
+        Task<bool> ExistsAsync();
         IReadOnlyList<HistoryRow> GetAppliedMigrations();
+        Task<IReadOnlyList<HistoryRow>> GetAppliedMigrationsAsync();
         string GetCreateScript();
         string GetCreateIfNotExistsScript();
         string GetInsertScript([NotNull] HistoryRow row);

--- a/src/EntityFramework.Relational/Migrations/IMigrator.cs
+++ b/src/EntityFramework.Relational/Migrations/IMigrator.cs
@@ -2,12 +2,15 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using System.Threading.Tasks;
 
 namespace Microsoft.Data.Entity.Migrations
 {
     public interface IMigrator
     {
         void Migrate([CanBeNull] string targetMigration = null);
+
+        Task MigrateAsync([CanBeNull] string targetMigration = null);
 
         string GenerateScript([CanBeNull] string fromMigration = null, [CanBeNull] string toMigration = null, bool idempotent = false);
     }

--- a/src/EntityFramework.Relational/RelationalDatabaseFacadeExtensions.cs
+++ b/src/EntityFramework.Relational/RelationalDatabaseFacadeExtensions.cs
@@ -20,6 +20,9 @@ namespace Microsoft.Data.Entity
         public static void Migrate([NotNull] this DatabaseFacade databaseFacade)
             => Check.NotNull(databaseFacade, nameof(databaseFacade)).GetService<IMigrator>().Migrate();
 
+        public static Task MigrateAsync([NotNull] this DatabaseFacade databaseFacade)
+            => Check.NotNull(databaseFacade, nameof(databaseFacade)).GetService<IMigrator>().MigrateAsync();
+
         public static void ExecuteSqlCommand(
             [NotNull] this DatabaseFacade databaseFacade,
             [NotNull] string sql,

--- a/test/EntityFramework.Relational.FunctionalTests/MigrationsTestBase.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/MigrationsTestBase.cs
@@ -96,6 +96,74 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
+        public async Task Can_apply_all_migrations_async()
+        {
+            using (var db = _fixture.CreateContext())
+            {
+                db.Database.EnsureDeleted();
+
+                await db.Database.MigrateAsync();
+
+                var history = db.GetService().GetRequiredService<IHistoryRepository>();
+                Assert.Collection(
+                    history.GetAppliedMigrations(),
+                    x => Assert.Equal("00000000000001_Migration1", x.MigrationId),
+                    x => Assert.Equal("00000000000002_Migration2", x.MigrationId));
+            }
+        }
+
+        [Fact]
+        public async Task Can_apply_one_migration_async()
+        {
+            using (var db = _fixture.CreateContext())
+            {
+                db.Database.EnsureDeleted();
+
+                var migrator = db.GetService().GetRequiredService<IMigrator>();
+                await migrator.MigrateAsync("Migration1");
+
+                var history = db.GetService().GetRequiredService<IHistoryRepository>();
+                Assert.Collection(
+                    history.GetAppliedMigrations(),
+                    x => Assert.Equal("00000000000001_Migration1", x.MigrationId));
+            }
+        }
+
+        [Fact]
+        public async Task Can_revert_all_migrations_async()
+        {
+            using (var db = _fixture.CreateContext())
+            {
+                db.Database.EnsureDeleted();
+                await db.Database.MigrateAsync();
+
+                var migrator = db.GetService().GetRequiredService<IMigrator>();
+                await migrator.MigrateAsync(Migration.InitialDatabase);
+
+                var history = db.GetService().GetRequiredService<IHistoryRepository>();
+                Assert.Empty(history.GetAppliedMigrations());
+            }
+        }
+
+        [Fact]
+        public async Task Can_revert_one_migrations_async()
+        {
+            using (var db = _fixture.CreateContext())
+            {
+                db.Database.EnsureDeleted();
+                await db.Database.MigrateAsync();
+
+                var migrator = db.GetService().GetRequiredService<IMigrator>();
+                await migrator.MigrateAsync("Migration1");
+
+                var history = db.GetService().GetRequiredService<IHistoryRepository>();
+                Assert.Collection(
+                    history.GetAppliedMigrations(),
+                    x => Assert.Equal("00000000000001_Migration1", x.MigrationId));
+            }
+        }
+
+        [Fact]
         public virtual void Can_generate_up_scripts()
         {
             using (var db = _fixture.CreateContext())


### PR DESCRIPTION
Add MigrateAsync method to IMigrator interface and implement it. 
Add related to it Async methods to IHistoryRepository (ExistsAsync and GetAppliedMigrationsAsync)
Refactor Migrator - extract logic for generatin Up and Down Relation Command batches to separate method to maximize code reusability in both sync and async Migrate methods.
Add extension to call this method throw RelationalDatabaseFacadeExtensions.
Add aync tests for MigrationsTestBase.

Related to PR #2557 (mistaken in merge for newest changes, so I closed #2557 and created new one)