### PR TITLE
Conditional facts and theories - support SQL2008 in testing

### DIFF
--- a/test/EntityFramework.Core.FunctionalTests/EntityFramework.Core.FunctionalTests.csproj
+++ b/test/EntityFramework.Core.FunctionalTests/EntityFramework.Core.FunctionalTests.csproj
@@ -138,6 +138,11 @@
     <Compile Include="TestUtilities\NavigationComparer.cs" />
     <Compile Include="TestUtilities\PropertyComparer.cs" />
     <Compile Include="TestUtilities\Extensions.cs" />
+    <Compile Include="TestUtilities\Xunit\ConditionalAttributeDiscoverer.cs" />
+    <Compile Include="TestUtilities\Xunit\ConditionalFactAttribute.cs" />
+    <Compile Include="TestUtilities\Xunit\ConditionalTheoryAttribute.cs" />
+    <Compile Include="TestUtilities\Xunit\ITestCondition.cs" />
+    <Compile Include="TestUtilities\Xunit\SkipReasonTestCase.cs" />
     <Compile Include="ThrowingMonsterStateManager.cs" />
     <None Include="project.json" />
   </ItemGroup>

--- a/test/EntityFramework.Core.FunctionalTests/GraphUpdatesTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/GraphUpdatesTestBase.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.Data.Entity.ChangeTracking;
+using Microsoft.Data.Entity.FunctionalTests.TestUtilities.Xunit;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
@@ -23,7 +24,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             TestStore = Fixture.CreateTestStore();
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData((int)ChangeMechanism.Principal, false)]
         [InlineData((int)ChangeMechanism.Principal, true)]
         [InlineData((int)ChangeMechanism.Dependent, false)]
@@ -111,7 +112,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData((int)ChangeMechanism.Principal, false)]
         [InlineData((int)ChangeMechanism.Principal, true)]
         [InlineData((int)ChangeMechanism.Dependent, false)]
@@ -200,7 +201,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData((int)ChangeMechanism.Principal)]
         [InlineData((int)ChangeMechanism.Dependent)]
         [InlineData((int)ChangeMechanism.FK)]
@@ -259,7 +260,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData((int)ChangeMechanism.Principal)]
         [InlineData((int)ChangeMechanism.Dependent)]
         public virtual void Save_removed_required_many_to_one_dependents(ChangeMechanism changeMechanism)
@@ -291,7 +292,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData((int)ChangeMechanism.Dependent, false)]
         [InlineData((int)ChangeMechanism.Dependent, true)]
         [InlineData((int)ChangeMechanism.Principal, false)]
@@ -377,7 +378,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData((int)ChangeMechanism.Dependent, false)]
         [InlineData((int)ChangeMechanism.Dependent, true)]
         [InlineData((int)ChangeMechanism.Principal, false)]
@@ -465,7 +466,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             //}
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData((int)ChangeMechanism.Dependent, false)]
         [InlineData((int)ChangeMechanism.Dependent, true)]
         [InlineData((int)ChangeMechanism.Principal, false)]
@@ -553,7 +554,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             //}
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData((int)ChangeMechanism.Dependent)]
         [InlineData((int)ChangeMechanism.Principal)]
         [InlineData((int)ChangeMechanism.FK)]
@@ -609,7 +610,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData((int)ChangeMechanism.Dependent)]
         [InlineData((int)ChangeMechanism.Principal)]
         public virtual void Sever_required_one_to_one(ChangeMechanism changeMechanism)
@@ -635,7 +636,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData((int)ChangeMechanism.Dependent)]
         [InlineData((int)ChangeMechanism.Principal)]
         public virtual void Sever_required_non_PK_one_to_one(ChangeMechanism changeMechanism)
@@ -661,7 +662,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData((int)ChangeMechanism.Dependent, false)]
         [InlineData((int)ChangeMechanism.Dependent, true)]
         [InlineData((int)ChangeMechanism.Principal, false)]
@@ -736,7 +737,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData((int)ChangeMechanism.Dependent, false)]
         [InlineData((int)ChangeMechanism.Dependent, true)]
         [InlineData((int)ChangeMechanism.Principal, false)]
@@ -785,7 +786,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData((int)ChangeMechanism.Dependent, false)]
         [InlineData((int)ChangeMechanism.Dependent, true)]
         [InlineData((int)ChangeMechanism.Principal, false)]
@@ -860,7 +861,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData((int)ChangeMechanism.Principal, false)]
         [InlineData((int)ChangeMechanism.Principal, true)]
         [InlineData((int)ChangeMechanism.Dependent, false)]
@@ -948,7 +949,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData((int)ChangeMechanism.Principal, false)]
         [InlineData((int)ChangeMechanism.Principal, true)]
         [InlineData((int)ChangeMechanism.Dependent, false)]
@@ -1037,7 +1038,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData((int)ChangeMechanism.Principal)]
         [InlineData((int)ChangeMechanism.Dependent)]
         [InlineData((int)ChangeMechanism.FK)]
@@ -1096,7 +1097,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData((int)ChangeMechanism.Principal)]
         [InlineData((int)ChangeMechanism.Dependent)]
         public virtual void Save_removed_required_many_to_one_dependents_with_alternate_key(ChangeMechanism changeMechanism)
@@ -1128,7 +1129,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData((int)ChangeMechanism.Dependent, false)]
         [InlineData((int)ChangeMechanism.Dependent, true)]
         [InlineData((int)ChangeMechanism.Principal, false)]
@@ -1214,7 +1215,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData((int)ChangeMechanism.Dependent, false)]
         [InlineData((int)ChangeMechanism.Dependent, true)]
         [InlineData((int)ChangeMechanism.Principal, false)]
@@ -1303,7 +1304,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             //}
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData((int)ChangeMechanism.Dependent, false)]
         [InlineData((int)ChangeMechanism.Dependent, true)]
         [InlineData((int)ChangeMechanism.Principal, false)]
@@ -1392,7 +1393,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             //}
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData((int)ChangeMechanism.Dependent)]
         [InlineData((int)ChangeMechanism.Principal)]
         [InlineData((int)ChangeMechanism.FK)]
@@ -1448,7 +1449,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData((int)ChangeMechanism.Dependent)]
         [InlineData((int)ChangeMechanism.Principal)]
         public virtual void Sever_required_one_to_one_with_alternate_key(ChangeMechanism changeMechanism)
@@ -1474,7 +1475,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData((int)ChangeMechanism.Dependent)]
         [InlineData((int)ChangeMechanism.Principal)]
         public virtual void Sever_required_non_PK_one_to_one_with_alternate_key(ChangeMechanism changeMechanism)
@@ -1500,7 +1501,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData((int)ChangeMechanism.Dependent, false)]
         [InlineData((int)ChangeMechanism.Dependent, true)]
         [InlineData((int)ChangeMechanism.Principal, false)]
@@ -1575,7 +1576,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData((int)ChangeMechanism.Dependent, false)]
         [InlineData((int)ChangeMechanism.Dependent, true)]
         [InlineData((int)ChangeMechanism.Principal, false)]
@@ -1624,7 +1625,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData((int)ChangeMechanism.Dependent, false)]
         [InlineData((int)ChangeMechanism.Dependent, true)]
         [InlineData((int)ChangeMechanism.Principal, false)]

--- a/test/EntityFramework.Core.FunctionalTests/TestUtilities/Xunit/ConditionalAttributeDiscoverer.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestUtilities/Xunit/ConditionalAttributeDiscoverer.cs
@@ -1,0 +1,67 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.Data.Entity.FunctionalTests.TestUtilities.Xunit
+{
+    public class ConditionalAttributeDiscoverer : IXunitTestCaseDiscoverer
+    {
+        private readonly IMessageSink _diagnosticMessageSink;
+
+        public ConditionalAttributeDiscoverer(IMessageSink diagnosticMessageSink)
+        {
+            _diagnosticMessageSink = diagnosticMessageSink;
+        }
+
+        public IEnumerable<IXunitTestCase> Discover(
+            ITestFrameworkDiscoveryOptions discoveryOptions,
+            ITestMethod testMethod,
+            IAttributeInfo factAttribute)
+        {
+            var skipReason = EvaluateSkipConditions(testMethod);
+
+            IXunitTestCaseDiscoverer innerDiscoverer;
+            if (testMethod.Method.GetCustomAttributes(typeof(TheoryAttribute)).Any())
+            {
+                innerDiscoverer = new TheoryDiscoverer(_diagnosticMessageSink);
+            }
+            else
+            {
+                innerDiscoverer = new FactDiscoverer(_diagnosticMessageSink);
+            }
+
+            var res = innerDiscoverer.Discover(discoveryOptions, testMethod, factAttribute)
+                .Select(testCase => new SkipReasonTestCase(skipReason, testCase));
+            return res;
+        }
+
+        private string EvaluateSkipConditions(ITestMethod testMethod)
+        {
+            var conditionAttributes = testMethod.Method
+                .GetCustomAttributes(typeof(ITestCondition))
+                .OfType<ReflectionAttributeInfo>()
+                .Select(attributeInfo => attributeInfo.Attribute)
+                .ToList();
+
+            conditionAttributes.AddRange(testMethod.TestClass.Class
+                .GetCustomAttributes(typeof(ITestCondition))
+                .OfType<ReflectionAttributeInfo>()
+                .Select(attributeInfo => attributeInfo.Attribute));
+
+            foreach (ITestCondition condition in conditionAttributes)
+            {
+                if (!condition.IsMet)
+                {
+                    return condition.SkipReason;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/test/EntityFramework.Core.FunctionalTests/TestUtilities/Xunit/ConditionalFactAttribute.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestUtilities/Xunit/ConditionalFactAttribute.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Microsoft.Data.Entity.FunctionalTests.TestUtilities.Xunit
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    [XunitTestCaseDiscoverer("Microsoft.Data.Entity.FunctionalTests.TestUtilities.Xunit.ConditionalAttributeDiscoverer", "EntityFramework.Core.FunctionalTests")]
+    public class ConditionalFactAttribute : FactAttribute
+    {
+    }
+}

--- a/test/EntityFramework.Core.FunctionalTests/TestUtilities/Xunit/ConditionalTheoryAttribute.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestUtilities/Xunit/ConditionalTheoryAttribute.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Microsoft.Data.Entity.FunctionalTests.TestUtilities.Xunit
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    [XunitTestCaseDiscoverer("Microsoft.Data.Entity.FunctionalTests.TestUtilities.Xunit.ConditionalAttributeDiscoverer", "EntityFramework.Core.FunctionalTests")]
+    public class ConditionalTheoryAttribute : TheoryAttribute
+    {
+    }
+}

--- a/test/EntityFramework.Core.FunctionalTests/TestUtilities/Xunit/ITestCondition.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestUtilities/Xunit/ITestCondition.cs
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Data.Entity.FunctionalTests.TestUtilities.Xunit
+{
+    public interface ITestCondition
+    {
+        bool IsMet { get; }
+
+        string SkipReason { get; }
+    }
+}

--- a/test/EntityFramework.Core.FunctionalTests/TestUtilities/Xunit/SkipReasonTestCase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestUtilities/Xunit/SkipReasonTestCase.cs
@@ -1,0 +1,65 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.Data.Entity.FunctionalTests.TestUtilities.Xunit
+{
+    internal class SkipReasonTestCase : IXunitTestCase
+    {
+        private readonly IXunitTestCase _wrappedTestCase;
+
+        public SkipReasonTestCase(string skipReason, IXunitTestCase wrappedTestCase)
+        {
+            SkipReason = wrappedTestCase.SkipReason ?? skipReason;
+            _wrappedTestCase = wrappedTestCase;
+        }
+
+        public string DisplayName => _wrappedTestCase.DisplayName;
+
+        public IMethodInfo Method => _wrappedTestCase.Method;
+
+        public string SkipReason { get; }
+
+        public ISourceInformation SourceInformation
+        {
+            get { return _wrappedTestCase.SourceInformation; }
+            set { _wrappedTestCase.SourceInformation = value; }
+        }
+
+        public ITestMethod TestMethod => _wrappedTestCase.TestMethod;
+
+        public object[] TestMethodArguments => _wrappedTestCase.TestMethodArguments;
+
+        public Dictionary<string, List<string>> Traits => _wrappedTestCase.Traits;
+
+        public string UniqueID => _wrappedTestCase.UniqueID;
+
+        public void Deserialize(IXunitSerializationInfo info) => _wrappedTestCase.Deserialize(info);
+
+        public Task<RunSummary> RunAsync(
+            IMessageSink diagnosticMessageSink,
+            IMessageBus messageBus,
+            object[] constructorArguments,
+            ExceptionAggregator aggregator,
+            CancellationTokenSource cancellationTokenSource)
+        {
+            XunitTestCaseRunner runner;
+            if (_wrappedTestCase is XunitTheoryTestCase)
+            {
+                runner = new XunitTheoryTestCaseRunner(this, DisplayName, SkipReason, constructorArguments, diagnosticMessageSink, messageBus, aggregator, cancellationTokenSource);
+            }
+            else
+            {
+                runner = new XunitTestCaseRunner(this, DisplayName, SkipReason, constructorArguments, TestMethodArguments, messageBus, aggregator, cancellationTokenSource);
+            }
+            return runner.RunAsync();
+        }
+
+        public void Serialize(IXunitSerializationInfo info) => _wrappedTestCase.Serialize(info);
+    }
+}

--- a/test/EntityFramework.CrossStore.FunctionalTests/TestModels/CrossStoreContext.cs
+++ b/test/EntityFramework.CrossStore.FunctionalTests/TestModels/CrossStoreContext.cs
@@ -23,7 +23,6 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
                 .Entity<SimpleEntity>(eb =>
                     {
                         eb.Property(typeof(string), SimpleEntity.ShadowPartitionIdName);
-                        eb.Property(e => e.Id).UseSqlServerSequenceHiLo();
                         eb.ToTable("RelationalSimpleEntity"); // TODO: specify schema when #948 is fixed
                         eb.Property(typeof(string), SimpleEntity.ShadowPropertyName);
                         eb.Key(e => e.Id);

--- a/test/EntityFramework.SqlServer.FunctionalTests/CommandConfigurationTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/CommandConfigurationTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Data.Common;
 using System.Linq;
 using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Data.Entity.FunctionalTests.TestUtilities.Xunit;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Query;
@@ -299,7 +300,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
+        [SqlServerCondition(SqlServerCondition.SupportsSequences)]
         [InlineData(51, 6)]
         [InlineData(50, 5)]
         [InlineData(20, 2)]
@@ -401,7 +403,10 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
             protected override void OnModelCreating(ModelBuilder modelBuilder)
             {
-                modelBuilder.UseSqlServerSequenceHiLo();
+                if (TestEnvironment.GetFlag(nameof(SqlServerCondition.SupportsSequences)) ?? true)
+                {
+                    modelBuilder.UseSqlServerSequenceHiLo();
+                }
             }
         }
 

--- a/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
+++ b/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
@@ -90,6 +90,7 @@
     <Compile Include="OptimisticConcurrencySqlServerTest.cs" />
     <Compile Include="SequenceEndToEndTest.cs" />
     <Compile Include="SequentialGuidEndToEndTest.cs" />
+    <Compile Include="Utilities\DbContextOptionsBuilderExtensions.cs" />
     <Compile Include="Utilities\SqlFileLogger.cs" />
     <Compile Include="SqlServerConfigPatternsTest.cs" />
     <Compile Include="SqlServerDatabaseCreationTest.cs" />
@@ -98,6 +99,7 @@
     <Compile Include="SentinelGraphUpdatesSqlServerTest.cs" />
     <Compile Include="MonsterFixupSqlServerTest.cs" />
     <Compile Include="Utilities\SqlConnectionStringBuilderExtensions.cs" />
+    <Compile Include="Utilities\SqlServerConditionAttribute.cs" />
     <Compile Include="Utilities\SqlServerTestStore.cs" />
     <Compile Include="SqlServerValueGenerationScenariosTest.cs" />
     <Compile Include="StoreGeneratedSqlServerTest.cs" />
@@ -105,6 +107,7 @@
     <Compile Include="TransactionSqlServerFixture.cs" />
     <Compile Include="TransactionSqlServerTest.cs" />
     <Compile Include="TestModels\SqlServerNorthwindContext.cs" />
+    <Compile Include="Utilities\TestEnvironment.cs" />
     <Compile Include="Utilities\TestSqlServerModelSource.cs" />
     <None Include="config.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/test/EntityFramework.SqlServer.FunctionalTests/GraphUpdatesWithSequenceSqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/GraphUpdatesWithSequenceSqlServerTest.cs
@@ -1,8 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.Data.Entity.SqlServer.FunctionalTests;
+
 namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 {
+    [SqlServerCondition(SqlServerCondition.SupportsSequences)]
     public class GraphUpdatesWithSequenceSqlServerTest : GraphUpdatesSqlServerTestBase<GraphUpdatesWithSequenceSqlServerTest.GraphUpdatesWithSequenceSqlServerFixture>
     {
         public GraphUpdatesWithSequenceSqlServerTest(GraphUpdatesWithSequenceSqlServerFixture fixture)
@@ -15,6 +18,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             protected override string DatabaseName => "GraphSequenceUpdatesTest";
 
             public override int IntSentinel => 0;
+
             protected override void OnModelCreating(ModelBuilder modelBuilder)
             {
                 modelBuilder.UseSqlServerSequenceHiLo(); // ensure model uses sequences

--- a/test/EntityFramework.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/IncludeSqlServerTest.cs
@@ -468,8 +468,10 @@ ORDER BY [c].[CustomerID]",
         {
             base.Include_duplicate_collection();
 
-            Assert.Equal(
-                @"SELECT [t0].[CustomerID], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region], [t1].[CustomerID], [t1].[Address], [t1].[City], [t1].[CompanyName], [t1].[ContactName], [t1].[ContactTitle], [t1].[Country], [t1].[Fax], [t1].[Phone], [t1].[PostalCode], [t1].[Region]
+            if (TestEnvironment.GetFlag(nameof(SqlServerCondition.SupportsOffset)) ?? true)
+            {
+                Assert.Equal(
+                    @"SELECT [t0].[CustomerID], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region], [t1].[CustomerID], [t1].[Address], [t1].[City], [t1].[CompanyName], [t1].[ContactName], [t1].[ContactTitle], [t1].[Country], [t1].[Fax], [t1].[Phone], [t1].[PostalCode], [t1].[Region]
 FROM (
     SELECT TOP(2) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
@@ -518,15 +520,18 @@ INNER JOIN (
     ) AS [t1]
 ) AS [t0] ON [o].[CustomerID] = [t0].[CustomerID]
 ORDER BY [t0].[CustomerID]",
-                Sql);
+                    Sql);
+            }
         }
 
         public override void Include_duplicate_collection_result_operator()
         {
             base.Include_duplicate_collection_result_operator();
 
-            Assert.Equal(
-                @"SELECT TOP(1) [t0].[CustomerID], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region], [t1].[CustomerID], [t1].[Address], [t1].[City], [t1].[CompanyName], [t1].[ContactName], [t1].[ContactTitle], [t1].[Country], [t1].[Fax], [t1].[Phone], [t1].[PostalCode], [t1].[Region]
+            if (TestEnvironment.GetFlag(nameof(SqlServerCondition.SupportsOffset)) ?? true)
+            {
+                Assert.Equal(
+                    @"SELECT TOP(1) [t0].[CustomerID], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region], [t1].[CustomerID], [t1].[Address], [t1].[City], [t1].[CompanyName], [t1].[ContactName], [t1].[ContactTitle], [t1].[Country], [t1].[Fax], [t1].[Phone], [t1].[PostalCode], [t1].[Region]
 FROM (
     SELECT TOP(2) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
@@ -575,7 +580,8 @@ INNER JOIN (
     ) AS [t1]
 ) AS [t0] ON [o].[CustomerID] = [t0].[CustomerID]
 ORDER BY [t0].[CustomerID]",
-                Sql);
+                    Sql);
+            }
         }
 
         public override void Include_collection_on_join_clause_with_order_by_and_filter()
@@ -619,9 +625,10 @@ CROSS JOIN [Customers] AS [c]",
         public override void Include_duplicate_collection_result_operator2()
         {
             base.Include_duplicate_collection_result_operator2();
-
-            Assert.Equal(
-                @"SELECT TOP(1) [t0].[CustomerID], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region], [t1].[CustomerID], [t1].[Address], [t1].[City], [t1].[CompanyName], [t1].[ContactName], [t1].[ContactTitle], [t1].[Country], [t1].[Fax], [t1].[Phone], [t1].[PostalCode], [t1].[Region]
+            if (TestEnvironment.GetFlag(nameof(SqlServerCondition.SupportsOffset)) ?? true)
+            {
+                Assert.Equal(
+                    @"SELECT TOP(1) [t0].[CustomerID], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region], [t1].[CustomerID], [t1].[Address], [t1].[City], [t1].[CompanyName], [t1].[ContactName], [t1].[ContactTitle], [t1].[Country], [t1].[Fax], [t1].[Phone], [t1].[PostalCode], [t1].[Region]
 FROM (
     SELECT TOP(2) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
     FROM [Customers] AS [c]
@@ -652,7 +659,8 @@ INNER JOIN (
     ) AS [t1]
 ) AS [t0] ON [o].[CustomerID] = [t0].[CustomerID]
 ORDER BY [t0].[CustomerID]",
-                Sql);
+                    Sql);
+            }
         }
 
         public override void Include_reference()
@@ -693,8 +701,10 @@ INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]",
         {
             base.Include_duplicate_reference();
 
-            Assert.Equal(
-                @"SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+            if (TestEnvironment.GetFlag(nameof(SqlServerCondition.SupportsOffset)) ?? true)
+            {
+                Assert.Equal(
+                    @"SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
 FROM (
     SELECT TOP(2) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
@@ -708,15 +718,18 @@ CROSS JOIN (
 ) AS [t1]
 LEFT JOIN [Customers] AS [c] ON [t0].[CustomerID] = [c].[CustomerID]
 LEFT JOIN [Customers] AS [c0] ON [t1].[CustomerID] = [c0].[CustomerID]",
-                Sql);
+                    Sql);
+            }
         }
 
         public override void Include_duplicate_reference2()
         {
             base.Include_duplicate_reference2();
 
-            Assert.Equal(
-                @"SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+            if (TestEnvironment.GetFlag(nameof(SqlServerCondition.SupportsOffset)) ?? true)
+            {
+                Assert.Equal(
+                    @"SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM (
     SELECT TOP(2) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
@@ -729,15 +742,18 @@ CROSS JOIN (
     OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
 ) AS [t1]
 LEFT JOIN [Customers] AS [c] ON [t0].[CustomerID] = [c].[CustomerID]",
-                Sql);
+                    Sql);
+            }
         }
 
         public override void Include_duplicate_reference3()
         {
             base.Include_duplicate_reference3();
 
-            Assert.Equal(
-                @"SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+            if (TestEnvironment.GetFlag(nameof(SqlServerCondition.SupportsOffset)) ?? true)
+            {
+                Assert.Equal(
+                    @"SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate], [t1].[OrderID], [t1].[CustomerID], [t1].[EmployeeID], [t1].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM (
     SELECT TOP(2) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
@@ -750,7 +766,8 @@ CROSS JOIN (
     OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
 ) AS [t1]
 LEFT JOIN [Customers] AS [c] ON [t1].[CustomerID] = [c].[CustomerID]",
-                Sql);
+                    Sql);
+            }
         }
 
         public override void Include_reference_when_projection()

--- a/test/EntityFramework.SqlServer.FunctionalTests/NorthwindQuerySqlServerFixture.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/NorthwindQuerySqlServerFixture.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         {
             var optionsBuilder = new DbContextOptionsBuilder();
 
-            optionsBuilder.UseSqlServer(_testStore.Connection.ConnectionString);
+            var sqlOptions = optionsBuilder.UseSqlServer(_testStore.Connection.ConnectionString).ApplyConfiguration();
 
             return optionsBuilder.Options;
         }

--- a/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using Microsoft.Data.Entity.FunctionalTests;
 using Microsoft.Data.Entity.FunctionalTests.TestModels.Northwind;
+using Microsoft.Data.Entity.FunctionalTests.TestUtilities.Xunit;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -768,6 +769,8 @@ FROM (
                 Sql);
         }
 
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.SupportsOffset)]
         public override void Skip()
         {
             base.Skip();
@@ -780,6 +783,8 @@ OFFSET 5 ROWS",
                 Sql);
         }
 
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.SupportsOffset)]
         public override void Skip_no_orderby()
         {
             base.Skip_no_orderby();
@@ -792,6 +797,8 @@ OFFSET 5 ROWS",
                 Sql);
         }
 
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.SupportsOffset)]
         public override void Skip_Take()
         {
             base.Skip_Take();
@@ -804,6 +811,8 @@ OFFSET 5 ROWS FETCH NEXT 10 ROWS ONLY",
                 Sql);
         }
 
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.SupportsOffset)]
         public override void Take_Skip()
         {
             base.Take_Skip();
@@ -820,6 +829,8 @@ OFFSET 5 ROWS",
                 Sql);
         }
 
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.SupportsOffset)]
         public override void Take_Skip_Distinct()
         {
             base.Take_Skip_Distinct();
@@ -2332,6 +2343,22 @@ FROM [Customers] AS [c]",
 FROM [Customers] AS [c]",
                 Sql);
         }
+
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.SupportsOffset)]
+        public override void Distinct_Skip() => base.Distinct_Skip();
+
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.SupportsOffset)]
+        public override void Distinct_Skip_Take() => base.Distinct_Skip_Take();
+
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.SupportsOffset)]
+        public override void Skip_Distinct() => base.Skip_Distinct();
+
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.SupportsOffset)]
+        public override void Skip_Take_Distinct() => base.Skip_Take_Distinct();
 
         public override void OrderBy()
         {
@@ -3870,6 +3897,8 @@ WHERE COALESCE([c].[CompanyName], [c].[ContactName]) = 'The Big Cheese'",
                 Sql);
         }
 
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.SupportsOffset)]
         public override void Take_skip_null_coalesce_operator()
         {
             base.Take_skip_null_coalesce_operator();
@@ -3896,6 +3925,8 @@ FROM [Customers] AS [c]
 ORDER BY [Coalesce]", Sql);
         }
 
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.SupportsOffset)]
         public override void Select_take_skip_null_coalesce_operator()
         {
             base.Select_take_skip_null_coalesce_operator();

--- a/test/EntityFramework.SqlServer.FunctionalTests/SentinelGraphUpdatesSqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SentinelGraphUpdatesSqlServerTest.cs
@@ -20,9 +20,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             {
                 base.OnModelCreating(modelBuilder);
 
-                modelBuilder.Sequence("StartAtZeroSequence").StartsAt(0);
-                modelBuilder.UseSqlServerSequenceHiLo("StartAtZeroSequence");
-
                 SetSentinelValues(modelBuilder, IntSentinel);
             }
         }

--- a/test/EntityFramework.SqlServer.FunctionalTests/SequenceEndToEndTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SequenceEndToEndTest.cs
@@ -5,14 +5,17 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Data.Entity.FunctionalTests.TestUtilities.Xunit;
+using Microsoft.Data.Entity.SqlServer.FunctionalTests;
 using Microsoft.Framework.DependencyInjection;
 using Xunit;
 
 namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 {
+    [SqlServerCondition(SqlServerCondition.SupportsSequences)]
     public class SequenceEndToEndTest
     {
-        [Fact]
+        [ConditionalFact]
         public void Can_use_sequence_end_to_end()
         {
             var serviceProvider = new ServiceCollection()
@@ -66,7 +69,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task Can_use_sequence_end_to_end_async()
         {
             var serviceProvider = new ServiceCollection()
@@ -120,7 +123,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             }
         }
 
-        // [Fact] Currently disabled due to GitHub issue #266
+        // [ConditionalFact] Currently disabled due to GitHub issue #266
         public async Task Can_use_sequence_end_to_end_from_multiple_contexts_concurrently_async()
         {
             var serviceProvider = new ServiceCollection()
@@ -163,7 +166,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public void Can_use_explicit_values()
         {
             var serviceProvider = new ServiceCollection()
@@ -255,7 +258,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             public string Name { get; set; }
         }
 
-        [Fact] // Issue #478
+        [ConditionalFact] // Issue #478
         public void Can_use_sequence_with_nullable_key_end_to_end()
         {
             var serviceProvider = new ServiceCollection()
@@ -286,7 +289,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             }
         }
 
-        [Fact] // Issue #478
+        [ConditionalFact] // Issue #478
         public void Can_use_identity_with_nullable_key_end_to_end()
         {
             var serviceProvider = new ServiceCollection()

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
@@ -125,7 +125,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                     .ServiceCollection()
                     .AddInstance<ILoggerFactory>(loggingFactory)
                     .BuildServiceProvider();
-
                 using (var db = new BloggingContext(serviceProvider, optionsBuilder.Options))
                 {
                     var toUpdate = db.Blogs.Single(b => b.Name == "Blog1");
@@ -139,35 +138,35 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                     db.Entry(toDelete).State = EntityState.Deleted;
 
                     var toAdd = db.Add(new Blog
-                    {
-                        Name = "Blog to Insert",
-                        George = true,
-                        TheGu = new Guid("0456AEF1-B7FC-47AA-8102-975D6BA3A9BF"),
-                        NotFigTime = new DateTime(1973, 9, 3, 0, 10, 33, 777),
-                        ToEat = 64,
-                        OrNothing = 0.123456789,
-                        Fuse = 777,
-                        WayRound = 9876543210,
-                        Away = 0.12345f,
-                        AndChew = new byte[16]
-                    }).Entity;
-                    var addedId = toAdd.Id;
+                        {
+                            Name = "Blog to Insert",
+                            George = true,
+                            TheGu = new Guid("0456AEF1-B7FC-47AA-8102-975D6BA3A9BF"),
+                            NotFigTime = new DateTime(1973, 9, 3, 0, 10, 33, 777),
+                            ToEat = 64,
+                            OrNothing = 0.123456789,
+                            Fuse = 777,
+                            WayRound = 9876543210,
+                            Away = 0.12345f,
+                            AndChew = new byte[16]
+                        }).Entity;
 
                     await db.SaveChangesAsync();
 
+                    var addedId = toAdd.Id;
                     Assert.NotEqual(0, addedId);
 
                     Assert.Equal(EntityState.Unchanged, db.Entry(toUpdate).State);
                     Assert.Equal(EntityState.Unchanged, db.Entry(toAdd).State);
                     Assert.DoesNotContain(toDelete, db.ChangeTracker.Entries().Select(e => e.Entity));
 
-                    Assert.Equal(5, TestSqlLoggerFactory.SqlStatements.Count);
+                    Assert.Equal(4, TestSqlLoggerFactory.SqlStatements.Count);
                     Assert.Contains("SELECT", TestSqlLoggerFactory.SqlStatements[0]);
                     Assert.Contains("SELECT", TestSqlLoggerFactory.SqlStatements[1]);
-                    Assert.Contains("@p0: " + deletedId, TestSqlLoggerFactory.SqlStatements[3]);
-                    Assert.Contains("DELETE", TestSqlLoggerFactory.SqlStatements[4]);
-                    Assert.Contains("UPDATE", TestSqlLoggerFactory.SqlStatements[4]);
-                    Assert.Contains("INSERT", TestSqlLoggerFactory.SqlStatements[4]);
+                    Assert.Contains("@p0: " + deletedId, TestSqlLoggerFactory.SqlStatements[2]);
+                    Assert.Contains("DELETE", TestSqlLoggerFactory.SqlStatements[3]);
+                    Assert.Contains("UPDATE", TestSqlLoggerFactory.SqlStatements[3]);
+                    Assert.Contains("INSERT", TestSqlLoggerFactory.SqlStatements[3]);
 
                     var rows = await testDatabase.ExecuteScalarAsync<int>(
                         $@"SELECT Count(*) FROM [dbo].[Blog] WHERE Id = {updatedId} AND Name = 'Blog is Updated'",
@@ -187,6 +186,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
                     Assert.Equal(1, rows);
                 }
+
             }
         }
 
@@ -536,11 +536,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             public BloggingContext(IServiceProvider serviceProvider, DbContextOptions options)
                 : base(serviceProvider, options)
             {
-            }
-
-            protected override void OnModelCreating(ModelBuilder modelBuilder)
-            {
-                modelBuilder.UseSqlServerSequenceHiLo();
             }
         }
 

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerValueGenerationScenariosTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerValueGenerationScenariosTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Data.Entity.FunctionalTests.TestUtilities.Xunit;
 using Xunit;
 
 namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
@@ -38,9 +39,10 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             }
         }
 
+        [SqlServerCondition(SqlServerCondition.SupportsSequences)]
         public class SequenceHiLo : TestBase<SequenceHiLo.BlogContext>
         {
-            [Fact]
+            [ConditionalFact]
             public void Insert_with_sequence_HiLo()
             {
                 using (var context = new BlogContext())
@@ -68,7 +70,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
         public class IdentityColumnWithDefaultValue : TestBase<IdentityColumnWithDefaultValue.BlogContext>
         {
-            [Fact]
+            [ConditionalFact]
+            [SqlServerCondition(SqlServerCondition.SupportsSequences)]
             public void Insert_with_default_value_from_sequence()
             {
                 using (var context = new BlogContext())
@@ -105,7 +108,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
         public class ReadOnlyIdentityColumnWithDefaultValue : TestBase<ReadOnlyIdentityColumnWithDefaultValue.BlogContext>
         {
-            [Fact]
+            [ConditionalFact]
+            [SqlServerCondition(SqlServerCondition.SupportsSequences)]
             public void Insert_with_default_value_from_sequence()
             {
                 using (var context = new BlogContext())
@@ -540,7 +544,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
         public class ReadOnlyIdentityColumnWithDefaultValueThrows : TestBase<ReadOnlyIdentityColumnWithDefaultValueThrows.BlogContext>
         {
-            [Fact]
+            [ConditionalFact]
+            [SqlServerCondition(SqlServerCondition.SupportsSequences)]
             public void Insert_explicit_value_throws_when_readonly_before_save()
             {
                 using (var context = new BlogContext())

--- a/test/EntityFramework.SqlServer.FunctionalTests/Utilities/DbContextOptionsBuilderExtensions.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/Utilities/DbContextOptionsBuilderExtensions.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Infrastructure;
+
+namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
+{
+    public static class DbContextOptionsBuilderExtensions
+    {
+        public static SqlServerDbContextOptionsBuilder ApplyConfiguration(this SqlServerDbContextOptionsBuilder optionsBuilder)
+        {
+            var maxBatch = TestEnvironment.GetInt(nameof(SqlServerDbContextOptionsBuilder.MaxBatchSize));
+
+            if (maxBatch.HasValue)
+            {
+                optionsBuilder.MaxBatchSize(maxBatch.Value);
+            }
+
+            var offsetSupport = TestEnvironment.GetFlag(nameof(SqlServerCondition.SupportsOffset)) ?? true;
+            if (!offsetSupport)
+            {
+                optionsBuilder.UseRowNumberForPaging();
+            }
+
+            return optionsBuilder;
+        }
+    }
+}

--- a/test/EntityFramework.SqlServer.FunctionalTests/Utilities/SqlConnectionStringBuilderExtensions.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/Utilities/SqlConnectionStringBuilderExtensions.cs
@@ -1,9 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Data.SqlClient;
-using Microsoft.Framework.Configuration;
 
 namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 {
@@ -13,23 +11,12 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         private const int DefaultConnectTimeout = 30;
         private const bool DefaultIntegratedSecurity = true;
 
-        private static readonly IConfiguration _config;
-
-        static SqlConnectionStringBuilderExtensions()
-        {
-            var configBuilder = new ConfigurationBuilder(".")
-                .AddJsonFile("config.json", optional: true)
-                .AddJsonFile("config.test.json", optional: true)
-                .AddEnvironmentVariables();
-
-            _config = configBuilder.Build()
-                        .GetSection("Test:SqlServer");
-        }
-
         public static SqlConnectionStringBuilder ApplyConfiguration(this SqlConnectionStringBuilder builder)
         {
+            var config = TestEnvironment.Config;
+
             int connectTimeout;
-            if (!int.TryParse(_config["ConnectTimeout"], out connectTimeout))
+            if (!int.TryParse(config["ConnectTimeout"], out connectTimeout))
             {
                 connectTimeout = DefaultConnectTimeout;
             }
@@ -37,23 +24,23 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             builder.ConnectTimeout = connectTimeout;
 
             bool integratedSecurity;
-            if (!bool.TryParse(_config["IntegratedSecurity"], out integratedSecurity))
+            if (!bool.TryParse(config["IntegratedSecurity"], out integratedSecurity))
             {
                 integratedSecurity = DefaultIntegratedSecurity;
             }
 
             builder.IntegratedSecurity = integratedSecurity;
 
-            builder.DataSource = string.IsNullOrEmpty(_config["DataSource"]) ? DefaultDataSource : _config["DataSource"];
+            builder.DataSource = string.IsNullOrEmpty(config["DataSource"]) ? DefaultDataSource : config["DataSource"];
 
-            if (!string.IsNullOrEmpty(_config["UserID"]))
+            if (!string.IsNullOrEmpty(config["UserID"]))
             {
-                builder.UserID = _config["UserID"];
+                builder.UserID = config["UserID"];
             }
 
-            if (!string.IsNullOrEmpty(_config["Password"]))
+            if (!string.IsNullOrEmpty(config["Password"]))
             {
-                builder.Password = _config["Password"];
+                builder.Password = config["Password"];
             }
 
             return builder;

--- a/test/EntityFramework.SqlServer.FunctionalTests/Utilities/SqlServerConditionAttribute.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/Utilities/SqlServerConditionAttribute.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.Data.Entity.FunctionalTests.TestUtilities.Xunit;
+
+namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
+{
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
+    public class SqlServerConditionAttribute : Attribute, ITestCondition
+    {
+        public SqlServerCondition Conditions { get; set; }
+
+        public SqlServerConditionAttribute(SqlServerCondition conditions)
+        {
+            Conditions = conditions;
+        }
+
+        public bool IsMet
+        {
+            get
+            {
+                var isMet = true;
+                if (Conditions.HasFlag(SqlServerCondition.SupportsSequences))
+                {
+                    isMet &= TestEnvironment.GetFlag(nameof(SqlServerCondition.SupportsSequences)) ?? true;
+                }
+                if (Conditions.HasFlag(SqlServerCondition.SupportsOffset))
+                {
+                    isMet &= TestEnvironment.GetFlag(nameof(SqlServerCondition.SupportsOffset)) ?? true;
+                }
+                return isMet;
+            }
+        }
+
+        public string SkipReason =>
+            string.Format("The test SQL Server does not meet these conditions: '{0}'"
+                , string.Join(", ", Enum.GetValues(typeof(SqlServerCondition))
+                    .Cast<Enum>()
+                    .Where(f => Conditions.HasFlag(f))
+                    .Select(f => Enum.GetName(typeof(SqlServerCondition), f))));
+    }
+
+    [Flags]
+    public enum SqlServerCondition
+    {
+        SupportsSequences = 1 << 0,
+        SupportsOffset = 1 << 1
+    }
+}

--- a/test/EntityFramework.SqlServer.FunctionalTests/Utilities/TestEnvironment.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/Utilities/TestEnvironment.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Framework.Configuration;
+
+namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
+{
+    public static class TestEnvironment
+    {
+        public static IConfiguration Config { get; }
+
+        static TestEnvironment()
+        {
+            var configBuilder = new ConfigurationBuilder(".")
+                .AddJsonFile("config.json", optional: true)
+                .AddJsonFile("config.test.json", optional: true)
+                .AddEnvironmentVariables();
+
+            Config = configBuilder.Build()
+                .GetSection("Test:SqlServer");
+        }
+
+        public static bool? GetFlag(string key)
+        {
+            bool flag;
+            return bool.TryParse(Config[key], out flag) ? flag : (bool?)null;
+        }
+
+        public static int? GetInt(string key)
+        {
+            int value;
+            return int.TryParse(Config[key], out value) ? value : (int?)null;
+        }
+    }
+}


### PR DESCRIPTION
Adds `[ConditionalFact]` and  `[ConditionalTheory]` to our testing framework (similar to aspnet/testing, but better :) )

Allows skipping tests based on test configuration.

Fix #2897 
~~Depends on #3011~~