### PR TITLE
Set cascade delete by convention for required foreign keys

### DIFF
--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -160,7 +160,9 @@
     <Compile Include="DbContextOptionsBuilder`.cs" />
     <Compile Include="Metadata\Builders\ReferenceReferenceBuilder`.cs" />
     <Compile Include="Metadata\Conventions\ConventionSet.cs" />
+    <Compile Include="Metadata\Conventions\Internal\CascadeDeleteConvention.cs" />
     <Compile Include="Metadata\Conventions\Internal\INavigationRemovedConvention.cs" />
+    <Compile Include="Metadata\Conventions\Internal\IPropertyNullableConvention.cs" />
     <Compile Include="Metadata\Conventions\Internal\ModelCleanupConvention.cs" />
     <Compile Include="Metadata\Conventions\Internal\IBaseTypeConvention.cs" />
     <Compile Include="Metadata\Conventions\Internal\ForeignKeyAttributeConvention.cs" />

--- a/src/EntityFramework.Core/Metadata/Conventions/ConventionSet.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/ConventionSet.cs
@@ -20,5 +20,6 @@ namespace Microsoft.Data.Entity.Metadata.Conventions
         public virtual IList<INavigationConvention> NavigationAddedConventions { get; } = new List<INavigationConvention>();
         public virtual IList<INavigationRemovedConvention> NavigationRemovedConventions { get; } = new List<INavigationRemovedConvention>();
         public virtual IList<IPropertyConvention> PropertyAddedConventions { get; } = new List<IPropertyConvention>();
+        public virtual IList<IPropertyNullableConvention> PropertyNullableChangedConventions { get; } = new List<IPropertyNullableConvention>();
     }
 }

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/CascadeDeleteConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/CascadeDeleteConvention.cs
@@ -1,0 +1,33 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Metadata.Internal;
+
+namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
+{
+    public class CascadeDeleteConvention : IForeignKeyConvention, IPropertyNullableConvention
+    {
+        public virtual bool Apply(InternalPropertyBuilder propertyBuilder)
+        {
+            foreach (var foreignKey in propertyBuilder.Metadata.FindContainingForeignKeysInHierarchy())
+            {
+                Apply(propertyBuilder.ModelBuilder.Entity(foreignKey.DeclaringEntityType.Name, ConfigurationSource.Convention)
+                    .Relationship(foreignKey, true, ConfigurationSource.Convention));
+            }
+
+            return true;
+        }
+
+        public virtual InternalRelationshipBuilder Apply(InternalRelationshipBuilder relationshipBuilder)
+        {
+            relationshipBuilder.DeleteBehavior(
+                ((IForeignKey)relationshipBuilder.Metadata).IsRequired
+                    ? DeleteBehavior.Cascade
+                    : DeleteBehavior.None,
+                ConfigurationSource.Convention,
+                runConventions: false);
+
+            return relationshipBuilder;
+        }
+    }
+}

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/ConventionDispatcher.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/ConventionDispatcher.cs
@@ -206,5 +206,18 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
 
             return propertyBuilder;
         }
+
+        public virtual InternalPropertyBuilder OnPropertyNullableChanged([NotNull] InternalPropertyBuilder propertyBuilder)
+        {
+            foreach (var propertyConvention in _conventionSet.PropertyNullableChangedConventions)
+            {
+                if (!propertyConvention.Apply(propertyBuilder))
+                {
+                    break;
+                }
+            }
+
+            return propertyBuilder;
+        }
     }
 }

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
@@ -53,6 +53,10 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
             
             conventionSet.NavigationRemovedConventions.Add(relationshipDiscoveryConvention);
 
+            var cascadeDeleteConvention = new CascadeDeleteConvention();
+            conventionSet.ForeignKeyAddedConventions.Add(cascadeDeleteConvention);
+            conventionSet.PropertyNullableChangedConventions.Add(cascadeDeleteConvention);
+
             return conventionSet;
         }
     }

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/IPropertyNullableConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/IPropertyNullableConvention.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata.Internal;
+
+namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
+{
+    public interface IPropertyNullableConvention
+    {
+        bool Apply([NotNull] InternalPropertyBuilder propertyBuilder);
+    }
+}

--- a/src/EntityFramework.Core/Metadata/Internal/InternalPropertyBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/InternalPropertyBuilder.cs
@@ -64,7 +64,15 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             {
                 _isRequiredConfigurationSource = configurationSource.Max(_isRequiredConfigurationSource);
 
+                var isChanging = Metadata.IsNullable != !isRequired;
+
                 Metadata.IsNullable = !isRequired;
+
+                if (isChanging)
+                {
+                    ModelBuilder.ConventionDispatcher.OnPropertyNullableChanged(this);
+                }
+
                 return true;
             }
 

--- a/test/EntityFramework.Core.FunctionalTests/ComplexNavigationsQueryFixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/ComplexNavigationsQueryFixtureBase.cs
@@ -20,39 +20,39 @@ namespace Microsoft.Data.Entity.FunctionalTests
             modelBuilder.Entity<Level4>().Property(e => e.Id).ValueGeneratedNever();
 
             modelBuilder.Entity<Level1>().HasOne(e => e.OneToOne_Optional_Self).WithOne();
-            modelBuilder.Entity<Level1>().HasOne(e => e.OneToOne_Required_PK).WithOne(e => e.OneToOne_Required_PK_Inverse).PrincipalKey<Level1>(e => e.Id).Required(true);
+            modelBuilder.Entity<Level1>().HasOne(e => e.OneToOne_Required_PK).WithOne(e => e.OneToOne_Required_PK_Inverse).PrincipalKey<Level1>(e => e.Id).Required().WillCascadeOnDelete(false);
             modelBuilder.Entity<Level1>().HasOne(e => e.OneToOne_Optional_PK).WithOne(e => e.OneToOne_Optional_PK_Inverse).PrincipalKey<Level1>(e => e.Id).Required(false);
-            modelBuilder.Entity<Level1>().HasOne(e => e.OneToOne_Required_FK).WithOne(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level2>(e => e.Level1_Required_Id).Required(true);
+            modelBuilder.Entity<Level1>().HasOne(e => e.OneToOne_Required_FK).WithOne(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level2>(e => e.Level1_Required_Id).Required().WillCascadeOnDelete(false);
             modelBuilder.Entity<Level1>().HasOne(e => e.OneToOne_Optional_FK).WithOne(e => e.OneToOne_Optional_FK_Inverse).ForeignKey<Level2>(e => e.Level1_Optional_Id).Required(false);
-            modelBuilder.Entity<Level1>().HasMany(e => e.OneToMany_Required).WithOne(e => e.OneToMany_Required_Inverse).Required(true);
+            modelBuilder.Entity<Level1>().HasMany(e => e.OneToMany_Required).WithOne(e => e.OneToMany_Required_Inverse).Required().WillCascadeOnDelete(false);
             modelBuilder.Entity<Level1>().HasMany(e => e.OneToMany_Optional).WithOne(e => e.OneToMany_Optional_Inverse).Required(false);
-            modelBuilder.Entity<Level1>().HasMany(e => e.OneToMany_Required_Self).WithOne(e => e.OneToMany_Required_Self_Inverse).Required(true);
+            modelBuilder.Entity<Level1>().HasMany(e => e.OneToMany_Required_Self).WithOne(e => e.OneToMany_Required_Self_Inverse).Required().WillCascadeOnDelete(false);
             modelBuilder.Entity<Level1>().HasMany(e => e.OneToMany_Optional_Self).WithOne(e => e.OneToMany_Optional_Self_Inverse).Required(false);
 
             modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Optional_Self).WithOne();
-            modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Required_PK).WithOne(e => e.OneToOne_Required_PK_Inverse).PrincipalKey<Level2>(e => e.Id).Required(true);
+            modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Required_PK).WithOne(e => e.OneToOne_Required_PK_Inverse).PrincipalKey<Level2>(e => e.Id).Required().WillCascadeOnDelete(false);
             modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Optional_PK).WithOne(e => e.OneToOne_Optional_PK_Inverse).PrincipalKey<Level2>(e => e.Id).Required(false);
-            modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Required_FK).WithOne(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level3>(e => e.Level2_Required_Id).Required(true);
+            modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Required_FK).WithOne(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level3>(e => e.Level2_Required_Id).Required().WillCascadeOnDelete(false);
             modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Optional_FK).WithOne(e => e.OneToOne_Optional_FK_Inverse).ForeignKey<Level3>(e => e.Level2_Optional_Id).Required(false);
-            modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Required_FK).WithOne(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level3>(e => e.Level2_Required_Id).Required(true);
+            modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Required_FK).WithOne(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level3>(e => e.Level2_Required_Id).Required().WillCascadeOnDelete(false);
             modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Optional_FK).WithOne(e => e.OneToOne_Optional_FK_Inverse).ForeignKey<Level3>(e => e.Level2_Optional_Id).Required(false);
-            modelBuilder.Entity<Level2>().HasMany(e => e.OneToMany_Required).WithOne(e => e.OneToMany_Required_Inverse).Required(true);
+            modelBuilder.Entity<Level2>().HasMany(e => e.OneToMany_Required).WithOne(e => e.OneToMany_Required_Inverse).Required().WillCascadeOnDelete(false);
             modelBuilder.Entity<Level2>().HasMany(e => e.OneToMany_Optional).WithOne(e => e.OneToMany_Optional_Inverse).Required(false);
-            modelBuilder.Entity<Level2>().HasMany(e => e.OneToMany_Required_Self).WithOne(e => e.OneToMany_Required_Self_Inverse).Required(true);
+            modelBuilder.Entity<Level2>().HasMany(e => e.OneToMany_Required_Self).WithOne(e => e.OneToMany_Required_Self_Inverse).Required().WillCascadeOnDelete(false);
             modelBuilder.Entity<Level2>().HasMany(e => e.OneToMany_Optional_Self).WithOne(e => e.OneToMany_Optional_Self_Inverse).Required(false);
 
             modelBuilder.Entity<Level3>().HasOne(e => e.OneToOne_Optional_Self).WithOne();
-            modelBuilder.Entity<Level3>().HasOne(e => e.OneToOne_Required_PK).WithOne(e => e.OneToOne_Required_PK_Inverse).PrincipalKey<Level3>(e => e.Id).Required(true);
+            modelBuilder.Entity<Level3>().HasOne(e => e.OneToOne_Required_PK).WithOne(e => e.OneToOne_Required_PK_Inverse).PrincipalKey<Level3>(e => e.Id).Required().WillCascadeOnDelete(false);
             modelBuilder.Entity<Level3>().HasOne(e => e.OneToOne_Optional_PK).WithOne(e => e.OneToOne_Optional_PK_Inverse).PrincipalKey<Level3>(e => e.Id).Required(false);
-            modelBuilder.Entity<Level3>().HasOne(e => e.OneToOne_Required_FK).WithOne(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level4>(e => e.Level3_Required_Id).Required(true);
+            modelBuilder.Entity<Level3>().HasOne(e => e.OneToOne_Required_FK).WithOne(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level4>(e => e.Level3_Required_Id).Required().WillCascadeOnDelete(false);
             modelBuilder.Entity<Level3>().HasOne(e => e.OneToOne_Optional_FK).WithOne(e => e.OneToOne_Optional_FK_Inverse).ForeignKey<Level4>(e => e.Level3_Optional_Id).Required(false);
-            modelBuilder.Entity<Level3>().HasMany(e => e.OneToMany_Required).WithOne(e => e.OneToMany_Required_Inverse).Required(true);
+            modelBuilder.Entity<Level3>().HasMany(e => e.OneToMany_Required).WithOne(e => e.OneToMany_Required_Inverse).Required().WillCascadeOnDelete(false);
             modelBuilder.Entity<Level3>().HasMany(e => e.OneToMany_Optional).WithOne(e => e.OneToMany_Optional_Inverse).Required(false);
-            modelBuilder.Entity<Level3>().HasMany(e => e.OneToMany_Required_Self).WithOne(e => e.OneToMany_Required_Self_Inverse).Required(true);
+            modelBuilder.Entity<Level3>().HasMany(e => e.OneToMany_Required_Self).WithOne(e => e.OneToMany_Required_Self_Inverse).Required().WillCascadeOnDelete(false);
             modelBuilder.Entity<Level3>().HasMany(e => e.OneToMany_Optional_Self).WithOne(e => e.OneToMany_Optional_Self_Inverse).Required(false);
 
             modelBuilder.Entity<Level4>().HasOne(e => e.OneToOne_Optional_Self).WithOne();
-            modelBuilder.Entity<Level4>().HasMany(e => e.OneToMany_Required_Self).WithOne(e => e.OneToMany_Required_Self_Inverse).Required(true);
+            modelBuilder.Entity<Level4>().HasMany(e => e.OneToMany_Required_Self).WithOne(e => e.OneToMany_Required_Self_Inverse).Required().WillCascadeOnDelete(false);
             modelBuilder.Entity<Level4>().HasMany(e => e.OneToMany_Optional_Self).WithOne(e => e.OneToMany_Optional_Self_Inverse).Required(false);
 
             modelBuilder.Entity<ComplexNavigationField>().HasKey(e => e.Name);

--- a/test/EntityFramework.Core.FunctionalTests/GraphUpdatesTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/GraphUpdatesTestBase.cs
@@ -3026,8 +3026,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
                         b.HasMany(e => e.RequiredChildren)
                             .WithOne(e => e.Parent)
-                            .ForeignKey(e => e.ParentId)
-                            .WillCascadeOnDelete();
+                            .ForeignKey(e => e.ParentId);
 
                         b.HasMany(e => e.OptionalChildren)
                             .WithOne(e => e.Parent)
@@ -3035,8 +3034,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
                         b.HasOne(e => e.RequiredSingle)
                             .WithOne(e => e.Root)
-                            .ForeignKey<RequiredSingle1>(e => e.Id)
-                            .WillCascadeOnDelete();
+                            .ForeignKey<RequiredSingle1>(e => e.Id);
 
                         b.HasOne(e => e.OptionalSingle)
                             .WithOne(e => e.Root)
@@ -3044,14 +3042,12 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
                         b.HasOne(e => e.RequiredNonPkSingle)
                             .WithOne(e => e.Root)
-                            .ForeignKey<RequiredNonPkSingle1>(e => e.RootId)
-                            .WillCascadeOnDelete();
+                            .ForeignKey<RequiredNonPkSingle1>(e => e.RootId);
 
                         b.HasMany(e => e.RequiredChildrenAk)
                             .WithOne(e => e.Parent)
                             .PrincipalKey(e => e.AlternateId)
-                            .ForeignKey(e => e.ParentId)
-                            .WillCascadeOnDelete();
+                            .ForeignKey(e => e.ParentId);
 
                         b.HasMany(e => e.OptionalChildrenAk)
                             .WithOne(e => e.Parent)
@@ -3061,8 +3057,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                         b.HasOne(e => e.RequiredSingleAk)
                             .WithOne(e => e.Root)
                             .PrincipalKey<Root>(e => e.AlternateId)
-                            .ForeignKey<RequiredSingleAk1>(e => e.RootId)
-                            .WillCascadeOnDelete();
+                            .ForeignKey<RequiredSingleAk1>(e => e.RootId);
 
                         b.HasOne(e => e.OptionalSingleAk)
                             .WithOne(e => e.Root)
@@ -3072,15 +3067,13 @@ namespace Microsoft.Data.Entity.FunctionalTests
                         b.HasOne(e => e.RequiredNonPkSingleAk)
                             .WithOne(e => e.Root)
                             .PrincipalKey<Root>(e => e.AlternateId)
-                            .ForeignKey<RequiredNonPkSingleAk1>(e => e.RootId)
-                            .WillCascadeOnDelete();
+                            .ForeignKey<RequiredNonPkSingleAk1>(e => e.RootId);
                     });
 
                 modelBuilder.Entity<Required1>()
                     .HasMany(e => e.Children)
                     .WithOne(e => e.Parent)
-                    .ForeignKey(e => e.ParentId)
-                    .WillCascadeOnDelete();
+                    .ForeignKey(e => e.ParentId);
 
                 modelBuilder.Entity<Optional1>()
                     .HasMany(e => e.Children)
@@ -3090,8 +3083,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 modelBuilder.Entity<RequiredSingle1>()
                     .HasOne(e => e.Single)
                     .WithOne(e => e.Back)
-                    .ForeignKey<RequiredSingle2>(e => e.Id)
-                    .WillCascadeOnDelete();
+                    .ForeignKey<RequiredSingle2>(e => e.Id);
 
                 modelBuilder.Entity<OptionalSingle1>()
                     .HasOne(e => e.Single)
@@ -3101,8 +3093,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 modelBuilder.Entity<RequiredNonPkSingle1>()
                     .HasOne(e => e.Single)
                     .WithOne(e => e.Back)
-                    .ForeignKey<RequiredNonPkSingle2>(e => e.BackId)
-                    .WillCascadeOnDelete();
+                    .ForeignKey<RequiredNonPkSingle2>(e => e.BackId);
 
                 modelBuilder.Entity<RequiredAk1>(b =>
                     {
@@ -3112,8 +3103,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                         b.HasMany(e => e.Children)
                             .WithOne(e => e.Parent)
                             .PrincipalKey(e => e.AlternateId)
-                            .ForeignKey(e => e.ParentId)
-                            .WillCascadeOnDelete();
+                            .ForeignKey(e => e.ParentId);
                     });
 
                 modelBuilder.Entity<OptionalAk1>(b =>
@@ -3135,8 +3125,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                         b.HasOne(e => e.Single)
                             .WithOne(e => e.Back)
                             .ForeignKey<RequiredSingleAk2>(e => e.BackId)
-                            .PrincipalKey<RequiredSingleAk1>(e => e.AlternateId)
-                            .WillCascadeOnDelete();
+                            .PrincipalKey<RequiredSingleAk1>(e => e.AlternateId);
                     });
 
                 modelBuilder.Entity<OptionalSingleAk1>(b =>
@@ -3158,8 +3147,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                         b.HasOne(e => e.Single)
                             .WithOne(e => e.Back)
                             .ForeignKey<RequiredNonPkSingleAk2>(e => e.BackId)
-                            .PrincipalKey<RequiredNonPkSingleAk1>(e => e.AlternateId)
-                            .WillCascadeOnDelete();
+                            .PrincipalKey<RequiredNonPkSingleAk1>(e => e.AlternateId);
                     });
 
                 modelBuilder.Entity<RequiredAk2>()

--- a/test/EntityFramework.Core.Tests/EntityFramework.Core.Tests.csproj
+++ b/test/EntityFramework.Core.Tests/EntityFramework.Core.Tests.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Metadata\Internal\InternalPropertyBuilderTest.cs" />
     <Compile Include="Metadata\Internal\InternalRelationshipBuilderTest.cs" />
     <Compile Include="Metadata\MetadataBuilderTest.cs" />
+    <Compile Include="Metadata\ModelConventions\CascadeDeleteConventionTest.cs" />
     <Compile Include="Metadata\ModelConventions\ConventionDispatcherTest.cs" />
     <Compile Include="Metadata\ModelConventions\ForeignKeyPropertyDiscoveryConventionTest.cs" />
     <Compile Include="Metadata\ModelConventions\KeyConventionTest.cs" />

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/CascadeDeleteConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/CascadeDeleteConventionTest.cs
@@ -1,0 +1,131 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Metadata.Conventions.Internal;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
+{
+    public class CascadeDeleteConventionTest
+    {
+        [Fact]
+        public void Cascade_delete_is_set_when_required_FK_is_added()
+        {
+            var modelBuilder = CreateModelBuilder();
+
+            modelBuilder.Entity<Post>()
+                .Property(e => e.BlogId)
+                .IsRequired();
+
+            var fk = modelBuilder.Entity<Blog>()
+                .HasMany(e => e.Posts)
+                .WithOne(e => e.Blog).Metadata;
+
+            Assert.Equal(DeleteBehavior.Cascade, fk.DeleteBehavior);
+        }
+
+        [Fact]
+        public void Cascade_delete_is_not_set_when_optional_FK_is_added()
+        {
+            var modelBuilder = CreateModelBuilder();
+
+            var fk = modelBuilder.Entity<Blog>()
+                .HasMany(e => e.Posts)
+                .WithOne(e => e.Blog).Metadata;
+
+            Assert.Equal(DeleteBehavior.None, fk.DeleteBehavior);
+        }
+
+        [Fact]
+        public void Cascade_delete_is_set_when_optional_FK_is_made_required()
+        {
+            var modelBuilder = CreateModelBuilder();
+
+            var fk = modelBuilder.Entity<Blog>()
+                .HasMany(e => e.Posts)
+                .WithOne(e => e.Blog).Metadata;
+
+            modelBuilder.Entity<Post>()
+                .Property(e => e.BlogId)
+                .IsRequired();
+
+            Assert.Equal(DeleteBehavior.Cascade, fk.DeleteBehavior);
+        }
+
+        [Fact]
+        public void Cascade_delete_is_not_set_when_required_FK_is_made_optional()
+        {
+            var modelBuilder = CreateModelBuilder();
+
+            modelBuilder.Entity<Post>()
+                .Property(e => e.BlogId)
+                .IsRequired();
+
+            var fk = modelBuilder.Entity<Blog>()
+                .HasMany(e => e.Posts)
+                .WithOne(e => e.Blog).Metadata;
+
+            modelBuilder.Entity<Post>()
+                .Property(e => e.BlogId)
+                .IsRequired(false);
+
+            Assert.Equal(DeleteBehavior.None, fk.DeleteBehavior);
+        }
+
+        [Fact]
+        public void Cascade_delete_is_not_changed_when_set_explicitly_on_added_FK()
+        {
+            var modelBuilder = CreateModelBuilder();
+
+            var fk = modelBuilder.Entity<Blog>()
+                .HasMany(e => e.Posts)
+                .WithOne(e => e.Blog)
+                .WillCascadeOnDelete()
+                .Metadata;
+
+            Assert.Equal(DeleteBehavior.Cascade, fk.DeleteBehavior);
+        }
+
+        [Fact]
+        public void Cascade_delete_is_not_changed_set_when_set_explicitly_on_FK()
+        {
+            var modelBuilder = CreateModelBuilder();
+
+            modelBuilder.Entity<Post>()
+                .Property(e => e.BlogId)
+                .IsRequired();
+
+            var fk = modelBuilder.Entity<Blog>()
+                .HasMany(e => e.Posts)
+                .WithOne(e => e.Blog)
+                .WillCascadeOnDelete()
+                .Metadata;
+
+            modelBuilder.Entity<Post>()
+                .Property(e => e.BlogId)
+                .IsRequired(false);
+
+            Assert.Equal(DeleteBehavior.Cascade, fk.DeleteBehavior);
+        }
+
+        private class Blog
+        {
+            public int Id { get; set; }
+
+            public ICollection<Post> Posts { get; set; }
+        }
+
+        private class Post
+        {
+            public int Id { get; set; }
+
+            public Blog Blog { get; set; }
+            public int? BlogId { get; set; }
+        }
+
+        private static ModelBuilder CreateModelBuilder()
+            => new ModelBuilder(new CoreConventionSetBuilder().CreateConventionSet());
+    }
+}

--- a/test/EntityFramework.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
+++ b/test/EntityFramework.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
@@ -924,7 +924,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x.Property<int>("Id");
                         x.HasKey("Id");
                         x.Property<int>("ParentId");
-                        x.HasOne("Amoeba").WithMany().ForeignKey("ParentId");
+                        x.HasOne("Amoeba").WithMany().ForeignKey("ParentId").WillCascadeOnDelete(false);
                     }),
                 operations =>
                 {
@@ -1119,7 +1119,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x.Property<int>("Id");
                         x.HasKey("Id");
                         x.Property<int>("ParentId1");
-                        x.HasOne("Mushroom").WithMany().ForeignKey("ParentId1");
+                        x.HasOne("Mushroom").WithMany().ForeignKey("ParentId1").WillCascadeOnDelete(false);
                         x.Property<int>("ParentId2");
                     }),
                 target => target.Entity(


### PR DESCRIPTION
Convention is applied when a new FK is added or when the nullability of a property that is part of an FK is changed.