### PR TITLE
Fluent API renames

### DIFF
--- a/src/EntityFramework.Commands/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EntityFramework.Commands/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -208,14 +208,14 @@ namespace Microsoft.Data.Entity.Migrations.Design
                 {
                     stringBuilder
                         .AppendLine()
-                        .Append(".ConcurrencyToken()");
+                        .Append(".IsConcurrencyToken()");
                 }
 
                 if (property.IsNullable != (property.ClrType.IsNullableType() && !property.IsPrimaryKey()))
                 {
                     stringBuilder
                         .AppendLine()
-                        .Append(".Required()");
+                        .Append(".IsRequired()");
                 }
 
                 if (property.ValueGenerated != ValueGenerated.Never)
@@ -277,7 +277,7 @@ namespace Microsoft.Data.Entity.Migrations.Design
             stringBuilder
                 .AppendLine()
                 .AppendLine()
-                .Append(primary ? "b.Key(" : "b.AlternateKey(")
+                .Append(primary ? "b.HasKey(" : "b.HasAlternateKey(")
                 .Append(string.Join(", ", key.Properties.Select(p => _code.Literal(p.Name))))
                 .Append(")");
 
@@ -381,7 +381,7 @@ namespace Microsoft.Data.Entity.Migrations.Design
 
             stringBuilder
                 .AppendLine()
-                .Append("b.Reference(")
+                .Append("b.HasOne(")
                 .Append(_code.Literal(foreignKey.PrincipalEntityType.Name))
                 .Append(")")
                 .AppendLine();
@@ -391,7 +391,7 @@ namespace Microsoft.Data.Entity.Migrations.Design
                 if (foreignKey.IsUnique)
                 {
                     stringBuilder
-                        .AppendLine(".InverseReference()")
+                        .AppendLine(".WithOne()")
                         .Append(".ForeignKey(")
                         .Append(_code.Literal(foreignKey.DeclaringEntityType.Name))
                         .Append(", ")
@@ -414,7 +414,7 @@ namespace Microsoft.Data.Entity.Migrations.Design
                 else
                 {
                     stringBuilder
-                        .AppendLine(".InverseCollection()")
+                        .AppendLine(".WithMany()")
                         .Append(".ForeignKey(")
                         .Append(string.Join(", ", foreignKey.Properties.Select(p => _code.Literal(p.Name))))
                         .Append(")");

--- a/src/EntityFramework.Core/Metadata/Builders/CollectionNavigationBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Builders/CollectionNavigationBuilder.cs
@@ -52,18 +52,18 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         ///     If null, there is no navigation property on the other end of the relationship.
         /// </param>
         /// <returns> An object to further configure the relationship. </returns>
-        public virtual ReferenceCollectionBuilder InverseReference([CanBeNull] string reference = null)
-            => new ReferenceCollectionBuilder(InverseReferenceBuilder(reference));
+        public virtual ReferenceCollectionBuilder WithOne([CanBeNull] string reference = null)
+            => new ReferenceCollectionBuilder(WithOneBuilder(reference));
 
         /// <summary>
-        ///     Returns the internal builder to be used when <see cref="InverseReference" /> is called.
+        ///     Returns the internal builder to be used when <see cref="WithOne" /> is called.
         /// </summary>
         /// <param name="reference">
         ///     The name of the reference navigation property on the other end of this relationship.
         ///     If null, there is no navigation property on the other end of the relationship.
         /// </param>
         /// <returns> The internal builder to further configure the relationship. </returns>
-        protected virtual InternalRelationshipBuilder InverseReferenceBuilder([CanBeNull] string reference)
+        protected virtual InternalRelationshipBuilder WithOneBuilder([CanBeNull] string reference)
             => Builder.DependentToPrincipal(
                 reference,
                 ConfigurationSource.Explicit,

--- a/src/EntityFramework.Core/Metadata/Builders/CollectionNavigationBuilder`.cs
+++ b/src/EntityFramework.Core/Metadata/Builders/CollectionNavigationBuilder`.cs
@@ -49,8 +49,8 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         ///     configured without a navigation property on the other end of the relationship.
         /// </param>
         /// <returns> An object to further configure the relationship. </returns>
-        public virtual ReferenceCollectionBuilder<TEntity, TRelatedEntity> InverseReference([CanBeNull] Expression<Func<TRelatedEntity, TEntity>> reference)
-            => new ReferenceCollectionBuilder<TEntity, TRelatedEntity>(InverseReferenceBuilder(reference?.GetPropertyAccess().Name));
+        public virtual ReferenceCollectionBuilder<TEntity, TRelatedEntity> WithOne([CanBeNull] Expression<Func<TRelatedEntity, TEntity>> reference)
+            => new ReferenceCollectionBuilder<TEntity, TRelatedEntity>(WithOneBuilder(reference?.GetPropertyAccess().Name));
 
         /// <summary>
         ///     Configures this as a one-to-many relationship.
@@ -60,7 +60,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         ///     If null, there is no navigation property on the other end of the relationship.
         /// </param>
         /// <returns> An object to further configure the relationship. </returns>
-        public new virtual ReferenceCollectionBuilder<TEntity, TRelatedEntity> InverseReference([CanBeNull] string reference = null)
-            => new ReferenceCollectionBuilder<TEntity, TRelatedEntity>(InverseReferenceBuilder(reference));
+        public new virtual ReferenceCollectionBuilder<TEntity, TRelatedEntity> WithOne([CanBeNull] string reference = null)
+            => new ReferenceCollectionBuilder<TEntity, TRelatedEntity>(WithOneBuilder(reference));
     }
 }

--- a/src/EntityFramework.Core/Metadata/Builders/EntityTypeBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Builders/EntityTypeBuilder.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         /// </summary>
         /// <param name="propertyNames"> The names of the properties that make up the primary key. </param>
         /// <returns> An object that can be used to configure the primary key. </returns>
-        public virtual KeyBuilder Key([NotNull] params string[] propertyNames)
+        public virtual KeyBuilder HasKey([NotNull] params string[] propertyNames)
         {
             Check.NotEmpty(propertyNames, nameof(propertyNames));
 
@@ -109,11 +109,11 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         /// </summary>
         /// <param name="propertyNames"> The names of the properties that make up the unique constraint. </param>
         /// <returns> An object that can be used to configure the unique constraint. </returns>
-        public virtual KeyBuilder AlternateKey([NotNull] params string[] propertyNames)
+        public virtual KeyBuilder HasAlternateKey([NotNull] params string[] propertyNames)
         {
             Check.NotNull(propertyNames, nameof(propertyNames));
 
-            return new KeyBuilder(Builder.Key(propertyNames, ConfigurationSource.Explicit));
+            return new KeyBuilder(Builder.HasKey(propertyNames, ConfigurationSource.Explicit));
         }
 
         /// <summary>
@@ -188,8 +188,8 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         ///     </para>
         ///     <para>
         ///         After calling this method, you should chain a call to
-        ///         <see cref="ReferenceNavigationBuilder.InverseCollection(string)" />
-        ///         or <see cref="ReferenceNavigationBuilder.InverseReference(string)" /> to fully configure
+        ///         <see cref="ReferenceNavigationBuilder.WithMany" />
+        ///         or <see cref="ReferenceNavigationBuilder.WithOne" /> to fully configure
         ///         the relationship. Calling just this method without the chained call will not
         ///         produce a valid relationship.
         ///     </para>
@@ -201,7 +201,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         ///     end.
         /// </param>
         /// <returns> An object that can be used to configure the relationship. </returns>
-        public virtual ReferenceNavigationBuilder Reference(
+        public virtual ReferenceNavigationBuilder HasOne(
             [NotNull] Type relatedType,
             [CanBeNull] string navigationName = null)
         {
@@ -222,8 +222,8 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         ///     </para>
         ///     <para>
         ///         After calling this method, you should chain a call to
-        ///         <see cref="ReferenceNavigationBuilder.InverseCollection(string)" />
-        ///         or <see cref="ReferenceNavigationBuilder.InverseReference(string)" /> to fully configure
+        ///         <see cref="ReferenceNavigationBuilder.WithMany" />
+        ///         or <see cref="ReferenceNavigationBuilder.WithOne" /> to fully configure
         ///         the relationship. Calling just this method without the chained call will not
         ///         produce a valid relationship.
         ///     </para>
@@ -235,7 +235,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         ///     end.
         /// </param>
         /// <returns> An object that can be used to configure the relationship. </returns>
-        public virtual ReferenceNavigationBuilder Reference(
+        public virtual ReferenceNavigationBuilder HasOne(
             [NotNull] string relatedTypeName,
             [CanBeNull] string navigationName = null)
         {
@@ -256,7 +256,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         ///     </para>
         ///     <para>
         ///         After calling this method, you should chain a call to
-        ///         <see cref="CollectionNavigationBuilder.InverseReference(string)" />
+        ///         <see cref="CollectionNavigationBuilder.WithOne" />
         ///         to fully configure the relationship. Calling just this method without the chained call will not
         ///         produce a valid relationship.
         ///     </para>
@@ -268,7 +268,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         ///     end.
         /// </param>
         /// <returns> An object that can be used to configure the relationship. </returns>
-        public virtual CollectionNavigationBuilder Collection(
+        public virtual CollectionNavigationBuilder HasMany(
             [NotNull] Type relatedType,
             [CanBeNull] string navigationName = null)
         {
@@ -286,7 +286,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         ///     </para>
         ///     <para>
         ///         After calling this method, you should chain a call to
-        ///         <see cref="CollectionNavigationBuilder.InverseReference(string)" />
+        ///         <see cref="CollectionNavigationBuilder.WithOne" />
         ///         to fully configure the relationship. Calling just this method without the chained call will not
         ///         produce a valid relationship.
         ///     </para>
@@ -298,7 +298,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         ///     end.
         /// </param>
         /// <returns> An object that can be used to configure the relationship. </returns>
-        public virtual CollectionNavigationBuilder Collection(
+        public virtual CollectionNavigationBuilder HasMany(
             [NotNull] string relatedTypeName,
             [CanBeNull] string navigationName = null)
         {

--- a/src/EntityFramework.Core/Metadata/Builders/EntityTypeBuilder`.cs
+++ b/src/EntityFramework.Core/Metadata/Builders/EntityTypeBuilder`.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         ///     </para>
         /// </param>
         /// <returns> An object that can be used to configure the primary key. </returns>
-        public virtual KeyBuilder Key([NotNull] Expression<Func<TEntity, object>> keyExpression)
+        public virtual KeyBuilder HasKey([NotNull] Expression<Func<TEntity, object>> keyExpression)
         {
             Check.NotNull(keyExpression, nameof(keyExpression));
 
@@ -96,11 +96,11 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         ///     </para>
         /// </param>
         /// <returns> An object that can be used to configure the unique constraint. </returns>
-        public virtual KeyBuilder AlternateKey([NotNull] Expression<Func<TEntity, object>> keyExpression)
+        public virtual KeyBuilder HasAlternateKey([NotNull] Expression<Func<TEntity, object>> keyExpression)
         {
             Check.NotNull(keyExpression, nameof(keyExpression));
 
-            return new KeyBuilder(Builder.Key(keyExpression.GetPropertyAccessList(), ConfigurationSource.Explicit));
+            return new KeyBuilder(Builder.HasKey(keyExpression.GetPropertyAccessList(), ConfigurationSource.Explicit));
         }
 
         /// <summary>
@@ -182,10 +182,10 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         ///     <para>
         ///         After calling this method, you should chain a call to
         ///         <see
-        ///             cref="ReferenceNavigationBuilder{TEntity,TRelatedEntity}.InverseCollection(Expression{Func{TRelatedEntity, IEnumerable{TEntity}}})" />
+        ///             cref="ReferenceNavigationBuilder{TEntity,TRelatedEntity}.WithMany(System.Linq.Expressions.Expression{System.Func{TRelatedEntity,System.Collections.Generic.IEnumerable{TEntity}}})" />
         ///         or
         ///         <see
-        ///             cref="ReferenceNavigationBuilder{TEntity,TRelatedEntity}.InverseReference(Expression{Func{TRelatedEntity, TEntity}})" />
+        ///             cref="ReferenceNavigationBuilder{TEntity,TRelatedEntity}.WithOne(System.Linq.Expressions.Expression{System.Func{TRelatedEntity,TEntity}})" />
         ///         to fully configure the relationship. Calling just this method without the chained call will not
         ///         produce a valid relationship.
         ///     </para>
@@ -197,7 +197,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         ///     configured without a navigation property on this end.
         /// </param>
         /// <returns> An object that can be used to configure the relationship. </returns>
-        public virtual ReferenceNavigationBuilder<TEntity, TRelatedEntity> Reference<TRelatedEntity>(
+        public virtual ReferenceNavigationBuilder<TEntity, TRelatedEntity> HasOne<TRelatedEntity>(
             [CanBeNull] Expression<Func<TEntity, TRelatedEntity>> reference = null)
             where TRelatedEntity : class
         {
@@ -218,7 +218,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         ///     <para>
         ///         After calling this method, you should chain a call to
         ///         <see
-        ///             cref="CollectionNavigationBuilder{TEntity,TRelatedEntity}.InverseReference(Expression{Func{TRelatedEntity, TEntity}})" />
+        ///             cref="CollectionNavigationBuilder{TEntity,TRelatedEntity}.WithOne(System.Linq.Expressions.Expression{System.Func{TRelatedEntity,TEntity}})" />
         ///         to fully configure the relationship. Calling just this method without the chained call will not
         ///         produce a valid relationship.
         ///     </para>
@@ -230,7 +230,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         ///     configured without a navigation property on this end.
         /// </param>
         /// <returns> An object that can be used to configure the relationship. </returns>
-        public virtual CollectionNavigationBuilder<TEntity, TRelatedEntity> Collection<TRelatedEntity>(
+        public virtual CollectionNavigationBuilder<TEntity, TRelatedEntity> HasMany<TRelatedEntity>(
             [CanBeNull] Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> collection = null)
             where TRelatedEntity : class
         {

--- a/src/EntityFramework.Core/Metadata/Builders/PropertyBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Builders/PropertyBuilder.cs
@@ -76,9 +76,9 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         /// </summary>
         /// <param name="required"> A value indicating whether the property is required. </param>
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
-        public virtual PropertyBuilder Required(bool required = true)
+        public virtual PropertyBuilder IsRequired(bool required = true)
         {
-            Builder.Required(required, ConfigurationSource.Explicit);
+            Builder.IsRequired(required, ConfigurationSource.Explicit);
 
             return this;
         }
@@ -89,9 +89,9 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         /// </summary>
         /// <param name="maxLength"> The maximum length of data allowed in the property. </param>
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
-        public virtual PropertyBuilder MaxLength(int maxLength)
+        public virtual PropertyBuilder HasMaxLength(int maxLength)
         {
-            Builder.MaxLength(maxLength, ConfigurationSource.Explicit);
+            Builder.HasMaxLength(maxLength, ConfigurationSource.Explicit);
 
             return this;
         }
@@ -105,9 +105,9 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         /// </summary>
         /// <param name="concurrencyToken"> A value indicating whether this property is a concurrency token. </param>
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
-        public virtual PropertyBuilder ConcurrencyToken(bool concurrencyToken = true)
+        public virtual PropertyBuilder IsConcurrencyToken(bool concurrencyToken = true)
         {
-            Builder.ConcurrencyToken(concurrencyToken, ConfigurationSource.Explicit);
+            Builder.IsConcurrencyToken(concurrencyToken, ConfigurationSource.Explicit);
 
             return this;
         }

--- a/src/EntityFramework.Core/Metadata/Builders/PropertyBuilder`.cs
+++ b/src/EntityFramework.Core/Metadata/Builders/PropertyBuilder`.cs
@@ -50,8 +50,8 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         /// </summary>
         /// <param name="required"> A value indicating whether the property is required. </param>
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
-        public new virtual PropertyBuilder<TProperty> Required(bool required = true)
-            => (PropertyBuilder<TProperty>)base.Required(required);
+        public new virtual PropertyBuilder<TProperty> IsRequired(bool required = true)
+            => (PropertyBuilder<TProperty>)base.IsRequired(required);
 
         /// <summary>
         ///     Configures the maximum length of data that can be stored in this property.
@@ -59,8 +59,8 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         /// </summary>
         /// <param name="maxLength"> The maximum length of data allowed in the property. </param>
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
-        public new virtual PropertyBuilder<TProperty> MaxLength(int maxLength)
-            => (PropertyBuilder<TProperty>)base.MaxLength(maxLength);
+        public new virtual PropertyBuilder<TProperty> HasMaxLength(int maxLength)
+            => (PropertyBuilder<TProperty>)base.HasMaxLength(maxLength);
 
         /// <summary>
         ///     Configures whether this property should be used as a concurrency token. When a property is configured
@@ -71,8 +71,8 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         /// </summary>
         /// <param name="concurrencyToken"> A value indicating whether this property is a concurrency token. </param>
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
-        public new virtual PropertyBuilder<TProperty> ConcurrencyToken(bool concurrencyToken = true)
-            => (PropertyBuilder<TProperty>)base.ConcurrencyToken(concurrencyToken);
+        public new virtual PropertyBuilder<TProperty> IsConcurrencyToken(bool concurrencyToken = true)
+            => (PropertyBuilder<TProperty>)base.IsConcurrencyToken(concurrencyToken);
 
         /// <summary>
         ///     Configures a property to never have a value generated when an instance of this

--- a/src/EntityFramework.Core/Metadata/Builders/ReferenceNavigationBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Builders/ReferenceNavigationBuilder.cs
@@ -75,18 +75,18 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         ///     If null, there is no navigation property on the other end of the relationship.
         /// </param>
         /// <returns> An object to further configure the relationship. </returns>
-        public virtual ReferenceCollectionBuilder InverseCollection([CanBeNull] string collection = null)
-            => new ReferenceCollectionBuilder(InverseCollectionBuilder(collection));
+        public virtual ReferenceCollectionBuilder WithMany([CanBeNull] string collection = null)
+            => new ReferenceCollectionBuilder(WithManyBuilder(collection));
 
         /// <summary>
-        ///     Returns the internal builder to be used when <see cref="InverseCollection" /> is called.
+        ///     Returns the internal builder to be used when <see cref="WithMany" /> is called.
         /// </summary>
         /// <param name="collection">
         ///     The name of the collection navigation property on the other end of this relationship.
         ///     If null, there is no navigation property on the other end of the relationship.
         /// </param>
         /// <returns> The internal builder to further configure the relationship. </returns>
-        protected virtual InternalRelationshipBuilder InverseCollectionBuilder([CanBeNull] string collection)
+        protected virtual InternalRelationshipBuilder WithManyBuilder([CanBeNull] string collection)
         {
             var needToInvert = Builder.Metadata.PrincipalEntityType != RelatedEntityType;
 
@@ -117,18 +117,18 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         ///     If null, there is no navigation property on the other end of the relationship.
         /// </param>
         /// <returns> An object to further configure the relationship. </returns>
-        public virtual ReferenceReferenceBuilder InverseReference([CanBeNull] string reference = null)
-            => new ReferenceReferenceBuilder(InverseReferenceBuilder(reference));
+        public virtual ReferenceReferenceBuilder WithOne([CanBeNull] string reference = null)
+            => new ReferenceReferenceBuilder(WithOneBuilder(reference));
 
         /// <summary>
-        ///     Returns the internal builder to be used when <see cref="InverseReference" /> is called.
+        ///     Returns the internal builder to be used when <see cref="WithOne" /> is called.
         /// </summary>
         /// <param name="reference">
         ///     The name of the reference navigation property on the other end of this relationship.
         ///     If null, there is no navigation property on the other end of the relationship.
         /// </param>
         /// <returns> The internal builder to further configure the relationship. </returns>
-        protected virtual InternalRelationshipBuilder InverseReferenceBuilder([CanBeNull] string reference)
+        protected virtual InternalRelationshipBuilder WithOneBuilder([CanBeNull] string reference)
         {
             var builder = Builder;
             // TODO: Remove this when #1924 is fixed

--- a/src/EntityFramework.Core/Metadata/Builders/ReferenceNavigationBuilder`.cs
+++ b/src/EntityFramework.Core/Metadata/Builders/ReferenceNavigationBuilder`.cs
@@ -57,9 +57,9 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         ///     configured without a navigation property on the other end of the relationship.
         /// </param>
         /// <returns> An object to further configure the relationship. </returns>
-        public virtual ReferenceCollectionBuilder<TRelatedEntity, TEntity> InverseCollection(
+        public virtual ReferenceCollectionBuilder<TRelatedEntity, TEntity> WithMany(
             [CanBeNull] Expression<Func<TRelatedEntity, IEnumerable<TEntity>>> collection)
-            => new ReferenceCollectionBuilder<TRelatedEntity, TEntity>(InverseCollectionBuilder(collection?.GetPropertyAccess().Name));
+            => new ReferenceCollectionBuilder<TRelatedEntity, TEntity>(WithManyBuilder(collection?.GetPropertyAccess().Name));
 
         /// <summary>
         ///     Configures this as a one-to-one relationship.
@@ -70,8 +70,8 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         ///     configured without a navigation property on the other end of the relationship.
         /// </param>
         /// <returns> An object to further configure the relationship. </returns>
-        public virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> InverseReference([CanBeNull] Expression<Func<TRelatedEntity, TEntity>> reference)
-            => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(InverseReferenceBuilder(reference?.GetPropertyAccess().Name));
+        public virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> WithOne([CanBeNull] Expression<Func<TRelatedEntity, TEntity>> reference)
+            => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(WithOneBuilder(reference?.GetPropertyAccess().Name));
 
         /// <summary>
         ///     Configures this as a one-to-many relationship.
@@ -81,8 +81,8 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         ///     If null, there is no navigation property on the other end of the relationship.
         /// </param>
         /// <returns> An object to further configure the relationship. </returns>
-        public new virtual ReferenceCollectionBuilder<TRelatedEntity, TEntity> InverseCollection([CanBeNull] string collection = null)
-            => new ReferenceCollectionBuilder<TRelatedEntity, TEntity>(InverseCollectionBuilder(collection));
+        public new virtual ReferenceCollectionBuilder<TRelatedEntity, TEntity> WithMany([CanBeNull] string collection = null)
+            => new ReferenceCollectionBuilder<TRelatedEntity, TEntity>(WithManyBuilder(collection));
 
         /// <summary>
         ///     Configures this as a one-to-one relationship.
@@ -92,7 +92,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         ///     If null, there is no navigation property on the other end of the relationship.
         /// </param>
         /// <returns> An object to further configure the relationship. </returns>
-        public new virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> InverseReference([CanBeNull] string reference = null)
-            => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(InverseReferenceBuilder(reference));
+        public new virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> WithOne([CanBeNull] string reference = null)
+            => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(WithOneBuilder(reference));
     }
 }

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/ConcurrencyCheckAttributeConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/ConcurrencyCheckAttributeConvention.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
             Check.NotNull(propertyBuilder, nameof(propertyBuilder));
             Check.NotNull(attribute, nameof(attribute));
 
-            propertyBuilder.ConcurrencyToken(true, ConfigurationSource.DataAnnotation);
+            propertyBuilder.IsConcurrencyToken(true, ConfigurationSource.DataAnnotation);
 
             return propertyBuilder;
         }

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/MaxLengthAttributeConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/MaxLengthAttributeConvention.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
 
             if (attribute.Length > 0)
             {
-                propertyBuilder.MaxLength(attribute.Length, ConfigurationSource.DataAnnotation);
+                propertyBuilder.HasMaxLength(attribute.Length, ConfigurationSource.DataAnnotation);
             }
 
             return propertyBuilder;

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/RequiredPropertyAttributeConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/RequiredPropertyAttributeConvention.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
             Check.NotNull(propertyBuilder, nameof(propertyBuilder));
             Check.NotNull(attribute, nameof(attribute));
 
-            propertyBuilder.Required(true, ConfigurationSource.DataAnnotation);
+            propertyBuilder.IsRequired(true, ConfigurationSource.DataAnnotation);
 
             return propertyBuilder;
         }

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/StringLengthAttributeConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/StringLengthAttributeConvention.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
 
             if (attribute.MaximumLength > 0)
             {
-                propertyBuilder.MaxLength(attribute.MaximumLength, ConfigurationSource.DataAnnotation);
+                propertyBuilder.HasMaxLength(attribute.MaximumLength, ConfigurationSource.DataAnnotation);
             }
 
             return propertyBuilder;

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/TimestampAttributeConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/TimestampAttributeConvention.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
             Check.NotNull(clrProperty, nameof(clrProperty));
 
             propertyBuilder.ValueGenerated(ValueGenerated.OnAddOrUpdate, ConfigurationSource.DataAnnotation);
-            propertyBuilder.ConcurrencyToken(true, ConfigurationSource.DataAnnotation);
+            propertyBuilder.IsConcurrencyToken(true, ConfigurationSource.DataAnnotation);
 
             return propertyBuilder;
         }

--- a/src/EntityFramework.Core/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             if (Metadata.FindPrimaryKey(properties) != null)
             {
                 _primaryKeyConfigurationSource = configurationSource.Max(_primaryKeyConfigurationSource);
-                return Key(properties, configurationSource);
+                return HasKey(properties, configurationSource);
             }
 
             if (!_primaryKeyConfigurationSource.HasValue
@@ -65,7 +65,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 return null;
             }
 
-            var keyBuilder = Key(properties, configurationSource);
+            var keyBuilder = HasKey(properties, configurationSource);
             if (keyBuilder == null)
             {
                 return null;
@@ -100,13 +100,13 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             }
         }
 
-        public virtual InternalKeyBuilder Key([NotNull] IReadOnlyList<string> propertyNames, ConfigurationSource configurationSource)
-            => Key(GetOrCreateProperties(propertyNames, configurationSource), configurationSource);
+        public virtual InternalKeyBuilder HasKey([NotNull] IReadOnlyList<string> propertyNames, ConfigurationSource configurationSource)
+            => HasKey(GetOrCreateProperties(propertyNames, configurationSource), configurationSource);
 
-        public virtual InternalKeyBuilder Key([NotNull] IReadOnlyList<PropertyInfo> clrProperties, ConfigurationSource configurationSource)
-            => Key(GetOrCreateProperties(clrProperties, configurationSource), configurationSource);
+        public virtual InternalKeyBuilder HasKey([NotNull] IReadOnlyList<PropertyInfo> clrProperties, ConfigurationSource configurationSource)
+            => HasKey(GetOrCreateProperties(clrProperties, configurationSource), configurationSource);
 
-        private InternalKeyBuilder Key(IReadOnlyList<Property> properties, ConfigurationSource configurationSource)
+        private InternalKeyBuilder HasKey(IReadOnlyList<Property> properties, ConfigurationSource configurationSource)
         {
             if (properties == null)
             {
@@ -1382,7 +1382,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             Key principalKey;
             if (principalProperties != null)
             {
-                var keyBuilder = principalBaseEntityTypeBuilder.Key(principalProperties, ConfigurationSource.Convention);
+                var keyBuilder = principalBaseEntityTypeBuilder.HasKey(principalProperties, ConfigurationSource.Convention);
                 if (keyBuilder == null)
                 {
                     return null;
@@ -1416,7 +1416,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                             isRequired: true);
                     }
 
-                    var keyBuilder = principalBaseEntityTypeBuilder.Key(principalKeyProperties, ConfigurationSource.Convention);
+                    var keyBuilder = principalBaseEntityTypeBuilder.HasKey(principalKeyProperties, ConfigurationSource.Convention);
 
                     principalKey = keyBuilder.Metadata;
                 }
@@ -1433,7 +1433,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                         principalBaseEntityTypeBuilder,
                         isRequired: true);
 
-                    principalKey = principalBaseEntityTypeBuilder.Key(new[] { principalKeyProperty }, ConfigurationSource.Convention).Metadata;
+                    principalKey = principalBaseEntityTypeBuilder.HasKey(new[] { principalKeyProperty }, ConfigurationSource.Convention).Metadata;
                 }
 
                 var fkProperties = new Property[principalKey.Properties.Count];
@@ -1499,7 +1499,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                     if (isRequired.HasValue
                         && propertyType.IsNullableType())
                     {
-                        propertyBuilder.Required(isRequired.Value, ConfigurationSource.Convention);
+                        propertyBuilder.IsRequired(isRequired.Value, ConfigurationSource.Convention);
                     }
                     return propertyBuilder.Metadata;
                 }

--- a/src/EntityFramework.Core/Metadata/Internal/InternalPropertyBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/InternalPropertyBuilder.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             }
         }
 
-        public virtual bool Required(bool? isRequired, ConfigurationSource configurationSource)
+        public virtual bool IsRequired(bool? isRequired, ConfigurationSource configurationSource)
         {
             if (CanSetRequired(isRequired, configurationSource))
             {
@@ -79,7 +79,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             => configurationSource.CanSet(_isRequiredConfigurationSource, Metadata.IsNullable.HasValue)
                || ((IProperty)Metadata).IsNullable == !isRequired;
 
-        public virtual bool MaxLength(int? maxLength, ConfigurationSource configurationSource)
+        public virtual bool HasMaxLength(int? maxLength, ConfigurationSource configurationSource)
         {
             if (configurationSource.CanSet(_maxLengthConfigurationSource, Metadata.GetMaxLength().HasValue)
                 || Metadata.GetMaxLength().Value == maxLength)
@@ -93,7 +93,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             return false;
         }
 
-        public virtual bool ConcurrencyToken(bool? isConcurrencyToken, ConfigurationSource configurationSource)
+        public virtual bool IsConcurrencyToken(bool? isConcurrencyToken, ConfigurationSource configurationSource)
         {
             if (configurationSource.CanSet(_isConcurrencyTokenConfigurationSource, Metadata.IsConcurrencyToken.HasValue)
                 || Metadata.IsConcurrencyToken.Value == isConcurrencyToken)

--- a/src/EntityFramework.Core/Metadata/Internal/InternalRelationshipBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/InternalRelationshipBuilder.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
             foreach (var property in propertyBuilders)
             {
-                var requiredSet = property.Required(isRequired, configurationSource);
+                var requiredSet = property.IsRequired(isRequired, configurationSource);
                 if (requiredSet
                     && isRequired != true)
                 {
@@ -504,7 +504,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             {
                 _principalKeyConfigurationSource = configurationSource.Max(_principalKeyConfigurationSource);
                 var principalEntityTypeBuilder = ModelBuilder.Entity(Metadata.PrincipalKey.DeclaringEntityType.Name, configurationSource);
-                principalEntityTypeBuilder.Key(properties.Select(p => p.Name).ToList(), configurationSource);
+                principalEntityTypeBuilder.HasKey(properties.Select(p => p.Name).ToList(), configurationSource);
                 return this;
             }
 

--- a/src/EntityFramework.Relational.Design/ReverseEngineering/Configuration/KeyFluentApiConfiguration.cs
+++ b/src/EntityFramework.Relational.Design/ReverseEngineering/Configuration/KeyFluentApiConfiguration.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering.Configurati
             FluentApi = string.Format(
                 CultureInfo.InvariantCulture,
                 "{0}({1} => {2})",
-                nameof(EntityTypeBuilder.Key),
+                nameof(EntityTypeBuilder.HasKey),
                 lambdaIdentifier,
                 new ModelUtilities().GenerateLambdaToKey(properties, lambdaIdentifier));
         }

--- a/src/EntityFramework.Relational.Design/ReverseEngineering/Configuration/ModelConfiguration.cs
+++ b/src/EntityFramework.Relational.Design/ReverseEngineering/Configuration/ModelConfiguration.cs
@@ -240,7 +240,7 @@ namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering.Configurati
                 if (!entityKeyProperties.Contains(propertyConfiguration.Property))
                 {
                     propertyConfiguration.FluentApiConfigurations.Add(
-                        new FluentApiConfiguration(nameof(PropertyBuilder.Required))
+                        new FluentApiConfiguration(nameof(PropertyBuilder.IsRequired))
                         {
                             HasAttributeEquivalent = true
                         });
@@ -261,7 +261,7 @@ namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering.Configurati
                     CSharpUtilities.GenerateLiteral(
                         ((Property)propertyConfiguration.Property).GetMaxLength().Value);
                 propertyConfiguration.FluentApiConfigurations.Add(
-                    new FluentApiConfiguration(nameof(PropertyBuilder.MaxLength), maxLengthLiteral)
+                    new FluentApiConfiguration(nameof(PropertyBuilder.HasMaxLength), maxLengthLiteral)
                     {
                         HasAttributeEquivalent = true
                     });

--- a/src/EntityFramework.Relational.Design/ReverseEngineering/Internal/Templates/DbContextTemplate.cshtml
+++ b/src/EntityFramework.Relational.Design/ReverseEngineering/Internal/Templates/DbContextTemplate.cshtml
@@ -52,7 +52,7 @@
         string dependentEndLambdaIdentifier, string principalEndLambdaIdentifier)
     {
         var sb = new StringBuilder();
-        sb.Append("Reference(");
+        sb.Append("HasOne(");
         sb.Append(dependentEndLambdaIdentifier);
         sb.Append(" => ");
         sb.Append(dependentEndLambdaIdentifier);
@@ -62,11 +62,11 @@
 
         if (rc.ForeignKey.IsUnique)
         {
-            sb.Append(".InverseReference(");
+            sb.Append(".WithOne(");
         }
         else
         {
-            sb.Append(".InverseCollection(");
+            sb.Append(".WithMany(");
         }
         if (!string.IsNullOrEmpty(rc.PrincipalEndNavigationPropertyName))
         {

--- a/src/EntityFramework.Relational/Metadata/Internal/RelationalEntityTypeBuilderAnnotations.cs
+++ b/src/EntityFramework.Relational/Metadata/Internal/RelationalEntityTypeBuilderAnnotations.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var discriminatorSet = SetDiscriminatorProperty(propertyBuilder.Metadata);
             Debug.Assert(discriminatorSet);
 
-            propertyBuilder.Required(true, configurationSource);
+            propertyBuilder.IsRequired(true, configurationSource);
             //propertyBuilder.ReadOnlyBeforeSave(true, configurationSource);// #2132
             propertyBuilder.ReadOnlyAfterSave(true, configurationSource);
             propertyBuilder.UseValueGenerator(true, configurationSource);

--- a/src/EntityFramework.Relational/Migrations/HistoryRepository.cs
+++ b/src/EntityFramework.Relational/Migrations/HistoryRepository.cs
@@ -118,9 +118,9 @@ namespace Microsoft.Data.Entity.Migrations
         protected virtual void ConfigureTable([NotNull] EntityTypeBuilder<HistoryRow> history)
         {
             history.ToTable(DefaultTableName);
-            history.Key(h => h.MigrationId);
-            history.Property(h => h.MigrationId).MaxLength(150);
-            history.Property(h => h.ProductVersion).MaxLength(32).Required();
+            history.HasKey(h => h.MigrationId);
+            history.Property(h => h.MigrationId).HasMaxLength(150);
+            history.Property(h => h.ProductVersion).HasMaxLength(32).IsRequired();
         }
 
         public virtual IReadOnlyList<HistoryRow> GetAppliedMigrations()

--- a/src/EntityFramework.Sqlite.Design/ReverseEngineering/SqliteMetadataModelProvider.cs
+++ b/src/EntityFramework.Sqlite.Design/ReverseEngineering/SqliteMetadataModelProvider.cs
@@ -283,14 +283,14 @@ namespace Microsoft.Data.Entity.Sqlite.Design.ReverseEngineering
                                 }
                                 else
                                 {
-                                    property.Required(notNull);
+                                    property.IsRequired(notNull);
                                 }
                             }
                         }
 
                         if (keyProps.Count > 0)
                         {
-                            builder.Key(keyProps.ToArray());
+                            builder.HasKey(keyProps.ToArray());
                         }
                         else
                         {

--- a/test/EntityFramework.Commands.FunctionalTests/Migrations/ModelSnapshotTest.cs
+++ b/test/EntityFramework.Commands.FunctionalTests/Migrations/ModelSnapshotTest.cs
@@ -84,7 +84,7 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
         b.Property<int>(""Id"")
             .ValueGeneratedOnAdd();
 
-        b.Key(""Id"");
+        b.HasKey(""Id"");
     });
 
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", b =>
@@ -94,7 +94,7 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 
         b.Property<int>(""AlternateId"");
 
-        b.Key(""Id"");
+        b.HasKey(""Id"");
     });
 ",
                 o =>
@@ -122,7 +122,7 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
         b.Property<int>(""Id"")
             .ValueGeneratedOnAdd();
 
-        b.Key(""Id"");
+        b.HasKey(""Id"");
 
         b.Annotation(""AnnotationName"", ""AnnotationValue"");
     });
@@ -149,7 +149,7 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Bas
         b.Property<int>(""Id"")
             .ValueGeneratedOnAdd();
 
-        b.Key(""Id"");
+        b.HasKey(""Id"");
     });
 
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+AnotherDerivedEntity"", b =>
@@ -191,7 +191,7 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 
         b.Property<int>(""AlternateId"");
 
-        b.Key(""Id"");
+        b.HasKey(""Id"");
     });
 ",
                 o =>
@@ -209,7 +209,7 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
         public void Primary_key_is_stored_in_snapshot()
         {
             Test(
-                builder => { builder.Entity<EntityWithTwoProperties>().Key(t => new { t.Id, t.AlternateId }); },
+                builder => { builder.Entity<EntityWithTwoProperties>().HasKey(t => new { t.Id, t.AlternateId }); },
                 @"
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", b =>
     {
@@ -217,7 +217,7 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 
         b.Property<int>(""AlternateId"");
 
-        b.Key(""Id"", ""AlternateId"");
+        b.HasKey(""Id"", ""AlternateId"");
     });
 ",
                 o =>
@@ -235,7 +235,7 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
         public void Alternate_keys_are_stored_in_snapshot()
         {
             Test(
-                builder => { builder.Entity<EntityWithTwoProperties>().AlternateKey(t => new { t.Id, t.AlternateId }); },
+                builder => { builder.Entity<EntityWithTwoProperties>().HasAlternateKey(t => new { t.Id, t.AlternateId }); },
                 @"
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", b =>
     {
@@ -244,9 +244,9 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 
         b.Property<int>(""AlternateId"");
 
-        b.Key(""Id"");
+        b.HasKey(""Id"");
 
-        b.AlternateKey(""Id"", ""AlternateId"");
+        b.HasAlternateKey(""Id"", ""AlternateId"");
     });
 ",
                 o =>
@@ -272,7 +272,7 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 
         b.Property<int>(""AlternateId"");
 
-        b.Key(""Id"");
+        b.HasKey(""Id"");
 
         b.Index(""AlternateId"");
     });
@@ -297,7 +297,7 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 
         b.Property<int>(""AlternateId"");
 
-        b.Key(""Id"");
+        b.HasKey(""Id"");
 
         b.Index(""Id"", ""AlternateId"");
     });
@@ -316,14 +316,14 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
         public void Foreign_keys_are_stored_in_snapshot()
         {
             Test(
-                builder => { builder.Entity<EntityWithTwoProperties>().Reference<EntityWithOneProperty>().InverseReference().ForeignKey<EntityWithTwoProperties>(e => e.AlternateId); },
+                builder => { builder.Entity<EntityWithTwoProperties>().HasOne<EntityWithOneProperty>().WithOne().ForeignKey<EntityWithTwoProperties>(e => e.AlternateId); },
                 @"
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithOneProperty"", b =>
     {
         b.Property<int>(""Id"")
             .ValueGeneratedOnAdd();
 
-        b.Key(""Id"");
+        b.HasKey(""Id"");
     });
 
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", b =>
@@ -333,13 +333,13 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 
         b.Property<int>(""AlternateId"");
 
-        b.Key(""Id"");
+        b.HasKey(""Id"");
     });
 
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", b =>
     {
-        b.Reference(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithOneProperty"")
-            .InverseReference()
+        b.HasOne(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithOneProperty"")
+            .WithOne()
             .ForeignKey(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", ""AlternateId"");
     });
 ",
@@ -356,7 +356,7 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
             Test(
                 builder =>
                     {
-                        builder.Entity<EntityWithOneProperty>().Reference<EntityWithTwoProperties>().InverseReference()
+                        builder.Entity<EntityWithOneProperty>().HasOne<EntityWithTwoProperties>().WithOne()
                             .ForeignKey<EntityWithOneProperty>(e => e.Id).
                             PrincipalKey<EntityWithTwoProperties>(e => e.AlternateId);
                     },
@@ -365,7 +365,7 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
     {
         b.Property<int>(""Id"");
 
-        b.Key(""Id"");
+        b.HasKey(""Id"");
     });
 
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", b =>
@@ -375,13 +375,13 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 
         b.Property<int>(""AlternateId"");
 
-        b.Key(""Id"");
+        b.HasKey(""Id"");
     });
 
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithOneProperty"", b =>
     {
-        b.Reference(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"")
-            .InverseReference()
+        b.HasOne(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"")
+            .WithOne()
             .ForeignKey(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithOneProperty"", ""Id"")
             .PrincipalKey(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", ""AlternateId"");
     });
@@ -409,7 +409,7 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
             .ValueGeneratedOnAdd()
             .Annotation(""AnnotationName"", ""AnnotationValue"");
 
-        b.Key(""Id"");
+        b.HasKey(""Id"");
     });
 ",
                 o => { Assert.Equal("AnnotationValue", o.EntityTypes[0].GetProperty("Id")["AnnotationName"]); }
@@ -420,7 +420,7 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
         public void Property_isNullable_is_stored_in_snapshot()
         {
             Test(
-                builder => { builder.Entity<EntityWithStringProperty>().Property<string>("Name").Required(); },
+                builder => { builder.Entity<EntityWithStringProperty>().Property<string>("Name").IsRequired(); },
                 @"
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithStringProperty"", b =>
     {
@@ -428,9 +428,9 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
             .ValueGeneratedOnAdd();
 
         b.Property<string>(""Name"")
-            .Required();
+            .IsRequired();
 
-        b.Key(""Id"");
+        b.HasKey(""Id"");
     });
 ",
                 o => { Assert.Equal(false, o.EntityTypes[0].GetProperty("Name").IsNullable); });
@@ -450,7 +450,7 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
         b.Property<int>(""AlternateId"")
             .ValueGeneratedOnAdd();
 
-        b.Key(""Id"");
+        b.HasKey(""Id"");
     });
 ",
                 o => { Assert.Equal(ValueGenerated.OnAdd, o.EntityTypes[0].GetProperty("AlternateId").ValueGenerated); });
@@ -460,7 +460,7 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
         public void Property_maxLength_is_stored_in_snapshot()
         {
             Test(
-                builder => { builder.Entity<EntityWithStringProperty>().Property<string>("Name").MaxLength(100); },
+                builder => { builder.Entity<EntityWithStringProperty>().Property<string>("Name").HasMaxLength(100); },
                 @"
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithStringProperty"", b =>
     {
@@ -470,7 +470,7 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
         b.Property<string>(""Name"")
             .Annotation(""MaxLength"", 100);
 
-        b.Key(""Id"");
+        b.HasKey(""Id"");
     });
 ",
                 o => { Assert.Equal(100, o.EntityTypes[0].GetProperty("Name").GetMaxLength()); });
@@ -489,7 +489,7 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 
         b.Property<int>(""AlternateId"");
 
-        b.Key(""Id"");
+        b.HasKey(""Id"");
     });
 ",
                 o => { Assert.Equal(false, o.EntityTypes[0].GetProperty("AlternateId").RequiresValueGenerator); });
@@ -499,7 +499,7 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
         public void Property_concurrencyToken_is_stored_in_snapshot()
         {
             Test(
-                builder => { builder.Entity<EntityWithTwoProperties>().Property<int>("AlternateId").ConcurrencyToken(); },
+                builder => { builder.Entity<EntityWithTwoProperties>().Property<int>("AlternateId").IsConcurrencyToken(); },
                 @"
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", b =>
     {
@@ -507,9 +507,9 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
             .ValueGeneratedOnAdd();
 
         b.Property<int>(""AlternateId"")
-            .ConcurrencyToken();
+            .IsConcurrencyToken();
 
-        b.Key(""Id"");
+        b.HasKey(""Id"");
     });
 ",
                 o => { Assert.Equal(true, o.EntityTypes[0].GetProperty("AlternateId").IsConcurrencyToken); });
@@ -532,7 +532,7 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 
         b.Property<int>(""AlternateId"");
 
-        b.Key(""Id"");
+        b.HasKey(""Id"");
 
         b.Index(""AlternateId"")
             .Annotation(""AnnotationName"", ""AnnotationValue"");
@@ -554,7 +554,7 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 
         b.Property<int>(""AlternateId"");
 
-        b.Key(""Id"");
+        b.HasKey(""Id"");
 
         b.Index(""AlternateId"")
             .Unique();
@@ -574,8 +574,8 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
                 builder =>
                     {
                         builder.Entity<EntityWithTwoProperties>()
-                            .Reference<EntityWithOneProperty>()
-                            .InverseReference()
+                            .HasOne<EntityWithOneProperty>()
+                            .WithOne()
                             .ForeignKey<EntityWithTwoProperties>(e => e.AlternateId)
                             .Annotation("AnnotationName", "AnnotationValue");
                     },
@@ -585,7 +585,7 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
         b.Property<int>(""Id"")
             .ValueGeneratedOnAdd();
 
-        b.Key(""Id"");
+        b.HasKey(""Id"");
     });
 
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", b =>
@@ -595,13 +595,13 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 
         b.Property<int>(""AlternateId"");
 
-        b.Key(""Id"");
+        b.HasKey(""Id"");
     });
 
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", b =>
     {
-        b.Reference(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithOneProperty"")
-            .InverseReference()
+        b.HasOne(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithOneProperty"")
+            .WithOne()
             .ForeignKey(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", ""AlternateId"")
             .Annotation(""AnnotationName"", ""AnnotationValue"");
     });
@@ -616,8 +616,8 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
                 builder =>
                     {
                         builder.Entity<EntityWithStringProperty>()
-                            .Reference<EntityWithStringKey>()
-                            .InverseReference()
+                            .HasOne<EntityWithStringKey>()
+                            .WithOne()
                             .ForeignKey<EntityWithStringProperty>(e => e.Name)
                             .Required();
                     },
@@ -626,7 +626,7 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
     {
         b.Property<string>(""Id"");
 
-        b.Key(""Id"");
+        b.HasKey(""Id"");
     });
 
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithStringProperty"", b =>
@@ -635,15 +635,15 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
             .ValueGeneratedOnAdd();
 
         b.Property<string>(""Name"")
-            .Required();
+            .IsRequired();
 
-        b.Key(""Id"");
+        b.HasKey(""Id"");
     });
 
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithStringProperty"", b =>
     {
-        b.Reference(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithStringKey"")
-            .InverseReference()
+        b.HasOne(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithStringKey"")
+            .WithOne()
             .ForeignKey(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithStringProperty"", ""Name"");
     });
 ",
@@ -657,8 +657,8 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
                 builder =>
                     {
                         builder.Entity<EntityWithStringProperty>()
-                            .Reference<EntityWithStringKey>()
-                            .InverseCollection()
+                            .HasOne<EntityWithStringKey>()
+                            .WithMany()
                             .ForeignKey(e => e.Name);
                     },
                 @"
@@ -666,7 +666,7 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
     {
         b.Property<string>(""Id"");
 
-        b.Key(""Id"");
+        b.HasKey(""Id"");
     });
 
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithStringProperty"", b =>
@@ -676,13 +676,13 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 
         b.Property<string>(""Name"");
 
-        b.Key(""Id"");
+        b.HasKey(""Id"");
     });
 
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithStringProperty"", b =>
     {
-        b.Reference(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithStringKey"")
-            .InverseCollection()
+        b.HasOne(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithStringKey"")
+            .WithMany()
             .ForeignKey(""Name"");
     });
 ",

--- a/test/EntityFramework.Core.FunctionalTests/BuiltInDataTypesFixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/BuiltInDataTypesFixtureBase.cs
@@ -28,10 +28,10 @@ namespace Microsoft.Data.Entity.FunctionalTests
             modelBuilder.Entity<MaxLengthDataTypes>(b =>
                 {
                     b.Property(e => e.Id).ValueGeneratedNever();
-                    b.Property(e => e.ByteArray5).MaxLength(5);
-                    b.Property(e => e.String3).MaxLength(3);
-                    b.Property(e => e.ByteArray9000).MaxLength(9000);
-                    b.Property(e => e.String9000).MaxLength(9000);
+                    b.Property(e => e.ByteArray5).HasMaxLength(5);
+                    b.Property(e => e.String3).HasMaxLength(3);
+                    b.Property(e => e.ByteArray9000).HasMaxLength(9000);
+                    b.Property(e => e.String9000).HasMaxLength(9000);
                 });
         }
 

--- a/test/EntityFramework.Core.FunctionalTests/ComplexNavigationsQueryFixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/ComplexNavigationsQueryFixtureBase.cs
@@ -19,58 +19,58 @@ namespace Microsoft.Data.Entity.FunctionalTests
             modelBuilder.Entity<Level3>().Property(e => e.Id).ValueGeneratedNever();
             modelBuilder.Entity<Level4>().Property(e => e.Id).ValueGeneratedNever();
 
-            modelBuilder.Entity<Level1>().Reference(e => e.OneToOne_Required_PK).InverseReference(e => e.OneToOne_Required_PK_Inverse).PrincipalKey<Level1>(e => e.Id).Required(true);
-            modelBuilder.Entity<Level1>().Reference(e => e.OneToOne_Optional_PK).InverseReference(e => e.OneToOne_Optional_PK_Inverse).PrincipalKey<Level1>(e => e.Id).Required(false);
-            modelBuilder.Entity<Level1>().Reference(e => e.OneToOne_Required_FK).InverseReference(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level2>(e => e.Level1_Required_Id).Required(true);
-            modelBuilder.Entity<Level1>().Reference(e => e.OneToOne_Optional_FK).InverseReference(e => e.OneToOne_Optional_FK_Inverse).ForeignKey<Level2>(e => e.Level1_Optional_Id).Required(false);
-            modelBuilder.Entity<Level1>().Collection(e => e.OneToMany_Required).InverseReference(e => e.OneToMany_Required_Inverse).Required(true);
-            modelBuilder.Entity<Level1>().Collection(e => e.OneToMany_Optional).InverseReference(e => e.OneToMany_Optional_Inverse).Required(false);
-            modelBuilder.Entity<Level1>().Collection(e => e.OneToMany_Required_Self).InverseReference(e => e.OneToMany_Required_Self_Inverse).Required(true);
-            modelBuilder.Entity<Level1>().Collection(e => e.OneToMany_Optional_Self).InverseReference(e => e.OneToMany_Optional_Self_Inverse).Required(false);
+            modelBuilder.Entity<Level1>().HasOne(e => e.OneToOne_Required_PK).WithOne(e => e.OneToOne_Required_PK_Inverse).PrincipalKey<Level1>(e => e.Id).Required(true);
+            modelBuilder.Entity<Level1>().HasOne(e => e.OneToOne_Optional_PK).WithOne(e => e.OneToOne_Optional_PK_Inverse).PrincipalKey<Level1>(e => e.Id).Required(false);
+            modelBuilder.Entity<Level1>().HasOne(e => e.OneToOne_Required_FK).WithOne(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level2>(e => e.Level1_Required_Id).Required(true);
+            modelBuilder.Entity<Level1>().HasOne(e => e.OneToOne_Optional_FK).WithOne(e => e.OneToOne_Optional_FK_Inverse).ForeignKey<Level2>(e => e.Level1_Optional_Id).Required(false);
+            modelBuilder.Entity<Level1>().HasMany(e => e.OneToMany_Required).WithOne(e => e.OneToMany_Required_Inverse).Required(true);
+            modelBuilder.Entity<Level1>().HasMany(e => e.OneToMany_Optional).WithOne(e => e.OneToMany_Optional_Inverse).Required(false);
+            modelBuilder.Entity<Level1>().HasMany(e => e.OneToMany_Required_Self).WithOne(e => e.OneToMany_Required_Self_Inverse).Required(true);
+            modelBuilder.Entity<Level1>().HasMany(e => e.OneToMany_Optional_Self).WithOne(e => e.OneToMany_Optional_Self_Inverse).Required(false);
 
             // issue #1417
-            //modelBuilder.Entity<Level1>().Reference(e => e.OneToOne_Optional_Self).InverseReference(); 
+            //modelBuilder.Entity<Level1>().HasOne(e => e.OneToOne_Optional_Self).WithOne(); 
 
-            modelBuilder.Entity<Level2>().Reference(e => e.OneToOne_Required_PK).InverseReference(e => e.OneToOne_Required_PK_Inverse).PrincipalKey<Level2>(e => e.Id).Required(true);
-            modelBuilder.Entity<Level2>().Reference(e => e.OneToOne_Optional_PK).InverseReference(e => e.OneToOne_Optional_PK_Inverse).PrincipalKey<Level2>(e => e.Id).Required(false);
-            modelBuilder.Entity<Level2>().Reference(e => e.OneToOne_Required_FK).InverseReference(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level3>(e => e.Level2_Required_Id).Required(true);
-            modelBuilder.Entity<Level2>().Reference(e => e.OneToOne_Optional_FK).InverseReference(e => e.OneToOne_Optional_FK_Inverse).ForeignKey<Level3>(e => e.Level2_Optional_Id).Required(false);
-            modelBuilder.Entity<Level2>().Reference(e => e.OneToOne_Required_FK).InverseReference(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level3>(e => e.Level2_Required_Id).Required(true);
-            modelBuilder.Entity<Level2>().Reference(e => e.OneToOne_Optional_FK).InverseReference(e => e.OneToOne_Optional_FK_Inverse).ForeignKey<Level3>(e => e.Level2_Optional_Id).Required(false);
-            modelBuilder.Entity<Level2>().Collection(e => e.OneToMany_Required).InverseReference(e => e.OneToMany_Required_Inverse).Required(true);
-            modelBuilder.Entity<Level2>().Collection(e => e.OneToMany_Optional).InverseReference(e => e.OneToMany_Optional_Inverse).Required(false);
-            modelBuilder.Entity<Level2>().Collection(e => e.OneToMany_Required_Self).InverseReference(e => e.OneToMany_Required_Self_Inverse).Required(true);
-            modelBuilder.Entity<Level2>().Collection(e => e.OneToMany_Optional_Self).InverseReference(e => e.OneToMany_Optional_Self_Inverse).Required(false);
-
-            // issue #1417
-            //modelBuilder.Entity<Level2>().Reference(e => e.OneToOne_Optional_Self).InverseReference(); 
-
-            modelBuilder.Entity<Level3>().Reference(e => e.OneToOne_Required_PK).InverseReference(e => e.OneToOne_Required_PK_Inverse).PrincipalKey<Level3>(e => e.Id).Required(true);
-            modelBuilder.Entity<Level3>().Reference(e => e.OneToOne_Optional_PK).InverseReference(e => e.OneToOne_Optional_PK_Inverse).PrincipalKey<Level3>(e => e.Id).Required(false);
-            modelBuilder.Entity<Level3>().Reference(e => e.OneToOne_Required_FK).InverseReference(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level4>(e => e.Level3_Required_Id).Required(true);
-            modelBuilder.Entity<Level3>().Reference(e => e.OneToOne_Optional_FK).InverseReference(e => e.OneToOne_Optional_FK_Inverse).ForeignKey<Level4>(e => e.Level3_Optional_Id).Required(false);
-            modelBuilder.Entity<Level3>().Collection(e => e.OneToMany_Required).InverseReference(e => e.OneToMany_Required_Inverse).Required(true);
-            modelBuilder.Entity<Level3>().Collection(e => e.OneToMany_Optional).InverseReference(e => e.OneToMany_Optional_Inverse).Required(false);
-            modelBuilder.Entity<Level3>().Collection(e => e.OneToMany_Required_Self).InverseReference(e => e.OneToMany_Required_Self_Inverse).Required(true);
-            modelBuilder.Entity<Level3>().Collection(e => e.OneToMany_Optional_Self).InverseReference(e => e.OneToMany_Optional_Self_Inverse).Required(false);
+            modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Required_PK).WithOne(e => e.OneToOne_Required_PK_Inverse).PrincipalKey<Level2>(e => e.Id).Required(true);
+            modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Optional_PK).WithOne(e => e.OneToOne_Optional_PK_Inverse).PrincipalKey<Level2>(e => e.Id).Required(false);
+            modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Required_FK).WithOne(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level3>(e => e.Level2_Required_Id).Required(true);
+            modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Optional_FK).WithOne(e => e.OneToOne_Optional_FK_Inverse).ForeignKey<Level3>(e => e.Level2_Optional_Id).Required(false);
+            modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Required_FK).WithOne(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level3>(e => e.Level2_Required_Id).Required(true);
+            modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Optional_FK).WithOne(e => e.OneToOne_Optional_FK_Inverse).ForeignKey<Level3>(e => e.Level2_Optional_Id).Required(false);
+            modelBuilder.Entity<Level2>().HasMany(e => e.OneToMany_Required).WithOne(e => e.OneToMany_Required_Inverse).Required(true);
+            modelBuilder.Entity<Level2>().HasMany(e => e.OneToMany_Optional).WithOne(e => e.OneToMany_Optional_Inverse).Required(false);
+            modelBuilder.Entity<Level2>().HasMany(e => e.OneToMany_Required_Self).WithOne(e => e.OneToMany_Required_Self_Inverse).Required(true);
+            modelBuilder.Entity<Level2>().HasMany(e => e.OneToMany_Optional_Self).WithOne(e => e.OneToMany_Optional_Self_Inverse).Required(false);
 
             // issue #1417
-            //modelBuilder.Entity<Level3>().Reference(e => e.OneToOne_Optional_Self).InverseReference();
+            //modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Optional_Self).WithOne(); 
 
-            modelBuilder.Entity<Level4>().Collection(e => e.OneToMany_Required_Self).InverseReference(e => e.OneToMany_Required_Self_Inverse).Required(true);
-            modelBuilder.Entity<Level4>().Collection(e => e.OneToMany_Optional_Self).InverseReference(e => e.OneToMany_Optional_Self_Inverse).Required(false);
+            modelBuilder.Entity<Level3>().HasOne(e => e.OneToOne_Required_PK).WithOne(e => e.OneToOne_Required_PK_Inverse).PrincipalKey<Level3>(e => e.Id).Required(true);
+            modelBuilder.Entity<Level3>().HasOne(e => e.OneToOne_Optional_PK).WithOne(e => e.OneToOne_Optional_PK_Inverse).PrincipalKey<Level3>(e => e.Id).Required(false);
+            modelBuilder.Entity<Level3>().HasOne(e => e.OneToOne_Required_FK).WithOne(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level4>(e => e.Level3_Required_Id).Required(true);
+            modelBuilder.Entity<Level3>().HasOne(e => e.OneToOne_Optional_FK).WithOne(e => e.OneToOne_Optional_FK_Inverse).ForeignKey<Level4>(e => e.Level3_Optional_Id).Required(false);
+            modelBuilder.Entity<Level3>().HasMany(e => e.OneToMany_Required).WithOne(e => e.OneToMany_Required_Inverse).Required(true);
+            modelBuilder.Entity<Level3>().HasMany(e => e.OneToMany_Optional).WithOne(e => e.OneToMany_Optional_Inverse).Required(false);
+            modelBuilder.Entity<Level3>().HasMany(e => e.OneToMany_Required_Self).WithOne(e => e.OneToMany_Required_Self_Inverse).Required(true);
+            modelBuilder.Entity<Level3>().HasMany(e => e.OneToMany_Optional_Self).WithOne(e => e.OneToMany_Optional_Self_Inverse).Required(false);
 
-            modelBuilder.Entity<ComplexNavigationField>().Key(e => e.Name);
-            modelBuilder.Entity<ComplexNavigationString>().Key(e => e.DefaultText);
-            modelBuilder.Entity<ComplexNavigationGlobalization>().Key(e => e.Text);
-            modelBuilder.Entity<ComplexNavigationLanguage>().Key(e => e.Name);
+            // issue #1417
+            //modelBuilder.Entity<Level3>().HasOne(e => e.OneToOne_Optional_Self).WithOne();
 
-            modelBuilder.Entity<ComplexNavigationField>().Reference(f => f.Label);
-            modelBuilder.Entity<ComplexNavigationField>().Reference(f => f.Placeholder);
+            modelBuilder.Entity<Level4>().HasMany(e => e.OneToMany_Required_Self).WithOne(e => e.OneToMany_Required_Self_Inverse).Required(true);
+            modelBuilder.Entity<Level4>().HasMany(e => e.OneToMany_Optional_Self).WithOne(e => e.OneToMany_Optional_Self_Inverse).Required(false);
 
-            modelBuilder.Entity<ComplexNavigationString>().Collection(m => m.Globalizations);
+            modelBuilder.Entity<ComplexNavigationField>().HasKey(e => e.Name);
+            modelBuilder.Entity<ComplexNavigationString>().HasKey(e => e.DefaultText);
+            modelBuilder.Entity<ComplexNavigationGlobalization>().HasKey(e => e.Text);
+            modelBuilder.Entity<ComplexNavigationLanguage>().HasKey(e => e.Name);
 
-            modelBuilder.Entity<ComplexNavigationGlobalization>().Reference(g => g.Language);
+            modelBuilder.Entity<ComplexNavigationField>().HasOne(f => f.Label);
+            modelBuilder.Entity<ComplexNavigationField>().HasOne(f => f.Placeholder);
+
+            modelBuilder.Entity<ComplexNavigationString>().HasMany(m => m.Globalizations);
+
+            modelBuilder.Entity<ComplexNavigationGlobalization>().HasOne(g => g.Language);
         }
     }
 }

--- a/test/EntityFramework.Core.FunctionalTests/DatabaseErrorLogStateTest.cs
+++ b/test/EntityFramework.Core.FunctionalTests/DatabaseErrorLogStateTest.cs
@@ -175,7 +175,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
             protected override void OnModelCreating(ModelBuilder modelBuilder)
             {
-                modelBuilder.Entity<Blog>().Key(b => b.Url);
+                modelBuilder.Entity<Blog>().HasKey(b => b.Url);
             }
 
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)

--- a/test/EntityFramework.Core.FunctionalTests/F1FixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/F1FixtureBase.cs
@@ -18,23 +18,23 @@ namespace Microsoft.Data.Entity.FunctionalTests
             //builder.ComplexType<Location>();
             modelBuilder.Entity<Chassis>(b =>
                 {
-                    b.Key(c => c.TeamId);
+                    b.HasKey(c => c.TeamId);
                     b.Property(e => e.Version)
                         .ValueGeneratedOnAddOrUpdate()
-                        .ConcurrencyToken();
+                        .IsConcurrencyToken();
                 });
 
             modelBuilder.Entity<Driver>(b =>
                 {
                     b.Property(e => e.Version)
                         .ValueGeneratedOnAddOrUpdate()
-                        .ConcurrencyToken();
+                        .IsConcurrencyToken();
                 });
 
             modelBuilder.Entity<Engine>(b =>
                 {
-                    b.Property(e => e.EngineSupplierId).ConcurrencyToken();
-                    b.Property(e => e.Name).ConcurrencyToken();
+                    b.Property(e => e.EngineSupplierId).IsConcurrencyToken();
+                    b.Property(e => e.Name).IsConcurrencyToken();
                 });
 
             // TODO: Complex type
@@ -60,7 +60,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 {
                     b.Property(e => e.Version)
                         .ValueGeneratedOnAddOrUpdate()
-                        .ConcurrencyToken();
+                        .IsConcurrencyToken();
                 });
 
             // TODO: Complex type
@@ -77,10 +77,10 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 {
                     b.Property(t => t.Version)
                         .ValueGeneratedOnAddOrUpdate()
-                        .ConcurrencyToken();
+                        .IsConcurrencyToken();
 
-                    b.Reference(e => e.Gearbox).InverseReference().ForeignKey<Team>(e => e.GearboxId);
-                    b.Reference(e => e.Chassis).InverseReference(e => e.Team).ForeignKey<Chassis>(e => e.TeamId);
+                    b.HasOne(e => e.Gearbox).WithOne().ForeignKey<Team>(e => e.GearboxId);
+                    b.HasOne(e => e.Chassis).WithOne(e => e.Team).ForeignKey<Chassis>(e => e.TeamId);
                 });
 
             modelBuilder.Entity<TestDriver>();

--- a/test/EntityFramework.Core.FunctionalTests/FixupTest.cs
+++ b/test/EntityFramework.Core.FunctionalTests/FixupTest.cs
@@ -246,12 +246,12 @@ namespace Microsoft.Data.Entity.FunctionalTests
             {
                 modelBuilder.Entity<Product>(b =>
                     {
-                        b.Collection(e => e.SpecialOffers).InverseReference(e => e.Product);
+                        b.HasMany(e => e.SpecialOffers).WithOne(e => e.Product);
                     });
 
                 modelBuilder.Entity<Category>(b =>
                     {
-                        b.Collection(e => e.Products).InverseReference(e => e.Category);
+                        b.HasMany(e => e.Products).WithOne(e => e.Category);
                     });
             }
 

--- a/test/EntityFramework.Core.FunctionalTests/GearsOfWarQueryFixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/GearsOfWarQueryFixtureBase.cs
@@ -14,33 +14,33 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
         protected virtual void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.Entity<City>().Key(c => c.Name);
+            modelBuilder.Entity<City>().HasKey(c => c.Name);
 
             modelBuilder.Entity<Gear>(b =>
                 {
-                    b.Key(g => new { g.Nickname, g.SquadId });
+                    b.HasKey(g => new { g.Nickname, g.SquadId });
 
-                    b.Reference(g => g.CityOfBirth).InverseCollection(c => c.BornGears).ForeignKey(g => g.CityOrBirthName).Required();
-                    b.Collection(g => g.Reports).InverseReference().ForeignKey(g => new { g.LeaderNickname, g.LeaderSquadId });
-                    b.Reference(g => g.Tag).InverseReference(t => t.Gear).ForeignKey<CogTag>(t => new { t.GearNickName, t.GearSquadId });
-                    b.Reference(g => g.AssignedCity).InverseCollection(c => c.StationedGears).Required(false);
+                    b.HasOne(g => g.CityOfBirth).WithMany(c => c.BornGears).ForeignKey(g => g.CityOrBirthName).Required();
+                    b.HasMany(g => g.Reports).WithOne().ForeignKey(g => new { g.LeaderNickname, g.LeaderSquadId });
+                    b.HasOne(g => g.Tag).WithOne(t => t.Gear).ForeignKey<CogTag>(t => new { t.GearNickName, t.GearSquadId });
+                    b.HasOne(g => g.AssignedCity).WithMany(c => c.StationedGears).Required(false);
                 });
 
             modelBuilder.Entity<CogTag>(b =>
                 {
-                    b.Key(t => t.Id);
+                    b.HasKey(t => t.Id);
                 });
 
             modelBuilder.Entity<Squad>(b =>
                 {
-                    b.Key(s => s.Id);
-                    b.Collection(s => s.Members).InverseReference(g => g.Squad).ForeignKey(g => g.SquadId);
+                    b.HasKey(s => s.Id);
+                    b.HasMany(s => s.Members).WithOne(g => g.Squad).ForeignKey(g => g.SquadId);
                 });
 
             modelBuilder.Entity<Weapon>(b =>
                 {
-                    b.Reference(w => w.SynergyWith).InverseReference().ForeignKey<Weapon>(w => w.SynergyWithId);
-                    b.Reference(w => w.Owner).InverseCollection(g => g.Weapons).ForeignKey(w => w.OwnerFullName).PrincipalKey(g => g.FullName);
+                    b.HasOne(w => w.SynergyWith).WithOne().ForeignKey<Weapon>(w => w.SynergyWithId);
+                    b.HasOne(w => w.Owner).WithMany(g => g.Weapons).ForeignKey(w => w.OwnerFullName).PrincipalKey(g => g.FullName);
                 });
         }
     }

--- a/test/EntityFramework.Core.FunctionalTests/GraphUpdatesTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/GraphUpdatesTestBase.cs
@@ -2370,83 +2370,83 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     {
                         b.Property(e => e.AlternateId).ValueGeneratedOnAdd();
 
-                        b.Collection(e => e.RequiredChildren)
-                            .InverseReference(e => e.Parent)
+                        b.HasMany(e => e.RequiredChildren)
+                            .WithOne(e => e.Parent)
                             .ForeignKey(e => e.ParentId)
                             .WillCascadeOnDelete();
 
-                        b.Collection(e => e.OptionalChildren)
-                            .InverseReference(e => e.Parent)
+                        b.HasMany(e => e.OptionalChildren)
+                            .WithOne(e => e.Parent)
                             .ForeignKey(e => e.ParentId);
 
-                        b.Reference(e => e.RequiredSingle)
-                            .InverseReference(e => e.Root)
+                        b.HasOne(e => e.RequiredSingle)
+                            .WithOne(e => e.Root)
                             .ForeignKey<RequiredSingle1>(e => e.Id)
                             .WillCascadeOnDelete();
 
-                        b.Reference(e => e.OptionalSingle)
-                            .InverseReference(e => e.Root)
+                        b.HasOne(e => e.OptionalSingle)
+                            .WithOne(e => e.Root)
                             .ForeignKey<OptionalSingle1>(e => e.RootId);
 
-                        b.Reference(e => e.RequiredNonPkSingle)
-                            .InverseReference(e => e.Root)
+                        b.HasOne(e => e.RequiredNonPkSingle)
+                            .WithOne(e => e.Root)
                             .ForeignKey<RequiredNonPkSingle1>(e => e.RootId)
                             .WillCascadeOnDelete();
 
-                        b.Collection(e => e.RequiredChildrenAk)
-                            .InverseReference(e => e.Parent)
+                        b.HasMany(e => e.RequiredChildrenAk)
+                            .WithOne(e => e.Parent)
                             .PrincipalKey(e => e.AlternateId)
                             .ForeignKey(e => e.ParentId)
                             .WillCascadeOnDelete();
 
-                        b.Collection(e => e.OptionalChildrenAk)
-                            .InverseReference(e => e.Parent)
+                        b.HasMany(e => e.OptionalChildrenAk)
+                            .WithOne(e => e.Parent)
                             .PrincipalKey(e => e.AlternateId)
                             .ForeignKey(e => e.ParentId);
 
-                        b.Reference(e => e.RequiredSingleAk)
-                            .InverseReference(e => e.Root)
+                        b.HasOne(e => e.RequiredSingleAk)
+                            .WithOne(e => e.Root)
                             .PrincipalKey<Root>(e => e.AlternateId)
                             .ForeignKey<RequiredSingleAk1>(e => e.RootId)
                             .WillCascadeOnDelete();
 
-                        b.Reference(e => e.OptionalSingleAk)
-                            .InverseReference(e => e.Root)
+                        b.HasOne(e => e.OptionalSingleAk)
+                            .WithOne(e => e.Root)
                             .PrincipalKey<Root>(e => e.AlternateId)
                             .ForeignKey<OptionalSingleAk1>(e => e.RootId);
 
-                        b.Reference(e => e.RequiredNonPkSingleAk)
-                            .InverseReference(e => e.Root)
+                        b.HasOne(e => e.RequiredNonPkSingleAk)
+                            .WithOne(e => e.Root)
                             .PrincipalKey<Root>(e => e.AlternateId)
                             .ForeignKey<RequiredNonPkSingleAk1>(e => e.RootId)
                             .WillCascadeOnDelete();
                     });
 
                 modelBuilder.Entity<Required1>()
-                    .Collection(e => e.Children)
-                    .InverseReference(e => e.Parent)
+                    .HasMany(e => e.Children)
+                    .WithOne(e => e.Parent)
                     .ForeignKey(e => e.ParentId)
                     .WillCascadeOnDelete();
 
                 modelBuilder.Entity<Optional1>()
-                    .Collection(e => e.Children)
-                    .InverseReference(e => e.Parent)
+                    .HasMany(e => e.Children)
+                    .WithOne(e => e.Parent)
                     .ForeignKey(e => e.ParentId);
 
                 modelBuilder.Entity<RequiredSingle1>()
-                    .Reference(e => e.Single)
-                    .InverseReference(e => e.Back)
+                    .HasOne(e => e.Single)
+                    .WithOne(e => e.Back)
                     .ForeignKey<RequiredSingle2>(e => e.Id)
                     .WillCascadeOnDelete();
 
                 modelBuilder.Entity<OptionalSingle1>()
-                    .Reference(e => e.Single)
-                    .InverseReference(e => e.Back)
+                    .HasOne(e => e.Single)
+                    .WithOne(e => e.Back)
                     .ForeignKey<OptionalSingle2>(e => e.BackId);
 
                 modelBuilder.Entity<RequiredNonPkSingle1>()
-                    .Reference(e => e.Single)
-                    .InverseReference(e => e.Back)
+                    .HasOne(e => e.Single)
+                    .WithOne(e => e.Back)
                     .ForeignKey<RequiredNonPkSingle2>(e => e.BackId)
                     .WillCascadeOnDelete();
 
@@ -2455,8 +2455,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
                         b.Property(e => e.AlternateId)
                             .ValueGeneratedOnAdd();
 
-                        b.Collection(e => e.Children)
-                            .InverseReference(e => e.Parent)
+                        b.HasMany(e => e.Children)
+                            .WithOne(e => e.Parent)
                             .PrincipalKey(e => e.AlternateId)
                             .ForeignKey(e => e.ParentId)
                             .WillCascadeOnDelete();
@@ -2467,8 +2467,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
                         b.Property(e => e.AlternateId)
                             .ValueGeneratedOnAdd();
 
-                        b.Collection(e => e.Children)
-                            .InverseReference(e => e.Parent)
+                        b.HasMany(e => e.Children)
+                            .WithOne(e => e.Parent)
                             .PrincipalKey(e => e.AlternateId)
                             .ForeignKey(e => e.ParentId);
                     });
@@ -2478,8 +2478,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
                         b.Property(e => e.AlternateId)
                             .ValueGeneratedOnAdd();
 
-                        b.Reference(e => e.Single)
-                            .InverseReference(e => e.Back)
+                        b.HasOne(e => e.Single)
+                            .WithOne(e => e.Back)
                             .ForeignKey<RequiredSingleAk2>(e => e.BackId)
                             .PrincipalKey<RequiredSingleAk1>(e => e.AlternateId)
                             .WillCascadeOnDelete();
@@ -2490,8 +2490,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
                         b.Property(e => e.AlternateId)
                             .ValueGeneratedOnAdd();
 
-                        b.Reference(e => e.Single)
-                            .InverseReference(e => e.Back)
+                        b.HasOne(e => e.Single)
+                            .WithOne(e => e.Back)
                             .ForeignKey<OptionalSingleAk2>(e => e.BackId)
                             .PrincipalKey<OptionalSingleAk1>(e => e.AlternateId);
                     });
@@ -2501,8 +2501,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
                         b.Property(e => e.AlternateId)
                             .ValueGeneratedOnAdd();
 
-                        b.Reference(e => e.Single)
-                            .InverseReference(e => e.Back)
+                        b.HasOne(e => e.Single)
+                            .WithOne(e => e.Back)
                             .ForeignKey<RequiredNonPkSingleAk2>(e => e.BackId)
                             .PrincipalKey<RequiredNonPkSingleAk1>(e => e.AlternateId)
                             .WillCascadeOnDelete();

--- a/test/EntityFramework.Core.FunctionalTests/InheritanceFixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/InheritanceFixtureBase.cs
@@ -14,11 +14,11 @@ namespace Microsoft.Data.Entity.FunctionalTests
             modelBuilder.Entity<Kiwi>().BaseType<Bird>();
             modelBuilder.Entity<Eagle>().BaseType<Bird>();
             modelBuilder.Entity<Bird>().BaseType<Animal>();
-            modelBuilder.Entity<Animal>().Key(e => e.Species);
+            modelBuilder.Entity<Animal>().HasKey(e => e.Species);
             modelBuilder.Entity<Rose>().BaseType<Flower>();
             modelBuilder.Entity<Daisy>().BaseType<Flower>();
             modelBuilder.Entity<Flower>().BaseType<Plant>();
-            modelBuilder.Entity<Plant>().Key(e => e.Species);
+            modelBuilder.Entity<Plant>().HasKey(e => e.Species);
             modelBuilder.Entity<Country>();
         }
 

--- a/test/EntityFramework.Core.FunctionalTests/NorthwindQueryFixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/NorthwindQueryFixtureBase.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     e.Ignore(em => em.Region);
                     e.Ignore(em => em.TitleOfCourtesy);
 
-                    e.Reference(e1 => e1.Manager).InverseCollection().ForeignKey(e1 => e1.ReportsTo);
+                    e.HasOne(e1 => e1.Manager).WithMany().ForeignKey(e1 => e1.ReportsTo);
                 });
 
             modelBuilder.Entity<Product>(e =>
@@ -52,7 +52,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     e.Ignore(o => o.ShippedDate);
                 });
 
-            modelBuilder.Entity<OrderDetail>(e => { e.Key(od => new { od.OrderID, od.ProductID }); });
+            modelBuilder.Entity<OrderDetail>(e => { e.HasKey(od => new { od.OrderID, od.ProductID }); });
         }
 
         public abstract NorthwindContext CreateContext();

--- a/test/EntityFramework.Core.FunctionalTests/NullKeysTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/NullKeysTestBase.cs
@@ -185,27 +185,27 @@ namespace Microsoft.Data.Entity.FunctionalTests
             public virtual void OnModelCreating(ModelBuilder modelBuilder)
             {
                 modelBuilder.Entity<WithStringKey>()
-                    .Collection(e => e.Dependents).InverseReference(e => e.Principal)
+                    .HasMany(e => e.Dependents).WithOne(e => e.Principal)
                     .ForeignKey(e => e.Fk);
 
                 modelBuilder.Entity<WithStringFk>()
-                    .Reference<WithStringFk>()
-                    .InverseReference(e => e.Self)
+                    .HasOne<WithStringFk>()
+                    .WithOne(e => e.Self)
                     .ForeignKey<WithStringFk>(e => e.SelfFk);
 
                 modelBuilder.Entity<WithIntKey>(b =>
                     {
                         b.Property(e => e.Id).ValueGeneratedNever();
-                        b.Collection(e => e.Dependents)
-                            .InverseReference(e => e.Principal)
+                        b.HasMany(e => e.Dependents)
+                            .WithOne(e => e.Principal)
                             .ForeignKey(e => e.Fk);
                     });
 
                 modelBuilder.Entity<WithNullableIntKey>(b =>
                     {
                         b.Property(e => e.Id).ValueGeneratedNever();
-                        b.Collection(e => e.Dependents)
-                            .InverseReference(e => e.Principal)
+                        b.HasMany(e => e.Dependents)
+                            .WithOne(e => e.Principal)
                             .ForeignKey(e => e.Fk);
                     });
 

--- a/test/EntityFramework.Core.FunctionalTests/OneToOneQueryFixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/OneToOneQueryFixtureBase.cs
@@ -8,14 +8,14 @@ namespace Microsoft.Data.Entity.FunctionalTests
         protected virtual void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder
-                .Entity<Address>(e => e.Reference(a => a.Resident).InverseReference(p => p.Address)
+                .Entity<Address>(e => e.HasOne(a => a.Resident).WithOne(p => p.Address)
                     .PrincipalKey<Person>(person => person.Id));
 
             modelBuilder.Entity<Address2>().Property<int>("PersonId");
 
             modelBuilder
                 .Entity<Person2>(
-                    e => e.Reference(p => p.Address).InverseReference(a => a.Resident)
+                    e => e.HasOne(p => p.Address).WithOne(a => a.Resident)
                         .ForeignKey(typeof(Address2), "PersonId"));
         }
 

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/MonsterContext`.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/MonsterContext`.cs
@@ -216,170 +216,170 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
             modelBuilder.Ignore<ContactDetails>();
             modelBuilder.Ignore<Dimensions>();
 
-            modelBuilder.Entity<TBarcodeDetail>().Key(e => e.Code);
+            modelBuilder.Entity<TBarcodeDetail>().HasKey(e => e.Code);
 
             modelBuilder.Entity<TSuspiciousActivity>();
-            modelBuilder.Entity<TLastLogin>().Key(e => e.Username);
-            modelBuilder.Entity<TMessage>().Key(e => new { e.MessageId, e.FromUsername });
+            modelBuilder.Entity<TLastLogin>().HasKey(e => e.Username);
+            modelBuilder.Entity<TMessage>().HasKey(e => new { e.MessageId, e.FromUsername });
 
-            modelBuilder.Entity<TOrderNote>().Key(e => e.NoteId);
+            modelBuilder.Entity<TOrderNote>().HasKey(e => e.NoteId);
 
-            modelBuilder.Entity<TProductDetail>().Key(e => e.ProductId);
+            modelBuilder.Entity<TProductDetail>().HasKey(e => e.ProductId);
 
-            modelBuilder.Entity<TProductWebFeature>().Key(e => e.FeatureId);
+            modelBuilder.Entity<TProductWebFeature>().HasKey(e => e.FeatureId);
 
-            modelBuilder.Entity<TSupplierLogo>().Key(e => e.SupplierId);
+            modelBuilder.Entity<TSupplierLogo>().HasKey(e => e.SupplierId);
 
-            modelBuilder.Entity<TLicense>().Key(e => e.Name);
+            modelBuilder.Entity<TLicense>().HasKey(e => e.Name);
 
             modelBuilder.Entity<TAnOrder>(b =>
                 {
-                    b.Collection(e => (IEnumerable<TOrderLine>)e.OrderLines).InverseReference(e => (TAnOrder)e.Order)
+                    b.HasMany(e => (IEnumerable<TOrderLine>)e.OrderLines).WithOne(e => (TAnOrder)e.Order)
                         .ForeignKey(e => e.OrderId);
 
-                    b.Collection(e => (IEnumerable<TOrderNote>)e.Notes).InverseReference(e => (TAnOrder)e.Order)
+                    b.HasMany(e => (IEnumerable<TOrderNote>)e.Notes).WithOne(e => (TAnOrder)e.Order)
                         .PrincipalKey(e => e.AlternateId);
                 });
 
             modelBuilder.Entity<TOrderQualityCheck>(b =>
                 {
-                    b.Key(e => e.OrderId);
+                    b.HasKey(e => e.OrderId);
 
-                    b.Reference(e => (TAnOrder)e.Order).InverseReference()
+                    b.HasOne(e => (TAnOrder)e.Order).WithOne()
                         .ForeignKey<TOrderQualityCheck>(e => e.OrderId)
                         .PrincipalKey<TAnOrder>(e => e.AlternateId);
                 });
 
             modelBuilder.Entity<TProduct>(b =>
                 {
-                    b.Collection(e => (IEnumerable<TProductReview>)e.Reviews).InverseReference(e => (TProduct)e.Product);
-                    b.Collection(e => (IEnumerable<TBarcode>)e.Barcodes).InverseReference(e => (TProduct)e.Product);
-                    b.Collection(e => (IEnumerable<TProductPhoto>)e.Photos).InverseReference();
-                    b.Reference(e => (TProductDetail)e.Detail).InverseReference(e => (TProduct)e.Product)
+                    b.HasMany(e => (IEnumerable<TProductReview>)e.Reviews).WithOne(e => (TProduct)e.Product);
+                    b.HasMany(e => (IEnumerable<TBarcode>)e.Barcodes).WithOne(e => (TProduct)e.Product);
+                    b.HasMany(e => (IEnumerable<TProductPhoto>)e.Photos).WithOne();
+                    b.HasOne(e => (TProductDetail)e.Detail).WithOne(e => (TProduct)e.Product)
                         .ForeignKey<TProductDetail>(e => e.ProductId);
                 });
 
             modelBuilder.Entity<TOrderLine>(b =>
                 {
-                    b.Key(e => new { e.OrderId, e.ProductId });
+                    b.HasKey(e => new { e.OrderId, e.ProductId });
 
-                    b.Reference(e => (TProduct)e.Product).InverseCollection().ForeignKey(e => e.ProductId);
+                    b.HasOne(e => (TProduct)e.Product).WithMany().ForeignKey(e => e.ProductId);
                 });
 
-            modelBuilder.Entity<TSupplier>().Reference(e => (TSupplierLogo)e.Logo).InverseReference().ForeignKey<TSupplierLogo>(e => e.SupplierId);
+            modelBuilder.Entity<TSupplier>().HasOne(e => (TSupplierLogo)e.Logo).WithOne().ForeignKey<TSupplierLogo>(e => e.SupplierId);
 
             modelBuilder.Entity<TCustomer>(b =>
                 {
-                    b.Collection(e => (IEnumerable<TAnOrder>)e.Orders).InverseReference(e => (TCustomer)e.Customer);
-                    b.Collection(e => (IEnumerable<TLogin>)e.Logins).InverseReference(e => (TCustomer)e.Customer);
-                    b.Reference(e => (TCustomerInfo)e.Info).InverseReference().ForeignKey<TCustomerInfo>(e => e.CustomerInfoId);
+                    b.HasMany(e => (IEnumerable<TAnOrder>)e.Orders).WithOne(e => (TCustomer)e.Customer);
+                    b.HasMany(e => (IEnumerable<TLogin>)e.Logins).WithOne(e => (TCustomer)e.Customer);
+                    b.HasOne(e => (TCustomerInfo)e.Info).WithOne().ForeignKey<TCustomerInfo>(e => e.CustomerInfoId);
 
-                    b.Reference(e => (TCustomer)e.Husband).InverseReference(e => (TCustomer)e.Wife)
+                    b.HasOne(e => (TCustomer)e.Husband).WithOne(e => (TCustomer)e.Wife)
                         .ForeignKey<TCustomer>(e => e.HusbandId);
                 });
 
             modelBuilder.Entity<TComplaint>(b =>
                 {
-                    b.Reference(e => (TCustomer)e.Customer)
-                        .InverseCollection()
+                    b.HasOne(e => (TCustomer)e.Customer)
+                        .WithMany()
                         .ForeignKey(e => e.CustomerId);
 
-                    b.Reference(e => (TResolution)e.Resolution).InverseReference(e => (TComplaint)e.Complaint)
+                    b.HasOne(e => (TResolution)e.Resolution).WithOne(e => (TComplaint)e.Complaint)
                         .PrincipalKey<TComplaint>(e => e.AlternateId);
                 });
 
             modelBuilder.Entity<TProductPhoto>(b =>
                 {
-                    b.Key(e => new { e.PhotoId, e.ProductId });
+                    b.HasKey(e => new { e.PhotoId, e.ProductId });
 
-                    b.Collection(e => (IEnumerable<TProductWebFeature>)e.Features).InverseReference(e => (TProductPhoto)e.Photo)
+                    b.HasMany(e => (IEnumerable<TProductWebFeature>)e.Features).WithOne(e => (TProductPhoto)e.Photo)
                         .ForeignKey(e => new { e.PhotoId, e.ProductId })
                         .PrincipalKey(e => new { e.PhotoId, e.ProductId });
                 });
 
             modelBuilder.Entity<TProductReview>(b =>
                 {
-                    b.Key(e => new { e.ReviewId, e.ProductId });
+                    b.HasKey(e => new { e.ReviewId, e.ProductId });
 
-                    b.Collection(e => (IEnumerable<TProductWebFeature>)e.Features).InverseReference(e => (TProductReview)e.Review)
+                    b.HasMany(e => (IEnumerable<TProductWebFeature>)e.Features).WithOne(e => (TProductReview)e.Review)
                         .ForeignKey(e => new { e.ReviewId, e.ProductId })
                         .PrincipalKey(e => new { e.ReviewId, e.ProductId });
                 });
 
             modelBuilder.Entity<TLogin>(b =>
                 {
-                    var key = b.Key(e => e.Username);
+                    var key = b.HasKey(e => e.Username);
 
-                    b.Collection(e => (IEnumerable<TMessage>)e.SentMessages).InverseReference(e => (TLogin)e.Sender)
+                    b.HasMany(e => (IEnumerable<TMessage>)e.SentMessages).WithOne(e => (TLogin)e.Sender)
                         .ForeignKey(e => e.FromUsername);
 
-                    b.Collection(e => (IEnumerable<TMessage>)e.ReceivedMessages).InverseReference(e => (TLogin)e.Recipient)
+                    b.HasMany(e => (IEnumerable<TMessage>)e.ReceivedMessages).WithOne(e => (TLogin)e.Recipient)
                         .ForeignKey(e => e.ToUsername);
 
-                    b.Collection(e => (IEnumerable<TAnOrder>)e.Orders).InverseReference(e => (TLogin)e.Login)
+                    b.HasMany(e => (IEnumerable<TAnOrder>)e.Orders).WithOne(e => (TLogin)e.Login)
                         .ForeignKey(e => e.Username);
 
                     var entityType = b.Metadata;
                     var activityEntityType = entityType.Model.GetEntityType(typeof(TSuspiciousActivity));
                     activityEntityType.AddForeignKey(activityEntityType.GetProperty("Username"), key.Metadata, entityType);
 
-                    b.Reference(e => (TLastLogin)e.LastLogin).InverseReference(e => (TLogin)e.Login)
+                    b.HasOne(e => (TLastLogin)e.LastLogin).WithOne(e => (TLogin)e.Login)
                         .ForeignKey<TLastLogin>(e => e.Username);
                 });
 
             modelBuilder.Entity<TPasswordReset>(b =>
                 {
-                    b.Key(e => new { e.ResetNo, e.Username });
+                    b.HasKey(e => new { e.ResetNo, e.Username });
 
-                    b.Reference(e => (TLogin)e.Login).InverseCollection()
+                    b.HasOne(e => (TLogin)e.Login).WithMany()
                         .ForeignKey(e => e.Username)
                         .PrincipalKey(e => e.AlternateUsername);
                 });
 
-            modelBuilder.Entity<TPageView>().Reference(e => (TLogin)e.Login).InverseCollection()
+            modelBuilder.Entity<TPageView>().HasOne(e => (TLogin)e.Login).WithMany()
                 .ForeignKey(e => e.Username);
 
             modelBuilder.Entity<TBarcode>(b =>
                 {
-                    b.Key(e => e.Code);
+                    b.HasKey(e => e.Code);
 
-                    b.Collection(e => (IEnumerable<TIncorrectScan>)e.BadScans).InverseReference(e => (TBarcode)e.ExpectedBarcode)
+                    b.HasMany(e => (IEnumerable<TIncorrectScan>)e.BadScans).WithOne(e => (TBarcode)e.ExpectedBarcode)
                         .ForeignKey(e => e.ExpectedCode);
 
-                    b.Reference(e => (TBarcodeDetail)e.Detail).InverseReference()
+                    b.HasOne(e => (TBarcodeDetail)e.Detail).WithOne()
                         .ForeignKey<TBarcodeDetail>(e => e.Code);
                 });
 
-            modelBuilder.Entity<TIncorrectScan>().Reference(e => (TBarcode)e.ActualBarcode).InverseCollection()
+            modelBuilder.Entity<TIncorrectScan>().HasOne(e => (TBarcode)e.ActualBarcode).WithMany()
                 .ForeignKey(e => e.ActualCode);
 
-            modelBuilder.Entity<TSupplierInfo>().Reference(e => (TSupplier)e.Supplier).InverseCollection();
+            modelBuilder.Entity<TSupplierInfo>().HasOne(e => (TSupplier)e.Supplier).WithMany();
 
-            modelBuilder.Entity<TComputer>().Reference(e => (TComputerDetail)e.ComputerDetail).InverseReference(e => (TComputer)e.Computer)
+            modelBuilder.Entity<TComputer>().HasOne(e => (TComputerDetail)e.ComputerDetail).WithOne(e => (TComputer)e.Computer)
                 .ForeignKey<TComputerDetail>(e => e.ComputerDetailId);
 
             modelBuilder.Entity<TDriver>(b =>
                 {
-                    b.Key(e => e.Name);
-                    b.Reference(e => (TLicense)e.License).InverseReference(e => (TDriver)e.Driver)
+                    b.HasKey(e => e.Name);
+                    b.HasOne(e => (TLicense)e.License).WithOne(e => (TDriver)e.Driver)
                         .PrincipalKey<TDriver>(e => e.Name);
                 });
 
             modelBuilder.Entity<TSmartCard>(b =>
                 {
-                    b.Key(e => e.Username);
+                    b.HasKey(e => e.Username);
 
-                    b.Reference(e => (TLogin)e.Login).InverseReference()
+                    b.HasOne(e => (TLogin)e.Login).WithOne()
                         .ForeignKey<TSmartCard>(e => e.Username);
 
-                    b.Reference(e => (TLastLogin)e.LastLogin).InverseReference()
+                    b.HasOne(e => (TLastLogin)e.LastLogin).WithOne()
                         .ForeignKey<TLastLogin>(e => e.SmartcardUsername);
                 });
 
             modelBuilder.Entity<TRsaToken>(b =>
                 {
-                    b.Key(e => e.Serial);
-                    b.Reference(e => (TLogin)e.Login).InverseReference()
+                    b.HasKey(e => e.Serial);
+                    b.HasOne(e => (TLogin)e.Login).WithOne()
                         .ForeignKey<TRsaToken>(e => e.Username);
                 });
 

--- a/test/EntityFramework.Core.Tests/ChangeTracking/ChangeTrackerTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/ChangeTrackerTest.cs
@@ -1038,25 +1038,25 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             protected internal override void OnModelCreating(ModelBuilder modelBuilder)
             {
                 modelBuilder
-                    .Entity<Category>().Collection(e => e.Products).InverseReference(e => e.Category);
+                    .Entity<Category>().HasMany(e => e.Products).WithOne(e => e.Category);
 
                 modelBuilder
-                    .Entity<ProductDetailsTag>().Reference(e => e.TagDetails).InverseReference(e => e.Tag)
+                    .Entity<ProductDetailsTag>().HasOne(e => e.TagDetails).WithOne(e => e.Tag)
                     .ForeignKey<ProductDetailsTagDetails>(e => e.Id);
 
                 modelBuilder
-                    .Entity<ProductDetails>().Reference(e => e.Tag).InverseReference(e => e.Details)
+                    .Entity<ProductDetails>().HasOne(e => e.Tag).WithOne(e => e.Details)
                     .ForeignKey<ProductDetailsTag>(e => e.Id);
 
                 modelBuilder
-                    .Entity<Product>().Reference(e => e.Details).InverseReference(e => e.Product)
+                    .Entity<Product>().HasOne(e => e.Details).WithOne(e => e.Product)
                     .ForeignKey<ProductDetails>(e => e.Id);
 
                 modelBuilder.Entity<OrderDetails>(b =>
                     {
-                        b.Key(e => new { e.OrderId, e.ProductId });
-                        b.Reference(e => e.Order).InverseCollection(e => e.OrderDetails).ForeignKey(e => e.OrderId);
-                        b.Reference(e => e.Product).InverseCollection(e => e.OrderDetails).ForeignKey(e => e.ProductId);
+                        b.HasKey(e => new { e.OrderId, e.ProductId });
+                        b.HasOne(e => e.Order).WithMany(e => e.OrderDetails).ForeignKey(e => e.OrderId);
+                        b.HasOne(e => e.Product).WithMany(e => e.OrderDetails).ForeignKey(e => e.ProductId);
                     });
             }
 

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
@@ -1818,7 +1818,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             builder.Entity<Product>(b =>
                 {
-                    b.Reference(e => e.Tag).InverseReference(e => e.Product)
+                    b.HasOne(e => e.Tag).WithOne(e => e.Product)
                         .PrincipalKey<Product>(e => e.TagId)
                         .ForeignKey<ProductTag>(e => e.ProductId);
                     b.Property(e => e.TagId).Metadata.RequiresValueGenerator = false;
@@ -1826,19 +1826,19 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             builder.Entity<Category>(b =>
                 {
-                    b.Collection(e => e.Products).InverseReference(e => e.Category)
+                    b.HasMany(e => e.Products).WithOne(e => e.Category)
                         .ForeignKey(e => e.DependentId)
                         .PrincipalKey(e => e.PrincipalId);
                     b.Property(e => e.PrincipalId).Metadata.RequiresValueGenerator = false;
 
-                    b.Reference(e => e.Tag).InverseReference(e => e.Category)
+                    b.HasOne(e => e.Tag).WithOne(e => e.Category)
                         .ForeignKey<CategoryTag>(e => e.CategoryId)
                         .PrincipalKey<Category>(e => e.TagId);
                     b.Property(e => e.TagId).Metadata.RequiresValueGenerator = false;
                 });
 
             builder.Entity<Person>()
-                .Reference(e => e.Husband).InverseReference(e => e.Wife)
+                .HasOne(e => e.Husband).WithOne(e => e.Wife)
                 .ForeignKey<Person>(e => e.HusbandId);
 
             return builder.Model;
@@ -2043,7 +2043,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             builder.Entity<NotifyingProduct>(b =>
                 {
-                    b.Reference(e => e.Tag).InverseReference(e => e.Product)
+                    b.HasOne(e => e.Tag).WithOne(e => e.Product)
                         .PrincipalKey<NotifyingProduct>(e => e.TagId)
                         .ForeignKey<NotifyingProductTag>(e => e.ProductId);
                     b.Property(e => e.TagId).Metadata.RequiresValueGenerator = false;
@@ -2052,19 +2052,19 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             builder.Entity<NotifyingCategory>(b =>
                 {
-                    b.Collection(e => e.Products).InverseReference(e => e.Category)
+                    b.HasMany(e => e.Products).WithOne(e => e.Category)
                         .ForeignKey(e => e.DependentId)
                         .PrincipalKey(e => e.PrincipalId);
                     b.Property(e => e.PrincipalId).Metadata.RequiresValueGenerator = false;
 
-                    b.Reference(e => e.Tag).InverseReference(e => e.Category)
+                    b.HasOne(e => e.Tag).WithOne(e => e.Category)
                         .ForeignKey<NotifyingCategoryTag>(e => e.CategoryId)
                         .PrincipalKey<NotifyingCategory>(e => e.TagId);
                     b.Property(e => e.TagId).Metadata.RequiresValueGenerator = false;
                 });
 
             builder.Entity<NotifyingPerson>()
-                .Reference(e => e.Husband).InverseReference(e => e.Wife)
+                .HasOne(e => e.Husband).WithOne(e => e.Wife)
                 .ForeignKey<NotifyingPerson>(e => e.HusbandId);
 
             return builder.Model;
@@ -2103,7 +2103,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             builder.Entity<ProductWithChanging>();
             builder.Entity<CategoryWithChanging>()
-                .Collection(e => e.Products).InverseReference(e => e.Category)
+                .HasMany(e => e.Products).WithOne(e => e.Category)
                 .ForeignKey(e => e.DependentId);
 
             return builder.Model;
@@ -2142,7 +2142,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             builder.Entity<ProductWithChanged>();
             builder.Entity<CategoryWithChanged>()
-                .Collection(e => e.Products).InverseReference(e => e.Category)
+                .HasMany(e => e.Products).WithOne(e => e.Category)
                 .ForeignKey(e => e.DependentId);
 
             return builder.Model;

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/EntityKeyFactorySourceTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/EntityKeyFactorySourceTest.cs
@@ -137,16 +137,16 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
                     b.Property(e => e.NullableSentinelInt).Metadata.SentinelValue = -1;
                     b.Property(e => e.SentinelString).Metadata.SentinelValue = "Excellent!";
 
-                    b.AlternateKey(e => e.NullableInt);
-                    b.AlternateKey(e => e.NullableSentinelInt);
-                    b.AlternateKey(e => e.Guid1);
-                    b.AlternateKey(e => e.Guid2);
-                    b.AlternateKey(e => e.NullableGuid1);
-                    b.AlternateKey(e => e.NullableGuid2);
-                    b.AlternateKey(e => e.String);
-                    b.AlternateKey(e => e.SentinelString);
-                    b.AlternateKey(e => e.ByteArray);
-                    b.AlternateKey(e => new { e.Id, e.String });
+                    b.HasAlternateKey(e => e.NullableInt);
+                    b.HasAlternateKey(e => e.NullableSentinelInt);
+                    b.HasAlternateKey(e => e.Guid1);
+                    b.HasAlternateKey(e => e.Guid2);
+                    b.HasAlternateKey(e => e.NullableGuid1);
+                    b.HasAlternateKey(e => e.NullableGuid2);
+                    b.HasAlternateKey(e => e.String);
+                    b.HasAlternateKey(e => e.SentinelString);
+                    b.HasAlternateKey(e => e.ByteArray);
+                    b.HasAlternateKey(e => new { e.Id, e.String });
                 });
 
             return builder.Model.GetEntityType(typeof(ScissorSister));

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntityEntryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntityEntryTest.cs
@@ -1439,8 +1439,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             modelBuilder
                 .Entity<FirstDependent>()
-                .Reference(e => e.Second)
-                .InverseReference(e => e.First)
+                .HasOne(e => e.Second)
+                .WithOne(e => e.First)
                 .ForeignKey<SecondDependent>(e => e.Id)
                 .WillCascadeOnDelete();
 
@@ -1449,8 +1449,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
                     {
                         b.Property(e => e.Id).ValueGeneratedNever();
 
-                        b.Reference(e => e.First)
-                            .InverseReference(e => e.Root)
+                        b.HasOne(e => e.First)
+                            .WithOne(e => e.Root)
                             .ForeignKey<FirstDependent>(e => e.Id);
 
                     });

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntryEntrySubscriberTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntryEntrySubscriberTest.cs
@@ -161,7 +161,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             builder.Entity<FullNotificationEntity>(b =>
                 {
                     b.Ignore(e => e.NotMapped);
-                    b.Collection(e => e.RelatedCollection).InverseReference(e => e.Related).ForeignKey(e => e.Fk);
+                    b.HasMany(e => e.RelatedCollection).WithOne(e => e.Related).ForeignKey(e => e.Fk);
                 });
 
             return builder.Model;

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/KeyPropagatorTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/KeyPropagatorTest.cs
@@ -233,22 +233,22 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             builder.Entity<Product>(b =>
                 {
-                    b.Collection(e => e.OrderLines).InverseReference(e => e.Product);
-                    b.Reference(e => e.Detail).InverseReference(e => e.Product).ForeignKey<ProductDetail>(e => e.Id);
+                    b.HasMany(e => e.OrderLines).WithOne(e => e.Product);
+                    b.HasOne(e => e.Detail).WithOne(e => e.Product).ForeignKey<ProductDetail>(e => e.Id);
                 });
 
-            builder.Entity<Category>().Collection(e => e.Products).InverseReference(e => e.Category);
+            builder.Entity<Category>().HasMany(e => e.Products).WithOne(e => e.Category);
 
             builder.Entity<ProductDetail>();
 
-            builder.Entity<Order>().Collection(e => e.OrderLines).InverseReference(e => e.Order);
+            builder.Entity<Order>().HasMany(e => e.OrderLines).WithOne(e => e.Order);
 
-            builder.Entity<OrderLineDetail>().Key(e => new { e.OrderId, e.ProductId });
+            builder.Entity<OrderLineDetail>().HasKey(e => new { e.OrderId, e.ProductId });
 
             builder.Entity<OrderLine>(b =>
                 {
-                    b.Key(e => new { e.OrderId, e.ProductId });
-                    b.Reference(e => e.Detail).InverseReference(e => e.OrderLine);
+                    b.HasKey(e => new { e.OrderId, e.ProductId });
+                    b.HasOne(e => e.Detail).WithOne(e => e.OrderLine);
                 });
 
             return model;

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/NavigationFixerTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/NavigationFixerTest.cs
@@ -911,28 +911,28 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             builder.Entity<Product>(b =>
                 {
-                    b.Reference(e => e.AlternateProduct).InverseReference(e => e.OriginalProduct)
+                    b.HasOne(e => e.AlternateProduct).WithOne(e => e.OriginalProduct)
                         .ForeignKey<Product>(e => e.AlternateProductId);
 
-                    b.Reference(e => e.Detail).InverseReference(e => e.Product)
+                    b.HasOne(e => e.Detail).WithOne(e => e.Product)
                         .ForeignKey<ProductDetail>(e => e.Id);
                 });
 
-            builder.Entity<Category>().Collection(e => e.Products).InverseReference(e => e.Category);
+            builder.Entity<Category>().HasMany(e => e.Products).WithOne(e => e.Category);
 
             builder.Entity<ProductDetail>();
 
             builder.Entity<ProductPhoto>(b =>
                 {
-                    b.Key(e => new { e.ProductId, e.PhotoId });
-                    b.Collection(e => e.ProductTags).InverseReference(e => e.Photo)
+                    b.HasKey(e => new { e.ProductId, e.PhotoId });
+                    b.HasMany(e => e.ProductTags).WithOne(e => e.Photo)
                         .ForeignKey(e => new { e.ProductId, e.PhotoId });
                 });
 
             builder.Entity<ProductReview>(b =>
                 {
-                    b.Key(e => new { e.ProductId, e.ReviewId });
-                    b.Collection(e => e.ProductTags).InverseReference(e => e.Review)
+                    b.HasKey(e => new { e.ProductId, e.ReviewId });
+                    b.HasMany(e => e.ProductTags).WithOne(e => e.Review)
                         .ForeignKey(e => new { e.ProductId, e.ReviewId });
                 });
 

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/StateManagerTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/StateManagerTest.cs
@@ -605,7 +605,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var builder = new ModelBuilder(new CoreConventionSetBuilder().CreateConventionSet());
             var model = builder.Model;
 
-            builder.Entity<Product>().Reference<Category>().InverseReference()
+            builder.Entity<Product>().HasOne<Category>().WithOne()
                 .ForeignKey<Product>(e => e.DependentId)
                 .PrincipalKey<Category>(e => e.PrincipalId);
             builder.Entity<Category>();
@@ -614,7 +614,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
                 {
                     eb.Property<int>("Id");
                     eb.Property<string>("Planet");
-                    eb.Key("Id");
+                    eb.HasKey("Id");
                 });
 
             return model;

--- a/test/EntityFramework.Core.Tests/DbContextTest.cs
+++ b/test/EntityFramework.Core.Tests/DbContextTest.cs
@@ -1981,7 +1981,7 @@ namespace Microsoft.Data.Entity.Tests
             protected internal override void OnModelCreating(ModelBuilder modelBuilder)
             {
                 modelBuilder
-                    .Entity<Category>().Collection(e => e.Products).InverseReference(e => e.Category);
+                    .Entity<Category>().HasMany(e => e.Products).WithOne(e => e.Category);
             }
         }
 

--- a/test/EntityFramework.Core.Tests/Extensions/PropertyExtensionsTest.cs
+++ b/test/EntityFramework.Core.Tests/Extensions/PropertyExtensionsTest.cs
@@ -221,15 +221,15 @@ namespace Microsoft.Data.Entity.Tests
 
             modelBuilder
                 .Entity<Category>()
-                .Collection(e => e.Products)
-                .InverseReference(e => e.Category);
+                .HasMany(e => e.Products)
+                .WithOne(e => e.Category);
 
             modelBuilder
                 .Entity<ProductDetailsTag>(b =>
                 {
-                    b.Key(e => new { e.Id1, e.Id2 });
-                    b.Reference(e => e.TagDetails)
-                        .InverseReference(e => e.Tag)
+                    b.HasKey(e => new { e.Id1, e.Id2 });
+                    b.HasOne(e => e.TagDetails)
+                        .WithOne(e => e.Tag)
                         .PrincipalKey<ProductDetailsTag>(e => e.Id2)
                         .ForeignKey<ProductDetailsTagDetails>(e => e.Id);
                 });
@@ -237,26 +237,26 @@ namespace Microsoft.Data.Entity.Tests
             modelBuilder
                 .Entity<ProductDetails>(b =>
                 {
-                    b.Key(e => new { e.Id1, e.Id2 });
-                    b.Reference(e => e.Tag)
-                        .InverseReference(e => e.Details)
+                    b.HasKey(e => new { e.Id1, e.Id2 });
+                    b.HasOne(e => e.Tag)
+                        .WithOne(e => e.Details)
                         .ForeignKey<ProductDetailsTag>(e => new { e.Id1, e.Id2 });
                 });
 
             modelBuilder
                 .Entity<Product>()
-                .Reference(e => e.Details)
-                .InverseReference(e => e.Product)
+                .HasOne(e => e.Details)
+                .WithOne(e => e.Product)
                 .ForeignKey<ProductDetails>(e => new { e.Id1 });
 
             modelBuilder.Entity<OrderDetails>(b =>
             {
-                b.Key(e => new { e.OrderId, e.ProductId });
-                b.Reference(e => e.Order)
-                    .InverseCollection(e => e.OrderDetails)
+                b.HasKey(e => new { e.OrderId, e.ProductId });
+                b.HasOne(e => e.Order)
+                    .WithMany(e => e.OrderDetails)
                     .ForeignKey(e => e.OrderId);
-                b.Reference(e => e.Product)
-                    .InverseCollection(e => e.OrderDetails)
+                b.HasOne(e => e.Product)
+                    .WithMany(e => e.OrderDetails)
                     .ForeignKey(e => e.ProductId);
             });
 

--- a/test/EntityFramework.Core.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
@@ -490,7 +490,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var modelBuilder = CreateModelBuilder();
             var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
-            var keyBuilder = entityBuilder.Key(new[] { Order.IdProperty, Order.CustomerIdProperty }, ConfigurationSource.DataAnnotation);
+            var keyBuilder = entityBuilder.HasKey(new[] { Order.IdProperty, Order.CustomerIdProperty }, ConfigurationSource.DataAnnotation);
 
             Assert.NotNull(keyBuilder);
             Assert.Same(keyBuilder, entityBuilder.PrimaryKey(new[] { Order.IdProperty.Name, Order.CustomerIdProperty.Name }, ConfigurationSource.Convention));
@@ -505,7 +505,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var keyBuilder = entityBuilder.PrimaryKey(new[] { Order.IdProperty.Name, Order.CustomerIdProperty.Name }, ConfigurationSource.Convention);
 
             Assert.NotNull(keyBuilder);
-            Assert.Same(keyBuilder, entityBuilder.Key(new[] { Order.IdProperty, Order.CustomerIdProperty }, ConfigurationSource.DataAnnotation));
+            Assert.Same(keyBuilder, entityBuilder.HasKey(new[] { Order.IdProperty, Order.CustomerIdProperty }, ConfigurationSource.DataAnnotation));
         }
 
         [Fact]
@@ -516,7 +516,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
             Assert.Equal(Strings.NoClrProperty(Customer.UniqueProperty.Name, typeof(Order).FullName),
                 Assert.Throws<InvalidOperationException>(() =>
-                    entityBuilder.Key(new[] { Customer.UniqueProperty.Name }, ConfigurationSource.Convention)).Message);
+                    entityBuilder.HasKey(new[] { Customer.UniqueProperty.Name }, ConfigurationSource.Convention)).Message);
         }
 
         [Fact]
@@ -524,14 +524,14 @@ namespace Microsoft.Data.Entity.Metadata.Internal
         {
             var modelBuilder = CreateModelBuilder();
             var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-            var keyBuilder = entityBuilder.Key(new[] { Order.IdProperty.Name, Order.CustomerIdProperty.Name }, ConfigurationSource.Convention);
+            var keyBuilder = entityBuilder.HasKey(new[] { Order.IdProperty.Name, Order.CustomerIdProperty.Name }, ConfigurationSource.Convention);
 
             var derivedEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
             derivedEntityBuilder.BaseType(entityBuilder.Metadata, ConfigurationSource.Convention);
 
             Assert.Equal(Strings.DerivedEntityTypeKey(typeof(SpecialOrder).FullName),
                 Assert.Throws<InvalidOperationException>(() =>
-                    derivedEntityBuilder.Key(new[] { Order.IdProperty.Name, Order.CustomerIdProperty.Name }, ConfigurationSource.DataAnnotation)).Message);
+                    derivedEntityBuilder.HasKey(new[] { Order.IdProperty.Name, Order.CustomerIdProperty.Name }, ConfigurationSource.DataAnnotation)).Message);
         }
 
         [Fact]
@@ -542,7 +542,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
             Assert.Equal(Strings.PropertyNotFound(Order.IdProperty.Name, typeof(Order).Name),
                 Assert.Throws<ModelItemNotFoundException>(() =>
-                    entityBuilder.Key(new[] { Order.IdProperty.Name }, ConfigurationSource.Convention)).Message);
+                    entityBuilder.HasKey(new[] { Order.IdProperty.Name }, ConfigurationSource.Convention)).Message);
         }
 
         [Fact]
@@ -552,7 +552,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
             entityBuilder.Property(Order.CustomerIdProperty.Name, Order.CustomerIdProperty.PropertyType, ConfigurationSource.Convention);
 
-            Assert.NotNull(entityBuilder.Key(new[] { Order.CustomerIdProperty.Name }, ConfigurationSource.Convention));
+            Assert.NotNull(entityBuilder.HasKey(new[] { Order.CustomerIdProperty.Name }, ConfigurationSource.Convention));
 
             Assert.Equal(Order.CustomerIdProperty.Name, entityBuilder.Metadata.GetKeys().Single().Properties.Single().Name);
         }
@@ -564,7 +564,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
             entityBuilder.Ignore(Order.CustomerIdProperty.Name, ConfigurationSource.Explicit);
 
-            Assert.Null(entityBuilder.Key(new[] { Order.IdProperty, Order.CustomerIdProperty }, ConfigurationSource.DataAnnotation));
+            Assert.Null(entityBuilder.HasKey(new[] { Order.IdProperty, Order.CustomerIdProperty }, ConfigurationSource.DataAnnotation));
         }
 
         [Fact]
@@ -574,7 +574,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
             entityBuilder.Ignore(Order.CustomerIdProperty.Name, ConfigurationSource.DataAnnotation);
 
-            Assert.Null(entityBuilder.Key(new[] { Order.IdProperty.Name, Order.CustomerIdProperty.Name }, ConfigurationSource.Convention));
+            Assert.Null(entityBuilder.HasKey(new[] { Order.IdProperty.Name, Order.CustomerIdProperty.Name }, ConfigurationSource.Convention));
         }
 
         [Fact]
@@ -583,7 +583,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var modelBuilder = CreateModelBuilder();
             var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
-            var key = entityBuilder.Key(new[] { Order.CustomerIdProperty.Name }, ConfigurationSource.DataAnnotation);
+            var key = entityBuilder.HasKey(new[] { Order.CustomerIdProperty.Name }, ConfigurationSource.DataAnnotation);
             Assert.NotNull(key);
 
             Assert.Null(entityBuilder.RemoveKey(key.Metadata, ConfigurationSource.Convention));
@@ -600,7 +600,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
             var shadowProperty = entityBuilder.Property("Shadow", typeof(Guid), ConfigurationSource.Convention);
 
-            var key = entityBuilder.Key(new[] { Order.CustomerIdProperty.Name, shadowProperty.Metadata.Name }, ConfigurationSource.Convention);
+            var key = entityBuilder.HasKey(new[] { Order.CustomerIdProperty.Name, shadowProperty.Metadata.Name }, ConfigurationSource.Convention);
             Assert.NotNull(key);
 
             Assert.Equal(ConfigurationSource.Convention, entityBuilder.RemoveKey(key.Metadata, ConfigurationSource.DataAnnotation));
@@ -643,7 +643,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var shadowProperty = entityBuilder.Property("Shadow", typeof(Guid), ConfigurationSource.Convention);
             Assert.NotNull(shadowConfig(entityBuilder, shadowProperty.Metadata));
 
-            var key = entityBuilder.Key(new[] { Order.CustomerIdProperty.Name, shadowProperty.Metadata.Name }, ConfigurationSource.Convention);
+            var key = entityBuilder.HasKey(new[] { Order.CustomerIdProperty.Name, shadowProperty.Metadata.Name }, ConfigurationSource.Convention);
             Assert.NotNull(key);
 
             Assert.Equal(ConfigurationSource.Convention, entityBuilder.RemoveKey(key.Metadata, ConfigurationSource.DataAnnotation));
@@ -658,7 +658,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var modelBuilder = CreateModelBuilder();
             var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
             var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-            var key = principalEntityBuilder.Key(new[] { Customer.IdProperty, Customer.UniqueProperty }, ConfigurationSource.Convention);
+            var key = principalEntityBuilder.HasKey(new[] { Customer.IdProperty, Customer.UniqueProperty }, ConfigurationSource.Convention);
             dependentEntityBuilder.Relationship(
                 principalEntityBuilder,
                 dependentEntityBuilder,
@@ -691,7 +691,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var keyBuilder = entityBuilder.PrimaryKey(new[] { Order.IdProperty, Order.CustomerIdProperty }, ConfigurationSource.DataAnnotation);
 
             Assert.NotNull(keyBuilder);
-            Assert.Same(keyBuilder, entityBuilder.Key(new[] { Order.IdProperty.Name, Order.CustomerIdProperty.Name }, ConfigurationSource.Convention));
+            Assert.Same(keyBuilder, entityBuilder.HasKey(new[] { Order.IdProperty.Name, Order.CustomerIdProperty.Name }, ConfigurationSource.Convention));
 
             Assert.Same(entityBuilder.Metadata.GetPrimaryKey(), entityBuilder.Metadata.GetKeys().Single());
         }
@@ -702,7 +702,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var modelBuilder = CreateModelBuilder();
             var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
-            var keyBuilder = entityBuilder.Key(new[] { Order.IdProperty.Name, Order.CustomerIdProperty.Name }, ConfigurationSource.Convention);
+            var keyBuilder = entityBuilder.HasKey(new[] { Order.IdProperty.Name, Order.CustomerIdProperty.Name }, ConfigurationSource.Convention);
 
             Assert.NotNull(keyBuilder);
             Assert.Same(keyBuilder, entityBuilder.PrimaryKey(new[] { Order.IdProperty, Order.CustomerIdProperty }, ConfigurationSource.DataAnnotation));
@@ -793,7 +793,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             Assert.NotEqual(compositeKeyBuilder, simpleKeyBuilder);
             Assert.Equal(Order.IdProperty.Name, entityType.GetKeys().Single().Properties.Single().Name);
 
-            var simpleKeyBuilder2 = entityBuilder.Key(new[] { Order.IdProperty }, ConfigurationSource.Explicit);
+            var simpleKeyBuilder2 = entityBuilder.HasKey(new[] { Order.IdProperty }, ConfigurationSource.Explicit);
             Assert.Same(simpleKeyBuilder, simpleKeyBuilder2);
 
             var compositeKeyBuilder2 = entityBuilder.PrimaryKey(new[] { Order.IdProperty, Order.CustomerIdProperty }, ConfigurationSource.Convention);
@@ -858,7 +858,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var modelBuilder = CreateModelBuilder();
             var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
             var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-            var keyBuilder = principalEntityBuilder.Key(new[] { Customer.IdProperty, Customer.UniqueProperty }, ConfigurationSource.Convention);
+            var keyBuilder = principalEntityBuilder.HasKey(new[] { Customer.IdProperty, Customer.UniqueProperty }, ConfigurationSource.Convention);
             dependentEntityBuilder.Relationship(
                 principalEntityBuilder,
                 dependentEntityBuilder,
@@ -884,7 +884,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var modelBuilder = CreateModelBuilder();
             var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
             var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-            var existingKeyBuilder = principalEntityBuilder.Key(new[] { Customer.IdProperty, Customer.UniqueProperty }, ConfigurationSource.Convention);
+            var existingKeyBuilder = principalEntityBuilder.HasKey(new[] { Customer.IdProperty, Customer.UniqueProperty }, ConfigurationSource.Convention);
             dependentEntityBuilder.Relationship(
                 principalEntityBuilder,
                 dependentEntityBuilder,
@@ -1769,7 +1769,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var modelBuilder = CreateModelBuilder();
             var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
             var derivedEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
-            derivedEntityBuilder.Key(new[] { Order.IdProperty }, ConfigurationSource.DataAnnotation);
+            derivedEntityBuilder.HasKey(new[] { Order.IdProperty }, ConfigurationSource.DataAnnotation);
 
             Assert.Null(derivedEntityBuilder.BaseType(entityBuilder.Metadata, ConfigurationSource.Convention));
             Assert.Null(derivedEntityBuilder.Metadata.BaseType);

--- a/test/EntityFramework.Core.Tests/Metadata/Internal/InternalPropertyBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/Internal/InternalPropertyBuilderTest.cs
@@ -54,12 +54,12 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var builder = CreateInternalPropertyBuilder();
             var metadata = builder.Metadata;
 
-            Assert.True(builder.ConcurrencyToken(true, ConfigurationSource.DataAnnotation));
-            Assert.True(builder.ConcurrencyToken(false, ConfigurationSource.DataAnnotation));
+            Assert.True(builder.IsConcurrencyToken(true, ConfigurationSource.DataAnnotation));
+            Assert.True(builder.IsConcurrencyToken(false, ConfigurationSource.DataAnnotation));
 
             Assert.False(metadata.IsConcurrencyToken.Value);
 
-            Assert.False(builder.ConcurrencyToken(true, ConfigurationSource.Convention));
+            Assert.False(builder.IsConcurrencyToken(true, ConfigurationSource.Convention));
             Assert.False(metadata.IsConcurrencyToken.Value);
         }
 
@@ -70,12 +70,12 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             metadata.IsConcurrencyToken = true;
             var builder = CreateInternalPropertyBuilder(metadata);
 
-            Assert.True(builder.ConcurrencyToken(true, ConfigurationSource.DataAnnotation));
-            Assert.False(builder.ConcurrencyToken(false, ConfigurationSource.DataAnnotation));
+            Assert.True(builder.IsConcurrencyToken(true, ConfigurationSource.DataAnnotation));
+            Assert.False(builder.IsConcurrencyToken(false, ConfigurationSource.DataAnnotation));
 
             Assert.True(metadata.IsConcurrencyToken.Value);
 
-            Assert.True(builder.ConcurrencyToken(false, ConfigurationSource.Explicit));
+            Assert.True(builder.IsConcurrencyToken(false, ConfigurationSource.Explicit));
             Assert.False(metadata.IsConcurrencyToken.Value);
         }
 
@@ -147,12 +147,12 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var builder = CreateInternalPropertyBuilder();
             var metadata = builder.Metadata;
 
-            Assert.True(builder.MaxLength(1, ConfigurationSource.DataAnnotation));
-            Assert.True(builder.MaxLength(2, ConfigurationSource.DataAnnotation));
+            Assert.True(builder.HasMaxLength(1, ConfigurationSource.DataAnnotation));
+            Assert.True(builder.HasMaxLength(2, ConfigurationSource.DataAnnotation));
 
             Assert.Equal(2, metadata.GetMaxLength().Value);
 
-            Assert.False(builder.MaxLength(1, ConfigurationSource.Convention));
+            Assert.False(builder.HasMaxLength(1, ConfigurationSource.Convention));
             Assert.Equal(2, metadata.GetMaxLength().Value);
         }
 
@@ -163,12 +163,12 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             metadata.SetMaxLength(1);
             var builder = CreateInternalPropertyBuilder(metadata);
 
-            Assert.True(builder.MaxLength(1, ConfigurationSource.DataAnnotation));
-            Assert.False(builder.MaxLength(2, ConfigurationSource.DataAnnotation));
+            Assert.True(builder.HasMaxLength(1, ConfigurationSource.DataAnnotation));
+            Assert.False(builder.HasMaxLength(2, ConfigurationSource.DataAnnotation));
 
             Assert.Equal(1, metadata.GetMaxLength().Value);
 
-            Assert.True(builder.MaxLength(2, ConfigurationSource.Explicit));
+            Assert.True(builder.HasMaxLength(2, ConfigurationSource.Explicit));
             Assert.Equal(2, metadata.GetMaxLength().Value);
         }
 
@@ -178,12 +178,12 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var builder = CreateInternalPropertyBuilder();
             var metadata = builder.Metadata;
 
-            Assert.True(builder.Required(true, ConfigurationSource.DataAnnotation));
-            Assert.True(builder.Required(false, ConfigurationSource.DataAnnotation));
+            Assert.True(builder.IsRequired(true, ConfigurationSource.DataAnnotation));
+            Assert.True(builder.IsRequired(false, ConfigurationSource.DataAnnotation));
 
             Assert.True(metadata.IsNullable.Value);
 
-            Assert.False(builder.Required(true, ConfigurationSource.Convention));
+            Assert.False(builder.IsRequired(true, ConfigurationSource.Convention));
             Assert.True(metadata.IsNullable.Value);
         }
 
@@ -194,12 +194,12 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             metadata.IsNullable = false;
             var builder = CreateInternalPropertyBuilder(metadata);
 
-            Assert.True(builder.Required(true, ConfigurationSource.DataAnnotation));
-            Assert.False(builder.Required(false, ConfigurationSource.DataAnnotation));
+            Assert.True(builder.IsRequired(true, ConfigurationSource.DataAnnotation));
+            Assert.False(builder.IsRequired(false, ConfigurationSource.DataAnnotation));
 
             Assert.False(metadata.IsNullable.Value);
 
-            Assert.True(builder.Required(false, ConfigurationSource.Explicit));
+            Assert.True(builder.IsRequired(false, ConfigurationSource.Explicit));
             Assert.True(metadata.IsNullable.Value);
         }
 

--- a/test/EntityFramework.Core.Tests/Metadata/MetadataBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/MetadataBuilderTest.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var returnedBuilder = builder
                 .Entity<Gunter>()
-                .Key(e => e.Id)
+                .HasKey(e => e.Id)
                 .KeyBuilderExtension("V1")
                 .KeyBuilderExtension("V2");
 
@@ -159,7 +159,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var builder = CreateModelBuilder();
 
             var relationshipBuilder = builder
-                .Entity<Gunter>().Collection(e => e.Gates).InverseReference(e => e.Gunter);
+                .Entity<Gunter>().HasMany(e => e.Gates).WithOne(e => e.Gunter);
 
             var returnedBuilder = relationshipBuilder
                 .OneToManyBuilderExtension("V1")
@@ -181,7 +181,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var builder = CreateModelBuilder();
 
             var relationshipBuilder = builder
-                .Entity<Gate>().Reference(e => e.Gunter).InverseCollection(e => e.Gates);
+                .Entity<Gate>().HasOne(e => e.Gunter).WithMany(e => e.Gates);
 
             var returnedBuilder = relationshipBuilder
                 .ManyToOneBuilderExtension("V1")
@@ -203,7 +203,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var builder = CreateModelBuilder();
 
             var relationshipBuilder = builder
-                .Entity<Avatar>().Reference(e => e.Gunter).InverseReference(e => e.Avatar)
+                .Entity<Avatar>().HasOne(e => e.Gunter).WithOne(e => e.Avatar)
                 .PrincipalKey<Gunter>(e => e.Id);
 
             var returnedBuilder = relationshipBuilder
@@ -305,7 +305,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var returnedBuilder = builder
                 .Entity<Gunter>()
-                .Key(e => e.Id)
+                .HasKey(e => e.Id)
                 .SharedNameExtension("V1")
                 .SharedNameExtension("V2");
 
@@ -367,7 +367,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var builder = CreateModelBuilder();
 
             var relationshipBuilder = builder
-                .Entity<Gunter>().Collection(e => e.Gates).InverseReference(e => e.Gunter);
+                .Entity<Gunter>().HasMany(e => e.Gates).WithOne(e => e.Gunter);
 
             var returnedBuilder = relationshipBuilder
                 .SharedNameExtension("V1")
@@ -389,7 +389,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var builder = CreateModelBuilder();
 
             var relationshipBuilder = builder
-                .Entity<Gate>().Reference(e => e.Gunter).InverseCollection(e => e.Gates);
+                .Entity<Gate>().HasOne(e => e.Gunter).WithMany(e => e.Gates);
 
             var returnedBuilder = relationshipBuilder
                 .SharedNameExtension("V1")
@@ -411,7 +411,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var builder = CreateModelBuilder();
 
             var relationshipBuilder = builder
-                .Entity<Avatar>().Reference(e => e.Gunter).InverseReference(e => e.Avatar)
+                .Entity<Avatar>().HasOne(e => e.Gunter).WithOne(e => e.Avatar)
                 .PrincipalKey<Gunter>(e => e.Id);
 
             var returnedBuilder = relationshipBuilder

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/ConventionDispatcherTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/ConventionDispatcherTest.cs
@@ -297,7 +297,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             var builder = new InternalModelBuilder(new Model(), conventions);
 
             var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
-            var explicitKeyBuilder = entityBuilder.Key(new List<string> { "OrderId" }, ConfigurationSource.Convention);
+            var explicitKeyBuilder = entityBuilder.HasKey(new List<string> { "OrderId" }, ConfigurationSource.Convention);
 
             Assert.Null(explicitKeyBuilder);
             Assert.NotNull(keyBuilder);
@@ -342,7 +342,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             var entityBuilder = new InternalModelBuilder(new Model(), conventions)
                 .Entity(typeof(Order), ConfigurationSource.Convention);
 
-            entityBuilder.Key(new[] { "OrderId" }, ConfigurationSource.Convention);
+            entityBuilder.HasKey(new[] { "OrderId" }, ConfigurationSource.Convention);
             Assert.NotNull(entityBuilder.PrimaryKey(new[] { "OrderId" }, ConfigurationSource.Convention));
 
             Assert.NotNull(internalKeyBuilder);
@@ -364,7 +364,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             var entityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
             var foreignKey = new ForeignKey(
                 new[] { entityBuilder.Property("FK", typeof(int), ConfigurationSource.Convention).Metadata },
-                entityBuilder.Key(new[] { "OrderId" }, ConfigurationSource.Convention).Metadata,
+                entityBuilder.HasKey(new[] { "OrderId" }, ConfigurationSource.Convention).Metadata,
                 entityBuilder.Metadata,
                 entityBuilder.Metadata);
             var conventionDispatcher = new ConventionDispatcher(conventions);

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/ForeignKeyPropertyDiscoveryConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/ForeignKeyPropertyDiscoveryConventionTest.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             DependentTypeWithCompositeKey.Property(DependentEntityWithCompositeKey.NameProperty, ConfigurationSource.Convention);
             var fkProperty1 = DependentTypeWithCompositeKey.Property("No!No!", typeof(int), ConfigurationSource.Convention);
             var fkProperty2 = DependentTypeWithCompositeKey.Property("No!No!2", typeof(string), ConfigurationSource.Convention);
-            fkProperty2.Required(true, ConfigurationSource.Convention);
+            fkProperty2.IsRequired(true, ConfigurationSource.Convention);
 
             var relationshipBuilder = DependentTypeWithCompositeKey.Relationship(
                 PrincipalTypeWithCompositeKey,
@@ -136,7 +136,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
         {
             var fkProperty1 = DependentTypeWithCompositeKey.Property(DependentEntityWithCompositeKey.NavPropIdProperty, ConfigurationSource.Convention);
             var fkProperty2 = DependentTypeWithCompositeKey.Property(DependentEntityWithCompositeKey.NavPropNameProperty, ConfigurationSource.Convention);
-            fkProperty2.Required(true, ConfigurationSource.Convention);
+            fkProperty2.IsRequired(true, ConfigurationSource.Convention);
             DependentTypeWithCompositeKey.Property(DependentEntityWithCompositeKey.PrincipalEntityWithCompositeKeyIdProperty, ConfigurationSource.Convention);
             DependentTypeWithCompositeKey.Property(DependentEntityWithCompositeKey.PrincipalEntityWithCompositeKeyNameProperty, ConfigurationSource.Convention);
             DependentTypeWithCompositeKey.Property(DependentEntityWithCompositeKey.IdProperty, ConfigurationSource.Convention);
@@ -255,7 +255,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
         {
             var fkProperty1 = DependentTypeWithCompositeKey.Property(DependentEntityWithCompositeKey.PrincipalEntityWithCompositeKeyIdProperty, ConfigurationSource.Convention);
             var fkProperty2 = DependentTypeWithCompositeKey.Property(DependentEntityWithCompositeKey.PrincipalEntityWithCompositeKeyNameProperty, ConfigurationSource.Convention);
-            fkProperty2.Required(true, ConfigurationSource.Convention);
+            fkProperty2.IsRequired(true, ConfigurationSource.Convention);
             DependentTypeWithCompositeKey.Property(DependentEntityWithCompositeKey.IdProperty, ConfigurationSource.Convention);
             DependentTypeWithCompositeKey.Property(DependentEntityWithCompositeKey.NameProperty, ConfigurationSource.Convention);
 
@@ -339,7 +339,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
         {
             var fkProperty1 = DependentTypeWithCompositeKey.Property(DependentEntityWithCompositeKey.IdProperty, ConfigurationSource.Convention);
             var fkProperty2 = DependentTypeWithCompositeKey.Property(DependentEntityWithCompositeKey.NameProperty, ConfigurationSource.Convention);
-            fkProperty2.Required(true, ConfigurationSource.Convention);
+            fkProperty2.IsRequired(true, ConfigurationSource.Convention);
 
             var relationshipBuilder = DependentTypeWithCompositeKey.Relationship(
                 PrincipalTypeWithCompositeKey,
@@ -918,11 +918,11 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
 
             var principalTypeWithCompositeKey = modelBuilder.Entity(typeof(PrincipalEntityWithCompositeKey), ConfigurationSource.Explicit);
             principalTypeWithCompositeKey.PrimaryKey(new[] { PrincipalEntityWithCompositeKey.IdProperty, PrincipalEntityWithCompositeKey.NameProperty }, ConfigurationSource.Explicit);
-            principalTypeWithCompositeKey.Property(PrincipalEntityWithCompositeKey.NameProperty, ConfigurationSource.Explicit).Required(true, ConfigurationSource.Explicit);
+            principalTypeWithCompositeKey.Property(PrincipalEntityWithCompositeKey.NameProperty, ConfigurationSource.Explicit).IsRequired(true, ConfigurationSource.Explicit);
 
             var dependentTypeWithCompositeKey = modelBuilder.Entity(typeof(DependentEntityWithCompositeKey), ConfigurationSource.Explicit);
             dependentTypeWithCompositeKey.PrimaryKey(new[] { "NotId", "NotName" }, ConfigurationSource.Explicit);
-            dependentTypeWithCompositeKey.Property("NotName", typeof(string), ConfigurationSource.Explicit).Required(true, ConfigurationSource.Explicit);
+            dependentTypeWithCompositeKey.Property("NotName", typeof(string), ConfigurationSource.Explicit).IsRequired(true, ConfigurationSource.Explicit);
 
             return modelBuilder;
         }

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/KeyConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/KeyConventionTest.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
 
             var properties = new List<string> { "Id", "Name" };
-            var keyBuilder = entityBuilder.Key(properties, ConfigurationSource.Convention);
+            var keyBuilder = entityBuilder.HasKey(properties, ConfigurationSource.Convention);
 
             Assert.Same(keyBuilder, new KeyConvention().Apply(keyBuilder));
 
@@ -66,7 +66,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
                 null,
                 ConfigurationSource.Convention);
 
-            var keyBuilder = referencedEntityBuilder.Key(properties, ConfigurationSource.Convention);
+            var keyBuilder = referencedEntityBuilder.HasKey(properties, ConfigurationSource.Convention);
 
             Assert.Same(keyBuilder, new KeyConvention().Apply(keyBuilder));
 
@@ -93,7 +93,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
                 null,
                 ConfigurationSource.Convention);
 
-            var keyBuilder = referencedEntityBuilder.Key(new List<string> { "Id", "SampleEntityId" }, ConfigurationSource.Convention);
+            var keyBuilder = referencedEntityBuilder.HasKey(new List<string> { "Id", "SampleEntityId" }, ConfigurationSource.Convention);
 
             Assert.Same(keyBuilder, new KeyConvention().Apply(keyBuilder));
 
@@ -121,7 +121,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
                 null,
                 ConfigurationSource.Convention);
 
-            var keyBuilder = referencedEntityBuilder.Key(new List<string> { "SampleEntityId" }, ConfigurationSource.Convention);
+            var keyBuilder = referencedEntityBuilder.HasKey(new List<string> { "SampleEntityId" }, ConfigurationSource.Convention);
 
             Assert.Same(keyBuilder, new KeyConvention().Apply(keyBuilder));
 
@@ -139,7 +139,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             var properties = new List<string> { "Id" };
             entityBuilder.Property("Id", typeof(int), ConfigurationSource.Convention).UseValueGenerator(false, ConfigurationSource.Explicit);
 
-            var keyBuilder = entityBuilder.Key(properties, ConfigurationSource.Convention);
+            var keyBuilder = entityBuilder.HasKey(properties, ConfigurationSource.Convention);
 
             Assert.Same(keyBuilder, new KeyConvention().Apply(keyBuilder));
 
@@ -157,7 +157,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             var referencedEntityBuilder = modelBuilder.Entity(typeof(ReferencedEntity), ConfigurationSource.Convention);
 
             var properties = new List<string> { "SampleEntityId" };
-            var keyBuilder = referencedEntityBuilder.Key(properties, ConfigurationSource.Convention);
+            var keyBuilder = referencedEntityBuilder.HasKey(properties, ConfigurationSource.Convention);
 
             Assert.Same(keyBuilder, new KeyConvention().Apply(keyBuilder));
 
@@ -186,7 +186,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             var referencedEntityBuilder = modelBuilder.Entity(typeof(ReferencedEntity), ConfigurationSource.Convention);
 
             var properties = new List<string> { "SampleEntityId" };
-            var keyBuilder = referencedEntityBuilder.Key(properties, ConfigurationSource.Convention);
+            var keyBuilder = referencedEntityBuilder.HasKey(properties, ConfigurationSource.Convention);
 
             Assert.Same(keyBuilder, new KeyConvention().Apply(keyBuilder));
 
@@ -235,7 +235,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             var modelBuilder = CreateInternalModelBuilder();
             var entityBuilder = modelBuilder.Entity(typeof(SampleEntity), ConfigurationSource.Convention);
 
-            var keyBuilder = entityBuilder.Key(new List<string> { "Number" }, ConfigurationSource.Convention);
+            var keyBuilder = entityBuilder.HasKey(new List<string> { "Number" }, ConfigurationSource.Convention);
 
             Assert.Same(keyBuilder, new KeyConvention().Apply(keyBuilder));
 

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/NavigationAttributeConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/NavigationAttributeConventionTest.cs
@@ -494,7 +494,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions
         public void Navigation_attribute_convention_runs_for_private_property()
         {
             var modelBuilder = new ModelBuilder(new CoreConventionSetBuilder().CreateConventionSet());
-            var referenceBuilder = modelBuilder.Entity<BlogDetails>().Reference(typeof(Post), "Post").InverseReference();
+            var referenceBuilder = modelBuilder.Entity<BlogDetails>().HasOne(typeof(Post), "Post").WithOne();
 
             Assert.False(referenceBuilder.Metadata.Properties.First().IsNullable);
         }

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/PropertyAttributeConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/PropertyAttributeConventionTest.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions
 
             var propertyBuilder = entityTypeBuilder.Property("RowVersion", typeof(Guid), ConfigurationSource.Explicit);
 
-            propertyBuilder.ConcurrencyToken(false, ConfigurationSource.Convention);
+            propertyBuilder.IsConcurrencyToken(false, ConfigurationSource.Convention);
 
             new ConcurrencyCheckAttributeConvention().Apply(propertyBuilder);
 
@@ -38,7 +38,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions
 
             var propertyBuilder = entityTypeBuilder.Property("RowVersion", typeof(Guid), ConfigurationSource.Explicit);
 
-            propertyBuilder.ConcurrencyToken(false, ConfigurationSource.Explicit);
+            propertyBuilder.IsConcurrencyToken(false, ConfigurationSource.Explicit);
 
             new ConcurrencyCheckAttributeConvention().Apply(propertyBuilder);
 
@@ -204,7 +204,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions
 
             var propertyBuilder = entityTypeBuilder.Property("MaxLengthProperty", typeof(string), ConfigurationSource.Explicit);
 
-            propertyBuilder.MaxLength(100, ConfigurationSource.Convention);
+            propertyBuilder.HasMaxLength(100, ConfigurationSource.Convention);
 
             new MaxLengthAttributeConvention().Apply(propertyBuilder);
 
@@ -218,7 +218,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions
 
             var propertyBuilder = entityTypeBuilder.Property("MaxLengthProperty", typeof(string), ConfigurationSource.Explicit);
 
-            propertyBuilder.MaxLength(100, ConfigurationSource.Explicit);
+            propertyBuilder.HasMaxLength(100, ConfigurationSource.Explicit);
 
             new MaxLengthAttributeConvention().Apply(propertyBuilder);
 
@@ -280,7 +280,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions
 
             var propertyBuilder = entityTypeBuilder.Property("Name", typeof(string), ConfigurationSource.Explicit);
 
-            propertyBuilder.Required(false, ConfigurationSource.Convention);
+            propertyBuilder.IsRequired(false, ConfigurationSource.Convention);
 
             new RequiredPropertyAttributeConvention().Apply(propertyBuilder);
 
@@ -294,7 +294,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions
 
             var propertyBuilder = entityTypeBuilder.Property("Name", typeof(string), ConfigurationSource.Explicit);
 
-            propertyBuilder.Required(false, ConfigurationSource.Explicit);
+            propertyBuilder.IsRequired(false, ConfigurationSource.Explicit);
 
             new RequiredPropertyAttributeConvention().Apply(propertyBuilder);
 
@@ -321,7 +321,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions
 
             var propertyBuilder = entityTypeBuilder.Property("StringLengthProperty", typeof(string), ConfigurationSource.Explicit);
 
-            propertyBuilder.MaxLength(100, ConfigurationSource.Convention);
+            propertyBuilder.HasMaxLength(100, ConfigurationSource.Convention);
 
             new StringLengthAttributeConvention().Apply(propertyBuilder);
 
@@ -335,7 +335,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions
 
             var propertyBuilder = entityTypeBuilder.Property("StringLengthProperty", typeof(string), ConfigurationSource.Explicit);
 
-            propertyBuilder.MaxLength(100, ConfigurationSource.Explicit);
+            propertyBuilder.HasMaxLength(100, ConfigurationSource.Explicit);
 
             new StringLengthAttributeConvention().Apply(propertyBuilder);
 
@@ -363,7 +363,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions
             var propertyBuilder = entityTypeBuilder.Property("Timestamp", typeof(byte[]), ConfigurationSource.Explicit);
 
             propertyBuilder.ValueGenerated(ValueGenerated.Never, ConfigurationSource.Convention);
-            propertyBuilder.ConcurrencyToken(false, ConfigurationSource.Convention);
+            propertyBuilder.IsConcurrencyToken(false, ConfigurationSource.Convention);
 
             new TimestampAttributeConvention().Apply(propertyBuilder);
 
@@ -379,7 +379,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions
             var propertyBuilder = entityTypeBuilder.Property("Timestamp", typeof(byte[]), ConfigurationSource.Explicit);
 
             propertyBuilder.ValueGenerated(ValueGenerated.Never, ConfigurationSource.Explicit);
-            propertyBuilder.ConcurrencyToken(false, ConfigurationSource.Explicit);
+            propertyBuilder.IsConcurrencyToken(false, ConfigurationSource.Explicit);
 
             new TimestampAttributeConvention().Apply(propertyBuilder);
 
@@ -477,7 +477,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions
 
             protected internal override void OnModelCreating(ModelBuilder modelBuilder)
             {
-                modelBuilder.Entity<B>().Key(e => new { e.MyPrimaryKey, e.Id });
+                modelBuilder.Entity<B>().HasKey(e => new { e.MyPrimaryKey, e.Id });
             }
         }
     }

--- a/test/EntityFramework.Core.Tests/Metadata/NavigationExtensionsTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/NavigationExtensionsTest.cs
@@ -181,8 +181,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             var builder = TestHelpers.Instance.CreateConventionBuilder();
 
-            builder.Entity<Principal>().Collection(e => e.Dependents1).InverseReference(e => e.Principal1);
-            builder.Entity<Principal>().Collection(e => e.Dependents2).InverseReference(e => e.Principal2);
+            builder.Entity<Principal>().HasMany(e => e.Dependents1).WithOne(e => e.Principal1);
+            builder.Entity<Principal>().HasMany(e => e.Dependents2).WithOne(e => e.Principal2);
 
             return builder.Model;
         }

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/ManyToOneTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/ManyToOneTestBase.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Data.Entity.Tests
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
                 modelBuilder.Entity<Customer>()
-                    .Collection(e => e.Orders).InverseReference(e => e.Customer)
+                    .HasMany(e => e.Orders).WithOne(e => e.Customer)
                     .ForeignKey(e => e.CustomerId);
                 modelBuilder.Entity<Order>();
                 modelBuilder.Ignore<OrderDetails>();
@@ -36,7 +36,7 @@ namespace Microsoft.Data.Entity.Tests
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
 
-                modelBuilder.Entity<Order>().Reference(e => e.Customer).InverseCollection(e => e.Orders);
+                modelBuilder.Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders);
 
                 Assert.Same(fk, dependentType.GetForeignKeys().Single());
                 Assert.Same(navToPrincipal, dependentType.Navigations.Single());
@@ -59,7 +59,7 @@ namespace Microsoft.Data.Entity.Tests
                 var modelBuilder = CreateModelBuilder(model);
                 modelBuilder.Entity<Customer>();
                 modelBuilder
-                    .Entity<Order>().Reference(o => o.Customer).InverseCollection()
+                    .Entity<Order>().HasOne(o => o.Customer).WithMany()
                     .ForeignKey(c => c.CustomerId);
                 modelBuilder.Ignore<OrderDetails>();
                 modelBuilder.Ignore<CustomerDetails>();
@@ -73,7 +73,7 @@ namespace Microsoft.Data.Entity.Tests
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
 
-                modelBuilder.Entity<Order>().Reference(e => e.Customer).InverseCollection(e => e.Orders);
+                modelBuilder.Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders);
 
                 Assert.Equal(navigation.Name, dependentType.Navigations.Single().Name);
                 Assert.Equal("Orders", principalType.Navigations.Single().Name);
@@ -94,7 +94,7 @@ namespace Microsoft.Data.Entity.Tests
                 var modelBuilder = CreateModelBuilder(model);
                 modelBuilder.Entity<Customer>();
                 modelBuilder.Entity<Order>()
-                    .Reference<Customer>().InverseCollection(e => e.Orders)
+                    .HasOne<Customer>().WithMany(e => e.Orders)
                     .ForeignKey(e => e.CustomerId);
                 modelBuilder.Ignore<OrderDetails>();
                 modelBuilder.Ignore<CustomerDetails>();
@@ -107,7 +107,7 @@ namespace Microsoft.Data.Entity.Tests
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
 
-                modelBuilder.Entity<Order>().Reference(e => e.Customer).InverseCollection(e => e.Orders);
+                modelBuilder.Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders);
 
                 var newFk = dependentType.GetForeignKeys().Single();
                 AssertEqual(fk.Properties, newFk.Properties);
@@ -130,7 +130,7 @@ namespace Microsoft.Data.Entity.Tests
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
                 modelBuilder.Entity<Customer>();
-                modelBuilder.Entity<Order>().Reference<Customer>().InverseCollection().ForeignKey(e => e.CustomerId);
+                modelBuilder.Entity<Order>().HasOne<Customer>().WithMany().ForeignKey(e => e.CustomerId);
                 modelBuilder.Ignore<OrderDetails>();
                 modelBuilder.Ignore<CustomerDetails>();
 
@@ -141,7 +141,7 @@ namespace Microsoft.Data.Entity.Tests
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
 
-                modelBuilder.Entity<Order>().Reference(e => e.Customer).InverseCollection(e => e.Orders);
+                modelBuilder.Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders);
                 var newFk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey != fk);
 
                 Assert.NotSame(fk, newFk);
@@ -176,7 +176,7 @@ namespace Microsoft.Data.Entity.Tests
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
 
-                modelBuilder.Entity<Order>().Reference(e => e.Customer).InverseCollection(e => e.Orders);
+                modelBuilder.Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders);
 
                 var fk = dependentType.GetForeignKeys().Single();
                 Assert.Same(fkProperty, fk.Properties.Single());
@@ -212,7 +212,7 @@ namespace Microsoft.Data.Entity.Tests
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
 
-                modelBuilder.Entity<Order>().Reference(e => e.Customer).InverseCollection();
+                modelBuilder.Entity<Order>().HasOne(e => e.Customer).WithMany();
 
                 var fk = dependentType.GetForeignKeys().Single();
                 Assert.Same(fkProperty, fk.Properties.Single());
@@ -247,7 +247,7 @@ namespace Microsoft.Data.Entity.Tests
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
 
-                modelBuilder.Entity<Order>().Reference<Customer>().InverseCollection(e => e.Orders);
+                modelBuilder.Entity<Order>().HasOne<Customer>().WithMany(e => e.Orders);
 
                 var fk = dependentType.GetForeignKeys().Single();
                 Assert.Same(fkProperty, fk.Properties.Single());
@@ -284,7 +284,7 @@ namespace Microsoft.Data.Entity.Tests
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
 
-                modelBuilder.Entity<Order>().Reference<Customer>().InverseCollection();
+                modelBuilder.Entity<Order>().HasOne<Customer>().WithMany();
 
                 var newFk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey != fk);
 
@@ -319,7 +319,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Order>().Reference(e => e.Customer).InverseCollection(e => e.Orders)
+                    .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                     .ForeignKey(e => e.CustomerId);
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -358,7 +358,7 @@ namespace Microsoft.Data.Entity.Tests
                 fk.IsUnique = false;
 
                 modelBuilder
-                    .Entity<Pickle>().Reference(e => e.BigMak).InverseCollection(e => e.Pickles)
+                    .Entity<Pickle>().HasOne(e => e.BigMak).WithMany(e => e.Pickles)
                     .ForeignKey(e => e.BurgerId);
 
                 Assert.Same(fk, dependentType.GetForeignKeys().Single());
@@ -393,7 +393,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Pickle>().Reference(e => e.BigMak).InverseCollection(e => e.Pickles)
+                    .Entity<Pickle>().HasOne(e => e.BigMak).WithMany(e => e.Pickles)
                     .ForeignKey(e => e.BurgerId);
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -430,7 +430,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Pickle>().Reference(e => e.BigMak).InverseCollection()
+                    .Entity<Pickle>().HasOne(e => e.BigMak).WithMany()
                     .ForeignKey(e => e.BurgerId);
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -466,7 +466,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Pickle>().Reference<BigMak>().InverseCollection(e => e.Pickles)
+                    .Entity<Pickle>().HasOne<BigMak>().WithMany(e => e.Pickles)
                     .ForeignKey(e => e.BurgerId);
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -503,7 +503,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Pickle>().Reference<BigMak>().InverseCollection()
+                    .Entity<Pickle>().HasOne<BigMak>().WithMany()
                     .ForeignKey(e => e.BurgerId);
 
                 var newFk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey != fk);
@@ -535,7 +535,7 @@ namespace Microsoft.Data.Entity.Tests
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
 
-                modelBuilder.Entity<Pickle>().Reference(e => e.BigMak).InverseCollection(e => e.Pickles);
+                modelBuilder.Entity<Pickle>().HasOne(e => e.BigMak).WithMany(e => e.Pickles);
 
                 var fk = dependentType.GetForeignKeys().Single();
                 var fkProperty = (IProperty)fk.Properties.Single();
@@ -573,7 +573,7 @@ namespace Microsoft.Data.Entity.Tests
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
 
-                modelBuilder.Entity<Pickle>().Reference(e => e.BigMak).InverseCollection();
+                modelBuilder.Entity<Pickle>().HasOne(e => e.BigMak).WithMany();
 
                 var fk = dependentType.GetForeignKeys().Single();
                 var fkProperty = (IProperty)fk.Properties.Single();
@@ -610,7 +610,7 @@ namespace Microsoft.Data.Entity.Tests
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
 
-                modelBuilder.Entity<Pickle>().Reference<BigMak>().InverseCollection(e => e.Pickles);
+                modelBuilder.Entity<Pickle>().HasOne<BigMak>().WithMany(e => e.Pickles);
 
                 var fk = dependentType.GetForeignKeys().Single();
                 var fkProperty = (IProperty)fk.Properties.Single();
@@ -649,7 +649,7 @@ namespace Microsoft.Data.Entity.Tests
 
                 var fk = dependentType.GetForeignKeys().SingleOrDefault();
 
-                modelBuilder.Entity<Pickle>().Reference<BigMak>().InverseCollection();
+                modelBuilder.Entity<Pickle>().HasOne<BigMak>().WithMany();
 
                 var newFk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey != fk);
                 var fkProperty = (IProperty)newFk.Properties.Single();
@@ -686,7 +686,7 @@ namespace Microsoft.Data.Entity.Tests
 
                 var fkProperty = dependentType.GetProperty("BigMakId");
 
-                modelBuilder.Entity<Pickle>().Reference(e => e.BigMak).InverseCollection(e => e.Pickles);
+                modelBuilder.Entity<Pickle>().HasOne(e => e.BigMak).WithMany(e => e.Pickles);
 
                 var fk = dependentType.GetForeignKeys().Single();
                 Assert.Same(fkProperty, fk.Properties.Single());
@@ -710,7 +710,7 @@ namespace Microsoft.Data.Entity.Tests
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
                 modelBuilder
-                    .Entity<Pickle>().Reference(e => e.BigMak).InverseReference()
+                    .Entity<Pickle>().HasOne(e => e.BigMak).WithOne()
                     .ForeignKey<Pickle>(c => c.BurgerId);
                 modelBuilder.Ignore<Bun>();
 
@@ -724,7 +724,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Pickle>().Reference(e => e.BigMak).InverseCollection(e => e.Pickles)
+                    .Entity<Pickle>().HasOne(e => e.BigMak).WithMany(e => e.Pickles)
                     .ForeignKey(e => e.BurgerId);
 
                 Assert.Equal(1, dependentType.GetForeignKeys().Count());
@@ -765,7 +765,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Order>().Reference(e => e.Customer).InverseCollection(e => e.Orders)
+                    .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                     .PrincipalKey(e => e.Id);
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -807,7 +807,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Order>().Reference(e => e.Customer).InverseCollection(e => e.Orders)
+                    .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                     .PrincipalKey(e => e.AlternateKey);
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -854,7 +854,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Order>().Reference(e => e.Customer).InverseCollection(e => e.Orders)
+                    .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                     .ForeignKey(e => e.CustomerId)
                     .PrincipalKey(e => e.Id);
 
@@ -895,7 +895,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Order>().Reference(e => e.Customer).InverseCollection(e => e.Orders)
+                    .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                     .PrincipalKey(e => e.Id)
                     .ForeignKey(e => e.CustomerId);
 
@@ -934,7 +934,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Order>().Reference(e => e.Customer).InverseCollection(e => e.Orders)
+                    .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                     .ForeignKey(e => e.AnotherCustomerId)
                     .PrincipalKey(e => e.AlternateKey);
 
@@ -981,7 +981,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Order>().Reference(e => e.Customer).InverseCollection(e => e.Orders)
+                    .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                     .PrincipalKey(e => e.AlternateKey)
                     .ForeignKey(e => e.AnotherCustomerId);
 
@@ -1029,7 +1029,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Pickle>().Reference(e => e.BigMak).InverseCollection(e => e.Pickles)
+                    .Entity<Pickle>().HasOne(e => e.BigMak).WithMany(e => e.Pickles)
                     .ForeignKey(e => e.BurgerId)
                     .PrincipalKey(e => e.AlternateKey);
 
@@ -1074,7 +1074,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Pickle>().Reference(e => e.BigMak).InverseCollection(e => e.Pickles)
+                    .Entity<Pickle>().HasOne(e => e.BigMak).WithMany(e => e.Pickles)
                     .PrincipalKey(e => e.AlternateKey)
                     .ForeignKey(e => e.BurgerId);
 
@@ -1105,9 +1105,9 @@ namespace Microsoft.Data.Entity.Tests
             {
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
-                modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
+                modelBuilder.Entity<Whoopper>().HasKey(c => new { c.Id1, c.Id2 });
                 modelBuilder
-                    .Entity<Tomato>().Reference(e => e.Whoopper).InverseCollection()
+                    .Entity<Tomato>().HasOne(e => e.Whoopper).WithMany()
                     .ForeignKey(c => new { c.BurgerId1, c.BurgerId2 });
                 modelBuilder.Ignore<ToastedBun>();
                 modelBuilder.Ignore<Moostard>();
@@ -1121,7 +1121,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Tomato>().Reference(e => e.Whoopper).InverseCollection(e => e.Tomatoes)
+                    .Entity<Tomato>().HasOne(e => e.Whoopper).WithMany(e => e.Tomatoes)
                     .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
 
                 Assert.Same(fk, dependentType.GetForeignKeys().Single());
@@ -1143,7 +1143,7 @@ namespace Microsoft.Data.Entity.Tests
             {
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
-                modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
+                modelBuilder.Entity<Whoopper>().HasKey(c => new { c.Id1, c.Id2 });
                 modelBuilder.Entity<Tomato>();
                 modelBuilder.Ignore<ToastedBun>();
                 modelBuilder.Ignore<Moostard>();
@@ -1158,7 +1158,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetPrimaryKey();
 
                 modelBuilder
-                    .Entity<Tomato>().Reference(e => e.Whoopper).InverseCollection(e => e.Tomatoes)
+                    .Entity<Tomato>().HasOne(e => e.Whoopper).WithMany(e => e.Tomatoes)
                     .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -1183,7 +1183,7 @@ namespace Microsoft.Data.Entity.Tests
             {
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
-                modelBuilder.Entity<Whoopper>(b => b.Key(c => new { c.Id1, c.Id2 }));
+                modelBuilder.Entity<Whoopper>(b => b.HasKey(c => new { c.Id1, c.Id2 }));
                 modelBuilder.Entity<Tomato>();
                 modelBuilder.Ignore<ToastedBun>();
                 modelBuilder.Ignore<Moostard>();
@@ -1200,7 +1200,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Tomato>().Reference(e => e.Whoopper).InverseCollection(e => e.Tomatoes)
+                    .Entity<Tomato>().HasOne(e => e.Whoopper).WithMany(e => e.Tomatoes)
                     .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 })
                     .PrincipalKey(e => new { e.AlternateKey1, e.AlternateKey2 });
 
@@ -1233,7 +1233,7 @@ namespace Microsoft.Data.Entity.Tests
             {
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
-                modelBuilder.Entity<Whoopper>(b => b.Key(c => new { c.Id1, c.Id2 }));
+                modelBuilder.Entity<Whoopper>(b => b.HasKey(c => new { c.Id1, c.Id2 }));
                 modelBuilder.Entity<Tomato>();
                 modelBuilder.Ignore<ToastedBun>();
                 modelBuilder.Ignore<Moostard>();
@@ -1250,7 +1250,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetPrimaryKey();
 
                 modelBuilder
-                    .Entity<Tomato>().Reference(e => e.Whoopper).InverseCollection(e => e.Tomatoes)
+                    .Entity<Tomato>().HasOne(e => e.Whoopper).WithMany(e => e.Tomatoes)
                     .PrincipalKey(e => new { e.AlternateKey1, e.AlternateKey2 })
                     .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
 
@@ -1283,7 +1283,7 @@ namespace Microsoft.Data.Entity.Tests
             {
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
-                modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
+                modelBuilder.Entity<Whoopper>().HasKey(c => new { c.Id1, c.Id2 });
                 modelBuilder.Entity<Tomato>();
                 modelBuilder.Ignore<ToastedBun>();
                 modelBuilder.Ignore<Moostard>();
@@ -1298,7 +1298,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Tomato>().Reference(e => e.Whoopper).InverseCollection()
+                    .Entity<Tomato>().HasOne(e => e.Whoopper).WithMany()
                     .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -1322,7 +1322,7 @@ namespace Microsoft.Data.Entity.Tests
             {
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
-                modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
+                modelBuilder.Entity<Whoopper>().HasKey(c => new { c.Id1, c.Id2 });
                 modelBuilder.Entity<Tomato>();
                 modelBuilder.Ignore<ToastedBun>();
                 modelBuilder.Ignore<Moostard>();
@@ -1337,7 +1337,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Tomato>().Reference<Whoopper>().InverseCollection(e => e.Tomatoes)
+                    .Entity<Tomato>().HasOne<Whoopper>().WithMany(e => e.Tomatoes)
                     .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -1361,8 +1361,8 @@ namespace Microsoft.Data.Entity.Tests
             {
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
-                modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
-                modelBuilder.Entity<Whoopper>().Collection(w => w.Tomatoes).InverseReference(t => t.Whoopper);
+                modelBuilder.Entity<Whoopper>().HasKey(c => new { c.Id1, c.Id2 });
+                modelBuilder.Entity<Whoopper>().HasMany(w => w.Tomatoes).WithOne(t => t.Whoopper);
                 modelBuilder.Entity<Tomato>();
                 modelBuilder.Ignore<ToastedBun>();
                 modelBuilder.Ignore<Moostard>();
@@ -1379,7 +1379,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Tomato>().Reference<Whoopper>().InverseCollection()
+                    .Entity<Tomato>().HasOne<Whoopper>().WithMany()
                     .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
 
                 var fkProperty1 = dependentType.GetProperty("BurgerId1");
@@ -1404,7 +1404,7 @@ namespace Microsoft.Data.Entity.Tests
             {
                 var modelBuilder = HobNobBuilder();
                 var model = modelBuilder.Model;
-                modelBuilder.Entity<Nob>().Reference(e => e.Hob).InverseReference(e => e.Nob);
+                modelBuilder.Entity<Nob>().HasOne(e => e.Hob).WithOne(e => e.Nob);
 
                 var dependentType = model.GetEntityType(typeof(Hob));
                 var principalType = model.GetEntityType(typeof(Nob));
@@ -1413,7 +1413,7 @@ namespace Microsoft.Data.Entity.Tests
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
 
-                modelBuilder.Entity<Hob>().Reference(e => e.Nob).InverseCollection(e => e.Hobs);
+                modelBuilder.Entity<Hob>().HasOne(e => e.Nob).WithMany(e => e.Hobs);
 
                 var fk = dependentType.GetForeignKeys().Single();
                 Assert.False(fk.IsUnique);
@@ -1440,7 +1440,7 @@ namespace Microsoft.Data.Entity.Tests
 
                 var dependentType = model.GetEntityType(typeof(Order));
 
-                var builder = modelBuilder.Entity<Order>().Reference(e => e.Customer).InverseCollection(e => e.Orders);
+                var builder = modelBuilder.Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders);
                 builder = builder.Annotation("Fus", "Ro");
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -1454,7 +1454,7 @@ namespace Microsoft.Data.Entity.Tests
                 var modelBuilder = HobNobBuilder();
 
                 modelBuilder
-                    .Entity<Nob>().Reference(e => e.Hob).InverseCollection(e => e.Nobs)
+                    .Entity<Nob>().HasOne(e => e.Hob).WithMany(e => e.Nobs)
                     .ForeignKey(e => new { e.HobId1, e.HobId2 });
 
                 var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob));
@@ -1470,7 +1470,7 @@ namespace Microsoft.Data.Entity.Tests
                 var modelBuilder = HobNobBuilder();
 
                 modelBuilder
-                    .Entity<Hob>().Reference(e => e.Nob).InverseCollection(e => e.Hobs)
+                    .Entity<Hob>().HasOne(e => e.Nob).WithMany(e => e.Hobs)
                     .ForeignKey(e => new { e.NobId1, e.NobId2 });
 
                 var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Hob));
@@ -1486,7 +1486,7 @@ namespace Microsoft.Data.Entity.Tests
                 var modelBuilder = HobNobBuilder();
 
                 modelBuilder
-                    .Entity<Nob>().Reference(e => e.Hob).InverseCollection(e => e.Nobs)
+                    .Entity<Nob>().HasOne(e => e.Hob).WithMany(e => e.Nobs)
                     .ForeignKey(e => new { e.HobId1, e.HobId2 })
                     .Required();
 
@@ -1505,7 +1505,7 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Equal(
                     Strings.ForeignKeyCannotBeOptional("{'NobId1', 'NobId2'}", "Hob"),
                     Assert.Throws<InvalidOperationException>(() => modelBuilder
-                        .Entity<Hob>().Reference(e => e.Nob).InverseCollection(e => e.Hobs)
+                        .Entity<Hob>().HasOne(e => e.Nob).WithMany(e => e.Hobs)
                         .ForeignKey(e => new { e.NobId1, e.NobId2 })
                         .Required(false)).Message);
 
@@ -1523,13 +1523,13 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob));
 
                 modelBuilder
-                    .Entity<Nob>().Reference(e => e.Hob).InverseCollection(e => e.Nobs)
+                    .Entity<Nob>().HasOne(e => e.Hob).WithMany(e => e.Nobs)
                     .WillCascadeOnDelete();
 
                 Assert.Equal(DeleteBehavior.Cascade, dependentType.GetForeignKeys().Single().DeleteBehavior);
 
                 modelBuilder
-                    .Entity<Nob>().Reference(e => e.Hob).InverseCollection(e => e.Nobs)
+                    .Entity<Nob>().HasOne(e => e.Hob).WithMany(e => e.Nobs)
                     .WillCascadeOnDelete(false);
 
                 Assert.Equal(DeleteBehavior.None, dependentType.GetForeignKeys().Single().DeleteBehavior);

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderGenericRelationshipStringTest.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderGenericRelationshipStringTest.cs
@@ -56,11 +56,11 @@ namespace Microsoft.Data.Entity.Tests
             protected override TestEntityTypeBuilder<TEntity> Wrap(EntityTypeBuilder<TEntity> entityTypeBuilder)
                 => new GenericStringTestEntityTypeBuilder<TEntity>(entityTypeBuilder);
 
-            public override TestReferenceNavigationBuilder<TEntity, TRelatedEntity> Reference<TRelatedEntity>(Expression<Func<TEntity, TRelatedEntity>> reference = null)
-                => new GenericStringTestReferenceNavigationBuilder<TEntity, TRelatedEntity>(EntityTypeBuilder.Reference(reference));
+            public override TestReferenceNavigationBuilder<TEntity, TRelatedEntity> HasOne<TRelatedEntity>(Expression<Func<TEntity, TRelatedEntity>> reference = null)
+                => new GenericStringTestReferenceNavigationBuilder<TEntity, TRelatedEntity>(EntityTypeBuilder.HasOne(reference));
 
-            public override TestCollectionNavigationBuilder<TEntity, TRelatedEntity> Collection<TRelatedEntity>(Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> collection = null)
-                => new GenericStringTestCollectionNavigationBuilder<TEntity, TRelatedEntity>(EntityTypeBuilder.Collection(collection));
+            public override TestCollectionNavigationBuilder<TEntity, TRelatedEntity> HasMany<TRelatedEntity>(Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> collection = null)
+                => new GenericStringTestCollectionNavigationBuilder<TEntity, TRelatedEntity>(EntityTypeBuilder.HasMany(collection));
         }
 
         private class GenericStringTestReferenceNavigationBuilder<TEntity, TRelatedEntity> : GenericTestReferenceNavigationBuilder<TEntity, TRelatedEntity>
@@ -72,11 +72,11 @@ namespace Microsoft.Data.Entity.Tests
             {
             }
 
-            public override TestReferenceCollectionBuilder<TRelatedEntity, TEntity> InverseCollection(Expression<Func<TRelatedEntity, IEnumerable<TEntity>>> collection = null)
-                => new GenericStringTestReferenceCollectionBuilder<TRelatedEntity, TEntity>(ReferenceNavigationBuilder.InverseCollection(collection?.GetPropertyAccess().Name));
+            public override TestReferenceCollectionBuilder<TRelatedEntity, TEntity> WithMany(Expression<Func<TRelatedEntity, IEnumerable<TEntity>>> collection = null)
+                => new GenericStringTestReferenceCollectionBuilder<TRelatedEntity, TEntity>(ReferenceNavigationBuilder.WithMany(collection?.GetPropertyAccess().Name));
 
-            public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> InverseReference(Expression<Func<TRelatedEntity, TEntity>> reference = null)
-                => new GenericStringTestReferenceReferenceBuilder<TEntity, TRelatedEntity>(ReferenceNavigationBuilder.InverseReference(reference?.GetPropertyAccess().Name));
+            public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> WithOne(Expression<Func<TRelatedEntity, TEntity>> reference = null)
+                => new GenericStringTestReferenceReferenceBuilder<TEntity, TRelatedEntity>(ReferenceNavigationBuilder.WithOne(reference?.GetPropertyAccess().Name));
         }
 
         private class GenericStringTestCollectionNavigationBuilder<TEntity, TRelatedEntity> : GenericTestCollectionNavigationBuilder<TEntity, TRelatedEntity>
@@ -88,8 +88,8 @@ namespace Microsoft.Data.Entity.Tests
             {
             }
 
-            public override TestReferenceCollectionBuilder<TEntity, TRelatedEntity> InverseReference(Expression<Func<TRelatedEntity, TEntity>> reference = null)
-                => new GenericStringTestReferenceCollectionBuilder<TEntity, TRelatedEntity>(CollectionNavigationBuilder.InverseReference(reference?.GetPropertyAccess().Name));
+            public override TestReferenceCollectionBuilder<TEntity, TRelatedEntity> WithOne(Expression<Func<TRelatedEntity, TEntity>> reference = null)
+                => new GenericStringTestReferenceCollectionBuilder<TEntity, TRelatedEntity>(CollectionNavigationBuilder.WithOne(reference?.GetPropertyAccess().Name));
         }
 
         private class GenericStringTestReferenceCollectionBuilder<TEntity, TRelatedEntity> : GenericTestReferenceCollectionBuilder<TEntity, TRelatedEntity>

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderGenericRelationshipTypeTest.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderGenericRelationshipTypeTest.cs
@@ -45,8 +45,8 @@ namespace Microsoft.Data.Entity.Tests
             protected override TestEntityTypeBuilder<TEntity> Wrap(EntityTypeBuilder<TEntity> entityTypeBuilder)
                 => new GenericTypeTestEntityTypeBuilder<TEntity>(entityTypeBuilder);
 
-            public override TestReferenceNavigationBuilder<TEntity, TRelatedEntity> Reference<TRelatedEntity>(Expression<Func<TEntity, TRelatedEntity>> reference = null)
-                => new GenericTypeTestReferenceNavigationBuilder<TEntity, TRelatedEntity>(EntityTypeBuilder.Reference(reference));
+            public override TestReferenceNavigationBuilder<TEntity, TRelatedEntity> HasOne<TRelatedEntity>(Expression<Func<TEntity, TRelatedEntity>> reference = null)
+                => new GenericTypeTestReferenceNavigationBuilder<TEntity, TRelatedEntity>(EntityTypeBuilder.HasOne(reference));
         }
 
         private class GenericTypeTestReferenceNavigationBuilder<TEntity, TRelatedEntity> : GenericTestReferenceNavigationBuilder<TEntity, TRelatedEntity>
@@ -58,8 +58,8 @@ namespace Microsoft.Data.Entity.Tests
             {
             }
 
-            public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> InverseReference(Expression<Func<TRelatedEntity, TEntity>> reference = null)
-                => new GenericTypeTestReferenceReferenceBuilder<TEntity, TRelatedEntity>(ReferenceNavigationBuilder.InverseReference(reference?.GetPropertyAccess().Name));
+            public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> WithOne(Expression<Func<TRelatedEntity, TEntity>> reference = null)
+                => new GenericTypeTestReferenceReferenceBuilder<TEntity, TRelatedEntity>(ReferenceNavigationBuilder.WithOne(reference?.GetPropertyAccess().Name));
         }
         
         private class GenericTypeTestReferenceReferenceBuilder<TEntity, TRelatedEntity> : GenericTestReferenceReferenceBuilder<TEntity, TRelatedEntity>

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderGenericTest.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderGenericTest.cs
@@ -138,17 +138,17 @@ namespace Microsoft.Data.Entity.Tests
             public override TestEntityTypeBuilder<TEntity> BaseEntity(string baseEntityTypeName)
                 => Wrap(EntityTypeBuilder.BaseType(baseEntityTypeName));
 
-            public override TestKeyBuilder Key(Expression<Func<TEntity, object>> keyExpression)
-                => new TestKeyBuilder(EntityTypeBuilder.Key(keyExpression));
+            public override TestKeyBuilder HasKey(Expression<Func<TEntity, object>> keyExpression)
+                => new TestKeyBuilder(EntityTypeBuilder.HasKey(keyExpression));
 
-            public override TestKeyBuilder Key(params string[] propertyNames)
-                => new TestKeyBuilder(EntityTypeBuilder.Key(propertyNames));
+            public override TestKeyBuilder HasKey(params string[] propertyNames)
+                => new TestKeyBuilder(EntityTypeBuilder.HasKey(propertyNames));
 
-            public override TestKeyBuilder AlternateKey(Expression<Func<TEntity, object>> keyExpression)
-                => new TestKeyBuilder(EntityTypeBuilder.AlternateKey(keyExpression));
+            public override TestKeyBuilder HasAlternateKey(Expression<Func<TEntity, object>> keyExpression)
+                => new TestKeyBuilder(EntityTypeBuilder.HasAlternateKey(keyExpression));
 
-            public override TestKeyBuilder AlternateKey(params string[] propertyNames)
-                => new TestKeyBuilder(EntityTypeBuilder.AlternateKey(propertyNames));
+            public override TestKeyBuilder HasAlternateKey(params string[] propertyNames)
+                => new TestKeyBuilder(EntityTypeBuilder.HasAlternateKey(propertyNames));
 
             public override TestPropertyBuilder<TProperty> Property<TProperty>(Expression<Func<TEntity, TProperty>> propertyExpression)
                 => new GenericTestPropertyBuilder<TProperty>(EntityTypeBuilder.Property(propertyExpression));
@@ -168,11 +168,11 @@ namespace Microsoft.Data.Entity.Tests
             public override TestIndexBuilder Index(params string[] propertyNames)
                 => new TestIndexBuilder(EntityTypeBuilder.Index(propertyNames));
 
-            public override TestReferenceNavigationBuilder<TEntity, TRelatedEntity> Reference<TRelatedEntity>(Expression<Func<TEntity, TRelatedEntity>> reference = null)
-                => new GenericTestReferenceNavigationBuilder<TEntity, TRelatedEntity>(EntityTypeBuilder.Reference(reference));
+            public override TestReferenceNavigationBuilder<TEntity, TRelatedEntity> HasOne<TRelatedEntity>(Expression<Func<TEntity, TRelatedEntity>> reference = null)
+                => new GenericTestReferenceNavigationBuilder<TEntity, TRelatedEntity>(EntityTypeBuilder.HasOne(reference));
 
-            public override TestCollectionNavigationBuilder<TEntity, TRelatedEntity> Collection<TRelatedEntity>(Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> collection = null)
-                => new GenericTestCollectionNavigationBuilder<TEntity, TRelatedEntity>(EntityTypeBuilder.Collection(collection));
+            public override TestCollectionNavigationBuilder<TEntity, TRelatedEntity> HasMany<TRelatedEntity>(Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> collection = null)
+                => new GenericTestCollectionNavigationBuilder<TEntity, TRelatedEntity>(EntityTypeBuilder.HasMany(collection));
         }
 
         protected class GenericTestPropertyBuilder<TProperty> : TestPropertyBuilder<TProperty>
@@ -189,14 +189,14 @@ namespace Microsoft.Data.Entity.Tests
             public override TestPropertyBuilder<TProperty> Annotation(string annotation, object value)
                 => new GenericTestPropertyBuilder<TProperty>(PropertyBuilder.Annotation(annotation, value));
 
-            public override TestPropertyBuilder<TProperty> Required(bool isRequired = true)
-                => new GenericTestPropertyBuilder<TProperty>(PropertyBuilder.Required(isRequired));
+            public override TestPropertyBuilder<TProperty> IsRequired(bool isRequired = true)
+                => new GenericTestPropertyBuilder<TProperty>(PropertyBuilder.IsRequired(isRequired));
 
-            public override TestPropertyBuilder<TProperty> MaxLength(int maxLength)
-                => new GenericTestPropertyBuilder<TProperty>(PropertyBuilder.MaxLength(maxLength));
+            public override TestPropertyBuilder<TProperty> HasMaxLength(int maxLength)
+                => new GenericTestPropertyBuilder<TProperty>(PropertyBuilder.HasMaxLength(maxLength));
 
-            public override TestPropertyBuilder<TProperty> ConcurrencyToken(bool isConcurrencyToken = true)
-                => new GenericTestPropertyBuilder<TProperty>(PropertyBuilder.ConcurrencyToken(isConcurrencyToken));
+            public override TestPropertyBuilder<TProperty> IsConcurrencyToken(bool isConcurrencyToken = true)
+                => new GenericTestPropertyBuilder<TProperty>(PropertyBuilder.IsConcurrencyToken(isConcurrencyToken));
 
             public override TestPropertyBuilder<TProperty> ValueGeneratedNever()
                 => new GenericTestPropertyBuilder<TProperty>(PropertyBuilder.ValueGeneratedNever());
@@ -219,11 +219,11 @@ namespace Microsoft.Data.Entity.Tests
 
             protected ReferenceNavigationBuilder<TEntity, TRelatedEntity> ReferenceNavigationBuilder { get; }
 
-            public override TestReferenceCollectionBuilder<TRelatedEntity, TEntity> InverseCollection(Expression<Func<TRelatedEntity, IEnumerable<TEntity>>> collection = null)
-                => new GenericTestReferenceCollectionBuilder<TRelatedEntity, TEntity>(ReferenceNavigationBuilder.InverseCollection(collection));
+            public override TestReferenceCollectionBuilder<TRelatedEntity, TEntity> WithMany(Expression<Func<TRelatedEntity, IEnumerable<TEntity>>> collection = null)
+                => new GenericTestReferenceCollectionBuilder<TRelatedEntity, TEntity>(ReferenceNavigationBuilder.WithMany(collection));
 
-            public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> InverseReference(Expression<Func<TRelatedEntity, TEntity>> reference = null)
-                => new GenericTestReferenceReferenceBuilder<TEntity, TRelatedEntity>(ReferenceNavigationBuilder.InverseReference(reference));
+            public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> WithOne(Expression<Func<TRelatedEntity, TEntity>> reference = null)
+                => new GenericTestReferenceReferenceBuilder<TEntity, TRelatedEntity>(ReferenceNavigationBuilder.WithOne(reference));
         }
 
         protected class GenericTestCollectionNavigationBuilder<TEntity, TRelatedEntity> : TestCollectionNavigationBuilder<TEntity, TRelatedEntity>
@@ -237,8 +237,8 @@ namespace Microsoft.Data.Entity.Tests
 
             protected CollectionNavigationBuilder<TEntity, TRelatedEntity> CollectionNavigationBuilder { get; }
 
-            public override TestReferenceCollectionBuilder<TEntity, TRelatedEntity> InverseReference(Expression<Func<TRelatedEntity, TEntity>> reference = null)
-                => new GenericTestReferenceCollectionBuilder<TEntity, TRelatedEntity>(CollectionNavigationBuilder.InverseReference(reference));
+            public override TestReferenceCollectionBuilder<TEntity, TRelatedEntity> WithOne(Expression<Func<TRelatedEntity, TEntity>> reference = null)
+                => new GenericTestReferenceCollectionBuilder<TEntity, TRelatedEntity>(CollectionNavigationBuilder.WithOne(reference));
         }
 
         protected class GenericTestReferenceCollectionBuilder<TEntity, TRelatedEntity> : TestReferenceCollectionBuilder<TEntity, TRelatedEntity>

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderNonGenericStringTest.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderNonGenericStringTest.cs
@@ -59,11 +59,11 @@ namespace Microsoft.Data.Entity.Tests
             public override TestEntityTypeBuilder<TEntity> BaseEntity<TBaseEntity>()
                 => Wrap(EntityTypeBuilder.BaseType(typeof(TBaseEntity)));
 
-            public override TestReferenceNavigationBuilder<TEntity, TRelatedEntity> Reference<TRelatedEntity>(Expression<Func<TEntity, TRelatedEntity>> reference = null)
-                => new NonGenericStringTestReferenceNavigationBuilder<TEntity, TRelatedEntity>(EntityTypeBuilder.Reference(typeof(TRelatedEntity).FullName, reference?.GetPropertyAccess().Name));
+            public override TestReferenceNavigationBuilder<TEntity, TRelatedEntity> HasOne<TRelatedEntity>(Expression<Func<TEntity, TRelatedEntity>> reference = null)
+                => new NonGenericStringTestReferenceNavigationBuilder<TEntity, TRelatedEntity>(EntityTypeBuilder.HasOne(typeof(TRelatedEntity).FullName, reference?.GetPropertyAccess().Name));
 
-            public override TestCollectionNavigationBuilder<TEntity, TRelatedEntity> Collection<TRelatedEntity>(Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> collection = null)
-                => new NonGenericTestCollectionNavigationBuilder<TEntity, TRelatedEntity>(EntityTypeBuilder.Collection(typeof(TRelatedEntity).FullName, collection?.GetPropertyAccess().Name));
+            public override TestCollectionNavigationBuilder<TEntity, TRelatedEntity> HasMany<TRelatedEntity>(Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> collection = null)
+                => new NonGenericTestCollectionNavigationBuilder<TEntity, TRelatedEntity>(EntityTypeBuilder.HasMany(typeof(TRelatedEntity).FullName, collection?.GetPropertyAccess().Name));
         }
 
         private class NonGenericStringTestReferenceNavigationBuilder<TEntity, TRelatedEntity> : NonGenericTestReferenceNavigationBuilder<TEntity, TRelatedEntity>
@@ -75,10 +75,10 @@ namespace Microsoft.Data.Entity.Tests
             {
             }
 
-            public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> InverseReference(Expression<Func<TRelatedEntity, TEntity>> reference = null)
+            public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> WithOne(Expression<Func<TRelatedEntity, TEntity>> reference = null)
             {
                 var referenceName = reference?.GetPropertyAccess().Name;
-                return new NonGenericStringTestReferenceReferenceBuilder<TEntity, TRelatedEntity>(ReferenceNavigationBuilder.InverseReference(referenceName));
+                return new NonGenericStringTestReferenceReferenceBuilder<TEntity, TRelatedEntity>(ReferenceNavigationBuilder.WithOne(referenceName));
             }
         }
 

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderNonGenericTest.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderNonGenericTest.cs
@@ -90,17 +90,17 @@ namespace Microsoft.Data.Entity.Tests
             public override TestEntityTypeBuilder<TEntity> BaseEntity(string baseEntityTypeName)
                 => Wrap(EntityTypeBuilder.BaseType(baseEntityTypeName));
 
-            public override TestKeyBuilder Key(Expression<Func<TEntity, object>> keyExpression)
-                => new TestKeyBuilder(EntityTypeBuilder.Key(keyExpression.GetPropertyAccessList().Select(p => p.Name).ToArray()));
+            public override TestKeyBuilder HasKey(Expression<Func<TEntity, object>> keyExpression)
+                => new TestKeyBuilder(EntityTypeBuilder.HasKey(keyExpression.GetPropertyAccessList().Select(p => p.Name).ToArray()));
 
-            public override TestKeyBuilder Key(params string[] propertyNames)
-                => new TestKeyBuilder(EntityTypeBuilder.Key(propertyNames));
+            public override TestKeyBuilder HasKey(params string[] propertyNames)
+                => new TestKeyBuilder(EntityTypeBuilder.HasKey(propertyNames));
 
-            public override TestKeyBuilder AlternateKey(Expression<Func<TEntity, object>> keyExpression)
-                => new TestKeyBuilder(EntityTypeBuilder.AlternateKey(keyExpression.GetPropertyAccessList().Select(p => p.Name).ToArray()));
+            public override TestKeyBuilder HasAlternateKey(Expression<Func<TEntity, object>> keyExpression)
+                => new TestKeyBuilder(EntityTypeBuilder.HasAlternateKey(keyExpression.GetPropertyAccessList().Select(p => p.Name).ToArray()));
 
-            public override TestKeyBuilder AlternateKey(params string[] propertyNames)
-                => new TestKeyBuilder(EntityTypeBuilder.AlternateKey(propertyNames));
+            public override TestKeyBuilder HasAlternateKey(params string[] propertyNames)
+                => new TestKeyBuilder(EntityTypeBuilder.HasAlternateKey(propertyNames));
 
             public override TestPropertyBuilder<TProperty> Property<TProperty>(Expression<Func<TEntity, TProperty>> propertyExpression)
             {
@@ -123,11 +123,11 @@ namespace Microsoft.Data.Entity.Tests
             public override TestIndexBuilder Index(params string[] propertyNames)
                 => new TestIndexBuilder(EntityTypeBuilder.Index(propertyNames));
 
-            public override TestReferenceNavigationBuilder<TEntity, TRelatedEntity> Reference<TRelatedEntity>(Expression<Func<TEntity, TRelatedEntity>> reference = null)
-                => new NonGenericTestReferenceNavigationBuilder<TEntity, TRelatedEntity>(EntityTypeBuilder.Reference(typeof(TRelatedEntity), reference?.GetPropertyAccess().Name));
+            public override TestReferenceNavigationBuilder<TEntity, TRelatedEntity> HasOne<TRelatedEntity>(Expression<Func<TEntity, TRelatedEntity>> reference = null)
+                => new NonGenericTestReferenceNavigationBuilder<TEntity, TRelatedEntity>(EntityTypeBuilder.HasOne(typeof(TRelatedEntity), reference?.GetPropertyAccess().Name));
 
-            public override TestCollectionNavigationBuilder<TEntity, TRelatedEntity> Collection<TRelatedEntity>(Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> collection = null)
-                => new NonGenericTestCollectionNavigationBuilder<TEntity, TRelatedEntity>(EntityTypeBuilder.Collection(typeof(TRelatedEntity), collection?.GetPropertyAccess().Name));
+            public override TestCollectionNavigationBuilder<TEntity, TRelatedEntity> HasMany<TRelatedEntity>(Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> collection = null)
+                => new NonGenericTestCollectionNavigationBuilder<TEntity, TRelatedEntity>(EntityTypeBuilder.HasMany(typeof(TRelatedEntity), collection?.GetPropertyAccess().Name));
         }
 
         protected class NonGenericTestPropertyBuilder<TProperty> : TestPropertyBuilder<TProperty>
@@ -144,14 +144,14 @@ namespace Microsoft.Data.Entity.Tests
             public override TestPropertyBuilder<TProperty> Annotation(string annotation, object value)
                 => new NonGenericTestPropertyBuilder<TProperty>(PropertyBuilder.Annotation(annotation, value));
 
-            public override TestPropertyBuilder<TProperty> Required(bool isRequired = true)
-                => new NonGenericTestPropertyBuilder<TProperty>(PropertyBuilder.Required(isRequired));
+            public override TestPropertyBuilder<TProperty> IsRequired(bool isRequired = true)
+                => new NonGenericTestPropertyBuilder<TProperty>(PropertyBuilder.IsRequired(isRequired));
 
-            public override TestPropertyBuilder<TProperty> MaxLength(int maxLength)
-                => new NonGenericTestPropertyBuilder<TProperty>(PropertyBuilder.MaxLength(maxLength));
+            public override TestPropertyBuilder<TProperty> HasMaxLength(int maxLength)
+                => new NonGenericTestPropertyBuilder<TProperty>(PropertyBuilder.HasMaxLength(maxLength));
 
-            public override TestPropertyBuilder<TProperty> ConcurrencyToken(bool isConcurrencyToken = true)
-                => new NonGenericTestPropertyBuilder<TProperty>(PropertyBuilder.ConcurrencyToken(isConcurrencyToken));
+            public override TestPropertyBuilder<TProperty> IsConcurrencyToken(bool isConcurrencyToken = true)
+                => new NonGenericTestPropertyBuilder<TProperty>(PropertyBuilder.IsConcurrencyToken(isConcurrencyToken));
 
             public override TestPropertyBuilder<TProperty> ValueGeneratedNever()
                 => new NonGenericTestPropertyBuilder<TProperty>(PropertyBuilder.ValueGeneratedNever());
@@ -174,11 +174,11 @@ namespace Microsoft.Data.Entity.Tests
 
             protected ReferenceNavigationBuilder ReferenceNavigationBuilder { get; }
 
-            public override TestReferenceCollectionBuilder<TRelatedEntity, TEntity> InverseCollection(Expression<Func<TRelatedEntity, IEnumerable<TEntity>>> collection = null)
-                => new NonGenericTestReferenceCollectionBuilder<TRelatedEntity, TEntity>(ReferenceNavigationBuilder.InverseCollection(collection?.GetPropertyAccess().Name));
+            public override TestReferenceCollectionBuilder<TRelatedEntity, TEntity> WithMany(Expression<Func<TRelatedEntity, IEnumerable<TEntity>>> collection = null)
+                => new NonGenericTestReferenceCollectionBuilder<TRelatedEntity, TEntity>(ReferenceNavigationBuilder.WithMany(collection?.GetPropertyAccess().Name));
 
-            public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> InverseReference(Expression<Func<TRelatedEntity, TEntity>> reference = null)
-                => new NonGenericTestReferenceReferenceBuilder<TEntity, TRelatedEntity>(ReferenceNavigationBuilder.InverseReference(reference?.GetPropertyAccess().Name));
+            public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> WithOne(Expression<Func<TRelatedEntity, TEntity>> reference = null)
+                => new NonGenericTestReferenceReferenceBuilder<TEntity, TRelatedEntity>(ReferenceNavigationBuilder.WithOne(reference?.GetPropertyAccess().Name));
         }
 
         protected class NonGenericTestCollectionNavigationBuilder<TEntity, TRelatedEntity> : TestCollectionNavigationBuilder<TEntity, TRelatedEntity>
@@ -192,8 +192,8 @@ namespace Microsoft.Data.Entity.Tests
 
             private CollectionNavigationBuilder CollectionNavigationBuilder { get; }
 
-            public override TestReferenceCollectionBuilder<TEntity, TRelatedEntity> InverseReference(Expression<Func<TRelatedEntity, TEntity>> reference = null)
-                => new NonGenericTestReferenceCollectionBuilder<TEntity, TRelatedEntity>(CollectionNavigationBuilder.InverseReference(reference?.GetPropertyAccess().Name));
+            public override TestReferenceCollectionBuilder<TEntity, TRelatedEntity> WithOne(Expression<Func<TRelatedEntity, TEntity>> reference = null)
+                => new NonGenericTestReferenceCollectionBuilder<TEntity, TRelatedEntity>(CollectionNavigationBuilder.WithOne(reference?.GetPropertyAccess().Name));
         }
 
         protected class NonGenericTestReferenceCollectionBuilder<TEntity, TRelatedEntity> : TestReferenceCollectionBuilder<TEntity, TRelatedEntity>

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderTestBase.cs
@@ -100,8 +100,8 @@ namespace Microsoft.Data.Entity.Tests
             {
                 var builder = CreateModelBuilder(new Model());
 
-                builder.Entity<Hob>().Key(e => new { e.Id1, e.Id2 });
-                builder.Entity<Nob>().Key(e => new { e.Id1, e.Id2 });
+                builder.Entity<Hob>().HasKey(e => new { e.Id1, e.Id2 });
+                builder.Entity<Nob>().HasKey(e => new { e.Id1, e.Id2 });
 
                 return builder;
             }
@@ -144,10 +144,10 @@ namespace Microsoft.Data.Entity.Tests
                 where TBaseEntity : class;
 
             public abstract TestEntityTypeBuilder<TEntity> BaseEntity(string baseEntityTypeName);
-            public abstract TestKeyBuilder Key(Expression<Func<TEntity, object>> keyExpression);
-            public abstract TestKeyBuilder Key(params string[] propertyNames);
-            public abstract TestKeyBuilder AlternateKey(Expression<Func<TEntity, object>> keyExpression);
-            public abstract TestKeyBuilder AlternateKey(params string[] propertyNames);
+            public abstract TestKeyBuilder HasKey(Expression<Func<TEntity, object>> keyExpression);
+            public abstract TestKeyBuilder HasKey(params string[] propertyNames);
+            public abstract TestKeyBuilder HasAlternateKey(Expression<Func<TEntity, object>> keyExpression);
+            public abstract TestKeyBuilder HasAlternateKey(params string[] propertyNames);
 
             public abstract TestPropertyBuilder<TProperty> Property<TProperty>(
                 Expression<Func<TEntity, TProperty>> propertyExpression);
@@ -162,11 +162,11 @@ namespace Microsoft.Data.Entity.Tests
             public abstract TestIndexBuilder Index(Expression<Func<TEntity, object>> indexExpression);
             public abstract TestIndexBuilder Index(params string[] propertyNames);
 
-            public abstract TestReferenceNavigationBuilder<TEntity, TRelatedEntity> Reference<TRelatedEntity>(
+            public abstract TestReferenceNavigationBuilder<TEntity, TRelatedEntity> HasOne<TRelatedEntity>(
                 Expression<Func<TEntity, TRelatedEntity>> reference = null)
                 where TRelatedEntity : class;
 
-            public abstract TestCollectionNavigationBuilder<TEntity, TRelatedEntity> Collection<TRelatedEntity>(
+            public abstract TestCollectionNavigationBuilder<TEntity, TRelatedEntity> HasMany<TRelatedEntity>(
                 Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> collection = null)
                 where TRelatedEntity : class;
         }
@@ -212,9 +212,9 @@ namespace Microsoft.Data.Entity.Tests
         {
             public abstract Property Metadata { get; }
             public abstract TestPropertyBuilder<TProperty> Annotation(string annotation, object value);
-            public abstract TestPropertyBuilder<TProperty> Required(bool isRequired = true);
-            public abstract TestPropertyBuilder<TProperty> MaxLength(int maxLength);
-            public abstract TestPropertyBuilder<TProperty> ConcurrencyToken(bool isConcurrencyToken = true);
+            public abstract TestPropertyBuilder<TProperty> IsRequired(bool isRequired = true);
+            public abstract TestPropertyBuilder<TProperty> HasMaxLength(int maxLength);
+            public abstract TestPropertyBuilder<TProperty> IsConcurrencyToken(bool isConcurrencyToken = true);
 
             public abstract TestPropertyBuilder<TProperty> ValueGeneratedNever();
             public abstract TestPropertyBuilder<TProperty> ValueGeneratedOnAdd();
@@ -225,7 +225,7 @@ namespace Microsoft.Data.Entity.Tests
             where TEntity : class
             where TRelatedEntity : class
         {
-            public abstract TestReferenceCollectionBuilder<TEntity, TRelatedEntity> InverseReference(
+            public abstract TestReferenceCollectionBuilder<TEntity, TRelatedEntity> WithOne(
                 Expression<Func<TRelatedEntity, TEntity>> reference = null);
         }
 
@@ -233,10 +233,10 @@ namespace Microsoft.Data.Entity.Tests
             where TEntity : class
             where TRelatedEntity : class
         {
-            public abstract TestReferenceCollectionBuilder<TRelatedEntity, TEntity> InverseCollection(
+            public abstract TestReferenceCollectionBuilder<TRelatedEntity, TEntity> WithMany(
                 Expression<Func<TRelatedEntity, IEnumerable<TEntity>>> collection = null);
 
-            public abstract TestReferenceReferenceBuilder<TEntity, TRelatedEntity> InverseReference(
+            public abstract TestReferenceReferenceBuilder<TEntity, TRelatedEntity> WithOne(
                 Expression<Func<TRelatedEntity, TEntity>> reference = null);
         }
 

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/NonRelationshipTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/NonRelationshipTestBase.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Data.Entity.Tests
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
 
-                modelBuilder.Entity<Customer>().Key(b => b.Id);
+                modelBuilder.Entity<Customer>().HasKey(b => b.Id);
 
                 var entity = model.GetEntityType(typeof(Customer));
 
@@ -51,7 +51,7 @@ namespace Microsoft.Data.Entity.Tests
                         b.Property<int>(Customer.IdProperty.Name + 1);
                         b.Ignore(p => p.Details);
                         b.Ignore(p => p.Orders);
-                        b.Key(Customer.IdProperty.Name + 1);
+                        b.HasKey(Customer.IdProperty.Name + 1);
                     });
 
                 var entity = model.GetEntityType(typeof(Customer));
@@ -68,7 +68,7 @@ namespace Microsoft.Data.Entity.Tests
                 modelBuilder.Entity<Customer>(b =>
                     {
                         b.Ignore(Customer.IdProperty.Name);
-                        b.Key(e => e.Id);
+                        b.HasKey(e => e.Id);
                     });
 
                 var entity = modelBuilder.Model.GetEntityType(typeof(Customer));
@@ -85,7 +85,7 @@ namespace Microsoft.Data.Entity.Tests
 
                 modelBuilder
                     .Entity<Customer>()
-                    .Key(e => new { e.Id, e.Name });
+                    .HasKey(e => new { e.Id, e.Name });
 
                 var entity = model.GetEntityType(typeof(Customer));
 
@@ -105,7 +105,7 @@ namespace Microsoft.Data.Entity.Tests
                 modelBuilder.Entity<Customer>(b =>
                     {
                         b.Property<string>(Customer.NameProperty.Name + "Shadow");
-                        b.Key(Customer.IdProperty.Name, Customer.NameProperty.Name + "Shadow");
+                        b.HasKey(Customer.IdProperty.Name, Customer.NameProperty.Name + "Shadow");
                     });
 
                 var entity = model.GetEntityType(typeof(Customer));
@@ -123,7 +123,7 @@ namespace Microsoft.Data.Entity.Tests
 
                 var keyBuilder = modelBuilder
                     .Entity<Customer>()
-                    .Key(e => new { e.Id, e.Name });
+                    .HasKey(e => new { e.Id, e.Name });
 
                 keyBuilder.Annotation("A1", "V1")
                     .Annotation("A2", "V2");
@@ -145,7 +145,7 @@ namespace Microsoft.Data.Entity.Tests
                 var entity = model.GetEntityType(typeof(Customer));
                 var key = entity.AddKey(entity.GetOrAddProperty(Customer.NameProperty));
 
-                modelBuilder.Entity<Customer>().Key(b => b.Name);
+                modelBuilder.Entity<Customer>().HasKey(b => b.Name);
 
                 Assert.Same(key, entity.GetKeys().Single());
                 Assert.Equal(Customer.NameProperty.Name, entity.GetPrimaryKey().Properties.Single().Name);
@@ -161,7 +161,7 @@ namespace Microsoft.Data.Entity.Tests
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
 
-                modelBuilder.Entity<Customer>().AlternateKey(b => b.AlternateKey);
+                modelBuilder.Entity<Customer>().HasAlternateKey(b => b.AlternateKey);
 
                 var entity = model.GetEntityType(typeof(Customer));
 
@@ -178,7 +178,7 @@ namespace Microsoft.Data.Entity.Tests
                 modelBuilder.Entity<Customer>(b =>
                     {
                         b.Property<int>(Customer.AlternateKeyProperty.Name + 1);
-                        b.AlternateKey(Customer.AlternateKeyProperty.Name + 1);
+                        b.HasAlternateKey(Customer.AlternateKeyProperty.Name + 1);
                     });
 
                 var entity = model.GetEntityType(typeof(Customer));
@@ -194,7 +194,7 @@ namespace Microsoft.Data.Entity.Tests
                 modelBuilder.Entity<Customer>(b =>
                     {
                         b.Ignore(Customer.AlternateKeyProperty.Name);
-                        b.AlternateKey(e => e.AlternateKey);
+                        b.HasAlternateKey(e => e.AlternateKey);
                     });
 
                 var entity = modelBuilder.Model.GetEntityType(typeof(Customer));
@@ -313,7 +313,7 @@ namespace Microsoft.Data.Entity.Tests
                 var modelBuilder = CreateModelBuilder(model);
 
                 var entityBuilder = modelBuilder.Entity<Customer>();
-                entityBuilder.Key(e => e.Id);
+                entityBuilder.HasKey(e => e.Id);
                 entityBuilder.Ignore(e => e.Id);
 
                 Assert.Null(entityBuilder.Metadata.FindProperty(Customer.IdProperty.Name));
@@ -389,12 +389,12 @@ namespace Microsoft.Data.Entity.Tests
 
                 modelBuilder.Entity<Quarks>(b =>
                     {
-                        b.Property(e => e.Up).Required();
-                        b.Property(e => e.Down).Required();
-                        b.Property<int>("Charm").Required();
-                        b.Property<string>("Strange").Required();
-                        b.Property<int>("Top").Required();
-                        b.Property<string>("Bottom").Required();
+                        b.Property(e => e.Up).IsRequired();
+                        b.Property(e => e.Down).IsRequired();
+                        b.Property<int>("Charm").IsRequired();
+                        b.Property<string>("Strange").IsRequired();
+                        b.Property<int>("Top").IsRequired();
+                        b.Property<string>("Bottom").IsRequired();
                     });
 
                 var entityType = (IEntityType)model.GetEntityType(typeof(Quarks));
@@ -415,9 +415,9 @@ namespace Microsoft.Data.Entity.Tests
 
                 modelBuilder.Entity<Quarks>(b =>
                     {
-                        b.Property(e => e.Down).Required(false);
-                        b.Property<string>("Strange").Required(false);
-                        b.Property<string>("Bottom").Required(false);
+                        b.Property(e => e.Down).IsRequired(false);
+                        b.Property<string>("Strange").IsRequired(false);
+                        b.Property<string>("Bottom").IsRequired(false);
                     });
 
                 var entityType = (IEntityType)model.GetEntityType(typeof(Quarks));
@@ -437,15 +437,15 @@ namespace Microsoft.Data.Entity.Tests
                     {
                         Assert.Equal(
                             Strings.CannotBeNullable("Up", "Quarks", "Int32"),
-                            Assert.Throws<InvalidOperationException>(() => b.Property(e => e.Up).Required(false)).Message);
+                            Assert.Throws<InvalidOperationException>(() => b.Property(e => e.Up).IsRequired(false)).Message);
 
                         Assert.Equal(
                             Strings.CannotBeNullable("Charm", "Quarks", "Int32"),
-                            Assert.Throws<InvalidOperationException>(() => b.Property<int>("Charm").Required(false)).Message);
+                            Assert.Throws<InvalidOperationException>(() => b.Property<int>("Charm").IsRequired(false)).Message);
 
                         Assert.Equal(
                             Strings.CannotBeNullable("Top", "Quarks", "Int32"),
-                            Assert.Throws<InvalidOperationException>(() => b.Property<int>("Top").Required(false)).Message);
+                            Assert.Throws<InvalidOperationException>(() => b.Property<int>("Top").IsRequired(false)).Message);
                     });
 
                 var entityType = (IEntityType)model.GetEntityType(typeof(Quarks));
@@ -492,12 +492,12 @@ namespace Microsoft.Data.Entity.Tests
 
                 modelBuilder.Entity<Quarks>(b =>
                     {
-                        b.Property(e => e.Up).ConcurrencyToken();
-                        b.Property(e => e.Down).ConcurrencyToken(false);
-                        b.Property<int>("Charm").ConcurrencyToken(true);
-                        b.Property<string>("Strange").ConcurrencyToken(false);
-                        b.Property<int>("Top").ConcurrencyToken();
-                        b.Property<string>("Bottom").ConcurrencyToken(false);
+                        b.Property(e => e.Up).IsConcurrencyToken();
+                        b.Property(e => e.Down).IsConcurrencyToken(false);
+                        b.Property<int>("Charm").IsConcurrencyToken(true);
+                        b.Property<string>("Strange").IsConcurrencyToken(false);
+                        b.Property<int>("Top").IsConcurrencyToken();
+                        b.Property<string>("Bottom").IsConcurrencyToken(false);
                     });
 
                 var entityType = (IEntityType)model.GetEntityType(typeof(Quarks));
@@ -555,7 +555,7 @@ namespace Microsoft.Data.Entity.Tests
 
                 modelBuilder.Entity<Quarks>(b =>
                     {
-                        b.Key(e => e.Id);
+                        b.HasKey(e => e.Id);
                         b.Property(e => e.Up).ValueGeneratedOnAddOrUpdate();
                         b.Property(e => e.Down).ValueGeneratedNever();
                         b.Property<int>("Charm").ValueGeneratedOnAdd();
@@ -583,12 +583,12 @@ namespace Microsoft.Data.Entity.Tests
 
                 modelBuilder.Entity<Quarks>(b =>
                     {
-                        b.Property(e => e.Up).MaxLength(0);
-                        b.Property(e => e.Down).MaxLength(100);
-                        b.Property<int>("Charm").MaxLength(0);
-                        b.Property<string>("Strange").MaxLength(100);
-                        b.Property<int>("Top").MaxLength(0);
-                        b.Property<string>("Bottom").MaxLength(100);
+                        b.Property(e => e.Up).HasMaxLength(0);
+                        b.Property(e => e.Down).HasMaxLength(100);
+                        b.Property<int>("Charm").HasMaxLength(0);
+                        b.Property<string>("Strange").HasMaxLength(100);
+                        b.Property<int>("Top").HasMaxLength(0);
+                        b.Property<string>("Bottom").HasMaxLength(100);
                     });
 
                 var entityType = model.GetEntityType(typeof(Quarks));
@@ -608,14 +608,14 @@ namespace Microsoft.Data.Entity.Tests
                 CreateModelBuilder()
                     .Entity<Quarks>()
                     .Property(e => e.Up)
-                    .Required()
+                    .IsRequired()
                     .Annotation("A", "V")
-                    .ConcurrencyToken()
+                    .IsConcurrencyToken()
                     .ValueGeneratedNever()
                     .ValueGeneratedOnAdd()
                     .ValueGeneratedOnAddOrUpdate()
-                    .MaxLength(100)
-                    .Required();
+                    .HasMaxLength(100)
+                    .IsRequired();
             }
 
             [Fact]

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/OneToManyTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/OneToManyTestBase.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Data.Entity.Tests
                 var modelBuilder = CreateModelBuilder(model);
                 modelBuilder.Entity<Customer>();
                 modelBuilder.Entity<Order>()
-                    .Reference(o => o.Customer).InverseCollection(c => c.Orders)
+                    .HasOne(o => o.Customer).WithMany(c => c.Orders)
                     .ForeignKey(c => c.CustomerId);
                 modelBuilder.Ignore<OrderDetails>();
                 modelBuilder.Ignore<CustomerDetails>();
@@ -38,7 +38,7 @@ namespace Microsoft.Data.Entity.Tests
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
 
-                modelBuilder.Entity<Customer>().Collection(e => e.Orders).InverseReference(e => e.Customer);
+                modelBuilder.Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer);
 
                 Assert.Same(fk, dependentType.GetForeignKeys().Single());
                 Assert.Equal(navToPrincipal.Name, dependentType.Navigations.Single().Name);
@@ -61,7 +61,7 @@ namespace Microsoft.Data.Entity.Tests
                 var modelBuilder = CreateModelBuilder(model);
                 modelBuilder.Entity<Customer>();
                 modelBuilder
-                    .Entity<Order>().Reference(c => c.Customer).InverseCollection()
+                    .Entity<Order>().HasOne(c => c.Customer).WithMany()
                     .ForeignKey(c => c.CustomerId);
                 modelBuilder.Ignore<OrderDetails>();
                 modelBuilder.Ignore<CustomerDetails>();
@@ -75,7 +75,7 @@ namespace Microsoft.Data.Entity.Tests
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
 
-                modelBuilder.Entity<Customer>().Collection(e => e.Orders).InverseReference(e => e.Customer);
+                modelBuilder.Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer);
 
                 Assert.Equal(1, dependentType.GetForeignKeys().Count());
                 Assert.Equal("Orders", principalType.Navigations.Single().Name);
@@ -94,7 +94,7 @@ namespace Microsoft.Data.Entity.Tests
             {
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
-                modelBuilder.Entity<Customer>().Collection(e => e.Orders).InverseReference()
+                modelBuilder.Entity<Customer>().HasMany(e => e.Orders).WithOne()
                     .ForeignKey(e => e.CustomerId);
                 modelBuilder.Entity<Order>();
                 modelBuilder.Ignore<OrderDetails>();
@@ -108,7 +108,7 @@ namespace Microsoft.Data.Entity.Tests
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
 
-                modelBuilder.Entity<Customer>().Collection(e => e.Orders).InverseReference(e => e.Customer);
+                modelBuilder.Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer);
 
                 var newFk = dependentType.GetForeignKeys().Single();
                 AssertEqual(fk.Properties, newFk.Properties);
@@ -132,7 +132,7 @@ namespace Microsoft.Data.Entity.Tests
                 var modelBuilder = CreateModelBuilder(model);
                 modelBuilder.Entity<Customer>();
                 modelBuilder
-                    .Entity<Order>().Reference(e => e.Customer).InverseCollection(e => e.Orders)
+                    .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                     .ForeignKey(c => c.CustomerId);
                 modelBuilder.Ignore<OrderDetails>();
                 modelBuilder.Ignore<CustomerDetails>();
@@ -144,7 +144,7 @@ namespace Microsoft.Data.Entity.Tests
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
 
-                modelBuilder.Entity<Customer>().Collection(e => e.Orders).InverseReference(e => e.Customer);
+                modelBuilder.Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer);
 
                 Assert.Same(fk, dependentType.GetForeignKeys().Single());
                 Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -178,7 +178,7 @@ namespace Microsoft.Data.Entity.Tests
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
 
-                modelBuilder.Entity<Customer>().Collection(e => e.Orders).InverseReference(e => e.Customer);
+                modelBuilder.Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer);
 
                 var fk = dependentType.GetForeignKeys().Single();
                 Assert.Same(fkProperty, fk.Properties.Single());
@@ -214,7 +214,7 @@ namespace Microsoft.Data.Entity.Tests
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
 
-                modelBuilder.Entity<Customer>().Collection(e => e.Orders).InverseReference();
+                modelBuilder.Entity<Customer>().HasMany(e => e.Orders).WithOne();
 
                 var fk = dependentType.GetForeignKeys().Single();
                 Assert.Same(fkProperty, fk.Properties.Single());
@@ -250,7 +250,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 // Passing null as the first arg is not super-compelling, but it is consistent
-                modelBuilder.Entity<Customer>().Collection<Order>().InverseReference(e => e.Customer);
+                modelBuilder.Entity<Customer>().HasMany<Order>().WithOne(e => e.Customer);
 
                 var fk = dependentType.GetForeignKeys().Single();
                 Assert.Same(fkProperty, fk.Properties.Single());
@@ -287,7 +287,7 @@ namespace Microsoft.Data.Entity.Tests
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
 
-                modelBuilder.Entity<Customer>().Collection<Order>().InverseReference();
+                modelBuilder.Entity<Customer>().HasMany<Order>().WithOne();
 
                 var newFk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey != fk);
 
@@ -323,7 +323,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Customer>().Collection(e => e.Orders).InverseReference(e => e.Customer)
+                    .Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer)
                     .ForeignKey(e => e.CustomerId);
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -349,7 +349,7 @@ namespace Microsoft.Data.Entity.Tests
                 var modelBuilder = CreateModelBuilder(model);
                 modelBuilder.Entity<BigMak>();
                 modelBuilder
-                    .Entity<Pickle>().Reference(e => e.BigMak).InverseCollection()
+                    .Entity<Pickle>().HasOne(e => e.BigMak).WithMany()
                     .ForeignKey(c => c.BurgerId);
                 modelBuilder.Ignore<Bun>();
 
@@ -362,7 +362,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<BigMak>().Collection(e => e.Pickles).InverseReference(e => e.BigMak)
+                    .Entity<BigMak>().HasMany(e => e.Pickles).WithOne(e => e.BigMak)
                     .ForeignKey(e => e.BurgerId);
 
                 Assert.Same(fk, dependentType.GetForeignKeys().Single());
@@ -397,7 +397,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<BigMak>().Collection(e => e.Pickles).InverseReference(e => e.BigMak)
+                    .Entity<BigMak>().HasMany(e => e.Pickles).WithOne(e => e.BigMak)
                     .ForeignKey(e => e.BurgerId);
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -434,7 +434,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<BigMak>().Collection(e => e.Pickles).InverseReference()
+                    .Entity<BigMak>().HasMany(e => e.Pickles).WithOne()
                     .ForeignKey(e => e.BurgerId);
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -470,7 +470,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<BigMak>().Collection<Pickle>().InverseReference(e => e.BigMak)
+                    .Entity<BigMak>().HasMany<Pickle>().WithOne(e => e.BigMak)
                     .ForeignKey(e => e.BurgerId);
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -507,7 +507,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<BigMak>().Collection<Pickle>().InverseReference()
+                    .Entity<BigMak>().HasMany<Pickle>().WithOne()
                     .ForeignKey(e => e.BurgerId);
 
                 var newFk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey != fk);
@@ -539,7 +539,7 @@ namespace Microsoft.Data.Entity.Tests
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
 
-                modelBuilder.Entity<BigMak>().Collection(e => e.Pickles).InverseReference(e => e.BigMak);
+                modelBuilder.Entity<BigMak>().HasMany(e => e.Pickles).WithOne(e => e.BigMak);
 
                 var fk = dependentType.GetForeignKeys().Single();
                 var fkProperty = (IProperty)fk.Properties.Single();
@@ -577,7 +577,7 @@ namespace Microsoft.Data.Entity.Tests
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
 
-                modelBuilder.Entity<BigMak>().Collection(e => e.Pickles).InverseReference();
+                modelBuilder.Entity<BigMak>().HasMany(e => e.Pickles).WithOne();
 
                 var fk = dependentType.GetForeignKeys().Single();
                 var fkProperty = (IProperty)fk.Properties.Single();
@@ -614,7 +614,7 @@ namespace Microsoft.Data.Entity.Tests
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
 
-                modelBuilder.Entity<BigMak>().Collection<Pickle>().InverseReference(e => e.BigMak);
+                modelBuilder.Entity<BigMak>().HasMany<Pickle>().WithOne(e => e.BigMak);
 
                 var fk = dependentType.GetForeignKeys().Single();
                 var fkProperty = (IProperty)fk.Properties.Single();
@@ -652,7 +652,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
                 var existingFk = dependentType.GetForeignKeys().Single();
 
-                modelBuilder.Entity<BigMak>().Collection<Pickle>().InverseReference();
+                modelBuilder.Entity<BigMak>().HasMany<Pickle>().WithOne();
 
                 var foreignKey = dependentType.GetForeignKeys().Single(fk => fk != existingFk);
                 var fkProperty = (IProperty)foreignKey.Properties.Single();
@@ -691,7 +691,7 @@ namespace Microsoft.Data.Entity.Tests
 
                 var fkProperty = dependentType.GetProperty("BigMakId");
 
-                modelBuilder.Entity<BigMak>().Collection(e => e.Pickles).InverseReference(e => e.BigMak);
+                modelBuilder.Entity<BigMak>().HasMany(e => e.Pickles).WithOne(e => e.BigMak);
 
                 var fk = dependentType.GetForeignKeys().Single();
                 Assert.Same(fkProperty, fk.Properties.Single());
@@ -715,7 +715,7 @@ namespace Microsoft.Data.Entity.Tests
             {
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
-                modelBuilder.Entity<BigMak>().Reference<Pickle>().InverseReference()
+                modelBuilder.Entity<BigMak>().HasOne<Pickle>().WithOne()
                     .ForeignKey<Pickle>(e => e.BurgerId);
                 modelBuilder.Ignore<Bun>();
 
@@ -730,7 +730,7 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.True(((IForeignKey)fk).IsUnique);
 
                 modelBuilder
-                    .Entity<BigMak>().Collection(e => e.Pickles).InverseReference(e => e.BigMak)
+                    .Entity<BigMak>().HasMany(e => e.Pickles).WithOne(e => e.BigMak)
                     .ForeignKey(e => e.BurgerId);
 
                 Assert.Equal(1, dependentType.GetForeignKeys().Count());
@@ -770,7 +770,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Customer>().Collection(e => e.Orders).InverseReference(e => e.Customer)
+                    .Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer)
                     .PrincipalKey(e => e.Id);
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -808,7 +808,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Customer>().Collection(e => e.Orders).InverseReference(e => e.Customer)
+                    .Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer)
                     .PrincipalKey(e => e.AlternateKey);
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -855,7 +855,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Customer>().Collection(e => e.Orders).InverseReference(e => e.Customer)
+                    .Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer)
                     .ForeignKey(e => e.CustomerId)
                     .PrincipalKey(e => e.Id);
 
@@ -896,7 +896,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Customer>().Collection(e => e.Orders).InverseReference(e => e.Customer)
+                    .Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer)
                     .PrincipalKey(e => e.Id)
                     .ForeignKey(e => e.CustomerId);
 
@@ -935,7 +935,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Customer>().Collection(e => e.Orders).InverseReference(e => e.Customer)
+                    .Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer)
                     .ForeignKey(e => e.AnotherCustomerId)
                     .PrincipalKey(e => e.AlternateKey);
 
@@ -982,7 +982,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Customer>().Collection(e => e.Orders).InverseReference(e => e.Customer)
+                    .Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer)
                     .PrincipalKey(e => e.AlternateKey)
                     .ForeignKey(e => e.AnotherCustomerId);
 
@@ -1030,7 +1030,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<BigMak>().Collection(e => e.Pickles).InverseReference(e => e.BigMak)
+                    .Entity<BigMak>().HasMany(e => e.Pickles).WithOne(e => e.BigMak)
                     .ForeignKey(e => e.BurgerId)
                     .PrincipalKey(e => e.AlternateKey);
 
@@ -1075,7 +1075,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<BigMak>().Collection(e => e.Pickles).InverseReference(e => e.BigMak)
+                    .Entity<BigMak>().HasMany(e => e.Pickles).WithOne(e => e.BigMak)
                     .PrincipalKey(e => e.AlternateKey)
                     .ForeignKey(e => e.BurgerId);
 
@@ -1107,7 +1107,7 @@ namespace Microsoft.Data.Entity.Tests
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
                 modelBuilder
-                    .Entity<BigMak>().Collection(e => e.Pickles).InverseReference(e => e.BigMak)
+                    .Entity<BigMak>().HasMany(e => e.Pickles).WithOne(e => e.BigMak)
                     .ForeignKey(e => e.BurgerId);
                 modelBuilder.Ignore<Bun>();
 
@@ -1119,7 +1119,7 @@ namespace Microsoft.Data.Entity.Tests
                 var expectedPrincipalProperties = principalType.Properties.ToList();
                 var expectedDependentProperties = dependentType.Properties.ToList();
 
-                modelBuilder.Entity<BigMak>().Key(e => e.AlternateKey);
+                modelBuilder.Entity<BigMak>().HasKey(e => e.AlternateKey);
                 
                 var fk = dependentType.GetForeignKeys().Single();
                 var principalProperty = principalType.GetProperty("AlternateKey");
@@ -1147,7 +1147,7 @@ namespace Microsoft.Data.Entity.Tests
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
                 modelBuilder
-                    .Entity<BigMak>().Collection(e => e.Pickles).InverseReference(e => e.BigMak)
+                    .Entity<BigMak>().HasMany(e => e.Pickles).WithOne(e => e.BigMak)
                     .ForeignKey(e => new { e.BurgerId, e.Id });
                 modelBuilder.Ignore<Bun>();
 
@@ -1162,7 +1162,7 @@ namespace Microsoft.Data.Entity.Tests
                 var expectedDependentProperties = dependentType.Properties.ToList();
                 var expectedPrincipalProperties = principalType.Properties.ToList();
 
-                modelBuilder.Entity<BigMak>().Key(e => e.AlternateKey);
+                modelBuilder.Entity<BigMak>().HasKey(e => e.AlternateKey);
 
                 var principalProperty = principalType.GetProperty("AlternateKey");
                 var fk = dependentType.GetForeignKeys().Single();
@@ -1193,7 +1193,7 @@ namespace Microsoft.Data.Entity.Tests
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
                 modelBuilder
-                    .Entity<BigMak>().Collection(e => e.Pickles).InverseReference(e => e.BigMak)
+                    .Entity<BigMak>().HasMany(e => e.Pickles).WithOne(e => e.BigMak)
                     .PrincipalKey(e => new { e.Id });
                 modelBuilder.Ignore<Bun>();
 
@@ -1208,7 +1208,7 @@ namespace Microsoft.Data.Entity.Tests
                 var expectedPrincipalProperties = modelClone.GetEntityType(typeof(BigMak)).GetProperties().ToList();
                 var expectedDependentProperties = modelClone.GetEntityType(typeof(Pickle)).GetProperties().ToList();
 
-                modelBuilder.Entity<BigMak>().Key(e => e.AlternateKey);
+                modelBuilder.Entity<BigMak>().HasKey(e => e.AlternateKey);
 
                 var principalProperty = principalType.GetProperty("AlternateKey");
                 var fk = dependentType.GetForeignKeys().Single();
@@ -1241,9 +1241,9 @@ namespace Microsoft.Data.Entity.Tests
             {
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
-                modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
+                modelBuilder.Entity<Whoopper>().HasKey(c => new { c.Id1, c.Id2 });
                 modelBuilder
-                    .Entity<Tomato>().Reference(e => e.Whoopper).InverseCollection()
+                    .Entity<Tomato>().HasOne(e => e.Whoopper).WithMany()
                     .ForeignKey(c => new { c.BurgerId1, c.BurgerId2 });
                 modelBuilder.Ignore<ToastedBun>();
                 modelBuilder.Ignore<Moostard>();
@@ -1256,7 +1256,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Whoopper>().Collection(e => e.Tomatoes).InverseReference(e => e.Whoopper)
+                    .Entity<Whoopper>().HasMany(e => e.Tomatoes).WithOne(e => e.Whoopper)
                     .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
 
                 Assert.Equal(1, dependentType.GetForeignKeys().Count());
@@ -1277,7 +1277,7 @@ namespace Microsoft.Data.Entity.Tests
             {
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
-                modelBuilder.Entity<Whoopper>(b => b.Key(c => new { c.Id1, c.Id2 }));
+                modelBuilder.Entity<Whoopper>(b => b.HasKey(c => new { c.Id1, c.Id2 }));
                 modelBuilder.Entity<Tomato>();
                 modelBuilder.Ignore<ToastedBun>();
                 modelBuilder.Ignore<Moostard>();
@@ -1292,7 +1292,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Whoopper>().Collection(e => e.Tomatoes).InverseReference(e => e.Whoopper)
+                    .Entity<Whoopper>().HasMany(e => e.Tomatoes).WithOne(e => e.Whoopper)
                     .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -1317,7 +1317,7 @@ namespace Microsoft.Data.Entity.Tests
             {
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
-                modelBuilder.Entity<Whoopper>(b => b.Key(c => new { c.Id1, c.Id2 }));
+                modelBuilder.Entity<Whoopper>(b => b.HasKey(c => new { c.Id1, c.Id2 }));
                 modelBuilder.Entity<Tomato>();
                 modelBuilder.Ignore<ToastedBun>();
                 modelBuilder.Ignore<Moostard>();
@@ -1334,7 +1334,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Whoopper>().Collection(e => e.Tomatoes).InverseReference(e => e.Whoopper)
+                    .Entity<Whoopper>().HasMany(e => e.Tomatoes).WithOne(e => e.Whoopper)
                     .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 })
                     .PrincipalKey(e => new { e.AlternateKey1, e.AlternateKey2 });
 
@@ -1367,7 +1367,7 @@ namespace Microsoft.Data.Entity.Tests
             {
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
-                modelBuilder.Entity<Whoopper>(b => b.Key(c => new { c.Id1, c.Id2 }));
+                modelBuilder.Entity<Whoopper>(b => b.HasKey(c => new { c.Id1, c.Id2 }));
                 modelBuilder.Entity<Tomato>();
                 modelBuilder.Ignore<ToastedBun>();
                 modelBuilder.Ignore<Moostard>();
@@ -1384,7 +1384,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Whoopper>().Collection(e => e.Tomatoes).InverseReference(e => e.Whoopper)
+                    .Entity<Whoopper>().HasMany(e => e.Tomatoes).WithOne(e => e.Whoopper)
                     .PrincipalKey(e => new { e.AlternateKey1, e.AlternateKey2 })
                     .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
 
@@ -1417,7 +1417,7 @@ namespace Microsoft.Data.Entity.Tests
             {
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
-                modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
+                modelBuilder.Entity<Whoopper>().HasKey(c => new { c.Id1, c.Id2 });
                 modelBuilder.Entity<Tomato>(b =>
                     {
                         b.Property(e => e.BurgerId1);
@@ -1436,7 +1436,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Whoopper>().Collection(e => e.Tomatoes).InverseReference()
+                    .Entity<Whoopper>().HasMany(e => e.Tomatoes).WithOne()
                     .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -1460,7 +1460,7 @@ namespace Microsoft.Data.Entity.Tests
             {
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
-                modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
+                modelBuilder.Entity<Whoopper>().HasKey(c => new { c.Id1, c.Id2 });
                 modelBuilder.Entity<Tomato>();
                 modelBuilder.Ignore<ToastedBun>();
                 modelBuilder.Ignore<Moostard>();
@@ -1475,7 +1475,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Whoopper>().Collection<Tomato>().InverseReference(e => e.Whoopper)
+                    .Entity<Whoopper>().HasMany<Tomato>().WithOne(e => e.Whoopper)
                     .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -1499,8 +1499,8 @@ namespace Microsoft.Data.Entity.Tests
             {
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
-                modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
-                modelBuilder.Entity<Whoopper>().Collection(w => w.Tomatoes).InverseReference(t => t.Whoopper);
+                modelBuilder.Entity<Whoopper>().HasKey(c => new { c.Id1, c.Id2 });
+                modelBuilder.Entity<Whoopper>().HasMany(w => w.Tomatoes).WithOne(t => t.Whoopper);
                 modelBuilder.Entity<Tomato>();
                 modelBuilder.Ignore<Moostard>();
                 modelBuilder.Ignore<ToastedBun>();
@@ -1516,7 +1516,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetPrimaryKey();
 
                 modelBuilder
-                    .Entity<Whoopper>().Collection<Tomato>().InverseReference()
+                    .Entity<Whoopper>().HasMany<Tomato>().WithOne()
                     .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
 
                 var newFk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey != fk);
@@ -1539,7 +1539,7 @@ namespace Microsoft.Data.Entity.Tests
             {
                 var modelBuilder = HobNobBuilder();
                 var model = modelBuilder.Model;
-                modelBuilder.Entity<Nob>().Reference(e => e.Hob).InverseReference(e => e.Nob);
+                modelBuilder.Entity<Nob>().HasOne(e => e.Hob).WithOne(e => e.Nob);
 
                 var dependentType = model.GetEntityType(typeof(Hob));
                 var principalType = model.GetEntityType(typeof(Nob));
@@ -1548,7 +1548,7 @@ namespace Microsoft.Data.Entity.Tests
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
 
-                modelBuilder.Entity<Nob>().Collection(e => e.Hobs).InverseReference(e => e.Nob);
+                modelBuilder.Entity<Nob>().HasMany(e => e.Hobs).WithOne(e => e.Nob);
 
                 var fk = dependentType.GetForeignKeys().Single();
                 Assert.False(fk.IsUnique);
@@ -1575,7 +1575,7 @@ namespace Microsoft.Data.Entity.Tests
 
                 var dependentType = model.GetEntityType(typeof(Order));
 
-                var builder = modelBuilder.Entity<Customer>().Collection(e => e.Orders).InverseReference(e => e.Customer);
+                var builder = modelBuilder.Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer);
                 builder = builder.Annotation("Fus", "Ro");
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -1589,7 +1589,7 @@ namespace Microsoft.Data.Entity.Tests
                 var modelBuilder = HobNobBuilder();
 
                 modelBuilder
-                    .Entity<Hob>().Collection(e => e.Nobs).InverseReference(e => e.Hob)
+                    .Entity<Hob>().HasMany(e => e.Nobs).WithOne(e => e.Hob)
                     .ForeignKey(e => new { e.HobId1, e.HobId2 });
 
                 var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob));
@@ -1605,7 +1605,7 @@ namespace Microsoft.Data.Entity.Tests
                 var modelBuilder = HobNobBuilder();
 
                 modelBuilder
-                    .Entity<Nob>().Collection(e => e.Hobs).InverseReference(e => e.Nob)
+                    .Entity<Nob>().HasMany(e => e.Hobs).WithOne(e => e.Nob)
                     .ForeignKey(e => new { e.NobId1, e.NobId2 });
 
                 var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Hob));
@@ -1621,7 +1621,7 @@ namespace Microsoft.Data.Entity.Tests
                 var modelBuilder = HobNobBuilder();
 
                 modelBuilder
-                    .Entity<Hob>().Collection(e => e.Nobs).InverseReference(e => e.Hob)
+                    .Entity<Hob>().HasMany(e => e.Nobs).WithOne(e => e.Hob)
                     .ForeignKey(e => new { e.HobId1, e.HobId2 })
                     .Required();
 
@@ -1640,7 +1640,7 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Equal(
                     Strings.ForeignKeyCannotBeOptional("{'NobId1', 'NobId2'}", typeof(Hob).Name),
                     Assert.Throws<InvalidOperationException>(() => modelBuilder
-                        .Entity<Nob>().Collection(e => e.Hobs).InverseReference(e => e.Nob)
+                        .Entity<Nob>().HasMany(e => e.Hobs).WithOne(e => e.Nob)
                         .ForeignKey(e => new { e.NobId1, e.NobId2 })
                         .Required(false)).Message);
 
@@ -1658,13 +1658,13 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob));
 
                 modelBuilder
-                    .Entity<Hob>().Collection(e => e.Nobs).InverseReference(e => e.Hob)
+                    .Entity<Hob>().HasMany(e => e.Nobs).WithOne(e => e.Hob)
                     .WillCascadeOnDelete();
 
                 Assert.Equal(DeleteBehavior.Cascade, dependentType.GetForeignKeys().Single().DeleteBehavior);
 
                 modelBuilder
-                    .Entity<Hob>().Collection(e => e.Nobs).InverseReference(e => e.Hob)
+                    .Entity<Hob>().HasMany(e => e.Nobs).WithOne(e => e.Hob)
                     .WillCascadeOnDelete(false);
 
                 Assert.Equal(DeleteBehavior.None, dependentType.GetForeignKeys().Single().DeleteBehavior);

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/OneToOneTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/OneToOneTestBase.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Data.Entity.Tests
                 var modelBuilder = CreateModelBuilder(model);
                 modelBuilder.Entity<Customer>();
                 modelBuilder
-                    .Entity<CustomerDetails>().Reference(d => d.Customer).InverseReference(c => c.Details)
+                    .Entity<CustomerDetails>().HasOne(d => d.Customer).WithOne(c => c.Details)
                     .ForeignKey<CustomerDetails>(c => c.Id);
                 modelBuilder.Ignore<Order>();
 
@@ -36,7 +36,7 @@ namespace Microsoft.Data.Entity.Tests
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
 
-                modelBuilder.Entity<Customer>().Reference(e => e.Details).InverseReference(e => e.Customer);
+                modelBuilder.Entity<Customer>().HasOne(e => e.Details).WithOne(e => e.Customer);
 
                 Assert.Equal(1, dependentType.GetForeignKeys().Count());
                 Assert.Same(navToPrincipal, dependentType.Navigations.Single());
@@ -56,7 +56,7 @@ namespace Microsoft.Data.Entity.Tests
             {
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
-                modelBuilder.Entity<CustomerDetails>().Reference(c => c.Customer).InverseReference();
+                modelBuilder.Entity<CustomerDetails>().HasOne(c => c.Customer).WithOne();
                 modelBuilder.Ignore<Order>();
 
                 var dependentType = model.GetEntityType(typeof(CustomerDetails));
@@ -67,7 +67,7 @@ namespace Microsoft.Data.Entity.Tests
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
 
-                modelBuilder.Entity<Customer>().Reference(e => e.Details).InverseReference(e => e.Customer);
+                modelBuilder.Entity<Customer>().HasOne(e => e.Details).WithOne(e => e.Customer);
 
                 var fk = dependentType.GetForeignKeys().Single();
                 Assert.Same(fk.DependentToPrincipal, dependentType.Navigations.Single());
@@ -86,7 +86,7 @@ namespace Microsoft.Data.Entity.Tests
             {
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
-                modelBuilder.Entity<Customer>().Reference(c => c.Details).InverseReference()
+                modelBuilder.Entity<Customer>().HasOne(c => c.Details).WithOne()
                     .ForeignKey<CustomerDetails>(c => c.Id);
                 modelBuilder.Entity<CustomerDetails>();
                 modelBuilder.Ignore<Order>();
@@ -100,7 +100,7 @@ namespace Microsoft.Data.Entity.Tests
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
 
-                modelBuilder.Entity<Customer>().Reference(e => e.Details).InverseReference(e => e.Customer);
+                modelBuilder.Entity<Customer>().HasOne(e => e.Details).WithOne(e => e.Customer);
 
                 Assert.Equal(1, dependentType.GetForeignKeys().Count());
                 Assert.Equal("Customer", dependentType.Navigations.Single().Name);
@@ -120,8 +120,8 @@ namespace Microsoft.Data.Entity.Tests
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
                 modelBuilder.Entity<Customer>()
-                    .Reference<CustomerDetails>()
-                    .InverseReference()
+                    .HasOne<CustomerDetails>()
+                    .WithOne()
                     .ForeignKey<CustomerDetails>(e => e.Id);
                 modelBuilder.Entity<CustomerDetails>();
                 modelBuilder.Ignore<Order>();
@@ -135,7 +135,7 @@ namespace Microsoft.Data.Entity.Tests
                 var expectedPrincipalProperties = principalType.Properties.ToList();
                 var expectedDependentProperties = dependentType.Properties.ToList();
 
-                modelBuilder.Entity<CustomerDetails>().Reference(e => e.Customer).InverseReference(e => e.Details)
+                modelBuilder.Entity<CustomerDetails>().HasOne(e => e.Customer).WithOne(e => e.Details)
                     .PrincipalKey<Customer>(e => e.Id);
                 var newFk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey != fk);
 
@@ -169,7 +169,7 @@ namespace Microsoft.Data.Entity.Tests
                 var expectedPrincipalProperties = principalType.Properties.ToList();
                 var expectedDependentProperties = dependentType.Properties.ToList();
 
-                modelBuilder.Entity<CustomerDetails>().Reference(e => e.Customer).InverseReference(e => e.Details);
+                modelBuilder.Entity<CustomerDetails>().HasOne(e => e.Customer).WithOne(e => e.Details);
 
                 var fk = dependentType.GetForeignKeys().Single();
 
@@ -195,8 +195,8 @@ namespace Microsoft.Data.Entity.Tests
                 modelBuilder.Entity<OrderDetails>();
                 modelBuilder
                     .Entity<Order>()
-                    .Reference(e => e.Details)
-                    .InverseReference()
+                    .HasOne(e => e.Details)
+                    .WithOne()
                     .ForeignKey<OrderDetails>(c => c.Id);
                 modelBuilder.Ignore<Customer>();
 
@@ -209,7 +209,7 @@ namespace Microsoft.Data.Entity.Tests
                 var expectedPrincipalProperties = principalType.Properties.ToList();
                 var expectedDependentProperties = dependentType.Properties.ToList();
 
-                modelBuilder.Entity<OrderDetails>().Reference(e => e.Order).InverseReference(e => e.Details);
+                modelBuilder.Entity<OrderDetails>().HasOne(e => e.Order).WithOne(e => e.Details);
 
                 var fk = dependentType.GetForeignKeys().Single();
                 Assert.NotSame(existingFk, fk);
@@ -242,7 +242,7 @@ namespace Microsoft.Data.Entity.Tests
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
 
-                modelBuilder.Entity<OrderDetails>().Reference(e => e.Order).InverseReference(e => e.Details);
+                modelBuilder.Entity<OrderDetails>().HasOne(e => e.Order).WithOne(e => e.Details);
 
                 var fk = dependentType.GetForeignKeys().Single();
                 Assert.Same(fkProperty, fk.Properties.Single());
@@ -277,7 +277,7 @@ namespace Microsoft.Data.Entity.Tests
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
 
-                modelBuilder.Entity<Customer>().Reference(e => e.Details).InverseReference();
+                modelBuilder.Entity<Customer>().HasOne(e => e.Details).WithOne();
 
                 var fk = dependentType.Navigations.Single().ForeignKey;
                 if (fk.DeclaringEntityType == dependentType)
@@ -315,7 +315,7 @@ namespace Microsoft.Data.Entity.Tests
                 var expectedPrincipalProperties = principalType.Properties.ToList();
                 var expectedDependentProperties = dependentType.Properties.ToList();
 
-                modelBuilder.Entity<CustomerDetails>().Reference<Customer>().InverseReference(e => e.Details);
+                modelBuilder.Entity<CustomerDetails>().HasOne<Customer>().WithOne(e => e.Details);
 
                 var fk = principalType.Navigations.Single().ForeignKey;
 
@@ -347,7 +347,7 @@ namespace Microsoft.Data.Entity.Tests
                 var expectedPrincipalProperties = principalType.Properties.ToList();
                 var expectedDependentProperties = dependentType.Properties.ToList();
 
-                modelBuilder.Entity<CustomerDetails>().Reference<Customer>().InverseReference();
+                modelBuilder.Entity<CustomerDetails>().HasOne<Customer>().WithOne();
 
                 var fk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey.PrincipalToDependent == null);
 
@@ -379,7 +379,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Order>().Reference(e => e.Details).InverseReference(e => e.Order)
+                    .Entity<Order>().HasOne(e => e.Details).WithOne(e => e.Order)
                     .ForeignKey<OrderDetails>(e => e.OrderId);
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -416,7 +416,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Customer>().Reference(e => e.Details).InverseReference(e => e.Customer)
+                    .Entity<Customer>().HasOne(e => e.Details).WithOne(e => e.Customer)
                     .ForeignKey<CustomerDetails>(e => e.Id);
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -441,7 +441,7 @@ namespace Microsoft.Data.Entity.Tests
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
                 modelBuilder.Entity<BigMak>();
-                modelBuilder.Entity<Bun>().Reference<BigMak>().InverseReference()
+                modelBuilder.Entity<Bun>().HasOne<BigMak>().WithOne()
                     .ForeignKey<Bun>(e => e.BurgerId);
                 modelBuilder.Ignore<Pickle>();
 
@@ -454,7 +454,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<BigMak>().Reference(e => e.Bun).InverseReference(e => e.BigMak)
+                    .Entity<BigMak>().HasOne(e => e.Bun).WithOne(e => e.BigMak)
                     .ForeignKey<Bun>(e => e.BurgerId);
 
                 Assert.Same(fk, dependentType.GetForeignKeys().Single());
@@ -489,7 +489,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<BigMak>().Reference(e => e.Bun).InverseReference(e => e.BigMak)
+                    .Entity<BigMak>().HasOne(e => e.Bun).WithOne(e => e.BigMak)
                     .ForeignKey<Bun>(e => e.BurgerId);
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -526,7 +526,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<BigMak>().Reference(e => e.Bun).InverseReference()
+                    .Entity<BigMak>().HasOne(e => e.Bun).WithOne()
                     .ForeignKey<Bun>(e => e.BurgerId);
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -562,7 +562,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<BigMak>().Reference<Bun>().InverseReference(e => e.BigMak)
+                    .Entity<BigMak>().HasOne<Bun>().WithOne(e => e.BigMak)
                     .ForeignKey<Bun>(e => e.BurgerId);
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -598,7 +598,7 @@ namespace Microsoft.Data.Entity.Tests
                 var expectedDependentProperties = dependentType.Properties.ToList();
 
                 modelBuilder
-                    .Entity<BigMak>().Reference<Bun>().InverseReference()
+                    .Entity<BigMak>().HasOne<Bun>().WithOne()
                     .ForeignKey<Bun>(e => e.BurgerId);
 
                 var newFk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey.Properties.All(p => p.Name == "BurgerId"));
@@ -619,7 +619,7 @@ namespace Microsoft.Data.Entity.Tests
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
                 modelBuilder.Entity<BigMak>();
-                modelBuilder.Entity<Bun>().Reference<BigMak>().InverseCollection()
+                modelBuilder.Entity<Bun>().HasOne<BigMak>().WithMany()
                     .ForeignKey(e => e.BurgerId);
                 modelBuilder.Ignore<Pickle>();
 
@@ -631,7 +631,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<BigMak>().Reference(e => e.Bun).InverseReference(e => e.BigMak)
+                    .Entity<BigMak>().HasOne(e => e.Bun).WithOne(e => e.BigMak)
                     .ForeignKey<Bun>(e => e.BurgerId);
 
                 Assert.Equal(1, dependentType.GetForeignKeys().Count());
@@ -662,7 +662,7 @@ namespace Microsoft.Data.Entity.Tests
                 modelBuilder.Entity<Order>();
                 modelBuilder.Entity<OrderDetails>();
                 modelBuilder
-                    .Entity<OrderDetails>().Reference<Order>().InverseReference()
+                    .Entity<OrderDetails>().HasOne<Order>().WithOne()
                     .ForeignKey<OrderDetails>(c => c.Id);
                 modelBuilder.Ignore<Customer>();
 
@@ -674,7 +674,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<OrderDetails>().Reference(e => e.Order).InverseReference(e => e.Details)
+                    .Entity<OrderDetails>().HasOne(e => e.Order).WithOne(e => e.Details)
                     .ForeignKey<OrderDetails>(e => e.Id);
 
                 var newFk = dependentType.GetForeignKeys().Single();
@@ -713,7 +713,7 @@ namespace Microsoft.Data.Entity.Tests
                 var expectedDependentProperties = dependentType.Properties.ToList();
 
                 modelBuilder
-                    .Entity<OrderDetails>().Reference(e => e.Order).InverseReference(e => e.Details)
+                    .Entity<OrderDetails>().HasOne(e => e.Order).WithOne(e => e.Details)
                     .ForeignKey<OrderDetails>(e => e.OrderId);
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -752,7 +752,7 @@ namespace Microsoft.Data.Entity.Tests
                 var expectedDependentProperties = dependentType.Properties.ToList();
 
                 modelBuilder
-                    .Entity<OrderDetails>().Reference(e => e.Order).InverseReference(e => e.Details)
+                    .Entity<OrderDetails>().HasOne(e => e.Order).WithOne(e => e.Details)
                     .ForeignKey<Order>(e => e.OrderId);
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -791,7 +791,7 @@ namespace Microsoft.Data.Entity.Tests
                 var expectedDependentProperties = dependentType.Properties.ToList();
 
                 modelBuilder
-                    .Entity<CustomerDetails>().Reference(e => e.Customer).InverseReference()
+                    .Entity<CustomerDetails>().HasOne(e => e.Customer).WithOne()
                     .ForeignKey<Customer>(e => e.Id);
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -828,7 +828,7 @@ namespace Microsoft.Data.Entity.Tests
                 var expectedDependentProperties = dependentType.Properties.Where(p => !((IProperty)p).IsShadowProperty).ToList();
 
                 modelBuilder
-                    .Entity<CustomerDetails>().Reference(e => e.Customer).InverseReference()
+                    .Entity<CustomerDetails>().HasOne(e => e.Customer).WithOne()
                     .ForeignKey<CustomerDetails>(e => e.Id);
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -865,7 +865,7 @@ namespace Microsoft.Data.Entity.Tests
                 var expectedDependentProperties = dependentType.Properties.ToList();
 
                 modelBuilder
-                    .Entity<CustomerDetails>().Reference<Customer>().InverseReference(e => e.Details)
+                    .Entity<CustomerDetails>().HasOne<Customer>().WithOne(e => e.Details)
                     .ForeignKey<Customer>(e => e.Id);
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -902,7 +902,7 @@ namespace Microsoft.Data.Entity.Tests
                 var expectedDependentProperties = dependentType.Properties.Where(p => !((IProperty)p).IsShadowProperty).ToList();
 
                 modelBuilder
-                    .Entity<CustomerDetails>().Reference<Customer>().InverseReference(e => e.Details)
+                    .Entity<CustomerDetails>().HasOne<Customer>().WithOne(e => e.Details)
                     .ForeignKey<CustomerDetails>(e => e.Id);
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -942,7 +942,7 @@ namespace Microsoft.Data.Entity.Tests
                 var expectedDependentProperties = dependentType.Properties.ToList();
 
                 modelBuilder
-                    .Entity<CustomerDetails>().Reference<Customer>().InverseReference()
+                    .Entity<CustomerDetails>().HasOne<Customer>().WithOne()
                     .ForeignKey<CustomerDetails>(e => e.Id);
 
                 var newForeignKey = dependentType.GetForeignKeys().Single(fk => fk != existingFk);
@@ -982,7 +982,7 @@ namespace Microsoft.Data.Entity.Tests
                 var expectedDependentProperties = dependentType.Properties.ToList();
 
                 modelBuilder
-                    .Entity<CustomerDetails>().Reference<Customer>().InverseReference()
+                    .Entity<CustomerDetails>().HasOne<Customer>().WithOne()
                     .ForeignKey<Customer>(e => e.Id);
 
                 var newForeignKey = dependentType.GetForeignKeys().Single(fk => fk != existingFk);
@@ -1017,7 +1017,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<CustomerDetails>().Reference(e => e.Customer).InverseReference(e => e.Details)
+                    .Entity<CustomerDetails>().HasOne(e => e.Customer).WithOne(e => e.Details)
                     .ForeignKey<CustomerDetails>(e => e.Id);
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -1056,7 +1056,7 @@ namespace Microsoft.Data.Entity.Tests
                 var expectedDependentProperties = dependentType.Properties.ToList();
 
                 modelBuilder
-                    .Entity<Customer>().Reference(e => e.Details).InverseReference(e => e.Customer)
+                    .Entity<Customer>().HasOne(e => e.Details).WithOne(e => e.Customer)
                     .PrincipalKey<Customer>(e => e.Id);
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -1093,7 +1093,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Customer>().Reference(e => e.Details).InverseReference(e => e.Customer)
+                    .Entity<Customer>().HasOne(e => e.Details).WithOne(e => e.Customer)
                     .PrincipalKey<Customer>(e => e.AlternateKey);
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -1141,7 +1141,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Order>().Reference(e => e.Details).InverseReference(e => e.Order)
+                    .Entity<Order>().HasOne(e => e.Details).WithOne(e => e.Order)
                     .ForeignKey<OrderDetails>(e => e.OrderId)
                     .PrincipalKey<Order>(e => e.OrderId);
 
@@ -1183,7 +1183,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Order>().Reference(e => e.Details).InverseReference(e => e.Order)
+                    .Entity<Order>().HasOne(e => e.Details).WithOne(e => e.Order)
                     .PrincipalKey<Order>(e => e.OrderId)
                     .ForeignKey<OrderDetails>(e => e.OrderId);
 
@@ -1223,7 +1223,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<BigMak>().Reference(e => e.Bun).InverseReference(e => e.BigMak)
+                    .Entity<BigMak>().HasOne(e => e.Bun).WithOne(e => e.BigMak)
                     .ForeignKey<Bun>(e => e.BurgerId)
                     .PrincipalKey<BigMak>(e => e.AlternateKey);
 
@@ -1268,7 +1268,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<BigMak>().Reference(e => e.Bun).InverseReference(e => e.BigMak)
+                    .Entity<BigMak>().HasOne(e => e.Bun).WithOne(e => e.BigMak)
                     .PrincipalKey<BigMak>(e => e.AlternateKey)
                     .ForeignKey<Bun>(e => e.BurgerId);
 
@@ -1301,7 +1301,7 @@ namespace Microsoft.Data.Entity.Tests
                 var modelBuilder = CreateModelBuilder(model);
                 modelBuilder.Entity<Order>();
                 modelBuilder.Entity<OrderDetails>()
-                    .Reference<Order>().InverseReference()
+                    .HasOne<Order>().WithOne()
                     .ForeignKey<OrderDetails>(e => e.Id);
                 modelBuilder.Ignore<Customer>();
                 modelBuilder.Ignore<CustomerDetails>();
@@ -1316,7 +1316,7 @@ namespace Microsoft.Data.Entity.Tests
                 var expectedDependentProperties = dependentType.Properties.ToList();
 
                 modelBuilder
-                    .Entity<OrderDetails>().Reference(e => e.Order).InverseReference(e => e.Details)
+                    .Entity<OrderDetails>().HasOne(e => e.Order).WithOne(e => e.Details)
                     .PrincipalKey<Order>(e => e.OrderId);
 
                 var newFk = dependentType.GetForeignKeys().Single(fk => fk != existingFk);
@@ -1355,7 +1355,7 @@ namespace Microsoft.Data.Entity.Tests
                 var expectedDependentProperties = dependentType.Properties.ToList();
 
                 modelBuilder
-                    .Entity<OrderDetails>().Reference(e => e.Order).InverseReference(e => e.Details)
+                    .Entity<OrderDetails>().HasOne(e => e.Order).WithOne(e => e.Details)
                     .PrincipalKey<Order>(e => e.OrderId);
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -1395,7 +1395,7 @@ namespace Microsoft.Data.Entity.Tests
                 var expectedDependentProperties = dependentType.Properties.ToList();
 
                 modelBuilder
-                    .Entity<OrderDetails>().Reference(e => e.Order).InverseReference(e => e.Details)
+                    .Entity<OrderDetails>().HasOne(e => e.Order).WithOne(e => e.Details)
                     .PrincipalKey<OrderDetails>(e => e.OrderId);
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -1436,7 +1436,7 @@ namespace Microsoft.Data.Entity.Tests
                 var expectedDependentProperties = dependentType.Properties.ToList();
 
                 modelBuilder
-                    .Entity<OrderDetails>().Reference(e => e.Order).InverseReference(e => e.Details)
+                    .Entity<OrderDetails>().HasOne(e => e.Order).WithOne(e => e.Details)
                     .ForeignKey<OrderDetails>(e => e.OrderId)
                     .PrincipalKey<Order>(e => e.OrderId);
 
@@ -1477,7 +1477,7 @@ namespace Microsoft.Data.Entity.Tests
                 var expectedDependentProperties = dependentType.Properties.ToList();
 
                 modelBuilder
-                    .Entity<OrderDetails>().Reference(e => e.Order).InverseReference(e => e.Details)
+                    .Entity<OrderDetails>().HasOne(e => e.Order).WithOne(e => e.Details)
                     .PrincipalKey<Order>(e => e.OrderId)
                     .ForeignKey<OrderDetails>(e => e.OrderId);
 
@@ -1518,7 +1518,7 @@ namespace Microsoft.Data.Entity.Tests
                 var expectedDependentProperties = dependentType.Properties.ToList();
 
                 modelBuilder
-                    .Entity<OrderDetails>().Reference(e => e.Order).InverseReference(e => e.Details)
+                    .Entity<OrderDetails>().HasOne(e => e.Order).WithOne(e => e.Details)
                     .ForeignKey<Order>(e => e.OrderId)
                     .PrincipalKey<OrderDetails>(e => e.OrderId);
 
@@ -1545,14 +1545,14 @@ namespace Microsoft.Data.Entity.Tests
                 var modelBuilder = CreateModelBuilder(model);
                 modelBuilder.Entity<Order>();
                 modelBuilder.Entity<OrderDetails>()
-                    .Reference(e => e.Order).InverseReference(e => e.Details)
+                    .HasOne(e => e.Order).WithOne(e => e.Details)
                     .PrincipalKey<OrderDetails>(e => e.Id);
                 modelBuilder.Ignore<Customer>();
                 modelBuilder.Ignore<CustomerDetails>();
 
                 Assert.Equal(Strings.RelationshipCannotBeInverted,
                     Assert.Throws<InvalidOperationException>(() => modelBuilder
-                        .Entity<OrderDetails>().Reference(e => e.Order).InverseReference(e => e.Details)
+                        .Entity<OrderDetails>().HasOne(e => e.Order).WithOne(e => e.Details)
                         .ForeignKey<OrderDetails>(e => e.OrderId)
                         .PrincipalKey<OrderDetails>(e => e.OrderId)).Message);
             }
@@ -1564,14 +1564,14 @@ namespace Microsoft.Data.Entity.Tests
                 var modelBuilder = CreateModelBuilder(model);
                 modelBuilder.Entity<Order>();
                 modelBuilder.Entity<OrderDetails>()
-                    .Reference(e => e.Order).InverseReference(e => e.Details)
+                    .HasOne(e => e.Order).WithOne(e => e.Details)
                     .PrincipalKey<OrderDetails>(e => e.Id);
                 modelBuilder.Ignore<Customer>();
                 modelBuilder.Ignore<CustomerDetails>();
 
                 Assert.Equal(Strings.RelationshipCannotBeInverted,
                     Assert.Throws<InvalidOperationException>(() => modelBuilder
-                        .Entity<OrderDetails>().Reference(e => e.Order).InverseReference(e => e.Details)
+                        .Entity<OrderDetails>().HasOne(e => e.Order).WithOne(e => e.Details)
                         .PrincipalKey<OrderDetails>(e => e.OrderId)
                         .ForeignKey<OrderDetails>(e => e.OrderId)).Message);
             }
@@ -1594,7 +1594,7 @@ namespace Microsoft.Data.Entity.Tests
                 var expectedDependentProperties = dependentType.Properties.ToList();
 
                 modelBuilder
-                    .Entity<Customer>().Reference(e => e.Details).InverseReference()
+                    .Entity<Customer>().HasOne(e => e.Details).WithOne()
                     .PrincipalKey<Customer>(e => e.Id);
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -1629,7 +1629,7 @@ namespace Microsoft.Data.Entity.Tests
                 var expectedDependentProperties = dependentType.Properties.ToList();
 
                 modelBuilder
-                    .Entity<CustomerDetails>().Reference(e => e.Customer).InverseReference()
+                    .Entity<CustomerDetails>().HasOne(e => e.Customer).WithOne()
                     .PrincipalKey<Customer>(e => e.Id);
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -1664,7 +1664,7 @@ namespace Microsoft.Data.Entity.Tests
                 var expectedDependentProperties = dependentType.Properties.ToList();
 
                 modelBuilder
-                    .Entity<Customer>().Reference<CustomerDetails>().InverseReference(e => e.Customer)
+                    .Entity<Customer>().HasOne<CustomerDetails>().WithOne(e => e.Customer)
                     .PrincipalKey<Customer>(e => e.Id);
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -1699,7 +1699,7 @@ namespace Microsoft.Data.Entity.Tests
                 var expectedDependentProperties = dependentType.Properties.ToList();
 
                 modelBuilder
-                    .Entity<CustomerDetails>().Reference<Customer>().InverseReference(e => e.Details)
+                    .Entity<CustomerDetails>().HasOne<Customer>().WithOne(e => e.Details)
                     .PrincipalKey<Customer>(e => e.Id);
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -1735,7 +1735,7 @@ namespace Microsoft.Data.Entity.Tests
                 var expectedDependentProperties = dependentType.Properties.ToList();
 
                 modelBuilder
-                    .Entity<Customer>().Reference<CustomerDetails>().InverseReference()
+                    .Entity<Customer>().HasOne<CustomerDetails>().WithOne()
                     .PrincipalKey<Customer>(e => e.Id);
 
                 var fk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey != existingFk);
@@ -1772,7 +1772,7 @@ namespace Microsoft.Data.Entity.Tests
                 var expectedDependentProperties = dependentType.Properties.ToList();
 
                 modelBuilder
-                    .Entity<CustomerDetails>().Reference<Customer>().InverseReference()
+                    .Entity<CustomerDetails>().HasOne<Customer>().WithOne()
                     .PrincipalKey<Customer>(e => e.Id);
 
                 var fk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey != existingFk);
@@ -1795,9 +1795,9 @@ namespace Microsoft.Data.Entity.Tests
             {
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
-                modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
+                modelBuilder.Entity<Whoopper>().HasKey(c => new { c.Id1, c.Id2 });
                 var dependentType = model.GetEntityType(typeof(ToastedBun));
-                modelBuilder.Entity<ToastedBun>().Reference<Whoopper>().InverseReference()
+                modelBuilder.Entity<ToastedBun>().HasOne<Whoopper>().WithOne()
                     .ForeignKey<ToastedBun>(e => new { e.BurgerId1, e.BurgerId2 });
                 modelBuilder.Ignore<Tomato>();
                 modelBuilder.Ignore<Moostard>();
@@ -1810,7 +1810,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetPrimaryKey();
 
                 modelBuilder
-                    .Entity<Whoopper>().Reference(e => e.ToastedBun).InverseReference(e => e.Whoopper)
+                    .Entity<Whoopper>().HasOne(e => e.ToastedBun).WithOne(e => e.Whoopper)
                     .ForeignKey<ToastedBun>(e => new { e.BurgerId1, e.BurgerId2 });
 
                 Assert.Same(fk, dependentType.GetForeignKeys().Single());
@@ -1832,7 +1832,7 @@ namespace Microsoft.Data.Entity.Tests
             {
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
-                modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
+                modelBuilder.Entity<Whoopper>().HasKey(c => new { c.Id1, c.Id2 });
                 modelBuilder.Entity<ToastedBun>();
                 modelBuilder.Ignore<Tomato>();
                 modelBuilder.Ignore<Moostard>();
@@ -1847,7 +1847,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Whoopper>().Reference(e => e.ToastedBun).InverseReference(e => e.Whoopper)
+                    .Entity<Whoopper>().HasOne(e => e.ToastedBun).WithOne(e => e.Whoopper)
                     .ForeignKey<ToastedBun>(e => new { e.BurgerId1, e.BurgerId2 });
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -1872,7 +1872,7 @@ namespace Microsoft.Data.Entity.Tests
             {
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
-                modelBuilder.Entity<Whoopper>(b => b.Key(c => new { c.Id1, c.Id2 }));
+                modelBuilder.Entity<Whoopper>(b => b.HasKey(c => new { c.Id1, c.Id2 }));
                 modelBuilder.Entity<ToastedBun>();
                 modelBuilder.Ignore<Tomato>();
                 modelBuilder.Ignore<Moostard>();
@@ -1889,7 +1889,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Whoopper>().Reference(e => e.ToastedBun).InverseReference(e => e.Whoopper)
+                    .Entity<Whoopper>().HasOne(e => e.ToastedBun).WithOne(e => e.Whoopper)
                     .ForeignKey<ToastedBun>(e => new { e.BurgerId1, e.BurgerId2 })
                     .PrincipalKey<Whoopper>(e => new { e.AlternateKey1, e.AlternateKey2 });
 
@@ -1922,7 +1922,7 @@ namespace Microsoft.Data.Entity.Tests
             {
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
-                modelBuilder.Entity<Whoopper>(b => b.Key(c => new { c.Id1, c.Id2 }));
+                modelBuilder.Entity<Whoopper>(b => b.HasKey(c => new { c.Id1, c.Id2 }));
                 modelBuilder.Entity<ToastedBun>();
                 modelBuilder.Ignore<Tomato>();
                 modelBuilder.Ignore<Moostard>();
@@ -1939,7 +1939,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Whoopper>().Reference(e => e.ToastedBun).InverseReference(e => e.Whoopper)
+                    .Entity<Whoopper>().HasOne(e => e.ToastedBun).WithOne(e => e.Whoopper)
                     .PrincipalKey<Whoopper>(e => new { e.AlternateKey1, e.AlternateKey2 })
                     .ForeignKey<ToastedBun>(e => new { e.BurgerId1, e.BurgerId2 });
 
@@ -1972,8 +1972,8 @@ namespace Microsoft.Data.Entity.Tests
             {
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
-                modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
-                modelBuilder.Entity<Moostard>().Key(c => new { c.Id1, c.Id2 });
+                modelBuilder.Entity<Whoopper>().HasKey(c => new { c.Id1, c.Id2 });
+                modelBuilder.Entity<Moostard>().HasKey(c => new { c.Id1, c.Id2 });
                 modelBuilder.Ignore<Tomato>();
                 modelBuilder.Ignore<ToastedBun>();
 
@@ -1987,7 +1987,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetPrimaryKey();
 
                 modelBuilder
-                    .Entity<Moostard>().Reference(e => e.Whoopper).InverseReference(e => e.Moostard)
+                    .Entity<Moostard>().HasOne(e => e.Whoopper).WithOne(e => e.Moostard)
                     .ForeignKey<Moostard>(e => new { e.Id1, e.Id2 });
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -2013,8 +2013,8 @@ namespace Microsoft.Data.Entity.Tests
             {
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
-                modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
-                modelBuilder.Entity<Moostard>().Key(c => new { c.Id1, c.Id2 });
+                modelBuilder.Entity<Whoopper>().HasKey(c => new { c.Id1, c.Id2 });
+                modelBuilder.Entity<Moostard>().HasKey(c => new { c.Id1, c.Id2 });
                 modelBuilder.Ignore<Tomato>();
                 modelBuilder.Ignore<ToastedBun>();
 
@@ -2028,7 +2028,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetPrimaryKey();
 
                 modelBuilder
-                    .Entity<Moostard>().Reference(e => e.Whoopper).InverseReference(e => e.Moostard)
+                    .Entity<Moostard>().HasOne(e => e.Whoopper).WithOne(e => e.Moostard)
                     .ForeignKey<Moostard>(e => new { e.Id1, e.Id2 });
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -2053,8 +2053,8 @@ namespace Microsoft.Data.Entity.Tests
             {
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
-                modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
-                modelBuilder.Entity<Moostard>().Key(c => new { c.Id1, c.Id2 });
+                modelBuilder.Entity<Whoopper>().HasKey(c => new { c.Id1, c.Id2 });
+                modelBuilder.Entity<Moostard>().HasKey(c => new { c.Id1, c.Id2 });
                 modelBuilder.Ignore<Tomato>();
                 modelBuilder.Ignore<ToastedBun>();
 
@@ -2068,7 +2068,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetPrimaryKey();
 
                 modelBuilder
-                    .Entity<Moostard>().Reference(e => e.Whoopper).InverseReference(e => e.Moostard)
+                    .Entity<Moostard>().HasOne(e => e.Whoopper).WithOne(e => e.Moostard)
                     .PrincipalKey<Whoopper>(e => new { e.Id1, e.Id2 })
                     .Required();
 
@@ -2094,7 +2094,7 @@ namespace Microsoft.Data.Entity.Tests
             {
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
-                modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
+                modelBuilder.Entity<Whoopper>().HasKey(c => new { c.Id1, c.Id2 });
                 modelBuilder.Entity<ToastedBun>();
                 modelBuilder.Ignore<Tomato>();
                 modelBuilder.Ignore<Moostard>();
@@ -2109,7 +2109,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Whoopper>().Reference(e => e.ToastedBun).InverseReference()
+                    .Entity<Whoopper>().HasOne(e => e.ToastedBun).WithOne()
                     .ForeignKey<ToastedBun>(e => new { e.BurgerId1, e.BurgerId2 });
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -2133,7 +2133,7 @@ namespace Microsoft.Data.Entity.Tests
             {
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
-                modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
+                modelBuilder.Entity<Whoopper>().HasKey(c => new { c.Id1, c.Id2 });
                 modelBuilder.Entity<ToastedBun>();
                 modelBuilder.Ignore<Tomato>();
                 modelBuilder.Ignore<Moostard>();
@@ -2148,7 +2148,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Whoopper>().Reference<ToastedBun>().InverseReference(e => e.Whoopper)
+                    .Entity<Whoopper>().HasOne<ToastedBun>().WithOne(e => e.Whoopper)
                     .ForeignKey<ToastedBun>(e => new { e.BurgerId1, e.BurgerId2 });
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -2172,7 +2172,7 @@ namespace Microsoft.Data.Entity.Tests
             {
                 var model = new Model();
                 var modelBuilder = CreateModelBuilder(model);
-                modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
+                modelBuilder.Entity<Whoopper>().HasKey(c => new { c.Id1, c.Id2 });
                 modelBuilder.Entity<ToastedBun>();
                 modelBuilder.Ignore<Tomato>();
                 modelBuilder.Ignore<Moostard>();
@@ -2187,7 +2187,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder
-                    .Entity<Whoopper>().Reference<ToastedBun>().InverseReference()
+                    .Entity<Whoopper>().HasOne<ToastedBun>().WithOne()
                     .ForeignKey<ToastedBun>(e => new { e.BurgerId1, e.BurgerId2 });
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -2210,7 +2210,7 @@ namespace Microsoft.Data.Entity.Tests
             {
                 var modelBuilder = CreateModelBuilder();
                 modelBuilder
-                    .Entity<SelfRef>().Reference(e => e.SelfRef1).InverseReference(e => e.SelfRef2);
+                    .Entity<SelfRef>().HasOne(e => e.SelfRef1).WithOne(e => e.SelfRef2);
 
                 var entityType = modelBuilder.Model.GetEntityType(typeof(SelfRef));
                 var fk = entityType.GetForeignKeys().Single();
@@ -2218,14 +2218,14 @@ namespace Microsoft.Data.Entity.Tests
                 var navigationToPrincipal = fk.DependentToPrincipal;
                 var navigationToDependent = fk.PrincipalToDependent;
 
-                modelBuilder.Entity<SelfRef>().Reference(e => e.SelfRef1).InverseReference(e => e.SelfRef2);
+                modelBuilder.Entity<SelfRef>().HasOne(e => e.SelfRef1).WithOne(e => e.SelfRef2);
 
                 Assert.Same(fk, entityType.GetForeignKeys().Single());
                 Assert.Equal(navigationToDependent.Name, fk.PrincipalToDependent.Name);
                 Assert.Equal(navigationToPrincipal.Name, fk.DependentToPrincipal.Name);
                 Assert.True(((IForeignKey)fk).IsRequired);
 
-                modelBuilder.Entity<SelfRef>().Reference(e => e.SelfRef2).InverseReference(e => e.SelfRef1);
+                modelBuilder.Entity<SelfRef>().HasOne(e => e.SelfRef2).WithOne(e => e.SelfRef1);
 
                 var newFk = entityType.GetForeignKeys().Single();
 
@@ -2242,14 +2242,14 @@ namespace Microsoft.Data.Entity.Tests
                 var modelBuilder = CreateModelBuilder();
                 modelBuilder.Entity<SelfRef>(eb =>
                     {
-                        eb.Key(e => e.Id);
+                        eb.HasKey(e => e.Id);
                         eb.Property(e => e.SelfRefId);
                     });
 
                 var entityType = modelBuilder.Model.GetEntityType(typeof(SelfRef));
                 var expectedProperties = entityType.Properties.ToList();
 
-                modelBuilder.Entity<SelfRef>().Reference(e => e.SelfRef1).InverseReference();
+                modelBuilder.Entity<SelfRef>().HasOne(e => e.SelfRef1).WithOne();
 
                 var fk = entityType.GetForeignKeys().Single();
                 var navigationToPrincipal = fk.DependentToPrincipal;
@@ -2270,14 +2270,14 @@ namespace Microsoft.Data.Entity.Tests
                 var modelBuilder = CreateModelBuilder();
                 modelBuilder.Entity<SelfRef>(eb =>
                     {
-                        eb.Key(e => e.Id);
+                        eb.HasKey(e => e.Id);
                         eb.Property(e => e.SelfRefId);
                     });
 
                 var entityType = modelBuilder.Model.GetEntityType(typeof(SelfRef));
                 var expectedProperties = entityType.Properties.ToList();
 
-                modelBuilder.Entity<SelfRef>().Reference<SelfRef>().InverseReference(e => e.SelfRef1);
+                modelBuilder.Entity<SelfRef>().HasOne<SelfRef>().WithOne(e => e.SelfRef1);
 
                 var fk = entityType.GetForeignKeys().Single();
                 var navigationToPrincipal = fk.DependentToPrincipal;
@@ -2296,7 +2296,7 @@ namespace Microsoft.Data.Entity.Tests
             public virtual void Principal_and_dependent_can_be_flipped_when_self_referencing_with_navigation_to_principal()
             {
                 var modelBuilder = CreateModelBuilder();
-                modelBuilder.Entity<SelfRef>().Reference(e => e.SelfRef1).InverseReference();
+                modelBuilder.Entity<SelfRef>().HasOne(e => e.SelfRef1).WithOne();
 
                 var entityType = modelBuilder.Model.GetEntityType(typeof(SelfRef));
                 var fk = entityType.GetForeignKeys().Single();
@@ -2304,14 +2304,14 @@ namespace Microsoft.Data.Entity.Tests
                 var navigationToPrincipal = fk.DependentToPrincipal;
                 var navigationToDependent = fk.PrincipalToDependent;
 
-                modelBuilder.Entity<SelfRef>().Reference(e => e.SelfRef1).InverseReference();
+                modelBuilder.Entity<SelfRef>().HasOne(e => e.SelfRef1).WithOne();
 
                 Assert.Same(fk, entityType.GetForeignKeys().Single());
                 Assert.Equal(navigationToDependent?.Name, fk.PrincipalToDependent?.Name);
                 Assert.Equal(navigationToPrincipal.Name, fk.DependentToPrincipal.Name);
                 Assert.True(((IForeignKey)fk).IsRequired);
 
-                modelBuilder.Entity<SelfRef>().Reference<SelfRef>().InverseReference(e => e.SelfRef1);
+                modelBuilder.Entity<SelfRef>().HasOne<SelfRef>().WithOne(e => e.SelfRef1);
 
                 var newFk = entityType.GetForeignKeys().Single();
 
@@ -2326,7 +2326,7 @@ namespace Microsoft.Data.Entity.Tests
             public virtual void Principal_and_dependent_can_be_flipped_when_self_referencing_with_navigation_to_dependent()
             {
                 var modelBuilder = CreateModelBuilder();
-                modelBuilder.Entity<SelfRef>().Reference<SelfRef>().InverseReference(e => e.SelfRef2);
+                modelBuilder.Entity<SelfRef>().HasOne<SelfRef>().WithOne(e => e.SelfRef2);
 
                 var entityType = modelBuilder.Model.GetEntityType(typeof(SelfRef));
                 var fk = entityType.GetForeignKeys().Single();
@@ -2334,14 +2334,14 @@ namespace Microsoft.Data.Entity.Tests
                 var navigationToPrincipal = fk.DependentToPrincipal;
                 var navigationToDependent = fk.PrincipalToDependent;
 
-                modelBuilder.Entity<SelfRef>().Reference<SelfRef>().InverseReference(e => e.SelfRef2);
+                modelBuilder.Entity<SelfRef>().HasOne<SelfRef>().WithOne(e => e.SelfRef2);
 
                 Assert.Same(fk, entityType.GetForeignKeys().Single());
                 Assert.Equal(navigationToDependent.Name, fk.PrincipalToDependent.Name);
                 Assert.Equal(navigationToPrincipal?.Name, fk.DependentToPrincipal?.Name);
                 Assert.True(((IForeignKey)fk).IsRequired);
 
-                modelBuilder.Entity<SelfRef>().Reference(e => e.SelfRef2).InverseReference();
+                modelBuilder.Entity<SelfRef>().HasOne(e => e.SelfRef2).WithOne();
 
                 var newFk = entityType.GetForeignKeys().Single();
 
@@ -2359,7 +2359,7 @@ namespace Microsoft.Data.Entity.Tests
 
                 Assert.Equal(Strings.DuplicateNavigation("SelfRef1", typeof(SelfRef).FullName),
                     Assert.Throws<InvalidOperationException>(() =>
-                        modelBuilder.Entity<SelfRef>().Reference(e => e.SelfRef1).InverseReference(e => e.SelfRef1)).Message);
+                        modelBuilder.Entity<SelfRef>().HasOne(e => e.SelfRef1).WithOne(e => e.SelfRef1)).Message);
             }
 
             [Fact]
@@ -2374,7 +2374,7 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Equal(Strings.ForeignKeyTypeMismatch("{'GuidProperty'}", typeof(CustomerDetails).FullName, typeof(Customer).FullName),
                     Assert.Throws<InvalidOperationException>(() =>
                         modelBuilder
-                            .Entity<Customer>().Reference(c => c.Details).InverseReference(d => d.Customer)
+                            .Entity<Customer>().HasOne(c => c.Details).WithOne(d => d.Customer)
                             .PrincipalKey(typeof(Customer), "Id")
                             .ForeignKey(typeof(CustomerDetails), "GuidProperty")).Message);
             }
@@ -2391,7 +2391,7 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Equal(Strings.ForeignKeyTypeMismatch("{'GuidProperty'}", typeof(CustomerDetails).FullName, typeof(Customer).FullName),
                     Assert.Throws<InvalidOperationException>(() =>
                         modelBuilder
-                            .Entity<Customer>().Reference(c => c.Details).InverseReference(d => d.Customer)
+                            .Entity<Customer>().HasOne(c => c.Details).WithOne(d => d.Customer)
                             .ForeignKey(typeof(CustomerDetails), "GuidProperty")
                             .PrincipalKey(typeof(Customer), "Id")).Message);
             }
@@ -2408,7 +2408,7 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Equal(Strings.ForeignKeyCountMismatch("{'Id', 'GuidProperty'}", typeof(CustomerDetails).FullName, "{'Id'}", typeof(Customer).FullName),
                     Assert.Throws<InvalidOperationException>(() =>
                         modelBuilder
-                            .Entity<Customer>().Reference(c => c.Details).InverseReference(d => d.Customer)
+                            .Entity<Customer>().HasOne(c => c.Details).WithOne(d => d.Customer)
                             .PrincipalKey(typeof(Customer), "Id")
                             .ForeignKey(typeof(CustomerDetails), "Id", "GuidProperty")).Message);
             }
@@ -2425,7 +2425,7 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Equal(Strings.ForeignKeyCountMismatch("{'Id', 'GuidProperty'}", typeof(CustomerDetails).FullName, "{'Id'}", typeof(Customer).FullName),
                     Assert.Throws<InvalidOperationException>(() =>
                         modelBuilder
-                            .Entity<Customer>().Reference(c => c.Details).InverseReference(d => d.Customer)
+                            .Entity<Customer>().HasOne(c => c.Details).WithOne(d => d.Customer)
                             .ForeignKey(typeof(CustomerDetails), "Id", "GuidProperty")
                             .PrincipalKey(typeof(Customer), "Id")).Message);
             }
@@ -2435,7 +2435,7 @@ namespace Microsoft.Data.Entity.Tests
             {
                 var modelBuilder = HobNobBuilder();
                 var model = modelBuilder.Model;
-                modelBuilder.Entity<Hob>().Reference(e => e.Nob).InverseCollection(e => e.Hobs);
+                modelBuilder.Entity<Hob>().HasOne(e => e.Nob).WithMany(e => e.Hobs);
 
                 var dependentType = model.GetEntityType(typeof(Nob));
                 var principalType = model.GetEntityType(typeof(Hob));
@@ -2444,7 +2444,7 @@ namespace Microsoft.Data.Entity.Tests
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
 
-                modelBuilder.Entity<Nob>().Reference(e => e.Hob).InverseReference(e => e.Nob);
+                modelBuilder.Entity<Nob>().HasOne(e => e.Hob).WithOne(e => e.Nob);
 
                 var fk = dependentType.GetForeignKeys().Single();
                 Assert.True(fk.IsUnique);
@@ -2464,7 +2464,7 @@ namespace Microsoft.Data.Entity.Tests
             {
                 var modelBuilder = HobNobBuilder();
                 var model = modelBuilder.Model;
-                modelBuilder.Entity<Hob>().Collection(e => e.Nobs).InverseReference(e => e.Hob);
+                modelBuilder.Entity<Hob>().HasMany(e => e.Nobs).WithOne(e => e.Hob);
 
                 var dependentType = model.GetEntityType(typeof(Nob));
                 var principalType = model.GetEntityType(typeof(Hob));
@@ -2473,7 +2473,7 @@ namespace Microsoft.Data.Entity.Tests
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
 
-                modelBuilder.Entity<Nob>().Reference(e => e.Hob).InverseReference(e => e.Nob);
+                modelBuilder.Entity<Nob>().HasOne(e => e.Hob).WithOne(e => e.Nob);
 
                 var fk = dependentType.GetForeignKeys().Single();
                 Assert.True(fk.IsUnique);
@@ -2499,7 +2499,7 @@ namespace Microsoft.Data.Entity.Tests
 
                 var dependentType = model.GetEntityType(typeof(CustomerDetails));
 
-                var builder = modelBuilder.Entity<CustomerDetails>().Reference(e => e.Customer).InverseReference(e => e.Details);
+                var builder = modelBuilder.Entity<CustomerDetails>().HasOne(e => e.Customer).WithOne(e => e.Details);
                 builder = builder.Annotation("Fus", "Ro");
 
                 var fk = dependentType.GetForeignKeys().Single();
@@ -2513,7 +2513,7 @@ namespace Microsoft.Data.Entity.Tests
                 var modelBuilder = HobNobBuilder();
 
                 modelBuilder
-                    .Entity<Hob>().Reference(e => e.Nob).InverseReference(e => e.Hob)
+                    .Entity<Hob>().HasOne(e => e.Nob).WithOne(e => e.Hob)
                     .ForeignKey<Nob>(e => new { e.HobId1, e.HobId2 });
 
                 var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob));
@@ -2529,7 +2529,7 @@ namespace Microsoft.Data.Entity.Tests
                 var modelBuilder = HobNobBuilder();
 
                 modelBuilder
-                    .Entity<Nob>().Reference(e => e.Hob).InverseReference(e => e.Nob)
+                    .Entity<Nob>().HasOne(e => e.Hob).WithOne(e => e.Nob)
                     .ForeignKey<Hob>(e => new { e.NobId1, e.NobId2 });
 
                 var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Hob));
@@ -2549,7 +2549,7 @@ namespace Microsoft.Data.Entity.Tests
                 var expectedDependentProperties = dependentType.GetProperties().ToList();
 
                 modelBuilder
-                    .Entity<Hob>().Reference(e => e.Nob).InverseReference(e => e.Hob)
+                    .Entity<Hob>().HasOne(e => e.Nob).WithOne(e => e.Hob)
                     .Required()
                     .ForeignKey<Nob>(e => new { e.HobId1, e.HobId2 });
 
@@ -2569,7 +2569,7 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Equal(
                     Strings.ForeignKeyCannotBeOptional("{'NobId1', 'NobId2'}", "Hob"),
                     Assert.Throws<InvalidOperationException>(() => modelBuilder
-                        .Entity<Nob>().Reference(e => e.Hob).InverseReference(e => e.Nob)
+                        .Entity<Nob>().HasOne(e => e.Hob).WithOne(e => e.Nob)
                         .ForeignKey<Hob>(e => new { e.NobId1, e.NobId2 })
                         .Required(false)).Message);
 
@@ -2588,7 +2588,7 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Equal(
                     Strings.ForeignKeyCannotBeOptional("{'NobId1', 'NobId2'}", "Hob"),
                     Assert.Throws<InvalidOperationException>(() => modelBuilder
-                        .Entity<Nob>().Reference(e => e.Hob).InverseReference(e => e.Nob)
+                        .Entity<Nob>().HasOne(e => e.Hob).WithOne(e => e.Nob)
                         .Required(false)
                         .ForeignKey<Hob>(e => new { e.NobId1, e.NobId2 })).Message);
 
@@ -2609,7 +2609,7 @@ namespace Microsoft.Data.Entity.Tests
                 var expectedDependentProperties = dependentType.GetProperties().ToList();
 
                 modelBuilder
-                    .Entity<Hob>().Reference(e => e.Nob).InverseReference(e => e.Hob)
+                    .Entity<Hob>().HasOne(e => e.Nob).WithOne(e => e.Hob)
                     .Required(false)
                     .PrincipalKey<Nob>(e => new { e.Id1, e.Id2 });
 
@@ -2631,7 +2631,7 @@ namespace Microsoft.Data.Entity.Tests
                 var expectedDependentProperties = dependentType.GetProperties().ToList();
 
                 modelBuilder
-                    .Entity<Hob>().Reference(e => e.Nob).InverseReference(e => e.Hob)
+                    .Entity<Hob>().HasOne(e => e.Nob).WithOne(e => e.Hob)
                     .PrincipalKey<Nob>(e => new { e.Id1, e.Id2 })
                     .Required(false);
 
@@ -2653,7 +2653,7 @@ namespace Microsoft.Data.Entity.Tests
                 var expectedDependentProperties = dependentType.GetProperties().ToList();
 
                 modelBuilder
-                    .Entity<Hob>().Reference(e => e.Nob).InverseReference(e => e.Hob)
+                    .Entity<Hob>().HasOne(e => e.Nob).WithOne(e => e.Hob)
                     .Required()
                     .PrincipalKey<Nob>(e => new { e.Id1, e.Id2 });
 
@@ -2674,13 +2674,13 @@ namespace Microsoft.Data.Entity.Tests
                 modelBuilder
                     .Entity<Hob>(eb =>
                         {
-                            eb.Reference(e => e.Nob).InverseReference(e => e.Hob)
+                            eb.HasOne(e => e.Nob).WithOne(e => e.Hob)
                                 .ForeignKey<Nob>(e => new { e.HobId1, e.HobId2 })
                                 .PrincipalKey<Hob>(e => new { e.Id1, e.Id2 });
-                            eb.Key(e => new { e.Id1, e.Id2 });
+                            eb.HasKey(e => new { e.Id1, e.Id2 });
                         });
 
-                modelBuilder.Entity<Nob>().Key(e => new { e.Id1, e.Id2 });
+                modelBuilder.Entity<Nob>().HasKey(e => new { e.Id1, e.Id2 });
 
                 var dependentEntityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob));
                 var fk = dependentEntityType.GetForeignKeys().Single();
@@ -2699,13 +2699,13 @@ namespace Microsoft.Data.Entity.Tests
                 modelBuilder
                     .Entity<Hob>(eb =>
                         {
-                            eb.Reference(e => e.Nob).InverseReference(e => e.Hob)
+                            eb.HasOne(e => e.Nob).WithOne(e => e.Hob)
                                 .ForeignKey<Hob>(e => new { e.NobId1, e.NobId2 })
                                 .PrincipalKey<Nob>(e => new { e.Id1, e.Id2 });
-                            eb.Key(e => new { e.Id1, e.Id2 });
+                            eb.HasKey(e => new { e.Id1, e.Id2 });
                         });
 
-                modelBuilder.Entity<Nob>().Key(e => new { e.Id1, e.Id2 });
+                modelBuilder.Entity<Nob>().HasKey(e => new { e.Id1, e.Id2 });
 
                 var dependentEntityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Hob));
                 var fk = dependentEntityType.GetForeignKeys().Single();
@@ -2722,13 +2722,13 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Hob));
 
                 modelBuilder
-                    .Entity<Hob>().Reference(e => e.Nob).InverseReference(e => e.Hob)
+                    .Entity<Hob>().HasOne(e => e.Nob).WithOne(e => e.Hob)
                     .WillCascadeOnDelete();
 
                 Assert.Equal(DeleteBehavior.Cascade, dependentType.GetForeignKeys().Single().DeleteBehavior);
 
                 modelBuilder
-                    .Entity<Hob>().Reference(e => e.Nob).InverseReference(e => e.Hob)
+                    .Entity<Hob>().HasOne(e => e.Nob).WithOne(e => e.Hob)
                     .WillCascadeOnDelete(false);
 
                 Assert.Equal(DeleteBehavior.None, dependentType.GetForeignKeys().Single().DeleteBehavior);

--- a/test/EntityFramework.CrossStore.FunctionalTests/TestModels/CrossStoreContext.cs
+++ b/test/EntityFramework.CrossStore.FunctionalTests/TestModels/CrossStoreContext.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
                         eb.Property(typeof(string), SimpleEntity.ShadowPartitionIdName);
                         eb.ToTable("RelationalSimpleEntity"); // TODO: specify schema when #948 is fixed
                         eb.Property(typeof(string), SimpleEntity.ShadowPropertyName);
-                        eb.Key(e => e.Id);
+                        eb.HasKey(e => e.Id);
                     });
         }
 

--- a/test/EntityFramework.InMemory.FunctionalTests/CompositeKeyEndToEndTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/CompositeKeyEndToEndTest.cs
@@ -188,11 +188,11 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
 
             protected override void OnModelCreating(ModelBuilder modelBuilder)
             {
-                modelBuilder.Entity<Pegasus>().Key(e => new { e.Id1, e.Id2 });
+                modelBuilder.Entity<Pegasus>().HasKey(e => new { e.Id1, e.Id2 });
 
-                modelBuilder.Entity<Unicorn>().Key(e => new { e.Id1, e.Id2, e.Id3 });
+                modelBuilder.Entity<Unicorn>().HasKey(e => new { e.Id1, e.Id2, e.Id3 });
 
-                modelBuilder.Entity<EarthPony>().Key(e => new { e.Id1, e.Id2 });
+                modelBuilder.Entity<EarthPony>().HasKey(e => new { e.Id1, e.Id2 });
             }
         }
 

--- a/test/EntityFramework.InMemory.FunctionalTests/DatabaseInMemoryTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/DatabaseInMemoryTest.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
 
             protected override void OnModelCreating(ModelBuilder modelBuilder)
             {
-                modelBuilder.Entity<Artist>().Key(a => a.ArtistId);
+                modelBuilder.Entity<Artist>().HasKey(a => a.ArtistId);
             }
 
             public class Artist : ArtistBase<string>

--- a/test/EntityFramework.InMemory.FunctionalTests/MusicStoreQueryTests.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/MusicStoreQueryTests.cs
@@ -81,11 +81,11 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
 
             protected override void OnModelCreating(ModelBuilder builder)
             {
-                builder.Entity<Album>().Key(a => a.AlbumId);
-                builder.Entity<Artist>().Key(a => a.ArtistId);
-                builder.Entity<Order>().Key(o => o.OrderId);
-                builder.Entity<Genre>().Key(g => g.GenreId);
-                builder.Entity<OrderDetail>().Key(o => o.OrderDetailId);
+                builder.Entity<Album>().HasKey(a => a.AlbumId);
+                builder.Entity<Artist>().HasKey(a => a.ArtistId);
+                builder.Entity<Order>().HasKey(o => o.OrderId);
+                builder.Entity<Genre>().HasKey(g => g.GenreId);
+                builder.Entity<OrderDetail>().HasKey(o => o.OrderDetailId);
 
                 base.OnModelCreating(builder);
             }

--- a/test/EntityFramework.InMemory.Tests/InMemoryDatabaseCreatorTest.cs
+++ b/test/EntityFramework.InMemory.Tests/InMemoryDatabaseCreatorTest.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
 
             modelBuilder.Entity<Test>(b =>
                 {
-                    b.Key(c => c.Id);
+                    b.HasKey(c => c.Id);
                     b.Property(c => c.Name);
                 });
 

--- a/test/EntityFramework.InMemory.Tests/InMemoryDatabaseTest.cs
+++ b/test/EntityFramework.InMemory.Tests/InMemoryDatabaseTest.cs
@@ -191,7 +191,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
 
             modelBuilder.Entity<Customer>(b =>
                 {
-                    b.Key(c => c.Id);
+                    b.HasKey(c => c.Id);
                     b.Property(c => c.Name);
                 });
 

--- a/test/EntityFramework.Microbenchmarks/Models/AdventureWorks/AdventureWorksContext.cs
+++ b/test/EntityFramework.Microbenchmarks/Models/AdventureWorks/AdventureWorksContext.cs
@@ -106,18 +106,18 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
             {
                 entity.ToTable("Address", "Person");
 
-                entity.Property(e => e.AddressLine1).Required();
+                entity.Property(e => e.AddressLine1).IsRequired();
 
-                entity.Property(e => e.City).Required();
+                entity.Property(e => e.City).IsRequired();
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
-                entity.Property(e => e.PostalCode).Required();
+                entity.Property(e => e.PostalCode).IsRequired();
 
                 entity.Property(e => e.rowguid).HasDefaultValueSql("newid()");
                 
-                entity.Reference(d => d.StateProvince)
-                      .InverseCollection(p => p.Address)
+                entity.HasOne(d => d.StateProvince)
+                      .WithMany(p => p.Address)
                       .ForeignKey(d => d.StateProvinceID);
             });
 
@@ -127,7 +127,7 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
-                entity.Property(e => e.Name).Required();
+                entity.Property(e => e.Name).IsRequired();
 
                 entity.Property(e => e.rowguid).HasDefaultValueSql("newid()");
             });
@@ -144,18 +144,18 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
 
                 entity.Property(e => e.StartDate).HasDefaultValueSql("getdate()");
 
-                entity.Property(e => e.UnitMeasureCode).Required();
+                entity.Property(e => e.UnitMeasureCode).IsRequired();
 
-                entity.Reference(d => d.Component)
-                      .InverseCollection(p => p.BillOfMaterials)
+                entity.HasOne(d => d.Component)
+                      .WithMany(p => p.BillOfMaterials)
                       .ForeignKey(d => d.ComponentID);
 
-                entity.Reference(d => d.ProductAssembly)
-                      .InverseCollection(p => p.BillOfMaterialsNavigation)
+                entity.HasOne(d => d.ProductAssembly)
+                      .WithMany(p => p.BillOfMaterialsNavigation)
                       .ForeignKey(d => d.ProductAssemblyID);
 
-                entity.Reference(d => d.UnitMeasureCodeNavigation)
-                      .InverseCollection(p => p.BillOfMaterials)
+                entity.HasOne(d => d.UnitMeasureCodeNavigation)
+                      .WithMany(p => p.BillOfMaterials)
                       .ForeignKey(d => d.UnitMeasureCode);
             });
 
@@ -170,7 +170,7 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
 
             modelBuilder.Entity<BusinessEntityAddress>(entity =>
             {
-                entity.Key(e => new { e.BusinessEntityID, e.AddressID, e.AddressTypeID });
+                entity.HasKey(e => new { e.BusinessEntityID, e.AddressID, e.AddressTypeID });
 
                 entity.ToTable("BusinessEntityAddress", "Person");
 
@@ -178,22 +178,22 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
 
                 entity.Property(e => e.rowguid).HasDefaultValueSql("newid()");
 
-                entity.Reference(d => d.Address)
-                      .InverseCollection(p => p.BusinessEntityAddress)
+                entity.HasOne(d => d.Address)
+                      .WithMany(p => p.BusinessEntityAddress)
                       .ForeignKey(d => d.AddressID);
 
-                entity.Reference(d => d.AddressType)
-                      .InverseCollection(p => p.BusinessEntityAddress)
+                entity.HasOne(d => d.AddressType)
+                      .WithMany(p => p.BusinessEntityAddress)
                       .ForeignKey(d => d.AddressTypeID);
 
-                entity.Reference(d => d.BusinessEntity)
-                      .InverseCollection(p => p.BusinessEntityAddress)
+                entity.HasOne(d => d.BusinessEntity)
+                      .WithMany(p => p.BusinessEntityAddress)
                       .ForeignKey(d => d.BusinessEntityID);
             });
 
             modelBuilder.Entity<BusinessEntityContact>(entity =>
             {
-                entity.Key(e => new { e.BusinessEntityID, e.PersonID, e.ContactTypeID });
+                entity.HasKey(e => new { e.BusinessEntityID, e.PersonID, e.ContactTypeID });
 
                 entity.ToTable("BusinessEntityContact", "Person");
 
@@ -201,16 +201,16 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
 
                 entity.Property(e => e.rowguid).HasDefaultValueSql("newid()");
 
-                entity.Reference(d => d.BusinessEntity)
-                      .InverseCollection(p => p.BusinessEntityContact)
+                entity.HasOne(d => d.BusinessEntity)
+                      .WithMany(p => p.BusinessEntityContact)
                       .ForeignKey(d => d.BusinessEntityID);
 
-                entity.Reference(d => d.ContactType)
-                      .InverseCollection(p => p.BusinessEntityContact)
+                entity.HasOne(d => d.ContactType)
+                      .WithMany(p => p.BusinessEntityContact)
                       .ForeignKey(d => d.ContactTypeID);
 
-                entity.Reference(d => d.Person)
-                      .InverseCollection(p => p.BusinessEntityContact)
+                entity.HasOne(d => d.Person)
+                      .WithMany(p => p.BusinessEntityContact)
                       .ForeignKey(d => d.PersonID);
             });
 
@@ -220,34 +220,34 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
-                entity.Property(e => e.Name).Required();
+                entity.Property(e => e.Name).IsRequired();
             });
 
             modelBuilder.Entity<CountryRegion>(entity =>
             {
-                entity.Key(e => e.CountryRegionCode);
+                entity.HasKey(e => e.CountryRegionCode);
 
                 entity.ToTable("CountryRegion", "Person");
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
-                entity.Property(e => e.Name).Required();
+                entity.Property(e => e.Name).IsRequired();
             });
 
             modelBuilder.Entity<CountryRegionCurrency>(entity =>
             {
-                entity.Key(e => new { e.CountryRegionCode, e.CurrencyCode });
+                entity.HasKey(e => new { e.CountryRegionCode, e.CurrencyCode });
 
                 entity.ToTable("CountryRegionCurrency", "Sales");
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
-                entity.Reference(d => d.CountryRegionCodeNavigation)
-                      .InverseCollection(p => p.CountryRegionCurrency)
+                entity.HasOne(d => d.CountryRegionCodeNavigation)
+                      .WithMany(p => p.CountryRegionCurrency)
                       .ForeignKey(d => d.CountryRegionCode);
 
-                entity.Reference(d => d.CurrencyCodeNavigation)
-                      .InverseCollection(p => p.CountryRegionCurrency)
+                entity.HasOne(d => d.CurrencyCodeNavigation)
+                      .WithMany(p => p.CountryRegionCurrency)
                       .ForeignKey(d => d.CurrencyCode);
             });
 
@@ -255,9 +255,9 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
             {
                 entity.ToTable("CreditCard", "Sales");
 
-                entity.Property(e => e.CardNumber).Required();
+                entity.Property(e => e.CardNumber).IsRequired();
 
-                entity.Property(e => e.CardType).Required();
+                entity.Property(e => e.CardType).IsRequired();
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
             });
@@ -268,36 +268,36 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
-                entity.Property(e => e.Name).Required();
+                entity.Property(e => e.Name).IsRequired();
             });
 
             modelBuilder.Entity<Currency>(entity =>
             {
-                entity.Key(e => e.CurrencyCode);
+                entity.HasKey(e => e.CurrencyCode);
 
                 entity.ToTable("Currency", "Sales");
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
-                entity.Property(e => e.Name).Required();
+                entity.Property(e => e.Name).IsRequired();
             });
 
             modelBuilder.Entity<CurrencyRate>(entity =>
             {
                 entity.ToTable("CurrencyRate", "Sales");
 
-                entity.Property(e => e.FromCurrencyCode).Required();
+                entity.Property(e => e.FromCurrencyCode).IsRequired();
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
-                entity.Property(e => e.ToCurrencyCode).Required();
+                entity.Property(e => e.ToCurrencyCode).IsRequired();
 
-                entity.Reference(d => d.FromCurrencyCodeNavigation)
-                      .InverseCollection(p => p.CurrencyRate)
+                entity.HasOne(d => d.FromCurrencyCodeNavigation)
+                      .WithMany(p => p.CurrencyRate)
                       .ForeignKey(d => d.FromCurrencyCode);
 
-                entity.Reference(d => d.ToCurrencyCodeNavigation)
-                      .InverseCollection(p => p.CurrencyRateNavigation)
+                entity.HasOne(d => d.ToCurrencyCodeNavigation)
+                      .WithMany(p => p.CurrencyRateNavigation)
                       .ForeignKey(d => d.ToCurrencyCode);
             });
 
@@ -306,23 +306,23 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
                 entity.ToTable("Customer", "Sales");
 
                 entity.Property(e => e.AccountNumber)
-                    .Required()
+                    .IsRequired()
                     .ValueGeneratedOnAddOrUpdate();
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
                 entity.Property(e => e.rowguid).HasDefaultValueSql("newid()");
 
-                entity.Reference(d => d.Person)
-                      .InverseCollection(p => p.Customer)
+                entity.HasOne(d => d.Person)
+                      .WithMany(p => p.Customer)
                       .ForeignKey(d => d.PersonID);
 
-                entity.Reference(d => d.Store)
-                      .InverseCollection(p => p.Customer)
+                entity.HasOne(d => d.Store)
+                      .WithMany(p => p.Customer)
                       .ForeignKey(d => d.StoreID);
 
-                entity.Reference(d => d.Territory)
-                      .InverseCollection(p => p.Customer)
+                entity.HasOne(d => d.Territory)
+                      .WithMany(p => p.Customer)
                       .ForeignKey(d => d.TerritoryID);
             });
 
@@ -330,16 +330,16 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
             {
                 entity.ToTable("Department", "HumanResources");
 
-                entity.Property(e => e.GroupName).Required();
+                entity.Property(e => e.GroupName).IsRequired();
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
-                entity.Property(e => e.Name).Required();
+                entity.Property(e => e.Name).IsRequired();
             });
 
             modelBuilder.Entity<EmailAddress>(entity =>
             {
-                entity.Key(e => new { e.BusinessEntityID, e.EmailAddressID });
+                entity.HasKey(e => new { e.BusinessEntityID, e.EmailAddressID });
 
                 entity.ToTable("EmailAddress", "Person");
 
@@ -349,30 +349,30 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
 
                 entity.Property(e => e.rowguid).HasDefaultValueSql("newid()");
 
-                entity.Reference(d => d.BusinessEntity)
-                      .InverseCollection(p => p.EmailAddress)
+                entity.HasOne(d => d.BusinessEntity)
+                      .WithMany(p => p.EmailAddress)
                       .ForeignKey(d => d.BusinessEntityID);
             });
 
             modelBuilder.Entity<Employee>(entity =>
             {
-                entity.Key(e => e.BusinessEntityID);
+                entity.HasKey(e => e.BusinessEntityID);
 
                 entity.ToTable("Employee", "HumanResources");
 
                 entity.Property(e => e.CurrentFlag).HasDefaultValue(true);
 
-                entity.Property(e => e.Gender).Required();
+                entity.Property(e => e.Gender).IsRequired();
 
-                entity.Property(e => e.JobTitle).Required();
+                entity.Property(e => e.JobTitle).IsRequired();
 
-                entity.Property(e => e.LoginID).Required();
+                entity.Property(e => e.LoginID).IsRequired();
 
-                entity.Property(e => e.MaritalStatus).Required();
+                entity.Property(e => e.MaritalStatus).IsRequired();
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
-                entity.Property(e => e.NationalIDNumber).Required();
+                entity.Property(e => e.NationalIDNumber).IsRequired();
 
                 entity.Property(e => e.OrganizationLevel).ValueGeneratedOnAddOrUpdate();
 
@@ -384,42 +384,42 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
 
                 entity.Property(e => e.VacationHours).HasDefaultValue(0);
 
-                entity.Reference(d => d.BusinessEntity)
-                      .InverseReference(p => p.Employee)
+                entity.HasOne(d => d.BusinessEntity)
+                      .WithOne(p => p.Employee)
                       .ForeignKey<Employee>(d => d.BusinessEntityID);
             });
 
             modelBuilder.Entity<EmployeeDepartmentHistory>(entity =>
             {
-                entity.Key(e => new { e.BusinessEntityID, e.StartDate, e.DepartmentID, e.ShiftID });
+                entity.HasKey(e => new { e.BusinessEntityID, e.StartDate, e.DepartmentID, e.ShiftID });
 
                 entity.ToTable("EmployeeDepartmentHistory", "HumanResources");
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
-                entity.Reference(d => d.BusinessEntity)
-                      .InverseCollection(p => p.EmployeeDepartmentHistory)
+                entity.HasOne(d => d.BusinessEntity)
+                      .WithMany(p => p.EmployeeDepartmentHistory)
                       .ForeignKey(d => d.BusinessEntityID);
 
-                entity.Reference(d => d.Department)
-                      .InverseCollection(p => p.EmployeeDepartmentHistory)
+                entity.HasOne(d => d.Department)
+                      .WithMany(p => p.EmployeeDepartmentHistory)
                       .ForeignKey(d => d.DepartmentID);
 
-                entity.Reference(d => d.Shift)
-                      .InverseCollection(p => p.EmployeeDepartmentHistory)
+                entity.HasOne(d => d.Shift)
+                      .WithMany(p => p.EmployeeDepartmentHistory)
                       .ForeignKey(d => d.ShiftID);
             });
 
             modelBuilder.Entity<EmployeePayHistory>(entity =>
             {
-                entity.Key(e => new { e.BusinessEntityID, e.RateChangeDate });
+                entity.HasKey(e => new { e.BusinessEntityID, e.RateChangeDate });
 
                 entity.ToTable("EmployeePayHistory", "HumanResources");
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
-                entity.Reference(d => d.BusinessEntity)
-                      .InverseCollection(p => p.EmployeePayHistory)
+                entity.HasOne(d => d.BusinessEntity)
+                      .WithMany(p => p.EmployeePayHistory)
                       .ForeignKey(d => d.BusinessEntityID);
             });
 
@@ -436,8 +436,8 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
-                entity.Reference(d => d.BusinessEntity)
-                      .InverseCollection(p => p.JobCandidate)
+                entity.HasOne(d => d.BusinessEntity)
+                      .WithMany(p => p.JobCandidate)
                       .ForeignKey(d => d.BusinessEntityID);
             });
 
@@ -453,82 +453,82 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
-                entity.Property(e => e.Name).Required();
+                entity.Property(e => e.Name).IsRequired();
             });
 
             modelBuilder.Entity<Password>(entity =>
             {
-                entity.Key(e => e.BusinessEntityID);
+                entity.HasKey(e => e.BusinessEntityID);
 
                 entity.ToTable("Password", "Person");
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
-                entity.Property(e => e.PasswordHash).Required();
+                entity.Property(e => e.PasswordHash).IsRequired();
 
-                entity.Property(e => e.PasswordSalt).Required();
+                entity.Property(e => e.PasswordSalt).IsRequired();
 
                 entity.Property(e => e.rowguid).HasDefaultValueSql("newid()");
 
-                entity.Reference(d => d.BusinessEntity).InverseReference(p => p.Password).ForeignKey<Password>(d => d.BusinessEntityID);
+                entity.HasOne(d => d.BusinessEntity).WithOne(p => p.Password).ForeignKey<Password>(d => d.BusinessEntityID);
             });
 
             modelBuilder.Entity<Person>(entity =>
             {
-                entity.Key(e => e.BusinessEntityID);
+                entity.HasKey(e => e.BusinessEntityID);
 
                 entity.ToTable("Person", "Person");
 
                 entity.Property(e => e.EmailPromotion).HasDefaultValue(0);
 
-                entity.Property(e => e.FirstName).Required();
+                entity.Property(e => e.FirstName).IsRequired();
 
-                entity.Property(e => e.LastName).Required();
+                entity.Property(e => e.LastName).IsRequired();
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
                 entity.Property(e => e.NameStyle).HasDefaultValue(false);
 
-                entity.Property(e => e.PersonType).Required();
+                entity.Property(e => e.PersonType).IsRequired();
 
                 entity.Property(e => e.rowguid).HasDefaultValueSql("newid()");
 
-                entity.Reference(d => d.BusinessEntity)
-                      .InverseReference(p => p.Person)
+                entity.HasOne(d => d.BusinessEntity)
+                      .WithOne(p => p.Person)
                       .ForeignKey<Person>(d => d.BusinessEntityID);
             });
 
             modelBuilder.Entity<PersonCreditCard>(entity =>
             {
-                entity.Key(e => new { e.BusinessEntityID, e.CreditCardID });
+                entity.HasKey(e => new { e.BusinessEntityID, e.CreditCardID });
 
                 entity.ToTable("PersonCreditCard", "Sales");
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
-                entity.Reference(d => d.BusinessEntity)
-                      .InverseCollection(p => p.PersonCreditCard)
+                entity.HasOne(d => d.BusinessEntity)
+                      .WithMany(p => p.PersonCreditCard)
                       .ForeignKey(d => d.BusinessEntityID);
 
-                entity.Reference(d => d.CreditCard)
-                      .InverseCollection(p => p.PersonCreditCard)
+                entity.HasOne(d => d.CreditCard)
+                      .WithMany(p => p.PersonCreditCard)
                       .ForeignKey(d => d.CreditCardID);
             });
 
             modelBuilder.Entity<PersonPhone>(entity =>
             {
-                entity.Key(e => new { e.BusinessEntityID, e.PhoneNumber, e.PhoneNumberTypeID });
+                entity.HasKey(e => new { e.BusinessEntityID, e.PhoneNumber, e.PhoneNumberTypeID });
 
                 entity.ToTable("PersonPhone", "Person");
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
-                entity.Reference(d => d.BusinessEntity)
-                      .InverseCollection(p => p.PersonPhone)
+                entity.HasOne(d => d.BusinessEntity)
+                      .WithMany(p => p.PersonPhone)
                       .ForeignKey(d => d.BusinessEntityID);
 
-                entity.Reference(d => d.PhoneNumberType)
-                      .InverseCollection(p => p.PersonPhone)
+                entity.HasOne(d => d.PhoneNumberType)
+                      .WithMany(p => p.PersonPhone)
                       .ForeignKey(d => d.PhoneNumberTypeID);
             });
 
@@ -538,7 +538,7 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
-                entity.Property(e => e.Name).Required();
+                entity.Property(e => e.Name).IsRequired();
             });
 
             modelBuilder.Entity<Product>(entity =>
@@ -551,28 +551,28 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
-                entity.Property(e => e.Name).Required();
+                entity.Property(e => e.Name).IsRequired();
 
-                entity.Property(e => e.ProductNumber).Required();
+                entity.Property(e => e.ProductNumber).IsRequired();
 
                 entity.Property(e => e.rowguid).HasDefaultValueSql("newid()");
 
                 entity.Property(e => e.Weight).HasColumnType("decimal(8, 2)");
 
-                entity.Reference(d => d.ProductModel)
-                      .InverseCollection(p => p.Product)
+                entity.HasOne(d => d.ProductModel)
+                      .WithMany(p => p.Product)
                       .ForeignKey(d => d.ProductModelID);
 
-                entity.Reference(d => d.ProductSubcategory)
-                      .InverseCollection(p => p.Product)
+                entity.HasOne(d => d.ProductSubcategory)
+                      .WithMany(p => p.Product)
                       .ForeignKey(d => d.ProductSubcategoryID);
 
-                entity.Reference(d => d.SizeUnitMeasureCodeNavigation)
-                      .InverseCollection(p => p.Product)
+                entity.HasOne(d => d.SizeUnitMeasureCodeNavigation)
+                      .WithMany(p => p.Product)
                       .ForeignKey(d => d.SizeUnitMeasureCode);
 
-                entity.Reference(d => d.WeightUnitMeasureCodeNavigation)
-                      .InverseCollection(p => p.ProductNavigation)
+                entity.HasOne(d => d.WeightUnitMeasureCodeNavigation)
+                      .WithMany(p => p.ProductNavigation)
                       .ForeignKey(d => d.WeightUnitMeasureCode);
             });
 
@@ -582,21 +582,21 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
-                entity.Property(e => e.Name).Required();
+                entity.Property(e => e.Name).IsRequired();
 
                 entity.Property(e => e.rowguid).HasDefaultValueSql("newid()");
             });
 
             modelBuilder.Entity<ProductCostHistory>(entity =>
             {
-                entity.Key(e => new { e.ProductID, e.StartDate });
+                entity.HasKey(e => new { e.ProductID, e.StartDate });
 
                 entity.ToTable("ProductCostHistory", "Production");
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
-                entity.Reference(d => d.Product)
-                      .InverseCollection(p => p.ProductCostHistory)
+                entity.HasOne(d => d.Product)
+                      .WithMany(p => p.ProductCostHistory)
                       .ForeignKey(d => d.ProductID);
             });
 
@@ -604,7 +604,7 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
             {
                 entity.ToTable("ProductDescription", "Production");
 
-                entity.Property(e => e.Description).Required();
+                entity.Property(e => e.Description).IsRequired();
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
@@ -613,20 +613,20 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
 
             modelBuilder.Entity<ProductDocument>(entity =>
             {
-                entity.Key(e => new { e.ProductID, e.DocumentNode });
+                entity.HasKey(e => new { e.ProductID, e.DocumentNode });
 
                 entity.ToTable("ProductDocument", "Production");
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
-                entity.Reference(d => d.Product)
-                      .InverseCollection(p => p.ProductDocument)
+                entity.HasOne(d => d.Product)
+                      .WithMany(p => p.ProductDocument)
                       .ForeignKey(d => d.ProductID);
             });
 
             modelBuilder.Entity<ProductInventory>(entity =>
             {
-                entity.Key(e => new { e.ProductID, e.LocationID });
+                entity.HasKey(e => new { e.ProductID, e.LocationID });
 
                 entity.ToTable("ProductInventory", "Production");
 
@@ -636,27 +636,27 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
 
                 entity.Property(e => e.rowguid).HasDefaultValueSql("newid()");
 
-                entity.Property(e => e.Shelf).Required();
+                entity.Property(e => e.Shelf).IsRequired();
 
-                entity.Reference(d => d.Location)
-                      .InverseCollection(p => p.ProductInventory)
+                entity.HasOne(d => d.Location)
+                      .WithMany(p => p.ProductInventory)
                       .ForeignKey(d => d.LocationID);
 
-                entity.Reference(d => d.Product)
-                      .InverseCollection(p => p.ProductInventory)
+                entity.HasOne(d => d.Product)
+                      .WithMany(p => p.ProductInventory)
                       .ForeignKey(d => d.ProductID);
             });
 
             modelBuilder.Entity<ProductListPriceHistory>(entity =>
             {
-                entity.Key(e => new { e.ProductID, e.StartDate });
+                entity.HasKey(e => new { e.ProductID, e.StartDate });
 
                 entity.ToTable("ProductListPriceHistory", "Production");
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
-                entity.Reference(d => d.Product)
-                      .InverseCollection(p => p.ProductListPriceHistory)
+                entity.HasOne(d => d.Product)
+                      .WithMany(p => p.ProductListPriceHistory)
                       .ForeignKey(d => d.ProductID);
             });
 
@@ -666,46 +666,46 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
-                entity.Property(e => e.Name).Required();
+                entity.Property(e => e.Name).IsRequired();
 
                 entity.Property(e => e.rowguid).HasDefaultValueSql("newid()");
             });
 
             modelBuilder.Entity<ProductModelIllustration>(entity =>
             {
-                entity.Key(e => new { e.ProductModelID, e.IllustrationID });
+                entity.HasKey(e => new { e.ProductModelID, e.IllustrationID });
 
                 entity.ToTable("ProductModelIllustration", "Production");
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
-                entity.Reference(d => d.Illustration)
-                      .InverseCollection(p => p.ProductModelIllustration)
+                entity.HasOne(d => d.Illustration)
+                      .WithMany(p => p.ProductModelIllustration)
                       .ForeignKey(d => d.IllustrationID);
 
-                entity.Reference(d => d.ProductModel)
-                      .InverseCollection(p => p.ProductModelIllustration)
+                entity.HasOne(d => d.ProductModel)
+                      .WithMany(p => p.ProductModelIllustration)
                       .ForeignKey(d => d.ProductModelID);
             });
 
             modelBuilder.Entity<ProductModelProductDescriptionCulture>(entity =>
             {
-                entity.Key(e => new { e.ProductModelID, e.ProductDescriptionID, e.CultureID });
+                entity.HasKey(e => new { e.ProductModelID, e.ProductDescriptionID, e.CultureID });
 
                 entity.ToTable("ProductModelProductDescriptionCulture", "Production");
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
-                entity.Reference(d => d.Culture)
-                      .InverseCollection(p => p.ProductModelProductDescriptionCulture)
+                entity.HasOne(d => d.Culture)
+                      .WithMany(p => p.ProductModelProductDescriptionCulture)
                       .ForeignKey(d => d.CultureID);
 
-                entity.Reference(d => d.ProductDescription)
-                      .InverseCollection(p => p.ProductModelProductDescriptionCulture)
+                entity.HasOne(d => d.ProductDescription)
+                      .WithMany(p => p.ProductModelProductDescriptionCulture)
                       .ForeignKey(d => d.ProductDescriptionID);
 
-                entity.Reference(d => d.ProductModel)
-                      .InverseCollection(p => p.ProductModelProductDescriptionCulture)
+                entity.HasOne(d => d.ProductModel)
+                      .WithMany(p => p.ProductModelProductDescriptionCulture)
                       .ForeignKey(d => d.ProductModelID);
             });
 
@@ -718,7 +718,7 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
 
             modelBuilder.Entity<ProductProductPhoto>(entity =>
             {
-                entity.Key(e => new { e.ProductID, e.ProductPhotoID });
+                entity.HasKey(e => new { e.ProductID, e.ProductPhotoID });
 
                 entity.ToTable("ProductProductPhoto", "Production");
 
@@ -726,12 +726,12 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
 
                 entity.Property(e => e.Primary).HasDefaultValue(false);
 
-                entity.Reference(d => d.Product)
-                      .InverseCollection(p => p.ProductProductPhoto)
+                entity.HasOne(d => d.Product)
+                      .WithMany(p => p.ProductProductPhoto)
                       .ForeignKey(d => d.ProductID);
 
-                entity.Reference(d => d.ProductPhoto)
-                      .InverseCollection(p => p.ProductProductPhoto)
+                entity.HasOne(d => d.ProductPhoto)
+                      .WithMany(p => p.ProductProductPhoto)
                       .ForeignKey(d => d.ProductPhotoID);
             });
 
@@ -739,16 +739,16 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
             {
                 entity.ToTable("ProductReview", "Production");
 
-                entity.Property(e => e.EmailAddress).Required();
+                entity.Property(e => e.EmailAddress).IsRequired();
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
                 entity.Property(e => e.ReviewDate).HasDefaultValueSql("getdate()");
 
-                entity.Property(e => e.ReviewerName).Required();
+                entity.Property(e => e.ReviewerName).IsRequired();
 
-                entity.Reference(d => d.Product)
-                      .InverseCollection(p => p.ProductReview)
+                entity.HasOne(d => d.Product)
+                      .WithMany(p => p.ProductReview)
                       .ForeignKey(d => d.ProductID);
             });
 
@@ -758,41 +758,41 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
-                entity.Property(e => e.Name).Required();
+                entity.Property(e => e.Name).IsRequired();
 
                 entity.Property(e => e.rowguid).HasDefaultValueSql("newid()");
 
-                entity.Reference(d => d.ProductCategory)
-                      .InverseCollection(p => p.ProductSubcategory)
+                entity.HasOne(d => d.ProductCategory)
+                      .WithMany(p => p.ProductSubcategory)
                       .ForeignKey(d => d.ProductCategoryID);
             });
 
             modelBuilder.Entity<ProductVendor>(entity =>
             {
-                entity.Key(e => new { e.ProductID, e.BusinessEntityID });
+                entity.HasKey(e => new { e.ProductID, e.BusinessEntityID });
 
                 entity.ToTable("ProductVendor", "Purchasing");
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
-                entity.Property(e => e.UnitMeasureCode).Required();
+                entity.Property(e => e.UnitMeasureCode).IsRequired();
 
-                entity.Reference(d => d.BusinessEntity)
-                      .InverseCollection(p => p.ProductVendor)
+                entity.HasOne(d => d.BusinessEntity)
+                      .WithMany(p => p.ProductVendor)
                       .ForeignKey(d => d.BusinessEntityID);
 
-                entity.Reference(d => d.Product)
-                      .InverseCollection(p => p.ProductVendor)
+                entity.HasOne(d => d.Product)
+                      .WithMany(p => p.ProductVendor)
                       .ForeignKey(d => d.ProductID);
 
-                entity.Reference(d => d.UnitMeasureCodeNavigation)
-                      .InverseCollection(p => p.ProductVendor)
+                entity.HasOne(d => d.UnitMeasureCodeNavigation)
+                      .WithMany(p => p.ProductVendor)
                       .ForeignKey(d => d.UnitMeasureCode);
             });
 
             modelBuilder.Entity<PurchaseOrderDetail>(entity =>
             {
-                entity.Key(e => new { e.PurchaseOrderID, e.PurchaseOrderDetailID });
+                entity.HasKey(e => new { e.PurchaseOrderID, e.PurchaseOrderDetailID });
 
                 entity.ToTable("PurchaseOrderDetail", "Purchasing");
 
@@ -808,18 +808,18 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
                     .ValueGeneratedOnAddOrUpdate()
                     .HasColumnType("decimal(9, 2)");
 
-                entity.Reference(d => d.Product)
-                      .InverseCollection(p => p.PurchaseOrderDetail)
+                entity.HasOne(d => d.Product)
+                      .WithMany(p => p.PurchaseOrderDetail)
                       .ForeignKey(d => d.ProductID);
 
-                entity.Reference(d => d.PurchaseOrder)
-                      .InverseCollection(p => p.PurchaseOrderDetail)
+                entity.HasOne(d => d.PurchaseOrder)
+                      .WithMany(p => p.PurchaseOrderDetail)
                       .ForeignKey(d => d.PurchaseOrderID);
             });
 
             modelBuilder.Entity<PurchaseOrderHeader>(entity =>
             {
-                entity.Key(e => e.PurchaseOrderID);
+                entity.HasKey(e => e.PurchaseOrderID);
 
                 entity.ToTable("PurchaseOrderHeader", "Purchasing");
 
@@ -839,22 +839,22 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
 
                 entity.Property(e => e.TotalDue).ValueGeneratedOnAddOrUpdate();
 
-                entity.Reference(d => d.Employee)
-                      .InverseCollection(p => p.PurchaseOrderHeader)
+                entity.HasOne(d => d.Employee)
+                      .WithMany(p => p.PurchaseOrderHeader)
                       .ForeignKey(d => d.EmployeeID);
 
-                entity.Reference(d => d.ShipMethod)
-                      .InverseCollection(p => p.PurchaseOrderHeader)
+                entity.HasOne(d => d.ShipMethod)
+                      .WithMany(p => p.PurchaseOrderHeader)
                       .ForeignKey(d => d.ShipMethodID);
 
-                entity.Reference(d => d.Vendor)
-                      .InverseCollection(p => p.PurchaseOrderHeader)
+                entity.HasOne(d => d.Vendor)
+                      .WithMany(p => p.PurchaseOrderHeader)
                       .ForeignKey(d => d.VendorID);
             });
 
             modelBuilder.Entity<SalesOrderDetail>(entity =>
             {
-                entity.Key(e => new { e.SalesOrderID, e.SalesOrderDetailID });
+                entity.HasKey(e => new { e.SalesOrderID, e.SalesOrderDetailID });
 
                 entity.ToTable("SalesOrderDetail", "Sales");
 
@@ -868,18 +868,18 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
 
                 entity.Property(e => e.UnitPriceDiscount).HasDefaultValue(0.0m);
 
-                entity.Reference(d => d.SalesOrder)
-                      .InverseCollection(p => p.SalesOrderDetail)
+                entity.HasOne(d => d.SalesOrder)
+                      .WithMany(p => p.SalesOrderDetail)
                       .ForeignKey(d => d.SalesOrderID);
 
-                entity.Reference(d => d.SpecialOfferProduct)
-                      .InverseCollection(p => p.SalesOrderDetail)
+                entity.HasOne(d => d.SpecialOfferProduct)
+                      .WithMany(p => p.SalesOrderDetail)
                       .ForeignKey(d => new { d.SpecialOfferID, d.ProductID });
             });
 
             modelBuilder.Entity<SalesOrderHeader>(entity =>
             {
-                entity.Key(e => e.SalesOrderID);
+                entity.HasKey(e => e.SalesOrderID);
 
                 entity.ToTable("SalesOrderHeader", "Sales");
 
@@ -896,7 +896,7 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
                 entity.Property(e => e.rowguid).HasDefaultValueSql("newid()");
 
                 entity.Property(e => e.SalesOrderNumber)
-                    .Required()
+                    .IsRequired()
                     .ValueGeneratedOnAddOrUpdate();
 
                 entity.Property(e => e.Status).HasDefaultValue(1);
@@ -907,59 +907,59 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
 
                 entity.Property(e => e.TotalDue).ValueGeneratedOnAddOrUpdate();
 
-                entity.Reference(d => d.BillToAddress)
-                      .InverseCollection(p => p.SalesOrderHeader)
+                entity.HasOne(d => d.BillToAddress)
+                      .WithMany(p => p.SalesOrderHeader)
                       .ForeignKey(d => d.BillToAddressID);
 
-                entity.Reference(d => d.CreditCard)
-                      .InverseCollection(p => p.SalesOrderHeader)
+                entity.HasOne(d => d.CreditCard)
+                      .WithMany(p => p.SalesOrderHeader)
                       .ForeignKey(d => d.CreditCardID);
 
-                entity.Reference(d => d.CurrencyRate)
-                      .InverseCollection(p => p.SalesOrderHeader)
+                entity.HasOne(d => d.CurrencyRate)
+                      .WithMany(p => p.SalesOrderHeader)
                       .ForeignKey(d => d.CurrencyRateID);
 
-                entity.Reference(d => d.Customer)
-                      .InverseCollection(p => p.SalesOrderHeader)
+                entity.HasOne(d => d.Customer)
+                      .WithMany(p => p.SalesOrderHeader)
                       .ForeignKey(d => d.CustomerID);
 
-                entity.Reference(d => d.SalesPerson)
-                      .InverseCollection(p => p.SalesOrderHeader)
+                entity.HasOne(d => d.SalesPerson)
+                      .WithMany(p => p.SalesOrderHeader)
                       .ForeignKey(d => d.SalesPersonID);
 
-                entity.Reference(d => d.ShipMethod)
-                      .InverseCollection(p => p.SalesOrderHeader)
+                entity.HasOne(d => d.ShipMethod)
+                      .WithMany(p => p.SalesOrderHeader)
                       .ForeignKey(d => d.ShipMethodID);
 
-                entity.Reference(d => d.ShipToAddress)
-                      .InverseCollection(p => p.SalesOrderHeaderNavigation)
+                entity.HasOne(d => d.ShipToAddress)
+                      .WithMany(p => p.SalesOrderHeaderNavigation)
                       .ForeignKey(d => d.ShipToAddressID);
 
-                entity.Reference(d => d.Territory)
-                      .InverseCollection(p => p.SalesOrderHeader)
+                entity.HasOne(d => d.Territory)
+                      .WithMany(p => p.SalesOrderHeader)
                       .ForeignKey(d => d.TerritoryID);
             });
 
             modelBuilder.Entity<SalesOrderHeaderSalesReason>(entity =>
             {
-                entity.Key(e => new { e.SalesOrderID, e.SalesReasonID });
+                entity.HasKey(e => new { e.SalesOrderID, e.SalesReasonID });
 
                 entity.ToTable("SalesOrderHeaderSalesReason", "Sales");
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
-                entity.Reference(d => d.SalesOrder)
-                      .InverseCollection(p => p.SalesOrderHeaderSalesReason)
+                entity.HasOne(d => d.SalesOrder)
+                      .WithMany(p => p.SalesOrderHeaderSalesReason)
                       .ForeignKey(d => d.SalesOrderID);
 
-                entity.Reference(d => d.SalesReason)
-                      .InverseCollection(p => p.SalesOrderHeaderSalesReason)
+                entity.HasOne(d => d.SalesReason)
+                      .WithMany(p => p.SalesOrderHeaderSalesReason)
                       .ForeignKey(d => d.SalesReasonID);
             });
 
             modelBuilder.Entity<SalesPerson>(entity =>
             {
-                entity.Key(e => e.BusinessEntityID);
+                entity.HasKey(e => e.BusinessEntityID);
 
                 entity.ToTable("SalesPerson", "Sales");
 
@@ -975,18 +975,18 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
 
                 entity.Property(e => e.SalesYTD).HasDefaultValue(0.00m);
 
-                entity.Reference(d => d.BusinessEntity)
-                      .InverseReference(p => p.SalesPerson)
+                entity.HasOne(d => d.BusinessEntity)
+                      .WithOne(p => p.SalesPerson)
                       .ForeignKey<SalesPerson>(d => d.BusinessEntityID);
 
-                entity.Reference(d => d.Territory)
-                      .InverseCollection(p => p.SalesPerson)
+                entity.HasOne(d => d.Territory)
+                      .WithMany(p => p.SalesPerson)
                       .ForeignKey(d => d.TerritoryID);
             });
 
             modelBuilder.Entity<SalesPersonQuotaHistory>(entity =>
             {
-                entity.Key(e => new { e.BusinessEntityID, e.QuotaDate });
+                entity.HasKey(e => new { e.BusinessEntityID, e.QuotaDate });
 
                 entity.ToTable("SalesPersonQuotaHistory", "Sales");
 
@@ -994,8 +994,8 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
 
                 entity.Property(e => e.rowguid).HasDefaultValueSql("newid()");
                 
-                entity.Reference(d => d.BusinessEntity)
-                      .InverseCollection(p => p.SalesPersonQuotaHistory)
+                entity.HasOne(d => d.BusinessEntity)
+                      .WithMany(p => p.SalesPersonQuotaHistory)
                       .ForeignKey(d => d.BusinessEntityID);
             });
 
@@ -1005,9 +1005,9 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
-                entity.Property(e => e.Name).Required();
+                entity.Property(e => e.Name).IsRequired();
 
-                entity.Property(e => e.ReasonType).Required();
+                entity.Property(e => e.ReasonType).IsRequired();
             });
 
             modelBuilder.Entity<SalesTaxRate>(entity =>
@@ -1016,20 +1016,20 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
-                entity.Property(e => e.Name).Required();
+                entity.Property(e => e.Name).IsRequired();
 
                 entity.Property(e => e.rowguid).HasDefaultValueSql("newid()");
                 
                 entity.Property(e => e.TaxRate).HasDefaultValue(0.00m);
                 
-                entity.Reference(d => d.StateProvince)
-                      .InverseCollection(p => p.SalesTaxRate)
+                entity.HasOne(d => d.StateProvince)
+                      .WithMany(p => p.SalesTaxRate)
                       .ForeignKey(d => d.StateProvinceID);
             });
 
             modelBuilder.Entity<SalesTerritory>(entity =>
             {
-                entity.Key(e => e.TerritoryID);
+                entity.HasKey(e => e.TerritoryID);
 
                 entity.ToTable("SalesTerritory", "Sales");
 
@@ -1037,13 +1037,13 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
 
                 entity.Property(e => e.CostYTD).HasDefaultValue(0.00m);
 
-                entity.Property(e => e.CountryRegionCode).Required();
+                entity.Property(e => e.CountryRegionCode).IsRequired();
 
-                entity.Property(e => e.Group).Required();
+                entity.Property(e => e.Group).IsRequired();
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
-                entity.Property(e => e.Name).Required();
+                entity.Property(e => e.Name).IsRequired();
 
                 entity.Property(e => e.rowguid).HasDefaultValueSql("newid()");
 
@@ -1051,14 +1051,14 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
 
                 entity.Property(e => e.SalesYTD).HasDefaultValue(0.00m);
 
-                entity.Reference(d => d.CountryRegionCodeNavigation)
-                      .InverseCollection(p => p.SalesTerritory)
+                entity.HasOne(d => d.CountryRegionCodeNavigation)
+                      .WithMany(p => p.SalesTerritory)
                       .ForeignKey(d => d.CountryRegionCode);
             });
 
             modelBuilder.Entity<SalesTerritoryHistory>(entity =>
             {
-                entity.Key(e => new { e.BusinessEntityID, e.StartDate, e.TerritoryID });
+                entity.HasKey(e => new { e.BusinessEntityID, e.StartDate, e.TerritoryID });
 
                 entity.ToTable("SalesTerritoryHistory", "Sales");
 
@@ -1066,12 +1066,12 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
 
                 entity.Property(e => e.rowguid).HasDefaultValueSql("newid()");
 
-                entity.Reference(d => d.BusinessEntity)
-                      .InverseCollection(p => p.SalesTerritoryHistory)
+                entity.HasOne(d => d.BusinessEntity)
+                      .WithMany(p => p.SalesTerritoryHistory)
                       .ForeignKey(d => d.BusinessEntityID);
 
-                entity.Reference(d => d.Territory)
-                      .InverseCollection(p => p.SalesTerritoryHistory)
+                entity.HasOne(d => d.Territory)
+                      .WithMany(p => p.SalesTerritoryHistory)
                       .ForeignKey(d => d.TerritoryID);
             });
 
@@ -1081,7 +1081,7 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
-                entity.Property(e => e.Name).Required();
+                entity.Property(e => e.Name).IsRequired();
             });
 
             modelBuilder.Entity<Shift>(entity =>
@@ -1090,7 +1090,7 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
                 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
-                entity.Property(e => e.Name).Required();
+                entity.Property(e => e.Name).IsRequired();
             });
 
             modelBuilder.Entity<ShipMethod>(entity =>
@@ -1099,7 +1099,7 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
-                entity.Property(e => e.Name).Required();
+                entity.Property(e => e.Name).IsRequired();
 
                 entity.Property(e => e.rowguid).HasDefaultValueSql("newid()");
 
@@ -1118,8 +1118,8 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
                 
                 entity.Property(e => e.Quantity).HasDefaultValue(1);
                 
-                entity.Reference(d => d.Product)
-                      .InverseCollection(p => p.ShoppingCartItem)
+                entity.HasOne(d => d.Product)
+                      .WithMany(p => p.ShoppingCartItem)
                       .ForeignKey(d => d.ProductID);
             });
 
@@ -1127,9 +1127,9 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
             {
                 entity.ToTable("SpecialOffer", "Sales");
 
-                entity.Property(e => e.Category).Required();
+                entity.Property(e => e.Category).IsRequired();
 
-                entity.Property(e => e.Description).Required();
+                entity.Property(e => e.Description).IsRequired();
 
                 entity.Property(e => e.DiscountPct).HasDefaultValue(0.00m);
                 
@@ -1139,12 +1139,12 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
 
                 entity.Property(e => e.rowguid).HasDefaultValueSql("newid()");
                 
-                entity.Property(e => e.Type).Required();
+                entity.Property(e => e.Type).IsRequired();
             });
 
             modelBuilder.Entity<SpecialOfferProduct>(entity =>
             {
-                entity.Key(e => new { e.SpecialOfferID, e.ProductID });
+                entity.HasKey(e => new { e.SpecialOfferID, e.ProductID });
 
                 entity.ToTable("SpecialOfferProduct", "Sales");
 
@@ -1152,12 +1152,12 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
 
                 entity.Property(e => e.rowguid).HasDefaultValueSql("newid()");
 
-                entity.Reference(d => d.Product)
-                      .InverseCollection(p => p.SpecialOfferProduct)
+                entity.HasOne(d => d.Product)
+                      .WithMany(p => p.SpecialOfferProduct)
                       .ForeignKey(d => d.ProductID);
 
-                entity.Reference(d => d.SpecialOffer)
-                      .InverseCollection(p => p.SpecialOfferProduct)
+                entity.HasOne(d => d.SpecialOffer)
+                      .WithMany(p => p.SpecialOfferProduct)
                       .ForeignKey(d => d.SpecialOfferID);
             });
 
@@ -1165,51 +1165,51 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
             {
                 entity.ToTable("StateProvince", "Person");
 
-                entity.Property(e => e.CountryRegionCode).Required();
+                entity.Property(e => e.CountryRegionCode).IsRequired();
 
                 entity.Property(e => e.IsOnlyStateProvinceFlag).HasDefaultValue(true);
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
-                entity.Property(e => e.Name).Required();
+                entity.Property(e => e.Name).IsRequired();
 
                 entity.Property(e => e.rowguid).HasDefaultValueSql("newid()");
 
-                entity.Property(e => e.StateProvinceCode).Required();
+                entity.Property(e => e.StateProvinceCode).IsRequired();
                 
-                entity.Reference(d => d.CountryRegionCodeNavigation)
-                      .InverseCollection(p => p.StateProvince)
+                entity.HasOne(d => d.CountryRegionCodeNavigation)
+                      .WithMany(p => p.StateProvince)
                       .ForeignKey(d => d.CountryRegionCode);
 
-                entity.Reference(d => d.Territory)
-                      .InverseCollection(p => p.StateProvince)
+                entity.HasOne(d => d.Territory)
+                      .WithMany(p => p.StateProvince)
                       .ForeignKey(d => d.TerritoryID);
             });
 
             modelBuilder.Entity<Store>(entity =>
             {
-                entity.Key(e => e.BusinessEntityID);
+                entity.HasKey(e => e.BusinessEntityID);
 
                 entity.ToTable("Store", "Sales");
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
-                entity.Property(e => e.Name).Required();
+                entity.Property(e => e.Name).IsRequired();
 
                 entity.Property(e => e.rowguid).HasDefaultValueSql("newid()");
 
-                entity.Reference(d => d.BusinessEntity)
-                      .InverseReference(p => p.Store)
+                entity.HasOne(d => d.BusinessEntity)
+                      .WithOne(p => p.Store)
                       .ForeignKey<Store>(d => d.BusinessEntityID);
 
-                entity.Reference(d => d.SalesPerson)
-                      .InverseCollection(p => p.Store)
+                entity.HasOne(d => d.SalesPerson)
+                      .WithMany(p => p.Store)
                       .ForeignKey(d => d.SalesPersonID);
             });
 
             modelBuilder.Entity<TransactionHistory>(entity =>
             {
-                entity.Key(e => e.TransactionID);
+                entity.HasKey(e => e.TransactionID);
 
                 entity.ToTable("TransactionHistory", "Production");
                 
@@ -1219,16 +1219,16 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
 
                 entity.Property(e => e.TransactionDate).HasDefaultValueSql("getdate()");
 
-                entity.Property(e => e.TransactionType).Required();
+                entity.Property(e => e.TransactionType).IsRequired();
 
-                entity.Reference(d => d.Product)
-                      .InverseCollection(p => p.TransactionHistory)
+                entity.HasOne(d => d.Product)
+                      .WithMany(p => p.TransactionHistory)
                       .ForeignKey(d => d.ProductID);
             });
 
             modelBuilder.Entity<TransactionHistoryArchive>(entity =>
             {
-                entity.Key(e => e.TransactionID);
+                entity.HasKey(e => e.TransactionID);
 
                 entity.ToTable("TransactionHistoryArchive", "Production");
                 
@@ -1238,38 +1238,38 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
 
                 entity.Property(e => e.TransactionDate).HasDefaultValueSql("getdate()");
 
-                entity.Property(e => e.TransactionType).Required();
+                entity.Property(e => e.TransactionType).IsRequired();
             });
 
             modelBuilder.Entity<UnitMeasure>(entity =>
             {
-                entity.Key(e => e.UnitMeasureCode);
+                entity.HasKey(e => e.UnitMeasureCode);
 
                 entity.ToTable("UnitMeasure", "Production");
 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
-                entity.Property(e => e.Name).Required();
+                entity.Property(e => e.Name).IsRequired();
             });
 
             modelBuilder.Entity<Vendor>(entity =>
             {
-                entity.Key(e => e.BusinessEntityID);
+                entity.HasKey(e => e.BusinessEntityID);
 
                 entity.ToTable("Vendor", "Purchasing");
 
-                entity.Property(e => e.AccountNumber).Required();
+                entity.Property(e => e.AccountNumber).IsRequired();
 
                 entity.Property(e => e.ActiveFlag).HasDefaultValue(true);
                 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
 
-                entity.Property(e => e.Name).Required();
+                entity.Property(e => e.Name).IsRequired();
 
                 entity.Property(e => e.PreferredVendorStatus).HasDefaultValue(true);
 
-                entity.Reference(d => d.BusinessEntity)
-                      .InverseReference(p => p.Vendor)
+                entity.HasOne(d => d.BusinessEntity)
+                      .WithOne(p => p.Vendor)
                       .ForeignKey<Vendor>(d => d.BusinessEntityID);
             });
 
@@ -1281,18 +1281,18 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
                 
                 entity.Property(e => e.StockedQty).ValueGeneratedOnAddOrUpdate();
 
-                entity.Reference(d => d.Product)
-                      .InverseCollection(p => p.WorkOrder)
+                entity.HasOne(d => d.Product)
+                      .WithMany(p => p.WorkOrder)
                       .ForeignKey(d => d.ProductID);
 
-                entity.Reference(d => d.ScrapReason)
-                      .InverseCollection(p => p.WorkOrder)
+                entity.HasOne(d => d.ScrapReason)
+                      .WithMany(p => p.WorkOrder)
                       .ForeignKey(d => d.ScrapReasonID);
             });
 
             modelBuilder.Entity<WorkOrderRouting>(entity =>
             {
-                entity.Key(e => new { e.WorkOrderID, e.ProductID, e.OperationSequence });
+                entity.HasKey(e => new { e.WorkOrderID, e.ProductID, e.OperationSequence });
 
                 entity.ToTable("WorkOrderRouting", "Production");
 
@@ -1300,12 +1300,12 @@ namespace EntityFramework.Microbenchmarks.Models.AdventureWorks
                 
                 entity.Property(e => e.ModifiedDate).HasDefaultValueSql("getdate()");
                 
-                entity.Reference(d => d.Location)
-                      .InverseCollection(p => p.WorkOrderRouting)
+                entity.HasOne(d => d.Location)
+                      .WithMany(p => p.WorkOrderRouting)
                       .ForeignKey(d => d.LocationID);
 
-                entity.Reference(d => d.WorkOrder)
-                      .InverseCollection(p => p.WorkOrderRouting)
+                entity.HasOne(d => d.WorkOrder)
+                      .WithMany(p => p.WorkOrderRouting)
                       .ForeignKey(d => d.WorkOrderID);
             });
         }

--- a/test/EntityFramework.Microbenchmarks/Models/Orders/OrdersContext.cs
+++ b/test/EntityFramework.Microbenchmarks/Models/Orders/OrdersContext.cs
@@ -42,13 +42,13 @@ namespace EntityFramework.Microbenchmarks.Models.Orders
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.Entity<Customer>().Collection(c => c.Orders).InverseReference(o => o.Customer)
+            modelBuilder.Entity<Customer>().HasMany(c => c.Orders).WithOne(o => o.Customer)
                 .ForeignKey(o => o.CustomerId);
 
-            modelBuilder.Entity<Order>().Collection(o => o.OrderLines).InverseReference(ol => ol.Order)
+            modelBuilder.Entity<Order>().HasMany(o => o.OrderLines).WithOne(ol => ol.Order)
                 .ForeignKey(ol => ol.OrderId);
 
-            modelBuilder.Entity<Product>().Collection(p => p.OrderLines).InverseReference(ol => ol.Product)
+            modelBuilder.Entity<Product>().HasMany(p => p.OrderLines).WithOne(ol => ol.Product)
                 .ForeignKey(ol => ol.ProductId);
         }
     }

--- a/test/EntityFramework.Relational.FunctionalTests/MappingQueryFixtureBase.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/MappingQueryFixtureBase.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
             modelBuilder.Entity<MappingQueryTestBase.MappedCustomer>(e =>
                 {
-                    e.Key(c => c.CustomerID);
+                    e.HasKey(c => c.CustomerID);
                     e.Property(c => c.CompanyName2).Metadata.Relational().ColumnName = "Broken";
                     e.Metadata.Relational().TableName = "Broken";
                     if (!string.IsNullOrEmpty(DatabaseSchema))
@@ -28,7 +28,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
             modelBuilder.Entity<MappingQueryTestBase.MappedEmployee>(e =>
                 {
-                    e.Key(em => em.EmployeeID);
+                    e.HasKey(em => em.EmployeeID);
                     e.Property(em => em.City2).Metadata.Relational().ColumnName = "City";
                     e.Metadata.Relational().TableName = "Employees";
                     e.Metadata.Relational().Schema = DatabaseSchema;
@@ -36,7 +36,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
             modelBuilder.Entity<MappingQueryTestBase.MappedOrder>(e =>
                 {
-                    e.Key(o => o.OrderID);
+                    e.HasKey(o => o.OrderID);
                     e.Property(em => em.ShipVia2).Metadata.Relational().ColumnName = "ShipVia";
                     e.Metadata.Relational().TableName = "Orders";
                     e.Metadata.Relational().Schema = DatabaseSchema;

--- a/test/EntityFramework.Relational.FunctionalTests/NorthwindSprocQueryRelationalFixture.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/NorthwindSprocQueryRelationalFixture.cs
@@ -11,8 +11,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             base.OnModelCreating(modelBuilder);
 
-            modelBuilder.Entity<CustomerOrderHistory>().Key(coh => coh.ProductName);
-            modelBuilder.Entity<MostExpensiveProduct>().Key(mep => mep.TenMostExpensiveProducts);
+            modelBuilder.Entity<CustomerOrderHistory>().HasKey(coh => coh.ProductName);
+            modelBuilder.Entity<MostExpensiveProduct>().HasKey(mep => mep.TenMostExpensiveProducts);
         }
     }
 }

--- a/test/EntityFramework.Relational.FunctionalTests/NullSemanticsQueryRelationalFixture.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/NullSemanticsQueryRelationalFixture.cs
@@ -16,15 +16,15 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             modelBuilder.Entity<NullSemanticsEntity1>().Property(e => e.Id).ValueGeneratedNever();
 
-            modelBuilder.Entity<NullSemanticsEntity1>().Property(e => e.StringA).Required();
-            modelBuilder.Entity<NullSemanticsEntity1>().Property(e => e.StringB).Required();
-            modelBuilder.Entity<NullSemanticsEntity1>().Property(e => e.StringC).Required();
+            modelBuilder.Entity<NullSemanticsEntity1>().Property(e => e.StringA).IsRequired();
+            modelBuilder.Entity<NullSemanticsEntity1>().Property(e => e.StringB).IsRequired();
+            modelBuilder.Entity<NullSemanticsEntity1>().Property(e => e.StringC).IsRequired();
 
             modelBuilder.Entity<NullSemanticsEntity2>().Property(e => e.Id).ValueGeneratedNever();
 
-            modelBuilder.Entity<NullSemanticsEntity2>().Property(e => e.StringA).Required();
-            modelBuilder.Entity<NullSemanticsEntity2>().Property(e => e.StringB).Required();
-            modelBuilder.Entity<NullSemanticsEntity2>().Property(e => e.StringC).Required();
+            modelBuilder.Entity<NullSemanticsEntity2>().Property(e => e.StringA).IsRequired();
+            modelBuilder.Entity<NullSemanticsEntity2>().Property(e => e.StringB).IsRequired();
+            modelBuilder.Entity<NullSemanticsEntity2>().Property(e => e.StringC).IsRequired();
         }
     }
 }

--- a/test/EntityFramework.Relational.Tests/Metadata/InternalRelationalMetadataBuilderExtensionsTest.cs
+++ b/test/EntityFramework.Relational.Tests/Metadata/InternalRelationalMetadataBuilderExtensionsTest.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Data.Entity.Metadata
             var modelBuilder = CreateBuilder();
             var entityTypeBuilder = modelBuilder.Entity(typeof(Splot), ConfigurationSource.Convention);
             var idProperty = entityTypeBuilder.Property("Id", ConfigurationSource.Convention).Metadata;
-            var keyBuilder = entityTypeBuilder.Key(new[] { idProperty.Name }, ConfigurationSource.Convention);
+            var keyBuilder = entityTypeBuilder.HasKey(new[] { idProperty.Name }, ConfigurationSource.Convention);
 
             Assert.True(keyBuilder.Relational(ConfigurationSource.Convention).Name("Splew"));
             Assert.Equal("Splew", keyBuilder.Metadata.Relational().Name);

--- a/test/EntityFramework.Relational.Tests/Metadata/RelationalBuilderExtensionsTest.cs
+++ b/test/EntityFramework.Relational.Tests/Metadata/RelationalBuilderExtensionsTest.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Data.Entity.Metadata.Tests
 
             modelBuilder
                 .Entity<Customer>()
-                .Key(e => e.Id)
+                .HasKey(e => e.Id)
                 .Name("KeyLimePie");
 
             var key = modelBuilder.Model.GetEntityType(typeof(Customer)).GetPrimaryKey();
@@ -112,7 +112,7 @@ namespace Microsoft.Data.Entity.Metadata.Tests
             var modelBuilder = CreateConventionModelBuilder();
 
             modelBuilder
-                .Entity<Customer>().Collection(e => e.Orders).InverseReference(e => e.Customer)
+                .Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer)
                 .ConstraintName("LemonSupreme");
 
             var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).GetForeignKeys().Single(fk => fk.PrincipalEntityType.ClrType == typeof(Customer));
@@ -120,7 +120,7 @@ namespace Microsoft.Data.Entity.Metadata.Tests
             Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
 
             modelBuilder
-                .Entity<Customer>().Collection(e => e.Orders).InverseReference(e => e.Customer)
+                .Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer)
                 .ConstraintName(null);
 
             Assert.Equal("FK_Order_Customer_CustomerId", foreignKey.Relational().Name);
@@ -132,7 +132,7 @@ namespace Microsoft.Data.Entity.Metadata.Tests
             var modelBuilder = CreateConventionModelBuilder();
 
             modelBuilder
-                .Entity<Customer>().Collection(e => e.Orders).InverseReference(e => e.Customer)
+                .Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer)
                 .ForeignKey(e => e.CustomerId)
                 .ConstraintName("LemonSupreme");
 
@@ -147,7 +147,7 @@ namespace Microsoft.Data.Entity.Metadata.Tests
             var modelBuilder = CreateConventionModelBuilder();
 
             modelBuilder
-                .Entity<Order>().Reference(e => e.Customer).InverseCollection(e => e.Orders)
+                .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                 .ConstraintName("LemonSupreme");
 
             var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).GetForeignKeys().Single(fk => fk.PrincipalEntityType.ClrType == typeof(Customer));
@@ -155,7 +155,7 @@ namespace Microsoft.Data.Entity.Metadata.Tests
             Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
 
             modelBuilder
-                .Entity<Order>().Reference(e => e.Customer).InverseCollection(e => e.Orders)
+                .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                 .ConstraintName(null);
 
             Assert.Equal("FK_Order_Customer_CustomerId", foreignKey.Relational().Name);
@@ -167,7 +167,7 @@ namespace Microsoft.Data.Entity.Metadata.Tests
             var modelBuilder = CreateConventionModelBuilder();
 
             modelBuilder
-                .Entity<Order>().Reference(e => e.Customer).InverseCollection(e => e.Orders)
+                .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                 .ForeignKey(e => e.CustomerId)
                 .ConstraintName("LemonSupreme");
 
@@ -182,7 +182,7 @@ namespace Microsoft.Data.Entity.Metadata.Tests
             var modelBuilder = CreateConventionModelBuilder();
 
             modelBuilder
-                .Entity<Order>().Reference(e => e.Details).InverseReference(e => e.Order)
+                .Entity<Order>().HasOne(e => e.Details).WithOne(e => e.Order)
                 .PrincipalKey<Order>(e => e.OrderId)
                 .ConstraintName("LemonSupreme");
 
@@ -191,7 +191,7 @@ namespace Microsoft.Data.Entity.Metadata.Tests
             Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
 
             modelBuilder
-                .Entity<Order>().Reference(e => e.Details).InverseReference(e => e.Order)
+                .Entity<Order>().HasOne(e => e.Details).WithOne(e => e.Order)
                 .ConstraintName(null);
 
             Assert.Equal("FK_OrderDetails_Order_OrderId", foreignKey.Relational().Name);
@@ -203,7 +203,7 @@ namespace Microsoft.Data.Entity.Metadata.Tests
             var modelBuilder = CreateConventionModelBuilder();
 
             modelBuilder
-                .Entity<Order>().Reference(e => e.Details).InverseReference(e => e.Order)
+                .Entity<Order>().HasOne(e => e.Details).WithOne(e => e.Order)
                 .ForeignKey<OrderDetails>(e => e.Id)
                 .ConstraintName("LemonSupreme");
 
@@ -785,22 +785,22 @@ namespace Microsoft.Data.Entity.Metadata.Tests
 
             AssertIsGeneric(
                 modelBuilder
-                    .Entity<Customer>().Collection(e => e.Orders)
-                    .InverseReference(e => e.Customer)
+                    .Entity<Customer>().HasMany(e => e.Orders)
+                    .WithOne(e => e.Customer)
                     .ConstraintName("Will"));
 
             AssertIsGeneric(
                 modelBuilder
                     .Entity<Order>()
-                    .Reference(e => e.Customer)
-                    .InverseCollection(e => e.Orders)
+                    .HasOne(e => e.Customer)
+                    .WithMany(e => e.Orders)
                     .ConstraintName("Jay"));
 
             AssertIsGeneric(
                 modelBuilder
                     .Entity<Order>()
-                    .Reference(e => e.Details)
-                    .InverseReference(e => e.Order)
+                    .HasOne(e => e.Details)
+                    .WithOne(e => e.Order)
                     .ConstraintName("Simon"));
         }
 
@@ -810,20 +810,20 @@ namespace Microsoft.Data.Entity.Metadata.Tests
             var modelBuilder = CreateConventionModelBuilder();
 
             modelBuilder
-                .Entity<Customer>().Collection(typeof(Order), "Orders")
-                .InverseReference("Customer")
+                .Entity<Customer>().HasMany(typeof(Order), "Orders")
+                .WithOne("Customer")
                 .ConstraintName("Will");
 
             modelBuilder
                 .Entity<Order>()
-                .Reference(e => e.Customer)
-                .InverseCollection(e => e.Orders)
+                .HasOne(e => e.Customer)
+                .WithMany(e => e.Orders)
                 .ConstraintName("Jay");
 
             modelBuilder
                 .Entity<Order>()
-                .Reference(e => e.Details)
-                .InverseReference(e => e.Order)
+                .HasOne(e => e.Details)
+                .WithOne(e => e.Order)
                 .ConstraintName("Simon");
         }
 

--- a/test/EntityFramework.Relational.Tests/Metadata/RelationalMetadataExtensionsTest.cs
+++ b/test/EntityFramework.Relational.Tests/Metadata/RelationalMetadataExtensionsTest.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Data.Entity.Metadata.Tests
 
             var key = modelBuilder
                 .Entity<Customer>()
-                .Key(e => e.Id)
+                .HasKey(e => e.Id)
                 .Metadata;
 
             Assert.Equal("PK_Customer", key.Relational().Name);
@@ -188,12 +188,12 @@ namespace Microsoft.Data.Entity.Metadata.Tests
 
             modelBuilder
                 .Entity<Customer>()
-                .Key(e => e.Id);
+                .HasKey(e => e.Id);
 
             var foreignKey = modelBuilder
                 .Entity<Order>()
-                .Reference<Customer>()
-                .InverseReference()
+                .HasOne<Customer>()
+                .WithOne()
                 .ForeignKey<Order>(e => e.CustomerId)
                 .Metadata;
 

--- a/test/EntityFramework.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
+++ b/test/EntityFramework.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("ID");
-                            x.Key("ID");
+                            x.HasKey("ID");
                             x.Property<int>("FK");
                         });
 
@@ -33,12 +33,12 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("ID");
-                            x.Key("ID");
+                            x.HasKey("ID");
                             x.Property<int>("FK");
                         });
 
-                    modelBuilder.Entity("First").Reference("Second").InverseCollection().ForeignKey("FK").PrincipalKey("ID");
-                    modelBuilder.Entity("Second").Reference("First").InverseCollection().ForeignKey("FK").PrincipalKey("ID");
+                    modelBuilder.Entity("First").HasOne("Second").WithMany().ForeignKey("FK").PrincipalKey("ID");
+                    modelBuilder.Entity("Second").HasOne("First").WithMany().ForeignKey("FK").PrincipalKey("ID");
                 },
                 result =>
                 {
@@ -69,7 +69,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("FourthId");
                         });
                     modelBuilder.Entity(
@@ -77,12 +77,12 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("ThirdId");
                         });
 
-                    modelBuilder.Entity("Third").Reference("Fourth").InverseCollection().ForeignKey("FourthId");
-                    modelBuilder.Entity("Fourth").Reference("Third").InverseCollection().ForeignKey("ThirdId");
+                    modelBuilder.Entity("Third").HasOne("Fourth").WithMany().ForeignKey("FourthId");
+                    modelBuilder.Entity("Fourth").HasOne("Third").WithMany().ForeignKey("ThirdId");
                 },
                 _ => { },
                 operations =>
@@ -106,11 +106,11 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Node", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("AltId");
-                        x.AlternateKey("AltId");
+                        x.HasAlternateKey("AltId");
                         x.Property<int?>("ParentAltId");
-                        x.Reference("Node").InverseCollection().ForeignKey("ParentAltId");
+                        x.HasOne("Node").WithMany().ForeignKey("ParentAltId");
                         x.Index("ParentAltId");
                     }),
                 operations =>
@@ -159,7 +159,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Cat", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                     }),
                 target => target.Entity(
                     "Cat",
@@ -167,7 +167,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Cats", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                     }),
                 operations =>
                 {
@@ -191,14 +191,14 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("People", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                     }),
                 target => target.Entity("Person",
                     x =>
                     {
                         x.ToTable("People", "public");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                     }),
                 operations =>
                 {
@@ -224,7 +224,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id").Name("PK_Dog");
+                        x.HasKey("Id").Name("PK_Dog");
                     }),
                 target => target.Entity(
                     "Doge",
@@ -232,7 +232,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Dog");
                         x.Property<int>("Id");
-                        x.Key("Id").Name("PK_Dog");
+                        x.HasKey("Id").Name("PK_Dog");
                     }),
                 operations => Assert.Empty(operations));
         }
@@ -247,7 +247,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Dragon", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                     }),
                 target => target.Entity(
                     "Dragon",
@@ -255,10 +255,10 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Dragon", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<string>("Name")
                             .HasColumnType("nvarchar(30)")
-                            .Required()
+                            .IsRequired()
                             .HasDefaultValue("Draco")
                             .HasDefaultValueSql("CreateDragonName()");
                     }),
@@ -288,7 +288,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Dragon", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                     }),
                 target => target.Entity(
                     "Dragon",
@@ -296,10 +296,10 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Dragon", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<string>("Name")
                             .HasColumnType("nvarchar(30)")
-                            .Required()
+                            .IsRequired()
                             .HasDefaultValue("Draco")
                             .HasComputedColumnSql("CreateDragonName()");
                     }),
@@ -332,15 +332,15 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                     }),
                 target => target.Entity(
                     "Robin",
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id");
-                        x.Property(type, "Value").Required();
+                        x.HasKey("Id");
+                        x.Property(type, "Value").IsRequired();
                     }),
                 operations =>
                 {
@@ -363,7 +363,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Firefly", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<string>("Name").HasColumnType("nvarchar(30)");
                     }),
                 target => target.Entity(
@@ -372,7 +372,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Firefly", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                     }),
                 operations =>
                 {
@@ -395,7 +395,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Zebra", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<string>("Name").HasColumnType("nvarchar(30)");
                     }),
                 target => target.Entity(
@@ -404,7 +404,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Zebra", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<string>("Name").HasColumnName("ZebraName").HasColumnType("nvarchar(30)");
                     }),
                 operations =>
@@ -429,7 +429,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Buffalo", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<string>("BuffaloName").HasColumnType("nvarchar(30)");
                     }),
                 target => target.Entity(
@@ -438,7 +438,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Buffalo", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<string>("Name").HasColumnName("BuffaloName").HasColumnType("nvarchar(30)");
                     }),
                 operations => Assert.Empty(operations));
@@ -454,10 +454,10 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Bison", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<string>("Name")
                             .HasColumnType("nvarchar(30)")
-                            .Required(true)
+                            .IsRequired(true)
                             .HasDefaultValue("Buffy")
                             .HasDefaultValueSql("CreateBisonName()");
                     }),
@@ -467,10 +467,10 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Bison", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<string>("Name")
                             .HasColumnType("nvarchar(30)")
-                            .Required(false)
+                            .IsRequired(false)
                             .HasDefaultValue("Buffy")
                             .HasDefaultValueSql("CreateBisonName()");
                     }),
@@ -500,10 +500,10 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Puma", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<string>("Name")
                             .HasColumnType("nvarchar(30)")
-                            .Required()
+                            .IsRequired()
                             .HasDefaultValue("Puff")
                             .HasDefaultValueSql("CreatePumaName()");
                     }),
@@ -513,10 +513,10 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Puma", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<string>("Name")
                             .HasColumnType("nvarchar(450)")
-                            .Required()
+                            .IsRequired()
                             .HasDefaultValue("Puff")
                             .HasDefaultValueSql("CreatePumaName()");
                     }),
@@ -546,10 +546,10 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Cougar", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<string>("Name")
                             .HasColumnType("nvarchar(30)")
-                            .Required()
+                            .IsRequired()
                             .HasDefaultValue("Butch")
                             .HasDefaultValueSql("CreateCougarName()");
                     }),
@@ -559,10 +559,10 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Cougar", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<string>("Name")
                             .HasColumnType("nvarchar(30)")
-                            .Required()
+                            .IsRequired()
                             .HasDefaultValue("Cosmo")
                             .HasDefaultValueSql("CreateCougarName()");
                     }),
@@ -592,10 +592,10 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("MountainLion", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<string>("Name")
                             .HasColumnType("nvarchar(30)")
-                            .Required()
+                            .IsRequired()
                             .HasDefaultValue("Liam")
                             .HasDefaultValueSql("CreateMountainLionName()");
                     }),
@@ -605,10 +605,10 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("MountainLion", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<string>("Name")
                             .HasColumnType("nvarchar(30)")
-                            .Required()
+                            .IsRequired()
                             .HasDefaultValue("Liam")
                             .HasDefaultValueSql("CreateCatamountName()");
                     }),
@@ -638,10 +638,10 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("MountainLion", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<string>("Name")
                             .HasColumnType("nvarchar(30)")
-                            .Required()
+                            .IsRequired()
                             .HasDefaultValue("Liam")
                             .HasComputedColumnSql("CreateMountainLionName()");
                     }),
@@ -651,10 +651,10 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("MountainLion", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<string>("Name")
                             .HasColumnType("nvarchar(30)")
-                            .Required()
+                            .IsRequired()
                             .HasDefaultValue("Liam")
                             .HasComputedColumnSql("CreateCatamountName()");
                     }),
@@ -684,7 +684,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Flamingo", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("AlternateId");
                     }),
                 target => target.Entity(
@@ -693,9 +693,9 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Flamingo", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("AlternateId");
-                        x.AlternateKey("AlternateId");
+                        x.HasAlternateKey("AlternateId");
                     }),
                 operations =>
                 {
@@ -719,9 +719,9 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Penguin", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("AlternateId");
-                        x.AlternateKey("AlternateId");
+                        x.HasAlternateKey("AlternateId");
                     }),
                 target => target.Entity(
                     "Penguin",
@@ -729,7 +729,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Penguin", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("AlternateId");
                     }),
                 operations =>
@@ -753,9 +753,9 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Pelican", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("AlternateId");
-                        x.AlternateKey("AlternateId");
+                        x.HasAlternateKey("AlternateId");
                     }),
                 target => target.Entity(
                     "Pelican",
@@ -763,9 +763,9 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Pelican", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("AlternateId");
-                        x.AlternateKey("AlternateId").Name("AK_dbo.Pelican_AlternateId");
+                        x.HasAlternateKey("AlternateId").Name("AK_dbo.Pelican_AlternateId");
                     }),
                 operations =>
                 {
@@ -794,9 +794,9 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Rook", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("AlternateId");
-                        x.AlternateKey("AlternateId");
+                        x.HasAlternateKey("AlternateId");
                         x.Property<int>("AlternateRookId");
                     }),
                 target => target.Entity(
@@ -805,10 +805,10 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Rook", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("AlternateId");
                         x.Property<int>("AlternateRookId");
-                        x.AlternateKey("AlternateRookId").Name("AK_Rook_AlternateId");
+                        x.HasAlternateKey("AlternateRookId").Name("AK_Rook_AlternateId");
                     }),
                 operations =>
                 {
@@ -837,7 +837,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Puffin", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                     }),
                 target => target.Entity(
                     "Puffin",
@@ -845,7 +845,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Puffin", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id").Name("PK_dbo.Puffin");
+                        x.HasKey("Id").Name("PK_dbo.Puffin");
                     }),
                 operations =>
                 {
@@ -874,7 +874,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Raven", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("RavenId");
                     }),
                 target => target.Entity(
@@ -884,7 +884,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x.ToTable("Raven", "dbo");
                         x.Property<int>("Id");
                         x.Property<int>("RavenId");
-                        x.Key("RavenId");
+                        x.HasKey("RavenId");
                     }),
                 operations =>
                 {
@@ -913,7 +913,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Amoeba", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("ParentId");
                     }),
                 target => target.Entity(
@@ -922,9 +922,9 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Amoeba", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("ParentId");
-                        x.Reference("Amoeba").InverseCollection().ForeignKey("ParentId");
+                        x.HasOne("Amoeba").WithMany().ForeignKey("ParentId");
                     }),
                 operations =>
                 {
@@ -953,7 +953,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Amoeba", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("ParentId");
                     }),
                 target => target.Entity(
@@ -962,9 +962,9 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Amoeba", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("ParentId");
-                        x.Reference("Amoeba").InverseCollection().ForeignKey("ParentId").WillCascadeOnDelete();
+                        x.HasOne("Amoeba").WithMany().ForeignKey("ParentId").WillCascadeOnDelete();
                     }),
                 operations =>
                 {
@@ -993,9 +993,9 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Anemone", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("ParentId");
-                        x.Reference("Anemone").InverseCollection().ForeignKey("ParentId");
+                        x.HasOne("Anemone").WithMany().ForeignKey("ParentId");
                     }),
                 target => target.Entity(
                     "Anemone",
@@ -1003,7 +1003,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Anemone", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("ParentId");
                     }),
                 operations =>
@@ -1027,9 +1027,9 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Nematode", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("ParentId");
-                        x.Reference("Nematode").InverseCollection().ForeignKey("ParentId");
+                        x.HasOne("Nematode").WithMany().ForeignKey("ParentId");
                     }),
                 target => target.Entity(
                     "Nematode",
@@ -1037,9 +1037,9 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Nematode", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("ParentId");
-                        x.Reference("Nematode").InverseCollection().ForeignKey("ParentId").ConstraintName("FK_Nematode_NematodeParent");
+                        x.HasOne("Nematode").WithMany().ForeignKey("ParentId").ConstraintName("FK_Nematode_NematodeParent");
                     }),
                 operations =>
                 {
@@ -1071,9 +1071,9 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Mushroom", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("ParentId1");
-                        x.Reference("Mushroom").InverseCollection().ForeignKey("ParentId1");
+                        x.HasOne("Mushroom").WithMany().ForeignKey("ParentId1");
                         x.Property<int>("ParentId2");
                     }),
                 target => target.Entity(
@@ -1082,10 +1082,10 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Mushroom", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("ParentId1");
                         x.Property<int>("ParentId2");
-                        x.Reference("Mushroom").InverseCollection().ForeignKey("ParentId2").ConstraintName("FK_Mushroom_Mushroom_ParentId1");
+                        x.HasOne("Mushroom").WithMany().ForeignKey("ParentId2").ConstraintName("FK_Mushroom_Mushroom_ParentId1");
                     }),
                 operations =>
                 {
@@ -1117,9 +1117,9 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Mushroom", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("ParentId1");
-                        x.Reference("Mushroom").InverseCollection().ForeignKey("ParentId1");
+                        x.HasOne("Mushroom").WithMany().ForeignKey("ParentId1");
                         x.Property<int>("ParentId2");
                     }),
                 target => target.Entity(
@@ -1128,9 +1128,9 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Mushroom", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("ParentId1");
-                        x.Reference("Mushroom").InverseCollection().ForeignKey("ParentId1").WillCascadeOnDelete();
+                        x.HasOne("Mushroom").WithMany().ForeignKey("ParentId1").WillCascadeOnDelete();
                         x.Property<int>("ParentId2");
                     }),
                 operations =>
@@ -1167,7 +1167,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Lion", "odb");
                             x.Property<int>("LionId");
-                            x.Key("LionId");
+                            x.HasKey("LionId");
                         });
                     source.Entity(
                         "Tiger",
@@ -1175,7 +1175,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Tiger", "bod");
                             x.Property<int>("TigerId");
-                            x.Key("TigerId");
+                            x.HasKey("TigerId");
                         });
                     source.Entity(
                         "Liger",
@@ -1183,9 +1183,9 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Liger", "dbo");
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("ParentId");
-                            x.Reference("Lion").InverseCollection().ForeignKey("ParentId");
+                            x.HasOne("Lion").WithMany().ForeignKey("ParentId");
                         });
                 },
                 target =>
@@ -1196,7 +1196,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Lion", "odb");
                             x.Property<int>("LionId");
-                            x.Key("LionId");
+                            x.HasKey("LionId");
                         });
                     target.Entity(
                         "Tiger",
@@ -1204,7 +1204,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Tiger", "bod");
                             x.Property<int>("TigerId");
-                            x.Key("TigerId");
+                            x.HasKey("TigerId");
                         });
                     target.Entity(
                         "Liger",
@@ -1212,9 +1212,9 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Liger", "dbo");
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("ParentId");
-                            x.Reference("Tiger").InverseCollection().ForeignKey("ParentId").ConstraintName("FK_Liger_Lion_ParentId");
+                            x.HasOne("Tiger").WithMany().ForeignKey("ParentId").ConstraintName("FK_Liger_Lion_ParentId");
                         });
                 },
                 operations =>
@@ -1247,7 +1247,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Hippo", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("Value");
                     }),
                 target => target.Entity(
@@ -1256,7 +1256,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Hippo", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("Value");
                         x.Index("Value").Unique();
                     }),
@@ -1283,7 +1283,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Horse", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("Value");
                         x.Index("Value");
                     }),
@@ -1293,7 +1293,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Horse", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("Value");
                     }),
                 operations =>
@@ -1317,7 +1317,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Donkey", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("Value");
                         x.Index("Value");
                     }),
@@ -1327,7 +1327,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Donkey", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("Value");
                         x.Index("Value").Name("IX_dbo.Donkey_Value");
                     }),
@@ -1353,7 +1353,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Muel", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("Value");
                         x.Index("Value");
                         x.Property<int>("MuleValue");
@@ -1364,7 +1364,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Muel", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("Value");
                         x.Property<int>("MuleValue");
                         x.Index("MuleValue").Name("IX_Muel_Value");
@@ -1396,7 +1396,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Pony", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("Value");
                         x.Index("Value").Unique(false);
                     }),
@@ -1406,7 +1406,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Pony", "dbo");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("Value");
                         x.Index("Value").Unique(true);
                     }),
@@ -1699,7 +1699,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int?>("Value");
                     }),
                 target => target.Entity(
@@ -1707,7 +1707,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("Value");
                     }),
                 operations =>
@@ -1728,7 +1728,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("Value");
                     }),
                 target => target.Entity(
@@ -1736,7 +1736,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int?>("Value");
                     }),
                 operations =>
@@ -1757,7 +1757,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("Value");
                     }),
                 target => target.Entity(
@@ -1765,7 +1765,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("Value").HasColumnType("integer");
                     }),
                 operations =>
@@ -1786,14 +1786,14 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                     }),
                 target => target.Entity(
                     "Jaguar",
                     x =>
                     {
                         x.Property<string>("Name");
-                        x.Key("Name");
+                        x.HasKey("Name");
                     }),
                 operations => Assert.Collection(
                     operations,
@@ -1812,16 +1812,16 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                     }),
                 target => target.Entity(
                     "Panther",
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("AlternateId");
-                        x.AlternateKey("AlternateId");
+                        x.HasAlternateKey("AlternateId");
                     }),
                 operations => Assert.Collection(
                     operations,
@@ -1838,16 +1838,16 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("AlternateId");
-                        x.AlternateKey("AlternateId");
+                        x.HasAlternateKey("AlternateId");
                     }),
                 target => target.Entity(
                     "Bobcat",
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                     }),
                 operations => Assert.Collection(
                     operations,
@@ -1864,14 +1864,14 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                     }),
                 target => target.Entity(
                     "Coyote",
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("Value");
                         x.Index("Value");
                     }),
@@ -1890,7 +1890,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("Value");
                         x.Index("Value");
                     }),
@@ -1899,7 +1899,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                     }),
                 operations => Assert.Collection(
                     operations,
@@ -1916,16 +1916,16 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                     }),
                 target => target.Entity(
                     "Algae",
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("ParentId");
-                        x.Reference("Algae").InverseCollection().ForeignKey("ParentId");
+                        x.HasOne("Algae").WithMany().ForeignKey("ParentId");
                     }),
                 operations => Assert.Collection(
                     operations,
@@ -1942,16 +1942,16 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("ParentId");
-                        x.Reference("Bacteria").InverseCollection().ForeignKey("ParentId");
+                        x.HasOne("Bacteria").WithMany().ForeignKey("ParentId");
                     }),
                 target => target.Entity(
                     "Bacteria",
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                     }),
                 operations => Assert.Collection(
                     operations,
@@ -1968,7 +1968,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("MakerId");
                     }),
                 target =>
@@ -1978,16 +1978,16 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                         });
                     target.Entity(
                         "Car",
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("MakerId");
-                            x.Reference("Maker").InverseCollection().ForeignKey("MakerId");
+                            x.HasOne("Maker").WithMany().ForeignKey("MakerId");
                         });
                 },
                 operations => Assert.Collection(
@@ -2007,16 +2007,16 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                         });
                     source.Entity(
                         "Boat",
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("MakerId");
-                            x.Reference("Maker").InverseCollection().ForeignKey("MakerId");
+                            x.HasOne("Maker").WithMany().ForeignKey("MakerId");
                         });
                 },
                 target => target.Entity(
@@ -2024,7 +2024,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("MakerId");
                     }),
                 operations => Assert.Collection(
@@ -2044,14 +2044,14 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                         });
                     source.Entity(
                         "Airplane",
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("MakerId");
                         });
                 },
@@ -2062,7 +2062,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("AlternateId");
                         });
                     target.Entity(
@@ -2070,9 +2070,9 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("MakerId");
-                            x.Reference("Maker").InverseCollection().ForeignKey("MakerId").PrincipalKey("AlternateId");
+                            x.HasOne("Maker").WithMany().ForeignKey("MakerId").PrincipalKey("AlternateId");
                         });
                 },
                 operations => Assert.Collection(
@@ -2093,7 +2093,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("AlternateId");
                         });
                     source.Entity(
@@ -2101,9 +2101,9 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("MakerId");
-                            x.Reference("Maker").InverseCollection().ForeignKey("MakerId").PrincipalKey("AlternateId");
+                            x.HasOne("Maker").WithMany().ForeignKey("MakerId").PrincipalKey("AlternateId");
                         });
                 },
                 target =>
@@ -2113,14 +2113,14 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                         });
                     target.Entity(
                         "Submarine",
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("MakerId");
                         });
                 },
@@ -2143,16 +2143,16 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                         });
                     modelBuilder.Entity(
                         "Helicopter",
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("MakerId");
-                            x.Reference("Maker").InverseCollection().ForeignKey("MakerId");
+                            x.HasOne("Maker").WithMany().ForeignKey("MakerId");
                         });
                 },
                 operations =>
@@ -2178,16 +2178,16 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                         });
                     modelBuilder.Entity(
                         "Glider",
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("MakerId");
-                            x.Reference("Maker").InverseCollection().ForeignKey("MakerId");
+                            x.HasOne("Maker").WithMany().ForeignKey("MakerId");
                         });
                 },
                 _ => { },
@@ -2212,14 +2212,14 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                     }),
                 target => target.Entity(
                     "Hornet",
                     x =>
                     {
                         x.Property<int>("Id").HasColumnName("HornetId");
-                        x.Key("Id");
+                        x.HasKey("Id");
                     }),
                 operations =>
                 {
@@ -2238,18 +2238,18 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<string>("Name");
-                        x.AlternateKey("Name");
+                        x.HasAlternateKey("Name");
                     }),
                 target => target.Entity(
                     "Wasp",
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<string>("Name").HasColumnName("WaspName");
-                        x.AlternateKey("Name");
+                        x.HasAlternateKey("Name");
                     }),
                 operations =>
                 {
@@ -2268,7 +2268,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<string>("Name");
                         x.Index("Name");
                     }),
@@ -2277,7 +2277,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<string>("Name").HasColumnName("BeeName");
                         x.Index("Name");
                     }),
@@ -2298,9 +2298,9 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<string>("Name");
-                        x.AlternateKey("Name");
+                        x.HasAlternateKey("Name");
                     }),
                 target => target.Entity(
                     "Fly",
@@ -2308,9 +2308,9 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Flies");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<string>("Name");
-                        x.AlternateKey("Name");
+                        x.HasAlternateKey("Name");
                     }),
                 operations =>
                 {
@@ -2329,7 +2329,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<string>("Name");
                         x.Index("Name");
                     }),
@@ -2339,7 +2339,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Gnats");
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<string>("Name");
                         x.Index("Name");
                     }),
@@ -2360,18 +2360,18 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<string>("Name");
-                        x.AlternateKey("Name");
+                        x.HasAlternateKey("Name");
                     }),
                 target => target.Entity(
                     "grasshopper",
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id").Name("PK_Grasshopper");
+                        x.HasKey("Id").Name("PK_Grasshopper");
                         x.Property<string>("Name");
-                        x.AlternateKey("Name").Name("AK_Grasshopper_Name");
+                        x.HasAlternateKey("Name").Name("AK_Grasshopper_Name");
                     }),
                 operations =>
                 {
@@ -2390,7 +2390,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<string>("Name");
                         x.Index("Name");
                     }),
@@ -2399,7 +2399,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id").Name("PK_Cricket");
+                        x.HasKey("Id").Name("PK_Cricket");
                         x.Property<string>("Name");
                         x.Index("Name").Name("IX_Cricket_Name");
                     }),
@@ -2420,18 +2420,18 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("ParentId");
-                        x.Reference("Yeast").InverseCollection().ForeignKey("ParentId");
+                        x.HasOne("Yeast").WithMany().ForeignKey("ParentId");
                     }),
                 target => target.Entity(
                     "Yeast",
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("ParentId").HasColumnName("ParentYeastId");
-                        x.Reference("Yeast").InverseCollection().ForeignKey("ParentId");
+                        x.HasOne("Yeast").WithMany().ForeignKey("ParentId");
                     }),
                 operations =>
                 {
@@ -2449,18 +2449,18 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("ParentId");
-                        x.Reference("Mucor").InverseCollection().ForeignKey("ParentId");
+                        x.HasOne("Mucor").WithMany().ForeignKey("ParentId");
                     }),
                 target => target.Entity(
                     "Mucor",
                     x =>
                     {
                         x.Property<int>("Id").HasColumnName("MucorId");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<int>("ParentId");
-                        x.Reference("Mucor").InverseCollection().ForeignKey("ParentId");
+                        x.HasOne("Mucor").WithMany().ForeignKey("ParentId");
                     }),
                 operations =>
                 {
@@ -2480,16 +2480,16 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                         });
                     source.Entity(
                         "Zonkey",
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("ParentId");
-                            x.Reference("Zebra").InverseCollection().ForeignKey("ParentId");
+                            x.HasOne("Zebra").WithMany().ForeignKey("ParentId");
                         });
                 },
                 target =>
@@ -2499,7 +2499,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                         });
                     target.Entity(
                         "Zonkey",
@@ -2507,9 +2507,9 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Zonkeys");
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("ParentId");
-                            x.Reference("Zebra").InverseCollection().ForeignKey("ParentId");
+                            x.HasOne("Zebra").WithMany().ForeignKey("ParentId");
                         });
                 },
                 operations =>
@@ -2530,16 +2530,16 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                         });
                     source.Entity(
                         "Jaglion",
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("ParentId");
-                            x.Reference("Jaguar").InverseCollection().ForeignKey("ParentId");
+                            x.HasOne("Jaguar").WithMany().ForeignKey("ParentId");
                         });
                 },
                 target =>
@@ -2550,16 +2550,16 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Jaguars");
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                         });
                     target.Entity(
                         "Jaglion",
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("ParentId");
-                            x.Reference("Jaguar").InverseCollection().ForeignKey("ParentId");
+                            x.HasOne("Jaguar").WithMany().ForeignKey("ParentId");
                         });
                 },
                 operations =>
@@ -2582,8 +2582,8 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
-                            var discriminatorProperty = x.Property<string>("Discriminator").Required().Metadata;
+                            x.HasKey("Id");
+                            var discriminatorProperty = x.Property<string>("Discriminator").IsRequired().Metadata;
 
                             animal = x.Metadata;
                             animal.Relational().DiscriminatorProperty = discriminatorProperty;
@@ -2623,8 +2623,8 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
-                            var discriminatorProperty = x.Property<string>("Discriminator").Required().Metadata;
+                            x.HasKey("Id");
+                            var discriminatorProperty = x.Property<string>("Discriminator").IsRequired().Metadata;
 
                             animal = x.Metadata;
                             animal.Relational().DiscriminatorProperty = discriminatorProperty;
@@ -2664,8 +2664,8 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Animal", "dbo");
                             x.Property<int>("Id");
-                            x.Key("Id");
-                            var discriminatorProperty = x.Property<string>("Discriminator").Required().Metadata;
+                            x.HasKey("Id");
+                            var discriminatorProperty = x.Property<string>("Discriminator").IsRequired().Metadata;
 
                             animal = x.Metadata;
                             animal.Relational().DiscriminatorProperty = discriminatorProperty;
@@ -2688,8 +2688,8 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Animal", "dbo");
                             x.Property<int>("Id");
-                            x.Key("Id");
-                            var discriminatorProperty = x.Property<string>("Discriminator").Required().Metadata;
+                            x.HasKey("Id");
+                            var discriminatorProperty = x.Property<string>("Discriminator").IsRequired().Metadata;
 
                             animal = x.Metadata;
                             animal.Relational().DiscriminatorProperty = discriminatorProperty;
@@ -2727,8 +2727,8 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
-                            var discriminatorProperty = x.Property<string>("Discriminator").Required().Metadata;
+                            x.HasKey("Id");
+                            var discriminatorProperty = x.Property<string>("Discriminator").IsRequired().Metadata;
 
                             animal = x.Metadata;
                             animal.Relational().DiscriminatorProperty = discriminatorProperty;
@@ -2750,8 +2750,8 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
-                            var discriminatorProperty = x.Property<string>("Discriminator").Required().Metadata;
+                            x.HasKey("Id");
+                            var discriminatorProperty = x.Property<string>("Discriminator").IsRequired().Metadata;
 
                             animal = x.Metadata;
                             animal.Relational().DiscriminatorProperty = discriminatorProperty;
@@ -2790,8 +2790,8 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Animal", "dbo");
                             x.Property<int>("Id");
-                            x.Key("Id");
-                            var discriminatorProperty = x.Property<string>("Discriminator").Required().Metadata;
+                            x.HasKey("Id");
+                            var discriminatorProperty = x.Property<string>("Discriminator").IsRequired().Metadata;
 
                             animal = x.Metadata;
                             animal.Relational().DiscriminatorProperty = discriminatorProperty;
@@ -2815,8 +2815,8 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Animal", "dbo");
                             x.Property<int>("Id");
-                            x.Key("Id");
-                            var discriminatorProperty = x.Property<string>("Discriminator").Required().Metadata;
+                            x.HasKey("Id");
+                            var discriminatorProperty = x.Property<string>("Discriminator").IsRequired().Metadata;
 
                             animal = x.Metadata;
                             animal.Relational().DiscriminatorProperty = discriminatorProperty;
@@ -2854,8 +2854,8 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Animal", "dbo");
                             x.Property<int>("Id");
-                            x.Key("Id");
-                            var discriminatorProperty = x.Property<string>("Discriminator").Required().Metadata;
+                            x.HasKey("Id");
+                            var discriminatorProperty = x.Property<string>("Discriminator").IsRequired().Metadata;
 
                             animal = x.Metadata;
                             animal.Relational().DiscriminatorProperty = discriminatorProperty;
@@ -2879,8 +2879,8 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Animal", "dbo");
                             x.Property<int>("Id");
-                            x.Key("Id");
-                            var discriminatorProperty = x.Property<string>("Discriminator").Required().Metadata;
+                            x.HasKey("Id");
+                            var discriminatorProperty = x.Property<string>("Discriminator").IsRequired().Metadata;
 
                             animal = x.Metadata;
                             animal.Relational().DiscriminatorProperty = discriminatorProperty;
@@ -2920,8 +2920,8 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Animal", "dbo");
                             x.Property<int>("Id");
-                            x.Key("Id");
-                            var discriminatorProperty = x.Property<string>("Discriminator").Required().Metadata;
+                            x.HasKey("Id");
+                            var discriminatorProperty = x.Property<string>("Discriminator").IsRequired().Metadata;
 
                             animal = x.Metadata;
                             animal.Relational().DiscriminatorProperty = discriminatorProperty;
@@ -2945,8 +2945,8 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Animal", "dbo");
                             x.Property<int>("Id");
-                            x.Key("Id");
-                            var discriminatorProperty = x.Property<string>("Discriminator").Required().Metadata;
+                            x.HasKey("Id");
+                            var discriminatorProperty = x.Property<string>("Discriminator").IsRequired().Metadata;
 
                             animal = x.Metadata;
                             animal.Relational().DiscriminatorProperty = discriminatorProperty;
@@ -2987,8 +2987,8 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Animal", "dbo");
                             x.Property<int>("Id");
-                            x.Key("Id");
-                            var discriminatorProperty = x.Property<string>("Discriminator").Required().Metadata;
+                            x.HasKey("Id");
+                            var discriminatorProperty = x.Property<string>("Discriminator").IsRequired().Metadata;
 
                             animal = x.Metadata;
                             animal.Relational().DiscriminatorProperty = discriminatorProperty;
@@ -3013,8 +3013,8 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Animal", "dbo");
                             x.Property<int>("Id");
-                            x.Key("Id");
-                            var discriminatorProperty = x.Property<string>("Discriminator").Required().Metadata;
+                            x.HasKey("Id");
+                            var discriminatorProperty = x.Property<string>("Discriminator").IsRequired().Metadata;
 
                             animal = x.Metadata;
                             animal.Relational().DiscriminatorProperty = discriminatorProperty;
@@ -3055,8 +3055,8 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Animal", "dbo");
                             x.Property<int>("Id");
-                            x.Key("Id");
-                            var discriminatorProperty = x.Property<string>("Discriminator").Required().Metadata;
+                            x.HasKey("Id");
+                            var discriminatorProperty = x.Property<string>("Discriminator").IsRequired().Metadata;
 
                             animal = x.Metadata;
                             animal.Relational().DiscriminatorProperty = discriminatorProperty;
@@ -3081,8 +3081,8 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Animal", "dbo");
                             x.Property<int>("Id");
-                            x.Key("Id");
-                            var discriminatorProperty = x.Property<string>("Discriminator").Required().Metadata;
+                            x.HasKey("Id");
+                            var discriminatorProperty = x.Property<string>("Discriminator").IsRequired().Metadata;
 
                             animal = x.Metadata;
                             animal.Relational().DiscriminatorProperty = discriminatorProperty;
@@ -3120,16 +3120,16 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                         });
                     modelBuilder.Entity(
                         "Animal",
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("HandlerId");
-                            x.Reference("Person").InverseCollection().ForeignKey("HandlerId");
+                            x.HasOne("Person").WithMany().ForeignKey("HandlerId");
                         });
                     modelBuilder.Entity("Wyvern").BaseType("Animal");
                 },
@@ -3162,7 +3162,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                         });
                     EntityType animal = null;
                     modelBuilder.Entity(
@@ -3170,8 +3170,8 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
-                            var discriminatorProperty = x.Property<string>("Discriminator").Required().Metadata;
+                            x.HasKey("Id");
+                            var discriminatorProperty = x.Property<string>("Discriminator").IsRequired().Metadata;
 
                             animal = x.Metadata;
                             animal.Relational().DiscriminatorProperty = discriminatorProperty;
@@ -3183,7 +3183,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.Metadata.BaseType = animal;
                             x.Property<int>("HandlerId");
-                            x.Reference("Person").InverseCollection().ForeignKey("HandlerId");
+                            x.HasOne("Person").WithMany().ForeignKey("HandlerId");
                             x.Metadata.Relational().DiscriminatorValue = "Stag";
                         });
                 },
@@ -3218,8 +3218,8 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
-                            var discriminatorProperty = x.Property<string>("Discriminator").Required().Metadata;
+                            x.HasKey("Id");
+                            var discriminatorProperty = x.Property<string>("Discriminator").IsRequired().Metadata;
 
                             animal = x.Metadata;
                             animal.Relational().DiscriminatorProperty = discriminatorProperty;
@@ -3237,9 +3237,9 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("PetId");
-                            x.Reference("DomesticAnimal").InverseCollection().ForeignKey("PetId");
+                            x.HasOne("DomesticAnimal").WithMany().ForeignKey("PetId");
                         });
                 },
                 operations =>
@@ -3273,8 +3273,8 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
-                            var discriminatorProperty = x.Property<string>("Discriminator").Required().Metadata;
+                            x.HasKey("Id");
+                            var discriminatorProperty = x.Property<string>("Discriminator").IsRequired().Metadata;
 
                             animal = x.Metadata;
                             animal.Relational().DiscriminatorProperty = discriminatorProperty;
@@ -3286,7 +3286,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.Metadata.BaseType = animal;
                             x.Property<int>("PreyId");
-                            x.Reference("Animal").InverseCollection().ForeignKey("PreyId");
+                            x.HasOne("Animal").WithMany().ForeignKey("PreyId");
                             x.Metadata.Relational().DiscriminatorValue = "Predator";
                         });
                 },
@@ -3316,14 +3316,14 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                         });
                     modelBuilder.Entity(
                         "Animal",
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("HandlerId");
                         });
                     modelBuilder.Entity("Drakee").BaseType("Animal");
@@ -3335,16 +3335,16 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                         });
                     modelBuilder.Entity(
                         "Animal",
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("HandlerId");
-                            x.Reference("Person").InverseCollection().ForeignKey("HandlerId");
+                            x.HasOne("Person").WithMany().ForeignKey("HandlerId");
                         });
                     modelBuilder.Entity("Drakee").BaseType("Animal");
                 },
@@ -3372,7 +3372,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                         });
                     EntityType animal = null;
                     source.Entity(
@@ -3380,8 +3380,8 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
-                            var discriminatorProperty = x.Property<string>("Discriminator").Required().Metadata;
+                            x.HasKey("Id");
+                            var discriminatorProperty = x.Property<string>("Discriminator").IsRequired().Metadata;
 
                             animal = x.Metadata;
                             animal.Relational().DiscriminatorProperty = discriminatorProperty;
@@ -3403,7 +3403,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                         });
                     EntityType animal = null;
                     target.Entity(
@@ -3411,8 +3411,8 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
-                            var discriminatorProperty = x.Property<string>("Discriminator").Required().Metadata;
+                            x.HasKey("Id");
+                            var discriminatorProperty = x.Property<string>("Discriminator").IsRequired().Metadata;
 
                             animal = x.Metadata;
                             animal.Relational().DiscriminatorProperty = discriminatorProperty;
@@ -3424,7 +3424,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.Metadata.BaseType = animal;
                             x.Property<int>("HunterId");
-                            x.Reference("Person").InverseCollection().ForeignKey("HunterId");
+                            x.HasOne("Person").WithMany().ForeignKey("HunterId");
                             x.Metadata.Relational().DiscriminatorValue = "GameAnimal";
                         });
                 },
@@ -3453,8 +3453,8 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
-                            var discriminatorProperty = x.Property<string>("Discriminator").Required().Metadata;
+                            x.HasKey("Id");
+                            var discriminatorProperty = x.Property<string>("Discriminator").IsRequired().Metadata;
 
                             animal = x.Metadata;
                             animal.Relational().DiscriminatorProperty = discriminatorProperty;
@@ -3472,7 +3472,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("TrophyId");
                         });
                 },
@@ -3484,8 +3484,8 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
-                            var discriminatorProperty = x.Property<string>("Discriminator").Required().Metadata;
+                            x.HasKey("Id");
+                            var discriminatorProperty = x.Property<string>("Discriminator").IsRequired().Metadata;
 
                             animal = x.Metadata;
                             animal.Relational().DiscriminatorProperty = discriminatorProperty;
@@ -3503,9 +3503,9 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("TrophyId");
-                            x.Reference("TrophyAnimal").InverseCollection().ForeignKey("TrophyId");
+                            x.HasOne("TrophyAnimal").WithMany().ForeignKey("TrophyId");
                         });
                 },
                 operations =>
@@ -3532,7 +3532,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                         });
                     EntityType animal = null;
                     source.Entity(
@@ -3540,8 +3540,8 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
-                            var discriminatorProperty = x.Property<string>("Discriminator").Required().Metadata;
+                            x.HasKey("Id");
+                            var discriminatorProperty = x.Property<string>("Discriminator").IsRequired().Metadata;
 
                             animal = x.Metadata;
                             animal.Relational().DiscriminatorProperty = discriminatorProperty;
@@ -3553,7 +3553,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.Metadata.BaseType = animal;
                             x.Property<int>("RiderId");
-                            x.Reference("Person").InverseCollection().ForeignKey("RiderId");
+                            x.HasOne("Person").WithMany().ForeignKey("RiderId");
                             x.Metadata.Relational().DiscriminatorValue = "MountAnimal";
                         });
                 },
@@ -3564,7 +3564,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                         });
                     EntityType animal = null;
                     target.Entity(
@@ -3572,8 +3572,8 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
-                            var discriminatorProperty = x.Property<string>("Discriminator").Required().Metadata;
+                            x.HasKey("Id");
+                            var discriminatorProperty = x.Property<string>("Discriminator").IsRequired().Metadata;
 
                             animal = x.Metadata;
                             animal.Relational().DiscriminatorProperty = discriminatorProperty;
@@ -3607,7 +3607,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<bool>("Value").HasDefaultValue(true);
                     }),
                  target => target.Entity(
@@ -3615,7 +3615,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                     {
                         x.Property<int>("Id");
-                        x.Key("Id");
+                        x.HasKey("Id");
                         x.Property<bool>("Value").HasDefaultValue(true);
                     }),
                  Assert.Empty);

--- a/test/EntityFramework.Relational.Tests/Update/CommandBatchPreparerTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/CommandBatchPreparerTest.cs
@@ -289,15 +289,15 @@ namespace Microsoft.Data.Entity.Tests.Update
 
             modelBuilder.Entity<FakeEntity>(b =>
                 {
-                    b.Key(c => c.Id);
+                    b.HasKey(c => c.Id);
                     b.Property(c => c.Value);
                 });
 
             modelBuilder.Entity<RelatedFakeEntity>(b =>
                 {
-                    b.Key(c => c.Id);
-                    b.Reference<FakeEntity>()
-                        .InverseReference()
+                    b.HasKey(c => c.Id);
+                    b.HasOne<FakeEntity>()
+                        .WithOne()
                         .ForeignKey<RelatedFakeEntity>(c => c.Id);
                 });
 
@@ -310,22 +310,22 @@ namespace Microsoft.Data.Entity.Tests.Update
 
             modelBuilder.Entity<FakeEntity>(b =>
                 {
-                    b.Key(c => c.Id);
+                    b.HasKey(c => c.Id);
                     b.Property(c => c.Value);
                 });
 
             modelBuilder.Entity<RelatedFakeEntity>(b =>
                 {
-                    b.Key(c => c.Id);
-                    b.Reference<FakeEntity>()
-                        .InverseReference()
+                    b.HasKey(c => c.Id);
+                    b.HasOne<FakeEntity>()
+                        .WithOne()
                         .ForeignKey<RelatedFakeEntity>(c => c.RelatedId);
                 });
 
             modelBuilder
                 .Entity<FakeEntity>()
-                .Reference<RelatedFakeEntity>()
-                .InverseReference()
+                .HasOne<RelatedFakeEntity>()
+                .WithOne()
                 .ForeignKey<FakeEntity>(c => c.RelatedId);
 
             return modelBuilder.Model;

--- a/test/EntityFramework.SqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/SqlServerReverseEngineerTestE2EContext.expected
+++ b/test/EntityFramework.SqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/SqlServerReverseEngineerTestE2EContext.expected
@@ -25,50 +25,50 @@ namespace E2ETest.Namespace
 
             modelBuilder.Entity<OneToManyDependent>(entity =>
             {
-                entity.Key(e => new { e.OneToManyDependentID1, e.OneToManyDependentID2 });
+                entity.HasKey(e => new { e.OneToManyDependentID1, e.OneToManyDependentID2 });
 
-                entity.Property(e => e.SomeDependentEndColumn).Required();
+                entity.Property(e => e.SomeDependentEndColumn).IsRequired();
 
-                entity.Reference(d => d.OneToManyDependentFK).InverseCollection(p => p.OneToManyDependent).ForeignKey(d => new { d.OneToManyDependentFK1, d.OneToManyDependentFK2 });
+                entity.HasOne(d => d.OneToManyDependentFK).WithMany(p => p.OneToManyDependent).ForeignKey(d => new { d.OneToManyDependentFK1, d.OneToManyDependentFK2 });
             });
 
             modelBuilder.Entity<OneToManyPrincipal>(entity =>
             {
-                entity.Key(e => new { e.OneToManyPrincipalID1, e.OneToManyPrincipalID2 });
+                entity.HasKey(e => new { e.OneToManyPrincipalID1, e.OneToManyPrincipalID2 });
 
-                entity.Property(e => e.Other).Required();
+                entity.Property(e => e.Other).IsRequired();
             });
 
             modelBuilder.Entity<OneToOneDependent>(entity =>
             {
-                entity.Key(e => new { e.OneToOneDependentID1, e.OneToOneDependentID2 });
+                entity.HasKey(e => new { e.OneToOneDependentID1, e.OneToOneDependentID2 });
 
-                entity.Property(e => e.SomeDependentEndColumn).Required();
+                entity.Property(e => e.SomeDependentEndColumn).IsRequired();
 
-                entity.Reference(d => d.OneToOneDependentNavigation).InverseReference(p => p.OneToOneDependent).ForeignKey<OneToOneDependent>(d => new { d.OneToOneDependentID1, d.OneToOneDependentID2 });
+                entity.HasOne(d => d.OneToOneDependentNavigation).WithOne(p => p.OneToOneDependent).ForeignKey<OneToOneDependent>(d => new { d.OneToOneDependentID1, d.OneToOneDependentID2 });
             });
 
             modelBuilder.Entity<OneToOnePrincipal>(entity =>
             {
-                entity.Key(e => new { e.OneToOnePrincipalID1, e.OneToOnePrincipalID2 });
+                entity.HasKey(e => new { e.OneToOnePrincipalID1, e.OneToOnePrincipalID2 });
 
-                entity.Property(e => e.SomeOneToOnePrincipalColumn).Required();
+                entity.Property(e => e.SomeOneToOnePrincipalColumn).IsRequired();
             });
 
             modelBuilder.Entity<OneToOneSeparateFKDependent>(entity =>
             {
-                entity.Key(e => new { e.OneToOneSeparateFKDependentID1, e.OneToOneSeparateFKDependentID2 });
+                entity.HasKey(e => new { e.OneToOneSeparateFKDependentID1, e.OneToOneSeparateFKDependentID2 });
 
-                entity.Property(e => e.SomeDependentEndColumn).Required();
+                entity.Property(e => e.SomeDependentEndColumn).IsRequired();
 
-                entity.Reference(d => d.OneToOneSeparateFKDependentFK).InverseReference(p => p.OneToOneSeparateFKDependent).ForeignKey<OneToOneSeparateFKDependent>(d => new { d.OneToOneSeparateFKDependentFK1, d.OneToOneSeparateFKDependentFK2 });
+                entity.HasOne(d => d.OneToOneSeparateFKDependentFK).WithOne(p => p.OneToOneSeparateFKDependent).ForeignKey<OneToOneSeparateFKDependent>(d => new { d.OneToOneSeparateFKDependentFK1, d.OneToOneSeparateFKDependentFK2 });
             });
 
             modelBuilder.Entity<OneToOneSeparateFKPrincipal>(entity =>
             {
-                entity.Key(e => new { e.OneToOneSeparateFKPrincipalID1, e.OneToOneSeparateFKPrincipalID2 });
+                entity.HasKey(e => new { e.OneToOneSeparateFKPrincipalID1, e.OneToOneSeparateFKPrincipalID2 });
 
-                entity.Property(e => e.SomeOneToOneSeparateFKPrincipalColumn).Required();
+                entity.Property(e => e.SomeOneToOneSeparateFKPrincipalColumn).IsRequired();
             });
 
             modelBuilder.Entity<PropertyConfiguration>(entity =>
@@ -76,7 +76,7 @@ namespace E2ETest.Namespace
                 entity.Property(e => e.PropertyConfigurationID).ValueGeneratedNever();
 
                 entity.Property(e => e.RowversionColumn)
-                    .Required()
+                    .IsRequired()
                     .ValueGeneratedOnAddOrUpdate();
 
                 entity.Property(e => e.SumOfAAndB).ValueGeneratedOnAddOrUpdate();
@@ -96,7 +96,7 @@ namespace E2ETest.Namespace
             {
                 entity.Property(e => e.ReferredToByTableWithUnmappablePrimaryKeyColumnID).ValueGeneratedNever();
 
-                entity.Property(e => e.AColumn).Required();
+                entity.Property(e => e.AColumn).IsRequired();
 
                 entity.Property(e => e.ValueGeneratedOnAddColumn).ValueGeneratedOnAdd();
             });
@@ -105,11 +105,11 @@ namespace E2ETest.Namespace
             {
                 entity.Property(e => e.SelfReferencingID).ValueGeneratedNever();
 
-                entity.Property(e => e.Description).Required();
+                entity.Property(e => e.Description).IsRequired();
 
-                entity.Property(e => e.Name).Required();
+                entity.Property(e => e.Name).IsRequired();
 
-                entity.Reference(d => d.SelfReferenceFKNavigation).InverseCollection(p => p.InverseSelfReferenceFKNavigation).ForeignKey(d => d.SelfReferenceFK);
+                entity.HasOne(d => d.SelfReferenceFKNavigation).WithMany(p => p.InverseSelfReferenceFKNavigation).ForeignKey(d => d.SelfReferenceFK);
             });
 
             modelBuilder.Entity<Test_Spaces_Keywords_Table>(entity =>

--- a/test/EntityFramework.SqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/SqlServerReverseEngineerTestE2EContext.expected
+++ b/test/EntityFramework.SqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/SqlServerReverseEngineerTestE2EContext.expected
@@ -25,32 +25,32 @@ namespace E2ETest.Namespace
 
             modelBuilder.Entity<OneToManyDependent>(entity =>
             {
-                entity.Key(e => new { e.OneToManyDependentID1, e.OneToManyDependentID2 });
+                entity.HasKey(e => new { e.OneToManyDependentID1, e.OneToManyDependentID2 });
             });
 
             modelBuilder.Entity<OneToManyPrincipal>(entity =>
             {
-                entity.Key(e => new { e.OneToManyPrincipalID1, e.OneToManyPrincipalID2 });
+                entity.HasKey(e => new { e.OneToManyPrincipalID1, e.OneToManyPrincipalID2 });
             });
 
             modelBuilder.Entity<OneToOneDependent>(entity =>
             {
-                entity.Key(e => new { e.OneToOneDependentID1, e.OneToOneDependentID2 });
+                entity.HasKey(e => new { e.OneToOneDependentID1, e.OneToOneDependentID2 });
             });
 
             modelBuilder.Entity<OneToOnePrincipal>(entity =>
             {
-                entity.Key(e => new { e.OneToOnePrincipalID1, e.OneToOnePrincipalID2 });
+                entity.HasKey(e => new { e.OneToOnePrincipalID1, e.OneToOnePrincipalID2 });
             });
 
             modelBuilder.Entity<OneToOneSeparateFKDependent>(entity =>
             {
-                entity.Key(e => new { e.OneToOneSeparateFKDependentID1, e.OneToOneSeparateFKDependentID2 });
+                entity.HasKey(e => new { e.OneToOneSeparateFKDependentID1, e.OneToOneSeparateFKDependentID2 });
             });
 
             modelBuilder.Entity<OneToOneSeparateFKPrincipal>(entity =>
             {
-                entity.Key(e => new { e.OneToOneSeparateFKPrincipalID1, e.OneToOneSeparateFKPrincipalID2 });
+                entity.HasKey(e => new { e.OneToOneSeparateFKPrincipalID1, e.OneToOneSeparateFKPrincipalID2 });
             });
 
             modelBuilder.Entity<PropertyConfiguration>(entity =>

--- a/test/EntityFramework.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerFixture.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerFixture.cs
@@ -71,13 +71,13 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
             modelBuilder.Entity<MappedDataTypes>(b =>
                 {
-                    b.Key(e => e.Int);
+                    b.HasKey(e => e.Int);
                     b.Property(e => e.Int).ValueGeneratedNever();
                 });
 
             modelBuilder.Entity<MappedNullableDataTypes>(b =>
                 {
-                    b.Key(e => e.Int);
+                    b.HasKey(e => e.Int);
                     b.Property(e => e.Int)
                         .ValueGeneratedNever();
                 });

--- a/test/EntityFramework.SqlServer.FunctionalTests/CompositeKeyEndToEndTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/CompositeKeyEndToEndTest.cs
@@ -200,18 +200,18 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
             protected override void OnModelCreating(ModelBuilder modelBuilder)
             {
-                modelBuilder.Entity<Pegasus>().Key(e => new { e.Id1, e.Id2 });
+                modelBuilder.Entity<Pegasus>().HasKey(e => new { e.Id1, e.Id2 });
 
                 modelBuilder.Entity<Unicorn>(b =>
                     {
-                        b.Key(e => new { e.Id1, e.Id2, e.Id3 });
+                        b.HasKey(e => new { e.Id1, e.Id2, e.Id3 });
                         b.Property(e => e.Id1).UseSqlServerIdentityColumn();
                         b.Property(e => e.Id3).ValueGeneratedOnAdd();
                     });
 
                 modelBuilder.Entity<EarthPony>(b =>
                 {
-                    b.Key(e => new { e.Id1, e.Id2});
+                    b.HasKey(e => new { e.Id1, e.Id2});
                     b.Property(e => e.Id1).UseSqlServerIdentityColumn();
                 });
             }

--- a/test/EntityFramework.SqlServer.FunctionalTests/ConnectionSpecificationTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/ConnectionSpecificationTest.cs
@@ -480,7 +480,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             {
                 modelBuilder.Entity<Customer>(b =>
                     {
-                        b.Key(c => c.CustomerID);
+                        b.HasKey(c => c.CustomerID);
                         b.ToSqlServerTable("Customers");
                     });
             }

--- a/test/EntityFramework.SqlServer.FunctionalTests/ExistingConnectionTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/ExistingConnectionTest.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             {
                 modelBuilder.Entity<Customer>(b =>
                     {
-                        b.Key(c => c.CustomerID);
+                        b.HasKey(c => c.CustomerID);
                         b.ToSqlServerTable("Customers");
                     });
             }

--- a/test/EntityFramework.SqlServer.FunctionalTests/NavigationTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/NavigationTest.cs
@@ -21,8 +21,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             {
                 context.ConfigAction = modelBuilder =>
                     {
-                        modelBuilder.Entity<Person>().Collection(p => p.Siblings).InverseReference(p => p.SiblingReverse).Required(false);
-                        modelBuilder.Entity<Person>().Reference(p => p.Lover).InverseReference(p => p.LoverReverse).Required(false);
+                        modelBuilder.Entity<Person>().HasMany(p => p.Siblings).WithOne(p => p.SiblingReverse).Required(false);
+                        modelBuilder.Entity<Person>().HasOne(p => p.Lover).WithOne(p => p.LoverReverse).Required(false);
                         return 0;
                     };
 
@@ -41,8 +41,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             {
                 context.ConfigAction = modelBuilder =>
                     {
-                        modelBuilder.Entity<Person>().Reference(p => p.SiblingReverse).InverseCollection(p => p.Siblings).Required(false);
-                        modelBuilder.Entity<Person>().Reference(p => p.Lover).InverseReference(p => p.LoverReverse).Required(false);
+                        modelBuilder.Entity<Person>().HasOne(p => p.SiblingReverse).WithMany(p => p.Siblings).Required(false);
+                        modelBuilder.Entity<Person>().HasOne(p => p.Lover).WithOne(p => p.LoverReverse).Required(false);
                         return 0;
                     };
 

--- a/test/EntityFramework.SqlServer.FunctionalTests/QueryBugsTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/QueryBugsTest.cs
@@ -264,8 +264,8 @@ LEFT JOIN [Customer] AS [c] ON ([o].[CustomerFirstName] = [c].[FirstName]) AND (
             {
                 modelBuilder.Entity<Customer>(m =>
                     {
-                        m.Key(c => new { c.FirstName, c.LastName });
-                        m.Collection(c => c.Orders).InverseReference(o => o.Customer);
+                        m.HasKey(c => new { c.FirstName, c.LastName });
+                        m.HasMany(c => c.Orders).WithOne(o => o.Customer);
                     });
             }
         }
@@ -401,9 +401,9 @@ Queen of the Andals and the Rhoynar and the First Men, Khaleesi of the Great Gra
             {
                 modelBuilder.Entity<Targaryen>(m =>
                     {
-                        m.Key(t => t.Id);
-                        m.Collection(t => t.Dragons).InverseReference(d => d.Mother).ForeignKey(d => d.MotherId);
-                        m.Reference(t => t.Details).InverseReference(d => d.Targaryen).ForeignKey<Details>(d => d.TargaryenId);
+                        m.HasKey(t => t.Id);
+                        m.HasMany(t => t.Dragons).WithOne(d => d.Mother).ForeignKey(d => d.MotherId);
+                        m.HasOne(t => t.Details).WithOne(d => d.Targaryen).ForeignKey<Details>(d => d.TargaryenId);
                     });
             }
         }

--- a/test/EntityFramework.SqlServer.FunctionalTests/SequenceEndToEndTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SequenceEndToEndTest.cs
@@ -246,7 +246,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             {
                 modelBuilder.Entity<Pegasus>(b =>
                     {
-                        b.Key(e => e.Identifier);
+                        b.HasKey(e => e.Identifier);
                         b.Property(e => e.Identifier).UseSqlServerSequenceHiLo();
                     });
             }
@@ -357,7 +357,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             {
                 modelBuilder.Entity<Unicon>(b =>
                     {
-                        b.Key(e => e.Identifier);
+                        b.HasKey(e => e.Identifier);
                         if (_useSequence)
                         {
                             b.Property(e => e.Identifier).UseSqlServerSequenceHiLo();

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerConfigPatternsTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerConfigPatternsTest.cs
@@ -708,7 +708,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         {
             builder.Entity<Customer>(b =>
                 {
-                    b.Key(c => c.CustomerID);
+                    b.HasKey(c => c.CustomerID);
                     b.ToSqlServerTable("Customers");
                 });
         }

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerDatabaseCreationTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerDatabaseCreationTest.cs
@@ -327,8 +327,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             {
                 modelBuilder.Entity<Blog>(b =>
                     {
-                        b.Key(e => new { e.Key1, e.Key2 });
-                        b.Property(e => e.AndRow).ConcurrencyToken().ValueGeneratedOnAddOrUpdate();
+                        b.HasKey(e => new { e.Key1, e.Key2 });
+                        b.Property(e => e.AndRow).IsConcurrencyToken().ValueGeneratedOnAddOrUpdate();
                     });
             }
 

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
@@ -334,12 +334,12 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 modelBuilder
                     .Entity<Jack>()
                     .ToTable("Jack", "Apple")
-                    .Key(e => e.MyKey);
+                    .HasKey(e => e.MyKey);
 
                 modelBuilder
                     .Entity<Black>()
                     .ToSqlServerTable("Black", "Apple")
-                    .Key(e => e.MyKey);
+                    .HasKey(e => e.MyKey);
             }
         }
 
@@ -518,7 +518,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             {
                 modelBuilder.Entity<Customer>(b =>
                     {
-                        b.Key(c => c.CustomerID);
+                        b.HasKey(c => c.CustomerID);
                         b.ToSqlServerTable("Customers");
                     });
             }

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerValueGenerationScenariosTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerValueGenerationScenariosTest.cs
@@ -719,7 +719,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                     modelBuilder.Entity<ConcurrentBlog>()
                         .Property(e => e.Timestamp)
                         .ValueGeneratedOnAddOrUpdate()
-                        .ConcurrencyToken();
+                        .IsConcurrencyToken();
                 }
             }
         }

--- a/test/EntityFramework.SqlServer.Tests/Metadata/InternalSqlServerMetadataBuilderExtensionsTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/Metadata/InternalSqlServerMetadataBuilderExtensionsTest.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             var modelBuilder = CreateBuilder();
             var entityTypeBuilder = modelBuilder.Entity(typeof(Splot), ConfigurationSource.Convention);
             var idProperty = entityTypeBuilder.Property("Id", ConfigurationSource.Convention).Metadata;
-            var keyBuilder = entityTypeBuilder.Key(new[] { idProperty.Name }, ConfigurationSource.Convention);
+            var keyBuilder = entityTypeBuilder.HasKey(new[] { idProperty.Name }, ConfigurationSource.Convention);
 
             Assert.True(keyBuilder.SqlServer(ConfigurationSource.Convention).Clustered(true));
             Assert.True(keyBuilder.Metadata.SqlServer().IsClustered);

--- a/test/EntityFramework.SqlServer.Tests/Metadata/SqlServerBuilderExtensionsTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/Metadata/SqlServerBuilderExtensionsTest.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
 
             modelBuilder
                 .Entity<Customer>()
-                .Key(e => e.Id)
+                .HasKey(e => e.Id)
                 .Name("KeyLimePie")
                 .SqlServerKeyName("LemonSupreme");
 
@@ -148,7 +148,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             var modelBuilder = CreateConventionModelBuilder();
 
             modelBuilder
-                .Entity<Customer>().Collection(e => e.Orders).InverseReference(e => e.Customer)
+                .Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer)
                 .ConstraintName("LemonSupreme")
                 .SqlServerConstraintName("ChocolateLimes");
 
@@ -158,7 +158,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             Assert.Equal("ChocolateLimes", foreignKey.SqlServer().Name);
 
             modelBuilder
-                .Entity<Customer>().Collection(e => e.Orders).InverseReference(e => e.Customer)
+                .Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer)
                 .SqlServerConstraintName(null);
 
             Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
@@ -171,7 +171,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             var modelBuilder = CreateConventionModelBuilder();
 
             modelBuilder
-                .Entity<Customer>().Collection(e => e.Orders).InverseReference(e => e.Customer)
+                .Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer)
                 .ForeignKey(e => e.CustomerId)
                 .ConstraintName("LemonSupreme")
                 .SqlServerConstraintName("ChocolateLimes");
@@ -188,7 +188,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             var modelBuilder = CreateConventionModelBuilder();
 
             modelBuilder
-                .Entity<Order>().Reference(e => e.Customer).InverseCollection(e => e.Orders)
+                .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                 .ConstraintName("LemonSupreme")
                 .SqlServerConstraintName("ChocolateLimes");
 
@@ -198,7 +198,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             Assert.Equal("ChocolateLimes", foreignKey.SqlServer().Name);
 
             modelBuilder
-                .Entity<Order>().Reference(e => e.Customer).InverseCollection(e => e.Orders)
+                .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                 .SqlServerConstraintName(null);
 
             Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
@@ -211,7 +211,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             var modelBuilder = CreateConventionModelBuilder();
 
             modelBuilder
-                .Entity<Order>().Reference(e => e.Customer).InverseCollection(e => e.Orders)
+                .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                 .ForeignKey(e => e.CustomerId)
                 .ConstraintName("LemonSupreme")
                 .SqlServerConstraintName("ChocolateLimes");
@@ -228,7 +228,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             var modelBuilder = CreateConventionModelBuilder();
 
             modelBuilder
-                .Entity<Order>().Reference(e => e.Details).InverseReference(e => e.Order)
+                .Entity<Order>().HasOne(e => e.Details).WithOne(e => e.Order)
                 .PrincipalKey<Order>(e => e.OrderId)
                 .ConstraintName("LemonSupreme")
                 .SqlServerConstraintName("ChocolateLimes");
@@ -239,7 +239,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             Assert.Equal("ChocolateLimes", foreignKey.SqlServer().Name);
 
             modelBuilder
-                .Entity<Order>().Reference(e => e.Details).InverseReference(e => e.Order)
+                .Entity<Order>().HasOne(e => e.Details).WithOne(e => e.Order)
                 .SqlServerConstraintName(null);
 
             Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
@@ -252,7 +252,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             var modelBuilder = CreateConventionModelBuilder();
 
             modelBuilder
-                .Entity<Order>().Reference(e => e.Details).InverseReference(e => e.Order)
+                .Entity<Order>().HasOne(e => e.Details).WithOne(e => e.Order)
                 .ForeignKey<OrderDetails>(e => e.Id)
                 .ConstraintName("LemonSupreme")
                 .SqlServerConstraintName("ChocolateLimes");
@@ -374,7 +374,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
 
             modelBuilder
                 .Entity<Customer>()
-                .Key(e => e.Id)
+                .HasKey(e => e.Id)
                 .SqlServerClustered();
 
             var key = modelBuilder.Model.GetEntityType(typeof(Customer)).GetPrimaryKey();
@@ -1233,22 +1233,22 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
 
             AssertIsGeneric(
                 modelBuilder
-                    .Entity<Customer>().Collection(e => e.Orders)
-                    .InverseReference(e => e.Customer)
+                    .Entity<Customer>().HasMany(e => e.Orders)
+                    .WithOne(e => e.Customer)
                     .SqlServerConstraintName("Will"));
 
             AssertIsGeneric(
                 modelBuilder
                     .Entity<Order>()
-                    .Reference(e => e.Customer)
-                    .InverseCollection(e => e.Orders)
+                    .HasOne(e => e.Customer)
+                    .WithMany(e => e.Orders)
                     .SqlServerConstraintName("Jay"));
 
             AssertIsGeneric(
                 modelBuilder
                     .Entity<Order>()
-                    .Reference(e => e.Details)
-                    .InverseReference(e => e.Order)
+                    .HasOne(e => e.Details)
+                    .WithOne(e => e.Order)
                     .SqlServerConstraintName("Simon"));
         }
 
@@ -1258,20 +1258,20 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             var modelBuilder = CreateConventionModelBuilder();
 
             modelBuilder
-                .Entity<Customer>().Collection(typeof(Order), "Orders")
-                .InverseReference("Customer")
+                .Entity<Customer>().HasMany(typeof(Order), "Orders")
+                .WithOne("Customer")
                 .SqlServerConstraintName("Will");
 
             modelBuilder
                 .Entity<Order>()
-                .Reference(e => e.Customer)
-                .InverseCollection(e => e.Orders)
+                .HasOne(e => e.Customer)
+                .WithMany(e => e.Orders)
                 .SqlServerConstraintName("Jay");
 
             modelBuilder
                 .Entity<Order>()
-                .Reference(e => e.Details)
-                .InverseReference(e => e.Order)
+                .HasOne(e => e.Details)
+                .WithOne(e => e.Order)
                 .SqlServerConstraintName("Simon");
         }
 

--- a/test/EntityFramework.SqlServer.Tests/Metadata/SqlServerMetadataExtensionsTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/Metadata/SqlServerMetadataExtensionsTest.cs
@@ -224,7 +224,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
 
             var key = modelBuilder
                 .Entity<Customer>()
-                .Key(e => e.Id)
+                .HasKey(e => e.Id)
                 .Metadata;
 
             Assert.Equal("PK_Customer", key.Relational().Name);
@@ -257,12 +257,12 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
 
             modelBuilder
                 .Entity<Customer>()
-                .Key(e => e.Id);
+                .HasKey(e => e.Id);
 
             var foreignKey = modelBuilder
                 .Entity<Order>()
-                .Reference<Customer>()
-                .InverseReference()
+                .HasOne<Customer>()
+                .WithOne()
                 .ForeignKey<Order>(e => e.CustomerId)
                 .Metadata;
 
@@ -353,7 +353,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
 
             var key = modelBuilder
                 .Entity<Customer>()
-                .Key(e => e.Id)
+                .HasKey(e => e.Id)
                 .Metadata;
 
             Assert.Null(key.SqlServer().IsClustered);

--- a/test/EntityFramework.SqlServer.Tests/Migrations/SqlServerModelDifferTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/Migrations/SqlServerModelDifferTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id").SqlServerKeyName("PK_People");
+                            x.HasKey("Id").SqlServerKeyName("PK_People");
                             x.ToSqlServerTable("People", "dbo");
                         }),
                 operations =>
@@ -47,14 +47,14 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                         }),
                 target => target.Entity(
                     "Person",
                     x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.ToSqlServerTable("People", "dbo");
                         }),
                 operations =>
@@ -80,7 +80,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.ToSqlServerTable("People", "dbo");
                         }),
                 _ => { },
@@ -103,7 +103,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("Value");
                         }),
                 target => target.Entity(
@@ -111,7 +111,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("Value").HasSqlServerColumnName("PersonValue");
                         }),
                 operations =>
@@ -134,7 +134,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("Value");
                         }),
                 target => target.Entity(
@@ -142,7 +142,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("Value")
                                 .HasSqlServerColumnType("varchar(8000)")
                                 .HasDefaultValueSql("1 + 1");
@@ -169,7 +169,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Lamb", "bah");
                             x.Property<int>("Id").ValueGeneratedNever();
-                            x.Key("Id");
+                            x.HasKey("Id");
                         }),
                 target => target.Entity(
                     "Lamb",
@@ -177,7 +177,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Lamb", "bah");
                             x.Property<int>("Id").ValueGeneratedOnAdd();
-                            x.Key("Id");
+                            x.HasKey("Id");
                         }),
                 operations =>
                     {
@@ -201,7 +201,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Sheep", "bah");
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("Now");
                         }),
                 target => target.Entity(
@@ -210,7 +210,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Sheep", "bah");
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("Now").HasSqlServerComputedColumnSql("CAST(CURRENT_TIMESTAMP AS int)");
                         }),
                 operations =>
@@ -234,14 +234,14 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                         }),
                 target => target.Entity(
                     "Person",
                     x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("Value").HasSqlServerColumnName("PersonValue");
                         }),
                 operations =>
@@ -263,7 +263,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("Value").HasSqlServerColumnName("PersonValue");
                         }),
                 target => target.Entity(
@@ -271,7 +271,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                         {
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                         }),
                 operations =>
                     {
@@ -293,7 +293,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Ram", "bah");
                             x.Property<int>("Id");
-                            x.Key("Id").SqlServerClustered(false);
+                            x.HasKey("Id").SqlServerClustered(false);
                         }),
                 target => target.Entity(
                     "Ram",
@@ -301,7 +301,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Ram", "bah");
                             x.Property<int>("Id");
-                            x.Key("Id").SqlServerClustered(true);
+                            x.HasKey("Id").SqlServerClustered(true);
                         }),
                 operations =>
                     {
@@ -330,9 +330,9 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Ewe", "bah");
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("AlternateId");
-                            x.AlternateKey("AlternateId").SqlServerClustered(false);
+                            x.HasAlternateKey("AlternateId").SqlServerClustered(false);
                         }),
                 target => target.Entity(
                     "Ewe",
@@ -340,9 +340,9 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Ewe", "bah");
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("AlternateId");
-                            x.AlternateKey("AlternateId").SqlServerClustered(true);
+                            x.HasAlternateKey("AlternateId").SqlServerClustered(true);
                         }),
                 operations =>
                     {
@@ -371,7 +371,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Ewe", "bah");
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("AlternateId");
                         }),
                 target => target.Entity(
@@ -380,9 +380,9 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Ewe", "bah");
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("AlternateId");
-                            x.AlternateKey("AlternateId").SqlServerKeyName("AK_Ewe");
+                            x.HasAlternateKey("AlternateId").SqlServerKeyName("AK_Ewe");
                         }),
                 operations =>
                     {
@@ -405,9 +405,9 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Ewe", "bah");
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("AlternateId");
-                            x.AlternateKey("AlternateId").SqlServerKeyName("AK_Ewe");
+                            x.HasAlternateKey("AlternateId").SqlServerKeyName("AK_Ewe");
                         }),
                 target => target.Entity(
                     "Ewe",
@@ -415,7 +415,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Ewe", "bah");
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("AlternateId");
                         }),
                 operations =>
@@ -439,7 +439,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Amoeba", "dbo");
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("ParentId");
                         }),
                 target => target.Entity(
@@ -448,9 +448,9 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Amoeba", "dbo");
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("ParentId");
-                            x.Reference("Amoeba").InverseCollection().ForeignKey("ParentId").SqlServerConstraintName("FK_Amoeba_Parent");
+                            x.HasOne("Amoeba").WithMany().ForeignKey("ParentId").SqlServerConstraintName("FK_Amoeba_Parent");
                         }),
                 operations =>
                     {
@@ -473,9 +473,9 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Anemone", "dbo");
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("ParentId");
-                            x.Reference("Anemone").InverseCollection().ForeignKey("ParentId").SqlServerConstraintName("FK_Anemone_Parent");
+                            x.HasOne("Anemone").WithMany().ForeignKey("ParentId").SqlServerConstraintName("FK_Anemone_Parent");
                         }),
                 target => target.Entity(
                     "Anemone",
@@ -483,7 +483,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Anemone", "dbo");
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("ParentId");
                         }),
                 operations =>
@@ -507,7 +507,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Mutton", "bah");
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("Value");
                             x.Index("Value").SqlServerClustered(false);
                         }),
@@ -517,7 +517,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Mutton", "bah");
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("Value");
                             x.Index("Value").SqlServerClustered(true);
                         }),
@@ -548,7 +548,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Donkey", "dbo");
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("Value");
                             x.Index("Value");
                         }),
@@ -558,7 +558,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Donkey", "dbo");
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("Value");
                             x.Index("Value").SqlServerIndexName("IX_dbo.Donkey_Value");
                         }),
@@ -584,7 +584,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Hippo", "dbo");
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("Value");
                         }),
                 target => target.Entity(
@@ -593,7 +593,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Hippo", "dbo");
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("Value");
                             x.Index("Value").SqlServerIndexName("IX_HipVal");
                         }),
@@ -618,7 +618,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Horse", "dbo");
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("Value");
                             x.Index("Value").SqlServerIndexName("IX_HorseVal");
                         }),
@@ -628,7 +628,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Horse", "dbo");
                             x.Property<int>("Id");
-                            x.Key("Id");
+                            x.HasKey("Id");
                             x.Property<int>("Value");
                         }),
                 operations =>

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/ManyToMany/ManyToManyFluentApiContext.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/ManyToMany/ManyToManyFluentApiContext.expected
@@ -14,9 +14,9 @@ namespace E2E.Sqlite
         {
             modelBuilder.Entity<Users_Groups>(entity =>
             {
-                entity.Reference(d => d.Group).InverseCollection(p => p.Users_Groups).ForeignKey(d => d.GroupId);
+                entity.HasOne(d => d.Group).WithMany(p => p.Users_Groups).ForeignKey(d => d.GroupId);
 
-                entity.Reference(d => d.User).InverseCollection(p => p.Users_Groups).ForeignKey(d => d.UserId);
+                entity.HasOne(d => d.User).WithMany(p => p.Users_Groups).ForeignKey(d => d.UserId);
             });
         }
 

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/OneToMany/OneToManyFluentApiContext.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/OneToMany/OneToManyFluentApiContext.expected
@@ -14,7 +14,7 @@ namespace E2E.Sqlite
         {
             modelBuilder.Entity<OneToManyDependent>(entity =>
             {
-                entity.Key(e => new { e.OneToManyDependentID1, e.OneToManyDependentID2 });
+                entity.HasKey(e => new { e.OneToManyDependentID1, e.OneToManyDependentID2 });
 
                 entity.Property(e => e.OneToManyDependentID1).HasColumnType("INT");
 
@@ -25,22 +25,22 @@ namespace E2E.Sqlite
                 entity.Property(e => e.OneToManyDependentFK2).HasColumnType("INT");
 
                 entity.Property(e => e.SomeDependentEndColumn)
-                    .Required()
+                    .IsRequired()
                     .HasColumnType("VARCHAR");
 
-                entity.Reference(d => d.OneToManyDependentFK).InverseCollection(p => p.OneToManyDependent).ForeignKey(d => new { d.OneToManyDependentFK1, d.OneToManyDependentFK2 });
+                entity.HasOne(d => d.OneToManyDependentFK).WithMany(p => p.OneToManyDependent).ForeignKey(d => new { d.OneToManyDependentFK1, d.OneToManyDependentFK2 });
             });
 
             modelBuilder.Entity<OneToManyPrincipal>(entity =>
             {
-                entity.Key(e => new { e.OneToManyPrincipalID1, e.OneToManyPrincipalID2 });
+                entity.HasKey(e => new { e.OneToManyPrincipalID1, e.OneToManyPrincipalID2 });
 
                 entity.Property(e => e.OneToManyPrincipalID1).HasColumnType("INT");
 
                 entity.Property(e => e.OneToManyPrincipalID2).HasColumnType("INT");
 
                 entity.Property(e => e.Other)
-                    .Required()
+                    .IsRequired()
                     .HasColumnType("TEXT");
             });
         }

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/OneToOne/OneToOneFluentApiContext.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/OneToOne/OneToOneFluentApiContext.expected
@@ -18,7 +18,7 @@ namespace E2E.Sqlite
 
                 entity.Property(e => e.PrincipalId).HasColumnType("INT");
 
-                entity.Reference(d => d.Principal).InverseReference(p => p.Dependent).ForeignKey<Dependent>(d => d.PrincipalId);
+                entity.HasOne(d => d.Principal).WithOne(p => p.Dependent).ForeignKey<Dependent>(d => d.PrincipalId);
             });
 
             modelBuilder.Entity<Principal>(entity =>

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/SelfRef/SelfRefFluentApiContext.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/SelfRef/SelfRefFluentApiContext.expected
@@ -18,7 +18,7 @@ namespace E2E.Sqlite
 
                 entity.Property(e => e.SelfForeignKey).HasColumnType("INTEGER");
 
-                entity.Reference(d => d.SelfForeignKeyNavigation).InverseCollection(p => p.InverseSelfForeignKeyNavigation).ForeignKey(d => d.SelfForeignKey);
+                entity.HasOne(d => d.SelfForeignKeyNavigation).WithMany(p => p.InverseSelfForeignKeyNavigation).ForeignKey(d => d.SelfForeignKey);
             });
         }
 

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/OneToMany/OneToManyAttributesContext.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/OneToMany/OneToManyAttributesContext.expected
@@ -14,7 +14,7 @@ namespace E2E.Sqlite
         {
             modelBuilder.Entity<OneToManyDependent>(entity =>
             {
-                entity.Key(e => new { e.OneToManyDependentID1, e.OneToManyDependentID2 });
+                entity.HasKey(e => new { e.OneToManyDependentID1, e.OneToManyDependentID2 });
 
                 entity.Property(e => e.OneToManyDependentID1).HasColumnType("INT");
 
@@ -29,7 +29,7 @@ namespace E2E.Sqlite
 
             modelBuilder.Entity<OneToManyPrincipal>(entity =>
             {
-                entity.Key(e => new { e.OneToManyPrincipalID1, e.OneToManyPrincipalID2 });
+                entity.HasKey(e => new { e.OneToManyPrincipalID1, e.OneToManyPrincipalID2 });
 
                 entity.Property(e => e.OneToManyPrincipalID1).HasColumnType("INT");
 

--- a/test/EntityFramework.Sqlite.FunctionalTests/AutoincrementTest.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/AutoincrementTest.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
             modelBuilder.Entity<Person>(b =>
                 {
                     b.ToSqliteTable("People2");
-                    b.Key(t => t.Name);
+                    b.HasKey(t => t.Name);
                     b.Property(t => t.Name).ValueGeneratedOnAdd();
                 });
         }

--- a/test/EntityFramework.Sqlite.FunctionalTests/BuiltInDataTypesSqliteFixture.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/BuiltInDataTypesSqliteFixture.cs
@@ -51,9 +51,9 @@ namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
                 {
                     b.Property(e => e.Integer).HasColumnType("Integer");
                     b.Property(e => e.Real).HasColumnType("Real");
-                    b.Property(e => e.Text).HasColumnType("Text").Required();
-                    b.Property(e => e.Blob).HasColumnType("Blob").Required();
-                    b.Property(e => e.SomeString).HasColumnType("SomeString").Required();
+                    b.Property(e => e.Text).HasColumnType("Text").IsRequired();
+                    b.Property(e => e.Blob).HasColumnType("Blob").IsRequired();
+                    b.Property(e => e.SomeString).HasColumnType("SomeString").IsRequired();
                     b.Property(e => e.Int).HasColumnType("Int");
                 });
 

--- a/test/EntityFramework.Sqlite.FunctionalTests/CompositeKeyEndToEndTest.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/CompositeKeyEndToEndTest.cs
@@ -137,11 +137,11 @@ namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
 
             protected override void OnModelCreating(ModelBuilder modelBuilder)
             {
-                modelBuilder.Entity<Pegasus>().Key(e => new { e.Id1, e.Id2 });
+                modelBuilder.Entity<Pegasus>().HasKey(e => new { e.Id1, e.Id2 });
 
                 modelBuilder.Entity<EarthPony>(b =>
                     {
-                        b.Key(e => new { e.Id1, e.Id2 });
+                        b.HasKey(e => new { e.Id1, e.Id2 });
                         b.Property(e => e.Id1);
                     });
             }

--- a/test/EntityFramework.Sqlite.FunctionalTests/ForeignKeyTest.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/ForeignKeyTest.cs
@@ -60,8 +60,8 @@ namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder.Entity<Parent>()
-                .Collection(b => b.Children)
-                .InverseReference(b => b.MyParent)
+                .HasMany(b => b.Children)
+                .WithOne(b => b.MyParent)
                 .ForeignKey(b => b.ParentId);
         }
     }

--- a/test/EntityFramework.Sqlite.FunctionalTests/MonsterFixupSqliteTest.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/MonsterFixupSqliteTest.cs
@@ -71,9 +71,9 @@ namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
         public override void OnModelCreating<TMessage, TProductPhoto, TProductReview>(ModelBuilder builder)
         {
             base.OnModelCreating<TMessage, TProductPhoto, TProductReview>(builder);
-            builder.Entity<TMessage>().Key(e => e.MessageId);
-            builder.Entity<TProductPhoto>().Key(e => e.PhotoId);
-            builder.Entity<TProductReview>().Key(e => e.ReviewId);
+            builder.Entity<TMessage>().HasKey(e => e.MessageId);
+            builder.Entity<TProductPhoto>().HasKey(e => e.PhotoId);
+            builder.Entity<TProductReview>().HasKey(e => e.ReviewId);
         }
     }
 }

--- a/test/EntityFramework.Sqlite.Tests/Metadata/Builders/SqliteBuilderExtensionsTest.cs
+++ b/test/EntityFramework.Sqlite.Tests/Metadata/Builders/SqliteBuilderExtensionsTest.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Data.Entity.Sqlite.Metadata.Builders
 
             var key = modelBuilder
                 .Entity<Customer>()
-                .Key(e => e.Id)
+                .HasKey(e => e.Id)
                 .SqliteKeyName("LemonSupreme")
                 .Metadata;
 
@@ -113,7 +113,7 @@ namespace Microsoft.Data.Entity.Sqlite.Metadata.Builders
             var modelBuilder = new ModelBuilder(new ConventionSet());
 
             var foreignKey = modelBuilder
-                .Entity<Customer>().Collection(e => e.Orders).InverseReference(e => e.Customer)
+                .Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer)
                 .SqliteConstraintName("ChocolateLimes")
                 .Metadata;
 
@@ -126,7 +126,7 @@ namespace Microsoft.Data.Entity.Sqlite.Metadata.Builders
             var modelBuilder = new ModelBuilder(new ConventionSet());
 
             var foreignKey = modelBuilder
-                .Entity<Customer>().Collection(typeof(Order)).InverseReference()
+                .Entity<Customer>().HasMany(typeof(Order)).WithOne()
                 .SqliteConstraintName("ChocolateLimes")
                 .Metadata;
 
@@ -139,7 +139,7 @@ namespace Microsoft.Data.Entity.Sqlite.Metadata.Builders
             var modelBuilder = new ModelBuilder(new ConventionSet());
 
             var foreignKey = modelBuilder
-                .Entity<Order>().Reference(e => e.Customer).InverseCollection(e => e.Orders)
+                .Entity<Order>().HasOne(e => e.Customer).WithMany(e => e.Orders)
                 .SqliteConstraintName("ChocolateLimes")
                 .Metadata;
 
@@ -152,7 +152,7 @@ namespace Microsoft.Data.Entity.Sqlite.Metadata.Builders
             var modelBuilder = new ModelBuilder(new ConventionSet());
 
             var foreignKey = modelBuilder
-                .Entity<Order>().Reference(typeof(Customer)).InverseCollection()
+                .Entity<Order>().HasOne(typeof(Customer)).WithMany()
                 .SqliteConstraintName("ChocolateLimes")
                 .Metadata;
 
@@ -165,7 +165,7 @@ namespace Microsoft.Data.Entity.Sqlite.Metadata.Builders
             var modelBuilder = new ModelBuilder(new ConventionSet());
 
             var foreignKey = modelBuilder
-                .Entity<Order>().Reference(e => e.Details).InverseReference(e => e.Order)
+                .Entity<Order>().HasOne(e => e.Details).WithOne(e => e.Order)
                 .SqliteConstraintName("ChocolateLimes")
                 .Metadata;
 
@@ -178,7 +178,7 @@ namespace Microsoft.Data.Entity.Sqlite.Metadata.Builders
             var modelBuilder = new ModelBuilder(new ConventionSet());
 
             var foreignKey = modelBuilder
-                .Entity<Order>().Reference(typeof(OrderDetails)).InverseReference()
+                .Entity<Order>().HasOne(typeof(OrderDetails)).WithOne()
                 .SqliteConstraintName("ChocolateLimes")
                 .Metadata;
 

--- a/test/EntityFramework.Sqlite.Tests/Metadata/Internal/SqliteInternalMetadataBuilderExtensionsTest.cs
+++ b/test/EntityFramework.Sqlite.Tests/Metadata/Internal/SqliteInternalMetadataBuilderExtensionsTest.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Data.Entity.Sqlite.Metadata
             var modelBuilder = CreateBuilder();
             var entityTypeBuilder = modelBuilder.Entity(typeof(Splot), ConfigurationSource.Convention);
             var idProperty = entityTypeBuilder.Property("Id", ConfigurationSource.Convention).Metadata;
-            var keyBuilder = entityTypeBuilder.Key(new[] { idProperty.Name }, ConfigurationSource.Convention);
+            var keyBuilder = entityTypeBuilder.HasKey(new[] { idProperty.Name }, ConfigurationSource.Convention);
 
             Assert.True(keyBuilder.Sqlite(ConfigurationSource.Convention).Name("Splew"));
             Assert.Equal("Splew", keyBuilder.Metadata.Sqlite().Name);

--- a/test/EntityFramework.Sqlite.Tests/Metadata/SqliteMetadataExtensionsTest.cs
+++ b/test/EntityFramework.Sqlite.Tests/Metadata/SqliteMetadataExtensionsTest.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Data.Entity.Sqlite.Metadata
 
             var key = modelBuilder
                 .Entity<Customer>()
-                .Key(e => e.Id)
+                .HasKey(e => e.Id)
                 .Metadata;
 
             Assert.Equal("PK_Customer", key.Sqlite().Name);
@@ -178,12 +178,12 @@ namespace Microsoft.Data.Entity.Sqlite.Metadata
 
             modelBuilder
                 .Entity<Customer>()
-                .Key(e => e.Id);
+                .HasKey(e => e.Id);
 
             var foreignKey = modelBuilder
                 .Entity<Order>()
-                .Reference<Customer>()
-                .InverseReference()
+                .HasOne<Customer>()
+                .WithOne()
                 .ForeignKey<Order>(e => e.CustomerId)
                 .Metadata;
 


### PR DESCRIPTION
Make names align where old stack had same methods and update to the latest relationship API decision. Issue #3071.