### PR TITLE
Re-enable in-memory graph update test

### DIFF
--- a/test/EntityFramework.InMemory.FunctionalTests/GraphUpdatesInMemoryTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/GraphUpdatesInMemoryTest.cs
@@ -1,19 +1,18 @@
-// TODO won't work until we get named in-memory database
-//// Copyright (c) .NET Foundation. All rights reserved.
-//// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-//namespace Microsoft.Data.Entity.InMemory.FunctionalTests
-//{
-//    public class GraphUpdatesInMemoryTest : GraphUpdatesInMemoryTestBase<GraphUpdatesInMemoryTest.GraphUpdatesInMemoryFixture>
-//    {
-//        public GraphUpdatesInMemoryTest(GraphUpdatesInMemoryFixture fixture)
-//            : base(fixture)
-//        {
-//        }
+namespace Microsoft.Data.Entity.InMemory.FunctionalTests
+{
+    public class GraphUpdatesInMemoryTest : GraphUpdatesInMemoryTestBase<GraphUpdatesInMemoryTest.GraphUpdatesInMemoryFixture>
+    {
+        public GraphUpdatesInMemoryTest(GraphUpdatesInMemoryFixture fixture)
+            : base(fixture)
+        {
+        }
 
-//        public class GraphUpdatesInMemoryFixture : GraphUpdatesInMemoryFixtureBase
-//        {
-//            public override int IntSentinel => 0;
-//        }
-//    }
-//}
+        public class GraphUpdatesInMemoryFixture : GraphUpdatesInMemoryFixtureBase
+        {
+            public override int IntSentinel => 0;
+        }
+    }
+}

--- a/test/EntityFramework.InMemory.FunctionalTests/SentinelGraphUpdatesInMemoryTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/SentinelGraphUpdatesInMemoryTest.cs
@@ -1,26 +1,25 @@
-// TODO won't work until we get named in-memory database
-//// Copyright (c) .NET Foundation. All rights reserved.
-//// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-//namespace Microsoft.Data.Entity.InMemory.FunctionalTests
-//{
-//    public class SentinelGraphUpdatesInMemoryTest : GraphUpdatesInMemoryTestBase<SentinelGraphUpdatesInMemoryTest.SentinelGraphUpdatesInMemoryFixture>
-//    {
-//        public SentinelGraphUpdatesInMemoryTest(SentinelGraphUpdatesInMemoryFixture fixture)
-//            : base(fixture)
-//        {
-//        }
+namespace Microsoft.Data.Entity.InMemory.FunctionalTests
+{
+    public class SentinelGraphUpdatesInMemoryTest : GraphUpdatesInMemoryTestBase<SentinelGraphUpdatesInMemoryTest.SentinelGraphUpdatesInMemoryFixture>
+    {
+        public SentinelGraphUpdatesInMemoryTest(SentinelGraphUpdatesInMemoryFixture fixture)
+            : base(fixture)
+        {
+        }
 
-//        public class SentinelGraphUpdatesInMemoryFixture : GraphUpdatesInMemoryFixtureBase
-//        {
-//            public override int IntSentinel => -1;
+        public class SentinelGraphUpdatesInMemoryFixture : GraphUpdatesInMemoryFixtureBase
+        {
+            public override int IntSentinel => -1;
 
-//            protected override void OnModelCreating(ModelBuilder modelBuilder)
-//            {
-//                base.OnModelCreating(modelBuilder);
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                base.OnModelCreating(modelBuilder);
 
-//                SetSentinelValues(modelBuilder, IntSentinel);
-//            }
-//        }
-//    }
-//}
+                SetSentinelValues(modelBuilder, IntSentinel);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fix was to re-add the code that was removed and change it to clear data from the in-memory database directly rather than going through EnsureDeleted.