### PR TITLE
[TINY] "Cold Hard DNX" Disable cold start on DNX451

### DIFF
--- a/test/EntityFramework.Microbenchmarks/InitializationTests.cs
+++ b/test/EntityFramework.Microbenchmarks/InitializationTests.cs
@@ -17,7 +17,7 @@ namespace EntityFramework.Microbenchmarks
     public partial class InitializationTests : IClassFixture<AdventureWorksFixture>
     {
         [Benchmark]
-#if !DNXCORE50
+#if !DNXCORE50 && !DNX451
         [BenchmarkVariation("Cold (1 instance)", true, 1)]
 #endif
         [BenchmarkVariation("Warm (100 instances)", false, 100)]
@@ -27,7 +27,7 @@ namespace EntityFramework.Microbenchmarks
         }
 
         [AdventureWorksDatabaseBenchmark]
-#if !DNXCORE50
+#if !DNXCORE50 && !DNX451
         [BenchmarkVariation("Cold (1 instance)", true, 1)]
 #endif
         [BenchmarkVariation("Warm (10 instances)", false, 10)]
@@ -37,7 +37,7 @@ namespace EntityFramework.Microbenchmarks
         }
 
         [AdventureWorksDatabaseBenchmark]
-#if !DNXCORE50
+#if !DNXCORE50 && !DNX451
         [BenchmarkVariation("Cold (1 instance)", true, 1)]
 #endif
         [BenchmarkVariation("Warm (10 instances)", false, 10)]


### PR DESCRIPTION
Getting the application assembly loaded into a new AppDomain is just
difficult on DNX because they are in-memory. Filed
aspnet/dnx#2663 to see if this can be made
easier.

In the meantime, just disabling the cold start tests on DNX451.