### PR TITLE
Benchmark queries without caching

### DIFF
--- a/test/EntityFramework.Microbenchmarks.EF6/Extensions.cs
+++ b/test/EntityFramework.Microbenchmarks.EF6/Extensions.cs
@@ -2,14 +2,40 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Data.Entity;
+using System.Data.Entity.Core.Objects;
+using System.Data.Entity.Infrastructure;
 using System.Linq;
+using System.Reflection;
 
 namespace EntityFramework.Microbenchmarks.EF6
 {
     public static class Extensions
     {
+        private static MethodInfo _getObjectQueryMethodInfo = typeof(DbQuery).Assembly
+            .GetType("System.Data.Entity.Internal.Linq.IInternalQuery", throwOnError: true)
+            .GetProperty("ObjectQuery")
+            .GetMethod;
+
+        public static IQueryable<TEntity> ApplyCaching<TEntity>(this IQueryable<TEntity> query, bool caching)
+            where TEntity : class
+        {
+            if (!caching)
+            {
+                var internalQuery = typeof(DbQuery<TEntity>)
+                    .GetProperty("System.Data.Entity.Internal.Linq.IInternalQueryAdapter.InternalQuery", BindingFlags.NonPublic | BindingFlags.Instance)
+                    .GetMethod
+                    .Invoke(query, new object[0]);
+
+                var objectQuery = (ObjectQuery)_getObjectQueryMethodInfo.Invoke(internalQuery, new object[0]);
+
+                objectQuery.EnablePlanCaching = false;
+            }
+
+            return query;
+        }
+
         public static IQueryable<TEntity> ApplyTracking<TEntity>(this IQueryable<TEntity> query, bool tracking)
-       where TEntity : class
+            where TEntity : class
         {
             return tracking
                     ? query

--- a/test/EntityFramework.Microbenchmarks.EF6/Query/SimpleQueryTests.cs
+++ b/test/EntityFramework.Microbenchmarks.EF6/Query/SimpleQueryTests.cs
@@ -1,10 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Data.Entity;
-using System.Linq;
 using EntityFramework.Microbenchmarks.Core;
 using EntityFramework.Microbenchmarks.EF6.Models.Orders;
+using System.Data.Entity;
+using System.Linq;
 using Xunit;
 
 namespace EntityFramework.Microbenchmarks.EF6.Query
@@ -18,15 +18,19 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
             _fixture = fixture;
         }
 
-        [Benchmark]
-        [BenchmarkVariation("Tracking On", true)]
-        [BenchmarkVariation("Tracking Off", false)]
-        public void LoadAll(MetricCollector collector, bool tracking)
+        [Benchmark(Iterations = 1, WarmupIterations = 0)]
+        [BenchmarkVariation("Tracking On", true, true)]
+        [BenchmarkVariation("Tracking Off", false, true)]
+        [BenchmarkVariation("Tracking On (No Query Cache)", true, false)]
+        [BenchmarkVariation("Tracking Off (No Query Cache)", false, false)]
+        public void LoadAll(MetricCollector collector, bool tracking, bool caching)
         {
             using (var context = _fixture.CreateContext())
             {
-                var query = context.Products.ApplyTracking(tracking);
-
+                var query = context.Products
+                    .ApplyCaching(caching)
+                    .ApplyTracking(tracking);
+                
                 collector.StartCollection();
                 var result = query.ToList();
                 collector.StopCollection();
@@ -35,13 +39,16 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
         }
 
         [Benchmark]
-        [BenchmarkVariation("Tracking On", true)]
-        [BenchmarkVariation("Tracking Off", false)]
-        public void Where(MetricCollector collector, bool tracking)
+        [BenchmarkVariation("Tracking On", true, true)]
+        [BenchmarkVariation("Tracking Off", false, true)]
+        [BenchmarkVariation("Tracking On (No Query Cache)", true, false)]
+        [BenchmarkVariation("Tracking Off (No Query Cache)", false, false)]
+        public void Where(MetricCollector collector, bool tracking, bool caching)
         {
             using (var context = _fixture.CreateContext())
             {
                 var query = context.Products
+                    .ApplyCaching(caching)
                     .ApplyTracking(tracking)
                     .Where(p => p.Retail < 15);
 
@@ -53,13 +60,16 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
         }
 
         [Benchmark]
-        [BenchmarkVariation("Tracking On", true)]
-        [BenchmarkVariation("Tracking Off", false)]
-        public void OrderBy(MetricCollector collector, bool tracking)
+        [BenchmarkVariation("Tracking On", true, true)]
+        [BenchmarkVariation("Tracking Off", false, true)]
+        [BenchmarkVariation("Tracking On (No Query Cache)", true, false)]
+        [BenchmarkVariation("Tracking Off (No Query Cache)", false, false)]
+        public void OrderBy(MetricCollector collector, bool tracking, bool caching)
         {
             using (var context = _fixture.CreateContext())
             {
                 var query = context.Products
+                    .ApplyCaching(caching)
                     .ApplyTracking(tracking)
                     .OrderBy(p => p.Retail);
 
@@ -71,11 +81,14 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
         }
 
         [Benchmark]
-        public void Count(MetricCollector collector)
+        [BenchmarkVariation("Default", true)]
+        [BenchmarkVariation("No Query Cache", false)]
+        public void Count(MetricCollector collector, bool caching)
         {
             using (var context = _fixture.CreateContext())
             {
-                var query = context.Products;
+                var query = context.Products
+                    .ApplyCaching(caching);
 
                 collector.StartCollection();
                 var result = query.Count();
@@ -85,13 +98,16 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
         }
 
         [Benchmark]
-        [BenchmarkVariation("Tracking On", true)]
-        [BenchmarkVariation("Tracking Off", false)]
-        public void SkipTake(MetricCollector collector, bool tracking)
+        [BenchmarkVariation("Tracking On", true, true)]
+        [BenchmarkVariation("Tracking Off", false, true)]
+        [BenchmarkVariation("Tracking On (No Query Cache)", true, false)]
+        [BenchmarkVariation("Tracking Off (No Query Cache)", false, false)]
+        public void SkipTake(MetricCollector collector, bool tracking, bool caching)
         {
             using (var context = _fixture.CreateContext())
             {
                 var query = context.Products
+                    .ApplyCaching(caching)
                     .ApplyTracking(tracking)
                     .OrderBy(p => p.ProductId)
                     .Skip(500).Take(500);
@@ -104,11 +120,14 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
         }
 
         [Benchmark]
-        public void GroupBy(MetricCollector collector)
+        [BenchmarkVariation("Default", true)]
+        [BenchmarkVariation("No Query Cache", false)]
+        public void GroupBy(MetricCollector collector, bool caching)
         {
             using (var context = _fixture.CreateContext())
             {
                 var query = context.Products
+                    .ApplyCaching(caching)
                     .GroupBy(p => p.Retail)
                     .Select(g => new
                     {
@@ -125,13 +144,16 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
         }
 
         [Benchmark]
-        [BenchmarkVariation("Tracking On", true)]
-        [BenchmarkVariation("Tracking Off", false)]
-        public void Include(MetricCollector collector, bool tracking)
+        [BenchmarkVariation("Tracking On", true, true)]
+        [BenchmarkVariation("Tracking Off", false, true)]
+        [BenchmarkVariation("Tracking On (No Query Cache)", true, false)]
+        [BenchmarkVariation("Tracking Off (No Query Cache)", false, false)]
+        public void Include(MetricCollector collector, bool tracking, bool caching)
         {
             using (var context = _fixture.CreateContext())
             {
                 var query = context.Customers
+                    .ApplyCaching(caching)
                     .ApplyTracking(tracking)
                     .Include(c => c.Orders);
 
@@ -144,11 +166,14 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
         }
 
         [Benchmark]
-        public void Projection(MetricCollector collector)
+        [BenchmarkVariation("Default", true)]
+        [BenchmarkVariation("No Query Cache", false)]
+        public void Projection(MetricCollector collector, bool caching)
         {
             using (var context = _fixture.CreateContext())
             {
                 var query = context.Products
+                    .ApplyCaching(caching)
                     .Select(p => new { p.Name, p.Retail });
 
                 collector.StartCollection();
@@ -159,16 +184,20 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
         }
 
         [Benchmark]
-        public void ProjectionAcrossNavigation(MetricCollector collector)
+        [BenchmarkVariation("Default", true)]
+        [BenchmarkVariation("No Query Cache", false)]
+        public void ProjectionAcrossNavigation(MetricCollector collector, bool caching)
         {
             using (var context = _fixture.CreateContext())
             {
                 // TODO Use navigation for projection when supported (#325)
-                var query = context.Orders.Join(
-                    context.Customers,
-                    o => o.CustomerId,
-                    c => c.CustomerId,
-                    (o, c) => new { CustomerName = c.Name, OrderDate = o.Date });
+                var query = context.Orders
+                    .ApplyCaching(caching)
+                    .Join(
+                        context.Customers,
+                        o => o.CustomerId,
+                        c => c.CustomerId,
+                        (o, c) => new { CustomerName = c.Name, OrderDate = o.Date });
 
                 collector.StartCollection();
                 var result = query.ToList();

--- a/test/EntityFramework.Microbenchmarks/Models/Orders/OrdersContext.cs
+++ b/test/EntityFramework.Microbenchmarks/Models/Orders/OrdersContext.cs
@@ -3,6 +3,7 @@
 
 using EntityFramework.Microbenchmarks.Core.Models.Orders;
 using Microsoft.Data.Entity;
+using System;
 
 namespace EntityFramework.Microbenchmarks.Models.Orders
 {
@@ -12,6 +13,13 @@ namespace EntityFramework.Microbenchmarks.Models.Orders
         private readonly bool _disableBatching;
 
         public OrdersContext(string connectionString, bool disableBatching = false)
+        {
+            _connectionString = connectionString;
+            _disableBatching = disableBatching;
+        }
+
+        public OrdersContext(IServiceProvider serviceProvider, string connectionString, bool disableBatching = false)
+            :base(serviceProvider)
         {
             _connectionString = connectionString;
             _disableBatching = disableBatching;

--- a/test/EntityFramework.Microbenchmarks/Models/Orders/OrdersFixture.cs
+++ b/test/EntityFramework.Microbenchmarks/Models/Orders/OrdersFixture.cs
@@ -16,6 +16,8 @@ namespace EntityFramework.Microbenchmarks.Models.Orders
             new OrdersSeedData().EnsureCreated(_connectionString, productCount, customerCount, ordersPerCustomer, linesPerOrder);
         }
 
+        public string ConnectionString => _connectionString;
+
         public OrdersContext CreateContext(bool disableBatching = false)
         {
             return new OrdersContext(_connectionString, disableBatching);

--- a/test/EntityFramework.Microbenchmarks/Query/SimpleQueryTests.cs
+++ b/test/EntityFramework.Microbenchmarks/Query/SimpleQueryTests.cs
@@ -1,11 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Linq;
 using EntityFramework.Microbenchmarks.Core;
 using EntityFramework.Microbenchmarks.Models.Orders;
 using Microsoft.Data.Entity;
+using Microsoft.Framework.Caching.Memory;
+using Microsoft.Framework.DependencyInjection;
+using System;
+using System.Linq;
 using Xunit;
 
 namespace EntityFramework.Microbenchmarks.Query
@@ -20,11 +22,13 @@ namespace EntityFramework.Microbenchmarks.Query
         }
 
         [Benchmark]
-        [BenchmarkVariation("Tracking On", true)]
-        [BenchmarkVariation("Tracking Off", false)]
-        public void LoadAll(MetricCollector collector, bool tracking)
+        [BenchmarkVariation("Tracking On", true, true)]
+        [BenchmarkVariation("Tracking Off", false, true)]
+        [BenchmarkVariation("Tracking On (No Query Cache)", true, false)]
+        [BenchmarkVariation("Tracking Off (No Query Cache)", false, false)]
+        public void LoadAll(MetricCollector collector, bool tracking, bool caching)
         {
-            using (var context = _fixture.CreateContext())
+            using (var context = _fixture.CreateContext(queryCachingEnabled: caching))
             {
                 var query = context.Products.ApplyTracking(tracking);
 
@@ -36,11 +40,13 @@ namespace EntityFramework.Microbenchmarks.Query
         }
 
         [Benchmark]
-        [BenchmarkVariation("Tracking On", true)]
-        [BenchmarkVariation("Tracking Off", false)]
-        public void Where(MetricCollector collector, bool tracking)
+        [BenchmarkVariation("Tracking On", true, true)]
+        [BenchmarkVariation("Tracking Off", false, true)]
+        [BenchmarkVariation("Tracking On (No Query Cache)", true, false)]
+        [BenchmarkVariation("Tracking Off (No Query Cache)", false, false)]
+        public void Where(MetricCollector collector, bool tracking, bool caching)
         {
-            using (var context = _fixture.CreateContext())
+            using (var context = _fixture.CreateContext(queryCachingEnabled: caching))
             {
                 var query = context.Products
                     .ApplyTracking(tracking)
@@ -54,11 +60,13 @@ namespace EntityFramework.Microbenchmarks.Query
         }
 
         [Benchmark]
-        [BenchmarkVariation("Tracking On", true)]
-        [BenchmarkVariation("Tracking Off", false)]
-        public void OrderBy(MetricCollector collector, bool tracking)
+        [BenchmarkVariation("Tracking On", true, true)]
+        [BenchmarkVariation("Tracking Off", false, true)]
+        [BenchmarkVariation("Tracking On (No Query Cache)", true, false)]
+        [BenchmarkVariation("Tracking Off (No Query Cache)", false, false)]
+        public void OrderBy(MetricCollector collector, bool tracking, bool caching)
         {
-            using (var context = _fixture.CreateContext())
+            using (var context = _fixture.CreateContext(queryCachingEnabled: caching))
             {
                 var query = context.Products
                     .ApplyTracking(tracking)
@@ -72,9 +80,11 @@ namespace EntityFramework.Microbenchmarks.Query
         }
 
         [Benchmark]
-        public void Count(MetricCollector collector)
+        [BenchmarkVariation("Default", true)]
+        [BenchmarkVariation("No Query Cache", false)]
+        public void Count(MetricCollector collector, bool caching)
         {
-            using (var context = _fixture.CreateContext())
+            using (var context = _fixture.CreateContext(queryCachingEnabled: caching))
             {
                 var query = context.Products;
 
@@ -86,11 +96,13 @@ namespace EntityFramework.Microbenchmarks.Query
         }
 
         [Benchmark]
-        [BenchmarkVariation("Tracking On", true)]
-        [BenchmarkVariation("Tracking Off", false)]
-        public void SkipTake(MetricCollector collector, bool tracking)
+        [BenchmarkVariation("Tracking On", true, true)]
+        [BenchmarkVariation("Tracking Off", false, true)]
+        [BenchmarkVariation("Tracking On (No Query Cache)", true, false)]
+        [BenchmarkVariation("Tracking Off (No Query Cache)", false, false)]
+        public void SkipTake(MetricCollector collector, bool tracking, bool caching)
         {
-            using (var context = _fixture.CreateContext())
+            using (var context = _fixture.CreateContext(queryCachingEnabled: caching))
             {
                 var query = context.Products
                     .ApplyTracking(tracking)
@@ -105,9 +117,11 @@ namespace EntityFramework.Microbenchmarks.Query
         }
 
         [Benchmark]
-        public void GroupBy(MetricCollector collector)
+        [BenchmarkVariation("Default", true)]
+        [BenchmarkVariation("No Query Cache", false)]
+        public void GroupBy(MetricCollector collector, bool caching)
         {
-            using (var context = _fixture.CreateContext())
+            using (var context = _fixture.CreateContext(queryCachingEnabled: caching))
             {
                 var query = context.Products
                     .GroupBy(p => p.Retail)
@@ -126,11 +140,13 @@ namespace EntityFramework.Microbenchmarks.Query
         }
 
         [Benchmark(Iterations = 2)]
-        [BenchmarkVariation("Tracking On", true)]
-        [BenchmarkVariation("Tracking Off", false)]
-        public void Include(MetricCollector collector, bool tracking)
+        [BenchmarkVariation("Tracking On", true, true)]
+        [BenchmarkVariation("Tracking Off", false, true)]
+        [BenchmarkVariation("Tracking On (No Query Cache)", true, false)]
+        [BenchmarkVariation("Tracking Off (No Query Cache)", false, false)]
+        public void Include(MetricCollector collector, bool tracking, bool caching)
         {
-            using (var context = _fixture.CreateContext())
+            using (var context = _fixture.CreateContext(queryCachingEnabled: caching))
             {
                 var query = context.Customers
                     .ApplyTracking(tracking)
@@ -145,9 +161,11 @@ namespace EntityFramework.Microbenchmarks.Query
         }
 
         [Benchmark]
-        public void Projection(MetricCollector collector)
+        [BenchmarkVariation("Default", true)]
+        [BenchmarkVariation("No Query Cache", false)]
+        public void Projection(MetricCollector collector, bool caching)
         {
-            using (var context = _fixture.CreateContext())
+            using (var context = _fixture.CreateContext(queryCachingEnabled: caching))
             {
                 var query = context.Products
                     .Select(p => new { p.Name, p.Retail });
@@ -160,9 +178,11 @@ namespace EntityFramework.Microbenchmarks.Query
         }
 
         [Benchmark]
-        public void ProjectionAcrossNavigation(MetricCollector collector)
+        [BenchmarkVariation("Default", true)]
+        [BenchmarkVariation("No Query Cache", false)]
+        public void ProjectionAcrossNavigation(MetricCollector collector, bool caching)
         {
-            using (var context = _fixture.CreateContext())
+            using (var context = _fixture.CreateContext(queryCachingEnabled: caching))
             {
                 // TODO Use navigation for projection when supported (#325)
                 var query = context.Orders.Join(
@@ -180,9 +200,51 @@ namespace EntityFramework.Microbenchmarks.Query
 
         public class SimpleQueryFixture : OrdersFixture
         {
+            private readonly IServiceProvider _noQueryCacheServiceProvider;
+
             public SimpleQueryFixture()
                 : base("Perf_Query_Simple", 1000, 1000, 2, 2)
-            { }
+            {
+                var collection = new ServiceCollection();
+                collection.AddEntityFramework().AddSqlServer();
+                collection.AddSingleton<IMemoryCache, NonCachingMemoryCache>();
+                _noQueryCacheServiceProvider = collection.BuildServiceProvider();
+            }
+
+            public OrdersContext CreateContext(bool disableBatching = false, bool queryCachingEnabled = true)
+            {
+                if (!queryCachingEnabled)
+                {
+                    return new OrdersContext(_noQueryCacheServiceProvider, ConnectionString, disableBatching);
+                }
+
+                return base.CreateContext(disableBatching);
+            }
+
+            private class NonCachingMemoryCache : IMemoryCache
+            {
+                public bool TryGetValue(object key, out object value)
+                {
+                    value = null;
+                    return false;
+                }
+
+                public object Set(object key, object value, MemoryCacheEntryOptions options)
+                {
+                    return value;
+                }
+
+                public void Remove(object key)
+                { }
+
+                public IEntryLink CreateLinkingScope()
+                {
+                    throw new NotImplementedException();
+                }
+
+                public void Dispose()
+                { }
+            }
         }
     }
 }


### PR DESCRIPTION
Adding variations of the query tests that disable the query cache. This
gives us an idea of what overhead is involved in query compilation.

For EF7 I'm using a null implementation of IMemoryCache, which means
that we still go through all the locking etc. in CompiledQueryCache.
This gives the best approximation of running a query where it does not
already exist in the cache.

For EF6 we need to use reflection to get the ObjectQuery to disable
caching :facepunch:.