### PR TITLE
Had cascade delete flag to core metadata and fluent API

### DIFF
--- a/src/EntityFramework.Core/Metadata/Builders/ReferenceCollectionBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Builders/ReferenceCollectionBuilder.cs
@@ -124,5 +124,9 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
         public virtual ReferenceCollectionBuilder Required(bool required = true)
             => new ReferenceCollectionBuilder(Builder.Required(required, ConfigurationSource.Explicit));
+
+        public virtual ReferenceCollectionBuilder WillCascadeOnDelete(bool cascade = true)
+            => new ReferenceCollectionBuilder(
+                Builder.DeleteBehavior(cascade ? DeleteBehavior.Cascade : DeleteBehavior.None, ConfigurationSource.Explicit));
     }
 }

--- a/src/EntityFramework.Core/Metadata/Builders/ReferenceCollectionBuilder`.cs
+++ b/src/EntityFramework.Core/Metadata/Builders/ReferenceCollectionBuilder`.cs
@@ -168,6 +168,10 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         public new virtual ReferenceCollectionBuilder<TPrincipalEntity, TDependentEntity> Required(bool required = true)
             => new ReferenceCollectionBuilder<TPrincipalEntity, TDependentEntity>(Builder.Required(required, ConfigurationSource.Explicit));
 
+        public new virtual ReferenceCollectionBuilder<TPrincipalEntity, TDependentEntity> WillCascadeOnDelete(bool cascade = true)
+            => new ReferenceCollectionBuilder<TPrincipalEntity, TDependentEntity>(
+                Builder.DeleteBehavior(cascade ? DeleteBehavior.Cascade : DeleteBehavior.None, ConfigurationSource.Explicit));
+
         private InternalRelationshipBuilder Builder => this.GetService<InternalRelationshipBuilder>();
     }
 }

--- a/src/EntityFramework.Core/Metadata/Builders/ReferenceReferenceBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Builders/ReferenceReferenceBuilder.cs
@@ -198,6 +198,10 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         public virtual ReferenceReferenceBuilder Required(bool required = true)
             => new ReferenceReferenceBuilder(Builder.Required(required, ConfigurationSource.Explicit));
 
+        public virtual ReferenceReferenceBuilder WillCascadeOnDelete(bool cascade = true)
+            => new ReferenceReferenceBuilder(
+                Builder.DeleteBehavior(cascade ? DeleteBehavior.Cascade : DeleteBehavior.None, ConfigurationSource.Explicit));
+
         private InternalRelationshipBuilder Builder => this.GetService<InternalRelationshipBuilder>();
     }
 }

--- a/src/EntityFramework.Core/Metadata/Builders/ReferenceReferenceBuilder`.cs
+++ b/src/EntityFramework.Core/Metadata/Builders/ReferenceReferenceBuilder`.cs
@@ -242,6 +242,10 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         public new virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> Required(bool required = true)
             => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(Builder.Required(required, ConfigurationSource.Explicit));
 
+        public new virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> WillCascadeOnDelete(bool cascade = true)
+            => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
+                Builder.DeleteBehavior(cascade ? DeleteBehavior.Cascade : DeleteBehavior.None, ConfigurationSource.Explicit));
+
         private InternalRelationshipBuilder Builder => this.GetService<InternalRelationshipBuilder>();
     }
 }

--- a/src/EntityFramework.Core/Metadata/ForeignKey.cs
+++ b/src/EntityFramework.Core/Metadata/ForeignKey.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Data.Entity.Metadata
     {
         private Navigation _dependentToPrincipal;
         private Navigation _principalToDependent;
+        private DeleteBehavior? _deleteBehavior;
 
         public ForeignKey(
             [NotNull] IReadOnlyList<Property> dependentProperties,
@@ -152,6 +153,21 @@ namespace Microsoft.Data.Entity.Metadata
 
         protected virtual bool DefaultIsRequired => !((IForeignKey)this).Properties.Any(p => p.IsNullable);
 
+        public virtual DeleteBehavior? DeleteBehavior
+        {
+            get { return _deleteBehavior; }
+            set
+            {
+                if (value != null)
+                {
+                    Check.IsDefined(value.Value, nameof(value));
+                }
+                _deleteBehavior = value;
+            }
+        }
+
+        protected virtual DeleteBehavior DefaultDeleteBehavior => Metadata.DeleteBehavior.None;
+
         IReadOnlyList<IProperty> IForeignKey.Properties => Properties;
 
         IEntityType IForeignKey.DeclaringEntityType => DeclaringEntityType;
@@ -167,6 +183,8 @@ namespace Microsoft.Data.Entity.Metadata
         bool IForeignKey.IsUnique => IsUnique ?? DefaultIsUnique;
 
         bool IForeignKey.IsRequired => IsRequired ?? DefaultIsRequired;
+
+        DeleteBehavior IForeignKey.DeleteBehavior => DeleteBehavior ?? DefaultDeleteBehavior;
 
         public override string ToString()
             => $"'{DeclaringEntityType.DisplayName()}' {Property.Format(Properties)} -> '{PrincipalEntityType.DisplayName()}' {Property.Format(PrincipalKey.Properties)}";

--- a/src/EntityFramework.Core/Metadata/IForeignKey.cs
+++ b/src/EntityFramework.Core/Metadata/IForeignKey.cs
@@ -16,5 +16,12 @@ namespace Microsoft.Data.Entity.Metadata
         INavigation PrincipalToDependent { get; }
         bool IsUnique { get; }
         bool IsRequired { get; }
+        DeleteBehavior DeleteBehavior { get; }
+    }
+
+    public enum DeleteBehavior
+    {
+        None,
+        Cascade,
     }
 }

--- a/src/EntityFramework.Core/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -1054,6 +1054,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             ConfigurationSource configurationSource,
             bool? isUnique = null,
             bool? isRequired = null,
+            DeleteBehavior? deleteBehavior = null,
             bool strictPrincipal = true,
             [CanBeNull] Func<InternalRelationshipBuilder, InternalRelationshipBuilder> onRelationshipAdding = null)
         {
@@ -1072,6 +1073,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                     configurationSource,
                     isUnique,
                     isRequired,
+                    deleteBehavior,
                     strictPrincipal,
                     onRelationshipAdding);
             }
@@ -1162,6 +1164,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                     principalProperties,
                     isUnique,
                     isRequired,
+                    deleteBehavior,
                     configurationSource);
 
                 if (foreignKey == null)
@@ -1249,6 +1252,10 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 {
                     builder = builder.Required(foreignKey.IsRequired, configurationSource);
                 }
+                if (deleteBehavior.HasValue)
+                {
+                    builder = builder.DeleteBehavior(foreignKey.DeleteBehavior, configurationSource);
+                }
                 if (foreignKeyProperties != null)
                 {
                     builder = builder.ForeignKey(foreignKey.Properties, configurationSource);
@@ -1275,6 +1282,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             [CanBeNull] IReadOnlyList<Property> principalProperties,
             bool? isUnique,
             bool? isRequired,
+            DeleteBehavior? deleteBehavior,
             ConfigurationSource configurationSource)
         {
             var principalType = principalEntityTypeBuilder.Metadata;
@@ -1360,6 +1368,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
             var newForeignKey = dependentType.AddForeignKey(foreignKeyProperties, principalKey, principalType);
             newForeignKey.IsUnique = isUnique;
+            newForeignKey.DeleteBehavior = deleteBehavior;
 
             foreach (var foreignKeyProperty in foreignKeyProperties)
             {

--- a/test/EntityFramework.Core.Tests/Metadata/ForeignKeyTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ForeignKeyTest.cs
@@ -752,6 +752,38 @@ namespace Microsoft.Data.Entity.Metadata.Tests
         }
 
         [Fact]
+        public void Can_change_cascade_delete_flag()
+        {
+            var entityType = new Model().AddEntityType("E");
+            var keyProp = entityType.AddProperty("Id", typeof(int));
+            var dependentProp = entityType.AddProperty("P", typeof(int));
+            var principalProp = entityType.AddProperty("U", typeof(int));
+            entityType.GetOrSetPrimaryKey(keyProp);
+            var principalKey = entityType.AddKey(principalProp);
+
+            var foreignKey
+                = new ForeignKey(new[] { dependentProp }, principalKey, entityType, entityType);
+
+            Assert.Null(foreignKey.DeleteBehavior);
+            Assert.Equal(DeleteBehavior.None, ((IForeignKey)foreignKey).DeleteBehavior);
+
+            foreignKey.DeleteBehavior = DeleteBehavior.Cascade;
+
+            Assert.Equal(DeleteBehavior.Cascade, foreignKey.DeleteBehavior);
+            Assert.Equal(DeleteBehavior.Cascade, ((IForeignKey)foreignKey).DeleteBehavior);
+
+            foreignKey.DeleteBehavior = DeleteBehavior.None;
+
+            Assert.Equal(DeleteBehavior.None, foreignKey.DeleteBehavior);
+            Assert.Equal(DeleteBehavior.None, ((IForeignKey)foreignKey).DeleteBehavior);
+
+            foreignKey.DeleteBehavior = null;
+
+            Assert.Null(foreignKey.DeleteBehavior);
+            Assert.Equal(DeleteBehavior.None, ((IForeignKey)foreignKey).DeleteBehavior);
+        }
+
+        [Fact]
         public void Can_find_targets_for_non_hierarchical_foreign_keys()
         {
             var fk = CreateOneToManyFK();

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/ManyToOneTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/ManyToOneTestBase.cs
@@ -1516,6 +1516,25 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.False(entityType.GetProperty("NobId1").IsNullable);
                 Assert.True(entityType.GetForeignKeys().Single().IsRequired);
             }
+
+            [Fact]
+            public virtual void Can_turn_cascade_delete_on_and_off()
+            {
+                var modelBuilder = HobNobBuilder();
+                var dependentType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob));
+
+                modelBuilder
+                    .Entity<Nob>().Reference(e => e.Hob).InverseCollection(e => e.Nobs)
+                    .WillCascadeOnDelete();
+
+                Assert.Equal(DeleteBehavior.Cascade, dependentType.GetForeignKeys().Single().DeleteBehavior);
+
+                modelBuilder
+                    .Entity<Nob>().Reference(e => e.Hob).InverseCollection(e => e.Nobs)
+                    .WillCascadeOnDelete(false);
+
+                Assert.Equal(DeleteBehavior.None, dependentType.GetForeignKeys().Single().DeleteBehavior);
+            }
         }
     }
 }

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderGenericTest.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderGenericTest.cs
@@ -274,6 +274,9 @@ namespace Microsoft.Data.Entity.Tests
 
             public override TestReferenceCollectionBuilder<TEntity, TRelatedEntity> Required(bool isRequired = true)
                 => Wrap(ReferenceCollectionBuilder.Required(isRequired));
+
+            public override TestReferenceCollectionBuilder<TEntity, TRelatedEntity> WillCascadeOnDelete(bool cascade = true)
+                => Wrap(ReferenceCollectionBuilder.WillCascadeOnDelete(cascade));
         }
 
         protected class GenericTestReferenceReferenceBuilder<TEntity, TRelatedEntity> : TestReferenceReferenceBuilder<TEntity, TRelatedEntity>
@@ -309,6 +312,9 @@ namespace Microsoft.Data.Entity.Tests
 
             public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> Required(bool isRequired = true)
                 => Wrap(ReferenceReferenceBuilder.Required(isRequired));
+
+            public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> WillCascadeOnDelete(bool cascade = true)
+                => Wrap(ReferenceReferenceBuilder.WillCascadeOnDelete(cascade));
         }
     }
 }

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderNonGenericTest.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderNonGenericTest.cs
@@ -226,6 +226,9 @@ namespace Microsoft.Data.Entity.Tests
 
             public override TestReferenceCollectionBuilder<TEntity, TRelatedEntity> Required(bool isRequired = true)
                 => new NonGenericTestReferenceCollectionBuilder<TEntity, TRelatedEntity>(ReferenceCollectionBuilder.Required(isRequired));
+
+            public override TestReferenceCollectionBuilder<TEntity, TRelatedEntity> WillCascadeOnDelete(bool cascade = true)
+                => new NonGenericTestReferenceCollectionBuilder<TEntity, TRelatedEntity>(ReferenceCollectionBuilder.WillCascadeOnDelete(cascade));
         }
 
         protected class NonGenericTestReferenceReferenceBuilder<TEntity, TRelatedEntity> : TestReferenceReferenceBuilder<TEntity, TRelatedEntity>
@@ -261,6 +264,9 @@ namespace Microsoft.Data.Entity.Tests
 
             public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> Required(bool isRequired = true)
                 => Wrap(ReferenceReferenceBuilder.Required(isRequired));
+
+            public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> WillCascadeOnDelete(bool cascade = true)
+                => Wrap(ReferenceReferenceBuilder.WillCascadeOnDelete(cascade));
         }
     }
 }

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderTestBase.cs
@@ -257,6 +257,8 @@ namespace Microsoft.Data.Entity.Tests
                 string annotation, object value);
 
             public abstract TestReferenceCollectionBuilder<TEntity, TRelatedEntity> Required(bool isRequired = true);
+
+            public abstract TestReferenceCollectionBuilder<TEntity, TRelatedEntity> WillCascadeOnDelete(bool cascade = true);
         }
 
         public abstract class TestReferenceReferenceBuilder<TEntity, TRelatedEntity>
@@ -281,6 +283,8 @@ namespace Microsoft.Data.Entity.Tests
                 Type principalEntityType, params string[] keyPropertyNames);
 
             public abstract TestReferenceReferenceBuilder<TEntity, TRelatedEntity> Required(bool isRequired = true);
+
+            public abstract TestReferenceReferenceBuilder<TEntity, TRelatedEntity> WillCascadeOnDelete(bool cascade = true);
         }
     }
 }

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/OneToManyTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/OneToManyTestBase.cs
@@ -1642,6 +1642,25 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.False(entityType.GetProperty("NobId1").IsNullable);
                 Assert.True(entityType.GetForeignKeys().Single().IsRequired);
             }
+            
+            [Fact]
+            public virtual void Can_turn_cascade_delete_on_and_off()
+            {
+                var modelBuilder = HobNobBuilder();
+                var dependentType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob));
+
+                modelBuilder
+                    .Entity<Hob>().Collection(e => e.Nobs).InverseReference(e => e.Hob)
+                    .WillCascadeOnDelete();
+
+                Assert.Equal(DeleteBehavior.Cascade, dependentType.GetForeignKeys().Single().DeleteBehavior);
+
+                modelBuilder
+                    .Entity<Hob>().Collection(e => e.Nobs).InverseReference(e => e.Hob)
+                    .WillCascadeOnDelete(false);
+
+                Assert.Equal(DeleteBehavior.None, dependentType.GetForeignKeys().Single().DeleteBehavior);
+            }
         }
     }
 }

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/OneToOneTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/OneToOneTestBase.cs
@@ -2690,6 +2690,25 @@ namespace Microsoft.Data.Entity.Tests
                 var principalEntityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob));
                 AssertEqual(fk.PrincipalKey.Properties, principalEntityType.GetKeys().Single().Properties);
             }
+
+            [Fact]
+            public virtual void Can_turn_cascade_delete_on_and_off()
+            {
+                var modelBuilder = HobNobBuilder();
+                var dependentType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Hob));
+
+                modelBuilder
+                    .Entity<Hob>().Reference(e => e.Nob).InverseReference(e => e.Hob)
+                    .WillCascadeOnDelete();
+
+                Assert.Equal(DeleteBehavior.Cascade, dependentType.GetForeignKeys().Single().DeleteBehavior);
+
+                modelBuilder
+                    .Entity<Hob>().Reference(e => e.Nob).InverseReference(e => e.Hob)
+                    .WillCascadeOnDelete(false);
+
+                Assert.Equal(DeleteBehavior.None, dependentType.GetForeignKeys().Single().DeleteBehavior);
+            }
         }
     }
 }


### PR DESCRIPTION
Maintain fluent API from old stack; enum flag in core metatdata to allow for additional states in the future.