### PR TITLE
Allow providers and users to override design-time services

### DIFF
--- a/src/EntityFramework.Commands/Design/DatabaseOperations.cs
+++ b/src/EntityFramework.Commands/Design/DatabaseOperations.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Data.Entity.Design
             [NotNull] ILoggerProvider loggerProvider,
             [NotNull] string assemblyName,
             [NotNull] string startupAssemblyName,
+            [CanBeNull] string environment,
             [NotNull] string projectDir,
             [NotNull] string rootNamespace,
             [CanBeNull] IServiceProvider dnxServices = null)
@@ -38,7 +39,9 @@ namespace Microsoft.Data.Entity.Design
             _loggerProvider = loggerProvider;
             _projectDir = projectDir;
             _rootNamespace = rootNamespace;
-            _servicesBuilder = new DesignTimeServicesBuilder(dnxServices);
+
+            var startup = new StartupInvoker(startupAssemblyName, environment, dnxServices);
+            _servicesBuilder = new DesignTimeServicesBuilder(startup, dnxServices);
         }
 
         public virtual Task<ReverseEngineerFiles> ReverseEngineerAsync(

--- a/src/EntityFramework.Commands/Design/DbContextOperations.cs
+++ b/src/EntityFramework.Commands/Design/DbContextOperations.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Data.Entity.Design
         private readonly ILoggerProvider _loggerProvider;
         private readonly string _assemblyName;
         private readonly string _startupAssemblyName;
+        private readonly string _environment;
         private readonly IServiceProvider _dnxServices;
         private readonly LazyRef<ILogger> _logger;
         private Assembly _assembly;
@@ -33,6 +34,7 @@ namespace Microsoft.Data.Entity.Design
             [NotNull] ILoggerProvider loggerProvider,
             [NotNull] string assemblyName,
             [NotNull] string startupAssemblyName,
+            [CanBeNull] string environment,
             [CanBeNull] IServiceProvider dnxServices = null)
         {
             Check.NotNull(loggerProvider, nameof(loggerProvider));
@@ -42,6 +44,7 @@ namespace Microsoft.Data.Entity.Design
             _loggerProvider = loggerProvider;
             _assemblyName = assemblyName;
             _startupAssemblyName = startupAssemblyName;
+            _environment = environment;
             _dnxServices = dnxServices;
             _logger = new LazyRef<ILogger>(() => _loggerProvider.CreateCommandsLogger());
         }
@@ -72,7 +75,10 @@ namespace Microsoft.Data.Entity.Design
         private DbContext TryCreateContextFromStartup(Type type)
         {
             var hostBuilder = new WebHostBuilder(_dnxServices)
-                .UseEnvironment(EnvironmentName.Development);
+                .UseEnvironment(
+                    !string.IsNullOrEmpty(_environment)
+                        ? _environment
+                        : EnvironmentName.Development);
             if (_startupAssemblyName != null)
             {
                 hostBuilder.UseStartup(_startupAssemblyName);

--- a/src/EntityFramework.Commands/Design/Internal/StartupInvoker.cs
+++ b/src/EntityFramework.Commands/Design/Internal/StartupInvoker.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Utilities;
+using Microsoft.Framework.DependencyInjection;
+
+#if DNX451 || DNXCORE50
+using Microsoft.AspNet.Hosting;
+#endif
+
+namespace Microsoft.Data.Entity.Design.Internal
+{
+    public class StartupInvoker
+    {
+        private readonly TypeInfo _startupType;
+        private readonly string _environment;
+        private readonly IServiceProvider _dnxServices;
+
+        public StartupInvoker(
+            [NotNull] string startupAssemblyName,
+            [CanBeNull] string environment,
+            [CanBeNull] IServiceProvider dnxServices)
+        {
+            Check.NotEmpty(startupAssemblyName, nameof(startupAssemblyName));
+
+            _environment = !string.IsNullOrEmpty(environment)
+                ? environment
+                : "Development";
+
+            var startupAssembly = Assembly.Load(new AssemblyName(startupAssemblyName));
+            _startupType = startupAssembly.DefinedTypes.Where(t => t.Name == "Startup" + _environment)
+                .Concat(startupAssembly.DefinedTypes.Where(t => t.Name == "Startup"))
+                .FirstOrDefault();
+
+            _dnxServices = dnxServices;
+        }
+
+        public virtual void ConfigureDesignTimeServices([NotNull] IServiceCollection services)
+        {
+            if (_startupType == null)
+            {
+                return;
+            }
+
+            var method = _startupType.GetDeclaredMethod("ConfigureDesignTimeServices");
+            if (method == null)
+            {
+                return;
+            }
+
+            var instance = !method.IsStatic
+                ? ActivatorUtilities.GetServiceOrCreateInstance(GetHostServices(), _startupType.AsType())
+                : null;
+
+            var parameters = method.GetParameters();
+            var arguments = new object[parameters.Length];
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                var parameterType = parameters[i].ParameterType;
+                arguments[i] = parameterType == typeof(IServiceCollection)
+                    ? services
+                    : ActivatorUtilities.GetServiceOrCreateInstance(GetHostServices(), parameterType);
+            }
+
+            method.Invoke(instance, arguments);
+        }
+
+        protected virtual IServiceProvider GetHostServices()
+            => new ServiceCollection()
+#if DNX451 || DNXCORE50
+                .ImportDnxServices(_dnxServices)
+                .AddInstance<IHostingEnvironment>(new HostingEnvironment { EnvironmentName = _environment })
+#endif
+                .AddLogging()
+                .BuildServiceProvider();
+    }
+}

--- a/src/EntityFramework.Commands/Design/MigrationsOperations.cs
+++ b/src/EntityFramework.Commands/Design/MigrationsOperations.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Data.Entity.Design
             [NotNull] ILoggerProvider loggerProvider,
             [NotNull] string assemblyName,
             [NotNull] string startupAssemblyName,
+            [CanBeNull] string environment,
             [NotNull] string projectDir,
             [NotNull] string rootNamespace,
             [CanBeNull] IServiceProvider dnxServices = null)
@@ -46,12 +47,15 @@ namespace Microsoft.Data.Entity.Design
             _logger = new LazyRef<ILogger>(() => loggerFactory.CreateCommandsLogger());
             _projectDir = projectDir;
             _rootNamespace = rootNamespace;
-            _servicesBuilder = new DesignTimeServicesBuilder(dnxServices);
             _contextOperations = new DbContextOperations(
                 loggerProvider,
                 assemblyName,
                 startupAssemblyName,
+                environment,
                 dnxServices);
+
+            var startup = new StartupInvoker(startupAssemblyName, environment, dnxServices);
+            _servicesBuilder = new DesignTimeServicesBuilder(startup, dnxServices);
         }
 
         public virtual MigrationFiles AddMigration(

--- a/src/EntityFramework.Commands/Design/OperationExecutor.cs
+++ b/src/EntityFramework.Commands/Design/OperationExecutor.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Data.Entity.Design
 
             var targetName = (string)args["targetName"];
             var startupTargetName = (string)args["startupTargetName"];
+            var environment = (string)args["environment"];
             var projectDir = (string)args["projectDir"];
             var rootNamespace = (string)args["rootNamespace"];
 
@@ -37,12 +38,14 @@ namespace Microsoft.Data.Entity.Design
                 () => new DbContextOperations(
                     loggerProvider,
                     targetName,
-                    startupTargetName));
+                    startupTargetName,
+                    environment));
             _databaseOperations = new LazyRef<DatabaseOperations>(
                 () => new DatabaseOperations(
                     loggerProvider,
                     targetName,
                     startupTargetName,
+                    environment,
                     projectDir,
                     rootNamespace));
             _migrationsOperations = new LazyRef<MigrationsOperations>(
@@ -50,6 +53,7 @@ namespace Microsoft.Data.Entity.Design
                     loggerProvider,
                     targetName,
                     startupTargetName,
+                    environment,
                     projectDir,
                     rootNamespace));
         }

--- a/src/EntityFramework.Commands/EntityFramework.Commands.csproj
+++ b/src/EntityFramework.Commands/EntityFramework.Commands.csproj
@@ -49,6 +49,7 @@
     <Compile Include="..\Shared\SharedTypeExtensions.cs">
       <Link>Extensions\SharedTypeExtensions.cs</Link>
     </Compile>
+    <Compile Include="Design\Internal\StartupInvoker.cs" />
     <Compile Include="Design\MigrationInfo.cs" />
     <Compile Include="Design\OperationException.cs" />
     <Compile Include="Design\DbContextOperations.cs" />
@@ -59,6 +60,7 @@
     <Compile Include="Extensions\CommandLineUtilsExtensions.cs" />
     <Compile Include="Design\OperationHandlers.cs" />
     <Compile Include="Design\MigrationsOperations.cs" />
+    <Compile Include="Extensions\ServiceCollectionExtensions.cs" />
     <Compile Include="Migrations\Design\ScaffoldedMigration.cs" />
     <Compile Include="Migrations\Design\CSharpMigrationsGenerator.cs" />
     <Compile Include="Migrations\Design\CSharpMigrationOperationGenerator.cs" />

--- a/src/EntityFramework.Commands/Extensions/ServiceCollectionExtensions.cs
+++ b/src/EntityFramework.Commands/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if DNX451 || DNXCORE50
+
+// ReSharper disable once CheckNamespace
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.Dnx.Runtime;
+
+namespace Microsoft.Framework.DependencyInjection
+{
+    internal static class ServiceCollectionExtensions
+    {
+        public static IServiceCollection ImportDnxServices(
+            [NotNull] this IServiceCollection services,
+            [CanBeNull] IServiceProvider dnxServices)
+        {
+            if (dnxServices != null)
+            {
+                var runtimeServices = dnxServices.GetRequiredService<IRuntimeServices>();
+                foreach (var service in runtimeServices.Services)
+                {
+                    services.AddTransient(service, _ => dnxServices.GetService(service));
+                }
+            }
+
+            return services;
+        }
+    }
+}
+
+#endif

--- a/src/EntityFramework.Commands/project.json
+++ b/src/EntityFramework.Commands/project.json
@@ -26,18 +26,14 @@
       "dependencies": {
         "EntityFramework.Relational.Design": "7.0.0-*",
         "Microsoft.AspNet.Hosting": "1.0.0-*",
-        "Microsoft.Framework.CommandLineUtils.Sources": { "version": "1.0.0-*", "type": "build" },
-        "Microsoft.Framework.DependencyInjection.Abstractions": "1.0.0-*",
-        "Microsoft.Dnx.Runtime.Abstractions": "1.0.0-*"
+        "Microsoft.Framework.CommandLineUtils.Sources": { "version": "1.0.0-*", "type": "build" }
       }
     },
     "dnxcore50": {
       "dependencies": {
         "EntityFramework.Relational.Design": "7.0.0-*",
         "Microsoft.AspNet.Hosting": "1.0.0-*",
-        "Microsoft.Framework.CommandLineUtils.Sources": { "version": "1.0.0-*", "type": "build" },
-        "Microsoft.Framework.DependencyInjection.Abstractions": "1.0.0-*",
-        "Microsoft.Dnx.Runtime.Abstractions": "1.0.0-*"
+        "Microsoft.Framework.CommandLineUtils.Sources": { "version": "1.0.0-*", "type": "build" }
       }
     },
     "uap10.0": {

--- a/test/EntityFramework.Commands.Tests/Design/Internal/StartupInvokerTest.cs
+++ b/test/EntityFramework.Commands.Tests/Design/Internal/StartupInvokerTest.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Framework.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Design.Internal
+{
+    public class StartupInvokerTest
+    {
+        [Fact]
+        public void ConfigureDesignTimeServices_uses_Development_environment_when_unspecified()
+        {
+            var services = new ServiceCollection();
+            var startup = new StartupInvoker(
+                typeof(StartupInvokerTest).Assembly.FullName,
+                environment: null,
+                dnxServices: null);
+
+            startup.ConfigureDesignTimeServices(services);
+
+            var service = services.BuildServiceProvider().GetRequiredService<TestService>();
+            Assert.Equal("Development", service.Value);
+        }
+
+        [Fact]
+        public void ConfigureDesignTimeServices_invokes_static_methods()
+        {
+            var services = new ServiceCollection();
+            var startup = new StartupInvoker(
+                typeof(StartupInvokerTest).Assembly.FullName,
+                "Static",
+                dnxServices: null);
+
+            startup.ConfigureDesignTimeServices(services);
+
+            var service = services.BuildServiceProvider().GetRequiredService<TestService>();
+            Assert.Equal("Static", service.Value);
+        }
+    }
+
+    public class StartupDevelopment
+    {
+        public void ConfigureDesignTimeServices(IServiceCollection services)
+            => services.AddInstance(new TestService("Development"));
+    }
+
+    public class StartupStatic
+    {
+        public static void ConfigureDesignTimeServices(IServiceCollection services)
+            => services.AddInstance(new TestService("Static"));
+    }
+
+    public class TestService
+    {
+        public TestService(string value)
+        {
+            Value = value;
+        }
+
+        public string Value { get; }
+    }
+}

--- a/test/EntityFramework.Commands.Tests/EntityFramework.Commands.Tests.csproj
+++ b/test/EntityFramework.Commands.Tests/EntityFramework.Commands.Tests.csproj
@@ -8,7 +8,7 @@
     <ProjectGuid>{38F9AD16-B3B4-48A5-B814-77660CF409AE}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Microsoft.Data.Entity.Commands</RootNamespace>
+    <RootNamespace>Microsoft.Data.Entity</RootNamespace>
     <AssemblyName>EntityFramework.Commands.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
@@ -31,6 +31,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="System" />
     <Reference Include="System.Data" />
   </ItemGroup>
   <ItemGroup>
@@ -38,6 +39,7 @@
       <Link>Design\OperationHandlers.cs</Link>
     </Compile>
     <Compile Include="ApiConsistencyTest.cs" />
+    <Compile Include="Design\Internal\StartupInvokerTest.cs" />
     <Compile Include="Design\OperationResultHandlerTest.cs" />
     <Compile Include="Design\OperationExecutorTest.cs" />
     <Compile Include="Design\OperationLogHandlerTest.cs" />


### PR DESCRIPTION
Part of #2294

To override design-time services, add a method called `ConfigureDesignTimeServices` to your `Startup` class. The startup class is located using the same logic as Hosting. To use an environment other than **Development**, use the `-Environment` (NuGet) or `--environment` (DNX) parameter.

If the provider's design-time assembly is available, their design-time services will be registered during Migrations commands.

This also adds the `--verbose` option to the DNX commands (fixes #2871)