### PR TITLE
Fix #1856: Introduces DisableQueryClientEvaluation relational DbConte…

### DIFF
--- a/EntityFramework.sln.DotSettings
+++ b/EntityFramework.sln.DotSettings
@@ -9,9 +9,11 @@
 	
 	<s:String x:Key="/Default/CodeStyle/CodeCleanup/RecentlyUsedProfile/@EntryValue">EntityFramework</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeCleanup/SilentCleanupProfile/@EntryValue">EntityFramework</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ALIGN_LINQ_QUERY/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ALIGN_MULTILINE_ARGUMENT/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ALIGN_MULTILINE_CALLS_CHAIN/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ALIGN_MULTILINE_PARAMETER/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ALIGN_MULTLINE_TYPE_PARAMETER_CONSTRAINS/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ANONYMOUS_METHOD_DECLARATION_BRACES/@EntryValue">NEXT_LINE_SHIFTED_2</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_ATTRIBUTE_STYLE/@EntryValue">SEPARATE</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_CHOP_COMPOUND_DO_EXPRESSION/@EntryValue">True</s:Boolean>

--- a/src/EntityFramework.Relational/Infrastructure/RelationalDbContextOptionsBuilder.cs
+++ b/src/EntityFramework.Relational/Infrastructure/RelationalDbContextOptionsBuilder.cs
@@ -50,6 +50,9 @@ namespace Microsoft.Data.Entity.Infrastructure
         public virtual TBuilder UseRelationalNulls()
             => SetOption(e => e.UseRelationalNulls = true);
 
+        public virtual TBuilder DisableQueryClientEvaluation()
+            => SetOption(e => e.IsQueryClientEvaluationEnabled = false);
+
         protected virtual TBuilder SetOption([NotNull] Action<TExtension> setAction)
         {
             Check.NotNull(setAction, nameof(setAction));

--- a/src/EntityFramework.Relational/Infrastructure/RelationalOptionsExtension.cs
+++ b/src/EntityFramework.Relational/Infrastructure/RelationalOptionsExtension.cs
@@ -89,6 +89,7 @@ namespace Microsoft.Data.Entity.Infrastructure
         }
 
         public virtual bool UseRelationalNulls { get; set; }
+        public virtual bool IsQueryClientEvaluationEnabled { get; set; } = true;
 
         public virtual bool? ThrowOnAmbientTransaction { get; set; }
 
@@ -101,21 +102,22 @@ namespace Microsoft.Data.Entity.Infrastructure
         {
             Check.NotNull(options, nameof(options));
 
-            var configs = options.Extensions
-                .OfType<RelationalOptionsExtension>()
-                .ToArray();
+            var relationalOptionsExtensions
+                = options.Extensions
+                    .OfType<RelationalOptionsExtension>()
+                    .ToArray();
 
-            if (configs.Length == 0)
+            if (relationalOptionsExtensions.Length == 0)
             {
                 throw new InvalidOperationException(Strings.NoProviderConfigured);
             }
 
-            if (configs.Length > 1)
+            if (relationalOptionsExtensions.Length > 1)
             {
                 throw new InvalidOperationException(Strings.MultipleProvidersConfigured);
             }
 
-            return configs[0];
+            return relationalOptionsExtensions[0];
         }
 
         public abstract void ApplyServices(EntityFrameworkServicesBuilder builder);

--- a/src/EntityFramework.Relational/Properties/Strings.Designer.cs
+++ b/src/EntityFramework.Relational/Properties/Strings.Designer.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Data.Entity.Relational.Internal
     using System.Globalization;
     using System.Reflection;
     using System.Resources;
-	using JetBrains.Annotations;
+    using JetBrains.Annotations;
 
     public static class Strings
     {
@@ -450,6 +450,22 @@ namespace Microsoft.Data.Entity.Relational.Internal
         public static string InvalidKeyValue([CanBeNull] object entityType)
         {
             return string.Format(CultureInfo.CurrentCulture, GetString("InvalidKeyValue", "entityType"), entityType);
+        }
+
+        /// <summary>
+        /// Unabled to compile the LINQ expression '{expression}' because it requires client evaluation, which is disabled. Either enable client evaluation or rewrite the query to not require client evaluation.
+        /// </summary>
+        public static string ClientEvalDisabled([CanBeNull] object expression)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("ClientEvalDisabled", "expression"), expression);
+        }
+
+        /// <summary>
+        /// The LINQ expression '{expression}' could not be translated and will be evaluated locally.
+        /// </summary>
+        public static string ClientEvalWarning([CanBeNull] object expression)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("ClientEvalWarning", "expression"), expression);
         }
 
         private static string GetString(string name, params string[] formatterNames)

--- a/src/EntityFramework.Relational/Properties/Strings.resx
+++ b/src/EntityFramework.Relational/Properties/Strings.resx
@@ -283,4 +283,10 @@
   <data name="InvalidKeyValue" xml:space="preserve">
     <value>Unable to materialize an entity of type '{entityType}' because it has an invalid key value. Ensure that the key properties of the entity type have the correct sentinel value configuration.</value>
   </data>
+  <data name="ClientEvalDisabled" xml:space="preserve">
+    <value>Unabled to compile the LINQ expression '{expression}' because it requires client evaluation, which is disabled. Either enable client evaluation or rewrite the query to not require client evaluation.</value>
+  </data>
+  <data name="ClientEvalWarning" xml:space="preserve">
+    <value>The LINQ expression '{expression}' could not be translated and will be evaluated locally.</value>
+  </data>
 </root>

--- a/src/EntityFramework.Relational/Query/RelationalQueryModelVisitorFactory.cs
+++ b/src/EntityFramework.Relational/Query/RelationalQueryModelVisitorFactory.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Query.ExpressionVisitors;
@@ -33,7 +34,8 @@ namespace Microsoft.Data.Entity.Query
             [NotNull] ISqlTranslatingExpressionVisitorFactory sqlTranslatingExpressionVisitorFactory,
             [NotNull] ICompositePredicateExpressionVisitorFactory compositePredicateExpressionVisitorFactory,
             [NotNull] IQueryFlatteningExpressionVisitorFactory queryFlatteningExpressionVisitorFactory,
-            [NotNull] IShapedQueryFindingExpressionVisitorFactory shapedQueryFindingExpressionVisitorFactory)
+            [NotNull] IShapedQueryFindingExpressionVisitorFactory shapedQueryFindingExpressionVisitorFactory,
+            [NotNull] IDbContextOptions contextOptions)
             : base(
                 model,
                 queryOptimizer,
@@ -57,6 +59,7 @@ namespace Microsoft.Data.Entity.Query
             Check.NotNull(compositePredicateExpressionVisitorFactory, nameof(compositePredicateExpressionVisitorFactory));
             Check.NotNull(queryFlatteningExpressionVisitorFactory, nameof(queryFlatteningExpressionVisitorFactory));
             Check.NotNull(shapedQueryFindingExpressionVisitorFactory, nameof(shapedQueryFindingExpressionVisitorFactory));
+            Check.NotNull(contextOptions, nameof(contextOptions));
 
             RelationalAnnotationProvider = relationalAnnotationProvider;
             IncludeExpressionVisitorFactory = includeExpressionVisitorFactory;
@@ -64,6 +67,7 @@ namespace Microsoft.Data.Entity.Query
             CompositePredicateExpressionVisitorFactory = compositePredicateExpressionVisitorFactory;
             QueryFlatteningExpressionVisitorFactory = queryFlatteningExpressionVisitorFactory;
             ShapedQueryFindingExpressionVisitorFactory = shapedQueryFindingExpressionVisitorFactory;
+            ContextOptions = contextOptions;
         }
 
         protected virtual IRelationalAnnotationProvider RelationalAnnotationProvider { get; }
@@ -72,6 +76,7 @@ namespace Microsoft.Data.Entity.Query
         protected virtual ICompositePredicateExpressionVisitorFactory CompositePredicateExpressionVisitorFactory { get; }
         protected virtual IQueryFlatteningExpressionVisitorFactory QueryFlatteningExpressionVisitorFactory { get; }
         protected virtual IShapedQueryFindingExpressionVisitorFactory ShapedQueryFindingExpressionVisitorFactory { get; }
+        protected virtual IDbContextOptions ContextOptions { get; }
 
         public override EntityQueryModelVisitor Create(
             QueryCompilationContext queryCompilationContext,
@@ -98,6 +103,7 @@ namespace Microsoft.Data.Entity.Query
                 CompositePredicateExpressionVisitorFactory,
                 QueryFlatteningExpressionVisitorFactory,
                 ShapedQueryFindingExpressionVisitorFactory,
+                ContextOptions,
                 (RelationalQueryCompilationContext)Check.NotNull(queryCompilationContext, nameof(queryCompilationContext)),
                 (RelationalQueryModelVisitor)parentEntityQueryModelVisitor);
     }

--- a/src/EntityFramework.SqlServer/Query/Internal/SqlServerQueryModelVisitor.cs
+++ b/src/EntityFramework.SqlServer/Query/Internal/SqlServerQueryModelVisitor.cs
@@ -22,8 +22,6 @@ namespace Microsoft.Data.Entity.Query.Internal
     {
         private const string RowNumberColumnName = "__RowNumber__";
 
-        private readonly bool _useRowNumberPaging;
-
         public SqlServerQueryModelVisitor(
             [NotNull] IModel model,
             [NotNull] IQueryOptimizer queryOptimizer,
@@ -46,48 +44,43 @@ namespace Microsoft.Data.Entity.Query.Internal
             [NotNull] ICompositePredicateExpressionVisitorFactory compositePredicateExpressionVisitorFactory,
             [NotNull] IQueryFlatteningExpressionVisitorFactory queryFlatteningExpressionVisitorFactory,
             [NotNull] IShapedQueryFindingExpressionVisitorFactory shapedQueryFindingExpressionVisitorFactory,
-            [NotNull] IDbContextOptions options,
+            [NotNull] IDbContextOptions contextOptions,
             [NotNull] RelationalQueryCompilationContext queryCompilationContext,
             // ReSharper disable once SuggestBaseTypeForParameter
             [CanBeNull] SqlServerQueryModelVisitor parentQueryModelVisitor)
-            : base(model,
-                queryOptimizer,
-                navigationRewritingExpressionVisitorFactory,
-                subQueryMemberPushDownExpressionVisitor,
-                querySourceTracingExpressionVisitorFactory,
-                entityResultFindingExpressionVisitorFactory,
-                taskBlockingExpressionVisitor,
-                memberAccessBindingExpressionVisitorFactory,
-                orderingExpressionVisitorFactory,
-                projectionExpressionVisitorFactory,
-                entityQueryableExpressionVisitorFactory,
-                queryAnnotationExtractor,
-                resultOperatorHandler,
-                entityMaterializerSource,
-                expressionPrinter,
-                relationalAnnotationProvider,
-                includeExpressionVisitorFactory,
-                sqlTranslatingExpressionVisitorFactory,
-                compositePredicateExpressionVisitorFactory,
-                queryFlatteningExpressionVisitorFactory,
-                shapedQueryFindingExpressionVisitorFactory,
-                queryCompilationContext,
+            : base(
+                Check.NotNull(model, nameof(model)),
+                Check.NotNull(queryOptimizer, nameof(queryOptimizer)),
+                Check.NotNull(navigationRewritingExpressionVisitorFactory, nameof(navigationRewritingExpressionVisitorFactory)),
+                Check.NotNull(subQueryMemberPushDownExpressionVisitor, nameof(subQueryMemberPushDownExpressionVisitor)),
+                Check.NotNull(querySourceTracingExpressionVisitorFactory, nameof(querySourceTracingExpressionVisitorFactory)),
+                Check.NotNull(entityResultFindingExpressionVisitorFactory, nameof(entityResultFindingExpressionVisitorFactory)),
+                Check.NotNull(taskBlockingExpressionVisitor, nameof(taskBlockingExpressionVisitor)),
+                Check.NotNull(memberAccessBindingExpressionVisitorFactory, nameof(memberAccessBindingExpressionVisitorFactory)),
+                Check.NotNull(orderingExpressionVisitorFactory, nameof(orderingExpressionVisitorFactory)),
+                Check.NotNull(projectionExpressionVisitorFactory, nameof(projectionExpressionVisitorFactory)),
+                Check.NotNull(entityQueryableExpressionVisitorFactory, nameof(entityQueryableExpressionVisitorFactory)),
+                Check.NotNull(queryAnnotationExtractor, nameof(queryAnnotationExtractor)),
+                Check.NotNull(resultOperatorHandler, nameof(resultOperatorHandler)),
+                Check.NotNull(entityMaterializerSource, nameof(entityMaterializerSource)),
+                Check.NotNull(expressionPrinter, nameof(expressionPrinter)),
+                Check.NotNull(relationalAnnotationProvider, nameof(relationalAnnotationProvider)),
+                Check.NotNull(includeExpressionVisitorFactory, nameof(includeExpressionVisitorFactory)),
+                Check.NotNull(sqlTranslatingExpressionVisitorFactory, nameof(sqlTranslatingExpressionVisitorFactory)),
+                Check.NotNull(compositePredicateExpressionVisitorFactory, nameof(compositePredicateExpressionVisitorFactory)),
+                Check.NotNull(queryFlatteningExpressionVisitorFactory, nameof(queryFlatteningExpressionVisitorFactory)),
+                Check.NotNull(shapedQueryFindingExpressionVisitorFactory, nameof(queryFlatteningExpressionVisitorFactory)),
+                Check.NotNull(contextOptions, nameof(contextOptions)),
+                Check.NotNull(queryCompilationContext, nameof(queryCompilationContext)),
                 parentQueryModelVisitor)
         {
-            Check.NotNull(options, nameof(options));
-
-            var extension = options.FindExtension<SqlServerOptionsExtension>();
-
-            _useRowNumberPaging
-                = extension?.RowNumberPaging != null
-                  && extension.RowNumberPaging.Value;
         }
 
         public override void VisitQueryModel(QueryModel queryModel)
         {
             base.VisitQueryModel(queryModel);
 
-            if (_useRowNumberPaging)
+            if (ContextOptions.FindExtension<SqlServerOptionsExtension>()?.RowNumberPaging == true)
             {
                 var visitor = new RowNumberPagingExpressionVisitor();
 

--- a/src/EntityFramework.SqlServer/Query/Internal/SqlServerQueryModelVisitorFactory.cs
+++ b/src/EntityFramework.SqlServer/Query/Internal/SqlServerQueryModelVisitorFactory.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Data.Entity.Query.Internal
             [NotNull] ICompositePredicateExpressionVisitorFactory compositePredicateExpressionVisitorFactory,
             [NotNull] IQueryFlatteningExpressionVisitorFactory queryFlatteningExpressionVisitorFactory,
             [NotNull] IShapedQueryFindingExpressionVisitorFactory shapedQueryFindingExpressionVisitorFactory,
-            [NotNull] IDbContextOptions options)
+            [NotNull] IDbContextOptions contextOptions)
             : base(
                 model,
                 queryOptimizer,
@@ -56,14 +56,10 @@ namespace Microsoft.Data.Entity.Query.Internal
                 sqlTranslatingExpressionVisitorFactory,
                 compositePredicateExpressionVisitorFactory,
                 queryFlatteningExpressionVisitorFactory,
-                shapedQueryFindingExpressionVisitorFactory)
+                shapedQueryFindingExpressionVisitorFactory,
+                contextOptions)
         {
-            Check.NotNull(options, nameof(options));
-
-            ContextOptions = options;
         }
-
-        protected virtual IDbContextOptions ContextOptions { get; }
 
         public override EntityQueryModelVisitor Create(
             QueryCompilationContext queryCompilationContext,

--- a/test/EntityFramework.Relational.FunctionalTests/EntityFramework.Relational.FunctionalTests.csproj
+++ b/test/EntityFramework.Relational.FunctionalTests/EntityFramework.Relational.FunctionalTests.csproj
@@ -53,6 +53,7 @@
     <Compile Include="GearsOfWarQueryRelationalFixture.cs" />
     <Compile Include="NorthwindQueryRelationalFixture.cs" />
     <Compile Include="FromSqlQueryTestBase.cs" />
+    <Compile Include="QueryNoClientEvalTestBase.cs" />
     <Compile Include="RelationalTestHelpers.cs" />
     <Compile Include="RelationalTestStore.cs" />
     <Compile Include="SqlExecutorTestBase.cs" />

--- a/test/EntityFramework.Relational.FunctionalTests/FromSqlQueryTestBase.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/FromSqlQueryTestBase.cs
@@ -360,22 +360,7 @@ AND ((UnitsInStock + UnitsOnOrder) < ReorderLevel)")
             }
         }
 
-        [Fact]
-        public virtual void From_sql_composed_with_relational_null_comparison()
-        {
-            using (var context = CreateContext(useRelationalNulls: true))
-            {
-                var actual = context.Set<Customer>()
-                    .FromSql(@"SELECT * FROM ""Customers""")
-                    .Where(c => c.ContactName == c.CompanyName)
-                    .ToArray();
-
-                Assert.Equal(0, actual.Length);
-            }
-        }
-
-        protected NorthwindContext CreateContext(bool useRelationalNulls = false) 
-            => Fixture.CreateContext(useRelationalNulls);
+        protected NorthwindContext CreateContext() => Fixture.CreateContext();
 
         protected FromSqlQueryTestBase(TFixture fixture)
         {

--- a/test/EntityFramework.Relational.FunctionalTests/NorthwindQueryRelationalFixture.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/NorthwindQueryRelationalFixture.cs
@@ -20,7 +20,6 @@ namespace Microsoft.Data.Entity.FunctionalTests
             modelBuilder.Entity<OrderDetail>().ToTable("Order Details");
         }
 
-        public abstract NorthwindContext CreateContext(bool useRelationalNulls);
         public abstract CancellationToken CancelQuery();
     }
 }

--- a/test/EntityFramework.Relational.FunctionalTests/NullSemanticsQueryTestBase.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/NullSemanticsQueryTestBase.cs
@@ -528,6 +528,20 @@ namespace Microsoft.Data.Entity.FunctionalTests
             Assert.True(results1.Count != results2.Count);
         }
 
+        [Fact]
+        public virtual void From_sql_composed_with_relational_null_comparison()
+        {
+            using (var context = CreateContext(useRelationalNulls: true))
+            {
+                var actual = context.Entities1
+                    .FromSql(@"SELECT * FROM ""NullSemanticsEntity1""")
+                    .Where(c => c.StringA == c.StringB)
+                    .ToArray();
+
+                Assert.Equal(15, actual.Length);
+            }
+        }
+
         protected void AssertQuery<TItem>(
             Func<IQueryable<TItem>, IQueryable<TItem>> l2eQuery,
             Func<IQueryable<TItem>, IQueryable<TItem>> l2oQuery,

--- a/test/EntityFramework.Relational.FunctionalTests/QueryNoClientEvalTestBase.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/QueryNoClientEvalTestBase.cs
@@ -1,0 +1,236 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.Data.Entity.FunctionalTests.TestModels.Northwind;
+using Microsoft.Data.Entity.Relational.Internal;
+using Xunit;
+
+// ReSharper disable AccessToDisposedClosure
+
+namespace Microsoft.Data.Entity.FunctionalTests
+{
+    public abstract class QueryNoClientEvalTestBase<TFixture> : IClassFixture<TFixture>
+        where TFixture : NorthwindQueryRelationalFixture, new()
+    {
+        [Fact]
+        public virtual void Throws_when_where()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal(Strings.ClientEvalDisabled("[c].IsLondon"),
+                    Assert.Throws<InvalidOperationException>(
+                        () => context.Customers.Where(c => c.IsLondon).ToList()).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Throws_when_orderby()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal(Strings.ClientEvalDisabled("orderby [c].IsLondon asc"),
+                    Assert.Throws<InvalidOperationException>(
+                        () => context.Customers.OrderBy(c => c.IsLondon).ToList()).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Throws_when_orderby_multiple()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal(Strings.ClientEvalDisabled("orderby [c].IsLondon asc, ClientMethod([c]) asc"),
+                    Assert.Throws<InvalidOperationException>(
+                        () => context.Customers
+                            .OrderBy(c => c.IsLondon)
+                            .ThenBy(c => ClientMethod(c))
+                            .ToList()).Message);
+            }
+        }
+
+        private static object ClientMethod(object o) => o.GetHashCode();
+
+        [Fact]
+        public virtual void Throws_when_where_subquery_correlated()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal(Strings.ClientEvalDisabled(
+                    "{from Customer c2 in value(Microsoft.Data.Entity.Query.EntityQueryable`1[Microsoft.Data.Entity.FunctionalTests.TestModels.Northwind.Customer]) where (([c1].CustomerID == [c2].CustomerID) AndAlso [c2].IsLondon) select [c2] => Any()}"),
+                    Assert.Throws<InvalidOperationException>(
+                        () => context.Customers
+                            .Where(c1 => context.Customers
+                                .Any(c2 => c1.CustomerID == c2.CustomerID && c2.IsLondon))
+                            .ToList()).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Throws_when_all()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal(Strings.ClientEvalDisabled("All([c].IsLondon)"),
+                    Assert.Throws<InvalidOperationException>(
+                        () => context.Customers.All(c => c.IsLondon)).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Throws_when_from_sql_composed()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal(Strings.ClientEvalDisabled("[c].IsLondon"),
+                    Assert.Throws<InvalidOperationException>(
+                        () => context.Customers
+                            .FromSql("select * from Customers")
+                            .Where(c => c.IsLondon)
+                            .ToList()).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Doesnt_throw_when_from_sql_not_composed()
+        {
+            using (var context = CreateContext())
+            {
+                var customers
+                    = context.Customers
+                        .FromSql("select * from Customers")
+                        .ToList();
+
+                Assert.Equal(91, customers.Count);
+            }
+        }
+
+        [Fact]
+        public virtual void Throws_when_subquery_main_from_clause()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal(Strings.ClientEvalDisabled("[c].IsLondon"),
+                    Assert.Throws<InvalidOperationException>(
+                        () =>
+                            (from c1 in context.Customers
+                                .Where(c => c.IsLondon)
+                                .Take(5)
+                             select c1)
+                                .ToList()).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Throws_when_select_many()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal(Strings.ClientEvalDisabled("from Int32 i in __p_0"),
+                    Assert.Throws<InvalidOperationException>(
+                        () =>
+                            (from c1 in context.Customers
+                             from i in new[] { 1, 2, 3 }
+                             select c1)
+                                .ToList()).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Throws_when_join()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal(Strings.ClientEvalDisabled("join Int32 i in __p_0 on [e1].EmployeeID equals [i]"),
+                    Assert.Throws<InvalidOperationException>(
+                        () =>
+                            (from e1 in context.Employees
+                             join i in new[] { 1, 2, 3 } on e1.EmployeeID equals i
+                             select e1)
+                                .ToList()).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Throws_when_group_join()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal(Strings.ClientEvalDisabled("join Int32 i in __p_0 on [e1].EmployeeID equals [i]"),
+                    Assert.Throws<InvalidOperationException>(
+                        () =>
+                            (from e1 in context.Employees
+                             join i in new[] { 1, 2, 3 } on e1.EmployeeID equals i into g
+                             select e1)
+                                .ToList()).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Throws_when_group_by()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal(Strings.ClientEvalDisabled("GroupBy([c].CustomerID, [c])"),
+                    Assert.Throws<InvalidOperationException>(
+                        () => context.Customers
+                            .GroupBy(c => c.CustomerID)
+                            .ToList()).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Throws_when_first()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal(Strings.ClientEvalDisabled("[c].IsLondon"),
+                    Assert.Throws<InvalidOperationException>(
+                        () => context.Customers.First(c => c.IsLondon)).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Throws_when_single()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal(Strings.ClientEvalDisabled("[c].IsLondon"),
+                    Assert.Throws<InvalidOperationException>(
+                        () => context.Customers.Single(c => c.IsLondon)).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Throws_when_first_or_default()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal(Strings.ClientEvalDisabled("[c].IsLondon"),
+                    Assert.Throws<InvalidOperationException>(
+                        () => context.Customers.FirstOrDefault(c => c.IsLondon)).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Throws_when_single_or_default()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal(Strings.ClientEvalDisabled("[c].IsLondon"),
+                    Assert.Throws<InvalidOperationException>(
+                        () => context.Customers.SingleOrDefault(c => c.IsLondon)).Message);
+            }
+        }
+
+        protected NorthwindContext CreateContext() => Fixture.CreateContext();
+
+        protected QueryNoClientEvalTestBase(TFixture fixture)
+        {
+            Fixture = fixture;
+        }
+
+        protected TFixture Fixture { get; }
+    }
+}

--- a/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
+++ b/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
@@ -71,6 +71,8 @@
     <Compile Include="ComplexNavigationsQuerySqlServerTest.cs" />
     <Compile Include="F1SqlServerFixture.cs" />
     <Compile Include="QueryNavigationsSqlServerTest.cs" />
+    <Compile Include="QueryNoClientEvalSqlServerFixture.cs" />
+    <Compile Include="QueryNoClientEvalSqlServerTest.cs" />
     <Compile Include="RowNumberPagingTest.cs" />
     <Compile Include="SqlServerFixture.cs" />
     <Compile Include="GearsOfWarQuerySqlServerFixture.cs" />

--- a/test/EntityFramework.SqlServer.FunctionalTests/FromSqlQuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/FromSqlQuerySqlServerTest.cs
@@ -277,19 +277,6 @@ WHERE ([c].[ContactName] = [c].[CompanyName]) OR ([c].[ContactName] IS NULL AND 
                 Sql);
         }
 
-        public override void From_sql_composed_with_relational_null_comparison()
-        {
-            base.From_sql_composed_with_relational_null_comparison();
-
-            Assert.Equal(
-                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM (
-    SELECT * FROM ""Customers""
-) AS [c]
-WHERE [c].[ContactName] = [c].[CompanyName]",
-                Sql);
-        }
-
         public FromSqlQuerySqlServerTest(NorthwindQuerySqlServerFixture fixture)
             : base(fixture)
         {

--- a/test/EntityFramework.SqlServer.FunctionalTests/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/NullSemanticsQuerySqlServerTest.cs
@@ -989,6 +989,19 @@ WHERE [e].[NullableBoolA] = [e].[NullableBoolB]",
                 Sql);
         }
 
+        public override void From_sql_composed_with_relational_null_comparison()
+        {
+            base.From_sql_composed_with_relational_null_comparison();
+
+            Assert.Equal(
+                @"SELECT [c].[Id], [c].[BoolA], [c].[BoolB], [c].[BoolC], [c].[IntA], [c].[IntB], [c].[IntC], [c].[NullableBoolA], [c].[NullableBoolB], [c].[NullableBoolC], [c].[NullableIntA], [c].[NullableIntB], [c].[NullableIntC], [c].[NullableStringA], [c].[NullableStringB], [c].[NullableStringC], [c].[StringA], [c].[StringB], [c].[StringC]
+FROM (
+    SELECT * FROM ""NullSemanticsEntity1""
+) AS [c]
+WHERE [c].[StringA] = [c].[StringB]",
+                Sql);
+        }
+
         private static string Sql => TestSqlLoggerFactory.Sql;
     }
 }

--- a/test/EntityFramework.SqlServer.FunctionalTests/QueryNoClientEvalSqlServerFixture.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/QueryNoClientEvalSqlServerFixture.cs
@@ -1,13 +1,13 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Data.Entity.Infrastructure;
 
 namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 {
-    public class NorthwindRowNumberPagingQuerySqlServerFixture : NorthwindQuerySqlServerFixture
+    public class QueryNoClientEvalSqlServerFixture : NorthwindQuerySqlServerFixture
     {
         protected override void ConfigureOptions(SqlServerDbContextOptionsBuilder sqlServerDbContextOptionsBuilder)
-            => sqlServerDbContextOptionsBuilder.UseRowNumberForPaging();
+            => sqlServerDbContextOptionsBuilder.DisableQueryClientEvaluation();
     }
 }

--- a/test/EntityFramework.SqlServer.FunctionalTests/QueryNoClientEvalSqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/QueryNoClientEvalSqlServerTest.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.FunctionalTests;
+
+namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
+{
+    public class QueryNoClientEvalSqlServerTest : QueryNoClientEvalTestBase<QueryNoClientEvalSqlServerFixture>
+    {
+        public QueryNoClientEvalSqlServerTest(QueryNoClientEvalSqlServerFixture fixture)
+            : base(fixture)
+        {
+        }
+    }
+}

--- a/test/EntityFramework.SqlServer.FunctionalTests/Utilities/DbContextOptionsBuilderExtensions.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/Utilities/DbContextOptionsBuilderExtensions.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             }
 
             var offsetSupport = TestEnvironment.GetFlag(nameof(SqlServerCondition.SupportsOffset)) ?? true;
+
             if (!offsetSupport)
             {
                 optionsBuilder.UseRowNumberForPaging();

--- a/test/EntityFramework.Sqlite.FunctionalTests/EntityFramework.Sqlite.FunctionalTests.csproj
+++ b/test/EntityFramework.Sqlite.FunctionalTests/EntityFramework.Sqlite.FunctionalTests.csproj
@@ -74,6 +74,8 @@
     <Compile Include="OptimisticConcurrencySqliteTest.cs" />
     <Compile Include="PropertyEntrySqliteTest.cs" />
     <Compile Include="QueryNavigationsInMemoryTest.cs" />
+    <Compile Include="QueryNoClientEvalSqliteTest.cs" />
+    <Compile Include="QueryNoClientEvalSqliteFixture.cs" />
     <Compile Include="QuerySqliteTest.cs" />
     <Compile Include="SentinelGraphUpdatesSqliteTest.cs" />
     <Compile Include="SqliteTestHelpers.cs" />

--- a/test/EntityFramework.Sqlite.FunctionalTests/NorthwindQuerySqliteFixture.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/NorthwindQuerySqliteFixture.cs
@@ -31,24 +31,29 @@ namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
                     .AddInstance<ILoggerFactory>(_testSqlLoggerFactory)
                     .BuildServiceProvider();
 
-            _options = ConfigureOptions();
+            _options = BuildOptions();
+
+            _serviceProvider.GetRequiredService<ILoggerFactory>().MinimumLevel = LogLevel.Debug;
         }
 
-        protected virtual DbContextOptions ConfigureOptions()
+        protected DbContextOptions BuildOptions()
         {
             var optionsBuilder = new DbContextOptionsBuilder();
 
-            optionsBuilder.UseSqlite(_testStore.Connection.ConnectionString);
+            var sqliteDbContextOptionsBuilder
+                = optionsBuilder.UseSqlite(_testStore.Connection.ConnectionString);
+
+            ConfigureOptions(sqliteDbContextOptionsBuilder);
 
             return optionsBuilder.Options;
         }
 
-        public override NorthwindContext CreateContext() => CreateContext(useRelationalNulls: false);
-
-        public override NorthwindContext CreateContext(bool useRelationalNulls)
+        protected virtual void ConfigureOptions(SqliteDbContextOptionsBuilder sqliteDbContextOptionsBuilder)
         {
-            RelationalOptionsExtension.Extract(_options).UseRelationalNulls = useRelationalNulls;
+        }
 
+        public override NorthwindContext CreateContext()
+        {
             var context = new SqliteNorthwindContext(_serviceProvider, _options);
 
             context.ChangeTracker.AutoDetectChangesEnabled = false;

--- a/test/EntityFramework.Sqlite.FunctionalTests/QueryNoClientEvalSqliteFixture.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/QueryNoClientEvalSqliteFixture.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Infrastructure;
+
+namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
+{
+    public class QueryNoClientEvalSqliteFixture : NorthwindQuerySqliteFixture
+    {
+        protected override void ConfigureOptions(SqliteDbContextOptionsBuilder sqlServerDbContextOptionsBuilder)
+            => sqlServerDbContextOptionsBuilder.DisableQueryClientEvaluation();
+    }
+}

--- a/test/EntityFramework.Sqlite.FunctionalTests/QueryNoClientEvalSqliteTest.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/QueryNoClientEvalSqliteTest.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.FunctionalTests;
+
+namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
+{
+    public class QueryNoClientEvalSqliteTest : QueryNoClientEvalTestBase<QueryNoClientEvalSqliteFixture>
+    {
+        public QueryNoClientEvalSqliteTest(QueryNoClientEvalSqliteFixture fixture)
+            : base(fixture)
+        {
+        }
+    }
+}


### PR DESCRIPTION
…xt option.

- Lifts IDbContextOptions dependency to RelationalQueryModelVisitorFactory
- Client evals generate logging events at Warn level.