### PR TITLE
Replace cross apply with lateral join

### DIFF
--- a/src/EntityFramework.Relational/EntityFramework.Relational.csproj
+++ b/src/EntityFramework.Relational/EntityFramework.Relational.csproj
@@ -82,7 +82,7 @@
     <Compile Include="Migrations\MigrationAttribute.cs" />
     <Compile Include="Migrations\MigrationsAssemblyExtensions.cs" />
     <Compile Include="Query\Expressions\ColumnExpression.cs" />
-    <Compile Include="Query\Expressions\CrossApplyExpression.cs" />
+    <Compile Include="Query\Expressions\LateralJoinExpression.cs" />
     <Compile Include="Query\Expressions\ISelectExpressionFactory.cs" />
     <Compile Include="Query\Expressions\SelectExpressionFactory.cs" />
     <Compile Include="Query\ExpressionVisitors\CompositePredicateExpressionVisitorFactory.cs" />

--- a/src/EntityFramework.Relational/Query/Expressions/LateralJoinExpression.cs
+++ b/src/EntityFramework.Relational/Query/Expressions/LateralJoinExpression.cs
@@ -8,11 +8,11 @@ using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Query.Expressions
 {
-    public class CrossApplyExpression : TableExpressionBase
+    public class LateralJoinExpression : TableExpressionBase
     {
         private readonly TableExpressionBase _tableExpression;
 
-        public CrossApplyExpression([NotNull] TableExpressionBase tableExpression)
+        public LateralJoinExpression([NotNull] TableExpressionBase tableExpression)
             : base(
                 Check.NotNull(tableExpression, nameof(tableExpression)).QuerySource,
                 tableExpression.Alias)
@@ -29,12 +29,11 @@ namespace Microsoft.Data.Entity.Query.Expressions
             var specificVisitor = visitor as ISqlExpressionVisitor;
 
             return specificVisitor != null
-                ? specificVisitor.VisitCrossApply(this)
+                ? specificVisitor.VisitLateralJoin(this)
                 : base.Accept(visitor);
         }
 
-        public override string ToString() => "CROSS APPLY " + _tableExpression;
-
+        public override string ToString() => "LATERAL JOIN " + _tableExpression;
 
         protected override Expression VisitChildren(ExpressionVisitor visitor)
         {

--- a/src/EntityFramework.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/EntityFramework.Relational/Query/Expressions/SelectExpression.cs
@@ -605,7 +605,7 @@ namespace Microsoft.Data.Entity.Query.Expressions
             _projection.AddRange(projection);
         }
 
-        public virtual void AddCrossApply(
+        public virtual void AddLateralJoin(
             [NotNull] TableExpressionBase tableExpression,
             [NotNull] IEnumerable<Expression> projection)
         {
@@ -614,7 +614,7 @@ namespace Microsoft.Data.Entity.Query.Expressions
 
             tableExpression.Alias = CreateUniqueTableAlias(tableExpression.Alias);
 
-            _tables.Add(new CrossApplyExpression(tableExpression));
+            _tables.Add(new LateralJoinExpression(tableExpression));
             _projection.AddRange(projection);
         }
 

--- a/src/EntityFramework.Relational/Query/RelationalQueryCompilationContext.cs
+++ b/src/EntityFramework.Relational/Query/RelationalQueryCompilationContext.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Data.Entity.Query
             return relationalQueryModelVisitor;
         }
 
-        public virtual bool IsCrossApplySupported => false;
+        public virtual bool IsLateralJoinSupported => false;
 
         public override EntityQueryModelVisitor CreateQueryModelVisitor(EntityQueryModelVisitor parentEntityQueryModelVisitor)
         {

--- a/src/EntityFramework.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EntityFramework.Relational/Query/RelationalQueryModelVisitor.cs
@@ -305,13 +305,13 @@ namespace Microsoft.Data.Entity.Query
 
                         if (correlated)
                         {
-                            if (!QueryCompilationContext.IsCrossApplySupported)
+                            if (!QueryCompilationContext.IsLateralJoinSupported)
                             {
                                 return;
                             }
 
                             previousSelectExpression
-                                .AddCrossApply(selectExpression.Tables.First(), selectExpression.Projection);
+                                .AddLateralJoin(selectExpression.Tables.First(), selectExpression.Projection);
                         }
                         else
                         {
@@ -568,7 +568,7 @@ namespace Microsoft.Data.Entity.Query
             if (subSelectExpression != null
                 && (!subSelectExpression.OrderBy.Any()
                     || subSelectExpression.Limit != null)
-                && (QueryCompilationContext.IsCrossApplySupported
+                && (QueryCompilationContext.IsLateralJoinSupported
                     || (!subSelectExpression.IsCorrelated()
                         || !(querySource is AdditionalFromClause))))
             {

--- a/src/EntityFramework.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/EntityFramework.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -339,15 +339,15 @@ namespace Microsoft.Data.Entity.Query.Sql
             return crossJoinExpression;
         }
 
-        public virtual Expression VisitCrossApply(CrossApplyExpression crossApplyExpression)
+        public virtual Expression VisitLateralJoin(LateralJoinExpression lateralJoinExpression)
         {
-            Check.NotNull(crossApplyExpression, nameof(crossApplyExpression));
+            Check.NotNull(lateralJoinExpression, nameof(lateralJoinExpression));
 
-            _sql.Append("CROSS APPLY ");
+            _sql.Append("CROSS JOIN LATERAL ");
 
-            Visit(crossApplyExpression.TableExpression);
+            Visit(lateralJoinExpression.TableExpression);
 
-            return crossApplyExpression;
+            return lateralJoinExpression;
         }
 
         public virtual Expression VisitCount(CountExpression countExpression)

--- a/src/EntityFramework.Relational/Query/Sql/ISqlExpressionVisitor.cs
+++ b/src/EntityFramework.Relational/Query/Sql/ISqlExpressionVisitor.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Data.Entity.Query.Sql
         Expression VisitTable([NotNull] TableExpression tableExpression);
         Expression VisitRawSqlDerivedTable([NotNull] RawSqlDerivedTableExpression rawSqlDerivedTableExpression);
         Expression VisitCrossJoin([NotNull] CrossJoinExpression crossJoinExpression);
-        Expression VisitCrossApply([NotNull] CrossApplyExpression crossApplyExpression);
+        Expression VisitLateralJoin([NotNull] LateralJoinExpression lateralJoinExpression);
         Expression VisitInnerJoin([NotNull] InnerJoinExpression innerJoinExpression);
         Expression VisitOuterJoin([NotNull] LeftOuterJoinExpression leftOuterJoinExpression);
         Expression VisitExists([NotNull] ExistsExpression existsExpression);

--- a/src/EntityFramework.SqlServer/Query/Internal/SqlServerQueryCompilationContext.cs
+++ b/src/EntityFramework.SqlServer/Query/Internal/SqlServerQueryCompilationContext.cs
@@ -28,6 +28,6 @@ namespace Microsoft.Data.Entity.Query.Internal
         {
         }
 
-        public override bool IsCrossApplySupported => true;
+        public override bool IsLateralJoinSupported => true;
     }
 }

--- a/src/EntityFramework.SqlServer/Query/Sql/Internal/SqlServerQuerySqlGenerator.cs
+++ b/src/EntityFramework.SqlServer/Query/Sql/Internal/SqlServerQuerySqlGenerator.cs
@@ -22,6 +22,17 @@ namespace Microsoft.Data.Entity.Query.Sql.Internal
         {
         }
 
+        public override Expression VisitLateralJoin(LateralJoinExpression lateralJoinExpression)
+        {
+            Check.NotNull(lateralJoinExpression, nameof(lateralJoinExpression));
+
+            Sql.Append("CROSS APPLY ");
+
+            Visit(lateralJoinExpression.TableExpression);
+
+            return lateralJoinExpression;
+        }
+
         public override Expression VisitCount(CountExpression countExpression)
         {
             Check.NotNull(countExpression, nameof(countExpression));


### PR DESCRIPTION
To have the EF core follow the SQL standard more closely, replaced cross apply with lateral join. SqlServer overrides and uses cross apply.