### PR TITLE
Enable cascade delete tests on SQLite

### DIFF
--- a/test/EntityFramework.Sqlite.FunctionalTests/GraphUpdatesSqliteTestBase.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/GraphUpdatesSqliteTestBase.cs
@@ -3,9 +3,7 @@
 
 using System;
 using Microsoft.Data.Entity.FunctionalTests;
-using Microsoft.Data.Entity.FunctionalTests.TestUtilities.Xunit;
 using Microsoft.Framework.DependencyInjection;
-using Xunit;
 
 namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
 {
@@ -15,120 +13,6 @@ namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
         protected GraphUpdatesSqliteTestBase(TFixture fixture)
             : base(fixture)
         {
-        }
-
-        [ConditionalTheory]
-        public override void Save_required_one_to_one_changed_by_reference_with_alternate_key(ChangeMechanism changeMechanism, bool useExistingEntities)
-        {
-            // TODO: Cascade delete not yet supported by SQLite provider
-        }
-
-        [ConditionalTheory]
-        public override void Save_required_non_PK_one_to_one_changed_by_reference_with_alternate_key(ChangeMechanism changeMechanism, bool useExistingEntities)
-        {
-            // TODO: Cascade delete not yet supported by SQLite provider
-        }
-
-        [ConditionalTheory]
-        public override void Save_required_one_to_one_changed_by_reference(ChangeMechanism changeMechanism)
-        {
-            // TODO: Cascade delete not yet supported by SQLite provider
-        }
-
-        [ConditionalTheory]
-        public override void Save_removed_required_many_to_one_dependents(ChangeMechanism changeMechanism)
-        {
-            // TODO: Cascade delete not yet supported by SQLite provider
-        }
-
-        [ConditionalTheory]
-        public override void Save_required_non_PK_one_to_one_changed_by_reference(ChangeMechanism changeMechanism, bool useExistingEntities)
-        {
-            // TODO: Cascade delete not yet supported by SQLite provider
-        }
-
-        [ConditionalTheory]
-        public override void Sever_required_one_to_one_with_alternate_key(ChangeMechanism changeMechanism)
-        {
-            // TODO: Cascade delete not yet supported by SQLite provider
-        }
-
-        [ConditionalTheory]
-        public override void Sever_required_one_to_one(ChangeMechanism changeMechanism)
-        {
-            // TODO: Cascade delete not yet supported by SQLite provider
-        }
-
-        [ConditionalTheory]
-        public override void Sever_required_non_PK_one_to_one(ChangeMechanism changeMechanism)
-        {
-            // TODO: Cascade delete not yet supported by SQLite provider
-        }
-
-        [ConditionalTheory]
-        public override void Sever_required_non_PK_one_to_one_with_alternate_key(ChangeMechanism changeMechanism)
-        {
-            // TODO: Cascade delete not yet supported by SQLite provider
-        }
-
-        [ConditionalFact]
-        public override void Required_many_to_one_dependents_are_cascade_deleted_in_store()
-        {
-            // TODO: Cascade delete not yet supported by SQLite provider
-        }
-
-        [ConditionalFact]
-        public override void Required_one_to_one_are_cascade_deleted_in_store()
-        {
-            // TODO: Cascade delete not yet supported by SQLite provider
-        }
-
-        [ConditionalFact]
-        public override void Required_non_PK_one_to_one_are_cascade_deleted_in_store()
-        {
-            // TODO: Cascade delete not yet supported by SQLite provider
-        }
-
-        [ConditionalFact]
-        public override void Required_many_to_one_dependents_with_alternate_key_are_cascade_deleted_in_store()
-        {
-            // TODO: Cascade delete not yet supported by SQLite provider
-        }
-
-        [ConditionalFact]
-        public override void Required_one_to_one_with_alternate_key_are_cascade_deleted_in_store()
-        {
-            // TODO: Cascade delete not yet supported by SQLite provider
-        }
-
-        [ConditionalFact]
-        public override void Required_non_PK_one_to_one_with_alternate_key_are_cascade_deleted_in_store()
-        {
-            // TODO: Cascade delete not yet supported by SQLite provider
-        }
-
-        [ConditionalFact]
-        public override void Optional_many_to_one_dependents_are_orphaned_in_store()
-        {
-            // TODO: Cascade nulls not yet supported by SQLite provider
-        }
-
-        [ConditionalFact]
-        public override void Optional_one_to_one_are_orphaned_in_store()
-        {
-            // TODO: Cascade nulls not yet supported by SQLite provider
-        }
-
-        [ConditionalFact]
-        public override void Optional_many_to_one_dependents_with_alternate_key_are_orphaned_in_store()
-        {
-            // TODO: Cascade nulls not yet supported by SQLite provider
-        }
-
-        [ConditionalFact]
-        public override void Optional_one_to_one_with_alternate_key_are_orphaned_in_store()
-        {
-            // TODO: Cascade nulls not yet supported by SQLite provider
         }
 
         public abstract class GraphUpdatesSqliteFixtureBase : GraphUpdatesFixtureBase

--- a/test/EntityFramework.Sqlite.FunctionalTests/SqliteTestStore.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/SqliteTestStore.cs
@@ -45,9 +45,8 @@ namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
         {
             CreateShared(typeof(SqliteTestStore).Name + _name, initializeDatabase);
 
-            _connection = new SqliteConnection(CreateConnectionString(_name));
+            CreateAndOpenConnection();
 
-            _connection.Open();
             _transaction = _connection.BeginTransaction();
 
             return this;
@@ -55,11 +54,20 @@ namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
 
         private SqliteTestStore CreateTransient(bool sharedCache)
         {
+            CreateAndOpenConnection(sharedCache);
+
+            return AsTransient();
+        }
+
+        private void CreateAndOpenConnection(bool sharedCache = false)
+        {
             _connection = new SqliteConnection(CreateConnectionString(_name, sharedCache));
 
             _connection.Open();
 
-            return AsTransient();
+            var command = _connection.CreateCommand();
+            command.CommandText = "PRAGMA foreign_keys=ON;";
+            command.ExecuteNonQuery();
         }
 
         public SqliteTestStore AsTransient()


### PR DESCRIPTION
The issue was that the test store is creating and opening the connection and then opening a transaction, which meant that our code to enable FKs for the connection had no effect, which is, as I understand it, by design. The fix is to have the test store enable FKs before starting the Transaction.