### PR TITLE
:bug: Minor bug fixes for benchmarks infra

### DIFF
--- a/test/EntityFramework.Microbenchmarks.Core/BenchmarkIterationSummary.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/BenchmarkIterationSummary.cs
@@ -10,7 +10,7 @@ namespace EntityFramework.Microbenchmarks.Core
         public long TimeElapsed { get; set; }
         public long MemoryDelta { get; set; }
 
-        public void Aggregate(RunSummary other, MetricCollector collector)
+        public void Aggregate(RunSummary other, IMetricCollector collector)
         {
             Aggregate(other);
             TimeElapsed = collector.TimeElapsed;

--- a/test/EntityFramework.Microbenchmarks.Core/BenchmarkTestCaseBase.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/BenchmarkTestCaseBase.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace EntityFramework.Microbenchmarks.Core
+{
+    public abstract class BenchmarkTestCaseBase : XunitTestCase
+    {
+        public BenchmarkTestCaseBase(
+               string variation,
+               IMessageSink diagnosticMessageSink,
+               ITestMethod testMethod,
+               object[] testMethodArguments)
+            : base(diagnosticMessageSink, Xunit.Sdk.TestMethodDisplay.Method, testMethod, null)
+        {
+            // Override display name to avoid getting info about TestMethodArguments in the
+            // name (this is covered by the concept of Variation for benchmarks)
+            var name = TestMethod.Method.GetCustomAttributes(typeof(FactAttribute))
+                .First()
+                .GetNamedArgument<string>("DisplayName") ?? BaseDisplayName;
+
+            TestMethodName = name;
+            DisplayName = $"{name} [Variation: {variation}]";
+
+            DiagnosticMessageSink = diagnosticMessageSink;
+            Variation = variation;
+
+            var methodArguments = new List<object> { MetricCollector };
+            if (testMethodArguments != null)
+            {
+                methodArguments.AddRange(testMethodArguments);
+            }
+
+            TestMethodArguments = methodArguments.ToArray();
+        }
+
+        protected IMessageSink DiagnosticMessageSink { get; private set; }
+        public abstract IMetricCollector MetricCollector { get; }
+        public string TestMethodName { get; protected set; }
+        public string Variation { get; protected set; }
+
+        protected override string GetUniqueID()
+        {
+            return $"{TestMethod.TestClass.TestCollection.TestAssembly.Assembly.Name}{TestMethod.TestClass.Class.Name}{TestMethod.Method.Name}{Variation}";
+        }
+    }
+}

--- a/test/EntityFramework.Microbenchmarks.Core/EntityFramework.Microbenchmarks.Core.csproj
+++ b/test/EntityFramework.Microbenchmarks.Core/EntityFramework.Microbenchmarks.Core.csproj
@@ -40,10 +40,14 @@
     <Compile Include="BenchmarkIterationSummary.cs" />
     <Compile Include="BenchmarkRunSummary.cs" />
     <Compile Include="BenchmarkTestCase.cs" />
+    <Compile Include="BenchmarkTestCaseBase.cs" />
     <Compile Include="BenchmarkTestCaseDiscoverer.cs" />
     <Compile Include="BenchmarkTestCaseRunner.cs" />
     <Compile Include="BenchmarkVariationAttribute.cs" />
     <Compile Include="ColdStartSandbox.cs" />
+    <Compile Include="IMetricCollector.cs" />
+    <Compile Include="NonCollectingBenchmarkTestCase.cs" />
+    <Compile Include="NullMetricCollector.cs" />
     <Compile Include="MetricCollector.cs" />
     <Compile Include="Models\AdventureWorks\Address.cs" />
     <Compile Include="Models\AdventureWorks\AddressType.cs" />

--- a/test/EntityFramework.Microbenchmarks.Core/IMetricCollector.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/IMetricCollector.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace EntityFramework.Microbenchmarks.Core
+{
+    public interface IMetricCollector
+    {
+        IDisposable StartCollection();
+        void StopCollection();
+        void Reset();
+        long TimeElapsed { get; }
+        long MemoryDelta { get; }
+    }
+}

--- a/test/EntityFramework.Microbenchmarks.Core/MetricCollector.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/MetricCollector.cs
@@ -15,7 +15,7 @@ namespace EntityFramework.Microbenchmarks.Core
     }
 #endif
 
-    public partial class MetricCollector 
+    public partial class MetricCollector : IMetricCollector
     {
         private bool _collecting;
         private readonly Scope _scope;
@@ -70,9 +70,9 @@ namespace EntityFramework.Microbenchmarks.Core
 
         private partial class Scope : IDisposable
         {
-            private readonly MetricCollector _collector;
+            private readonly IMetricCollector _collector;
 
-            public Scope(MetricCollector collector)
+            public Scope(IMetricCollector collector)
             {
                 _collector = collector;
             }

--- a/test/EntityFramework.Microbenchmarks.Core/NonCollectingBenchmarkTestCase.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/NonCollectingBenchmarkTestCase.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+
+namespace EntityFramework.Microbenchmarks.Core
+{
+    public class NonCollectingBenchmarkTestCase : BenchmarkTestCaseBase
+    {
+        private readonly IMetricCollector _metricCollector = new NullMetricCollector();
+
+        public NonCollectingBenchmarkTestCase(
+               string variation,
+               IMessageSink diagnosticMessageSink,
+               ITestMethod testMethod,
+               object[] testMethodArguments)
+            : base(variation, diagnosticMessageSink, testMethod, testMethodArguments)
+        {
+        }
+
+        public override IMetricCollector MetricCollector => _metricCollector;
+    }
+}

--- a/test/EntityFramework.Microbenchmarks.Core/NullMetricCollector.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/NullMetricCollector.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+
+namespace EntityFramework.Microbenchmarks.Core
+{
+#if !DNXCORE50
+    public partial class NullMetricCollector : MarshalByRefObject
+    {
+        private partial class Scope : MarshalByRefObject
+        {
+        }
+    }
+#endif
+
+    public partial class NullMetricCollector : IMetricCollector
+    {
+        private readonly Scope _scope;
+
+        public NullMetricCollector()
+        {
+            _scope = new Scope();
+        }
+
+        public IDisposable StartCollection()
+        {
+            return _scope;
+        }
+
+        public void StopCollection()
+        { }
+
+        public void Reset()
+        { }
+
+        public long TimeElapsed => 0;
+
+        public long MemoryDelta => 0;
+
+        private partial class Scope : IDisposable
+        {
+            public Scope()
+            { }
+
+            public void Dispose()
+            { }
+        }
+
+    }
+}

--- a/test/EntityFramework.Microbenchmarks.EF6/ChangeTracker/DbSetOperationTests.cs
+++ b/test/EntityFramework.Microbenchmarks.EF6/ChangeTracker/DbSetOperationTests.cs
@@ -22,7 +22,7 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
         [Benchmark]
         [BenchmarkVariation("AutoDetectChanges On", true)]
         [BenchmarkVariation("AutoDetectChanges Off", false)]
-        public void Add(MetricCollector collector, bool autoDetectChanges)
+        public void Add(IMetricCollector collector, bool autoDetectChanges)
         {
             using (var context = _fixture.CreateContext())
             {
@@ -47,7 +47,7 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
         [Benchmark]
         [BenchmarkVariation("AutoDetectChanges On", true)]
         [BenchmarkVariation("AutoDetectChanges Off", false)]
-        public void AddCollection(MetricCollector collector, bool autoDetectChanges)
+        public void AddCollection(IMetricCollector collector, bool autoDetectChanges)
         {
             using (var context = _fixture.CreateContext())
             {
@@ -69,7 +69,7 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
         [Benchmark]
         [BenchmarkVariation("AutoDetectChanges On", true)]
         [BenchmarkVariation("AutoDetectChanges Off", false)]
-        public void Attach(MetricCollector collector, bool autoDetectChanges)
+        public void Attach(IMetricCollector collector, bool autoDetectChanges)
         {
             using (var context = _fixture.CreateContext())
             {
@@ -94,7 +94,7 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
         [Benchmark]
         [BenchmarkVariation("AutoDetectChanges On", true)]
         [BenchmarkVariation("AutoDetectChanges Off", false)]
-        public void Remove(MetricCollector collector, bool autoDetectChanges)
+        public void Remove(IMetricCollector collector, bool autoDetectChanges)
         {
             using (var context = _fixture.CreateContext())
             {
@@ -116,7 +116,7 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
         [Benchmark]
         [BenchmarkVariation("AutoDetectChanges On", true)]
         [BenchmarkVariation("AutoDetectChanges Off", false)]
-        public void RemoveCollection(MetricCollector collector, bool autoDetectChanges)
+        public void RemoveCollection(IMetricCollector collector, bool autoDetectChanges)
         {
             using (var context = _fixture.CreateContext())
             {
@@ -135,7 +135,7 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
         [Benchmark]
         [BenchmarkVariation("AutoDetectChanges On", true)]
         [BenchmarkVariation("AutoDetectChanges Off", false)]
-        public void Update(MetricCollector collector, bool autoDetectChanges)
+        public void Update(IMetricCollector collector, bool autoDetectChanges)
         {
             using (var context = _fixture.CreateContext())
             {

--- a/test/EntityFramework.Microbenchmarks.EF6/ChangeTracker/FixupTests.cs
+++ b/test/EntityFramework.Microbenchmarks.EF6/ChangeTracker/FixupTests.cs
@@ -20,7 +20,7 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
         }
 
         [Benchmark(Iterations = 10)]
-        public void AddChildren(MetricCollector collector)
+        public void AddChildren(IMetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
             {
@@ -45,7 +45,7 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
         //       only happens during SaveChanges for EF6.x (not during Add)
 
         [Benchmark(Iterations = 10)]
-        public void AttachChildren(MetricCollector collector)
+        public void AttachChildren(IMetricCollector collector)
         {
             List<Order> orders;
             using (var context = _fixture.CreateContext())
@@ -72,7 +72,7 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
         }
 
         [Benchmark(Iterations = 10)]
-        public void AttachParents(MetricCollector collector)
+        public void AttachParents(IMetricCollector collector)
         {
             List<Customer> customers;
             using (var context = _fixture.CreateContext())
@@ -99,7 +99,7 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
         }
 
         [Benchmark(Iterations = 10)]
-        public void QueryChildren(MetricCollector collector)
+        public void QueryChildren(IMetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
             {
@@ -116,7 +116,7 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
         }
 
         [Benchmark(Iterations = 10)]
-        public void QueryParents(MetricCollector collector)
+        public void QueryParents(IMetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
             {

--- a/test/EntityFramework.Microbenchmarks.EF6/InitializationTests.cs
+++ b/test/EntityFramework.Microbenchmarks.EF6/InitializationTests.cs
@@ -20,7 +20,7 @@ namespace EntityFramework.Microbenchmarks.EF6
         [BenchmarkVariation("Cold (1 instance)", true, 1)]
 #endif
         [BenchmarkVariation("Warm (100 instances)", false, 100)]
-        public void CreateAndDisposeUnusedContext(MetricCollector collector, bool cold, int count)
+        public void CreateAndDisposeUnusedContext(IMetricCollector collector, bool cold, int count)
         {
             RunColdStartEnabledTest(cold, c => c.CreateAndDisposeUnusedContext(collector, count));
         }
@@ -30,7 +30,7 @@ namespace EntityFramework.Microbenchmarks.EF6
         [BenchmarkVariation("Cold (1 instance)", true, 1)]
 #endif
         [BenchmarkVariation("Warm (10 instances)", false, 10)]
-        public void InitializeAndQuery_AdventureWorks(MetricCollector collector, bool cold, int count)
+        public void InitializeAndQuery_AdventureWorks(IMetricCollector collector, bool cold, int count)
         {
             RunColdStartEnabledTest(cold, c => c.InitializeAndQuery_AdventureWorks(collector, count));
         }
@@ -40,13 +40,13 @@ namespace EntityFramework.Microbenchmarks.EF6
         [BenchmarkVariation("Cold (1 instance)", true, 1)]
 #endif
         [BenchmarkVariation("Warm (10 instances)", false, 10)]
-        public void InitializeAndSaveChanges_AdventureWorks(MetricCollector collector, bool cold, int count)
+        public void InitializeAndSaveChanges_AdventureWorks(IMetricCollector collector, bool cold, int count)
         {
             RunColdStartEnabledTest(cold, t => t.InitializeAndSaveChanges_AdventureWorks(collector, count));
         }
 
         [Benchmark]
-        public void BuildModel_AdventureWorks(MetricCollector collector)
+        public void BuildModel_AdventureWorks(IMetricCollector collector)
         {
             collector.StartCollection();
 
@@ -77,7 +77,7 @@ namespace EntityFramework.Microbenchmarks.EF6
 
         private class ColdStartEnabledTests : MarshalByRefObject
         {
-            public void CreateAndDisposeUnusedContext(MetricCollector collector, int count)
+            public void CreateAndDisposeUnusedContext(IMetricCollector collector, int count)
             {
                 using (collector.StartCollection())
                 {
@@ -90,7 +90,7 @@ namespace EntityFramework.Microbenchmarks.EF6
                 }
             }
 
-            public void InitializeAndQuery_AdventureWorks(MetricCollector collector, int count)
+            public void InitializeAndQuery_AdventureWorks(IMetricCollector collector, int count)
             {
                 using (collector.StartCollection())
                 {
@@ -104,7 +104,7 @@ namespace EntityFramework.Microbenchmarks.EF6
                 }
             }
 
-            public void InitializeAndSaveChanges_AdventureWorks(MetricCollector collector, int count)
+            public void InitializeAndSaveChanges_AdventureWorks(IMetricCollector collector, int count)
             {
                 using (collector.StartCollection())
                 {

--- a/test/EntityFramework.Microbenchmarks.EF6/Query/FuncletizationTests.cs
+++ b/test/EntityFramework.Microbenchmarks.EF6/Query/FuncletizationTests.cs
@@ -19,7 +19,7 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
         }
 
         [Benchmark]
-        public void NewQueryInstance(MetricCollector collector)
+        public void NewQueryInstance(IMetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
             {
@@ -37,7 +37,7 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
         }
 
         [Benchmark]
-        public void SameQueryInstance(MetricCollector collector)
+        public void SameQueryInstance(IMetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
             {
@@ -57,7 +57,7 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
         }
 
         [Benchmark]
-        public void ValueFromObject(MetricCollector collector)
+        public void ValueFromObject(IMetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
             {

--- a/test/EntityFramework.Microbenchmarks.EF6/Query/SimpleQueryTests.cs
+++ b/test/EntityFramework.Microbenchmarks.EF6/Query/SimpleQueryTests.cs
@@ -23,7 +23,7 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
         [BenchmarkVariation("Tracking Off", false, true)]
         [BenchmarkVariation("Tracking On (No Query Cache)", true, false)]
         [BenchmarkVariation("Tracking Off (No Query Cache)", false, false)]
-        public void LoadAll(MetricCollector collector, bool tracking, bool caching)
+        public void LoadAll(IMetricCollector collector, bool tracking, bool caching)
         {
             using (var context = _fixture.CreateContext())
             {
@@ -43,7 +43,7 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
         [BenchmarkVariation("Tracking Off", false, true)]
         [BenchmarkVariation("Tracking On (No Query Cache)", true, false)]
         [BenchmarkVariation("Tracking Off (No Query Cache)", false, false)]
-        public void Where(MetricCollector collector, bool tracking, bool caching)
+        public void Where(IMetricCollector collector, bool tracking, bool caching)
         {
             using (var context = _fixture.CreateContext())
             {
@@ -64,7 +64,7 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
         [BenchmarkVariation("Tracking Off", false, true)]
         [BenchmarkVariation("Tracking On (No Query Cache)", true, false)]
         [BenchmarkVariation("Tracking Off (No Query Cache)", false, false)]
-        public void OrderBy(MetricCollector collector, bool tracking, bool caching)
+        public void OrderBy(IMetricCollector collector, bool tracking, bool caching)
         {
             using (var context = _fixture.CreateContext())
             {
@@ -83,7 +83,7 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
         [Benchmark]
         [BenchmarkVariation("Default", true)]
         [BenchmarkVariation("No Query Cache", false)]
-        public void Count(MetricCollector collector, bool caching)
+        public void Count(IMetricCollector collector, bool caching)
         {
             using (var context = _fixture.CreateContext())
             {
@@ -102,7 +102,7 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
         [BenchmarkVariation("Tracking Off", false, true)]
         [BenchmarkVariation("Tracking On (No Query Cache)", true, false)]
         [BenchmarkVariation("Tracking Off (No Query Cache)", false, false)]
-        public void SkipTake(MetricCollector collector, bool tracking, bool caching)
+        public void SkipTake(IMetricCollector collector, bool tracking, bool caching)
         {
             using (var context = _fixture.CreateContext())
             {
@@ -122,7 +122,7 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
         [Benchmark]
         [BenchmarkVariation("Default", true)]
         [BenchmarkVariation("No Query Cache", false)]
-        public void GroupBy(MetricCollector collector, bool caching)
+        public void GroupBy(IMetricCollector collector, bool caching)
         {
             using (var context = _fixture.CreateContext())
             {
@@ -148,7 +148,7 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
         [BenchmarkVariation("Tracking Off", false, true)]
         [BenchmarkVariation("Tracking On (No Query Cache)", true, false)]
         [BenchmarkVariation("Tracking Off (No Query Cache)", false, false)]
-        public void Include(MetricCollector collector, bool tracking, bool caching)
+        public void Include(IMetricCollector collector, bool tracking, bool caching)
         {
             using (var context = _fixture.CreateContext())
             {
@@ -168,7 +168,7 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
         [Benchmark]
         [BenchmarkVariation("Default", true)]
         [BenchmarkVariation("No Query Cache", false)]
-        public void Projection(MetricCollector collector, bool caching)
+        public void Projection(IMetricCollector collector, bool caching)
         {
             using (var context = _fixture.CreateContext())
             {
@@ -186,7 +186,7 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
         [Benchmark]
         [BenchmarkVariation("Default", true)]
         [BenchmarkVariation("No Query Cache", false)]
-        public void ProjectionAcrossNavigation(MetricCollector collector, bool caching)
+        public void ProjectionAcrossNavigation(IMetricCollector collector, bool caching)
         {
             using (var context = _fixture.CreateContext())
             {

--- a/test/EntityFramework.Microbenchmarks.EF6/UpdatePipeline/SimpleUpdatePipelineTests.cs
+++ b/test/EntityFramework.Microbenchmarks.EF6/UpdatePipeline/SimpleUpdatePipelineTests.cs
@@ -19,7 +19,7 @@ namespace EntityFramework.Microbenchmarks.EF6.UpdatePipeline
         }
 
         [Benchmark]
-        public void Insert(MetricCollector collector)
+        public void Insert(IMetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
             {
@@ -40,7 +40,7 @@ namespace EntityFramework.Microbenchmarks.EF6.UpdatePipeline
         }
 
         [Benchmark]
-        public void Update(MetricCollector collector)
+        public void Update(IMetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
             {
@@ -61,7 +61,7 @@ namespace EntityFramework.Microbenchmarks.EF6.UpdatePipeline
         }
 
         [Benchmark]
-        public void Delete(MetricCollector collector)
+        public void Delete(IMetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
             {
@@ -82,7 +82,7 @@ namespace EntityFramework.Microbenchmarks.EF6.UpdatePipeline
         }
 
         [Benchmark]
-        public void Mixed(MetricCollector collector)
+        public void Mixed(IMetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
             {

--- a/test/EntityFramework.Microbenchmarks/CalibrationTests.cs
+++ b/test/EntityFramework.Microbenchmarks/CalibrationTests.cs
@@ -10,7 +10,7 @@ namespace EntityFramework.Microbenchmarks
     public class CalibrationTests
     {
         [Benchmark]
-        public void Calibration_100ms(MetricCollector collector)
+        public void Calibration_100ms(IMetricCollector collector)
         {
             using (collector.StartCollection())
             {
@@ -19,7 +19,7 @@ namespace EntityFramework.Microbenchmarks
         }
 
         [Benchmark]
-        public void Calibration_100ms_controlled(MetricCollector collector)
+        public void Calibration_100ms_controlled(IMetricCollector collector)
         {
 
             Thread.Sleep(100);
@@ -31,7 +31,7 @@ namespace EntityFramework.Microbenchmarks
 
 #if !DNXCORE50 && !DNX451
         [Benchmark]
-        public void ColdStartSandbox_100ms(MetricCollector collector)
+        public void ColdStartSandbox_100ms(IMetricCollector collector)
         {
             using (var sandbox = new ColdStartSandbox())
             {
@@ -42,7 +42,7 @@ namespace EntityFramework.Microbenchmarks
 
         private partial class ColdStartEnabledTests : MarshalByRefObject
         {
-            public void Sleep100ms(MetricCollector collector)
+            public void Sleep100ms(IMetricCollector collector)
             {
                 using (collector.StartCollection())
                 {

--- a/test/EntityFramework.Microbenchmarks/ChangeTracker/DbSetOperationTests.cs
+++ b/test/EntityFramework.Microbenchmarks/ChangeTracker/DbSetOperationTests.cs
@@ -21,7 +21,7 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
         [Benchmark]
         [BenchmarkVariation("AutoDetectChanges On", true)]
         [BenchmarkVariation("AutoDetectChanges Off", false)]
-        public void Add(MetricCollector collector, bool autoDetectChanges)
+        public void Add(IMetricCollector collector, bool autoDetectChanges)
         {
             using (var context = _fixture.CreateContext())
             {
@@ -46,7 +46,7 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
         [Benchmark]
         [BenchmarkVariation("AutoDetectChanges On", true)]
         [BenchmarkVariation("AutoDetectChanges Off", false)]
-        public void AddCollection(MetricCollector collector, bool autoDetectChanges)
+        public void AddCollection(IMetricCollector collector, bool autoDetectChanges)
         {
             using (var context = _fixture.CreateContext())
             {
@@ -69,7 +69,7 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
         [Benchmark]
         [BenchmarkVariation("AutoDetectChanges On", true)]
         [BenchmarkVariation("AutoDetectChanges Off", false)]
-        public void Attach(MetricCollector collector, bool autoDetectChanges)
+        public void Attach(IMetricCollector collector, bool autoDetectChanges)
         {
             using (var context = _fixture.CreateContext())
             {
@@ -92,7 +92,7 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
         [Benchmark]
         [BenchmarkVariation("AutoDetectChanges On", true)]
         [BenchmarkVariation("AutoDetectChanges Off", false)]
-        public void AttachCollection(MetricCollector collector, bool autoDetectChanges)
+        public void AttachCollection(IMetricCollector collector, bool autoDetectChanges)
         {
             using (var context = _fixture.CreateContext())
             {
@@ -111,7 +111,7 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
         [Benchmark]
         [BenchmarkVariation("AutoDetectChanges On", true)]
         [BenchmarkVariation("AutoDetectChanges Off", false)]
-        public void Remove(MetricCollector collector, bool autoDetectChanges)
+        public void Remove(IMetricCollector collector, bool autoDetectChanges)
         {
             using (var context = _fixture.CreateContext())
             {
@@ -133,7 +133,7 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
         [Benchmark]
         [BenchmarkVariation("AutoDetectChanges On", true)]
         [BenchmarkVariation("AutoDetectChanges Off", false)]
-        public void RemoveCollection(MetricCollector collector, bool autoDetectChanges)
+        public void RemoveCollection(IMetricCollector collector, bool autoDetectChanges)
         {
             using (var context = _fixture.CreateContext())
             {
@@ -152,7 +152,7 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
         [Benchmark]
         [BenchmarkVariation("AutoDetectChanges On", true)]
         [BenchmarkVariation("AutoDetectChanges Off", false)]
-        public void Update(MetricCollector collector, bool autoDetectChanges)
+        public void Update(IMetricCollector collector, bool autoDetectChanges)
         {
             using (var context = _fixture.CreateContext())
             {
@@ -174,7 +174,7 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
         [Benchmark]
         [BenchmarkVariation("AutoDetectChanges On", true)]
         [BenchmarkVariation("AutoDetectChanges Off", false)]
-        public void UpdateCollection(MetricCollector collector, bool autoDetectChanges)
+        public void UpdateCollection(IMetricCollector collector, bool autoDetectChanges)
         {
             using (var context = _fixture.CreateContext())
             {

--- a/test/EntityFramework.Microbenchmarks/ChangeTracker/FixupTests.cs
+++ b/test/EntityFramework.Microbenchmarks/ChangeTracker/FixupTests.cs
@@ -20,7 +20,7 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
         }
 
         [Benchmark(Iterations = 10)]
-        public void AddChildren(MetricCollector collector)
+        public void AddChildren(IMetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
             {
@@ -42,7 +42,7 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
         }
 
         [Benchmark(Iterations = 10)]
-        public void AddParents(MetricCollector collector)
+        public void AddParents(IMetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
             {
@@ -66,7 +66,7 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
         }
 
         [Benchmark(Iterations = 10)]
-        public void AttachChildren(MetricCollector collector)
+        public void AttachChildren(IMetricCollector collector)
         {
             List<Order> orders;
             using (var context = _fixture.CreateContext())
@@ -93,7 +93,7 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
         }
 
         [Benchmark(Iterations = 10)]
-        public void AttachParents(MetricCollector collector)
+        public void AttachParents(IMetricCollector collector)
         {
             List<Customer> customers;
             using (var context = _fixture.CreateContext())
@@ -120,7 +120,7 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
         }
 
         [Benchmark(Iterations = 10)]
-        public void QueryChildren(MetricCollector collector)
+        public void QueryChildren(IMetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
             {
@@ -137,7 +137,7 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
         }
 
         [Benchmark(Iterations = 10)]
-        public void QueryParents(MetricCollector collector)
+        public void QueryParents(IMetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
             {

--- a/test/EntityFramework.Microbenchmarks/InitializationTests.cs
+++ b/test/EntityFramework.Microbenchmarks/InitializationTests.cs
@@ -20,7 +20,7 @@ namespace EntityFramework.Microbenchmarks
         [BenchmarkVariation("Cold (1 instance)", true, 1)]
 #endif
         [BenchmarkVariation("Warm (100 instances)", false, 100)]
-        public void CreateAndDisposeUnusedContext(MetricCollector collector, bool cold, int count)
+        public void CreateAndDisposeUnusedContext(IMetricCollector collector, bool cold, int count)
         {
             RunColdStartEnabledTest(cold, c => c.CreateAndDisposeUnusedContext(collector, count));
         }
@@ -30,7 +30,7 @@ namespace EntityFramework.Microbenchmarks
         [BenchmarkVariation("Cold (1 instance)", true, 1)]
 #endif
         [BenchmarkVariation("Warm (10 instances)", false, 10)]
-        public void InitializeAndQuery_AdventureWorks(MetricCollector collector, bool cold, int count)
+        public void InitializeAndQuery_AdventureWorks(IMetricCollector collector, bool cold, int count)
         {
             RunColdStartEnabledTest(cold, c => c.InitializeAndQuery_AdventureWorks(collector, count));
         }
@@ -40,13 +40,13 @@ namespace EntityFramework.Microbenchmarks
         [BenchmarkVariation("Cold (1 instance)", true, 1)]
 #endif
         [BenchmarkVariation("Warm (10 instances)", false, 10)]
-        public void InitializeAndSaveChanges_AdventureWorks(MetricCollector collector, bool cold, int count)
+        public void InitializeAndSaveChanges_AdventureWorks(IMetricCollector collector, bool cold, int count)
         {
             RunColdStartEnabledTest(cold, t => t.InitializeAndSaveChanges_AdventureWorks(collector, count));
         }
 
         [Benchmark]
-        public void BuildModel_AdventureWorks(MetricCollector collector)
+        public void BuildModel_AdventureWorks(IMetricCollector collector)
         {
             collector.StartCollection();
 
@@ -91,7 +91,7 @@ namespace EntityFramework.Microbenchmarks
 
         private partial class ColdStartEnabledTests
         {
-            public void CreateAndDisposeUnusedContext(MetricCollector collector, int count)
+            public void CreateAndDisposeUnusedContext(IMetricCollector collector, int count)
             {
                 using (collector.StartCollection())
                 {
@@ -104,7 +104,7 @@ namespace EntityFramework.Microbenchmarks
                 }
             }
 
-            public void InitializeAndQuery_AdventureWorks(MetricCollector collector, int count)
+            public void InitializeAndQuery_AdventureWorks(IMetricCollector collector, int count)
             {
                 using (collector.StartCollection())
                 {
@@ -118,7 +118,7 @@ namespace EntityFramework.Microbenchmarks
                 }
             }
 
-            public void InitializeAndSaveChanges_AdventureWorks(MetricCollector collector, int count)
+            public void InitializeAndSaveChanges_AdventureWorks(IMetricCollector collector, int count)
             {
                 using (collector.StartCollection())
                 {

--- a/test/EntityFramework.Microbenchmarks/Query/FuncletizationTests.cs
+++ b/test/EntityFramework.Microbenchmarks/Query/FuncletizationTests.cs
@@ -20,7 +20,7 @@ namespace EntityFramework.Microbenchmarks.Query
         }
 
         [Benchmark]
-        public void NewQueryInstance(MetricCollector collector)
+        public void NewQueryInstance(IMetricCollector collector)
         {
 
             using (var context = _fixture.CreateContext())
@@ -39,7 +39,7 @@ namespace EntityFramework.Microbenchmarks.Query
         }
 
         [Benchmark]
-        public void SameQueryInstance(MetricCollector collector)
+        public void SameQueryInstance(IMetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
             {
@@ -59,7 +59,7 @@ namespace EntityFramework.Microbenchmarks.Query
         }
 
         [Benchmark]
-        public void ValueFromObject(MetricCollector collector)
+        public void ValueFromObject(IMetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
             {

--- a/test/EntityFramework.Microbenchmarks/Query/SimpleQueryTests.cs
+++ b/test/EntityFramework.Microbenchmarks/Query/SimpleQueryTests.cs
@@ -26,7 +26,7 @@ namespace EntityFramework.Microbenchmarks.Query
         [BenchmarkVariation("Tracking Off", false, true)]
         [BenchmarkVariation("Tracking On (No Query Cache)", true, false)]
         [BenchmarkVariation("Tracking Off (No Query Cache)", false, false)]
-        public void LoadAll(MetricCollector collector, bool tracking, bool caching)
+        public void LoadAll(IMetricCollector collector, bool tracking, bool caching)
         {
             using (var context = _fixture.CreateContext(queryCachingEnabled: caching))
             {
@@ -44,7 +44,7 @@ namespace EntityFramework.Microbenchmarks.Query
         [BenchmarkVariation("Tracking Off", false, true)]
         [BenchmarkVariation("Tracking On (No Query Cache)", true, false)]
         [BenchmarkVariation("Tracking Off (No Query Cache)", false, false)]
-        public void Where(MetricCollector collector, bool tracking, bool caching)
+        public void Where(IMetricCollector collector, bool tracking, bool caching)
         {
             using (var context = _fixture.CreateContext(queryCachingEnabled: caching))
             {
@@ -64,7 +64,7 @@ namespace EntityFramework.Microbenchmarks.Query
         [BenchmarkVariation("Tracking Off", false, true)]
         [BenchmarkVariation("Tracking On (No Query Cache)", true, false)]
         [BenchmarkVariation("Tracking Off (No Query Cache)", false, false)]
-        public void OrderBy(MetricCollector collector, bool tracking, bool caching)
+        public void OrderBy(IMetricCollector collector, bool tracking, bool caching)
         {
             using (var context = _fixture.CreateContext(queryCachingEnabled: caching))
             {
@@ -82,7 +82,7 @@ namespace EntityFramework.Microbenchmarks.Query
         [Benchmark]
         [BenchmarkVariation("Default", true)]
         [BenchmarkVariation("No Query Cache", false)]
-        public void Count(MetricCollector collector, bool caching)
+        public void Count(IMetricCollector collector, bool caching)
         {
             using (var context = _fixture.CreateContext(queryCachingEnabled: caching))
             {
@@ -100,7 +100,7 @@ namespace EntityFramework.Microbenchmarks.Query
         [BenchmarkVariation("Tracking Off", false, true)]
         [BenchmarkVariation("Tracking On (No Query Cache)", true, false)]
         [BenchmarkVariation("Tracking Off (No Query Cache)", false, false)]
-        public void SkipTake(MetricCollector collector, bool tracking, bool caching)
+        public void SkipTake(IMetricCollector collector, bool tracking, bool caching)
         {
             using (var context = _fixture.CreateContext(queryCachingEnabled: caching))
             {
@@ -119,7 +119,7 @@ namespace EntityFramework.Microbenchmarks.Query
         [Benchmark]
         [BenchmarkVariation("Default", true)]
         [BenchmarkVariation("No Query Cache", false)]
-        public void GroupBy(MetricCollector collector, bool caching)
+        public void GroupBy(IMetricCollector collector, bool caching)
         {
             using (var context = _fixture.CreateContext(queryCachingEnabled: caching))
             {
@@ -144,7 +144,7 @@ namespace EntityFramework.Microbenchmarks.Query
         [BenchmarkVariation("Tracking Off", false, true)]
         [BenchmarkVariation("Tracking On (No Query Cache)", true, false)]
         [BenchmarkVariation("Tracking Off (No Query Cache)", false, false)]
-        public void Include(MetricCollector collector, bool tracking, bool caching)
+        public void Include(IMetricCollector collector, bool tracking, bool caching)
         {
             using (var context = _fixture.CreateContext(queryCachingEnabled: caching))
             {
@@ -163,7 +163,7 @@ namespace EntityFramework.Microbenchmarks.Query
         [Benchmark]
         [BenchmarkVariation("Default", true)]
         [BenchmarkVariation("No Query Cache", false)]
-        public void Projection(MetricCollector collector, bool caching)
+        public void Projection(IMetricCollector collector, bool caching)
         {
             using (var context = _fixture.CreateContext(queryCachingEnabled: caching))
             {
@@ -180,7 +180,7 @@ namespace EntityFramework.Microbenchmarks.Query
         [Benchmark]
         [BenchmarkVariation("Default", true)]
         [BenchmarkVariation("No Query Cache", false)]
-        public void ProjectionAcrossNavigation(MetricCollector collector, bool caching)
+        public void ProjectionAcrossNavigation(IMetricCollector collector, bool caching)
         {
             using (var context = _fixture.CreateContext(queryCachingEnabled: caching))
             {

--- a/test/EntityFramework.Microbenchmarks/UpdatePipeline/SimpleUpdatePipelineTests.cs
+++ b/test/EntityFramework.Microbenchmarks/UpdatePipeline/SimpleUpdatePipelineTests.cs
@@ -22,7 +22,7 @@ namespace EntityFramework.Microbenchmarks.UpdatePipeline
         [Benchmark]
         [BenchmarkVariation("Batching Off", true)]
         [BenchmarkVariation("Default", false)]
-        public void Insert(MetricCollector collector, bool disableBatching)
+        public void Insert(IMetricCollector collector, bool disableBatching)
         {
             using (var context = _fixture.CreateContext(disableBatching))
             {
@@ -45,7 +45,7 @@ namespace EntityFramework.Microbenchmarks.UpdatePipeline
         [Benchmark]
         [BenchmarkVariation("Batching Off", true)]
         [BenchmarkVariation("Default", false)]
-        public void Update(MetricCollector collector, bool disableBatching)
+        public void Update(IMetricCollector collector, bool disableBatching)
         {
             using (var context = _fixture.CreateContext(disableBatching))
             {
@@ -68,7 +68,7 @@ namespace EntityFramework.Microbenchmarks.UpdatePipeline
         [Benchmark]
         [BenchmarkVariation("Batching Off", true)]
         [BenchmarkVariation("Default", false)]
-        public void Delete(MetricCollector collector, bool disableBatching)
+        public void Delete(IMetricCollector collector, bool disableBatching)
         {
             using (var context = _fixture.CreateContext(disableBatching))
             {
@@ -91,7 +91,7 @@ namespace EntityFramework.Microbenchmarks.UpdatePipeline
         [Benchmark]
         [BenchmarkVariation("Batching Off", true)]
         [BenchmarkVariation("Default", false)]
-        public void Mixed(MetricCollector collector, bool disableBatching)
+        public void Mixed(IMetricCollector collector, bool disableBatching)
         {
             using (var context = _fixture.CreateContext(disableBatching))
             {


### PR DESCRIPTION
* Adding a check to only store results if all iterations pass.
* Overriding GetUniqueID to avoid exception that was being swallowed by
xunit but resulted in warnings when diagnostic logging is switched on
(the default implementation serializes method arguments to get the
unique name - but we have the concept of Variation that serves that same
purpose).
* Since the above change introduced a new TestCase type that is used
when not running all iterations, I also took the opportunity to make
this more efficient by using a null collector that avoids garbage
collection etc. This turned out to be the cause of the extreme slow down on DNX... so also removing the logic that skipped tests on DNX.