### PR TITLE
Flow cascade delete from metadata into Migrations

### DIFF
--- a/EntityFramework.sln.DotSettings
+++ b/EntityFramework.sln.DotSettings
@@ -24,7 +24,7 @@
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_USING_BRACES_STYLE/@EntryValue">ALWAYS_ADD</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_WHILE_BRACES_STYLE/@EntryValue">ALWAYS_ADD</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INDENT_NESTED_USINGS_STMT/@EntryValue">True</s:Boolean>
-	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INITIALIZER_BRACES/@EntryValue">NEXT_LINE_SHIFTED_2</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INITIALIZER_BRACES/@EntryValue">NEXT_LINE</s:String>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_BLANK_LINES_IN_CODE/@EntryValue">1</s:Int64>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_BLANK_LINES_IN_DECLARATIONS/@EntryValue">1</s:Int64>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/LINE_FEED_AT_FILE_END/@EntryValue">True</s:Boolean>

--- a/test/EntityFramework.InMemory.FunctionalTests/GraphUpdatesInMemoryTestBase.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/GraphUpdatesInMemoryTestBase.cs
@@ -4,6 +4,7 @@
 using System;
 using Microsoft.Data.Entity.FunctionalTests;
 using Microsoft.Framework.DependencyInjection;
+using Xunit;
 
 namespace Microsoft.Data.Entity.InMemory.FunctionalTests
 {
@@ -13,6 +14,12 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
         protected GraphUpdatesInMemoryTestBase(TFixture fixture)
             : base(fixture)
         {
+        }
+
+        [Fact]
+        public override void Required_many_to_one_dependents_are_cascade_deleted()
+        {
+            // Cascade delete not supported by in-memory database
         }
 
         public abstract class GraphUpdatesInMemoryFixtureBase : GraphUpdatesFixtureBase

--- a/test/EntityFramework.Sqlite.FunctionalTests/GraphUpdatesSqliteTestBase.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/GraphUpdatesSqliteTestBase.cs
@@ -4,6 +4,7 @@
 using System;
 using Microsoft.Data.Entity.FunctionalTests;
 using Microsoft.Framework.DependencyInjection;
+using Xunit;
 
 namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
 {
@@ -13,6 +14,12 @@ namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
         protected GraphUpdatesSqliteTestBase(TFixture fixture)
             : base(fixture)
         {
+        }
+
+        [Fact]
+        public override void Required_many_to_one_dependents_are_cascade_deleted()
+        {
+            // Cascade delete not yet supported by SQLite provider
         }
 
         public abstract class GraphUpdatesSqliteFixtureBase : GraphUpdatesFixtureBase


### PR DESCRIPTION
Also, fix R# block indenting back to match what Visual Studio does so that we don't have so many conflicts between R# formatted code and VS formatted code.

Currently the functional test for this is disabled in SQLite since cascade delete for SQLite does not appear to be working at this time.