### PR TITLE
Partial fix to #3103 - Must be reducible node exception when performing Join

### DIFF
--- a/test/EntityFramework.Core.FunctionalTests/ComplexNavigationsQueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/ComplexNavigationsQueryTestBase.cs
@@ -228,5 +228,35 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 }
             }
         }
+
+        [Fact]
+        public virtual void Join_navigation_on_inner_selector_translated_to_FK()
+        {
+            using (var context = CreateContext())
+            {
+                var query = from e1 in context.LevelOne
+                            join e2 in context.LevelTwo on e1.Id equals e2.OneToOne_Optional_PK_Inverse.Id
+                            select new { Id1 = e1.Id, Id2 = e2.Id };
+
+                var result = query.ToList();
+
+                Assert.Equal(5, result.Count);
+            }
+        }
+
+        [Fact]
+        public virtual void Join_navigation_on_outer_selector_translated_to_FK()
+        {
+            using (var context = CreateContext())
+            {
+                var query = from e2 in context.LevelTwo
+                            join e1 in context.LevelOne on e2.OneToOne_Optional_PK_Inverse.Id equals e1.Id
+                            select new { Id2 = e2.Id, Id1 = e1.Id };
+
+                var result = query.ToList();
+
+                Assert.Equal(5, result.Count);
+            }
+        }
     }
 }

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -129,6 +129,28 @@ ORDER BY [c0].[DefaultText], [c0].[DefaultText0]",
                 Sql);
         }
 
+        public override void Join_navigation_on_inner_selector_translated_to_FK()
+        {
+            base.Join_navigation_on_inner_selector_translated_to_FK();
+
+            Assert.Equal(
+                @"SELECT [e1].[Id], [e2].[Id]
+FROM [Level1] AS [e1]
+INNER JOIN [Level2] AS [e2] ON [e1].[Id] = [e2].[OneToOne_Optional_PK_InverseId]",
+                Sql);
+        }
+
+        public override void Join_navigation_on_outer_selector_translated_to_FK()
+        {
+            base.Join_navigation_on_outer_selector_translated_to_FK();
+
+            Assert.Equal(
+                @"SELECT [e2].[Id], [e1].[Id]
+FROM [Level2] AS [e2]
+INNER JOIN [Level1] AS [e1] ON [e2].[OneToOne_Optional_PK_InverseId] = [e1].[Id]",
+                Sql);
+        }
+
         private static string Sql => TestSqlLoggerFactory.Sql;
     }
 }


### PR DESCRIPTION
Problem is in a query with join, that has a navigation property in inner key selector.
We normally try to expand the navigation property into a join clause, however if done for inner key selector, leads to chicken-and-egg problem:

e.g.
from p in ctx.Payouts
join a in ctx.Assets on p.Id equals a.Good.Id
select p

translated to:
from p in ctx.Payouts
join g in ctx.Good on a.Id equals g.Id // invalid, because a was not declared yet
join a in ctx.Assets on g.Id equals a.Id

(alternatively)

from p in ctx.Payouts
join a in ctx.Assets on g.Id equals a.Id // invalid, because g was not declared yet
join g in ctx.Good on a.Id equals g.Id

Is some cases this can we worked around by translating navigation property into a FK:
from p in ctx.Payouts
join a in ctx.Assets on p.Id equals a.GoodId
select p

This is only possible if we actually have foreign key on this side of the navigation, and if the navigation itself is simple (not nested, not composite and we are accessing PK after the navigation).