### PR TITLE
UseRowNumberForPaging supports group join and complex projection.

### DIFF
--- a/src/EntityFramework.SqlServer/Query/Internal/SqlServerQueryModelVisitor.cs
+++ b/src/EntityFramework.SqlServer/Query/Internal/SqlServerQueryModelVisitor.cs
@@ -124,12 +124,9 @@ namespace Microsoft.Data.Entity.Query.Internal
                     return selectExpression;
                 }
 
-                var projections = new List<Expression>();
-                projections.AddRange(selectExpression.Projection);
-
                 var subQuery = selectExpression.PushDownSubquery();
 
-                foreach (var projection in projections)
+                foreach (var projection in subQuery.Projection)
                 {
                     var alias = projection as AliasExpression;
                     var column = projection as ColumnExpression;
@@ -151,7 +148,8 @@ namespace Microsoft.Data.Entity.Query.Internal
                     }
                     else
                     {
-                        selectExpression.AddToProjection(projection);
+                        column = new ColumnExpression(alias.Alias, alias.Expression.Type, subQuery);
+                        selectExpression.AddToProjection(column);
                     }
                 }
 
@@ -165,9 +163,7 @@ namespace Microsoft.Data.Entity.Query.Internal
                 var rowNumber = new RowNumberExpression(columnExpression, subQuery.OrderBy);
 
                 subQuery.ClearOrderBy();
-                subQuery.ClearProjection();
-                subQuery.AddToProjection(rowNumber);
-                subQuery.IsProjectStar = true;
+                subQuery.AddToProjection(rowNumber, false);
 
                 Expression predicate = null;
 

--- a/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
@@ -120,6 +120,26 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
+        public virtual void Join_Customers_Orders_Skip_Take()
+        {
+            AssertQuery<Customer, Order>((cs, os) => (
+                from c in cs
+                join o in os on c.CustomerID equals o.CustomerID
+                orderby o.OrderID
+                select new { c.ContactName, o.OrderID }).Skip(10).Take(5));
+        }
+
+        [Fact]
+        public virtual void Join_Customers_Orders_Projection_With_String_Concat_Skip_Take()
+        {
+            AssertQuery<Customer, Order>((cs, os) => (
+                from c in cs
+                join o in os on c.CustomerID equals o.CustomerID
+                orderby o.OrderID
+                select new { Contact = c.ContactName + " " + c.ContactTitle, o.OrderID }).Skip(10).Take(5));
+        }
+
+        [Fact]
         public virtual void Distinct_Skip_Take()
         {
             AssertQuery<Customer>(

--- a/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -813,6 +813,34 @@ OFFSET 5 ROWS FETCH NEXT 10 ROWS ONLY",
 
         [ConditionalFact]
         [SqlServerCondition(SqlServerCondition.SupportsOffset)]
+        public override void Join_Customers_Orders_Skip_Take()
+        {
+            base.Join_Customers_Orders_Skip_Take();
+            Assert.Equal(
+                @"SELECT [c].[ContactName], [o].[OrderID]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+ORDER BY [o].[OrderID]
+OFFSET 10 ROWS FETCH NEXT 5 ROWS ONLY",
+                Sql);
+        }
+
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.SupportsOffset)]
+        public override void Join_Customers_Orders_Projection_With_String_Concat_Skip_Take()
+        {
+            base.Join_Customers_Orders_Projection_With_String_Concat_Skip_Take();
+            Assert.Equal(
+                @"SELECT ([c].[ContactName] + ' ') + [c].[ContactTitle], [o].[OrderID]
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+ORDER BY [o].[OrderID]
+OFFSET 10 ROWS FETCH NEXT 5 ROWS ONLY",
+                Sql);
+        }
+
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.SupportsOffset)]
         public override void Take_Skip()
         {
             base.Take_Skip();

--- a/test/EntityFramework.SqlServer.FunctionalTests/RowNumberPagingTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/RowNumberPagingTest.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             Assert.Equal(
                @"SELECT [t0].[CustomerID], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
 FROM (
-    SELECT [c].*, ROW_NUMBER() OVER(ORDER BY [c].[CustomerID]) AS [__RowNumber__]
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], ROW_NUMBER() OVER(ORDER BY [c].[CustomerID]) AS [__RowNumber__]
     FROM [Customers] AS [c]
 ) AS [t0]
 WHERE [t0].[__RowNumber__] > 5",
@@ -44,7 +44,7 @@ WHERE [t0].[__RowNumber__] > 5",
             Assert.EndsWith(
                 @"SELECT [t0].[CustomerID], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
 FROM (
-    SELECT [c].*, ROW_NUMBER() OVER(ORDER BY @@RowCount) AS [__RowNumber__]
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], ROW_NUMBER() OVER(ORDER BY @@RowCount) AS [__RowNumber__]
     FROM [Customers] AS [c]
 ) AS [t0]
 WHERE [t0].[__RowNumber__] > 5",
@@ -58,10 +58,38 @@ WHERE [t0].[__RowNumber__] > 5",
             Assert.Equal(
                 @"SELECT [t0].[CustomerID], [t0].[Address], [t0].[City], [t0].[CompanyName], [t0].[ContactName], [t0].[ContactTitle], [t0].[Country], [t0].[Fax], [t0].[Phone], [t0].[PostalCode], [t0].[Region]
 FROM (
-    SELECT [c].*, ROW_NUMBER() OVER(ORDER BY [c].[ContactName]) AS [__RowNumber__]
+    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], ROW_NUMBER() OVER(ORDER BY [c].[ContactName]) AS [__RowNumber__]
     FROM [Customers] AS [c]
 ) AS [t0]
 WHERE ([t0].[__RowNumber__] > 5) AND ([t0].[__RowNumber__] <= 15)",
+                Sql);
+        }
+
+        public override void Join_Customers_Orders_Skip_Take()
+        {
+            base.Join_Customers_Orders_Skip_Take();
+            Assert.Equal(
+                @"SELECT [t0].[ContactName], [t0].[OrderID]
+FROM (
+    SELECT [c].[ContactName], [o].[OrderID], ROW_NUMBER() OVER(ORDER BY [o].[OrderID]) AS [__RowNumber__]
+    FROM [Customers] AS [c]
+    INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+) AS [t0]
+WHERE ([t0].[__RowNumber__] > 10) AND ([t0].[__RowNumber__] <= 15)",
+                Sql);
+        }
+
+        public override void Join_Customers_Orders_Projection_With_String_Concat_Skip_Take()
+        {
+            base.Join_Customers_Orders_Projection_With_String_Concat_Skip_Take();
+            Assert.Equal(
+                @"SELECT [t0].[c0], [t0].[OrderID]
+FROM (
+    SELECT ([c].[ContactName] + ' ') + [c].[ContactTitle] AS [c0], [o].[OrderID], ROW_NUMBER() OVER(ORDER BY [o].[OrderID]) AS [__RowNumber__]
+    FROM [Customers] AS [c]
+    INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+) AS [t0]
+WHERE ([t0].[__RowNumber__] > 10) AND ([t0].[__RowNumber__] <= 15)",
                 Sql);
         }
 


### PR DESCRIPTION
``` c#
var query = from cs in context.Customers
            join os in context.Orders on cs.CustomerID equals os.CustomerID
            select new
            {
                Contact = cs.ContactName + " " + cs.ContactTitle,
                os.OrderID
            };
var result = query.Skip(10).Take(5).ToArray();
```

The preceding query works in Sql Server 2008 now.