### PR TITLE
[TINY] RevEng: Fixes blank context name from Scaffold-DbContext.

### DIFF
--- a/src/EntityFramework.Relational.Design/ReverseEngineering/Internal/Templates/DbContextTemplate.cshtml
+++ b/src/EntityFramework.Relational.Design/ReverseEngineering/Internal/Templates/DbContextTemplate.cshtml
@@ -116,8 +116,10 @@
     }
 }
 @{
-    var useFluentApi = this.Model.CustomConfiguration.UseFluentApiOnly;
-    var className = this.Model.CustomConfiguration.ContextClassName ?? Model.ClassName();
+    var useFluentApi = Model.CustomConfiguration.UseFluentApiOnly;
+    var className = string.IsNullOrWhiteSpace(Model.CustomConfiguration.ContextClassName)
+        ? Model.ClassName()
+        : Model.CustomConfiguration.ContextClassName;
 }using Microsoft.Data.Entity;
 using Microsoft.Data.Entity.Metadata;
 


### PR DESCRIPTION
@bricelam Fix for issue #3227.