### PR TITLE
[TINY] Can use IsPrimaryKey on an alternate key in absence of a primary key

### DIFF
--- a/src/EntityFramework.Core/Metadata/KeyExtensions.cs
+++ b/src/EntityFramework.Core/Metadata/KeyExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Data.Entity.Metadata
         {
             Check.NotNull(key, nameof(key));
 
-            return key.EntityType.GetPrimaryKey() == key;
+            return key == key.EntityType.FindPrimaryKey();
         }
     }
 }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/E2E.sql
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/E2E.sql
@@ -341,6 +341,10 @@ CREATE TABLE "TableWithUnmappablePrimaryKeyColumn" (
 	) REFERENCES "dbo"."ReferredToByTableWithUnmappablePrimaryKeyColumn" (
 		"ReferredToByTableWithUnmappablePrimaryKeyColumnID"
 	),
+	CONSTRAINT "UK_TableWithUnmappablePrimaryKeyColumn" UNIQUE
+	(
+		"AnotherColumn" -- tests that RevEng can assign an alternate key on a table with a PK which cannot be mapped
+	)
 )
 
 GO


### PR DESCRIPTION
Found a small bug where calling IsPrimaryKey on an alternate key on an EntityType that does not have a PK causes an exception. RevEng comes across this scenario for e.g. AdventureWorks. Changed to no longer throw and added a test.