### PR TITLE
Commands: Discover contexts registered in the service provider

### DIFF
--- a/src/EntityFramework.Commands/Design/Internal/HostingEnvironment.cs
+++ b/src/EntityFramework.Commands/Design/Internal/HostingEnvironment.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if DNX451 || DNXCORE50
+
+using Microsoft.AspNet.FileProviders;
+using Microsoft.AspNet.Hosting;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.Data.Entity.Design.Internal
+{
+    public class HostingEnvironment : IHostingEnvironment
+    {
+        public virtual string EnvironmentName { get; set; }
+        public virtual string WebRootPath { get; set; }
+        public virtual IFileProvider WebRootFileProvider { get; set; }
+    }
+}
+
+#endif

--- a/src/EntityFramework.Commands/project.json
+++ b/src/EntityFramework.Commands/project.json
@@ -25,14 +25,14 @@
     "dnx451": {
       "dependencies": {
         "EntityFramework.Relational.Design": "7.0.0-*",
-        "Microsoft.AspNet.Hosting": "1.0.0-*",
+        "Microsoft.AspNet.Hosting.Abstractions": "1.0.0-*",
         "Microsoft.Extensions.CommandLineUtils.Sources": { "version": "1.0.0-*", "type": "build" }
       }
     },
     "dnxcore50": {
       "dependencies": {
         "EntityFramework.Relational.Design": "7.0.0-*",
-        "Microsoft.AspNet.Hosting": "1.0.0-*",
+        "Microsoft.AspNet.Hosting.Abstractions": "1.0.0-*",
         "Microsoft.Extensions.CommandLineUtils.Sources": { "version": "1.0.0-*", "type": "build" }
       }
     },

--- a/test/EntityFramework.Commands.FunctionalTests/ExecutorTest.cs
+++ b/test/EntityFramework.Commands.FunctionalTests/ExecutorTest.cs
@@ -244,6 +244,8 @@ namespace Microsoft.Data.Entity.Commands
                                 BuildReference.ByName("EntityFramework.Relational", copyLocal: true),
                                 BuildReference.ByName("EntityFramework.Relational.Design", copyLocal: true),
                                 BuildReference.ByName("Microsoft.CodeAnalysis", copyLocal: true),
+                                BuildReference.ByName("Microsoft.Extensions.DependencyInjection", copyLocal: true),
+                                BuildReference.ByName("Microsoft.Extensions.DependencyInjection.Abstractions", copyLocal: true),
                                 BuildReference.ByName("Microsoft.Extensions.Logging", copyLocal: true),
                                 BuildReference.ByName("Microsoft.Extensions.Logging.Abstractions", copyLocal: true),
                                 BuildReference.ByPath(contextsBuild.TargetPath)

--- a/test/EntityFramework.Commands.Tests/Design/Internal/StartupInvokerTest.cs
+++ b/test/EntityFramework.Commands.Tests/Design/Internal/StartupInvokerTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -37,18 +38,99 @@ namespace Microsoft.Data.Entity.Design.Internal
             var service = services.BuildServiceProvider().GetRequiredService<TestService>();
             Assert.Equal("Static", service.Value);
         }
+
+        [Fact]
+        public void ConfigureDesignTimeServices_is_noop_when_not_found()
+        {
+            var startup = new StartupInvoker(
+                typeof(StartupInvokerTest).Assembly.FullName,
+                environment: "Unknown",
+                dnxServices: null);
+
+            startup.ConfigureDesignTimeServices(new ServiceCollection());
+        }
+
+        [Fact]
+        public void ConfigureServices_uses_Development_environment_when_unspecified()
+        {
+            var startup = new StartupInvoker(
+                typeof(StartupInvokerTest).Assembly.FullName,
+                environment: null,
+                dnxServices: null);
+
+            var services = startup.ConfigureServices();
+
+            var service = services.GetRequiredService<TestService>();
+            Assert.Equal("Development", service.Value);
+        }
+
+        [Fact]
+        public void ConfigureServices_is_noop_when_not_found()
+        {
+            var startup = new StartupInvoker(
+                typeof(StartupInvokerTest).Assembly.FullName,
+                environment: "Unknown",
+                dnxServices: null);
+
+            var services = startup.ConfigureServices();
+
+            Assert.NotNull(services);
+        }
+
+        [Fact]
+        public void ConfigureServices_invokes_static_methods()
+        {
+            var startup = new StartupInvoker(
+                typeof(StartupInvokerTest).Assembly.FullName,
+                "Static",
+                dnxServices: null);
+
+            var services = startup.ConfigureServices();
+
+            var service = services.GetRequiredService<TestService>();
+            Assert.Equal("Static", service.Value);
+        }
+
+        [Fact]
+        public void ConfigureServices_invokes_method_with_alternative_signature()
+        {
+            var startup = new StartupInvoker(
+                typeof(StartupInvokerTest).Assembly.FullName,
+                "Alternative",
+                dnxServices: null);
+
+            var services = startup.ConfigureServices();
+
+            var service = services.GetRequiredService<TestService>();
+            Assert.Equal("Alternative", service.Value);
+
+        }
     }
 
     public class StartupDevelopment
     {
+        public void ConfigureDevelopmentServices(IServiceCollection services)
+            => services.AddInstance(new TestService("Development"));
+
         public void ConfigureDesignTimeServices(IServiceCollection services)
             => services.AddInstance(new TestService("Development"));
     }
 
     public class StartupStatic
     {
+        public static void ConfigureServices(IServiceCollection services)
+            => services.AddInstance(new TestService("Static"));
+
         public static void ConfigureDesignTimeServices(IServiceCollection services)
             => services.AddInstance(new TestService("Static"));
+    }
+
+    public class StartupAlternative
+    {
+        public IServiceProvider ConfigureServices()
+            => new ServiceCollection()
+                .AddInstance(new TestService("Alternative"))
+                .BuildServiceProvider();
     }
 
     public class TestService


### PR DESCRIPTION
Fixes #2293

With this, it's now possible to have your `Startup`, `DbContext`, and `Migration` classes in three separate projects. But not on DNX yet because it's blocked by #2679.

Also stops throwing on DNX if `Startup` isn't found (fixes #2867)

Verification: Manual bashing :hammer: