### PR TITLE
Allow configuring implicit service provider

### DIFF
--- a/src/EntityFramework.Core/Internal/ServiceProviderCache.cs
+++ b/src/EntityFramework.Core/Internal/ServiceProviderCache.cs
@@ -16,7 +16,9 @@ namespace Microsoft.Data.Entity.Internal
 
         public static ServiceProviderCache Instance { get; } = new ServiceProviderCache();
 
-        public virtual IServiceProvider GetOrAdd([NotNull] IDbContextOptions options)
+        public virtual IServiceProvider GetOrAdd(
+            [NotNull] IDbContextOptions options,
+            [NotNull] Action<IServiceCollection> configureServicesAction)
         {
             var services = new ServiceCollection();
             var builder = services.AddEntityFramework();
@@ -25,6 +27,8 @@ namespace Microsoft.Data.Entity.Internal
             {
                 extension.ApplyServices(builder);
             }
+
+            configureServicesAction(services);
 
             // Decided that this hashing algorithm is robust enough. See issue #762.
             unchecked

--- a/test/EntityFramework.Core.Tests/ApiConsistencyTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ApiConsistencyTestBase.cs
@@ -63,6 +63,7 @@ namespace Microsoft.Data.Entity
                           && (method is ConstructorInfo
                               || ((MethodInfo)method).GetBaseDefinition().DeclaringType == method.DeclaringType)
                           && method.Name != nameof(DbContext.OnConfiguring)
+                          && method.Name != nameof(DbContext.OnConfiguringServices)
                           && method.Name != nameof(DbContext.OnModelCreating)
                     where type.IsInterface || !interfaceMappings.Any(im => im.TargetMethods.Contains(method))
                     where !events.Any(e => e.AddMethod == method || e.RemoveMethod == method)

--- a/test/EntityFramework.Core.Tests/DbContextTest.cs
+++ b/test/EntityFramework.Core.Tests/DbContextTest.cs
@@ -1600,7 +1600,7 @@ namespace Microsoft.Data.Entity.Tests
             var servicesMock = new Mock<IDatabaseProviderServices>();
             servicesMock.Setup(m => m.Database).Returns(database.Object);
             servicesMock.Setup(m => m.ModelSource).Returns(new Mock<ModelSource>(new DbSetFinder(), new CoreConventionSetBuilder())
-                { CallBase = true }.Object);
+            { CallBase = true }.Object);
             servicesMock
                 .Setup(m => m.ModelValidator)
                 .Returns(new LoggingModelValidator(new Logger<LoggingModelValidator>(new LoggerFactory())));
@@ -1644,7 +1644,7 @@ namespace Microsoft.Data.Entity.Tests
             servicesMock.Setup(m => m.Database).Returns(database.Object);
             servicesMock.Setup(m => m.ValueGeneratorSelector).Returns(valueGenMock.Object);
             servicesMock.Setup(m => m.ModelSource).Returns(new Mock<ModelSource>(new DbSetFinder(), new CoreConventionSetBuilder())
-                { CallBase = true }.Object);
+            { CallBase = true }.Object);
             servicesMock
                 .Setup(m => m.ModelValidator)
                 .Returns(new LoggingModelValidator(new Logger<LoggingModelValidator>(new LoggerFactory())));
@@ -1692,11 +1692,11 @@ namespace Microsoft.Data.Entity.Tests
             servicesMock.Setup(m => m.Database).Returns(database.Object);
             servicesMock.Setup(m => m.ValueGeneratorSelector).Returns(valueGenMock.Object);
             servicesMock.Setup(m => m.ModelSource).Returns(new Mock<ModelSource>(new DbSetFinder(), new CoreConventionSetBuilder())
-                { CallBase = true }.Object);
+            { CallBase = true }.Object);
             servicesMock
                 .Setup(m => m.ModelValidator)
                 .Returns(new LoggingModelValidator(new Logger<LoggingModelValidator>(new LoggerFactory())));
-                
+
             var sourceMock = new Mock<IDatabaseProvider>();
             sourceMock.Setup(m => m.IsConfigured(It.IsAny<IDbContextOptions>())).Returns(true);
             sourceMock.Setup(m => m.GetProviderServices(It.IsAny<IServiceProvider>())).Returns(servicesMock.Object);
@@ -2551,7 +2551,7 @@ namespace Microsoft.Data.Entity.Tests
                     .Select(p => p.Name)
                     .OrderBy(s => s)
                     .ToList()),
-                userMessage: "Unexpected properties on DbContext. " + 
+                userMessage: "Unexpected properties on DbContext. " +
                     "Update test to ensure all getters throw ObjectDisposedException after dispose.");
 
             Assert.Throws<ObjectDisposedException>(() => ((IAccessor<IServiceProvider>)context).Service);
@@ -2630,6 +2630,47 @@ namespace Microsoft.Data.Entity.Tests
                     Disposed = true;
                 }
             }
+        }
+
+        [Fact]
+        public void Can_configure_implicit_service_provider()
+        {
+            using (var context = new ContextWithConfiguredServices())
+            {
+                Assert.NotNull(context.GetService().GetService<MyCustomService>());
+            }
+        }
+
+        [Fact]
+        public void OnConfiguringServices_isnt_called_when_using_explicit_service_provider()
+        {
+            var serviceProvider = TestHelpers.Instance.CreateServiceProvider();
+
+            using (var context = new ContextWithConfiguredServices(serviceProvider))
+            {
+                Assert.Null(context.GetService().GetService<MyCustomService>());
+            }
+        }
+
+        private class ContextWithConfiguredServices : DbContext
+        {
+            public ContextWithConfiguredServices()
+            {
+            }
+
+            public ContextWithConfiguredServices(IServiceProvider serviceProvider)
+                : base(serviceProvider)
+            {
+            }
+
+            protected override void OnConfiguringServices(IServiceCollection serviceCollection)
+            {
+                serviceCollection.AddSingleton<MyCustomService>();
+            }
+        }
+
+        private class MyCustomService
+        {
         }
     }
 }

--- a/test/EntityFramework.Core.Tests/ServiceProviderCacheTest.cs
+++ b/test/EntityFramework.Core.Tests/ServiceProviderCacheTest.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Data.Entity.Tests
 
             var cache = new ServiceProviderCache();
 
-            Assert.Same(cache.GetOrAdd(config1), cache.GetOrAdd(config2));
+            Assert.Same(cache.GetOrAdd(config1, ConfigureServices), cache.GetOrAdd(config2, ConfigureServices));
         }
 
         [Fact]
@@ -54,7 +54,7 @@ namespace Microsoft.Data.Entity.Tests
 
             var cache = new ServiceProviderCache();
 
-            Assert.NotSame(cache.GetOrAdd(config1), cache.GetOrAdd(config2));
+            Assert.NotSame(cache.GetOrAdd(config1, ConfigureServices), cache.GetOrAdd(config2, ConfigureServices));
         }
 
         [Fact]
@@ -78,7 +78,7 @@ namespace Microsoft.Data.Entity.Tests
 
             var cache = new ServiceProviderCache();
 
-            Assert.NotSame(cache.GetOrAdd(config1), cache.GetOrAdd(config2));
+            Assert.NotSame(cache.GetOrAdd(config1, ConfigureServices), cache.GetOrAdd(config2, ConfigureServices));
         }
 
         [Fact]
@@ -102,7 +102,7 @@ namespace Microsoft.Data.Entity.Tests
 
             var cache = new ServiceProviderCache();
 
-            Assert.NotSame(cache.GetOrAdd(config1), cache.GetOrAdd(config2));
+            Assert.NotSame(cache.GetOrAdd(config1, ConfigureServices), cache.GetOrAdd(config2, ConfigureServices));
         }
 
         [Fact]
@@ -126,7 +126,11 @@ namespace Microsoft.Data.Entity.Tests
 
             var cache = new ServiceProviderCache();
 
-            Assert.NotSame(cache.GetOrAdd(config1), cache.GetOrAdd(config2));
+            Assert.NotSame(cache.GetOrAdd(config1, ConfigureServices), cache.GetOrAdd(config2, ConfigureServices));
+        }
+
+        private static void ConfigureServices(IServiceCollection serviceCollection)
+        {
         }
 
         private static DbContextOptions CreateOptions(Action<EntityFrameworkServicesBuilder> builderAction)


### PR DESCRIPTION
To use, override `DbContext.OnConfiguringServices`.

Resolves #3165

cc @rowanmiller @ajcvickers @divega 
I question the value of doing this. Managing it externally doesn't seem like too bad of an alternative. This also doesn't allow you use a different service container (e.g. Ninject).