### PR TITLE
:bug: Fix ServiceProviderCache Hash

### DIFF
--- a/src/EntityFramework.Core/Internal/ServiceProviderCache.cs
+++ b/src/EntityFramework.Core/Internal/ServiceProviderCache.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Data.Entity.Internal
         private static long CalculateHash(ServiceDescriptor descriptor)
             => ((((long)descriptor.Lifetime * 397)
                  ^ descriptor.ServiceType.GetHashCode()) * 397)
-               ^ (descriptor.ImplementationInstance
+               ^ (descriptor.ImplementationInstance?.GetType()
                   ?? descriptor.ImplementationType
                   ?? (object)descriptor.ImplementationFactory).GetHashCode();
     }

--- a/src/EntityFramework.Relational/Infrastructure/RelationalEntityFrameworkServicesBuilderExtensions.cs
+++ b/src/EntityFramework.Relational/Infrastructure/RelationalEntityFrameworkServicesBuilderExtensions.cs
@@ -33,12 +33,10 @@ namespace Microsoft.Data.Entity.Infrastructure
         {
             Check.NotNull(builder, nameof(builder));
 
-            var telemetrySource = new TelemetryListener("Microsoft.Data.Entity");
-            
             builder.GetService()
                 .TryAdd(new ServiceCollection()
-                .AddInstance<TelemetrySource>(telemetrySource)
-                .AddInstance(telemetrySource)
+                .AddSingleton(s => new TelemetryListener("Microsoft.Data.Entity"))
+                .AddSingleton<TelemetrySource>(s => s.GetService<TelemetryListener>())
                 .AddSingleton<ParameterNameGeneratorFactory>()
                 .AddSingleton<IComparer<ModificationCommand>, ModificationCommandComparer>()
                 .AddSingleton<IMigrationsIdGenerator, MigrationsIdGenerator>()

--- a/test/EntityFramework.Core.Tests/ServiceProviderCacheTest.cs
+++ b/test/EntityFramework.Core.Tests/ServiceProviderCacheTest.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Data.Entity.Tests
         }
 
         [Fact]
-        public void Returns_different_provider_for_configured_services_differing_by_instance()
+        public void Returns_same_provider_for_configured_services_differing_by_instance()
         {
             var config1 = CreateOptions(b =>
                 {
@@ -54,7 +54,7 @@ namespace Microsoft.Data.Entity.Tests
 
             var cache = new ServiceProviderCache();
 
-            Assert.NotSame(cache.GetOrAdd(config1), cache.GetOrAdd(config2));
+            Assert.Same(cache.GetOrAdd(config1), cache.GetOrAdd(config2));
         }
 
         [Fact]


### PR DESCRIPTION
The hashing algorithm for `ServiceProvider` was using the hash code on
the instance for anything that was added as an instance. This was broken
when we started adding `TelemetryListener` because we were adding a
different instance each time `AddRelational()` was called. 

This showed up as a massive slow down in our perf tests because we effectively
stopped caching anything when the context is responsible for managing
the `ServiceProvider`.

Two changes as part of this:
* Stop using the actual instance when calculating the hash and just use
the type.
* Swap to using `AddSingleton` instead of `AddInstance` for
`TelemetryListener`. Not strictly needed due to the previous change, but
it seems cleaner.