### PR TITLE
Fixes for ConfigurationSource handling

### DIFF
--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -162,6 +162,7 @@
     <Compile Include="Metadata\Conventions\Internal\ForeignKeyAttributeConvention.cs" />
     <Compile Include="Metadata\Conventions\Internal\INavigationConvention.cs" />
     <Compile Include="Metadata\Conventions\Internal\InversePropertyAttributeConvention.cs" />
+    <Compile Include="Metadata\Conventions\Internal\IPrimaryKeyConvention.cs" />
     <Compile Include="Metadata\Conventions\Internal\NavigationAttributeNavigationConvention.cs" />
     <Compile Include="Metadata\Conventions\Internal\NotMappedPropertyAttributeConvention.cs" />
     <Compile Include="Metadata\Conventions\Internal\NavigationAttributeEntityTypeConvention.cs" />

--- a/src/EntityFramework.Core/Metadata/Conventions/ConventionSet.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/ConventionSet.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions
         public virtual IList<IForeignKeyConvention> ForeignKeyAddedConventions { get; } = new List<IForeignKeyConvention>();
         public virtual IList<IForeignKeyRemovedConvention> ForeignKeyRemovedConventions { get; } = new List<IForeignKeyRemovedConvention>();
         public virtual IList<IKeyConvention> KeyAddedConventions { get; } = new List<IKeyConvention>();
+        public virtual IList<IPrimaryKeyConvention> PrimaryKeySetConventions { get; } = new List<IPrimaryKeyConvention>();
         public virtual IList<IModelConvention> ModelBuiltConventions { get; } = new List<IModelConvention>();
         public virtual IList<IModelConvention> ModelInitializedConventions { get; } = new List<IModelConvention>();
         public virtual IList<INavigationConvention> NavigationAddedConventions { get; } = new List<INavigationConvention>();

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/ConventionDispatcher.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/ConventionDispatcher.cs
@@ -36,13 +36,13 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
 
         public virtual InternalEntityTypeBuilder OnBaseEntityTypeSet(
             [NotNull] InternalEntityTypeBuilder entityTypeBuilder,
-            [CanBeNull] EntityType oldBaseType)
+            [CanBeNull] EntityType previousBaseType)
         {
             Check.NotNull(entityTypeBuilder, nameof(entityTypeBuilder));
 
             foreach (var entityTypeConvention in _conventionSet.BaseEntityTypeSetConventions)
             {
-                if (!entityTypeConvention.Apply(entityTypeBuilder, oldBaseType))
+                if (!entityTypeConvention.Apply(entityTypeBuilder, previousBaseType))
                 {
                     break;
                 }
@@ -86,6 +86,21 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
             {
                 keyBuilder = keyConvention.Apply(keyBuilder);
                 if (keyBuilder == null)
+                {
+                    break;
+                }
+            }
+
+            return keyBuilder;
+        }
+
+        public virtual InternalKeyBuilder OnPrimaryKeySet([NotNull] InternalKeyBuilder keyBuilder, [CanBeNull] Key previousPrimaryKey)
+        {
+            Check.NotNull(keyBuilder, nameof(keyBuilder));
+
+            foreach (var keyConvention in _conventionSet.PrimaryKeySetConventions)
+            {
+                if (!keyConvention.Apply(keyBuilder, previousPrimaryKey))
                 {
                     break;
                 }

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
@@ -30,6 +30,8 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
             var keyConvention = new KeyConvention();
             conventionSet.KeyAddedConventions.Add(keyConvention);
 
+            conventionSet.PrimaryKeySetConventions.Add(keyConvention);
+
             conventionSet.ForeignKeyAddedConventions.Add(new ForeignKeyAttributeConvention());
             conventionSet.ForeignKeyAddedConventions.Add(new ForeignKeyPropertyDiscoveryConvention());
 

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/IPrimaryKeyConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/IPrimaryKeyConvention.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata.Internal;
+
+namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
+{
+    public interface IPrimaryKeyConvention
+    {
+        bool Apply([NotNull] InternalKeyBuilder keyBuilder, [CanBeNull] Key previousPrimaryKey);
+    }
+}

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/InversePropertyAttributeConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/InversePropertyAttributeConvention.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -19,7 +19,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
             Check.NotNull(navigationPropertyInfo, nameof(navigationPropertyInfo));
             Check.NotNull(attribute, nameof(attribute));
 
-            if (!entityTypeBuilder.CanAddNavigation(navigationPropertyInfo.Name, ConfigurationSource.DataAnnotation))
+            if (!entityTypeBuilder.CanAddOrReplaceNavigation(navigationPropertyInfo.Name, ConfigurationSource.DataAnnotation))
             {
                 return entityTypeBuilder;
             }
@@ -32,7 +32,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
             }
 
             // The navigation could have been added when the target entity type was added
-            if (!entityTypeBuilder.CanAddNavigation(navigationPropertyInfo.Name, ConfigurationSource.DataAnnotation))
+            if (!entityTypeBuilder.CanAddOrReplaceNavigation(navigationPropertyInfo.Name, ConfigurationSource.DataAnnotation))
             {
                 return entityTypeBuilder;
             }

--- a/src/EntityFramework.Core/Metadata/Internal/MetadataDictionary.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/MetadataDictionary.cs
@@ -21,14 +21,13 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             [NotNull] Func<TKey> createKey,
             [NotNull] Func<TKey, TValue> createValue,
             ConfigurationSource configurationSource)
-            => GetOrAdd(getKey, createKey, createValue, null, null, configurationSource);
+            => GetOrAdd(getKey, createKey, createValue, null, configurationSource);
 
         public virtual TValue GetOrAdd(
             [NotNull] Func<TKey> getKey,
             [NotNull] Func<TKey> createKey,
             [NotNull] Func<TKey, TValue> createValue,
             [CanBeNull] Func<TValue, TValue> onNewKeyAdded,
-            [CanBeNull] ConfigurationSource? newKeyConfigurationSource,
             ConfigurationSource configurationSource)
         {
             var isNewKey = false;
@@ -50,18 +49,12 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             }
 
             value = createValue(key);
-            if (isNewKey)
+            Add(key, value, configurationSource);
+
+            if (isNewKey
+                && onNewKeyAdded != null)
             {
-                if (onNewKeyAdded != null)
-                {
-                    newKeyConfigurationSource = newKeyConfigurationSource?.Max(configurationSource) ?? configurationSource;
-                    Add(key, value, newKeyConfigurationSource.Value);
-
-                    value = onNewKeyAdded.Invoke(value);
-
-                    Remove(key, ConfigurationSource.Explicit);
-                }
-                Add(key, value, configurationSource);
+                value = onNewKeyAdded.Invoke(value);
             }
 
             return value;

--- a/src/EntityFramework.Core/Metadata/Navigation.cs
+++ b/src/EntityFramework.Core/Metadata/Navigation.cs
@@ -1,7 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Linq;
+using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Metadata
@@ -26,5 +30,75 @@ namespace Microsoft.Data.Entity.Metadata
         IForeignKey INavigation.ForeignKey => ForeignKey;
 
         public override string ToString() => DeclaringEntityType + "." + Name;
+
+        public static bool IsCompatible(
+            [NotNull] string navigationPropertyName,
+            [NotNull] EntityType sourceType,
+            [NotNull] EntityType targetType,
+            bool? shouldBeCollection,
+            bool shouldThrow)
+        {
+            Check.NotNull(navigationPropertyName, nameof(navigationPropertyName));
+            Check.NotNull(sourceType, nameof(sourceType));
+            Check.NotNull(targetType, nameof(targetType));
+
+            var sourceClrType = sourceType.ClrType;
+            if (sourceClrType == null)
+            {
+                if (shouldThrow)
+                {
+                    throw new InvalidOperationException(Strings.NavigationOnShadowEntity(navigationPropertyName, sourceType.Name));
+                }
+                return false;
+            }
+
+            var targetClrType = targetType.ClrType;
+            if (targetClrType == null)
+            {
+                if (shouldThrow)
+                {
+                    throw new InvalidOperationException(Strings.NavigationToShadowEntity(navigationPropertyName, sourceType.Name, targetType.Name));
+                }
+                return false;
+            }
+
+            var navigationProperty = sourceClrType.GetPropertiesInHierarchy(navigationPropertyName).FirstOrDefault();
+            if (navigationProperty == null)
+            {
+                if (shouldThrow)
+                {
+                    throw new InvalidOperationException(Strings.NoClrNavigation(navigationPropertyName, sourceType.Name));
+                }
+                return false;
+            }
+            
+            var navigationTargetClrType = navigationProperty.PropertyType.TryGetSequenceType();
+            if (shouldBeCollection == false
+                || navigationTargetClrType == null
+                || !navigationTargetClrType.GetTypeInfo().IsAssignableFrom(targetClrType.GetTypeInfo()))
+            {
+                if (shouldBeCollection == true)
+                {
+                    if (shouldThrow)
+                    {
+                        throw new InvalidOperationException(Strings.NavigationCollectionWrongClrType(
+                            navigationProperty.Name, sourceClrType.FullName, navigationProperty.PropertyType.FullName, targetClrType.FullName));
+                    }
+                    return false;
+                }
+
+                if (!navigationProperty.PropertyType.GetTypeInfo().IsAssignableFrom(targetClrType.GetTypeInfo()))
+                {
+                    if (shouldThrow)
+                    {
+                        throw new InvalidOperationException(Strings.NavigationSingleWrongClrType(
+                            navigationProperty.Name, sourceClrType.FullName, navigationProperty.PropertyType.FullName, targetClrType.FullName));
+                    }
+                    return false;
+                }
+            }
+
+            return true;
+        }
     }
 }

--- a/src/EntityFramework.Core/Metadata/Property.cs
+++ b/src/EntityFramework.Core/Metadata/Property.cs
@@ -248,40 +248,6 @@ namespace Microsoft.Data.Entity.Metadata
         internal static string Format(IEnumerable<IProperty> properties)
             => "{" + string.Join(", ", properties.Select(p => "'" + p.Name + "'")) + "}";
 
-        public static bool AreCompatible([NotNull] IReadOnlyList<Property> principalProperties,
-            [NotNull] IReadOnlyList<Property> dependentProperties)
-            => ArePropertyCountsEqual(principalProperties, dependentProperties)
-               && ArePropertyTypesCompatible(principalProperties, dependentProperties);
-
-        public static void EnsureCompatible([NotNull] IReadOnlyList<Property> principalProperties, [NotNull] IReadOnlyList<Property> dependentProperties, [NotNull] EntityType principalEntityType, [NotNull] EntityType dependentEntityType)
-        {
-            if (!ArePropertyCountsEqual(principalProperties, dependentProperties))
-            {
-                throw new InvalidOperationException(
-                    Strings.ForeignKeyCountMismatch(
-                        Format(dependentProperties),
-                        dependentProperties[0].DeclaringEntityType.Name,
-                        Format(principalProperties),
-                        principalProperties[0].DeclaringEntityType.Name));
-            }
-
-            if (!ArePropertyTypesCompatible(principalProperties, dependentProperties))
-            {
-                throw new InvalidOperationException(
-                    Strings.ForeignKeyTypeMismatch(
-                        Format(dependentProperties),
-                        dependentProperties[0].DeclaringEntityType.Name,
-                        principalProperties[0].DeclaringEntityType.Name));
-            }
-        }
-
-        private static bool ArePropertyCountsEqual(IReadOnlyList<IProperty> principalProperties, IReadOnlyList<IProperty> dependentProperties)
-            => principalProperties.Count == dependentProperties.Count;
-
-        private static bool ArePropertyTypesCompatible(IReadOnlyList<IProperty> principalProperties, IReadOnlyList<IProperty> dependentProperties)
-            => principalProperties.Select(p => p.ClrType.UnwrapNullableType()).SequenceEqual(
-                dependentProperties.Select(p => p.ClrType.UnwrapNullableType()));
-
         Type IProperty.ClrType => ClrType ?? DefaultClrType;
         bool IProperty.IsConcurrencyToken => IsConcurrencyToken ?? DefaultIsConcurrencyToken;
         bool IProperty.IsReadOnlyBeforeSave => IsReadOnlyBeforeSave ?? DefaultIsReadOnlyBeforeSave;

--- a/src/EntityFramework.Core/Properties/Strings.Designer.cs
+++ b/src/EntityFramework.Core/Properties/Strings.Designer.cs
@@ -997,6 +997,14 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
+        /// The foreign key {foreignKey} on entity type '{entityType}' cannot be marked as optional because it does not contain any property of a nullable type. Any foreign key can be marked as required, but only foreign keys with at least one property of a nullable type and which is not part of primary key can be marked as optional.
+        /// </summary>
+        public static string ForeignKeyCannotBeOptional([CanBeNull] object foreignKey, [CanBeNull] object entityType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("ForeignKeyCannotBeOptional", "foreignKey", "entityType"), foreignKey, entityType);
+        }
+
+        /// <summary>
         /// Entity type '{entityType}' is in shadow-state. A valid model requires all entity types to have corresponding CLR type.
         /// </summary>
         public static string ShadowEntity([CanBeNull] object entityType)

--- a/src/EntityFramework.Core/Properties/Strings.resx
+++ b/src/EntityFramework.Core/Properties/Strings.resx
@@ -485,6 +485,9 @@
   </data>
   <data name="CannotBeNullablePK" xml:space="preserve">
     <value>The property '{property}' on entity type '{entity}' cannot be marked as nullable/optional because the property is a part of the primary key. Any property can be marked as non-nullable/required, but only properties of nullable types and which are not part of primary key can be marked as nullable/optional.</value>
+  </data>  
+  <data name="ForeignKeyCannotBeOptional" xml:space="preserve">
+    <value>The foreign key {foreignKey} on entity type '{entityType}' cannot be marked as optional because it does not contain any property of a nullable type. Any foreign key can be marked as required, but only foreign keys with at least one property of a nullable type and which is not part of primary key can be marked as optional.</value>
   </data>
   <data name="ShadowEntity" xml:space="preserve">
     <value>Entity type '{entityType}' is in shadow-state. A valid model requires all entity types to have corresponding CLR type.</value>

--- a/src/EntityFramework.Relational.Design/ReverseEngineering/Configuration/ModelConfiguration.cs
+++ b/src/EntityFramework.Relational.Design/ReverseEngineering/Configuration/ModelConfiguration.cs
@@ -280,7 +280,7 @@ namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering.Configurati
                 case ValueGenerated.OnAdd:
                     // If this property is the single integer primary key on the EntityType then
                     // KeyConvention assumes ValueGeneratedOnAdd() so there is no need to add it.
-                    if (_keyConvention.ValueGeneratedOnAddProperty(
+                    if (_keyConvention.FindValueGeneratedOnAddProperty(
                         new List<Property> { (Property)propertyConfiguration.Property },
                         (EntityType)propertyConfiguration.EntityConfiguration.EntityType) == null)
                     {

--- a/src/EntityFramework.SqlServer.Design/ReverseEngineering/Configuration/SqlServerModelConfiguration.cs
+++ b/src/EntityFramework.SqlServer.Design/ReverseEngineering/Configuration/SqlServerModelConfiguration.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering.Configuratio
             // not have Identity set then we need to set to ValueGeneratedNever() to
             // override this behavior.
             if (propertyConfiguration.Property.SqlServer().IdentityStrategy == null
-                && _keyConvention.ValueGeneratedOnAddProperty(
+                && _keyConvention.FindValueGeneratedOnAddProperty(
                     new List<Property> { (Property)propertyConfiguration.Property },
                     (EntityType)propertyConfiguration.EntityConfiguration.EntityType) != null)
             {

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/MonsterContext`.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/MonsterContext`.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Data.Entity.Infrastructure;
-using Microsoft.Data.Entity.Metadata;
 
 namespace Microsoft.Data.Entity.FunctionalTests.TestModels
 {
@@ -303,7 +302,8 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
                     b.Key(e => new { e.ReviewId, e.ProductId });
 
                     b.Collection(e => (IEnumerable<TProductWebFeature>)e.Features).InverseReference(e => (TProductReview)e.Review)
-                        .ForeignKey(e => new { e.ReviewId, e.ProductId });
+                        .ForeignKey(e => new { e.ReviewId, e.ProductId })
+                        .PrincipalKey(e => new { e.ReviewId, e.ProductId });
                 });
 
             modelBuilder.Entity<TLogin>(b =>

--- a/test/EntityFramework.Core.FunctionalTests/TestUtilities/Extensions.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestUtilities/Extensions.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
         private static void CloneKeys(IEntityType sourceEntityType, EntityType targetEntityType)
         {
-            foreach (var key in sourceEntityType.GetKeys())
+            foreach (var key in sourceEntityType.GetDeclaredKeys())
             {
                 var clonedKey = targetEntityType.AddKey(
                     key.Properties.Select(p => targetEntityType.GetProperty(p.Name)).ToList());
@@ -128,7 +128,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 var clonedForeignKey = targetEntityType.AddForeignKey(
                     foreignKey.Properties.Select(p => targetEntityType.GetProperty(p.Name)).ToList(),
                     targetPrincipalEntityType.GetKey(
-                        foreignKey.PrincipalKey.Properties.Select(p => targetEntityType.GetProperty(p.Name)).ToList()),
+                        foreignKey.PrincipalKey.Properties.Select(p => targetPrincipalEntityType.GetProperty(p.Name)).ToList()),
                     targetPrincipalEntityType);
                 clonedForeignKey.IsUnique = foreignKey.IsUnique;
                 clonedForeignKey.IsRequired = foreignKey.IsRequired;

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/NavigationFixerTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/NavigationFixerTest.cs
@@ -837,9 +837,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         }
 
         private static IServiceProvider CreateContextServices(IModel model = null)
-        {
-            return TestHelpers.Instance.CreateContextServices(model ?? BuildModel());
-        }
+            => TestHelpers.Instance.CreateContextServices(model ?? BuildModel());
 
         private class Category
         {

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/ForeignKeyPropertyDiscoveryConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/ForeignKeyPropertyDiscoveryConventionTest.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
                 "NavProp",
                 null,
                 ConfigurationSource.Explicit,
-                false)
+                isUnique: false)
                 .ForeignKey(new[] { fkProperty1.Metadata, fkProperty2.Metadata }, ConfigurationSource.Explicit);
 
             Assert.Same(relationshipBuilder, new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder));
@@ -77,7 +77,6 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             Assert.Same(CompositePrimaryKey[0], fk.PrincipalKey.Properties[0]);
             Assert.Same(CompositePrimaryKey[1], fk.PrincipalKey.Properties[1]);
             Assert.False(fk.IsUnique);
-            Assert.True(fk.IsRequired);
         }
 
         [Fact]
@@ -99,7 +98,6 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             Assert.Same(fk, DependentType.Metadata.GetForeignKeys().Single());
             Assert.Equal("SomeNav" + PrimaryKey.Name, fk.Properties.Single().Name);
             Assert.False(fk.IsUnique);
-            Assert.False(fk.IsRequired);
         }
 
         [Fact]
@@ -165,7 +163,6 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             Assert.Same(CompositePrimaryKey[0], fk.PrincipalKey.Properties[0]);
             Assert.Same(CompositePrimaryKey[1], fk.PrincipalKey.Properties[1]);
             Assert.False(fk.IsUnique);
-            Assert.True(fk.IsRequired);
         }
 
         [Fact]
@@ -282,7 +279,6 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             Assert.Same(CompositePrimaryKey[0], fk.PrincipalKey.Properties[0]);
             Assert.Same(CompositePrimaryKey[1], fk.PrincipalKey.Properties[1]);
             Assert.True(fk.IsUnique);
-            Assert.True(fk.IsRequired);
         }
 
         [Fact]
@@ -365,7 +361,6 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             Assert.Same(CompositePrimaryKey[0], fk.PrincipalKey.Properties[0]);
             Assert.Same(CompositePrimaryKey[1], fk.PrincipalKey.Properties[1]);
             Assert.True(fk.IsUnique);
-            Assert.True(fk.IsRequired);
         }
 
         [Fact]
@@ -426,19 +421,19 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             var relationshipBuilder = DependentType.Relationship(
                 PrincipalType,
                 DependentType,
-                "SomeNav",
+                null,
                 "InverseReferenceNav",
                 null,
                 PrincipalType.Metadata.GetPrimaryKey().Properties,
                 ConfigurationSource.Convention,
-                isUnique: true,
-                isRequired: false);
+                isUnique: true);
+            relationshipBuilder.Required(false, ConfigurationSource.Explicit);
 
             Assert.Same(relationshipBuilder, new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder));
 
             var fk = (IForeignKey)relationshipBuilder.Metadata;
             Assert.NotSame(fkProperty, fk.Properties.Single());
-            Assert.Equal("SomeNav" + PrimaryKey.Name, fk.Properties.Single().Name);
+            Assert.Equal("PrincipalEntity" + PrimaryKey.Name, fk.Properties.Single().Name);
             Assert.Same(PrimaryKey, fk.PrincipalKey.Properties.Single());
             Assert.True(fk.IsUnique);
             Assert.False(fk.IsRequired);
@@ -932,10 +927,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             return modelBuilder;
         }
 
-        private Property PrimaryKey
-        {
-            get { return PrincipalType.Metadata.GetPrimaryKey().Properties.Single(); }
-        }
+        private Property PrimaryKey => PrincipalType.Metadata.GetPrimaryKey().Properties.Single();
 
         private InternalEntityTypeBuilder PrincipalType => _model.Entity(typeof(PrincipalEntity), ConfigurationSource.Convention);
 

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/KeyConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/KeyConventionTest.cs
@@ -398,6 +398,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
 
             conventions.KeyAddedConventions.Add(keyConvention);
             conventions.ForeignKeyRemovedConventions.Add(keyConvention);
+            conventions.PrimaryKeySetConventions.Add(keyConvention);
 
             return new InternalModelBuilder(new Model(), conventions);
         }

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/DataAnnotationsTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/DataAnnotationsTestBase.cs
@@ -32,12 +32,11 @@ namespace Microsoft.Data.Entity.Tests
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
                 modelBuilder.Entity<Book>();
-
-                Assert.Contains("Book", model.GetEntityType(typeof(BookLabel)).Navigations.Select(nav => nav.Name));
-                Assert.Equal("Label", model.GetEntityType(typeof(BookLabel)).FindNavigation("Book").ForeignKey.PrincipalToDependent.Name);
-
-                Assert.Contains("AlternateLabel", model.GetEntityType(typeof(Book)).Navigations.Select(nav => nav.Name));
-                Assert.Null(model.GetEntityType(typeof(Book)).FindNavigation("AlternateLabel").ForeignKey.PrincipalToDependent);
+                
+                Assert.Equal("Label",
+                    model.GetEntityType(typeof(BookLabel)).FindNavigation("Book").FindInverse().Name);
+                
+                Assert.Null(model.GetEntityType(typeof(Book)).FindNavigation("AlternateLabel").FindInverse());
             }
 
             [Fact]

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/ManyToOneTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/ManyToOneTestBase.cs
@@ -731,7 +731,6 @@ namespace Microsoft.Data.Entity.Tests
                 var newFk = (IForeignKey)dependentType.GetForeignKeys().Single();
 
                 Assert.False(newFk.IsUnique);
-                Assert.NotSame(fk, newFk);
 
                 Assert.Equal("BigMak", dependentType.Navigations.Single().Name);
                 Assert.Equal("Pickles", principalType.Navigations.Single().Name);
@@ -1504,7 +1503,7 @@ namespace Microsoft.Data.Entity.Tests
                 var modelBuilder = HobNobBuilder();
 
                 Assert.Equal(
-                    Strings.CannotBeNullable("NobId1", "Hob", "Int32"),
+                    Strings.ForeignKeyCannotBeOptional("{'NobId1', 'NobId2'}", "Hob"),
                     Assert.Throws<InvalidOperationException>(() => modelBuilder
                         .Entity<Hob>().Reference(e => e.Nob).InverseCollection(e => e.Hobs)
                         .ForeignKey(e => new { e.NobId1, e.NobId2 })

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/NonRelationshipTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/NonRelationshipTestBase.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Data.Entity.Tests
             {
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
-                modelBuilder.Entity<Customer>();
+                modelBuilder.Entity<Customer>().Property<int>(Customer.IdProperty.Name);
 
                 var entity = model.GetEntityType(typeof(Customer));
                 var key = entity.AddKey(entity.GetOrAddProperty(Customer.NameProperty));
@@ -158,6 +158,10 @@ namespace Microsoft.Data.Entity.Tests
 
                 Assert.Same(key, entity.GetKeys().Single());
                 Assert.Equal(Customer.NameProperty.Name, entity.GetPrimaryKey().Properties.Single().Name);
+
+                var idProperty = (IProperty)entity.GetProperty(Customer.IdProperty);
+                Assert.False(idProperty.RequiresValueGenerator);
+                Assert.Equal(ValueGenerated.Never, idProperty.ValueGenerated);
             }
 
             [Fact]
@@ -555,6 +559,7 @@ namespace Microsoft.Data.Entity.Tests
 
                 modelBuilder.Entity<Quarks>(b =>
                     {
+                        b.Key(e => e.Id);
                         b.Property(e => e.Up).ValueGeneratedOnAddOrUpdate();
                         b.Property(e => e.Down).ValueGeneratedNever();
                         b.Property<int>("Charm").ValueGeneratedOnAdd();

--- a/test/EntityFramework.Relational.Tests/Metadata/InternalRelationalMetadataBuilderExtensionsTest.cs
+++ b/test/EntityFramework.Relational.Tests/Metadata/InternalRelationalMetadataBuilderExtensionsTest.cs
@@ -120,8 +120,8 @@ namespace Microsoft.Data.Entity.Metadata
         {
             var modelBuilder = CreateBuilder();
             var entityTypeBuilder = modelBuilder.Entity(typeof(Splot), ConfigurationSource.Convention);
-            var property = entityTypeBuilder.Property("Id", typeof(int), ConfigurationSource.Convention).Metadata;
-            var keyBuilder = entityTypeBuilder.Key(new[] { property }, ConfigurationSource.Convention);
+            var idProperty = entityTypeBuilder.Property("Id", ConfigurationSource.Convention).Metadata;
+            var keyBuilder = entityTypeBuilder.Key(new[] { idProperty.Name }, ConfigurationSource.Convention);
 
             Assert.True(keyBuilder.Relational(ConfigurationSource.Convention).Name("Splew"));
             Assert.Equal("Splew", keyBuilder.Metadata.Relational().Name);

--- a/test/EntityFramework.SqlServer.Tests/Metadata/InternalSqlServerMetadataBuilderExtensionsTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/Metadata/InternalSqlServerMetadataBuilderExtensionsTest.cs
@@ -78,8 +78,8 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
         {
             var modelBuilder = CreateBuilder();
             var entityTypeBuilder = modelBuilder.Entity(typeof(Splot), ConfigurationSource.Convention);
-            var property = entityTypeBuilder.Property("Id", typeof(int), ConfigurationSource.Convention).Metadata;
-            var keyBuilder = entityTypeBuilder.Key(new[] { property }, ConfigurationSource.Convention);
+            var idProperty = entityTypeBuilder.Property("Id", ConfigurationSource.Convention).Metadata;
+            var keyBuilder = entityTypeBuilder.Key(new[] { idProperty.Name }, ConfigurationSource.Convention);
 
             Assert.True(keyBuilder.SqlServer(ConfigurationSource.Convention).Clustered(true));
             Assert.True(keyBuilder.Metadata.SqlServer().IsClustered);

--- a/test/EntityFramework.Sqlite.Tests/Metadata/InternalSqliteMetadataBuilderExtensionsTest.cs
+++ b/test/EntityFramework.Sqlite.Tests/Metadata/InternalSqliteMetadataBuilderExtensionsTest.cs
@@ -72,8 +72,8 @@ namespace Microsoft.Data.Entity.Sqlite.Metadata
         {
             var modelBuilder = CreateBuilder();
             var entityTypeBuilder = modelBuilder.Entity(typeof(Splot), ConfigurationSource.Convention);
-            var property = entityTypeBuilder.Property("Id", typeof(int), ConfigurationSource.Convention).Metadata;
-            var keyBuilder = entityTypeBuilder.Key(new[] { property }, ConfigurationSource.Convention);
+            var idProperty = entityTypeBuilder.Property("Id", ConfigurationSource.Convention).Metadata;
+            var keyBuilder = entityTypeBuilder.Key(new[] { idProperty.Name }, ConfigurationSource.Convention);
 
             Assert.True(keyBuilder.Sqlite(ConfigurationSource.Convention).Name("Splew"));
             Assert.Equal("Splew", keyBuilder.Metadata.Sqlite().Name);


### PR DESCRIPTION
Preserve configuration source of foreign key aspects when recreating it
Add a convention trigger for setting a primary key
Keep a record of the entity types on which conventions are running to avoid them getting garbage collected instead of assigning them a temporary configuration source

Fixes #3010