### PR TITLE
Block shadow keys on properties defined by conventions

### DIFF
--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/KeyAttributeConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/KeyAttributeConvention.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
                 throw new InvalidOperationException(Strings.KeyAttributeOnDerivedEntity(entityType.DisplayName(), propertyBuilder.Metadata.Name));
             }
 
-            var entityTypeBuilder = propertyBuilder.ModelBuilder.Entity(entityType.Name, ConfigurationSource.DataAnnotation);
+            var entityTypeBuilder = propertyBuilder.ModelBuilder.Entity(entityType.Name, ConfigurationSource.Convention);
             var currentKey = entityTypeBuilder.Metadata.FindPrimaryKey();
             var properties = new List<string> { propertyBuilder.Metadata.Name };
 

--- a/src/EntityFramework.Core/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -227,6 +227,18 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             return builder;
         }
 
+        public virtual bool CanRemoveProperty([NotNull] Property property, ConfigurationSource configurationSource, bool canOverrideSameSource = true)
+        {
+            Check.NotNull(property, nameof(property));
+            if (property.DeclaringEntityType != Metadata)
+            {
+                return ModelBuilder.Entity(property.DeclaringEntityType.Name, ConfigurationSource.Convention)
+                    .CanRemoveProperty(property, configurationSource, canOverrideSameSource);
+            }
+
+            return _propertyBuilders.CanRemove(property, configurationSource, canOverrideSameSource);
+        }
+
         public virtual bool CanAddNavigation([NotNull] string navigationName, ConfigurationSource configurationSource)
             => !IsIgnored(navigationName, configurationSource: configurationSource)
                && Metadata.FindNavigation(navigationName) == null;


### PR DESCRIPTION
Resolves #3156 
As shadow keys were already allowed in model. (only warnings are logged), this change blocks the shadow keys created by convention.