### PR TITLE
Implement cascade delete in the state manager

### DIFF
--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntityEntryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntityEntryTest.cs
@@ -1471,7 +1471,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             entry.SetEntityState(EntityState.Unchanged);
 
             entry[fkProperty] = null;
-            entry.PrepareToSave();
+            entry.HandleConceptualNulls();
 
             Assert.Equal(EntityState.Deleted, entry.EntityState);
         }
@@ -1489,7 +1489,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             entry.SetEntityState(EntityState.Added);
 
             entry[fkProperty] = null;
-            entry.PrepareToSave();
+            entry.HandleConceptualNulls();
 
             Assert.Equal(EntityState.Detached, entry.EntityState);
         }
@@ -1513,7 +1513,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             Assert.Equal(
                 CoreStrings.RelationshipConceptualNull("SomeEntity", "SomeDependentEntity"),
-                Assert.Throws<InvalidOperationException>(() => entry.PrepareToSave()).Message);
+                Assert.Throws<InvalidOperationException>(() => entry.HandleConceptualNulls()).Message);
         }
 
         [Fact]
@@ -1535,7 +1535,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             Assert.Equal(
                 CoreStrings.PropertyConceptualNull("JustAProperty", "SomeDependentEntity"),
-                Assert.Throws<InvalidOperationException>(() => entry.PrepareToSave()).Message);
+                Assert.Throws<InvalidOperationException>(() => entry.HandleConceptualNulls()).Message);
         }
 
         public class TestInMemoryValueGeneratorSelector : InMemoryValueGeneratorSelector

--- a/test/EntityFramework.InMemory.FunctionalTests/GraphUpdatesInMemoryTestBase.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/GraphUpdatesInMemoryTestBase.cs
@@ -18,12 +18,6 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
         {
         }
 
-        [ConditionalFact]
-        public override void Required_many_to_one_dependents_are_cascade_deleted()
-        {
-            // Cascade delete not supported by in-memory database
-        }
-
         [ConditionalTheory]
         [InlineData((int)ChangeMechanism.Principal, false)]
         public override void Save_required_one_to_one_changed_by_reference_with_alternate_key(ChangeMechanism changeMechanism, bool useExistingEntities)
@@ -83,6 +77,42 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
         [ConditionalTheory]
         [InlineData((int)ChangeMechanism.Principal)]
         public override void Sever_required_non_PK_one_to_one_with_alternate_key(ChangeMechanism changeMechanism)
+        {
+            // Cascade delete not supported by in-memory database
+        }
+
+        [ConditionalFact]
+        public override void Required_many_to_one_dependents_are_cascade_deleted_in_store()
+        {
+            // Cascade delete not supported by in-memory database
+        }
+
+        [ConditionalFact]
+        public override void Required_one_to_one_are_cascade_deleted_in_store()
+        {
+            // Cascade delete not supported by in-memory database
+        }
+
+        [ConditionalFact]
+        public override void Required_non_PK_one_to_one_are_cascade_deleted_in_store()
+        {
+            // Cascade delete not supported by in-memory database
+        }
+
+        [ConditionalFact]
+        public override void Required_many_to_one_dependents_with_alternate_key_are_cascade_deleted_in_store()
+        {
+            // Cascade delete not supported by in-memory database
+        }
+
+        [ConditionalFact]
+        public override void Required_one_to_one_with_alternate_key_are_cascade_deleted_in_store()
+        {
+            // Cascade delete not supported by in-memory database
+        }
+
+        [ConditionalFact]
+        public override void Required_non_PK_one_to_one_with_alternate_key_are_cascade_deleted_in_store()
         {
             // Cascade delete not supported by in-memory database
         }

--- a/test/EntityFramework.SqlServer.FunctionalTests/GraphUpdatesWithSequenceSqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/GraphUpdatesWithSequenceSqlServerTest.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.Data.Entity.SqlServer.FunctionalTests;
-
 namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 {
     [SqlServerCondition(SqlServerCondition.SupportsSequences)]

--- a/test/EntityFramework.Sqlite.FunctionalTests/GraphUpdatesSqliteTestBase.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/GraphUpdatesSqliteTestBase.cs
@@ -17,12 +17,6 @@ namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
         {
         }
 
-        [ConditionalFact]
-        public override void Required_many_to_one_dependents_are_cascade_deleted()
-        {
-            // TODO: Cascade delete not yet supported by SQLite provider
-        }
-
         [ConditionalTheory]
         [InlineData((int)ChangeMechanism.Principal, false)]
         public override void Save_required_one_to_one_changed_by_reference_with_alternate_key(ChangeMechanism changeMechanism, bool useExistingEntities)
@@ -82,6 +76,42 @@ namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
         [ConditionalTheory]
         [InlineData((int)ChangeMechanism.Principal)]
         public override void Sever_required_non_PK_one_to_one_with_alternate_key(ChangeMechanism changeMechanism)
+        {
+            // TODO: Cascade delete not yet supported by SQLite provider
+        }
+
+        [ConditionalFact]
+        public override void Required_many_to_one_dependents_are_cascade_deleted_in_store()
+        {
+            // TODO: Cascade delete not yet supported by SQLite provider
+        }
+
+        [ConditionalFact]
+        public override void Required_one_to_one_are_cascade_deleted_in_store()
+        {
+            // TODO: Cascade delete not yet supported by SQLite provider
+        }
+
+        [ConditionalFact]
+        public override void Required_non_PK_one_to_one_are_cascade_deleted_in_store()
+        {
+            // TODO: Cascade delete not yet supported by SQLite provider
+        }
+
+        [ConditionalFact]
+        public override void Required_many_to_one_dependents_with_alternate_key_are_cascade_deleted_in_store()
+        {
+            // TODO: Cascade delete not yet supported by SQLite provider
+        }
+
+        [ConditionalFact]
+        public override void Required_one_to_one_with_alternate_key_are_cascade_deleted_in_store()
+        {
+            // TODO: Cascade delete not yet supported by SQLite provider
+        }
+
+        [ConditionalFact]
+        public override void Required_non_PK_one_to_one_with_alternate_key_are_cascade_deleted_in_store()
         {
             // TODO: Cascade delete not yet supported by SQLite provider
         }


### PR DESCRIPTION
This change ensures that tracked entities are deleted as appropriate during SaveChanges and also that navigations to deleted entities are cleared after SaveChanges happens. (We don't do this immediately as in the old stack and we don't null FKs so as to do as little shredding of the graph as possible.)