### PR TITLE
[TINY] Fix SaveChanges init benchmark

### DIFF
--- a/test/EntityFramework.Microbenchmarks.EF6/InitializationTests.cs
+++ b/test/EntityFramework.Microbenchmarks.EF6/InitializationTests.cs
@@ -106,10 +106,10 @@ namespace EntityFramework.Microbenchmarks.EF6
                     {
                         using (var context = AdventureWorksFixture.CreateContext())
                         {
-                            context.Department.Add(new Department
+                            context.Currency.Add(new Currency
                             {
-                                Name = "Benchmarking",
-                                GroupName = "Engineering"
+                                CurrencyCode = "TMP",
+                                Name = "Temporary"
                             });
 
                             using (context.Database.BeginTransaction())

--- a/test/EntityFramework.Microbenchmarks/InitializationTests.cs
+++ b/test/EntityFramework.Microbenchmarks/InitializationTests.cs
@@ -127,10 +127,10 @@ namespace EntityFramework.Microbenchmarks
                     {
                         using (var context = AdventureWorksFixture.CreateContext())
                         {
-                            context.Department.Add(new Department
+                            context.Currency.Add(new Currency
                             {
-                                Name = "Benchmarking",
-                                GroupName = "Engineering"
+                                CurrencyCode = "TMP",
+                                Name = "Temporary"
                             });
 
                             using (context.Database.BeginTransaction())


### PR DESCRIPTION
Test would previously insert an entity type that used IDENTITY in the
database. Even though we roll the transaction back the value still gets
reserved in the database and so we were running out of IDENTITY values
after several test runs (the column is `smallint`, so this happened
after a few days). Swapping to use an entity with a non-generated key.