### PR TITLE
[TINY] Fix to #2599 - Unary expression visitation throws for certain 'Not (!)' subqueries

### DIFF
--- a/src/EntityFramework.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
@@ -419,13 +419,16 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
                 case ExpressionType.Not:
                 {
                     var operand = Visit(unaryExpression.Operand);
+                    if (operand != null)
+                    {
+                        return Expression.Not(operand);
+                    }
 
-                    return Expression.Not(operand);
+                    break;
                 }
                 case ExpressionType.Convert:
                 {
                     var operand = Visit(unaryExpression.Operand);
-
                     if (operand != null)
                     {
                         return Expression.Convert(operand, unaryExpression.Type);

--- a/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
@@ -1143,6 +1143,17 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
+        public virtual void Where_bool_client_side_negated()
+        {
+            AssertQuery<Product>(ps => ps.Where(p => !ClientFunc(p.ProductID) && p.Discontinued), entryCount: 8);
+        }
+
+        private static bool ClientFunc(int id)
+        {
+            return false;
+        }
+
+        [Fact]
         public virtual void Where_bool_member_negated_twice()
         {
             // ReSharper disable once NegativeEqualityExpression

--- a/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -2608,6 +2608,17 @@ WHERE [p].[Discontinued] = 0",
                 Sql);
         }
 
+        public override void Where_bool_client_side_negated()
+        {
+            base.Where_bool_client_side_negated();
+
+            Assert.Equal(
+                @"SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitsInStock]
+FROM [Products] AS [p]
+WHERE [p].[Discontinued] = 1",
+                Sql);
+        }
+
         public override void Where_bool_member_negated_twice()
         {
             base.Where_bool_member_negated_twice();


### PR DESCRIPTION
Fix is to add a null check for for cases where we can't translate the operand