### PR TITLE
Allow setting cascade action of SetNull

### DIFF
--- a/src/EntityFramework.Core/Metadata/Builders/ReferenceCollectionBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Builders/ReferenceCollectionBuilder.cs
@@ -125,8 +125,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         public virtual ReferenceCollectionBuilder Required(bool required = true)
             => new ReferenceCollectionBuilder(Builder.Required(required, ConfigurationSource.Explicit));
 
-        public virtual ReferenceCollectionBuilder WillCascadeOnDelete(bool cascade = true)
-            => new ReferenceCollectionBuilder(
-                Builder.DeleteBehavior(cascade ? DeleteBehavior.Cascade : DeleteBehavior.None, ConfigurationSource.Explicit));
+        public virtual ReferenceCollectionBuilder OnDelete(DeleteBehavior deleteBehavior)
+            => new ReferenceCollectionBuilder(Builder.DeleteBehavior(deleteBehavior, ConfigurationSource.Explicit));
     }
 }

--- a/src/EntityFramework.Core/Metadata/Builders/ReferenceCollectionBuilder`.cs
+++ b/src/EntityFramework.Core/Metadata/Builders/ReferenceCollectionBuilder`.cs
@@ -168,9 +168,9 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         public new virtual ReferenceCollectionBuilder<TPrincipalEntity, TDependentEntity> Required(bool required = true)
             => new ReferenceCollectionBuilder<TPrincipalEntity, TDependentEntity>(Builder.Required(required, ConfigurationSource.Explicit));
 
-        public new virtual ReferenceCollectionBuilder<TPrincipalEntity, TDependentEntity> WillCascadeOnDelete(bool cascade = true)
+        public new virtual ReferenceCollectionBuilder<TPrincipalEntity, TDependentEntity> OnDelete(DeleteBehavior deleteBehavior)
             => new ReferenceCollectionBuilder<TPrincipalEntity, TDependentEntity>(
-                Builder.DeleteBehavior(cascade ? DeleteBehavior.Cascade : DeleteBehavior.None, ConfigurationSource.Explicit));
+                Builder.DeleteBehavior(deleteBehavior, ConfigurationSource.Explicit));
 
         private InternalRelationshipBuilder Builder => this.GetService<InternalRelationshipBuilder>();
     }

--- a/src/EntityFramework.Core/Metadata/Builders/ReferenceReferenceBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Builders/ReferenceReferenceBuilder.cs
@@ -198,9 +198,8 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         public virtual ReferenceReferenceBuilder Required(bool required = true)
             => new ReferenceReferenceBuilder(Builder.Required(required, ConfigurationSource.Explicit));
 
-        public virtual ReferenceReferenceBuilder WillCascadeOnDelete(bool cascade = true)
-            => new ReferenceReferenceBuilder(
-                Builder.DeleteBehavior(cascade ? DeleteBehavior.Cascade : DeleteBehavior.None, ConfigurationSource.Explicit));
+        public virtual ReferenceReferenceBuilder OnDelete(DeleteBehavior deleteBehavior)
+            => new ReferenceReferenceBuilder(Builder.DeleteBehavior(deleteBehavior, ConfigurationSource.Explicit));
 
         private InternalRelationshipBuilder Builder => this.GetService<InternalRelationshipBuilder>();
     }

--- a/src/EntityFramework.Core/Metadata/Builders/ReferenceReferenceBuilder`.cs
+++ b/src/EntityFramework.Core/Metadata/Builders/ReferenceReferenceBuilder`.cs
@@ -242,9 +242,8 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         public new virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> Required(bool required = true)
             => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(Builder.Required(required, ConfigurationSource.Explicit));
 
-        public new virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> WillCascadeOnDelete(bool cascade = true)
-            => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
-                Builder.DeleteBehavior(cascade ? DeleteBehavior.Cascade : DeleteBehavior.None, ConfigurationSource.Explicit));
+        public new virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> OnDelete(DeleteBehavior deleteBehavior)
+            => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(Builder.DeleteBehavior(deleteBehavior, ConfigurationSource.Explicit));
 
         private InternalRelationshipBuilder Builder => this.GetService<InternalRelationshipBuilder>();
     }

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/CascadeDeleteConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/CascadeDeleteConvention.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
             relationshipBuilder.DeleteBehavior(
                 ((IForeignKey)relationshipBuilder.Metadata).IsRequired
                     ? DeleteBehavior.Cascade
-                    : DeleteBehavior.None,
+                    : DeleteBehavior.Restrict,
                 ConfigurationSource.Convention,
                 runConventions: false);
 

--- a/src/EntityFramework.Core/Metadata/DeleteBehavior.cs
+++ b/src/EntityFramework.Core/Metadata/DeleteBehavior.cs
@@ -5,7 +5,8 @@ namespace Microsoft.Data.Entity.Metadata
 {
     public enum DeleteBehavior
     {
-        None,
+        Restrict,
+        SetNull,
         Cascade
     }
 }

--- a/src/EntityFramework.Core/Metadata/ForeignKey.cs
+++ b/src/EntityFramework.Core/Metadata/ForeignKey.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Data.Entity.Metadata
             }
         }
 
-        protected virtual DeleteBehavior DefaultDeleteBehavior => Metadata.DeleteBehavior.None;
+        protected virtual DeleteBehavior DefaultDeleteBehavior => Metadata.DeleteBehavior.Restrict;
 
         IReadOnlyList<IProperty> IForeignKey.Properties => Properties;
 

--- a/src/EntityFramework.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EntityFramework.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -607,7 +607,9 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                 PrincipalColumns = GetColumns(target.PrincipalKey.Properties),
                 OnDelete = target.DeleteBehavior == DeleteBehavior.Cascade
                     ? ReferentialAction.Cascade
-                    : ReferentialAction.NoAction
+                    : target.DeleteBehavior == DeleteBehavior.SetNull
+                        ? ReferentialAction.SetNull
+                        : ReferentialAction.Restrict
             };
             CopyAnnotations(MigrationsAnnotations.For(target), operation);
 

--- a/test/EntityFramework.Core.FunctionalTests/ComplexNavigationsQueryFixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/ComplexNavigationsQueryFixtureBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Data.Entity.FunctionalTests.TestModels.ComplexNavigationsModel;
+using Microsoft.Data.Entity.Metadata;
 
 namespace Microsoft.Data.Entity.FunctionalTests
 {
@@ -20,39 +21,39 @@ namespace Microsoft.Data.Entity.FunctionalTests
             modelBuilder.Entity<Level4>().Property(e => e.Id).ValueGeneratedNever();
 
             modelBuilder.Entity<Level1>().HasOne(e => e.OneToOne_Optional_Self).WithOne();
-            modelBuilder.Entity<Level1>().HasOne(e => e.OneToOne_Required_PK).WithOne(e => e.OneToOne_Required_PK_Inverse).PrincipalKey<Level1>(e => e.Id).Required().WillCascadeOnDelete(false);
+            modelBuilder.Entity<Level1>().HasOne(e => e.OneToOne_Required_PK).WithOne(e => e.OneToOne_Required_PK_Inverse).PrincipalKey<Level1>(e => e.Id).Required().OnDelete(DeleteBehavior.Restrict);
             modelBuilder.Entity<Level1>().HasOne(e => e.OneToOne_Optional_PK).WithOne(e => e.OneToOne_Optional_PK_Inverse).PrincipalKey<Level1>(e => e.Id).Required(false);
-            modelBuilder.Entity<Level1>().HasOne(e => e.OneToOne_Required_FK).WithOne(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level2>(e => e.Level1_Required_Id).Required().WillCascadeOnDelete(false);
+            modelBuilder.Entity<Level1>().HasOne(e => e.OneToOne_Required_FK).WithOne(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level2>(e => e.Level1_Required_Id).Required().OnDelete(DeleteBehavior.Restrict);
             modelBuilder.Entity<Level1>().HasOne(e => e.OneToOne_Optional_FK).WithOne(e => e.OneToOne_Optional_FK_Inverse).ForeignKey<Level2>(e => e.Level1_Optional_Id).Required(false);
-            modelBuilder.Entity<Level1>().HasMany(e => e.OneToMany_Required).WithOne(e => e.OneToMany_Required_Inverse).Required().WillCascadeOnDelete(false);
+            modelBuilder.Entity<Level1>().HasMany(e => e.OneToMany_Required).WithOne(e => e.OneToMany_Required_Inverse).Required().OnDelete(DeleteBehavior.Restrict);
             modelBuilder.Entity<Level1>().HasMany(e => e.OneToMany_Optional).WithOne(e => e.OneToMany_Optional_Inverse).Required(false);
-            modelBuilder.Entity<Level1>().HasMany(e => e.OneToMany_Required_Self).WithOne(e => e.OneToMany_Required_Self_Inverse).Required().WillCascadeOnDelete(false);
+            modelBuilder.Entity<Level1>().HasMany(e => e.OneToMany_Required_Self).WithOne(e => e.OneToMany_Required_Self_Inverse).Required().OnDelete(DeleteBehavior.Restrict);
             modelBuilder.Entity<Level1>().HasMany(e => e.OneToMany_Optional_Self).WithOne(e => e.OneToMany_Optional_Self_Inverse).Required(false);
 
             modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Optional_Self).WithOne();
-            modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Required_PK).WithOne(e => e.OneToOne_Required_PK_Inverse).PrincipalKey<Level2>(e => e.Id).Required().WillCascadeOnDelete(false);
+            modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Required_PK).WithOne(e => e.OneToOne_Required_PK_Inverse).PrincipalKey<Level2>(e => e.Id).Required().OnDelete(DeleteBehavior.Restrict);
             modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Optional_PK).WithOne(e => e.OneToOne_Optional_PK_Inverse).PrincipalKey<Level2>(e => e.Id).Required(false);
-            modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Required_FK).WithOne(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level3>(e => e.Level2_Required_Id).Required().WillCascadeOnDelete(false);
+            modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Required_FK).WithOne(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level3>(e => e.Level2_Required_Id).Required().OnDelete(DeleteBehavior.Restrict);
             modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Optional_FK).WithOne(e => e.OneToOne_Optional_FK_Inverse).ForeignKey<Level3>(e => e.Level2_Optional_Id).Required(false);
-            modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Required_FK).WithOne(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level3>(e => e.Level2_Required_Id).Required().WillCascadeOnDelete(false);
+            modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Required_FK).WithOne(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level3>(e => e.Level2_Required_Id).Required().OnDelete(DeleteBehavior.Restrict);
             modelBuilder.Entity<Level2>().HasOne(e => e.OneToOne_Optional_FK).WithOne(e => e.OneToOne_Optional_FK_Inverse).ForeignKey<Level3>(e => e.Level2_Optional_Id).Required(false);
-            modelBuilder.Entity<Level2>().HasMany(e => e.OneToMany_Required).WithOne(e => e.OneToMany_Required_Inverse).Required().WillCascadeOnDelete(false);
+            modelBuilder.Entity<Level2>().HasMany(e => e.OneToMany_Required).WithOne(e => e.OneToMany_Required_Inverse).Required().OnDelete(DeleteBehavior.Restrict);
             modelBuilder.Entity<Level2>().HasMany(e => e.OneToMany_Optional).WithOne(e => e.OneToMany_Optional_Inverse).Required(false);
-            modelBuilder.Entity<Level2>().HasMany(e => e.OneToMany_Required_Self).WithOne(e => e.OneToMany_Required_Self_Inverse).Required().WillCascadeOnDelete(false);
+            modelBuilder.Entity<Level2>().HasMany(e => e.OneToMany_Required_Self).WithOne(e => e.OneToMany_Required_Self_Inverse).Required().OnDelete(DeleteBehavior.Restrict);
             modelBuilder.Entity<Level2>().HasMany(e => e.OneToMany_Optional_Self).WithOne(e => e.OneToMany_Optional_Self_Inverse).Required(false);
 
             modelBuilder.Entity<Level3>().HasOne(e => e.OneToOne_Optional_Self).WithOne();
-            modelBuilder.Entity<Level3>().HasOne(e => e.OneToOne_Required_PK).WithOne(e => e.OneToOne_Required_PK_Inverse).PrincipalKey<Level3>(e => e.Id).Required().WillCascadeOnDelete(false);
+            modelBuilder.Entity<Level3>().HasOne(e => e.OneToOne_Required_PK).WithOne(e => e.OneToOne_Required_PK_Inverse).PrincipalKey<Level3>(e => e.Id).Required().OnDelete(DeleteBehavior.Restrict);
             modelBuilder.Entity<Level3>().HasOne(e => e.OneToOne_Optional_PK).WithOne(e => e.OneToOne_Optional_PK_Inverse).PrincipalKey<Level3>(e => e.Id).Required(false);
-            modelBuilder.Entity<Level3>().HasOne(e => e.OneToOne_Required_FK).WithOne(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level4>(e => e.Level3_Required_Id).Required().WillCascadeOnDelete(false);
+            modelBuilder.Entity<Level3>().HasOne(e => e.OneToOne_Required_FK).WithOne(e => e.OneToOne_Required_FK_Inverse).ForeignKey<Level4>(e => e.Level3_Required_Id).Required().OnDelete(DeleteBehavior.Restrict);
             modelBuilder.Entity<Level3>().HasOne(e => e.OneToOne_Optional_FK).WithOne(e => e.OneToOne_Optional_FK_Inverse).ForeignKey<Level4>(e => e.Level3_Optional_Id).Required(false);
-            modelBuilder.Entity<Level3>().HasMany(e => e.OneToMany_Required).WithOne(e => e.OneToMany_Required_Inverse).Required().WillCascadeOnDelete(false);
+            modelBuilder.Entity<Level3>().HasMany(e => e.OneToMany_Required).WithOne(e => e.OneToMany_Required_Inverse).Required().OnDelete(DeleteBehavior.Restrict);
             modelBuilder.Entity<Level3>().HasMany(e => e.OneToMany_Optional).WithOne(e => e.OneToMany_Optional_Inverse).Required(false);
-            modelBuilder.Entity<Level3>().HasMany(e => e.OneToMany_Required_Self).WithOne(e => e.OneToMany_Required_Self_Inverse).Required().WillCascadeOnDelete(false);
+            modelBuilder.Entity<Level3>().HasMany(e => e.OneToMany_Required_Self).WithOne(e => e.OneToMany_Required_Self_Inverse).Required().OnDelete(DeleteBehavior.Restrict);
             modelBuilder.Entity<Level3>().HasMany(e => e.OneToMany_Optional_Self).WithOne(e => e.OneToMany_Optional_Self_Inverse).Required(false);
 
             modelBuilder.Entity<Level4>().HasOne(e => e.OneToOne_Optional_Self).WithOne();
-            modelBuilder.Entity<Level4>().HasMany(e => e.OneToMany_Required_Self).WithOne(e => e.OneToMany_Required_Self_Inverse).Required().WillCascadeOnDelete(false);
+            modelBuilder.Entity<Level4>().HasMany(e => e.OneToMany_Required_Self).WithOne(e => e.OneToMany_Required_Self_Inverse).Required().OnDelete(DeleteBehavior.Restrict);
             modelBuilder.Entity<Level4>().HasMany(e => e.OneToMany_Optional_Self).WithOne(e => e.OneToMany_Optional_Self_Inverse).Required(false);
 
             modelBuilder.Entity<ComplexNavigationField>().HasKey(e => e.Name);

--- a/test/EntityFramework.Core.FunctionalTests/GraphUpdatesTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/GraphUpdatesTestBase.cs
@@ -2519,6 +2519,202 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
+        [ConditionalFact]
+        public virtual void Optional_many_to_one_dependents_are_orphaned_in_store()
+        {
+            int removedId;
+            List<int> orphanedIds;
+
+            using (var context = CreateContext())
+            {
+                var removed = LoadFullGraph(context).OptionalChildren.First();
+
+                removedId = removed.Id;
+                orphanedIds = removed.Children.Select(e => e.Id).ToList();
+
+                Assert.Equal(2, orphanedIds.Count);
+            }
+
+            using (var context = CreateContext())
+            {
+                var root = context.Roots.Include(e => e.OptionalChildren).Single();
+
+                var removed = root.OptionalChildren.First(e => e.Id == removedId);
+
+                Assert.Equal(2, orphanedIds.Count);
+
+                context.Remove(removed);
+
+                context.SaveChanges();
+
+                Assert.Equal(EntityState.Detached, context.Entry(removed).State);
+
+                Assert.Equal(1, root.OptionalChildren.Count);
+                Assert.DoesNotContain(removedId, root.OptionalChildren.Select(e => e.Id));
+
+                Assert.Empty(context.Optional1s.Where(e => e.Id == removedId));
+
+                var orphaned = context.Optional2s.Where(e => orphanedIds.Contains(e.Id)).ToList();
+                Assert.Equal(orphanedIds.Count, orphaned.Count);
+                Assert.True(orphaned.All(e => e.ParentId == null));
+            }
+
+            using (var context = CreateContext())
+            {
+                var root = LoadFullGraph(context);
+
+                Assert.Equal(1, root.OptionalChildren.Count);
+                Assert.DoesNotContain(removedId, root.OptionalChildren.Select(e => e.Id));
+
+                Assert.Empty(context.Optional1s.Where(e => e.Id == removedId));
+
+                var orphaned = context.Optional2s.Where(e => orphanedIds.Contains(e.Id)).ToList();
+                Assert.Equal(orphanedIds.Count, orphaned.Count);
+                Assert.True(orphaned.All(e => e.ParentId == null));
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Optional_one_to_one_are_orphaned_in_store()
+        {
+            int removedId;
+            int orphanedId;
+
+            using (var context = CreateContext())
+            {
+                var removed = LoadFullGraph(context).OptionalSingle;
+
+                removedId = removed.Id;
+                orphanedId = removed.Single.Id;
+            }
+
+            using (var context = CreateContext())
+            {
+                var root = context.Roots.Include(e => e.OptionalSingle).Single();
+
+                var removed = root.OptionalSingle;
+
+                context.Remove(removed);
+
+                context.SaveChanges();
+
+                Assert.Equal(EntityState.Detached, context.Entry(removed).State);
+
+                Assert.Null(root.OptionalSingle);
+
+                Assert.Empty(context.OptionalSingle1s.Where(e => e.Id == removedId));
+                Assert.Null(context.OptionalSingle2s.Single(e => e.Id == orphanedId).BackId);
+            }
+
+            using (var context = CreateContext())
+            {
+                var root = LoadFullGraph(context);
+
+                Assert.Null(root.OptionalSingle);
+
+                Assert.Empty(context.OptionalSingle1s.Where(e => e.Id == removedId));
+                Assert.Null(context.OptionalSingle2s.Single(e => e.Id == orphanedId).BackId);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Optional_many_to_one_dependents_with_alternate_key_are_orphaned_in_store()
+        {
+            int removedId;
+            List<int> orphanedIds;
+
+            using (var context = CreateContext())
+            {
+                var removed = LoadFullGraph(context).OptionalChildrenAk.First();
+
+                removedId = removed.Id;
+                orphanedIds = removed.Children.Select(e => e.Id).ToList();
+
+                Assert.Equal(2, orphanedIds.Count);
+            }
+
+            using (var context = CreateContext())
+            {
+                var root = context.Roots.Include(e => e.OptionalChildrenAk).Single();
+
+                var removed = root.OptionalChildrenAk.First(e => e.Id == removedId);
+
+                Assert.Equal(2, orphanedIds.Count);
+
+                context.Remove(removed);
+
+                context.SaveChanges();
+
+                Assert.Equal(EntityState.Detached, context.Entry(removed).State);
+
+                Assert.Equal(1, root.OptionalChildrenAk.Count);
+                Assert.DoesNotContain(removedId, root.OptionalChildrenAk.Select(e => e.Id));
+
+                Assert.Empty(context.OptionalAk1s.Where(e => e.Id == removedId));
+
+                var orphaned = context.OptionalAk2s.Where(e => orphanedIds.Contains(e.Id)).ToList();
+                Assert.Equal(orphanedIds.Count, orphaned.Count);
+                Assert.True(orphaned.All(e => e.ParentId == null));
+            }
+
+            using (var context = CreateContext())
+            {
+                var root = LoadFullGraph(context);
+
+                Assert.Equal(1, root.OptionalChildrenAk.Count);
+                Assert.DoesNotContain(removedId, root.OptionalChildrenAk.Select(e => e.Id));
+
+                Assert.Empty(context.OptionalAk1s.Where(e => e.Id == removedId));
+
+                var orphaned = context.OptionalAk2s.Where(e => orphanedIds.Contains(e.Id)).ToList();
+                Assert.Equal(orphanedIds.Count, orphaned.Count);
+                Assert.True(orphaned.All(e => e.ParentId == null));
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Optional_one_to_one_with_alternate_key_are_orphaned_in_store()
+        {
+            int removedId;
+            int orphanedId;
+
+            using (var context = CreateContext())
+            {
+                var removed = LoadFullGraph(context).OptionalSingleAk;
+
+                removedId = removed.Id;
+                orphanedId = removed.Single.Id;
+            }
+
+            using (var context = CreateContext())
+            {
+                var root = context.Roots.Include(e => e.OptionalSingleAk).Single();
+
+                var removed = root.OptionalSingleAk;
+
+                context.Remove(removed);
+
+                context.SaveChanges();
+
+                Assert.Equal(EntityState.Detached, context.Entry(removed).State);
+
+                Assert.Null(root.OptionalSingleAk);
+
+                Assert.Empty(context.OptionalSingleAk1s.Where(e => e.Id == removedId));
+                Assert.Null(context.OptionalSingleAk2s.Single(e => e.Id == orphanedId).BackId);
+            }
+
+            using (var context = CreateContext())
+            {
+                var root = LoadFullGraph(context);
+
+                Assert.Null(root.OptionalSingleAk);
+
+                Assert.Empty(context.OptionalSingleAk1s.Where(e => e.Id == removedId));
+                Assert.Null(context.OptionalSingleAk2s.Single(e => e.Id == orphanedId).BackId);
+            }
+        }
+
         public enum ChangeMechanism
         {
             Dependent,
@@ -3030,7 +3226,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
                         b.HasMany(e => e.OptionalChildren)
                             .WithOne(e => e.Parent)
-                            .ForeignKey(e => e.ParentId);
+                            .ForeignKey(e => e.ParentId)
+                            .OnDelete(DeleteBehavior.SetNull);
 
                         b.HasOne(e => e.RequiredSingle)
                             .WithOne(e => e.Root)
@@ -3038,7 +3235,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
                         b.HasOne(e => e.OptionalSingle)
                             .WithOne(e => e.Root)
-                            .ForeignKey<OptionalSingle1>(e => e.RootId);
+                            .ForeignKey<OptionalSingle1>(e => e.RootId)
+                            .OnDelete(DeleteBehavior.SetNull);
 
                         b.HasOne(e => e.RequiredNonPkSingle)
                             .WithOne(e => e.Root)
@@ -3052,7 +3250,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
                         b.HasMany(e => e.OptionalChildrenAk)
                             .WithOne(e => e.Parent)
                             .PrincipalKey(e => e.AlternateId)
-                            .ForeignKey(e => e.ParentId);
+                            .ForeignKey(e => e.ParentId)
+                            .OnDelete(DeleteBehavior.SetNull);
 
                         b.HasOne(e => e.RequiredSingleAk)
                             .WithOne(e => e.Root)
@@ -3062,7 +3261,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
                         b.HasOne(e => e.OptionalSingleAk)
                             .WithOne(e => e.Root)
                             .PrincipalKey<Root>(e => e.AlternateId)
-                            .ForeignKey<OptionalSingleAk1>(e => e.RootId);
+                            .ForeignKey<OptionalSingleAk1>(e => e.RootId)
+                            .OnDelete(DeleteBehavior.SetNull);
 
                         b.HasOne(e => e.RequiredNonPkSingleAk)
                             .WithOne(e => e.Root)
@@ -3078,7 +3278,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 modelBuilder.Entity<Optional1>()
                     .HasMany(e => e.Children)
                     .WithOne(e => e.Parent)
-                    .ForeignKey(e => e.ParentId);
+                    .ForeignKey(e => e.ParentId)
+                    .OnDelete(DeleteBehavior.SetNull);
 
                 modelBuilder.Entity<RequiredSingle1>()
                     .HasOne(e => e.Single)
@@ -3088,7 +3289,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 modelBuilder.Entity<OptionalSingle1>()
                     .HasOne(e => e.Single)
                     .WithOne(e => e.Back)
-                    .ForeignKey<OptionalSingle2>(e => e.BackId);
+                    .ForeignKey<OptionalSingle2>(e => e.BackId)
+                    .OnDelete(DeleteBehavior.SetNull);
 
                 modelBuilder.Entity<RequiredNonPkSingle1>()
                     .HasOne(e => e.Single)
@@ -3114,7 +3316,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
                         b.HasMany(e => e.Children)
                             .WithOne(e => e.Parent)
                             .PrincipalKey(e => e.AlternateId)
-                            .ForeignKey(e => e.ParentId);
+                            .ForeignKey(e => e.ParentId)
+                            .OnDelete(DeleteBehavior.SetNull);
                     });
 
                 modelBuilder.Entity<RequiredSingleAk1>(b =>
@@ -3136,7 +3339,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
                         b.HasOne(e => e.Single)
                             .WithOne(e => e.Back)
                             .ForeignKey<OptionalSingleAk2>(e => e.BackId)
-                            .PrincipalKey<OptionalSingleAk1>(e => e.AlternateId);
+                            .PrincipalKey<OptionalSingleAk1>(e => e.AlternateId)
+                            .OnDelete(DeleteBehavior.SetNull);
                     });
 
                 modelBuilder.Entity<RequiredNonPkSingleAk1>(b =>

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntityEntryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntityEntryTest.cs
@@ -1441,7 +1441,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
                 .HasOne(e => e.Second)
                 .WithOne(e => e.First)
                 .ForeignKey<SecondDependent>(e => e.Id)
-                .WillCascadeOnDelete();
+                .OnDelete(DeleteBehavior.Cascade);
 
             modelBuilder
                 .Entity<Root>(b =>

--- a/test/EntityFramework.Core.Tests/Metadata/ForeignKeyTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ForeignKeyTest.cs
@@ -583,22 +583,22 @@ namespace Microsoft.Data.Entity.Metadata.Tests
                 = new ForeignKey(new[] { dependentProp }, principalKey, entityType, entityType);
 
             Assert.Null(foreignKey.DeleteBehavior);
-            Assert.Equal(DeleteBehavior.None, ((IForeignKey)foreignKey).DeleteBehavior);
+            Assert.Equal(DeleteBehavior.Restrict, ((IForeignKey)foreignKey).DeleteBehavior);
 
             foreignKey.DeleteBehavior = DeleteBehavior.Cascade;
 
             Assert.Equal(DeleteBehavior.Cascade, foreignKey.DeleteBehavior);
             Assert.Equal(DeleteBehavior.Cascade, ((IForeignKey)foreignKey).DeleteBehavior);
 
-            foreignKey.DeleteBehavior = DeleteBehavior.None;
+            foreignKey.DeleteBehavior = DeleteBehavior.Restrict;
 
-            Assert.Equal(DeleteBehavior.None, foreignKey.DeleteBehavior);
-            Assert.Equal(DeleteBehavior.None, ((IForeignKey)foreignKey).DeleteBehavior);
+            Assert.Equal(DeleteBehavior.Restrict, foreignKey.DeleteBehavior);
+            Assert.Equal(DeleteBehavior.Restrict, ((IForeignKey)foreignKey).DeleteBehavior);
 
             foreignKey.DeleteBehavior = null;
 
             Assert.Null(foreignKey.DeleteBehavior);
-            Assert.Equal(DeleteBehavior.None, ((IForeignKey)foreignKey).DeleteBehavior);
+            Assert.Equal(DeleteBehavior.Restrict, ((IForeignKey)foreignKey).DeleteBehavior);
         }
 
         [Fact]

--- a/test/EntityFramework.Core.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
@@ -172,7 +172,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             Assert.Null(relationshipBuilder.PrincipalKey(new[] { shadowId.Name, Customer.UniqueProperty.Name }, ConfigurationSource.DataAnnotation));
             Assert.Null(relationshipBuilder.Unique(true, ConfigurationSource.DataAnnotation));
             Assert.Null(relationshipBuilder.Required(true, ConfigurationSource.DataAnnotation));
-            Assert.Null(relationshipBuilder.DeleteBehavior(DeleteBehavior.None, ConfigurationSource.DataAnnotation));
+            Assert.Null(relationshipBuilder.DeleteBehavior(DeleteBehavior.Restrict, ConfigurationSource.DataAnnotation));
             Assert.Null(relationshipBuilder.Invert(ConfigurationSource.DataAnnotation));
             Assert.Null(relationshipBuilder.DependentToPrincipal(null, ConfigurationSource.DataAnnotation));
             Assert.Null(relationshipBuilder.PrincipalToDependent(null, ConfigurationSource.DataAnnotation));

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/CascadeDeleteConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/CascadeDeleteConventionTest.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
                 .HasMany(e => e.Posts)
                 .WithOne(e => e.Blog).Metadata;
 
-            Assert.Equal(DeleteBehavior.None, fk.DeleteBehavior);
+            Assert.Equal(DeleteBehavior.Restrict, fk.DeleteBehavior);
         }
 
         [Fact]
@@ -71,7 +71,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
                 .Property(e => e.BlogId)
                 .IsRequired(false);
 
-            Assert.Equal(DeleteBehavior.None, fk.DeleteBehavior);
+            Assert.Equal(DeleteBehavior.Restrict, fk.DeleteBehavior);
         }
 
         [Fact]
@@ -82,7 +82,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             var fk = modelBuilder.Entity<Blog>()
                 .HasMany(e => e.Posts)
                 .WithOne(e => e.Blog)
-                .WillCascadeOnDelete()
+                .OnDelete(DeleteBehavior.Cascade)
                 .Metadata;
 
             Assert.Equal(DeleteBehavior.Cascade, fk.DeleteBehavior);
@@ -100,7 +100,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             var fk = modelBuilder.Entity<Blog>()
                 .HasMany(e => e.Posts)
                 .WithOne(e => e.Blog)
-                .WillCascadeOnDelete()
+                .OnDelete(DeleteBehavior.Cascade)
                 .Metadata;
 
             modelBuilder.Entity<Post>()

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/ManyToOneTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/ManyToOneTestBase.cs
@@ -1503,22 +1503,28 @@ namespace Microsoft.Data.Entity.Tests
             }
 
             [Fact]
-            public virtual void Can_turn_cascade_delete_on_and_off()
+            public virtual void Can_change_delete_behavior()
             {
                 var modelBuilder = HobNobBuilder();
                 var dependentType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob));
 
                 modelBuilder
                     .Entity<Nob>().HasOne(e => e.Hob).WithMany(e => e.Nobs)
-                    .WillCascadeOnDelete();
+                    .OnDelete(DeleteBehavior.Cascade);
 
                 Assert.Equal(DeleteBehavior.Cascade, dependentType.GetForeignKeys().Single().DeleteBehavior);
 
                 modelBuilder
                     .Entity<Nob>().HasOne(e => e.Hob).WithMany(e => e.Nobs)
-                    .WillCascadeOnDelete(false);
+                    .OnDelete(DeleteBehavior.Restrict);
 
-                Assert.Equal(DeleteBehavior.None, dependentType.GetForeignKeys().Single().DeleteBehavior);
+                Assert.Equal(DeleteBehavior.Restrict, dependentType.GetForeignKeys().Single().DeleteBehavior);
+
+                modelBuilder
+                    .Entity<Nob>().HasOne(e => e.Hob).WithMany(e => e.Nobs)
+                    .OnDelete(DeleteBehavior.SetNull);
+
+                Assert.Equal(DeleteBehavior.SetNull, dependentType.GetForeignKeys().Single().DeleteBehavior);
             }
 
             [Fact]

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderGenericTest.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderGenericTest.cs
@@ -275,8 +275,8 @@ namespace Microsoft.Data.Entity.Tests
             public override TestReferenceCollectionBuilder<TEntity, TRelatedEntity> Required(bool isRequired = true)
                 => Wrap(ReferenceCollectionBuilder.Required(isRequired));
 
-            public override TestReferenceCollectionBuilder<TEntity, TRelatedEntity> WillCascadeOnDelete(bool cascade = true)
-                => Wrap(ReferenceCollectionBuilder.WillCascadeOnDelete(cascade));
+            public override TestReferenceCollectionBuilder<TEntity, TRelatedEntity> OnDelete(DeleteBehavior deleteBehavior)
+                => Wrap(ReferenceCollectionBuilder.OnDelete(deleteBehavior));
         }
 
         protected class GenericTestReferenceReferenceBuilder<TEntity, TRelatedEntity> : TestReferenceReferenceBuilder<TEntity, TRelatedEntity>
@@ -313,8 +313,8 @@ namespace Microsoft.Data.Entity.Tests
             public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> Required(bool isRequired = true)
                 => Wrap(ReferenceReferenceBuilder.Required(isRequired));
 
-            public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> WillCascadeOnDelete(bool cascade = true)
-                => Wrap(ReferenceReferenceBuilder.WillCascadeOnDelete(cascade));
+            public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> OnDelete(DeleteBehavior deleteBehavior)
+                => Wrap(ReferenceReferenceBuilder.OnDelete(deleteBehavior));
         }
     }
 }

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderNonGenericTest.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderNonGenericTest.cs
@@ -261,8 +261,8 @@ namespace Microsoft.Data.Entity.Tests
             public override TestReferenceCollectionBuilder<TEntity, TRelatedEntity> Required(bool isRequired = true)
                 => new NonGenericTestReferenceCollectionBuilder<TEntity, TRelatedEntity>(ReferenceCollectionBuilder.Required(isRequired));
 
-            public override TestReferenceCollectionBuilder<TEntity, TRelatedEntity> WillCascadeOnDelete(bool cascade = true)
-                => new NonGenericTestReferenceCollectionBuilder<TEntity, TRelatedEntity>(ReferenceCollectionBuilder.WillCascadeOnDelete(cascade));
+            public override TestReferenceCollectionBuilder<TEntity, TRelatedEntity> OnDelete(DeleteBehavior deleteBehavior)
+                => new NonGenericTestReferenceCollectionBuilder<TEntity, TRelatedEntity>(ReferenceCollectionBuilder.OnDelete(deleteBehavior));
         }
 
         protected class NonGenericTestReferenceReferenceBuilder<TEntity, TRelatedEntity> : TestReferenceReferenceBuilder<TEntity, TRelatedEntity>
@@ -299,8 +299,8 @@ namespace Microsoft.Data.Entity.Tests
             public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> Required(bool isRequired = true)
                 => Wrap(ReferenceReferenceBuilder.Required(isRequired));
 
-            public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> WillCascadeOnDelete(bool cascade = true)
-                => Wrap(ReferenceReferenceBuilder.WillCascadeOnDelete(cascade));
+            public override TestReferenceReferenceBuilder<TEntity, TRelatedEntity> OnDelete(DeleteBehavior deleteBehavior)
+                => Wrap(ReferenceReferenceBuilder.OnDelete(deleteBehavior));
         }
     }
 }

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderTestBase.cs
@@ -263,7 +263,7 @@ namespace Microsoft.Data.Entity.Tests
 
             public abstract TestReferenceCollectionBuilder<TEntity, TRelatedEntity> Required(bool isRequired = true);
 
-            public abstract TestReferenceCollectionBuilder<TEntity, TRelatedEntity> WillCascadeOnDelete(bool cascade = true);
+            public abstract TestReferenceCollectionBuilder<TEntity, TRelatedEntity> OnDelete(DeleteBehavior deleteBehavior);
         }
 
         public abstract class TestReferenceReferenceBuilder<TEntity, TRelatedEntity>
@@ -289,7 +289,7 @@ namespace Microsoft.Data.Entity.Tests
 
             public abstract TestReferenceReferenceBuilder<TEntity, TRelatedEntity> Required(bool isRequired = true);
 
-            public abstract TestReferenceReferenceBuilder<TEntity, TRelatedEntity> WillCascadeOnDelete(bool cascade = true);
+            public abstract TestReferenceReferenceBuilder<TEntity, TRelatedEntity> OnDelete(DeleteBehavior deleteBehavior);
         }
     }
 }

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/OneToManyTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/OneToManyTestBase.cs
@@ -1638,22 +1638,28 @@ namespace Microsoft.Data.Entity.Tests
             }
             
             [Fact]
-            public virtual void Can_turn_cascade_delete_on_and_off()
+            public virtual void Can_change_delete_behavior()
             {
                 var modelBuilder = HobNobBuilder();
                 var dependentType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob));
 
                 modelBuilder
                     .Entity<Hob>().HasMany(e => e.Nobs).WithOne(e => e.Hob)
-                    .WillCascadeOnDelete();
+                    .OnDelete(DeleteBehavior.Cascade);
 
                 Assert.Equal(DeleteBehavior.Cascade, dependentType.GetForeignKeys().Single().DeleteBehavior);
 
                 modelBuilder
                     .Entity<Hob>().HasMany(e => e.Nobs).WithOne(e => e.Hob)
-                    .WillCascadeOnDelete(false);
+                    .OnDelete(DeleteBehavior.Restrict);
 
-                Assert.Equal(DeleteBehavior.None, dependentType.GetForeignKeys().Single().DeleteBehavior);
+                Assert.Equal(DeleteBehavior.Restrict, dependentType.GetForeignKeys().Single().DeleteBehavior);
+
+                modelBuilder
+                    .Entity<Hob>().HasMany(e => e.Nobs).WithOne(e => e.Hob)
+                    .OnDelete(DeleteBehavior.SetNull);
+
+                Assert.Equal(DeleteBehavior.SetNull, dependentType.GetForeignKeys().Single().DeleteBehavior);
             }
 
             [Fact]

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/OneToOneTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/OneToOneTestBase.cs
@@ -2690,22 +2690,28 @@ namespace Microsoft.Data.Entity.Tests
             }
 
             [Fact]
-            public virtual void Can_turn_cascade_delete_on_and_off()
+            public virtual void Can_change_delete_behavior()
             {
                 var modelBuilder = HobNobBuilder();
                 var dependentType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Hob));
 
                 modelBuilder
                     .Entity<Hob>().HasOne(e => e.Nob).WithOne(e => e.Hob)
-                    .WillCascadeOnDelete();
+                    .OnDelete(DeleteBehavior.Cascade);
 
                 Assert.Equal(DeleteBehavior.Cascade, dependentType.GetForeignKeys().Single().DeleteBehavior);
 
                 modelBuilder
                     .Entity<Hob>().HasOne(e => e.Nob).WithOne(e => e.Hob)
-                    .WillCascadeOnDelete(false);
+                    .OnDelete(DeleteBehavior.Restrict);
 
-                Assert.Equal(DeleteBehavior.None, dependentType.GetForeignKeys().Single().DeleteBehavior);
+                Assert.Equal(DeleteBehavior.Restrict, dependentType.GetForeignKeys().Single().DeleteBehavior);
+
+                modelBuilder
+                    .Entity<Hob>().HasOne(e => e.Nob).WithOne(e => e.Hob)
+                    .OnDelete(DeleteBehavior.SetNull);
+
+                Assert.Equal(DeleteBehavior.SetNull, dependentType.GetForeignKeys().Single().DeleteBehavior);
             }
         }
     }

--- a/test/EntityFramework.InMemory.FunctionalTests/GraphUpdatesInMemoryTestBase.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/GraphUpdatesInMemoryTestBase.cs
@@ -19,63 +19,54 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
         }
 
         [ConditionalTheory]
-        [InlineData((int)ChangeMechanism.Principal, false)]
         public override void Save_required_one_to_one_changed_by_reference_with_alternate_key(ChangeMechanism changeMechanism, bool useExistingEntities)
         {
             // Cascade delete not supported by in-memory database
         }
 
         [ConditionalTheory]
-        [InlineData((int)ChangeMechanism.Principal, false)]
         public override void Save_required_non_PK_one_to_one_changed_by_reference_with_alternate_key(ChangeMechanism changeMechanism, bool useExistingEntities)
         {
             // Cascade delete not supported by in-memory database
         }
 
         [ConditionalTheory]
-        [InlineData((int)ChangeMechanism.Principal)]
         public override void Save_required_one_to_one_changed_by_reference(ChangeMechanism changeMechanism)
         {
             // Cascade delete not supported by in-memory database
         }
 
         [ConditionalTheory]
-        [InlineData((int)ChangeMechanism.Principal)]
         public override void Save_removed_required_many_to_one_dependents(ChangeMechanism changeMechanism)
         {
             // Cascade delete not supported by in-memory database
         }
 
         [ConditionalTheory]
-        [InlineData((int)ChangeMechanism.Principal, false)]
         public override void Save_required_non_PK_one_to_one_changed_by_reference(ChangeMechanism changeMechanism, bool useExistingEntities)
         {
             // Cascade delete not supported by in-memory database
         }
 
         [ConditionalTheory]
-        [InlineData((int)ChangeMechanism.Principal)]
         public override void Sever_required_one_to_one_with_alternate_key(ChangeMechanism changeMechanism)
         {
             // Cascade delete not supported by in-memory database
         }
 
         [ConditionalTheory]
-        [InlineData((int)ChangeMechanism.Principal)]
         public override void Sever_required_one_to_one(ChangeMechanism changeMechanism)
         {
             // Cascade delete not supported by in-memory database
         }
 
         [ConditionalTheory]
-        [InlineData((int)ChangeMechanism.Principal)]
         public override void Sever_required_non_PK_one_to_one(ChangeMechanism changeMechanism)
         {
             // Cascade delete not supported by in-memory database
         }
 
         [ConditionalTheory]
-        [InlineData((int)ChangeMechanism.Principal)]
         public override void Sever_required_non_PK_one_to_one_with_alternate_key(ChangeMechanism changeMechanism)
         {
             // Cascade delete not supported by in-memory database
@@ -115,6 +106,30 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
         public override void Required_non_PK_one_to_one_with_alternate_key_are_cascade_deleted_in_store()
         {
             // Cascade delete not supported by in-memory database
+        }
+
+        [ConditionalFact]
+        public override void Optional_many_to_one_dependents_are_orphaned_in_store()
+        {
+            // Cascade nulls not supported by in-memory database
+        }
+
+        [ConditionalFact]
+        public override void Optional_one_to_one_are_orphaned_in_store()
+        {
+            // Cascade nulls not supported by in-memory database
+        }
+
+        [ConditionalFact]
+        public override void Optional_many_to_one_dependents_with_alternate_key_are_orphaned_in_store()
+        {
+            // Cascade nulls not supported by in-memory database
+        }
+
+        [ConditionalFact]
+        public override void Optional_one_to_one_with_alternate_key_are_orphaned_in_store()
+        {
+            // Cascade nulls not supported by in-memory database
         }
 
         public abstract class GraphUpdatesInMemoryFixtureBase : GraphUpdatesFixtureBase

--- a/test/EntityFramework.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
+++ b/test/EntityFramework.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
@@ -924,7 +924,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x.Property<int>("Id");
                         x.HasKey("Id");
                         x.Property<int>("ParentId");
-                        x.HasOne("Amoeba").WithMany().ForeignKey("ParentId").WillCascadeOnDelete(false);
+                        x.HasOne("Amoeba").WithMany().ForeignKey("ParentId");
                     }),
                 operations =>
                 {
@@ -938,13 +938,93 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     Assert.Equal("dbo", operation.PrincipalSchema);
                     Assert.Equal("Amoeba", operation.PrincipalTable);
                     Assert.Equal(new[] { "Id" }, operation.PrincipalColumns);
-                    Assert.Equal(ReferentialAction.NoAction, operation.OnDelete);
+                    Assert.Equal(ReferentialAction.Cascade, operation.OnDelete);
                     Assert.Equal(ReferentialAction.NoAction, operation.OnUpdate);
                 });
         }
 
         [Fact]
-        public void Add_foreign_key_with_cascade_delete()
+        public void Add_optional_foreign_key()
+        {
+            Execute(
+                source => source.Entity(
+                    "Amoeba",
+                    x =>
+                    {
+                        x.ToTable("Amoeba", "dbo");
+                        x.Property<int>("Id");
+                        x.HasKey("Id");
+                        x.Property<int?>("ParentId");
+                    }),
+                target => target.Entity(
+                    "Amoeba",
+                    x =>
+                    {
+                        x.ToTable("Amoeba", "dbo");
+                        x.Property<int>("Id");
+                        x.HasKey("Id");
+                        x.Property<int?>("ParentId");
+                        x.HasOne("Amoeba").WithMany().ForeignKey("ParentId");
+                    }),
+                operations =>
+                {
+                    Assert.Equal(1, operations.Count);
+
+                    var operation = Assert.IsType<AddForeignKeyOperation>(operations[0]);
+                    Assert.Equal("dbo", operation.Schema);
+                    Assert.Equal("Amoeba", operation.Table);
+                    Assert.Equal("FK_Amoeba_Amoeba_ParentId", operation.Name);
+                    Assert.Equal(new[] { "ParentId" }, operation.Columns);
+                    Assert.Equal("dbo", operation.PrincipalSchema);
+                    Assert.Equal("Amoeba", operation.PrincipalTable);
+                    Assert.Equal(new[] { "Id" }, operation.PrincipalColumns);
+                    Assert.Equal(ReferentialAction.Restrict, operation.OnDelete);
+                    Assert.Equal(ReferentialAction.NoAction, operation.OnUpdate);
+                });
+        }
+
+        [Fact]
+        public void Add_optional_foreign_key_with_cascade_delete()
+        {
+            Execute(
+                source => source.Entity(
+                    "Amoeba",
+                    x =>
+                    {
+                        x.ToTable("Amoeba", "dbo");
+                        x.Property<int>("Id");
+                        x.HasKey("Id");
+                        x.Property<int?>("ParentId");
+                    }),
+                target => target.Entity(
+                    "Amoeba",
+                    x =>
+                    {
+                        x.ToTable("Amoeba", "dbo");
+                        x.Property<int>("Id");
+                        x.HasKey("Id");
+                        x.Property<int?>("ParentId");
+                        x.HasOne("Amoeba").WithMany().ForeignKey("ParentId").OnDelete(DeleteBehavior.Cascade);
+                    }),
+                operations =>
+                {
+                    Assert.Equal(1, operations.Count);
+
+                    var operation = Assert.IsType<AddForeignKeyOperation>(operations[0]);
+                    Assert.Equal("dbo", operation.Schema);
+                    Assert.Equal("Amoeba", operation.Table);
+                    Assert.Equal("FK_Amoeba_Amoeba_ParentId", operation.Name);
+                    Assert.Equal(new[] { "ParentId" }, operation.Columns);
+                    Assert.Equal("dbo", operation.PrincipalSchema);
+                    Assert.Equal("Amoeba", operation.PrincipalTable);
+                    Assert.Equal(new[] { "Id" }, operation.PrincipalColumns);
+                    Assert.Equal(ReferentialAction.Cascade, operation.OnDelete);
+                    Assert.Equal(ReferentialAction.NoAction, operation.OnUpdate);
+                });
+        }
+
+        [Fact]
+        public void Add_required_foreign_key_without_cascade_delete()
         {
             Execute(
                 source => source.Entity(
@@ -964,7 +1044,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x.Property<int>("Id");
                         x.HasKey("Id");
                         x.Property<int>("ParentId");
-                        x.HasOne("Amoeba").WithMany().ForeignKey("ParentId").WillCascadeOnDelete();
+                        x.HasOne("Amoeba").WithMany().ForeignKey("ParentId").OnDelete(DeleteBehavior.Restrict);
                     }),
                 operations =>
                 {
@@ -978,7 +1058,47 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     Assert.Equal("dbo", operation.PrincipalSchema);
                     Assert.Equal("Amoeba", operation.PrincipalTable);
                     Assert.Equal(new[] { "Id" }, operation.PrincipalColumns);
-                    Assert.Equal(ReferentialAction.Cascade, operation.OnDelete);
+                    Assert.Equal(ReferentialAction.Restrict, operation.OnDelete);
+                    Assert.Equal(ReferentialAction.NoAction, operation.OnUpdate);
+                });
+        }
+
+        [Fact]
+        public void Add_optional_foreign_key_wit_set_null()
+        {
+            Execute(
+                source => source.Entity(
+                    "Amoeba",
+                    x =>
+                    {
+                        x.ToTable("Amoeba", "dbo");
+                        x.Property<int>("Id");
+                        x.HasKey("Id");
+                        x.Property<int?>("ParentId");
+                    }),
+                target => target.Entity(
+                    "Amoeba",
+                    x =>
+                    {
+                        x.ToTable("Amoeba", "dbo");
+                        x.Property<int>("Id");
+                        x.HasKey("Id");
+                        x.Property<int?>("ParentId");
+                        x.HasOne("Amoeba").WithMany().ForeignKey("ParentId").OnDelete(DeleteBehavior.SetNull);
+                    }),
+                operations =>
+                {
+                    Assert.Equal(1, operations.Count);
+
+                    var operation = Assert.IsType<AddForeignKeyOperation>(operations[0]);
+                    Assert.Equal("dbo", operation.Schema);
+                    Assert.Equal("Amoeba", operation.Table);
+                    Assert.Equal("FK_Amoeba_Amoeba_ParentId", operation.Name);
+                    Assert.Equal(new[] { "ParentId" }, operation.Columns);
+                    Assert.Equal("dbo", operation.PrincipalSchema);
+                    Assert.Equal("Amoeba", operation.PrincipalTable);
+                    Assert.Equal(new[] { "Id" }, operation.PrincipalColumns);
+                    Assert.Equal(ReferentialAction.SetNull, operation.OnDelete);
                     Assert.Equal(ReferentialAction.NoAction, operation.OnUpdate);
                 });
         }
@@ -1119,7 +1239,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x.Property<int>("Id");
                         x.HasKey("Id");
                         x.Property<int>("ParentId1");
-                        x.HasOne("Mushroom").WithMany().ForeignKey("ParentId1").WillCascadeOnDelete(false);
+                        x.HasOne("Mushroom").WithMany().ForeignKey("ParentId1").OnDelete(DeleteBehavior.Restrict);
                         x.Property<int>("ParentId2");
                     }),
                 target => target.Entity(
@@ -1130,7 +1250,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         x.Property<int>("Id");
                         x.HasKey("Id");
                         x.Property<int>("ParentId1");
-                        x.HasOne("Mushroom").WithMany().ForeignKey("ParentId1").WillCascadeOnDelete();
+                        x.HasOne("Mushroom").WithMany().ForeignKey("ParentId1").OnDelete(DeleteBehavior.Cascade);
                         x.Property<int>("ParentId2");
                     }),
                 operations =>

--- a/test/EntityFramework.Sqlite.FunctionalTests/GraphUpdatesSqliteTestBase.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/GraphUpdatesSqliteTestBase.cs
@@ -18,63 +18,54 @@ namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
         }
 
         [ConditionalTheory]
-        [InlineData((int)ChangeMechanism.Principal, false)]
         public override void Save_required_one_to_one_changed_by_reference_with_alternate_key(ChangeMechanism changeMechanism, bool useExistingEntities)
         {
             // TODO: Cascade delete not yet supported by SQLite provider
         }
 
         [ConditionalTheory]
-        [InlineData((int)ChangeMechanism.Principal, false)]
         public override void Save_required_non_PK_one_to_one_changed_by_reference_with_alternate_key(ChangeMechanism changeMechanism, bool useExistingEntities)
         {
             // TODO: Cascade delete not yet supported by SQLite provider
         }
 
         [ConditionalTheory]
-        [InlineData((int)ChangeMechanism.Principal)]
         public override void Save_required_one_to_one_changed_by_reference(ChangeMechanism changeMechanism)
         {
             // TODO: Cascade delete not yet supported by SQLite provider
         }
 
         [ConditionalTheory]
-        [InlineData((int)ChangeMechanism.Principal)]
         public override void Save_removed_required_many_to_one_dependents(ChangeMechanism changeMechanism)
         {
             // TODO: Cascade delete not yet supported by SQLite provider
         }
 
         [ConditionalTheory]
-        [InlineData((int)ChangeMechanism.Principal, false)]
         public override void Save_required_non_PK_one_to_one_changed_by_reference(ChangeMechanism changeMechanism, bool useExistingEntities)
         {
             // TODO: Cascade delete not yet supported by SQLite provider
         }
 
         [ConditionalTheory]
-        [InlineData((int)ChangeMechanism.Principal)]
         public override void Sever_required_one_to_one_with_alternate_key(ChangeMechanism changeMechanism)
         {
             // TODO: Cascade delete not yet supported by SQLite provider
         }
 
         [ConditionalTheory]
-        [InlineData((int)ChangeMechanism.Principal)]
         public override void Sever_required_one_to_one(ChangeMechanism changeMechanism)
         {
             // TODO: Cascade delete not yet supported by SQLite provider
         }
 
         [ConditionalTheory]
-        [InlineData((int)ChangeMechanism.Principal)]
         public override void Sever_required_non_PK_one_to_one(ChangeMechanism changeMechanism)
         {
             // TODO: Cascade delete not yet supported by SQLite provider
         }
 
         [ConditionalTheory]
-        [InlineData((int)ChangeMechanism.Principal)]
         public override void Sever_required_non_PK_one_to_one_with_alternate_key(ChangeMechanism changeMechanism)
         {
             // TODO: Cascade delete not yet supported by SQLite provider
@@ -114,6 +105,30 @@ namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
         public override void Required_non_PK_one_to_one_with_alternate_key_are_cascade_deleted_in_store()
         {
             // TODO: Cascade delete not yet supported by SQLite provider
+        }
+
+        [ConditionalFact]
+        public override void Optional_many_to_one_dependents_are_orphaned_in_store()
+        {
+            // TODO: Cascade nulls not yet supported by SQLite provider
+        }
+
+        [ConditionalFact]
+        public override void Optional_one_to_one_are_orphaned_in_store()
+        {
+            // TODO: Cascade nulls not yet supported by SQLite provider
+        }
+
+        [ConditionalFact]
+        public override void Optional_many_to_one_dependents_with_alternate_key_are_orphaned_in_store()
+        {
+            // TODO: Cascade nulls not yet supported by SQLite provider
+        }
+
+        [ConditionalFact]
+        public override void Optional_one_to_one_with_alternate_key_are_orphaned_in_store()
+        {
+            // TODO: Cascade nulls not yet supported by SQLite provider
         }
 
         public abstract class GraphUpdatesSqliteFixtureBase : GraphUpdatesFixtureBase


### PR DESCRIPTION
This means that a principal with optional dependents can be deleted and without loading the dependents and the FKs will be set to null automatically by the database.

This is not turned on by default because SQL Server will frequently error out indicating that it generates cycles in the schema.