### PR TITLE
Dispose DbContext and service scope

### DIFF
--- a/src/EntityFramework.Core/Internal/DbContextServices.cs
+++ b/src/EntityFramework.Core/Internal/DbContextServices.cs
@@ -84,7 +84,5 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         public virtual IServiceProvider ServiceProvider => _provider;
-
-        public virtual void Dispose() => (_provider as IDisposable)?.Dispose();
     }
 }

--- a/src/EntityFramework.Core/Internal/IDbContextServices.cs
+++ b/src/EntityFramework.Core/Internal/IDbContextServices.cs
@@ -9,7 +9,7 @@ using Microsoft.Data.Entity.Storage;
 
 namespace Microsoft.Data.Entity.Internal
 {
-    public interface IDbContextServices : IDisposable
+    public interface IDbContextServices
     {
         IDbContextServices Initialize(
             [NotNull] IServiceProvider scopedProvider,

--- a/test/EntityFramework.Core.Tests/DatabaseFacadeTest.cs
+++ b/test/EntityFramework.Core.Tests/DatabaseFacadeTest.cs
@@ -81,5 +81,20 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Same(context.GetService<IModel>(), context.Database.GetService<IModel>());
             }
         }
+
+        [Fact]
+        public void Cannot_use_DatabaseFacade_after_dispose()
+        {
+            var context = TestHelpers.Instance.CreateContext();
+            var facade = context.Database;
+            context.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => context.Database.GetService<IModel>());
+
+            foreach (var methodInfo in facade.GetType().GetMethods(System.Reflection.BindingFlags.Public))
+            {
+                Assert.Throws<ObjectDisposedException>(() => methodInfo.Invoke(facade, null));
+            }
+        }
     }
 }


### PR DESCRIPTION
DbContext throws on use after disposal.
Properly disposes service scope.

Fix #1113.