### PR TITLE
[SMALL] Fix to 3163 - include doesn't work well with inheritance

### DIFF
--- a/src/EntityFramework.Core/Query/EntityQueryModelVisitor.cs
+++ b/src/EntityFramework.Core/Query/EntityQueryModelVisitor.cs
@@ -1105,10 +1105,13 @@ namespace Microsoft.Data.Entity.Query
 
                 properties.Add(property);
 
-                querySourceReferenceExpression
-                    = memberExpression.Expression as QuerySourceReferenceExpression;
+                querySourceReferenceExpression =
+                    memberExpression.Expression as QuerySourceReferenceExpression
+                    ?? (memberExpression.Expression as UnaryExpression)?.Operand as QuerySourceReferenceExpression;
 
-                memberExpression = memberExpression.Expression as MemberExpression;
+                memberExpression =
+                    memberExpression.Expression as MemberExpression
+                    ?? (memberExpression.Expression as UnaryExpression)?.Operand as MemberExpression;
             }
 
             return querySourceReferenceExpression != null

--- a/test/EntityFramework.Core.FunctionalTests/EntityFramework.Core.FunctionalTests.csproj
+++ b/test/EntityFramework.Core.FunctionalTests/EntityFramework.Core.FunctionalTests.csproj
@@ -78,6 +78,7 @@
     <Compile Include="TestModels\ComplexNavigationsModel\Level3.cs" />
     <Compile Include="TestModels\ComplexNavigationsModel\Level4.cs" />
     <Compile Include="TestModels\GearsOfWarModel\AmmunitionType.cs" />
+    <Compile Include="TestModels\GearsOfWarModel\Officer.cs" />
     <Compile Include="TestModels\Inheritance\Animal.cs" />
     <Compile Include="TestModels\Inheritance\Bird.cs" />
     <Compile Include="TestModels\Inheritance\Country.cs" />

--- a/test/EntityFramework.Core.FunctionalTests/GearsOfWarQueryFixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/GearsOfWarQueryFixtureBase.cs
@@ -21,9 +21,14 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     b.Key(g => new { g.Nickname, g.SquadId });
 
                     b.Reference(g => g.CityOfBirth).InverseCollection(c => c.BornGears).ForeignKey(g => g.CityOrBirthName).Required();
-                    b.Collection(g => g.Reports).InverseReference().ForeignKey(g => new { g.LeaderNickname, g.LeaderSquadId });
                     b.Reference(g => g.Tag).InverseReference(t => t.Gear).ForeignKey<CogTag>(t => new { t.GearNickName, t.GearSquadId });
                     b.Reference(g => g.AssignedCity).InverseCollection(c => c.StationedGears).Required(false);
+                });
+
+            modelBuilder.Entity<Officer>().BaseType<Gear>();
+            modelBuilder.Entity<Officer>(b =>
+                {
+                    b.Collection(o => o.Reports).InverseReference().ForeignKey(o => new { o.LeaderNickname, o.LeaderSquadId });
                 });
 
             modelBuilder.Entity<CogTag>(b =>

--- a/test/EntityFramework.Core.FunctionalTests/GearsOfWarQueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/GearsOfWarQueryTestBase.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             using (var context = CreateContext())
             {
-                var query = context.Tags.Include(t => t.Gear.Reports);
+                var query = context.Tags.Include(t => t.Gear.Weapons);
                 var result = query.ToList();
 
                 Assert.Equal(6, result.Count);
@@ -43,7 +43,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 var gears = result.Select(t => t.Gear).Where(g => g != null).ToList();
                 Assert.Equal(5, gears.Count);
 
-                Assert.True(gears.All(g => g.Reports != null));
+                Assert.True(gears.All(g => g.Weapons != null));
             }
         }
 
@@ -219,6 +219,24 @@ namespace Microsoft.Data.Entity.FunctionalTests
                         }
                     }
                 }
+            }
+        }
+
+        [Fact]
+        public virtual void Include_navigation_on_derived_type()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Gears.OfType<Officer>().Include(o => o.Reports);
+                var result = query.ToList();
+
+                Assert.Equal(1, result.Count);
+
+                var reports = result.Single().Reports.ToList();
+                Assert.Equal(3, reports.Count);
+                Assert.Contains("Baird", reports.Select(g => g.Nickname));
+                Assert.Contains("Cole Train", reports.Select(g => g.Nickname));
+                Assert.Contains("Dom", reports.Select(g => g.Nickname));
             }
         }
 

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/GearsOfWarModel/Gear.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/GearsOfWarModel/Gear.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel
 {
@@ -10,7 +11,6 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel
         public Gear()
         {
             Weapons = new List<Weapon>();
-            Reports = new List<Gear>();
         }
 
         // composite key
@@ -26,6 +26,8 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel
 
         public MilitaryRank Rank { get; set; }
 
+        // TODO: temporary hack, remove once #1704 is fixed
+        [NotMapped]
         public virtual CogTag Tag { get; set; }
         public virtual Squad Squad { get; set; }
 
@@ -34,9 +36,6 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel
 
         public string LeaderNickname { get; set; }
         public int LeaderSquadId { get; set; }
-
-        // 1 - many self reference
-        public virtual ICollection<Gear> Reports { get; set; }
 
         public bool IsMarcus => Nickname == "Marcus";
     }

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/GearsOfWarModel/GearsOfWarModelInitializer.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/GearsOfWarModel/GearsOfWarModelInitializer.cs
@@ -188,7 +188,6 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel
                         AssignedCity = ephyra,
                         CityOrBirthName = ephyra.Name,
                         Tag = domsTag,
-                        Reports = new List<Gear>(),
                         Weapons = new List<Weapon> { domsHammerburst, domsGnasher }
                     };
 
@@ -201,7 +200,6 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel
                         CityOrBirthName = hanover.Name,
                         AssignedCity = jacinto,
                         Tag = colesTag,
-                        Reports = new List<Gear>(),
                         Weapons = new List<Weapon> { colesGnasher, colesMulcher }
                     };
 
@@ -213,7 +211,6 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel
                         Rank = MilitaryRank.Private,
                         CityOrBirthName = unknown.Name,
                         Tag = paduksTag,
-                        Reports = new List<Gear>(),
                         Weapons = new List<Weapon> { paduksMarkza }
                     };
 
@@ -226,11 +223,10 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel
                         CityOrBirthName = unknown.Name,
                         AssignedCity = jacinto,
                         Tag = bairdsTag,
-                        Reports = new List<Gear> { paduk },
                         Weapons = new List<Weapon> { bairdsLancer, bairdsGnasher }
                     };
 
-                var marcus = new Gear
+                var marcus = new Officer
                     {
                         Nickname = "Marcus",
                         FullName = "Marcus Fenix",

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/GearsOfWarModel/Officer.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/GearsOfWarModel/Officer.cs
@@ -1,0 +1,19 @@
+﻿
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel
+{
+    public class Officer : Gear
+    {
+        public Officer()
+        {
+            Reports = new List<Gear>();
+        }
+
+        // 1 - many self reference
+        public virtual ICollection<Gear> Reports { get; set; }
+    }
+}

--- a/test/EntityFramework.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -210,6 +210,28 @@ ORDER BY [c].[Nickname], [c].[Name]",
                 Sql);
         }
 
+        public override void Include_navigation_on_derived_type()
+        {
+            base.Include_navigation_on_derived_type();
+
+            Assert.Equal(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+FROM [Gear] AS [g]
+WHERE [g].[Discriminator] = 'Officer'
+ORDER BY [g].[Nickname], [g].[SquadId]
+
+SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+FROM [Gear] AS [g]
+INNER JOIN (
+    SELECT DISTINCT [g].[Nickname], [g].[SquadId]
+    FROM [Gear] AS [g]
+    WHERE [g].[Discriminator] = 'Officer'
+) AS [g0] ON ([g].[LeaderNickname] = [g0].[Nickname]) AND ([g].[LeaderSquadId] = [g0].[SquadId])
+WHERE ([g].[Discriminator] = 'Officer') OR ([g].[Discriminator] = 'Gear')
+ORDER BY [g0].[Nickname], [g0].[SquadId]",
+                Sql);
+        }
+
         public override void Where_enum()
         {
             base.Where_enum();


### PR DESCRIPTION
Problem was that during binding we were assuming that memberExpression.Expression would always be QuerySourceReferenceExpression. However in some cases (inheritance related) it is wrapped in a convert.
Fix is to add a fallback mechanism to look for this pattern as well