### PR TITLE
:racehorse: Adjust benchmarks that are too quick

### DIFF
--- a/test/EntityFramework.Microbenchmarks.EF6/ChangeTracker/DbSetOperationTests.cs
+++ b/test/EntityFramework.Microbenchmarks.EF6/ChangeTracker/DbSetOperationTests.cs
@@ -47,7 +47,7 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
         [Benchmark]
         [BenchmarkVariation("AutoDetectChanges On", true)]
         [BenchmarkVariation("AutoDetectChanges Off", false)]
-        public void AddCollection(IMetricCollector collector, bool autoDetectChanges)
+        public void AddRange(IMetricCollector collector, bool autoDetectChanges)
         {
             using (var context = _fixture.CreateContext())
             {
@@ -75,9 +75,12 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
             {
                 context.Configuration.AutoDetectChangesEnabled = autoDetectChanges;
 
-                var customers = GetAllCustomersFromDatabase();
-                Assert.Equal(1000, customers.Length);
-                
+                var customers = new Customer[1000];
+                for (int i = 0; i < customers.Length; i++)
+                {
+                    customers[i] = new Customer { CustomerId = i + 1, Name = "Customer " + i };
+                }
+
                 using (collector.StartCollection())
                 {
                     foreach (var customer in customers)
@@ -88,7 +91,7 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
             }
         }
 
-        // Note: AttachCollection() not implemented because there is no
+        // Note: AttachRange() not implemented because there is no
         //       API for bulk attach in EF6.x
 
         [Benchmark]
@@ -100,8 +103,12 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
             {
                 context.Configuration.AutoDetectChangesEnabled = autoDetectChanges;
 
-                var customers = context.Customers.ToArray();
-                Assert.Equal(1000, customers.Length);
+                var customers = new Customer[1000];
+                for (int i = 0; i < customers.Length; i++)
+                {
+                    customers[i] = new Customer { CustomerId = i + 1, Name = "Customer " + i };
+                    context.Customers.Attach(customers[i]);
+                }
 
                 using (collector.StartCollection())
                 {
@@ -116,14 +123,18 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
         [Benchmark]
         [BenchmarkVariation("AutoDetectChanges On", true)]
         [BenchmarkVariation("AutoDetectChanges Off", false)]
-        public void RemoveCollection(IMetricCollector collector, bool autoDetectChanges)
+        public void RemoveRange(IMetricCollector collector, bool autoDetectChanges)
         {
             using (var context = _fixture.CreateContext())
             {
                 context.Configuration.AutoDetectChangesEnabled = autoDetectChanges;
 
-                var customers = context.Customers.ToArray();
-                Assert.Equal(1000, customers.Length);
+                var customers = new Customer[1000];
+                for (int i = 0; i < customers.Length; i++)
+                {
+                    customers[i] = new Customer { CustomerId = i + 1, Name = "Customer " + i };
+                    context.Customers.Attach(customers[i]);
+                }
 
                 using (collector.StartCollection())
                 {
@@ -141,8 +152,12 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
             {
                 context.Configuration.AutoDetectChangesEnabled = autoDetectChanges;
 
-                var customers = GetAllCustomersFromDatabase();
-                Assert.Equal(1000, customers.Length);
+                var customers = new Customer[1000];
+                for (int i = 0; i < customers.Length; i++)
+                {
+                    customers[i] = new Customer { CustomerId = i + 1, Name = "Customer " + i };
+                    context.Customers.Attach(customers[i]);
+                }
 
                 using (collector.StartCollection())
                 {
@@ -154,21 +169,13 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
             }
         }
 
-        // Note: UpdateCollection() not implemented because there is no
+        // Note: UpdateRange() not implemented because there is no
         //       API for bulk update in EF6.x
-
-        private Customer[] GetAllCustomersFromDatabase()
-        {
-            using (var context = _fixture.CreateContext())
-            {
-                return context.Customers.ToArray();
-            }
-        }
 
         public class DbSetOperationFixture : OrdersFixture
         {
             public DbSetOperationFixture()
-                : base("Perf_ChangeTracker_DbSetOperation_EF6", 0, 1000, 0, 0)
+                : base("Perf_ChangeTracker_DbSetOperation_EF6", 0, 0, 0, 0)
             { }
         }
     }

--- a/test/EntityFramework.Microbenchmarks.EF6/InitializationTests.cs
+++ b/test/EntityFramework.Microbenchmarks.EF6/InitializationTests.cs
@@ -19,7 +19,7 @@ namespace EntityFramework.Microbenchmarks.EF6
 #if !DNX451
         [BenchmarkVariation("Cold (1 instance)", true, 1)]
 #endif
-        [BenchmarkVariation("Warm (100 instances)", false, 100)]
+        [BenchmarkVariation("Warm (1000 instances)", false, 1000)]
         public void CreateAndDisposeUnusedContext(IMetricCollector collector, bool cold, int count)
         {
             RunColdStartEnabledTest(cold, c => c.CreateAndDisposeUnusedContext(collector, count));
@@ -29,7 +29,7 @@ namespace EntityFramework.Microbenchmarks.EF6
 #if !DNX451
         [BenchmarkVariation("Cold (1 instance)", true, 1)]
 #endif
-        [BenchmarkVariation("Warm (10 instances)", false, 10)]
+        [BenchmarkVariation("Warm (100 instances)", false, 100)]
         public void InitializeAndQuery_AdventureWorks(IMetricCollector collector, bool cold, int count)
         {
             RunColdStartEnabledTest(cold, c => c.InitializeAndQuery_AdventureWorks(collector, count));
@@ -39,7 +39,7 @@ namespace EntityFramework.Microbenchmarks.EF6
 #if !DNX451
         [BenchmarkVariation("Cold (1 instance)", true, 1)]
 #endif
-        [BenchmarkVariation("Warm (10 instances)", false, 10)]
+        [BenchmarkVariation("Warm (100 instances)", false, 100)]
         public void InitializeAndSaveChanges_AdventureWorks(IMetricCollector collector, bool cold, int count)
         {
             RunColdStartEnabledTest(cold, t => t.InitializeAndSaveChanges_AdventureWorks(collector, count));

--- a/test/EntityFramework.Microbenchmarks.EF6/Models/Orders/OrdersFixture.cs
+++ b/test/EntityFramework.Microbenchmarks.EF6/Models/Orders/OrdersFixture.cs
@@ -13,7 +13,7 @@ namespace EntityFramework.Microbenchmarks.EF6.Models.Orders
         {
             _connectionString = $@"Server={BenchmarkConfig.Instance.BenchmarkDatabaseInstance};Database={databaseName};Integrated Security=True;MultipleActiveResultSets=true;";
 
-            new OrdersSeedData().EnsureCreated(_connectionString, productCount, customerCount, ordersPerCustomer, linesPerOrder);
+            new OrdersSeedData(_connectionString, productCount, customerCount, ordersPerCustomer, linesPerOrder).EnsureCreated();
         }
 
         public OrdersContext CreateContext()

--- a/test/EntityFramework.Microbenchmarks.EF6/Query/SimpleQueryTests.cs
+++ b/test/EntityFramework.Microbenchmarks.EF6/Query/SimpleQueryTests.cs
@@ -18,32 +18,38 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
             _fixture = fixture;
         }
 
-        [Benchmark(Iterations = 1, WarmupIterations = 0)]
-        [BenchmarkVariation("Tracking On", true, true)]
-        [BenchmarkVariation("Tracking Off", false, true)]
-        [BenchmarkVariation("Tracking On (No Query Cache)", true, false)]
-        [BenchmarkVariation("Tracking Off (No Query Cache)", false, false)]
-        public void LoadAll(IMetricCollector collector, bool tracking, bool caching)
+        [Benchmark]
+        [BenchmarkVariation("Tracking On (1 query)", true, true, 1)]
+        [BenchmarkVariation("Tracking Off (10 queries)", false, true, 10)]
+        [BenchmarkVariation("Tracking On, Query Cache Off (1 query)", true, false, 1)]
+        [BenchmarkVariation("Tracking Off, Query Cache Off (10 queries)", false, false, 10)]
+        public void LoadAll(IMetricCollector collector, bool tracking, bool caching, int queriesPerIteration)
         {
             using (var context = _fixture.CreateContext())
             {
                 var query = context.Products
                     .ApplyCaching(caching)
                     .ApplyTracking(tracking);
-                
-                collector.StartCollection();
-                var result = query.ToList();
-                collector.StopCollection();
-                Assert.Equal(1000, result.Count);
+
+                using (collector.StartCollection())
+                {
+                    for (int i = 0; i < queriesPerIteration; i++)
+                    {
+                        query.ToList();
+                    }
+                }
+
+                Assert.Equal(1000, query.Count());
+                Assert.False(tracking && queriesPerIteration != 1, "Multiple queries per iteration not valid for tracking queries");
             }
         }
 
         [Benchmark]
-        [BenchmarkVariation("Tracking On", true, true)]
-        [BenchmarkVariation("Tracking Off", false, true)]
-        [BenchmarkVariation("Tracking On (No Query Cache)", true, false)]
-        [BenchmarkVariation("Tracking Off (No Query Cache)", false, false)]
-        public void Where(IMetricCollector collector, bool tracking, bool caching)
+        [BenchmarkVariation("Tracking On (1 query)", true, true, 1)]
+        [BenchmarkVariation("Tracking Off (10 queries)", false, true, 10)]
+        [BenchmarkVariation("Tracking On, Query Cache Off (1 query)", true, false, 1)]
+        [BenchmarkVariation("Tracking Off, Query Cache Off (10 queries)", false, false, 10)]
+        public void Where(IMetricCollector collector, bool tracking, bool caching, int queriesPerIteration)
         {
             using (var context = _fixture.CreateContext())
             {
@@ -52,19 +58,25 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
                     .ApplyTracking(tracking)
                     .Where(p => p.Retail < 15);
 
-                collector.StartCollection();
-                var result = query.ToList();
-                collector.StopCollection();
-                Assert.Equal(500, result.Count);
+                using (collector.StartCollection())
+                {
+                    for (int i = 0; i < queriesPerIteration; i++)
+                    {
+                        query.ToList();
+                    }
+                }
+
+                Assert.Equal(500, query.Count());
+                Assert.False(tracking && queriesPerIteration != 1, "Multiple queries per iteration not valid for tracking queries");
             }
         }
 
         [Benchmark]
-        [BenchmarkVariation("Tracking On", true, true)]
-        [BenchmarkVariation("Tracking Off", false, true)]
-        [BenchmarkVariation("Tracking On (No Query Cache)", true, false)]
-        [BenchmarkVariation("Tracking Off (No Query Cache)", false, false)]
-        public void OrderBy(IMetricCollector collector, bool tracking, bool caching)
+        [BenchmarkVariation("Tracking On (1 query)", true, true, 1)]
+        [BenchmarkVariation("Tracking Off (10 queries)", false, true, 10)]
+        [BenchmarkVariation("Tracking On, Query Cache Off  (1 query)", true, false, 1)]
+        [BenchmarkVariation("Tracking Off, Query Cache Off (10 queries)", false, false, 10)]
+        public void OrderBy(IMetricCollector collector, bool tracking, bool caching, int queriesPerIteration)
         {
             using (var context = _fixture.CreateContext())
             {
@@ -73,36 +85,47 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
                     .ApplyTracking(tracking)
                     .OrderBy(p => p.Retail);
 
-                collector.StartCollection();
-                var result = query.ToList();
-                collector.StopCollection();
-                Assert.Equal(1000, result.Count);
+                using (collector.StartCollection())
+                {
+                    for (int i = 0; i < queriesPerIteration; i++)
+                    {
+                        query.ToList();
+                    }
+                }
+
+                Assert.Equal(1000, query.Count());
+                Assert.False(tracking && queriesPerIteration != 1, "Multiple queries per iteration not valid for tracking queries");
             }
         }
 
         [Benchmark]
-        [BenchmarkVariation("Default", true)]
-        [BenchmarkVariation("No Query Cache", false)]
-        public void Count(IMetricCollector collector, bool caching)
+        [BenchmarkVariation("Default (100 queries)", true, 100)]
+        [BenchmarkVariation("Query Cache Off (100 queries)", false, 100)]
+        public void Count(IMetricCollector collector, bool caching, int queriesPerIteration)
         {
             using (var context = _fixture.CreateContext())
             {
                 var query = context.Products
                     .ApplyCaching(caching);
 
-                collector.StartCollection();
-                var result = query.Count();
-                collector.StopCollection();
-                Assert.Equal(1000, result);
+                using (collector.StartCollection())
+                {
+                    for (int i = 0; i < queriesPerIteration; i++)
+                    {
+                        query.Count();
+                    }
+                }
+
+                Assert.Equal(1000, query.Count());
             }
         }
 
         [Benchmark]
-        [BenchmarkVariation("Tracking On", true, true)]
-        [BenchmarkVariation("Tracking Off", false, true)]
-        [BenchmarkVariation("Tracking On (No Query Cache)", true, false)]
-        [BenchmarkVariation("Tracking Off (No Query Cache)", false, false)]
-        public void SkipTake(IMetricCollector collector, bool tracking, bool caching)
+        [BenchmarkVariation("Tracking On (1 query)", true, true, 1)]
+        [BenchmarkVariation("Tracking Off (10 queries)", false, true, 10)]
+        [BenchmarkVariation("Tracking On, Query Cache Off  (1 query)", true, false, 1)]
+        [BenchmarkVariation("Tracking Off, Query Cache Off (10 queries)", false, false, 10)]
+        public void SkipTake(IMetricCollector collector, bool tracking, bool caching, int queriesPerIteration)
         {
             using (var context = _fixture.CreateContext())
             {
@@ -112,17 +135,23 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
                     .OrderBy(p => p.ProductId)
                     .Skip(500).Take(500);
 
-                collector.StartCollection();
-                var result = query.ToList();
-                collector.StopCollection();
-                Assert.Equal(500, result.Count);
+                using (collector.StartCollection())
+                {
+                    for (int i = 0; i < queriesPerIteration; i++)
+                    {
+                        query.ToList();
+                    }
+                }
+
+                Assert.Equal(500, query.Count());
+                Assert.False(tracking && queriesPerIteration != 1, "Multiple queries per iteration not valid for tracking queries");
             }
         }
 
         [Benchmark]
-        [BenchmarkVariation("Default", true)]
-        [BenchmarkVariation("No Query Cache", false)]
-        public void GroupBy(IMetricCollector collector, bool caching)
+        [BenchmarkVariation("Default (10 queries)", true, 10)]
+        [BenchmarkVariation("Query Cache Off (10 queries)", false, 10)]
+        public void GroupBy(IMetricCollector collector, bool caching, int queriesPerIteration)
         {
             using (var context = _fixture.CreateContext())
             {
@@ -135,20 +164,26 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
                         Products = g
                     });
 
-                collector.StartCollection();
+                using (collector.StartCollection())
+                {
+                    for (int i = 0; i < queriesPerIteration; i++)
+                    {
+                        query.ToList();
+                    }
+                }
+
                 var result = query.ToList();
-                collector.StopCollection();
                 Assert.Equal(10, result.Count);
                 Assert.All(result, g => Assert.Equal(100, g.Products.Count()));
             }
         }
 
         [Benchmark]
-        [BenchmarkVariation("Tracking On", true, true)]
-        [BenchmarkVariation("Tracking Off", false, true)]
-        [BenchmarkVariation("Tracking On (No Query Cache)", true, false)]
-        [BenchmarkVariation("Tracking Off (No Query Cache)", false, false)]
-        public void Include(IMetricCollector collector, bool tracking, bool caching)
+        [BenchmarkVariation("Tracking On (1 query)", true, true, 1)]
+        [BenchmarkVariation("Tracking Off (1 query)", false, true, 1)]
+        [BenchmarkVariation("Tracking On, Query Cache Off  (1 query)", true, false, 1)]
+        [BenchmarkVariation("Tracking Off, Query Cache Off  (1 query)", false, false, 1)]
+        public void Include(IMetricCollector collector, bool tracking, bool caching, int queriesPerIteration)
         {
             using (var context = _fixture.CreateContext())
             {
@@ -157,18 +192,25 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
                     .ApplyTracking(tracking)
                     .Include(c => c.Orders);
 
-                collector.StartCollection();
+                using (collector.StartCollection())
+                {
+                    for (int i = 0; i < queriesPerIteration; i++)
+                    {
+                        query.ToList();
+                    }
+                }
+
                 var result = query.ToList();
-                collector.StopCollection();
                 Assert.Equal(1000, result.Count);
                 Assert.Equal(2000, result.SelectMany(c => c.Orders).Count());
+                Assert.False(tracking && queriesPerIteration != 1, "Multiple queries per iteration not valid for tracking queries");
             }
         }
 
         [Benchmark]
-        [BenchmarkVariation("Default", true)]
-        [BenchmarkVariation("No Query Cache", false)]
-        public void Projection(IMetricCollector collector, bool caching)
+        [BenchmarkVariation("Default (10 queries)", true, 10)]
+        [BenchmarkVariation("Query Cache Off (10 queries)", false, 10)]
+        public void Projection(IMetricCollector collector, bool caching, int queriesPerIteration)
         {
             using (var context = _fixture.CreateContext())
             {
@@ -176,33 +218,38 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
                     .ApplyCaching(caching)
                     .Select(p => new { p.Name, p.Retail });
 
-                collector.StartCollection();
-                var result = query.ToList();
-                collector.StopCollection();
-                Assert.Equal(1000, result.Count);
+                using (collector.StartCollection())
+                {
+                    for (int i = 0; i < queriesPerIteration; i++)
+                    {
+                        query.ToList();
+                    }
+                }
+
+                Assert.Equal(1000, query.Count());
             }
         }
 
         [Benchmark]
-        [BenchmarkVariation("Default", true)]
-        [BenchmarkVariation("No Query Cache", false)]
-        public void ProjectionAcrossNavigation(IMetricCollector collector, bool caching)
+        [BenchmarkVariation("Default (10 queries)", true, 10)]
+        [BenchmarkVariation("Query Cache Off (10 queries)", false, 10)]
+        public void ProjectionAcrossNavigation(IMetricCollector collector, bool caching, int queriesPerIteration)
         {
             using (var context = _fixture.CreateContext())
             {
-                // TODO Use navigation for projection when supported (#325)
                 var query = context.Orders
                     .ApplyCaching(caching)
-                    .Join(
-                        context.Customers,
-                        o => o.CustomerId,
-                        c => c.CustomerId,
-                        (o, c) => new { CustomerName = c.Name, OrderDate = o.Date });
+                    .Select(o => new { CustomerName = o.Customer.Name, OrderDate = o.Date });
 
-                collector.StartCollection();
-                var result = query.ToList();
-                collector.StopCollection();
-                Assert.Equal(2000, result.Count);
+                using (collector.StartCollection())
+                {
+                    for (int i = 0; i < queriesPerIteration; i++)
+                    {
+                        query.ToList();
+                    }
+                }
+
+                Assert.Equal(2000, query.Count());
             }
         }
 

--- a/test/EntityFramework.Microbenchmarks/ChangeTracker/DbSetOperationTests.cs
+++ b/test/EntityFramework.Microbenchmarks/ChangeTracker/DbSetOperationTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Linq;
 using EntityFramework.Microbenchmarks.Core;
 using EntityFramework.Microbenchmarks.Core.Models.Orders;
 using EntityFramework.Microbenchmarks.Models.Orders;
@@ -46,7 +45,7 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
         [Benchmark]
         [BenchmarkVariation("AutoDetectChanges On", true)]
         [BenchmarkVariation("AutoDetectChanges Off", false)]
-        public void AddCollection(IMetricCollector collector, bool autoDetectChanges)
+        public void AddRange(IMetricCollector collector, bool autoDetectChanges)
         {
             using (var context = _fixture.CreateContext())
             {
@@ -75,8 +74,11 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
             {
                 context.ChangeTracker.AutoDetectChangesEnabled = autoDetectChanges;
 
-                var customers = GetAllCustomersFromDatabase();
-                Assert.Equal(1000, customers.Length);
+                var customers = new Customer[1000];
+                for (int i = 0; i < customers.Length; i++)
+                {
+                    customers[i] = new Customer { CustomerId = i + 1, Name = "Customer " + i };
+                }
 
                 using (collector.StartCollection())
                 {
@@ -86,20 +88,22 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
                     }
                 }
             }
-
         }
 
         [Benchmark]
         [BenchmarkVariation("AutoDetectChanges On", true)]
         [BenchmarkVariation("AutoDetectChanges Off", false)]
-        public void AttachCollection(IMetricCollector collector, bool autoDetectChanges)
+        public void AttachRange(IMetricCollector collector, bool autoDetectChanges)
         {
             using (var context = _fixture.CreateContext())
             {
                 context.ChangeTracker.AutoDetectChangesEnabled = autoDetectChanges;
 
-                var customers = GetAllCustomersFromDatabase();
-                Assert.Equal(1000, customers.Length);
+                var customers = new Customer[1000];
+                for (int i = 0; i < customers.Length; i++)
+                {
+                    customers[i] = new Customer { CustomerId = i + 1, Name = "Customer " + i };
+                }
 
                 using (collector.StartCollection())
                 {
@@ -117,8 +121,12 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
             {
                 context.ChangeTracker.AutoDetectChangesEnabled = autoDetectChanges;
 
-                var customers = context.Customers.ToArray();
-                Assert.Equal(1000, customers.Length);
+                var customers = new Customer[1000];
+                for (int i = 0; i < customers.Length; i++)
+                {
+                    customers[i] = new Customer { CustomerId = i + 1, Name = "Customer " + i };
+                }
+                context.Customers.AttachRange(customers);
 
                 using (collector.StartCollection())
                 {
@@ -133,14 +141,18 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
         [Benchmark]
         [BenchmarkVariation("AutoDetectChanges On", true)]
         [BenchmarkVariation("AutoDetectChanges Off", false)]
-        public void RemoveCollection(IMetricCollector collector, bool autoDetectChanges)
+        public void RemoveRange(IMetricCollector collector, bool autoDetectChanges)
         {
             using (var context = _fixture.CreateContext())
             {
                 context.ChangeTracker.AutoDetectChangesEnabled = autoDetectChanges;
 
-                var customers = context.Customers.ToArray();
-                Assert.Equal(1000, customers.Length);
+                var customers = new Customer[1000];
+                for (int i = 0; i < customers.Length; i++)
+                {
+                    customers[i] = new Customer { CustomerId = i + 1, Name = "Customer " + i };
+                }
+                context.Customers.AttachRange(customers);
 
                 using (collector.StartCollection())
                 {
@@ -158,8 +170,12 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
             {
                 context.ChangeTracker.AutoDetectChangesEnabled = autoDetectChanges;
 
-                var customers = GetAllCustomersFromDatabase();
-                Assert.Equal(1000, customers.Length);
+                var customers = new Customer[1000];
+                for (int i = 0; i < customers.Length; i++)
+                {
+                    customers[i] = new Customer { CustomerId = i + 1, Name = "Customer " + i };
+                }
+                context.Customers.AttachRange(customers);
 
                 using (collector.StartCollection())
                 {
@@ -174,14 +190,18 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
         [Benchmark]
         [BenchmarkVariation("AutoDetectChanges On", true)]
         [BenchmarkVariation("AutoDetectChanges Off", false)]
-        public void UpdateCollection(IMetricCollector collector, bool autoDetectChanges)
+        public void UpdateRange(IMetricCollector collector, bool autoDetectChanges)
         {
             using (var context = _fixture.CreateContext())
             {
                 context.ChangeTracker.AutoDetectChangesEnabled = autoDetectChanges;
 
-                var customers = GetAllCustomersFromDatabase();
-                Assert.Equal(1000, customers.Length);
+                var customers = new Customer[1000];
+                for (int i = 0; i < customers.Length; i++)
+                {
+                    customers[i] = new Customer { CustomerId = i + 1, Name = "Customer " + i };
+                }
+                context.Customers.AttachRange(customers);
 
                 using (collector.StartCollection())
                 {
@@ -190,18 +210,10 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
             }
         }
 
-        private Customer[] GetAllCustomersFromDatabase()
-        {
-            using (var context = _fixture.CreateContext())
-            {
-                return context.Customers.ToArray();
-            }
-        }
-
         public class DbSetOperationFixture : OrdersFixture
         {
             public DbSetOperationFixture()
-                : base("Perf_ChangeTracker_DbSetOperation", 0, 1000, 0, 0)
+                : base("Perf_ChangeTracker_DbSetOperation", 0, 0, 0, 0)
             { }
         }
     }

--- a/test/EntityFramework.Microbenchmarks/ChangeTracker/FixupTests.cs
+++ b/test/EntityFramework.Microbenchmarks/ChangeTracker/FixupTests.cs
@@ -1,11 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-using System.Linq;
 using EntityFramework.Microbenchmarks.Core;
 using EntityFramework.Microbenchmarks.Core.Models.Orders;
 using EntityFramework.Microbenchmarks.Models.Orders;
+using System.Linq;
 using Xunit;
 
 namespace EntityFramework.Microbenchmarks.ChangeTracker
@@ -19,107 +18,103 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
             _fixture = fixture;
         }
 
-        [Benchmark(Iterations = 10)]
+        [Benchmark]
         public void AddChildren(IMetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
             {
-                var customers = context.Customers.ToList();
-                Assert.Equal(100, customers.Count);
-
-                foreach (var customer in customers)
+                var orders = new Order[1000];
+                for (var i = 0; i < orders.Length; i++)
                 {
-                    var order = new Order { CustomerId = customer.CustomerId };
+                    context.Customers.Attach(new Customer { CustomerId = i + 1 });
+                    orders[i] = new Order { CustomerId = i + 1 };
+                }
 
-                    using (collector.StartCollection())
+                using (collector.StartCollection())
+                {
+                    foreach (var order in orders)
                     {
                         context.Orders.Add(order);
                     }
-
-                    Assert.Same(order, order.Customer.Orders.Single());
                 }
+
+                Assert.All(orders, o => Assert.NotNull(o.Customer));
             }
         }
 
-        [Benchmark(Iterations = 10)]
+        [Benchmark]
         public void AddParents(IMetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
             {
-                var customers = new List<Customer>();
-                for (var i = 0; i < 100; i++)
+                var customers = new Customer[1000];
+                for (var i = 0; i < customers.Length; i++)
                 {
-                    customers.Add(new Customer { CustomerId = i + 1 });
+                    customers[i] = new Customer { CustomerId = i + 1 };
                     context.Orders.Add(new Order { CustomerId = i + 1 });
                 }
 
-                foreach (var customer in customers)
+                using (collector.StartCollection())
                 {
-                    using (collector.StartCollection())
+                    foreach (var customer in customers)
                     {
                         context.Customers.Add(customer);
                     }
-
-                    Assert.Same(customer, customer.Orders.Single().Customer);
                 }
+
+                Assert.All(customers, c => Assert.Equal(1, c.Orders.Count));
             }
         }
 
-        [Benchmark(Iterations = 10)]
+        [Benchmark]
         public void AttachChildren(IMetricCollector collector)
         {
-            List<Order> orders;
             using (var context = _fixture.CreateContext())
             {
-                orders = context.Orders.ToList();
-            }
-
-            using (var context = _fixture.CreateContext())
-            {
-                var customers = context.Customers.ToList();
-                Assert.Equal(100, orders.Count);
-                Assert.Equal(100, customers.Count);
-
-                foreach (var order in orders)
+                var orders = new Order[1000];
+                for (var i = 0; i < orders.Length; i++)
                 {
-                    using (collector.StartCollection())
+                    context.Customers.Attach(new Customer { CustomerId = i + 1 });
+                    orders[i] = new Order { OrderId = i + 1, CustomerId = i + 1 };
+                }
+
+                using (collector.StartCollection())
+                {
+                    foreach (var order in orders)
                     {
                         context.Orders.Attach(order);
                     }
-
-                    Assert.Same(order, order.Customer.Orders.Single());
                 }
+
+                Assert.All(orders, o => Assert.NotNull(o.Customer));
             }
         }
 
-        [Benchmark(Iterations = 10)]
+        [Benchmark]
         public void AttachParents(IMetricCollector collector)
         {
-            List<Customer> customers;
             using (var context = _fixture.CreateContext())
             {
-                customers = context.Customers.ToList();
-            }
-
-            using (var context = _fixture.CreateContext())
-            {
-                var orders = context.Orders.ToList();
-                Assert.Equal(100, orders.Count);
-                Assert.Equal(100, customers.Count);
-
-                foreach (var customer in customers)
+                var customers = new Customer[1000];
+                for (var i = 0; i < customers.Length; i++)
                 {
-                    using (collector.StartCollection())
+                    customers[i] = new Customer { CustomerId = i + 1 };
+                    context.Orders.Attach(new Order { OrderId = i + 1, CustomerId = i + 1 });
+                }
+
+                using (collector.StartCollection())
+                {
+                    foreach (var customer in customers)
                     {
                         context.Customers.Attach(customer);
                     }
-
-                    Assert.Same(customer, customer.Orders.Single().Customer);
                 }
+
+                Assert.All(customers, c => Assert.Equal(1, c.Orders.Count));
             }
         }
 
-        [Benchmark(Iterations = 10)]
+        [Benchmark]
         public void QueryChildren(IMetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
@@ -130,13 +125,13 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
                 var orders = context.Orders.ToList();
                 collector.StopCollection();
 
-                Assert.Equal(100, context.ChangeTracker.Entries<Customer>().Count());
-                Assert.Equal(100, context.ChangeTracker.Entries<Order>().Count());
+                Assert.Equal(1000, context.ChangeTracker.Entries<Customer>().Count());
+                Assert.Equal(1000, context.ChangeTracker.Entries<Order>().Count());
                 Assert.All(orders, o => Assert.NotNull(o.Customer));
             }
         }
 
-        [Benchmark(Iterations = 10)]
+        [Benchmark]
         public void QueryParents(IMetricCollector collector)
         {
             using (var context = _fixture.CreateContext())
@@ -147,8 +142,8 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
                 var customers = context.Customers.ToList();
                 collector.StopCollection();
 
-                Assert.Equal(100, context.ChangeTracker.Entries<Customer>().Count());
-                Assert.Equal(100, context.ChangeTracker.Entries<Order>().Count());
+                Assert.Equal(1000, context.ChangeTracker.Entries<Customer>().Count());
+                Assert.Equal(1000, context.ChangeTracker.Entries<Order>().Count());
                 Assert.All(customers, c => Assert.Equal(1, c.Orders.Count));
             }
         }
@@ -156,7 +151,7 @@ namespace EntityFramework.Microbenchmarks.ChangeTracker
         public class FixupFixture : OrdersFixture
         {
             public FixupFixture()
-                : base("Perf_ChangeTracker_Fixup", 100, 100, 1, 1)
+                : base("Perf_ChangeTracker_Fixup", 0, 1000, 1, 0)
             { }
         }
     }

--- a/test/EntityFramework.Microbenchmarks/InitializationTests.cs
+++ b/test/EntityFramework.Microbenchmarks/InitializationTests.cs
@@ -19,7 +19,7 @@ namespace EntityFramework.Microbenchmarks
 #if !DNXCORE50 && !DNX451
         [BenchmarkVariation("Cold (1 instance)", true, 1)]
 #endif
-        [BenchmarkVariation("Warm (100 instances)", false, 100)]
+        [BenchmarkVariation("Warm (1000 instances)", false, 1000)]
         public void CreateAndDisposeUnusedContext(IMetricCollector collector, bool cold, int count)
         {
             RunColdStartEnabledTest(cold, c => c.CreateAndDisposeUnusedContext(collector, count));
@@ -29,7 +29,7 @@ namespace EntityFramework.Microbenchmarks
 #if !DNXCORE50 && !DNX451
         [BenchmarkVariation("Cold (1 instance)", true, 1)]
 #endif
-        [BenchmarkVariation("Warm (10 instances)", false, 10)]
+        [BenchmarkVariation("Warm (100 instances)", false, 100)]
         public void InitializeAndQuery_AdventureWorks(IMetricCollector collector, bool cold, int count)
         {
             RunColdStartEnabledTest(cold, c => c.InitializeAndQuery_AdventureWorks(collector, count));
@@ -39,7 +39,7 @@ namespace EntityFramework.Microbenchmarks
 #if !DNXCORE50 && !DNX451
         [BenchmarkVariation("Cold (1 instance)", true, 1)]
 #endif
-        [BenchmarkVariation("Warm (10 instances)", false, 10)]
+        [BenchmarkVariation("Warm (100 instances)", false, 100)]
         public void InitializeAndSaveChanges_AdventureWorks(IMetricCollector collector, bool cold, int count)
         {
             RunColdStartEnabledTest(cold, t => t.InitializeAndSaveChanges_AdventureWorks(collector, count));

--- a/test/EntityFramework.Microbenchmarks/Models/Orders/OrdersFixture.cs
+++ b/test/EntityFramework.Microbenchmarks/Models/Orders/OrdersFixture.cs
@@ -13,7 +13,7 @@ namespace EntityFramework.Microbenchmarks.Models.Orders
         {
             _connectionString = $@"Server={BenchmarkConfig.Instance.BenchmarkDatabaseInstance};Database={databaseName};Integrated Security=True;MultipleActiveResultSets=true;";
 
-            new OrdersSeedData().EnsureCreated(_connectionString, productCount, customerCount, ordersPerCustomer, linesPerOrder);
+            new OrdersSeedData(_connectionString, productCount, customerCount, ordersPerCustomer, linesPerOrder).EnsureCreated();
         }
 
         public string ConnectionString => _connectionString;

--- a/test/EntityFramework.Microbenchmarks/Models/Orders/OrdersSeedData.cs
+++ b/test/EntityFramework.Microbenchmarks/Models/Orders/OrdersSeedData.cs
@@ -1,66 +1,92 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Linq;
 using EntityFramework.Microbenchmarks.Core.Models.Orders;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Storage;
+using System;
+using System.Linq;
 using Xunit;
 
 namespace EntityFramework.Microbenchmarks.Models.Orders
 {
     public class OrdersSeedData : OrdersSeedDataBase
     {
-        public void EnsureCreated(
+        private readonly string _connectionString;
+        private readonly int _productCount;
+        private readonly int _customerCount;
+        private readonly int _ordersPerCustomer;
+        private readonly int _linesPerOrder;
+
+        public OrdersSeedData(
             string connectionString,
             int productCount,
             int customerCount,
             int ordersPerCustomer,
             int linesPerOrder)
         {
-            using (var context = new OrdersContext(connectionString))
+            _connectionString = connectionString;
+            _productCount = productCount;
+            _customerCount = customerCount;
+            _ordersPerCustomer = ordersPerCustomer;
+            _linesPerOrder = linesPerOrder;
+        }
+
+        public void EnsureCreated()
+        {
+            using (var context = new OrdersContext(_connectionString))
             {
-                if (context.Database.EnsureCreated())
+                var database = ((IAccessor<IServiceProvider>)context).GetService<IRelationalDatabaseCreator>();
+                if(!database.Exists())
                 {
-                    InsertSeedData(connectionString, productCount, customerCount, ordersPerCustomer, linesPerOrder);
+                    context.Database.EnsureCreated();
+                    InsertSeedData();
+                }
+                else if(!IsDatabaseCorrect(context))
+                {
+                    context.Database.EnsureDeleted();
+                    context.Database.EnsureCreated();
+                    InsertSeedData();
                 }
 
-                Assert.Equal(productCount, context.Products.Count());
-                Assert.Equal(customerCount, context.Customers.Count());
-                Assert.Equal(customerCount * ordersPerCustomer, context.Orders.Count());
-                Assert.Equal(customerCount * ordersPerCustomer * linesPerOrder, context.OrderLines.Count());
+                Assert.True(IsDatabaseCorrect(context));
             }
         }
 
-        public void InsertSeedData(
-            string connectionString,
-            int productCount,
-            int customerCount,
-            int ordersPerCustomer,
-            int linesPerOrder)
+        private bool IsDatabaseCorrect(OrdersContext context)
         {
-            var products = CreateProducts(productCount);
-            using (var context = new OrdersContext(connectionString))
+            return _productCount == context.Products.Count()
+                && _customerCount == context.Customers.Count()
+                && _customerCount * _ordersPerCustomer == context.Orders.Count()
+                && _customerCount * _ordersPerCustomer * _linesPerOrder == context.OrderLines.Count();
+        }
+
+        public void InsertSeedData()
+        {
+            var products = CreateProducts(_productCount);
+            using (var context = new OrdersContext(_connectionString))
             {
                 context.Products.AddRange(products);
                 context.SaveChanges();
             }
 
-            var customers = CreateCustomers(customerCount);
-            using (var context = new OrdersContext(connectionString))
+            var customers = CreateCustomers(_customerCount);
+            using (var context = new OrdersContext(_connectionString))
             {
                 context.Customers.AddRange(customers);
                 context.SaveChanges();
             }
 
-            var orders = CreateOrders(ordersPerCustomer, customers);
-            using (var context = new OrdersContext(connectionString))
+            var orders = CreateOrders(_ordersPerCustomer, customers);
+            using (var context = new OrdersContext(_connectionString))
             {
                 context.Orders.AddRange(orders);
                 context.SaveChanges();
             }
 
-            var lines = CreateOrderLines(linesPerOrder, products, orders);
+            var lines = CreateOrderLines(_linesPerOrder, products, orders);
 
-            using (var context = new OrdersContext(connectionString))
+            using (var context = new OrdersContext(_connectionString))
             {
                 context.OrderLines.AddRange(lines);
                 context.SaveChanges();

--- a/test/EntityFramework.Microbenchmarks/Query/SimpleQueryTests.cs
+++ b/test/EntityFramework.Microbenchmarks/Query/SimpleQueryTests.cs
@@ -22,29 +22,35 @@ namespace EntityFramework.Microbenchmarks.Query
         }
 
         [Benchmark]
-        [BenchmarkVariation("Tracking On", true, true)]
-        [BenchmarkVariation("Tracking Off", false, true)]
-        [BenchmarkVariation("Tracking On (No Query Cache)", true, false)]
-        [BenchmarkVariation("Tracking Off (No Query Cache)", false, false)]
-        public void LoadAll(IMetricCollector collector, bool tracking, bool caching)
+        [BenchmarkVariation("Tracking On (1 query)", true, true, 1)]
+        [BenchmarkVariation("Tracking Off (10 queries)", false, true, 10)]
+        [BenchmarkVariation("Tracking On, Query Cache Off (1 query)", true, false, 1)]
+        [BenchmarkVariation("Tracking Off, Query Cache Off (10 queries)", false, false, 10)]
+        public void LoadAll(IMetricCollector collector, bool tracking, bool caching, int queriesPerIteration)
         {
             using (var context = _fixture.CreateContext(queryCachingEnabled: caching))
             {
                 var query = context.Products.ApplyTracking(tracking);
 
-                collector.StartCollection();
-                var result = query.ToList();
-                collector.StopCollection();
-                Assert.Equal(1000, result.Count);
+                using (collector.StartCollection())
+                {
+                    for (int i = 0; i < queriesPerIteration; i++)
+                    {
+                        query.ToList();
+                    }
+                }
+
+                Assert.Equal(1000, query.Count());
+                Assert.False(tracking && queriesPerIteration != 1, "Multiple queries per iteration not valid for tracking queries");
             }
         }
 
         [Benchmark]
-        [BenchmarkVariation("Tracking On", true, true)]
-        [BenchmarkVariation("Tracking Off", false, true)]
-        [BenchmarkVariation("Tracking On (No Query Cache)", true, false)]
-        [BenchmarkVariation("Tracking Off (No Query Cache)", false, false)]
-        public void Where(IMetricCollector collector, bool tracking, bool caching)
+        [BenchmarkVariation("Tracking On (1 query)", true, true, 1)]
+        [BenchmarkVariation("Tracking Off (10 queries)", false, true, 10)]
+        [BenchmarkVariation("Tracking On, Query Cache Off (1 query)", true, false, 1)]
+        [BenchmarkVariation("Tracking Off, Query Cache Off (10 queries)", false, false, 10)]
+        public void Where(IMetricCollector collector, bool tracking, bool caching, int queriesPerIteration)
         {
             using (var context = _fixture.CreateContext(queryCachingEnabled: caching))
             {
@@ -52,19 +58,25 @@ namespace EntityFramework.Microbenchmarks.Query
                     .ApplyTracking(tracking)
                     .Where(p => p.Retail < 15);
 
-                collector.StartCollection();
-                var result = query.ToList();
-                collector.StopCollection();
-                Assert.Equal(500, result.Count);
+                using (collector.StartCollection())
+                {
+                    for (int i = 0; i < queriesPerIteration; i++)
+                    {
+                        query.ToList();
+                    }
+                }
+
+                Assert.Equal(500, query.Count());
+                Assert.False(tracking && queriesPerIteration != 1, "Multiple queries per iteration not valid for tracking queries");
             }
         }
 
         [Benchmark]
-        [BenchmarkVariation("Tracking On", true, true)]
-        [BenchmarkVariation("Tracking Off", false, true)]
-        [BenchmarkVariation("Tracking On (No Query Cache)", true, false)]
-        [BenchmarkVariation("Tracking Off (No Query Cache)", false, false)]
-        public void OrderBy(IMetricCollector collector, bool tracking, bool caching)
+        [BenchmarkVariation("Tracking On (1 query)", true, true, 1)]
+        [BenchmarkVariation("Tracking Off (10 queries)", false, true, 10)]
+        [BenchmarkVariation("Tracking On, Query Cache Off  (1 query)", true, false, 1)]
+        [BenchmarkVariation("Tracking Off, Query Cache Off (10 queries)", false, false, 10)]
+        public void OrderBy(IMetricCollector collector, bool tracking, bool caching, int queriesPerIteration)
         {
             using (var context = _fixture.CreateContext(queryCachingEnabled: caching))
             {
@@ -72,35 +84,46 @@ namespace EntityFramework.Microbenchmarks.Query
                     .ApplyTracking(tracking)
                     .OrderBy(p => p.Retail);
 
-                collector.StartCollection();
-                var result = query.ToList();
-                collector.StopCollection();
-                Assert.Equal(1000, result.Count);
+                using (collector.StartCollection())
+                {
+                    for (int i = 0; i < queriesPerIteration; i++)
+                    {
+                        query.ToList();
+                    }
+                }
+
+                Assert.Equal(1000, query.Count());
+                Assert.False(tracking && queriesPerIteration != 1, "Multiple queries per iteration not valid for tracking queries");
             }
         }
 
         [Benchmark]
-        [BenchmarkVariation("Default", true)]
-        [BenchmarkVariation("No Query Cache", false)]
-        public void Count(IMetricCollector collector, bool caching)
+        [BenchmarkVariation("Default (100 queries)", true, 100)]
+        [BenchmarkVariation("Query Cache Off (100 queries)", false, 100)]
+        public void Count(IMetricCollector collector, bool caching, int queriesPerIteration)
         {
             using (var context = _fixture.CreateContext(queryCachingEnabled: caching))
             {
                 var query = context.Products;
 
-                collector.StartCollection();
-                var result = query.Count();
-                collector.StopCollection();
-                Assert.Equal(1000, result);
+                using (collector.StartCollection())
+                {
+                    for (int i = 0; i < queriesPerIteration; i++)
+                    {
+                        query.Count();
+                    }
+                }
+
+                Assert.Equal(1000, query.Count());
             }
         }
 
         [Benchmark]
-        [BenchmarkVariation("Tracking On", true, true)]
-        [BenchmarkVariation("Tracking Off", false, true)]
-        [BenchmarkVariation("Tracking On (No Query Cache)", true, false)]
-        [BenchmarkVariation("Tracking Off (No Query Cache)", false, false)]
-        public void SkipTake(IMetricCollector collector, bool tracking, bool caching)
+        [BenchmarkVariation("Tracking On (1 query)", true, true, 1)]
+        [BenchmarkVariation("Tracking Off (10 queries)", false, true, 10)]
+        [BenchmarkVariation("Tracking On, Query Cache Off  (1 query)", true, false, 1)]
+        [BenchmarkVariation("Tracking Off, Query Cache Off (10 queries)", false, false, 10)]
+        public void SkipTake(IMetricCollector collector, bool tracking, bool caching, int queriesPerIteration)
         {
             using (var context = _fixture.CreateContext(queryCachingEnabled: caching))
             {
@@ -109,17 +132,23 @@ namespace EntityFramework.Microbenchmarks.Query
                     .OrderBy(p => p.ProductId)
                     .Skip(500).Take(500);
 
-                collector.StartCollection();
-                var result = query.ToList();
-                collector.StopCollection();
-                Assert.Equal(500, result.Count);
+                using (collector.StartCollection())
+                {
+                    for (int i = 0; i < queriesPerIteration; i++)
+                    {
+                        query.ToList();
+                    }
+                }
+
+                Assert.Equal(500, query.Count());
+                Assert.False(tracking && queriesPerIteration != 1, "Multiple queries per iteration not valid for tracking queries");
             }
         }
 
         [Benchmark]
-        [BenchmarkVariation("Default", true)]
-        [BenchmarkVariation("No Query Cache", false)]
-        public void GroupBy(IMetricCollector collector, bool caching)
+        [BenchmarkVariation("Default (10 queries)", true, 10)]
+        [BenchmarkVariation("Query Cache Off (10 queries)", false, 10)]
+        public void GroupBy(IMetricCollector collector, bool caching, int queriesPerIteration)
         {
             using (var context = _fixture.CreateContext(queryCachingEnabled: caching))
             {
@@ -131,20 +160,26 @@ namespace EntityFramework.Microbenchmarks.Query
                         Products = g
                     });
 
-                collector.StartCollection();
+                using (collector.StartCollection())
+                {
+                    for (int i = 0; i < queriesPerIteration; i++)
+                    {
+                        query.ToList();
+                    }
+                }
+
                 var result = query.ToList();
-                collector.StopCollection();
                 Assert.Equal(10, result.Count);
                 Assert.All(result, g => Assert.Equal(100, g.Products.Count()));
             }
         }
 
-        [Benchmark(Iterations = 2)]
-        [BenchmarkVariation("Tracking On", true, true)]
-        [BenchmarkVariation("Tracking Off", false, true)]
-        [BenchmarkVariation("Tracking On (No Query Cache)", true, false)]
-        [BenchmarkVariation("Tracking Off (No Query Cache)", false, false)]
-        public void Include(IMetricCollector collector, bool tracking, bool caching)
+        [Benchmark]
+        [BenchmarkVariation("Tracking On (1 query)", true, true, 1)]
+        [BenchmarkVariation("Tracking Off (1 query)", false, true, 1)]
+        [BenchmarkVariation("Tracking On, Query Cache Off  (1 query)", true, false, 1)]
+        [BenchmarkVariation("Tracking Off, Query Cache Off  (1 query)", false, false, 1)]
+        public void Include(IMetricCollector collector, bool tracking, bool caching, int queriesPerIteration)
         {
             using (var context = _fixture.CreateContext(queryCachingEnabled: caching))
             {
@@ -152,49 +187,62 @@ namespace EntityFramework.Microbenchmarks.Query
                     .ApplyTracking(tracking)
                     .Include(c => c.Orders);
 
-                collector.StartCollection();
+                using (collector.StartCollection())
+                {
+                    for (int i = 0; i < queriesPerIteration; i++)
+                    {
+                        query.ToList();
+                    }
+                }
+
                 var result = query.ToList();
-                collector.StopCollection();
                 Assert.Equal(1000, result.Count);
                 Assert.Equal(2000, result.SelectMany(c => c.Orders).Count());
+                Assert.False(tracking && queriesPerIteration != 1, "Multiple queries per iteration not valid for tracking queries");
             }
         }
 
         [Benchmark]
-        [BenchmarkVariation("Default", true)]
-        [BenchmarkVariation("No Query Cache", false)]
-        public void Projection(IMetricCollector collector, bool caching)
+        [BenchmarkVariation("Default (10 queries)", true, 10)]
+        [BenchmarkVariation("Query Cache Off (10 queries)", false, 10)]
+        public void Projection(IMetricCollector collector, bool caching, int queriesPerIteration)
         {
             using (var context = _fixture.CreateContext(queryCachingEnabled: caching))
             {
                 var query = context.Products
                     .Select(p => new { p.Name, p.Retail });
 
-                collector.StartCollection();
-                var result = query.ToList();
-                collector.StopCollection();
-                Assert.Equal(1000, result.Count);
+                using (collector.StartCollection())
+                {
+                    for (int i = 0; i < queriesPerIteration; i++)
+                    {
+                        query.ToList();
+                    }
+                }
+
+                Assert.Equal(1000, query.Count());
             }
         }
 
         [Benchmark]
-        [BenchmarkVariation("Default", true)]
-        [BenchmarkVariation("No Query Cache", false)]
-        public void ProjectionAcrossNavigation(IMetricCollector collector, bool caching)
+        [BenchmarkVariation("Default (10 queries)", true, 10)]
+        [BenchmarkVariation("Query Cache Off (10 queries)", false, 10)]
+        public void ProjectionAcrossNavigation(IMetricCollector collector, bool caching, int queriesPerIteration)
         {
             using (var context = _fixture.CreateContext(queryCachingEnabled: caching))
             {
-                // TODO Use navigation for projection when supported (#325)
-                var query = context.Orders.Join(
-                    context.Customers,
-                    o => o.CustomerId,
-                    c => c.CustomerId,
-                    (o, c) => new { CustomerName = c.Name, OrderDate = o.Date });
+                var query = context.Orders
+                    .Select(o => new { CustomerName = o.Customer.Name, OrderDate = o.Date });
 
-                collector.StartCollection();
-                var result = query.ToList();
-                collector.StopCollection();
-                Assert.Equal(2000, result.Count);
+                using (collector.StartCollection())
+                {
+                    for (int i = 0; i < queriesPerIteration; i++)
+                    {
+                        query.ToList();
+                    }
+                }
+
+                Assert.Equal(2000, query.Count());
             }
         }
 


### PR DESCRIPTION
Some of our benchmarks complete too quickly and this tends to lead to
inconsistent results. In general it seems results are pretty consistent
if each iteration takes at least 50ms to complete and ideally 100ms.
Having at least 100 iterations also helps since we report on the 95th
percentile and this gives a bit of room for a few outliers.

Adjusting our benchmarks to try and fit with these numbers. In some
tests I've just increased the amount of data we deal with and in others
we run the same operation multiple times (depending on what works best
for the operation being tested).

Verified that this does not add any significant overhead for the single
iteration of each test that we run during build.cmd (~40sec for EF7 tests
and ~80sec for EF6 tests on my laptop - which is generally pretty slow).