### PR TITLE
Allow to reference entity type members from any level of the hierarchy.

### DIFF
--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -158,6 +158,7 @@
     <Compile Include="DbContextOptionsBuilder`.cs" />
     <Compile Include="Metadata\Builders\ReferenceReferenceBuilder`.cs" />
     <Compile Include="Metadata\Conventions\ConventionSet.cs" />
+    <Compile Include="Metadata\Conventions\Internal\INavigationRemovedConvention.cs" />
     <Compile Include="Metadata\Conventions\Internal\ModelCleanupConvention.cs" />
     <Compile Include="Metadata\Conventions\Internal\IBaseTypeConvention.cs" />
     <Compile Include="Metadata\Conventions\Internal\ForeignKeyAttributeConvention.cs" />

--- a/src/EntityFramework.Core/Metadata/Builders/CollectionNavigationBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Builders/CollectionNavigationBuilder.cs
@@ -67,6 +67,6 @@ namespace Microsoft.Data.Entity.Metadata.Builders
             => Builder.DependentToPrincipal(
                 reference,
                 ConfigurationSource.Explicit,
-                strictPreferExisting: true);
+                strictPrincipal: true);
     }
 }

--- a/src/EntityFramework.Core/Metadata/Builders/ReferenceNavigationBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Builders/ReferenceNavigationBuilder.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
 
             builder = builder.Unique(false, ConfigurationSource.Explicit);
 
-            return builder.PrincipalToDependent(collection, ConfigurationSource.Explicit, strictPreferExisting: true);
+            return builder.PrincipalToDependent(collection, ConfigurationSource.Explicit, strictPrincipal: true);
         }
 
         /// <summary>
@@ -130,16 +130,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         /// <returns> The internal builder to further configure the relationship. </returns>
         protected virtual InternalRelationshipBuilder WithOneBuilder([CanBeNull] string reference)
         {
-            var builder = Builder;
-            // TODO: Remove this when #1924 is fixed
-            if (!((IForeignKey)Builder.Metadata).IsUnique)
-            {
-                Debug.Assert(Builder.Metadata.DependentToPrincipal?.Name == ReferenceName);
-
-                builder = builder.PrincipalToDependent(null, ConfigurationSource.Explicit);
-            }
-
-            builder = builder.Unique(true, ConfigurationSource.Explicit);
+            var builder = Builder.Unique(true, ConfigurationSource.Explicit);
             var foreignKey = builder.Metadata;
 
             var isSelfReferencing = foreignKey.IsSelfReferencing();
@@ -157,8 +148,8 @@ namespace Microsoft.Data.Entity.Metadata.Builders
                          || foreignKey.DependentToPrincipal?.Name == ReferenceName);
 
             return inverseToPrincipal
-                ? builder.DependentToPrincipal(reference, ConfigurationSource.Explicit, strictPreferExisting: isSelfReferencing)
-                : builder.PrincipalToDependent(reference, ConfigurationSource.Explicit, strictPreferExisting: isSelfReferencing);
+                ? builder.DependentToPrincipal(reference, ConfigurationSource.Explicit, strictPrincipal: isSelfReferencing)
+                : builder.PrincipalToDependent(reference, ConfigurationSource.Explicit, strictPrincipal: isSelfReferencing);
         }
     }
 }

--- a/src/EntityFramework.Core/Metadata/Conventions/ConventionSet.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/ConventionSet.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions
         public virtual IList<IModelConvention> ModelBuiltConventions { get; } = new List<IModelConvention>();
         public virtual IList<IModelConvention> ModelInitializedConventions { get; } = new List<IModelConvention>();
         public virtual IList<INavigationConvention> NavigationAddedConventions { get; } = new List<INavigationConvention>();
+        public virtual IList<INavigationRemovedConvention> NavigationRemovedConventions { get; } = new List<INavigationRemovedConvention>();
         public virtual IList<IPropertyConvention> PropertyAddedConventions { get; } = new List<IPropertyConvention>();
     }
 }

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/ConventionDispatcher.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/ConventionDispatcher.cs
@@ -176,6 +176,21 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
             return relationshipBuilder;
         }
 
+        public virtual void OnNavigationRemoved(
+            [NotNull] InternalRelationshipBuilder relationshipBuilder, [NotNull] string navigationName, bool pointsToPrincipal)
+        {
+            Check.NotNull(relationshipBuilder, nameof(relationshipBuilder));
+            Check.NotNull(navigationName, nameof(navigationName));
+
+            foreach (var navigationConvention in _conventionSet.NavigationRemovedConventions)
+            {
+                if (!navigationConvention.Apply(relationshipBuilder, navigationName, pointsToPrincipal))
+                {
+                    break;
+                }
+            }
+        }
+
         public virtual InternalPropertyBuilder OnPropertyAdded([NotNull] InternalPropertyBuilder propertyBuilder)
         {
             Check.NotNull(propertyBuilder, nameof(propertyBuilder));

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
             conventionSet.EntityTypeAddedConventions.Add(new InversePropertyAttributeConvention());
             conventionSet.EntityTypeAddedConventions.Add(relationshipDiscoveryConvention);
 
+            // An ambiguity might have been resolved
             conventionSet.EntityTypeMemberIgnoredConventions.Add(relationshipDiscoveryConvention);
 
             conventionSet.PropertyAddedConventions.Add(new ConcurrencyCheckAttributeConvention());
@@ -33,9 +34,10 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
             conventionSet.KeyAddedConventions.Add(keyConvention);
 
             conventionSet.PrimaryKeySetConventions.Add(keyConvention);
-
+            
+            var foreignKeyPropertyDiscoveryConvention = new ForeignKeyPropertyDiscoveryConvention();
             conventionSet.ForeignKeyAddedConventions.Add(new ForeignKeyAttributeConvention());
-            conventionSet.ForeignKeyAddedConventions.Add(new ForeignKeyPropertyDiscoveryConvention());
+            conventionSet.ForeignKeyAddedConventions.Add(foreignKeyPropertyDiscoveryConvention);
 
             conventionSet.ForeignKeyRemovedConventions.Add(keyConvention);
 
@@ -43,6 +45,9 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
             conventionSet.ModelBuiltConventions.Add(keyAttributeConvention);
 
             conventionSet.NavigationAddedConventions.Add(new RequiredNavigationAttributeConvention());
+            conventionSet.NavigationAddedConventions.Add(foreignKeyPropertyDiscoveryConvention);
+            
+            conventionSet.NavigationRemovedConventions.Add(relationshipDiscoveryConvention);
 
             return conventionSet;
         }

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/ForeignKeyAttributeConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/ForeignKeyAttributeConvention.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
             }
 
             var dependentEntityTypebuilder = relationshipBuilder.ModelBuilder.Entity(foreignKey.DeclaringEntityType.Name, ConfigurationSource.Convention);
-            var removedConfigurationSource = dependentEntityTypebuilder.RemoveRelationship(foreignKey, ConfigurationSource.DataAnnotation);
+            var removedConfigurationSource = dependentEntityTypebuilder.RemoveForeignKey(foreignKey, ConfigurationSource.DataAnnotation);
 
             if (removedConfigurationSource == null)
             {

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/INavigationRemovedConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/INavigationRemovedConvention.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata.Internal;
+
+namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
+{
+    public interface INavigationRemovedConvention
+    {
+        bool Apply([NotNull] InternalRelationshipBuilder relationshipBuilder, [NotNull] string navigationName, bool pointsToPrincipal);
+    }
+}

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/RelationshipDiscoveryConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/RelationshipDiscoveryConvention.cs
@@ -10,7 +10,8 @@ using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
 {
-    public class RelationshipDiscoveryConvention : IEntityTypeConvention, IEntityTypeMemberIgnoredConvention
+    public class RelationshipDiscoveryConvention :
+        IEntityTypeConvention, IEntityTypeMemberIgnoredConvention, INavigationRemovedConvention
     {
         public virtual InternalEntityTypeBuilder Apply(InternalEntityTypeBuilder entityTypeBuilder)
         {
@@ -102,5 +103,13 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
         
         public virtual bool Apply(InternalEntityTypeBuilder entityTypeBuilder, string ignoredMemberName)
             => Apply(entityTypeBuilder) != null;
+
+        public virtual bool Apply(InternalRelationshipBuilder relationshipBuilder, string navigationName, bool pointsToPrincipal)
+        {
+            var owner = pointsToPrincipal
+                ? relationshipBuilder.Metadata.DeclaringEntityType
+                : relationshipBuilder.Metadata.PrincipalEntityType;
+            return Apply(relationshipBuilder.ModelBuilder.Entity(owner.Name, ConfigurationSource.Convention)) != null;
+        }
     }
 }

--- a/src/EntityFramework.Core/Metadata/EntityTypeExtensions.cs
+++ b/src/EntityFramework.Core/Metadata/EntityTypeExtensions.cs
@@ -157,16 +157,15 @@ namespace Microsoft.Data.Entity.Metadata
             return property;
         }
 
-        public static IEnumerable<IProperty> FindDerivedProperties([NotNull] this IEntityType entityType, [NotNull] IEnumerable<string> propertyNames)
+        public static IEnumerable<IProperty> FindDerivedProperties(
+            [NotNull] this IEntityType entityType,
+            [NotNull] string propertyName)
         {
             Check.NotNull(entityType, nameof(entityType));
-            Check.NotNull(propertyNames, nameof(propertyNames));
-
-            var searchProperties = new HashSet<string>(propertyNames);
-
-            return entityType.GetDerivedTypes()
-                .SelectMany(et => et.GetDeclaredProperties()
-                    .Where(property => searchProperties.Contains(property.Name)));
+            Check.NotNull(propertyName, nameof(propertyName));
+            
+            return entityType.GetDerivedTypes().SelectMany(et =>
+                et.GetDeclaredProperties().Where(property => propertyName.Equals(property.Name)));
         }
 
         [NotNull]
@@ -180,6 +179,7 @@ namespace Microsoft.Data.Entity.Metadata
             {
                 throw new ModelItemNotFoundException(Strings.NavigationNotFound(name, entityType.Name));
             }
+
             return navigation;
         }
 
@@ -192,15 +192,13 @@ namespace Microsoft.Data.Entity.Metadata
 
         public static IEnumerable<INavigation> FindDerivedNavigations(
             [NotNull] this IEntityType entityType,
-            [NotNull] IEnumerable<string> navigationNames)
+            [NotNull] string navigationName)
         {
             Check.NotNull(entityType, nameof(entityType));
-            Check.NotNull(navigationNames, nameof(navigationNames));
-
-            var searchNavigations = new HashSet<string>(navigationNames);
+            Check.NotNull(navigationName, nameof(navigationName));
 
             return entityType.GetDerivedTypes().SelectMany(et =>
-                et.GetDeclaredNavigations().Where(navigation => searchNavigations.Contains(navigation.Name)));
+                et.GetDeclaredNavigations().Where(navigation => navigationName == navigation.Name));
         }
 
         public static IEnumerable<IPropertyBase> GetPropertiesAndNavigations(
@@ -268,33 +266,14 @@ namespace Microsoft.Data.Entity.Metadata
             return foreignKey;
         }
 
+        public static ForeignKey FindForeignKey([NotNull] this EntityType entityType, [NotNull] Property property)
+            => entityType.FindForeignKey(new[] { property });
+
         public static IEnumerable<IForeignKey> GetDeclaredForeignKeys([NotNull] this IEntityType entityType)
         {
             Check.NotNull(entityType, nameof(entityType));
 
             return entityType.GetForeignKeys().Where(p => p.DeclaringEntityType == entityType);
-        }
-
-        public static ForeignKey FindForeignKey(
-            [NotNull] this EntityType entityType,
-            [NotNull] EntityType principalType,
-            [CanBeNull] string navigationToPrincipal,
-            [CanBeNull] string navigationToDependent,
-            [CanBeNull] IReadOnlyList<Property> foreignKeyProperties,
-            [CanBeNull] IReadOnlyList<Property> principalProperties,
-            bool? unique)
-        {
-            Check.NotNull(principalType, nameof(principalType));
-
-            return entityType.GetForeignKeys().FirstOrDefault(fk =>
-                fk.IsCompatible(
-                    principalType,
-                    entityType,
-                    navigationToPrincipal,
-                    navigationToDependent,
-                    foreignKeyProperties,
-                    principalProperties,
-                    unique));
         }
 
         public static IKey GetPrimaryKey([NotNull] this IEntityType entityType)

--- a/src/EntityFramework.Core/Metadata/ForeignKey.cs
+++ b/src/EntityFramework.Core/Metadata/ForeignKey.cs
@@ -203,7 +203,7 @@ namespace Microsoft.Data.Entity.Metadata
             Check.NotNull(principalEntityType, nameof(principalEntityType));
             Check.NotNull(dependentEntityType, nameof(dependentEntityType));
 
-            if (navigationToDependentName != null
+            if (!string.IsNullOrEmpty(navigationToDependentName)
                 && !Navigation.IsCompatible(
                     navigationToDependentName,
                     principalEntityType,
@@ -214,7 +214,7 @@ namespace Microsoft.Data.Entity.Metadata
                 return false;
             }
 
-            if (navigationToPrincipalName != null
+            if (!string.IsNullOrEmpty(navigationToPrincipalName)
                 && !Navigation.IsCompatible(
                     navigationToPrincipalName,
                     dependentEntityType,
@@ -294,9 +294,9 @@ namespace Microsoft.Data.Entity.Metadata
                     throw new InvalidOperationException(
                         Strings.ForeignKeyCountMismatch(
                             Property.Format(dependentProperties),
-                            dependentProperties[0].DeclaringEntityType.Name,
+                            dependentEntityType.Name,
                             Property.Format(principalProperties),
-                            principalProperties[0].DeclaringEntityType.Name));
+                            principalEntityType.Name));
                 }
                 return false;
             }
@@ -308,8 +308,9 @@ namespace Microsoft.Data.Entity.Metadata
                     throw new InvalidOperationException(
                         Strings.ForeignKeyTypeMismatch(
                             Property.Format(dependentProperties),
-                            dependentProperties[0].DeclaringEntityType.Name,
-                            principalProperties[0].DeclaringEntityType.Name));
+                            dependentEntityType.Name,
+                            Property.Format(principalProperties),
+                            principalEntityType.Name));
                 }
                 return false;
             }

--- a/src/EntityFramework.Core/Metadata/ForeignKeyExtensions.cs
+++ b/src/EntityFramework.Core/Metadata/ForeignKeyExtensions.cs
@@ -27,48 +27,6 @@ namespace Microsoft.Data.Entity.Metadata
                    && foreignKey.DeclaringEntityType == dependentType;
         }
 
-        public static bool IsCompatible(
-            [NotNull] this ForeignKey foreignKey,
-            [NotNull] EntityType principalType,
-            [NotNull] EntityType dependentType,
-            [CanBeNull] IReadOnlyList<Property> foreignKeyProperties,
-            [CanBeNull] IReadOnlyList<Property> principalProperties,
-            bool? unique)
-        {
-            Check.NotNull(foreignKey, nameof(foreignKey));
-            Check.NotNull(principalType, nameof(principalType));
-            Check.NotNull(dependentType, nameof(dependentType));
-
-            return foreignKey.IsCompatible(principalType, dependentType, unique)
-                   && (foreignKeyProperties == null
-                       || !foreignKeyProperties.Any()
-                       || foreignKey.Properties.SequenceEqual(foreignKeyProperties))
-                   && (principalProperties == null
-                       || !principalProperties.Any()
-                       || foreignKey.PrincipalKey.Properties.SequenceEqual(principalProperties));
-        }
-
-        public static bool IsCompatible(
-            [NotNull] this ForeignKey foreignKey,
-            [NotNull] EntityType principalType,
-            [NotNull] EntityType dependentType,
-            [CanBeNull] string navigationToPrincipal,
-            [CanBeNull] string navigationToDependent,
-            [CanBeNull] IReadOnlyList<Property> foreignKeyProperties,
-            [CanBeNull] IReadOnlyList<Property> principalProperties,
-            bool? unique)
-        {
-            Check.NotNull(foreignKey, nameof(foreignKey));
-            Check.NotNull(principalType, nameof(principalType));
-            Check.NotNull(dependentType, nameof(dependentType));
-
-            var existingNavigationToPrincipal = foreignKey.DependentToPrincipal;
-            var existingNavigationToDependent = foreignKey.PrincipalToDependent;
-            return foreignKey.IsCompatible(principalType, dependentType, foreignKeyProperties, principalProperties, unique)
-                   && (existingNavigationToPrincipal == null || existingNavigationToPrincipal.Name == navigationToPrincipal)
-                   && (existingNavigationToDependent == null || existingNavigationToDependent.Name == navigationToDependent);
-        }
-
         public static bool IsSelfReferencing([NotNull] this IForeignKey foreignKey)
         {
             Check.NotNull(foreignKey, nameof(foreignKey));

--- a/src/EntityFramework.Core/Metadata/Index.cs
+++ b/src/EntityFramework.Core/Metadata/Index.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata.Internal;
@@ -9,6 +10,7 @@ using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Metadata
 {
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class Index : Annotatable, IIndex
     {
         public Index([NotNull] IReadOnlyList<Property> properties)
@@ -33,5 +35,8 @@ namespace Microsoft.Data.Entity.Metadata
         IEntityType IIndex.DeclaringEntityType => DeclaringEntityType;
 
         bool IIndex.IsUnique => IsUnique ?? DefaultIsUnique;
+
+        [UsedImplicitly]
+        private string DebuggerDisplay => Property.Format(Properties);
     }
 }

--- a/src/EntityFramework.Core/Metadata/Internal/InternalModelBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/InternalModelBuilder.cs
@@ -123,13 +123,13 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
             foreach (var foreignKey in entityType.GetForeignKeys().ToList())
             {
-                var removed = entityTypeBuilder.RemoveRelationship(foreignKey, configurationSource);
+                var removed = entityTypeBuilder.RemoveForeignKey(foreignKey, configurationSource);
                 Debug.Assert(removed.HasValue);
             }
 
             foreach (var foreignKey in Metadata.FindReferencingForeignKeys(entityType).ToList())
             {
-                var removed = entityTypeBuilder.RemoveRelationship(foreignKey, configurationSource);
+                var removed = entityTypeBuilder.RemoveForeignKey(foreignKey, configurationSource);
                 Debug.Assert(removed.HasValue);
             }
 

--- a/src/EntityFramework.Core/Metadata/Key.cs
+++ b/src/EntityFramework.Core/Metadata/Key.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata.Internal;
@@ -9,6 +10,7 @@ using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Metadata
 {
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class Key : Annotatable, IKey
     {
         public Key([NotNull] IReadOnlyList<Property> properties)
@@ -27,5 +29,8 @@ namespace Microsoft.Data.Entity.Metadata
         IReadOnlyList<IProperty> IKey.Properties => Properties;
 
         IEntityType IKey.EntityType => DeclaringEntityType;
+
+        [UsedImplicitly]
+        private string DebuggerDisplay => Property.Format(Properties);
     }
 }

--- a/src/EntityFramework.Core/Properties/Strings.Designer.cs
+++ b/src/EntityFramework.Core/Properties/Strings.Designer.cs
@@ -349,11 +349,11 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
-        /// The property '{property}' cannot be added to the entity type '{entityType}' because a property with the same name already exists.
+        /// The property '{property}' cannot be added to the entity type '{entityType}' because a property with the same name already exists on entity type '{duplicateEntityType}'.
         /// </summary>
-        public static string DuplicateProperty([CanBeNull] object property, [CanBeNull] object entityType)
+        public static string DuplicateProperty([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object duplicateEntityType)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("DuplicateProperty", "property", "entityType"), property, entityType);
+            return string.Format(CultureInfo.CurrentCulture, GetString("DuplicateProperty", "property", "entityType", "duplicateEntityType"), property, entityType, duplicateEntityType);
         }
 
         /// <summary>
@@ -413,11 +413,11 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
-        /// The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because a navigation property with the same name already exists.
+        /// The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because a navigation property with the same name already exists on entity type '{duplicateEntityType}'.
         /// </summary>
-        public static string DuplicateNavigation([CanBeNull] object navigation, [CanBeNull] object entityType)
+        public static string DuplicateNavigation([CanBeNull] object navigation, [CanBeNull] object entityType, [CanBeNull] object duplicateEntityType)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("DuplicateNavigation", "navigation", "entityType"), navigation, entityType);
+            return string.Format(CultureInfo.CurrentCulture, GetString("DuplicateNavigation", "navigation", "entityType", "duplicateEntityType"), navigation, entityType, duplicateEntityType);
         }
 
         /// <summary>
@@ -477,11 +477,11 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
-        /// The types of the properties specified for the foreign key {foreignKey} on entity type '{dependentType}' do not match the types of the properties in the principal key on entity type '{principalType}'.
+        /// The types of the properties specified for the foreign key {foreignKey} on entity type '{dependentType}' do not match the types of the properties in the principal key {principalKey} on entity type '{principalType}'.
         /// </summary>
-        public static string ForeignKeyTypeMismatch([CanBeNull] object foreignKey, [CanBeNull] object dependentType, [CanBeNull] object principalType)
+        public static string ForeignKeyTypeMismatch([CanBeNull] object foreignKey, [CanBeNull] object dependentType, [CanBeNull] object principalKey, [CanBeNull] object principalType)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("ForeignKeyTypeMismatch", "foreignKey", "dependentType", "principalType"), foreignKey, dependentType, principalType);
+            return string.Format(CultureInfo.CurrentCulture, GetString("ForeignKeyTypeMismatch", "foreignKey", "dependentType", "principalKey", "principalType"), foreignKey, dependentType, principalKey, principalType);
         }
 
         /// <summary>
@@ -573,27 +573,27 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
-        /// The foreign key {foreignKey} cannot be added to the entity type '{entityType}' because a foreign key on the same properties already exists.
+        /// The foreign key {foreignKey} cannot be added to the entity type '{entityType}' because a foreign key on the same properties already exists on entity type '{duplicateEntityType}'.
         /// </summary>
-        public static string DuplicateForeignKey([CanBeNull] object foreignKey, [CanBeNull] object entityType)
+        public static string DuplicateForeignKey([CanBeNull] object foreignKey, [CanBeNull] object entityType, [CanBeNull] object duplicateEntityType)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("DuplicateForeignKey", "foreignKey", "entityType"), foreignKey, entityType);
+            return string.Format(CultureInfo.CurrentCulture, GetString("DuplicateForeignKey", "foreignKey", "entityType", "duplicateEntityType"), foreignKey, entityType, duplicateEntityType);
         }
 
         /// <summary>
-        /// The index {index} cannot be added to the entity type '{entityType}' because an index on the same properties already exists.
+        /// The index {index} cannot be added to the entity type '{entityType}' because an index on the same properties already exists on entity type '{duplicateEntityType}'.
         /// </summary>
-        public static string DuplicateIndex([CanBeNull] object index, [CanBeNull] object entityType)
+        public static string DuplicateIndex([CanBeNull] object index, [CanBeNull] object entityType, [CanBeNull] object duplicateEntityType)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("DuplicateIndex", "index", "entityType"), index, entityType);
+            return string.Format(CultureInfo.CurrentCulture, GetString("DuplicateIndex", "index", "entityType", "duplicateEntityType"), index, entityType, duplicateEntityType);
         }
 
         /// <summary>
-        /// The key {key} cannot be added to the entity type '{entityType}' because a key on the same properties already exists.
+        /// The key {key} cannot be added to the entity type '{entityType}' because a key on the same properties already exists on entity type '{duplicateEntityType}'.
         /// </summary>
-        public static string DuplicateKey([CanBeNull] object key, [CanBeNull] object entityType)
+        public static string DuplicateKey([CanBeNull] object key, [CanBeNull] object entityType, [CanBeNull] object duplicateEntityType)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("DuplicateKey", "key", "entityType"), key, entityType);
+            return string.Format(CultureInfo.CurrentCulture, GetString("DuplicateKey", "key", "entityType", "duplicateEntityType"), key, entityType, duplicateEntityType);
         }
 
         /// <summary>
@@ -637,11 +637,11 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
-        /// The specified entity type '{type}' is invalid. It should be either the dependent entity type '{dependentType}' or the principal entity type '{principalType}' or an entity type derived from one of them.
+        /// The specified entity type '{entityType}' is invalid. It should be either the dependent entity type '{dependentType}' or the principal entity type '{principalType}' or an entity type derived from one of them.
         /// </summary>
-        public static string EntityTypeNotInRelationship([CanBeNull] object type, [CanBeNull] object dependentType, [CanBeNull] object principalType)
+        public static string EntityTypeNotInRelationship([CanBeNull] object entityType, [CanBeNull] object dependentType, [CanBeNull] object principalType)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("EntityTypeNotInRelationship", "type", "dependentType", "principalType"), type, dependentType, principalType);
+            return string.Format(CultureInfo.CurrentCulture, GetString("EntityTypeNotInRelationship", "entityType", "dependentType", "principalType"), entityType, dependentType, principalType);
         }
 
         /// <summary>
@@ -733,11 +733,11 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
-        /// The property '{property}' on entity type '{entity}' cannot be marked as nullable/optional because the type of the property is '{propertyType}' which is not a nullable type. Any property can be marked as non-nullable/required, but only properties of nullable types and which are not part of primary key can be marked as nullable/optional.
+        /// The property '{property}' on entity type '{entityType}' cannot be marked as nullable/optional because the type of the property is '{propertyType}' which is not a nullable type. Any property can be marked as non-nullable/required, but only properties of nullable types and which are not part of primary key can be marked as nullable/optional.
         /// </summary>
-        public static string CannotBeNullable([CanBeNull] object property, [CanBeNull] object entity, [CanBeNull] object propertyType)
+        public static string CannotBeNullable([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object propertyType)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("CannotBeNullable", "property", "entity", "propertyType"), property, entity, propertyType);
+            return string.Format(CultureInfo.CurrentCulture, GetString("CannotBeNullable", "property", "entityType", "propertyType"), property, entityType, propertyType);
         }
 
         /// <summary>
@@ -853,7 +853,7 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
-        /// The property '{property}' on entity type '{entityType}' does not have value generation on add enabled and it is principal by at least one foreign key. Properties referenced by foreign keys should have value generation on add enabled.
+        /// The property '{property}' on entity type '{entityType}' does not have value generation on add enabled and it is referenced by at least one foreign key. Properties referenced by foreign keys should have value generation on add enabled.
         /// </summary>
         public static string PrincipalKeyNoValueGenerationOnAdd([CanBeNull] object property, [CanBeNull] object entityType)
         {
@@ -981,11 +981,11 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
-        /// The property '{property}' on entity type '{entity}' cannot be marked as nullable/optional because the property is a part of the primary key. Any property can be marked as non-nullable/required, but only properties of nullable types and which are not part of primary key can be marked as nullable/optional.
+        /// The property '{property}' on entity type '{entityType}' cannot be marked as nullable/optional because the property is a part of the primary key. Any property can be marked as non-nullable/required, but only properties of nullable types and which are not part of primary key can be marked as nullable/optional.
         /// </summary>
-        public static string CannotBeNullablePK([CanBeNull] object property, [CanBeNull] object entity)
+        public static string CannotBeNullablePK([CanBeNull] object property, [CanBeNull] object entityType)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("CannotBeNullablePK", "property", "entity"), property, entity);
+            return string.Format(CultureInfo.CurrentCulture, GetString("CannotBeNullablePK", "property", "entityType"), property, entityType);
         }
 
         /// <summary>
@@ -1173,19 +1173,19 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
-        /// The property '{property}' cannot be added to the entity type '{entityType}' because a navigation property with the same name already exists.
+        /// The property '{property}' cannot be added to the entity type '{entityType}' because a navigation property with the same name already exists on entity type '{duplicateEntityType}'.
         /// </summary>
-        public static string ConflictingNavigation([CanBeNull] object property, [CanBeNull] object entityType)
+        public static string ConflictingNavigation([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object duplicateEntityType)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("ConflictingNavigation", "property", "entityType"), property, entityType);
+            return string.Format(CultureInfo.CurrentCulture, GetString("ConflictingNavigation", "property", "entityType", "duplicateEntityType"), property, entityType, duplicateEntityType);
         }
 
         /// <summary>
-        /// The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because a property with the same name already exists.
+        /// The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because a property with the same name already exists on entity type '{duplicateEntityType}'.
         /// </summary>
-        public static string ConflictingProperty([CanBeNull] object navigation, [CanBeNull] object entityType)
+        public static string ConflictingProperty([CanBeNull] object navigation, [CanBeNull] object entityType, [CanBeNull] object duplicateEntityType)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("ConflictingProperty", "navigation", "entityType"), navigation, entityType);
+            return string.Format(CultureInfo.CurrentCulture, GetString("ConflictingProperty", "navigation", "entityType", "duplicateEntityType"), navigation, entityType, duplicateEntityType);
         }
 
         private static string GetString(string name, params string[] formatterNames)

--- a/src/EntityFramework.Core/Properties/Strings.resx
+++ b/src/EntityFramework.Core/Properties/Strings.resx
@@ -244,7 +244,7 @@
     <value>The EF.Property&lt;T&gt; method may only be used within LINQ queries.</value>
   </data>
   <data name="DuplicateProperty" xml:space="preserve">
-    <value>The property '{property}' cannot be added to the entity type '{entityType}' because a property with the same name already exists.</value>
+    <value>The property '{property}' cannot be added to the entity type '{entityType}' because a property with the same name already exists on entity type '{duplicateEntityType}'.</value>
   </data>
   <data name="NoClrProperty" xml:space="preserve">
     <value>The property '{property}' cannot exist on entity type '{entityType}' because the property is not marked as shadow state and no corresponding CLR property exists on the underlying type.</value>
@@ -268,7 +268,7 @@
     <value>The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because according to the specified foreign key it should belong to entity type '{existingEntityType}'.</value>
   </data>
   <data name="DuplicateNavigation" xml:space="preserve">
-    <value>The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because a navigation property with the same name already exists.</value>
+    <value>The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because a navigation property with the same name already exists on entity type '{duplicateEntityType}'.</value>
   </data>
   <data name="NavigationOnShadowEntity" xml:space="preserve">
     <value>The navigation property '{navigation}' cannot be added to entity type '{entityType}' because the entity type is defined in shadow state and navigations properties cannot be added to shadow state.</value>
@@ -292,7 +292,7 @@
     <value>The number of properties specified for the foreign key {foreignKey} on entity type '{dependentType}' does not match the number of properties in the principal key {principalKey} on entity type '{principalType}'.</value>
   </data>
   <data name="ForeignKeyTypeMismatch" xml:space="preserve">
-    <value>The types of the properties specified for the foreign key {foreignKey} on entity type '{dependentType}' do not match the types of the properties in the principal key on entity type '{principalType}'.</value>
+    <value>The types of the properties specified for the foreign key {foreignKey} on entity type '{dependentType}' do not match the types of the properties in the principal key {principalKey} on entity type '{principalType}'.</value>
   </data>
   <data name="NavigationBadType" xml:space="preserve">
     <value>The type of navigation property '{navigation}' on entity type '{entityType}' is '{foundType}' which does not implement ICollection&lt;{targetType}&gt;. Collection navigation properties must implement ICollection&lt;&gt; of the target type.</value>
@@ -328,13 +328,13 @@
     <value>The property '{property}' on entity type '{entityType}' is marked as null, but this cannot be saved because the property is marked as required.</value>
   </data>
   <data name="DuplicateForeignKey" xml:space="preserve">
-    <value>The foreign key {foreignKey} cannot be added to the entity type '{entityType}' because a foreign key on the same properties already exists.</value>
+    <value>The foreign key {foreignKey} cannot be added to the entity type '{entityType}' because a foreign key on the same properties already exists on entity type '{duplicateEntityType}'.</value>
   </data>
   <data name="DuplicateIndex" xml:space="preserve">
-    <value>The index {index} cannot be added to the entity type '{entityType}' because an index on the same properties already exists.</value>
+    <value>The index {index} cannot be added to the entity type '{entityType}' because an index on the same properties already exists on entity type '{duplicateEntityType}'.</value>
   </data>
   <data name="DuplicateKey" xml:space="preserve">
-    <value>The key {key} cannot be added to the entity type '{entityType}' because a key on the same properties already exists.</value>
+    <value>The key {key} cannot be added to the entity type '{entityType}' because a key on the same properties already exists on entity type '{duplicateEntityType}'.</value>
   </data>
   <data name="ForeignKeyNotFound" xml:space="preserve">
     <value>The foreign key {foreignKey} on entity type '{entityType}' could not be found. Ensure that the foreign key been added to the entity type.</value>
@@ -352,7 +352,7 @@
     <value>The collection argument '{argumentName}' must not contain any null references.</value>
   </data>
   <data name="EntityTypeNotInRelationship" xml:space="preserve">
-    <value>The specified entity type '{type}' is invalid. It should be either the dependent entity type '{dependentType}' or the principal entity type '{principalType}' or an entity type derived from one of them.</value>
+    <value>The specified entity type '{entityType}' is invalid. It should be either the dependent entity type '{dependentType}' or the principal entity type '{principalType}' or an entity type derived from one of them.</value>
   </data>
   <data name="DuplicateEntityType" xml:space="preserve">
     <value>The entity type '{entityType}' cannot be added to the model because an entity with the same name already exists.</value>
@@ -388,7 +388,7 @@
     <value>Tracking query sources: [{querySources}]</value>
   </data>
   <data name="CannotBeNullable" xml:space="preserve">
-    <value>The property '{property}' on entity type '{entity}' cannot be marked as nullable/optional because the type of the property is '{propertyType}' which is not a nullable type. Any property can be marked as non-nullable/required, but only properties of nullable types and which are not part of primary key can be marked as nullable/optional.</value>
+    <value>The property '{property}' on entity type '{entityType}' cannot be marked as nullable/optional because the type of the property is '{propertyType}' which is not a nullable type. Any property can be marked as non-nullable/required, but only properties of nullable types and which are not part of primary key can be marked as nullable/optional.</value>
   </data>
   <data name="RecursiveOnModelCreating" xml:space="preserve">
     <value>An attempt was made to use the model while it was being created. A DbContext instance cannot be used inside OnModelCreating in any way that makes use of the model that is being created.</value>
@@ -433,7 +433,7 @@
     <value>The root principal property found by following to foreign key chain starting on entity type '{entityType}' with {firstForeignKey} is '{firstEntityType}'.'{firstRootProperty}', which is different from the root principal property found by following to foreign key chain starting with {secondForeignKey} - '{secondEntityType}'.'{secondRootProperty}'</value>
   </data>
   <data name="PrincipalKeyNoValueGenerationOnAdd" xml:space="preserve">
-    <value>The property '{property}' on entity type '{entityType}' does not have value generation on add enabled and it is principal by at least one foreign key. Properties referenced by foreign keys should have value generation on add enabled.</value>
+    <value>The property '{property}' on entity type '{entityType}' does not have value generation on add enabled and it is referenced by at least one foreign key. Properties referenced by foreign keys should have value generation on add enabled.</value>
   </data>
   <data name="ExpressionParameterizationException" xml:space="preserve">
     <value>An exception was thrown while attempting to evaluate the LINQ query parameter expression '{expression}'.</value>
@@ -481,7 +481,7 @@
     <value>The instance of entity type '{entityType}' cannot be loaded because it has an invalid (e.g. null or CLR default) primary key.</value>
   </data>
   <data name="CannotBeNullablePK" xml:space="preserve">
-    <value>The property '{property}' on entity type '{entity}' cannot be marked as nullable/optional because the property is a part of the primary key. Any property can be marked as non-nullable/required, but only properties of nullable types and which are not part of primary key can be marked as nullable/optional.</value>
+    <value>The property '{property}' on entity type '{entityType}' cannot be marked as nullable/optional because the property is a part of the primary key. Any property can be marked as non-nullable/required, but only properties of nullable types and which are not part of primary key can be marked as nullable/optional.</value>
   </data>
   <data name="ForeignKeyCannotBeOptional" xml:space="preserve">
     <value>The foreign key {foreignKey} on entity type '{entityType}' cannot be marked as optional because it does not contain any property of a nullable type. Any foreign key can be marked as required, but only foreign keys with at least one property of a nullable type and which is not part of primary key can be marked as optional.</value>
@@ -553,9 +553,9 @@
     <value>Invalid relationship has been specified using InverseProperty and ForeignKey. The navigation '{navigation}' in entity type '{entityType}' and the navigation '{referencedNavigation}' in entity type '{referencedEntityType}' are related by InversePropertyAttribute but the ForeignKeyAttribute specified for both navigations have different values.</value>
   </data>
   <data name="ConflictingNavigation" xml:space="preserve">
-    <value>The property '{property}' cannot be added to the entity type '{entityType}' because a navigation property with the same name already exists.</value>
+    <value>The property '{property}' cannot be added to the entity type '{entityType}' because a navigation property with the same name already exists on entity type '{duplicateEntityType}'.</value>
   </data>
   <data name="ConflictingProperty" xml:space="preserve">
-    <value>The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because a property with the same name already exists.</value>
+    <value>The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because a property with the same name already exists on entity type '{duplicateEntityType}'.</value>
   </data>
 </root>

--- a/test/EntityFramework.Core.FunctionalTests/ComplexNavigationsQueryFixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/ComplexNavigationsQueryFixtureBase.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             modelBuilder.Entity<Level3>().Property(e => e.Id).ValueGeneratedNever();
             modelBuilder.Entity<Level4>().Property(e => e.Id).ValueGeneratedNever();
 
+            modelBuilder.Entity<Level1>().HasOne(e => e.OneToOne_Optional_Self).WithOne();
             modelBuilder.Entity<Level1>().HasOne(e => e.OneToOne_Required_PK).WithOne(e => e.OneToOne_Required_PK_Inverse).PrincipalKey<Level1>(e => e.Id).Required(true);
             modelBuilder.Entity<Level1>().HasOne(e => e.OneToOne_Optional_PK).WithOne(e => e.OneToOne_Optional_PK_Inverse).PrincipalKey<Level1>(e => e.Id).Required(false);
             modelBuilder.Entity<Level1>().HasOne(e => e.OneToOne_Required_FK).WithOne(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level2>(e => e.Level1_Required_Id).Required(true);
@@ -28,9 +29,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             modelBuilder.Entity<Level1>().HasMany(e => e.OneToMany_Required_Self).WithOne(e => e.OneToMany_Required_Self_Inverse).Required(true);
             modelBuilder.Entity<Level1>().HasMany(e => e.OneToMany_Optional_Self).WithOne(e => e.OneToMany_Optional_Self_Inverse).Required(false);
 
-            // issue #1417
-            //modelBuilder.Entity<Level1>().HasOne(e => e.OneToOne_Optional_Self).WithOne(); 
-
+            modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Optional_Self).WithOne();
             modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Required_PK).WithOne(e => e.OneToOne_Required_PK_Inverse).PrincipalKey<Level2>(e => e.Id).Required(true);
             modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Optional_PK).WithOne(e => e.OneToOne_Optional_PK_Inverse).PrincipalKey<Level2>(e => e.Id).Required(false);
             modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Required_FK).WithOne(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level3>(e => e.Level2_Required_Id).Required(true);
@@ -42,9 +41,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             modelBuilder.Entity<Level2>().HasMany(e => e.OneToMany_Required_Self).WithOne(e => e.OneToMany_Required_Self_Inverse).Required(true);
             modelBuilder.Entity<Level2>().HasMany(e => e.OneToMany_Optional_Self).WithOne(e => e.OneToMany_Optional_Self_Inverse).Required(false);
 
-            // issue #1417
-            //modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Optional_Self).WithOne(); 
-
+            modelBuilder.Entity<Level3>().HasOne(e => e.OneToOne_Optional_Self).WithOne();
             modelBuilder.Entity<Level3>().HasOne(e => e.OneToOne_Required_PK).WithOne(e => e.OneToOne_Required_PK_Inverse).PrincipalKey<Level3>(e => e.Id).Required(true);
             modelBuilder.Entity<Level3>().HasOne(e => e.OneToOne_Optional_PK).WithOne(e => e.OneToOne_Optional_PK_Inverse).PrincipalKey<Level3>(e => e.Id).Required(false);
             modelBuilder.Entity<Level3>().HasOne(e => e.OneToOne_Required_FK).WithOne(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level4>(e => e.Level3_Required_Id).Required(true);
@@ -54,9 +51,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             modelBuilder.Entity<Level3>().HasMany(e => e.OneToMany_Required_Self).WithOne(e => e.OneToMany_Required_Self_Inverse).Required(true);
             modelBuilder.Entity<Level3>().HasMany(e => e.OneToMany_Optional_Self).WithOne(e => e.OneToMany_Optional_Self_Inverse).Required(false);
 
-            // issue #1417
-            //modelBuilder.Entity<Level3>().HasOne(e => e.OneToOne_Optional_Self).WithOne();
-
+            modelBuilder.Entity<Level4>().HasOne(e => e.OneToOne_Optional_Self).WithOne();
             modelBuilder.Entity<Level4>().HasMany(e => e.OneToMany_Required_Self).WithOne(e => e.OneToMany_Required_Self_Inverse).Required(true);
             modelBuilder.Entity<Level4>().HasMany(e => e.OneToMany_Optional_Self).WithOne(e => e.OneToMany_Optional_Self_Inverse).Required(false);
 

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/ComplexNavigationsModel/ComplexNavigationsModelInitializer.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/ComplexNavigationsModel/ComplexNavigationsModelInitializer.cs
@@ -205,13 +205,12 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.ComplexNavigationsMod
                 l1s[5].OneToMany_Optional_Self = new List<Level1> { l1s[4] };
                 l1s[7].OneToMany_Optional_Self = new List<Level1> { l1s[6] };
                 l1s[9].OneToMany_Optional_Self = new List<Level1> { l1s[8] };
-
-                // issue #1417
-                //l1s[0].OneToOne_Optional_Self = l1s[9];
-                //l1s[1].OneToOne_Optional_Self = l1s[8];
-                //l1s[2].OneToOne_Optional_Self = l1s[7];
-                //l1s[3].OneToOne_Optional_Self = l1s[6];
-                //l1s[4].OneToOne_Optional_Self = l1s[5];
+                
+                l1s[0].OneToOne_Optional_Self = l1s[9];
+                l1s[1].OneToOne_Optional_Self = l1s[8];
+                l1s[2].OneToOne_Optional_Self = l1s[7];
+                l1s[3].OneToOne_Optional_Self = l1s[6];
+                l1s[4].OneToOne_Optional_Self = l1s[5];
 
                 l2s[0].OneToOne_Optional_PK = l3s[0];
                 l2s[2].OneToOne_Optional_PK = l3s[2];
@@ -233,13 +232,12 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.ComplexNavigationsMod
                 l2s[5].OneToMany_Optional_Self = new List<Level2> { l2s[4] };
                 l2s[7].OneToMany_Optional_Self = new List<Level2> { l2s[6] };
                 l2s[9].OneToMany_Optional_Self = new List<Level2> { l2s[8] };
-
-                // issue #1417
-                //l2s[0].OneToOne_Optional_Self = l2s[9];
-                //l2s[1].OneToOne_Optional_Self = l2s[8];
-                //l2s[2].OneToOne_Optional_Self = l2s[7];
-                //l2s[3].OneToOne_Optional_Self = l2s[6];
-                //l2s[4].OneToOne_Optional_Self = l2s[5];
+                
+                l2s[0].OneToOne_Optional_Self = l2s[9];
+                l2s[1].OneToOne_Optional_Self = l2s[8];
+                l2s[2].OneToOne_Optional_Self = l2s[7];
+                l2s[3].OneToOne_Optional_Self = l2s[6];
+                l2s[4].OneToOne_Optional_Self = l2s[5];
 
                 l3s[0].OneToOne_Optional_PK = l4s[0];
                 l3s[2].OneToOne_Optional_PK = l4s[2];
@@ -260,13 +258,12 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.ComplexNavigationsMod
                 l3s[5].OneToMany_Optional_Self = new List<Level3> { l3s[4] };
                 l3s[7].OneToMany_Optional_Self = new List<Level3> { l3s[6] };
                 l3s[9].OneToMany_Optional_Self = new List<Level3> { l3s[8] };
-
-                // issue #1417
-                //l3s[0].OneToOne_Optional_Self = l3s[9];
-                //l3s[1].OneToOne_Optional_Self = l3s[8];
-                //l3s[2].OneToOne_Optional_Self = l3s[7];
-                //l3s[3].OneToOne_Optional_Self = l3s[6];
-                //l3s[4].OneToOne_Optional_Self = l3s[5];
+                
+                l3s[0].OneToOne_Optional_Self = l3s[9];
+                l3s[1].OneToOne_Optional_Self = l3s[8];
+                l3s[2].OneToOne_Optional_Self = l3s[7];
+                l3s[3].OneToOne_Optional_Self = l3s[6];
+                l3s[4].OneToOne_Optional_Self = l3s[5];
 
                 l4s[1].OneToMany_Optional_Self = new List<Level4> { l4s[0] };
                 l4s[3].OneToMany_Optional_Self = new List<Level4> { l4s[2] };

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/ComplexNavigationsModel/Level1.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/ComplexNavigationsModel/Level1.cs
@@ -18,9 +18,8 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.ComplexNavigationsMod
 
         public ICollection<Level2> OneToMany_Required { get; set; }
         public ICollection<Level2> OneToMany_Optional { get; set; }
-
-        // issue #1417
-        //public Level1 OneToOne_Optional_Self { get; set; }
+        
+        public Level1 OneToOne_Optional_Self { get; set; }
 
         public ICollection<Level1> OneToMany_Required_Self { get; set; }
         public ICollection<Level1> OneToMany_Optional_Self { get; set; }

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/ComplexNavigationsModel/Level2.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/ComplexNavigationsModel/Level2.cs
@@ -29,9 +29,8 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.ComplexNavigationsMod
 
         public Level1 OneToMany_Required_Inverse { get; set; }
         public Level1 OneToMany_Optional_Inverse { get; set; }
-
-        // issue #1417
-        //public Level2 OneToOne_Optional_Self { get; set; }
+        
+        public Level2 OneToOne_Optional_Self { get; set; }
 
         public ICollection<Level2> OneToMany_Required_Self { get; set; }
         public ICollection<Level2> OneToMany_Optional_Self { get; set; }

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/ComplexNavigationsModel/Level3.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/ComplexNavigationsModel/Level3.cs
@@ -29,9 +29,8 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.ComplexNavigationsMod
 
         public Level2 OneToMany_Required_Inverse { get; set; }
         public Level2 OneToMany_Optional_Inverse { get; set; }
-
-        // issue #1417
-        //public Level3 OneToOne_Optional_Self { get; set; }
+        
+        public Level3 OneToOne_Optional_Self { get; set; }
 
         public ICollection<Level3> OneToMany_Required_Self { get; set; }
         public ICollection<Level3> OneToMany_Optional_Self { get; set; }

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/ComplexNavigationsModel/Level4.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/ComplexNavigationsModel/Level4.cs
@@ -20,9 +20,8 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.ComplexNavigationsMod
 
         public Level3 OneToMany_Required_Inverse { get; set; }
         public Level3 OneToMany_Optional_Inverse { get; set; }
-
-        // issue #1417
-        //public Level4 OneToOne_Optional_Self { get; set; }
+        
+        public Level4 OneToOne_Optional_Self { get; set; }
 
         public ICollection<Level4> OneToMany_Required_Self { get; set; }
         public ICollection<Level4> OneToMany_Optional_Self { get; set; }

--- a/test/EntityFramework.Core.Tests/Metadata/EntityTypeTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/EntityTypeTest.cs
@@ -242,7 +242,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var b = model.AddEntityType(typeof(B));
             b.BaseType = a;
 
-            Assert.Equal(Strings.DuplicateProperty("G", typeof(B).FullName),
+            Assert.Equal(Strings.DuplicateProperty("G", typeof(B).Name, typeof(A).Name),
                 Assert.Throws<InvalidOperationException>(() => b.AddProperty("G")).Message);
         }
 
@@ -261,7 +261,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             d.BaseType = c;
 
             Assert.Equal(
-                Strings.DuplicateProperty("G", typeof(D).FullName),
+                Strings.DuplicateProperty("G", typeof(D).Name, typeof(A).Name),
                 Assert.Throws<InvalidOperationException>(() => d.AddProperty("G")).Message);
         }
 
@@ -278,7 +278,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             b.AddProperty(A.GProperty);
 
             Assert.Equal(
-                Strings.DuplicateProperty("G", typeof(A).FullName),
+                Strings.DuplicateProperty("G", typeof(A).Name, typeof(B).Name),
                 Assert.Throws<InvalidOperationException>(() => a.AddProperty(A.GProperty)).Message);
         }
 
@@ -298,7 +298,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             d.AddProperty(A.GProperty);
 
             Assert.Equal(
-                Strings.DuplicateProperty("G", typeof(A).FullName),
+                Strings.DuplicateProperty("G", typeof(A).Name, typeof(D).Name),
                 Assert.Throws<InvalidOperationException>(() => a.AddProperty(A.GProperty)).Message);
         }
 
@@ -588,7 +588,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var specialCustomerForeignKey = orderType.GetOrAddForeignKey(derivedForeignKeyProperty, customerKey, specialCustomerType);
 
             Assert.Equal(
-                Strings.DuplicateNavigation("Orders", typeof(SpecialCustomer).FullName),
+                Strings.DuplicateNavigation("Orders", typeof(SpecialCustomer).Name, typeof(Customer).Name),
                 Assert.Throws<InvalidOperationException>(() =>
                     specialCustomerType.AddNavigation("Orders", specialCustomerForeignKey, pointsToPrincipal: false)).Message);
         }
@@ -617,7 +617,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var specialCustomerForeignKey = orderType.GetOrAddForeignKey(derivedForeignKeyProperty, customerKey, verySpecialCustomerType);
 
             Assert.Equal(
-                Strings.DuplicateNavigation("Orders", typeof(VerySpecialCustomer).FullName),
+                Strings.DuplicateNavigation("Orders", typeof(VerySpecialCustomer).Name, typeof(Customer).Name),
                 Assert.Throws<InvalidOperationException>(() =>
                     verySpecialCustomerType.AddNavigation("Orders", specialCustomerForeignKey, pointsToPrincipal: false)).Message);
         }
@@ -642,7 +642,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             specialCustomerType.AddNavigation("Orders", specialCustomerForeignKey, pointsToPrincipal: false);
 
             Assert.Equal(
-                Strings.DuplicateNavigation("Orders", typeof(Customer).FullName),
+                Strings.DuplicateNavigation("Orders", typeof(Customer).Name, typeof(SpecialCustomer).Name),
                 Assert.Throws<InvalidOperationException>(() =>
                     customerType.AddNavigation("Orders", customerForeignKey, pointsToPrincipal: false)).Message);
         }
@@ -670,7 +670,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             verySpecialCustomerType.AddNavigation("Orders", specialCustomerForeignKey, pointsToPrincipal: false);
 
             Assert.Equal(
-                Strings.DuplicateNavigation("Orders", typeof(Customer).FullName),
+                Strings.DuplicateNavigation("Orders", typeof(Customer).Name, typeof(VerySpecialCustomer).Name),
                 Assert.Throws<InvalidOperationException>(() =>
                     customerType.AddNavigation("Orders", customerForeignKey, pointsToPrincipal: false)).Message);
         }
@@ -866,7 +866,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             specialOrderType.BaseType = orderType;
 
             Assert.Equal(
-                Strings.DuplicateForeignKey(Property.Format(new[] { foreignKeyProperty }), typeof(SpecialOrder).FullName),
+                Strings.DuplicateForeignKey(Property.Format(new[] { foreignKeyProperty }), typeof(SpecialOrder).FullName, typeof(Order).FullName),
                 Assert.Throws<InvalidOperationException>(() =>
                     specialOrderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType)).Message);
         }
@@ -891,7 +891,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             verySpecialOrderType.BaseType = specialOrderType;
 
             Assert.Equal(
-                Strings.DuplicateForeignKey(Property.Format(new[] { foreignKeyProperty }), typeof(VerySpecialOrder).FullName),
+                Strings.DuplicateForeignKey(Property.Format(new[] { foreignKeyProperty }), typeof(VerySpecialOrder).FullName, typeof(Order).FullName),
                 Assert.Throws<InvalidOperationException>(() =>
                     verySpecialOrderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType)).Message);
         }
@@ -913,7 +913,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             specialOrderType.BaseType = orderType;
 
             Assert.Equal(
-                Strings.DuplicateForeignKey(Property.Format(new[] { foreignKeyProperty }), typeof(Order).FullName),
+                Strings.DuplicateForeignKey(Property.Format(new[] { foreignKeyProperty }), typeof(Order).FullName, typeof(SpecialOrder).FullName),
                 Assert.Throws<InvalidOperationException>(() =>
                     orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType)).Message);
         }
@@ -938,7 +938,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             verySpecialOrderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
 
             Assert.Equal(
-                Strings.DuplicateForeignKey(Property.Format(new[] { foreignKeyProperty }), typeof(Order).FullName),
+                Strings.DuplicateForeignKey(Property.Format(new[] { foreignKeyProperty }), typeof(Order).FullName, typeof(VerySpecialOrder).FullName),
                 Assert.Throws<InvalidOperationException>(() =>
                     orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType)).Message);
         }
@@ -1047,7 +1047,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             specialOrderType.BaseType = orderType;
 
             Assert.Equal(
-                Strings.DuplicateIndex(Property.Format(new[] { indexProperty }), typeof(SpecialOrder).FullName),
+                Strings.DuplicateIndex(Property.Format(new[] { indexProperty }), typeof(SpecialOrder).FullName, typeof(Order).FullName),
                 Assert.Throws<InvalidOperationException>(() =>
                     specialOrderType.GetOrAddIndex(indexProperty)).Message);
         }
@@ -1069,7 +1069,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             verySpecialOrderType.BaseType = specialOrderType;
 
             Assert.Equal(
-                Strings.DuplicateIndex(Property.Format(new[] { indexProperty }), typeof(VerySpecialOrder).FullName),
+                Strings.DuplicateIndex(Property.Format(new[] { indexProperty }), typeof(VerySpecialOrder).FullName, typeof(Order).FullName),
                 Assert.Throws<InvalidOperationException>(() =>
                     verySpecialOrderType.GetOrAddIndex(indexProperty)).Message);
         }
@@ -1088,7 +1088,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             specialOrderType.BaseType = orderType;
 
             Assert.Equal(
-                Strings.DuplicateIndex(Property.Format(new[] { indexProperty }), typeof(Order).FullName),
+                Strings.DuplicateIndex(Property.Format(new[] { indexProperty }), typeof(Order).FullName, typeof(SpecialOrder).FullName),
                 Assert.Throws<InvalidOperationException>(() =>
                     orderType.GetOrAddIndex(indexProperty)).Message);
         }
@@ -1110,7 +1110,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             specialOrderType.GetOrAddIndex(indexProperty);
 
             Assert.Equal(
-                Strings.DuplicateIndex(Property.Format(new[] { indexProperty }), typeof(Order).FullName),
+                Strings.DuplicateIndex(Property.Format(new[] { indexProperty }), typeof(Order).FullName, typeof(VerySpecialOrder).FullName),
                 Assert.Throws<InvalidOperationException>(() =>
                     orderType.GetOrAddIndex(indexProperty)).Message);
         }
@@ -1330,7 +1330,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             entityType.GetOrAddKey(new[] { idProperty, nameProperty });
 
             Assert.Equal(
-                Strings.DuplicateKey("{'" + Customer.IdProperty.Name + "', '" + Customer.NameProperty.Name + "'}", typeof(Customer).FullName),
+                Strings.DuplicateKey("{'" + Customer.IdProperty.Name + "', '" + Customer.NameProperty.Name + "'}", typeof(Customer).Name, typeof(Customer).Name),
                 Assert.Throws<InvalidOperationException>(() => entityType.AddKey(new[] { idProperty, nameProperty })).Message);
         }
 
@@ -1357,7 +1357,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             entityType.GetOrSetPrimaryKey(new[] { idProperty, nameProperty });
 
             Assert.Equal(
-                Strings.DuplicateKey("{'" + Customer.IdProperty.Name + "', '" + Customer.NameProperty.Name + "'}", typeof(Customer).FullName),
+                Strings.DuplicateKey("{'" + Customer.IdProperty.Name + "', '" + Customer.NameProperty.Name + "'}", typeof(Customer).Name, typeof(Customer).Name),
                 Assert.Throws<InvalidOperationException>(() => entityType.AddKey(new[] { idProperty, nameProperty })).Message);
         }
 
@@ -1552,7 +1552,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             orderType.AddForeignKey(customerFk1, customerKey, customerType);
 
             Assert.Equal(
-                Strings.DuplicateForeignKey("{'" + Order.CustomerIdProperty.Name + "'}", typeof(Order).FullName),
+                Strings.DuplicateForeignKey("{'" + Order.CustomerIdProperty.Name + "'}", typeof(Order).Name, typeof(Order).Name),
                 Assert.Throws<InvalidOperationException>(() => orderType.AddForeignKey(customerFk1, customerKey, customerType)).Message);
         }
 
@@ -1635,188 +1635,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(fk2, orderType.GetOrAddForeignKey(customerFk2, customerKey, customerType));
             Assert.Equal(new[] { fk1, fk2 }, orderType.GetForeignKeys().ToArray());
         }
-
-        [Fact]
-        public void TryGetForeignKey_finds_foreign_key_matching_principal_type_name_plus_PK_name()
-        {
-            var fkProperty = DependentType.AddProperty("PrincipalEntityPeEKaY", typeof(int));
-
-            var fk = DependentType.GetOrAddForeignKey(fkProperty, PrincipalType.GetPrimaryKey(), PrincipalType);
-
-            Assert.Same(fk, DependentType.FindForeignKey(
-                PrincipalType,
-                "SomeNav",
-                "SomeInverse",
-                null,
-                null,
-                unique: false));
-        }
-
-        [Fact]
-        public void TryGetForeignKey_finds_foreign_key_matching_given_properties()
-        {
-            DependentType.AddProperty("SomeNavID", typeof(int));
-            DependentType.AddProperty("SomeNavPeEKaY", typeof(int));
-            DependentType.AddProperty("PrincipalEntityID", typeof(int));
-            DependentType.AddProperty("PrincipalEntityPeEKaY", typeof(int));
-            var fkProperty = DependentType.AddProperty("HeToldMeYouKilledMyFk", typeof(int));
-
-            var fk = DependentType.GetOrAddForeignKey(fkProperty, PrincipalType.GetPrimaryKey(), PrincipalType);
-
-            Assert.Same(
-                fk,
-                DependentType.FindForeignKey(
-                    PrincipalType,
-                    "SomeNav",
-                    "SomeInverse",
-                    new[] { fkProperty },
-                    new Property[0],
-                    unique: false));
-        }
-
-        [Fact]
-        public void TryGetForeignKey_finds_foreign_key_matching_given_property()
-        {
-            DependentType.AddProperty("SomeNavID", typeof(int));
-            DependentType.AddProperty("SomeNavPeEKaY", typeof(int));
-            DependentType.AddProperty("PrincipalEntityID", typeof(int));
-            DependentType.AddProperty("PrincipalEntityPeEKaY", typeof(int));
-            var fkProperty1 = DependentType.AddProperty("No", typeof(int));
-            var fkProperty2 = DependentType.AddProperty("IAmYourFk", typeof(int));
-
-            var fk = DependentType.GetOrAddForeignKey(new[] { fkProperty1, fkProperty2 }, PrincipalType.GetOrAddKey(
-                new[]
-                {
-                    PrincipalType.AddProperty("Id1", typeof(int)),
-                    PrincipalType.AddProperty("Id2", typeof(int))
-                }),
-                PrincipalType);
-
-            Assert.Same(
-                fk,
-                DependentType.FindForeignKey(
-                    PrincipalType,
-                    "SomeNav",
-                    "SomeInverse",
-                    new[] { fkProperty1, fkProperty2 },
-                    new Property[0],
-                    unique: false));
-        }
-
-        [Fact]
-        public void TryGetForeignKey_finds_foreign_key_matching_navigation_plus_Id()
-        {
-            var fkProperty = DependentType.AddProperty("SomeNavID", typeof(int));
-            DependentType.AddProperty("SomeNavPeEKaY", typeof(int));
-            DependentType.AddProperty("PrincipalEntityID", typeof(int));
-            DependentType.AddProperty("PrincipalEntityPeEKaY", typeof(int));
-
-            var fk = DependentType.GetOrAddForeignKey(fkProperty, PrincipalType.GetPrimaryKey(), PrincipalType);
-
-            Assert.Same(
-                fk,
-                DependentType.FindForeignKey(
-                    PrincipalType,
-                    "SomeNav",
-                    "SomeInverse",
-                    null,
-                    null,
-                    unique: false));
-        }
-
-        [Fact]
-        public void TryGetForeignKey_finds_foreign_key_matching_navigation_plus_PK_name()
-        {
-            var fkProperty = DependentType.AddProperty("SomeNavPeEKaY", typeof(int));
-            DependentType.AddProperty("PrincipalEntityID", typeof(int));
-            DependentType.AddProperty("PrincipalEntityPeEKaY", typeof(int));
-
-            var fk = DependentType.GetOrAddForeignKey(fkProperty, PrincipalType.GetPrimaryKey(), PrincipalType);
-
-            Assert.Same(
-                fk,
-                DependentType.FindForeignKey(
-                    PrincipalType,
-                    "SomeNav",
-                    "SomeInverse",
-                    null,
-                    null,
-                    unique: false));
-        }
-
-        [Fact]
-        public void TryGetForeignKey_finds_foreign_key_matching_principal_type_name_plus_Id()
-        {
-            var fkProperty = DependentType.AddProperty("PrincipalEntityID", typeof(int));
-            DependentType.AddProperty("PrincipalEntityPeEKaY", typeof(int));
-
-            var fk = DependentType.GetOrAddForeignKey(fkProperty, PrincipalType.GetPrimaryKey(), PrincipalType);
-
-            Assert.Same(
-                fk,
-                DependentType.FindForeignKey(
-                    PrincipalType,
-                    "SomeNav",
-                    "SomeInverse",
-                    null,
-                    null,
-                    unique: false));
-        }
-
-        [Fact]
-        public void TryGetForeignKey_does_not_find_existing_FK_if_FK_has_different_navigation_to_principal()
-        {
-            var fkProperty = DependentType.AddProperty("SharedFk", typeof(int));
-            var fk = DependentType.GetOrAddForeignKey(fkProperty, PrincipalType.GetPrimaryKey(), PrincipalType);
-            DependentType.AddNavigation("AnotherNav", fk, pointsToPrincipal: true);
-
-            var newFk = DependentType.FindForeignKey(
-                PrincipalType,
-                "SomeNav",
-                "SomeInverse",
-                new[] { fkProperty },
-                new Property[0],
-                unique: false);
-
-            Assert.Null(newFk);
-        }
-
-        [Fact]
-        public void TryGetForeignKey_does_not_find_existing_FK_if_FK_has_different_navigation_to_dependent()
-        {
-            var fkProperty = DependentType.AddProperty("SharedFk", typeof(int));
-            var fk = DependentType.GetOrAddForeignKey(fkProperty, PrincipalType.GetPrimaryKey(), PrincipalType);
-            PrincipalType.AddNavigation("AnotherNav", fk, pointsToPrincipal: false);
-
-            var newFk = DependentType.FindForeignKey(
-                PrincipalType,
-                "SomeNav",
-                "SomeInverse",
-                new[] { fkProperty },
-                new Property[0],
-                unique: false);
-
-            Assert.Null(newFk);
-        }
-
-        [Fact]
-        public void TryGetForeignKey_does_not_find_existing_FK_if_FK_has_different_uniqueness()
-        {
-            var fkProperty = DependentType.AddProperty("SharedFk", typeof(int));
-            var fk = DependentType.GetOrAddForeignKey(fkProperty, PrincipalType.GetPrimaryKey(), PrincipalType);
-            fk.IsUnique = true;
-
-            var newFk = DependentType.FindForeignKey(
-                PrincipalType,
-                "SomeNav",
-                "SomeInverse",
-                new[] { fkProperty },
-                new Property[0],
-                unique: false);
-
-            Assert.Null(newFk);
-        }
-
+        
         private static Model BuildModel()
         {
             var model = new Model();
@@ -2035,7 +1854,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             orderType.AddNavigation("Customer", customerForeignKey, pointsToPrincipal: true);
 
             Assert.Equal(
-                Strings.DuplicateNavigation("Customer", typeof(Order).FullName),
+                Strings.DuplicateNavigation("Customer", typeof(Order).Name, typeof(Order).Name),
                 Assert.Throws<InvalidOperationException>(
                     () => orderType.AddNavigation("Customer", customerForeignKey, pointsToPrincipal: true)).Message);
         }
@@ -2054,7 +1873,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             orderType.AddProperty("Customer");
 
             Assert.Equal(
-                Strings.ConflictingProperty("Customer", typeof(Order).FullName),
+                Strings.ConflictingProperty("Customer", typeof(Order).Name, typeof(Order).Name),
                 Assert.Throws<InvalidOperationException>(
                     () => orderType.AddNavigation("Customer", customerForeignKey, pointsToPrincipal: true)).Message);
         }
@@ -2286,7 +2105,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             fk.IsUnique = true;
 
             entityType.AddNavigation("SelfRef1", fk, pointsToPrincipal: false);
-            Assert.Equal(Strings.DuplicateNavigation("SelfRef1", typeof(SelfRef).FullName),
+            Assert.Equal(Strings.DuplicateNavigation("SelfRef1", typeof(SelfRef).Name, typeof(SelfRef).Name),
                 Assert.Throws<InvalidOperationException>(() => entityType.AddNavigation("SelfRef1", fk, pointsToPrincipal: true)).Message);
         }
 
@@ -2375,7 +2194,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var property2 = entityType.AddProperty(Customer.NameProperty);
             entityType.AddIndex(new[] { property1, property2 });
 
-            Assert.Equal(Strings.DuplicateIndex("{'" + Customer.IdProperty.Name + "', '" + Customer.NameProperty.Name + "'}", typeof(Customer).FullName),
+            Assert.Equal(Strings.DuplicateIndex("{'" + Customer.IdProperty.Name + "', '" + Customer.NameProperty.Name + "'}", typeof(Customer).Name, typeof(Customer).Name),
                 Assert.Throws<InvalidOperationException>(
                     () => entityType.AddIndex(new[] { property1, property2 })).Message);
         }
@@ -2639,7 +2458,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             entityType.AddProperty(Customer.IdProperty);
 
             Assert.Equal(
-                Strings.DuplicateProperty("Id", typeof(Customer).FullName),
+                Strings.DuplicateProperty("Id", typeof(Customer).Name, typeof(Customer).Name),
                 Assert.Throws<InvalidOperationException>(() => entityType.AddProperty("Id")).Message);
         }
 
@@ -2657,7 +2476,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             orderType.AddNavigation("Customer", customerForeignKey, pointsToPrincipal: true);
 
             Assert.Equal(
-                Strings.ConflictingNavigation("Customer", typeof(Order).FullName),
+                Strings.ConflictingNavigation("Customer", typeof(Order).Name, typeof(Order).Name),
                 Assert.Throws<InvalidOperationException>(() => orderType.AddProperty("Customer")).Message);
         }
 

--- a/test/EntityFramework.Core.Tests/Metadata/ForeignKeyTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ForeignKeyTest.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Data.Entity.Metadata.Tests
             Assert.Equal(
                 Strings.ForeignKeyCountMismatch("{'P1', 'P2'}", "D", "{'Id'}", "P"),
                 Assert.Throws<InvalidOperationException>(
-                    () => new ForeignKey(new[] { dependentProperty1, dependentProperty2 }, principalType.GetPrimaryKey(), principalType, dependentType)).Message);
+                    () => new ForeignKey(new[] { dependentProperty1, dependentProperty2 }, principalType.GetPrimaryKey(), dependentType, principalType)).Message);
         }
 
         [Fact]
@@ -85,9 +85,9 @@ namespace Microsoft.Data.Entity.Metadata.Tests
                 });
 
             Assert.Equal(
-                Strings.ForeignKeyTypeMismatch("{'P1', 'P2'}", "D", "P"),
+                Strings.ForeignKeyTypeMismatch("{'P1', 'P2'}", "D", "{'Id1', 'Id2'}", "P"),
                 Assert.Throws<InvalidOperationException>(
-                    () => new ForeignKey(new[] { dependentProperty1, dependentProperty2 }, principalType.GetPrimaryKey(), principalType, dependentType)).Message);
+                    () => new ForeignKey(new[] { dependentProperty1, dependentProperty2 }, principalType.GetPrimaryKey(), dependentType, principalType)).Message);
         }
 
         [Fact]
@@ -268,132 +268,7 @@ namespace Microsoft.Data.Entity.Metadata.Tests
             Assert.True(dependentProp1.IsNullable.Value);
             Assert.True(dependentProp2.IsNullable.Value);
         }
-
-        [Fact]
-        public void IsCompatible_returns_true_for_one_to_many_if_all_critaria_match()
-        {
-            var fk = CreateOneToManyFK();
-
-            Assert.True(fk.IsCompatible(
-                fk.PrincipalEntityType,
-                fk.DeclaringEntityType,
-                "OneToManyPrincipal",
-                "OneToManyDependents",
-                fk.Properties,
-                fk.PrincipalKey.Properties,
-                false));
-        }
-
-        [Fact]
-        public void IsCompatible_returns_true_for_one_to_many_if_using_nulls()
-        {
-            var fk = CreateOneToManyFK();
-
-            Assert.True(fk.IsCompatible(
-                fk.PrincipalEntityType,
-                fk.DeclaringEntityType,
-                "OneToManyPrincipal",
-                "OneToManyDependents",
-                null,
-                null,
-                null));
-
-            Assert.True(fk.IsCompatible(
-                fk.PrincipalEntityType,
-                fk.DeclaringEntityType,
-                "OneToManyPrincipal",
-                "OneToManyDependents",
-                new Property[0],
-                new Property[0],
-                null));
-        }
-
-        [Fact]
-        public void IsCompatible_returns_true_for_one_to_many_if_no_navigations_exist()
-        {
-            var fk = CreateOneToManyFK();
-            fk.PrincipalEntityType.RemoveNavigation(fk.PrincipalToDependent);
-            fk.DeclaringEntityType.RemoveNavigation(fk.DependentToPrincipal);
-
-            Assert.True(fk.IsCompatible(
-                fk.PrincipalEntityType,
-                fk.DeclaringEntityType,
-                "Nav",
-                "Nav",
-                fk.Properties,
-                fk.PrincipalKey.Properties,
-                false));
-        }
-
-        [Fact]
-        public void IsCompatible_returns_false_for_one_to_many_if_any_critaria_does_not_match()
-        {
-            var fk = CreateOneToManyFK();
-
-            Assert.False(fk.IsCompatible(
-                fk.DeclaringEntityType,
-                fk.DeclaringEntityType,
-                "OneToManyPrincipal",
-                "OneToManyDependents",
-                fk.Properties,
-                fk.PrincipalKey.Properties,
-                false));
-
-            Assert.False(fk.IsCompatible(
-                fk.PrincipalEntityType,
-                fk.PrincipalEntityType,
-                "OneToManyPrincipal",
-                "OneToManyDependents",
-                fk.Properties,
-                fk.PrincipalKey.Properties,
-                false));
-
-            Assert.False(fk.IsCompatible(
-                fk.PrincipalEntityType,
-                fk.DeclaringEntityType,
-                null,
-                "OneToManyDependents",
-                fk.Properties,
-                fk.PrincipalKey.Properties,
-                false));
-
-            Assert.False(fk.IsCompatible(
-                fk.PrincipalEntityType,
-                fk.DeclaringEntityType,
-                "OneToManyPrincipal",
-                null,
-                fk.Properties,
-                fk.PrincipalKey.Properties,
-                false));
-
-            Assert.False(fk.IsCompatible(
-                fk.PrincipalEntityType,
-                fk.DeclaringEntityType,
-                "OneToManyPrincipal",
-                "OneToManyDependents",
-                fk.PrincipalKey.Properties,
-                fk.PrincipalKey.Properties,
-                false));
-
-            Assert.False(fk.IsCompatible(
-                fk.PrincipalEntityType,
-                fk.DeclaringEntityType,
-                "OneToManyPrincipal",
-                "OneToManyDependents",
-                fk.Properties,
-                fk.Properties,
-                false));
-
-            Assert.False(fk.IsCompatible(
-                fk.PrincipalEntityType,
-                fk.DeclaringEntityType,
-                "OneToManyPrincipal",
-                "OneToManyDependents",
-                fk.Properties,
-                fk.PrincipalKey.Properties,
-                true));
-        }
-
+        
         private ForeignKey CreateOneToManyFK()
         {
             var model = new Model();
@@ -473,63 +348,6 @@ namespace Microsoft.Data.Entity.Metadata.Tests
 
         public class DerivedOneToManyDependent : OneToManyDependent
         {
-        }
-
-        [Fact]
-        public void IsCompatible_returns_true_for_self_ref_one_to_one_if_all_critaria_match()
-        {
-            var fk = CreateSelfRefFK();
-
-            Assert.True(fk.IsCompatible(
-                fk.PrincipalEntityType,
-                fk.DeclaringEntityType,
-                "SelfRefPrincipal",
-                "SelfRefDependent",
-                fk.Properties,
-                fk.PrincipalKey.Properties,
-                true));
-        }
-
-        [Fact]
-        public void IsCompatible_returns_false_for_self_ref_one_to_one_if_any_critaria_does_not_match()
-        {
-            var fk = CreateSelfRefFK();
-
-            Assert.False(fk.IsCompatible(
-                fk.PrincipalEntityType,
-                fk.DeclaringEntityType,
-                "SelfRefDependent",
-                "SelfRefPrincipal",
-                fk.Properties,
-                fk.PrincipalKey.Properties,
-                true));
-
-            Assert.False(fk.IsCompatible(
-                fk.PrincipalEntityType,
-                fk.DeclaringEntityType,
-                null,
-                null,
-                fk.Properties,
-                fk.PrincipalKey.Properties,
-                true));
-
-            Assert.False(fk.IsCompatible(
-                fk.PrincipalEntityType,
-                fk.DeclaringEntityType,
-                "SelfRefPrincipal",
-                "SelfRefDependent",
-                fk.PrincipalKey.Properties,
-                fk.Properties,
-                true));
-
-            Assert.False(fk.IsCompatible(
-                fk.PrincipalEntityType,
-                fk.DeclaringEntityType,
-                "SelfRefPrincipal",
-                "SelfRefDependent",
-                fk.Properties,
-                fk.PrincipalKey.Properties,
-                false));
         }
 
         [Fact]

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/KeyConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/KeyConventionTest.cs
@@ -207,7 +207,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
 
             Assert.Null(keyProperties[0].RequiresValueGenerator);
 
-            referencedEntityBuilder.RemoveRelationship(relationshipBuilder.Metadata, ConfigurationSource.Convention);
+            referencedEntityBuilder.RemoveForeignKey(relationshipBuilder.Metadata, ConfigurationSource.Convention);
 
             Assert.True(keyProperties[0].RequiresValueGenerator);
         }
@@ -379,7 +379,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
 
             Assert.Null(property.ValueGenerated);
 
-            referencedEntityBuilder.RemoveRelationship(relationshipBuilder.Metadata, ConfigurationSource.Convention);
+            referencedEntityBuilder.RemoveForeignKey(relationshipBuilder.Metadata, ConfigurationSource.Convention);
 
             Assert.Same(keyBuilder, new KeyConvention().Apply(keyBuilder));
 

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/OneToManyTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/OneToManyTestBase.cs
@@ -68,20 +68,16 @@ namespace Microsoft.Data.Entity.Tests
 
                 var dependentType = model.GetEntityType(typeof(Order));
                 var principalType = model.GetEntityType(typeof(Customer));
-                var fk = dependentType.GetForeignKeys().Single();
-
-                var navigation = dependentType.GetNavigation("Customer");
+                
 
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
 
                 modelBuilder.Entity<Customer>().HasMany(e => e.Orders).WithOne(e => e.Customer);
 
-                Assert.Equal(1, dependentType.GetForeignKeys().Count());
-                Assert.Equal("Orders", principalType.Navigations.Single().Name);
-                Assert.Same(fk.PrincipalKey, principalType.Navigations.Single().ForeignKey.PrincipalKey);
-                AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name, Customer.NameProperty.Name }, principalType.Properties.Select(p => p.Name));
-                AssertEqual(new[] { "AnotherCustomerId", fk.Properties.Single().Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
+                var fk = dependentType.GetForeignKeys().Single();
+                Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+                Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
                 Assert.Empty(principalType.GetForeignKeys());
                 Assert.Same(principalKey, principalType.GetKeys().Single());
                 Assert.Same(dependentKey, dependentType.GetKeys().Single());
@@ -243,24 +239,17 @@ namespace Microsoft.Data.Entity.Tests
 
                 var dependentType = model.GetEntityType(typeof(Order));
                 var principalType = model.GetEntityType(typeof(Customer));
-
-                var fkProperty = dependentType.GetProperty("CustomerId");
-
+                
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
-
-                // Passing null as the first arg is not super-compelling, but it is consistent
+                
                 modelBuilder.Entity<Customer>().HasMany<Order>().WithOne(e => e.Customer);
 
-                var fk = dependentType.GetForeignKeys().Single();
-                Assert.Same(fkProperty, fk.Properties.Single());
-
-                Assert.Equal("Customer", dependentType.Navigations.Single().Name);
-                Assert.Empty(principalType.Navigations);
-                Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
-                AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name, Customer.NameProperty.Name }, principalType.Properties.Select(p => p.Name));
-                AssertEqual(new[] { "AnotherCustomerId", fk.Properties.Single().Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-                Assert.Empty(principalType.GetForeignKeys());
+                var fk = dependentType.Navigations.Single().ForeignKey;
+                Assert.Same(dependentType.GetProperty(nameof(Order.CustomerId)), fk.Properties.Single());
+                Assert.Equal(nameof(Order.Customer), fk.DependentToPrincipal.Name);
+                Assert.Null(fk.PrincipalToDependent);
+                Assert.NotSame(fk, principalType.Navigations.Single().ForeignKey);
                 Assert.Same(principalKey, principalType.GetKeys().Single());
                 Assert.Same(dependentKey, dependentType.GetKeys().Single());
                 Assert.Same(principalKey, principalType.GetPrimaryKey());
@@ -463,9 +452,7 @@ namespace Microsoft.Data.Entity.Tests
 
                 var dependentType = model.GetEntityType(typeof(Pickle));
                 var principalType = model.GetEntityType(typeof(BigMak));
-
-                var fkProperty = dependentType.GetProperty("BurgerId");
-
+                
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
 
@@ -473,15 +460,11 @@ namespace Microsoft.Data.Entity.Tests
                     .Entity<BigMak>().HasMany<Pickle>().WithOne(e => e.BigMak)
                     .ForeignKey(e => e.BurgerId);
 
-                var fk = dependentType.GetForeignKeys().Single();
-                Assert.Same(fkProperty, fk.Properties.Single());
-
-                Assert.Equal("BigMak", dependentType.Navigations.Single().Name);
-                Assert.Empty(principalType.Navigations);
-                Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
-                AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
-                AssertEqual(new[] { fk.Properties.Single().Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-                Assert.Empty(principalType.GetForeignKeys());
+                var fk = dependentType.Navigations.Single().ForeignKey;
+                Assert.Same(dependentType.GetProperty(nameof(Pickle.BurgerId)), fk.Properties.Single());
+                Assert.Equal(nameof(Pickle.BigMak), fk.DependentToPrincipal.Name);
+                Assert.Null(fk.PrincipalToDependent);
+                Assert.NotSame(fk, principalType.Navigations.Single().ForeignKey);
                 Assert.Same(principalKey, principalType.GetKeys().Single());
                 Assert.Same(dependentKey, dependentType.GetKeys().Single());
                 Assert.Same(principalKey, principalType.GetPrimaryKey());
@@ -616,7 +599,7 @@ namespace Microsoft.Data.Entity.Tests
 
                 modelBuilder.Entity<BigMak>().HasMany<Pickle>().WithOne(e => e.BigMak);
 
-                var fk = dependentType.GetForeignKeys().Single();
+                var fk = dependentType.Navigations.Single().ForeignKey;
                 var fkProperty = (IProperty)fk.Properties.Single();
 
                 Assert.Equal("BigMakId", fkProperty.Name);
@@ -624,12 +607,9 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Same(typeof(int?), fkProperty.ClrType);
                 Assert.Same(dependentType, fkProperty.DeclaringEntityType);
 
-                Assert.Equal("BigMak", dependentType.Navigations.Single().Name);
-                Assert.Empty(principalType.Navigations);
-                Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
-                AssertEqual(new[] { "AlternateKey", principalKey.Properties.Single().Name }, principalType.Properties.Select(p => p.Name));
-                AssertEqual(new[] { fk.Properties.Single().Name, "BurgerId", dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-                Assert.Empty(principalType.GetForeignKeys());
+                Assert.Equal(nameof(Pickle.BigMak), fk.DependentToPrincipal.Name);
+                Assert.Null(fk.PrincipalToDependent);
+                Assert.NotSame(fk, principalType.Navigations.Single().ForeignKey);
                 Assert.Same(principalKey, principalType.GetKeys().Single());
                 Assert.Same(dependentKey, dependentType.GetKeys().Single());
                 Assert.Same(principalKey, principalType.GetPrimaryKey());
@@ -1250,7 +1230,6 @@ namespace Microsoft.Data.Entity.Tests
 
                 var dependentType = model.GetEntityType(typeof(Tomato));
                 var principalType = model.GetEntityType(typeof(Whoopper));
-                var fk = dependentType.GetForeignKeys().Single();
 
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
@@ -1259,12 +1238,11 @@ namespace Microsoft.Data.Entity.Tests
                     .Entity<Whoopper>().HasMany(e => e.Tomatoes).WithOne(e => e.Whoopper)
                     .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
 
-                Assert.Equal(1, dependentType.GetForeignKeys().Count());
-                Assert.Equal("Whoopper", dependentType.Navigations.Single().Name);
-                Assert.Equal("Tomatoes", principalType.Navigations.Single().Name);
-                Assert.Same(fk.PrincipalKey, principalType.Navigations.Single().ForeignKey.PrincipalKey);
-                AssertEqual(new[] { "AlternateKey1", "AlternateKey2", principalKey.Properties[0].Name, principalKey.Properties[1].Name }, principalType.Properties.Select(p => p.Name));
-                AssertEqual(new[] { fk.Properties[0].Name, fk.Properties[1].Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
+                var fk = dependentType.GetForeignKeys().Single();
+                Assert.Equal(nameof(Tomato.Whoopper), dependentType.Navigations.Single().Name);
+                Assert.Equal(nameof(Whoopper.Tomatoes), principalType.Navigations.Single().Name);
+                Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+                Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
                 Assert.Empty(principalType.GetForeignKeys());
                 Assert.Same(principalKey, principalType.GetKeys().Single());
                 Assert.Same(dependentKey, dependentType.GetKeys().Single());
@@ -1467,10 +1445,7 @@ namespace Microsoft.Data.Entity.Tests
 
                 var dependentType = model.GetEntityType(typeof(Tomato));
                 var principalType = model.GetEntityType(typeof(Whoopper));
-
-                var fkProperty1 = dependentType.GetProperty("BurgerId1");
-                var fkProperty2 = dependentType.GetProperty("BurgerId2");
-
+                
                 var principalKey = principalType.GetPrimaryKey();
                 var dependentKey = dependentType.GetKeys().Single();
 
@@ -1478,16 +1453,13 @@ namespace Microsoft.Data.Entity.Tests
                     .Entity<Whoopper>().HasMany<Tomato>().WithOne(e => e.Whoopper)
                     .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
 
-                var fk = dependentType.GetForeignKeys().Single();
-                Assert.Same(fkProperty1, fk.Properties[0]);
-                Assert.Same(fkProperty2, fk.Properties[1]);
+                var fk = dependentType.Navigations.Single().ForeignKey;
+                Assert.Same(dependentType.GetProperty(nameof(Tomato.BurgerId1)), fk.Properties[0]);
+                Assert.Same(dependentType.GetProperty(nameof(Tomato.BurgerId2)), fk.Properties[1]);
 
-                Assert.Equal("Whoopper", dependentType.Navigations.Single().Name);
-                Assert.Empty(principalType.Navigations);
-                Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
-                AssertEqual(new[] { "AlternateKey1", "AlternateKey2", principalKey.Properties[0].Name, principalKey.Properties[1].Name }, principalType.Properties.Select(p => p.Name));
-                AssertEqual(new[] { fk.Properties[0].Name, fk.Properties[1].Name, dependentKey.Properties.Single().Name }, dependentType.Properties.Select(p => p.Name));
-                Assert.Empty(principalType.GetForeignKeys());
+                Assert.Equal(nameof(Tomato.Whoopper), fk.DependentToPrincipal.Name);
+                Assert.Null(fk.PrincipalToDependent);
+                Assert.NotSame(fk, principalType.Navigations.Single().ForeignKey);
                 Assert.Same(principalKey, principalType.GetKeys().Single());
                 Assert.Same(dependentKey, dependentType.GetKeys().Single());
                 Assert.Same(principalKey, principalType.GetPrimaryKey());
@@ -1591,12 +1563,16 @@ namespace Microsoft.Data.Entity.Tests
                 modelBuilder
                     .Entity<Hob>().HasMany(e => e.Nobs).WithOne(e => e.Hob)
                     .ForeignKey(e => new { e.HobId1, e.HobId2 });
-
+                
                 var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob));
-
-                Assert.True(entityType.GetProperty("HobId1").IsNullable);
-                Assert.True(entityType.GetProperty("HobId1").IsNullable);
-                Assert.False(entityType.GetForeignKeys().Single().IsRequired);
+                var fk = entityType.GetForeignKeys().Single();
+                Assert.False(fk.IsRequired);
+                var fkProperty1 = entityType.GetProperty(nameof(Nob.HobId1));
+                var fkProperty2 = entityType.GetProperty(nameof(Nob.HobId2));
+                Assert.True(fkProperty1.IsNullable);
+                Assert.True(fkProperty2.IsNullable);
+                Assert.Contains(fkProperty1, fk.Properties);
+                Assert.Contains(fkProperty2, fk.Properties);
             }
 
             [Fact]
@@ -1609,10 +1585,14 @@ namespace Microsoft.Data.Entity.Tests
                     .ForeignKey(e => new { e.NobId1, e.NobId2 });
 
                 var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Hob));
-
-                Assert.False(entityType.GetProperty("NobId1").IsNullable);
-                Assert.False(entityType.GetProperty("NobId1").IsNullable);
-                Assert.True(entityType.GetForeignKeys().Single().IsRequired);
+                var fk = entityType.GetForeignKeys().Single();
+                Assert.True(fk.IsRequired);
+                var fkProperty1 = entityType.GetProperty(nameof(Hob.NobId1));
+                var fkProperty2 = entityType.GetProperty(nameof(Hob.NobId2));
+                Assert.False(fkProperty1.IsNullable);
+                Assert.False(fkProperty2.IsNullable);
+                Assert.Contains(fkProperty1, fk.Properties);
+                Assert.Contains(fkProperty2, fk.Properties);
             }
 
             [Fact]
@@ -1626,29 +1606,35 @@ namespace Microsoft.Data.Entity.Tests
                     .Required();
 
                 var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob));
-
-                Assert.False(entityType.GetProperty("HobId1").IsNullable);
-                Assert.False(entityType.GetProperty("HobId1").IsNullable);
-                Assert.True(entityType.GetForeignKeys().Single().IsRequired);
+                var fk = entityType.GetForeignKeys().Single();
+                Assert.True(fk.IsRequired);
+                var fkProperty1 = entityType.GetProperty(nameof(Nob.HobId1));
+                var fkProperty2 = entityType.GetProperty(nameof(Nob.HobId2));
+                Assert.False(fkProperty1.IsNullable);
+                Assert.False(fkProperty2.IsNullable);
+                Assert.Contains(fkProperty1, fk.Properties);
+                Assert.Contains(fkProperty2, fk.Properties);
             }
 
             [Fact]
-            public virtual void Non_nullable_FK_cannot_be_made_optional()
+            public virtual void Non_nullable_FK_can_be_made_optional()
             {
                 var modelBuilder = HobNobBuilder();
-
-                Assert.Equal(
-                    Strings.ForeignKeyCannotBeOptional("{'NobId1', 'NobId2'}", typeof(Hob).Name),
-                    Assert.Throws<InvalidOperationException>(() => modelBuilder
-                        .Entity<Nob>().HasMany(e => e.Hobs).WithOne(e => e.Nob)
-                        .ForeignKey(e => new { e.NobId1, e.NobId2 })
-                        .Required(false)).Message);
+                
+                modelBuilder
+                    .Entity<Nob>().HasMany(e => e.Hobs).WithOne(e => e.Nob)
+                    .ForeignKey(e => new { e.NobId1, e.NobId2 })
+                    .Required(false);
 
                 var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Hob));
-
-                Assert.False(entityType.GetProperty("NobId1").IsNullable);
-                Assert.False(entityType.GetProperty("NobId1").IsNullable);
-                Assert.True(entityType.GetForeignKeys().Single().IsRequired);
+                var fk = entityType.GetForeignKeys().Single();
+                Assert.False(fk.IsRequired);
+                var fkProperty1 = entityType.GetProperty(nameof(Hob.NobId1));
+                var fkProperty2 = entityType.GetProperty(nameof(Hob.NobId2));
+                Assert.False(fkProperty1.IsNullable);
+                Assert.False(fkProperty2.IsNullable);
+                Assert.DoesNotContain(fkProperty1, fk.Properties);
+                Assert.DoesNotContain(fkProperty2, fk.Properties);
             }
             
             [Fact]

--- a/test/EntityFramework.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -20,11 +20,11 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             base.Multi_level_include_one_to_many_optional_and_one_to_many_optional_produces_valid_sql();
 
             Assert.Equal(
-                @"SELECT [e].[Id], [e].[Name], [e].[OneToMany_Optional_Self_InverseId], [e].[OneToMany_Required_Self_InverseId]
+                @"SELECT [e].[Id], [e].[Name], [e].[OneToMany_Optional_Self_InverseId], [e].[OneToMany_Required_Self_InverseId], [e].[OneToOne_Optional_SelfId]
 FROM [Level1] AS [e]
 ORDER BY [e].[Id]
 
-SELECT [l].[Id], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Name], [l].[OneToMany_Optional_InverseId], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_PK_InverseId]
+SELECT [l].[Id], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Name], [l].[OneToMany_Optional_InverseId], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_PK_InverseId], [l].[OneToOne_Optional_SelfId]
 FROM [Level2] AS [l]
 INNER JOIN (
     SELECT DISTINCT [e].[Id]
@@ -32,7 +32,7 @@ INNER JOIN (
 ) AS [e] ON [l].[OneToMany_Optional_InverseId] = [e].[Id]
 ORDER BY [e].[Id], [l].[Id]
 
-SELECT [l].[Id], [l].[Level2_Optional_Id], [l].[Level2_Required_Id], [l].[Name], [l].[OneToMany_Optional_InverseId], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_PK_InverseId]
+SELECT [l].[Id], [l].[Level2_Optional_Id], [l].[Level2_Required_Id], [l].[Name], [l].[OneToMany_Optional_InverseId], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_PK_InverseId], [l].[OneToOne_Optional_SelfId]
 FROM [Level3] AS [l]
 INNER JOIN (
     SELECT DISTINCT [e].[Id], [l].[Id] AS [Id0]
@@ -50,11 +50,11 @@ ORDER BY [l0].[Id], [l0].[Id0]", Sql);
             base.Multi_level_include_correct_PK_is_chosen_as_the_join_predicate_for_queries_that_join_same_table_multiple_times();
 
             Assert.Equal(
-                @"SELECT [e].[Id], [e].[Name], [e].[OneToMany_Optional_Self_InverseId], [e].[OneToMany_Required_Self_InverseId]
+                @"SELECT [e].[Id], [e].[Name], [e].[OneToMany_Optional_Self_InverseId], [e].[OneToMany_Required_Self_InverseId], [e].[OneToOne_Optional_SelfId]
 FROM [Level1] AS [e]
 ORDER BY [e].[Id]
 
-SELECT [l].[Id], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Name], [l].[OneToMany_Optional_InverseId], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_PK_InverseId]
+SELECT [l].[Id], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Name], [l].[OneToMany_Optional_InverseId], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_PK_InverseId], [l].[OneToOne_Optional_SelfId]
 FROM [Level2] AS [l]
 INNER JOIN (
     SELECT DISTINCT [e].[Id]
@@ -62,7 +62,7 @@ INNER JOIN (
 ) AS [e] ON [l].[OneToMany_Optional_InverseId] = [e].[Id]
 ORDER BY [e].[Id], [l].[Id]
 
-SELECT [l].[Id], [l].[Level2_Optional_Id], [l].[Level2_Required_Id], [l].[Name], [l].[OneToMany_Optional_InverseId], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_PK_InverseId], [l1].[Id], [l1].[Level1_Optional_Id], [l1].[Level1_Required_Id], [l1].[Name], [l1].[OneToMany_Optional_InverseId], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_PK_InverseId]
+SELECT [l].[Id], [l].[Level2_Optional_Id], [l].[Level2_Required_Id], [l].[Name], [l].[OneToMany_Optional_InverseId], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_PK_InverseId], [l].[OneToOne_Optional_SelfId], [l1].[Id], [l1].[Level1_Optional_Id], [l1].[Level1_Required_Id], [l1].[Name], [l1].[OneToMany_Optional_InverseId], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_PK_InverseId], [l1].[OneToOne_Optional_SelfId]
 FROM [Level3] AS [l]
 INNER JOIN (
     SELECT DISTINCT [e].[Id], [l].[Id] AS [Id0]
@@ -75,7 +75,7 @@ INNER JOIN (
 INNER JOIN [Level2] AS [l1] ON [l].[OneToMany_Required_InverseId] = [l1].[Id]
 ORDER BY [l0].[Id], [l0].[Id0], [l1].[Id]
 
-SELECT [l].[Id], [l].[Level2_Optional_Id], [l].[Level2_Required_Id], [l].[Name], [l].[OneToMany_Optional_InverseId], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_PK_InverseId]
+SELECT [l].[Id], [l].[Level2_Optional_Id], [l].[Level2_Required_Id], [l].[Name], [l].[OneToMany_Optional_InverseId], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_PK_InverseId], [l].[OneToOne_Optional_SelfId]
 FROM [Level3] AS [l]
 INNER JOIN (
     SELECT DISTINCT [l0].[Id], [l0].[Id0], [l1].[Id] AS [Id1]

--- a/test/EntityFramework.Sqlite.FunctionalTests/ComplexNavigationsQuerySqliteTest.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/ComplexNavigationsQuerySqliteTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Data.Entity.FunctionalTests.TestModels.ComplexNavigationsModel;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
@@ -18,11 +19,11 @@ namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
             base.Multi_level_include_one_to_many_optional_and_one_to_many_optional_produces_valid_sql();
 
             Assert.Equal(
-                @"SELECT ""e"".""Id"", ""e"".""Name"", ""e"".""OneToMany_Optional_Self_InverseId"", ""e"".""OneToMany_Required_Self_InverseId""
+                @"SELECT ""e"".""Id"", ""e"".""Name"", ""e"".""OneToMany_Optional_Self_InverseId"", ""e"".""OneToMany_Required_Self_InverseId"", ""e"".""OneToOne_Optional_SelfId""
 FROM ""Level1"" AS ""e""
 ORDER BY ""e"".""Id""
 
-SELECT ""l"".""Id"", ""l"".""Level1_Optional_Id"", ""l"".""Level1_Required_Id"", ""l"".""Name"", ""l"".""OneToMany_Optional_InverseId"", ""l"".""OneToMany_Optional_Self_InverseId"", ""l"".""OneToMany_Required_InverseId"", ""l"".""OneToMany_Required_Self_InverseId"", ""l"".""OneToOne_Optional_PK_InverseId""
+SELECT ""l"".""Id"", ""l"".""Level1_Optional_Id"", ""l"".""Level1_Required_Id"", ""l"".""Name"", ""l"".""OneToMany_Optional_InverseId"", ""l"".""OneToMany_Optional_Self_InverseId"", ""l"".""OneToMany_Required_InverseId"", ""l"".""OneToMany_Required_Self_InverseId"", ""l"".""OneToOne_Optional_PK_InverseId"", ""l"".""OneToOne_Optional_SelfId""
 FROM ""Level2"" AS ""l""
 INNER JOIN (
     SELECT DISTINCT ""e"".""Id""
@@ -30,7 +31,7 @@ INNER JOIN (
 ) AS ""e"" ON ""l"".""OneToMany_Optional_InverseId"" = ""e"".""Id""
 ORDER BY ""e"".""Id"", ""l"".""Id""
 
-SELECT ""l"".""Id"", ""l"".""Level2_Optional_Id"", ""l"".""Level2_Required_Id"", ""l"".""Name"", ""l"".""OneToMany_Optional_InverseId"", ""l"".""OneToMany_Optional_Self_InverseId"", ""l"".""OneToMany_Required_InverseId"", ""l"".""OneToMany_Required_Self_InverseId"", ""l"".""OneToOne_Optional_PK_InverseId""
+SELECT ""l"".""Id"", ""l"".""Level2_Optional_Id"", ""l"".""Level2_Required_Id"", ""l"".""Name"", ""l"".""OneToMany_Optional_InverseId"", ""l"".""OneToMany_Optional_Self_InverseId"", ""l"".""OneToMany_Required_InverseId"", ""l"".""OneToMany_Required_Self_InverseId"", ""l"".""OneToOne_Optional_PK_InverseId"", ""l"".""OneToOne_Optional_SelfId""
 FROM ""Level3"" AS ""l""
 INNER JOIN (
     SELECT DISTINCT ""e"".""Id"", ""l"".""Id"" AS ""Id0""
@@ -48,11 +49,11 @@ ORDER BY ""l0"".""Id"", ""l0"".""Id0""", Sql);
             base.Multi_level_include_correct_PK_is_chosen_as_the_join_predicate_for_queries_that_join_same_table_multiple_times();
 
             Assert.Equal(
-                @"SELECT ""e"".""Id"", ""e"".""Name"", ""e"".""OneToMany_Optional_Self_InverseId"", ""e"".""OneToMany_Required_Self_InverseId""
+                @"SELECT ""e"".""Id"", ""e"".""Name"", ""e"".""OneToMany_Optional_Self_InverseId"", ""e"".""OneToMany_Required_Self_InverseId"", ""e"".""OneToOne_Optional_SelfId""
 FROM ""Level1"" AS ""e""
 ORDER BY ""e"".""Id""
 
-SELECT ""l"".""Id"", ""l"".""Level1_Optional_Id"", ""l"".""Level1_Required_Id"", ""l"".""Name"", ""l"".""OneToMany_Optional_InverseId"", ""l"".""OneToMany_Optional_Self_InverseId"", ""l"".""OneToMany_Required_InverseId"", ""l"".""OneToMany_Required_Self_InverseId"", ""l"".""OneToOne_Optional_PK_InverseId""
+SELECT ""l"".""Id"", ""l"".""Level1_Optional_Id"", ""l"".""Level1_Required_Id"", ""l"".""Name"", ""l"".""OneToMany_Optional_InverseId"", ""l"".""OneToMany_Optional_Self_InverseId"", ""l"".""OneToMany_Required_InverseId"", ""l"".""OneToMany_Required_Self_InverseId"", ""l"".""OneToOne_Optional_PK_InverseId"", ""l"".""OneToOne_Optional_SelfId""
 FROM ""Level2"" AS ""l""
 INNER JOIN (
     SELECT DISTINCT ""e"".""Id""
@@ -60,7 +61,7 @@ INNER JOIN (
 ) AS ""e"" ON ""l"".""OneToMany_Optional_InverseId"" = ""e"".""Id""
 ORDER BY ""e"".""Id"", ""l"".""Id""
 
-SELECT ""l"".""Id"", ""l"".""Level2_Optional_Id"", ""l"".""Level2_Required_Id"", ""l"".""Name"", ""l"".""OneToMany_Optional_InverseId"", ""l"".""OneToMany_Optional_Self_InverseId"", ""l"".""OneToMany_Required_InverseId"", ""l"".""OneToMany_Required_Self_InverseId"", ""l"".""OneToOne_Optional_PK_InverseId"", ""l1"".""Id"", ""l1"".""Level1_Optional_Id"", ""l1"".""Level1_Required_Id"", ""l1"".""Name"", ""l1"".""OneToMany_Optional_InverseId"", ""l1"".""OneToMany_Optional_Self_InverseId"", ""l1"".""OneToMany_Required_InverseId"", ""l1"".""OneToMany_Required_Self_InverseId"", ""l1"".""OneToOne_Optional_PK_InverseId""
+SELECT ""l"".""Id"", ""l"".""Level2_Optional_Id"", ""l"".""Level2_Required_Id"", ""l"".""Name"", ""l"".""OneToMany_Optional_InverseId"", ""l"".""OneToMany_Optional_Self_InverseId"", ""l"".""OneToMany_Required_InverseId"", ""l"".""OneToMany_Required_Self_InverseId"", ""l"".""OneToOne_Optional_PK_InverseId"", ""l"".""OneToOne_Optional_SelfId"", ""l1"".""Id"", ""l1"".""Level1_Optional_Id"", ""l1"".""Level1_Required_Id"", ""l1"".""Name"", ""l1"".""OneToMany_Optional_InverseId"", ""l1"".""OneToMany_Optional_Self_InverseId"", ""l1"".""OneToMany_Required_InverseId"", ""l1"".""OneToMany_Required_Self_InverseId"", ""l1"".""OneToOne_Optional_PK_InverseId"", ""l1"".""OneToOne_Optional_SelfId""
 FROM ""Level3"" AS ""l""
 INNER JOIN (
     SELECT DISTINCT ""e"".""Id"", ""l"".""Id"" AS ""Id0""
@@ -73,7 +74,7 @@ INNER JOIN (
 INNER JOIN ""Level2"" AS ""l1"" ON ""l"".""OneToMany_Required_InverseId"" = ""l1"".""Id""
 ORDER BY ""l0"".""Id"", ""l0"".""Id0"", ""l1"".""Id""
 
-SELECT ""l"".""Id"", ""l"".""Level2_Optional_Id"", ""l"".""Level2_Required_Id"", ""l"".""Name"", ""l"".""OneToMany_Optional_InverseId"", ""l"".""OneToMany_Optional_Self_InverseId"", ""l"".""OneToMany_Required_InverseId"", ""l"".""OneToMany_Required_Self_InverseId"", ""l"".""OneToOne_Optional_PK_InverseId""
+SELECT ""l"".""Id"", ""l"".""Level2_Optional_Id"", ""l"".""Level2_Required_Id"", ""l"".""Name"", ""l"".""OneToMany_Optional_InverseId"", ""l"".""OneToMany_Optional_Self_InverseId"", ""l"".""OneToMany_Required_InverseId"", ""l"".""OneToMany_Required_Self_InverseId"", ""l"".""OneToOne_Optional_PK_InverseId"", ""l"".""OneToOne_Optional_SelfId""
 FROM ""Level3"" AS ""l""
 INNER JOIN (
     SELECT DISTINCT ""l0"".""Id"", ""l0"".""Id0"", ""l1"".""Id"" AS ""Id1""


### PR DESCRIPTION
Add OnNavigationRemoved to allow RelationshipDiscoveryConvention use the navigations that have been freed
Relationship configuration that conflicts with previous configuration will now override it instead of throwing
Refactor internal builders to remove redundant code.

Part of #1704
Fixes #2987