### PR TITLE
[SMALL] Record architecture for benchmarks

### DIFF
--- a/test/EntityFramework.Microbenchmarks.Core/BenchmarkRunSummary.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/BenchmarkRunSummary.cs
@@ -20,6 +20,7 @@ namespace EntityFramework.Microbenchmarks.Core
         public string MachineName { get; set; }
         public string ProductReportingVersion { get; set; }
         public string Framework { get; set; }
+        public string Architecture { get; set; }
         public string CustomData { get; set; }
         public DateTime RunStarted { get; set; }
         public int WarmupIterations { get; set; }

--- a/test/EntityFramework.Microbenchmarks.Core/BenchmarkTestCaseRunner.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/BenchmarkTestCaseRunner.cs
@@ -64,6 +64,7 @@ namespace EntityFramework.Microbenchmarks.Core
                 RunStarted = DateTime.UtcNow,
                 MachineName = _machineName,
                 Framework = _framework,
+                Architecture = IntPtr.Size > 4 ? "x64" : "x86",
                 WarmupIterations = TestCase.WarmupIterations,
                 Iterations = TestCase.Iterations,
                 CustomData = BenchmarkConfig.Instance.CustomData
@@ -95,7 +96,15 @@ namespace EntityFramework.Microbenchmarks.Core
 
                 foreach (var database in BenchmarkConfig.Instance.ResultDatabases)
                 {
-                    new SqlServerBenchmarkResultProcessor(database).SaveSummary(runSummary);
+                    try
+                    {
+                        new SqlServerBenchmarkResultProcessor(database).SaveSummary(runSummary);
+                    }
+                    catch (Exception ex)
+                    {
+                        _diagnosticMessageSink.OnMessage(new XunitDiagnosticMessage($"Failed to save results to {database}{Environment.NewLine} {ex.ToString()}"));
+                        throw;
+                    }
                 }
             }
 

--- a/test/EntityFramework.Microbenchmarks.Core/SqlServerBenchmarkResultProcessor.cs
+++ b/test/EntityFramework.Microbenchmarks.Core/SqlServerBenchmarkResultProcessor.cs
@@ -19,6 +19,7 @@ namespace EntityFramework.Microbenchmarks.Core
             ,[MachineName]
             ,[ProductReportingVersion]
             ,[Framework]
+            ,[Architecture]
             ,[CustomData]
             ,[RunStarted]
             ,[WarmupIterations]
@@ -41,6 +42,7 @@ namespace EntityFramework.Microbenchmarks.Core
            ,@MachineName
            ,@ProductReportingVersion
            ,@Framework
+           ,@Architecture
            ,@CustomData
            ,@RunStarted
            ,@WarmupIterations
@@ -67,6 +69,7 @@ namespace EntityFramework.Microbenchmarks.Core
 		[MachineName] [nvarchar](max) NULL,
 		[ProductReportingVersion] [nvarchar](max) NULL,
 		[Framework] [nvarchar](max) NULL,
+		[Architecture] [nvarchar](max) NULL,
 		[CustomData] [nvarchar](max) NULL,
 		[RunStarted] [datetime2](7) NOT NULL,
 		[WarmupIterations] [int] NOT NULL,
@@ -80,7 +83,9 @@ namespace EntityFramework.Microbenchmarks.Core
 		[MemoryDeltaPercentile90] [bigint] NOT NULL,
 		[MemoryDeltaPercentile95] [bigint] NOT NULL,
 		[MemoryDeltaPercentile99] [bigint] NOT NULL,
-		[MemoryDeltaStandardDeviation] [float] NOT NULL)";
+		[MemoryDeltaStandardDeviation] [float] NOT NULL)
+ELSE IF NOT EXISTS (SELECT * FROM syscolumns WHERE name = 'Architecture')
+	ALTER TABLE [dbo].[Runs] ADD [Architecture] nvarchar(max) NULL";
 
         public SqlServerBenchmarkResultProcessor(string connectionString)
         {
@@ -115,6 +120,7 @@ namespace EntityFramework.Microbenchmarks.Core
             cmd.Parameters.AddWithValue("@MachineName", summary.MachineName);
             cmd.Parameters.AddWithValue("@ProductReportingVersion", summary.ProductReportingVersion);
             cmd.Parameters.AddWithValue("@Framework", summary.Framework);
+            cmd.Parameters.AddWithValue("@Architecture", summary.Architecture);
             cmd.Parameters.Add("@CustomData", SqlDbType.NVarChar).Value = (object)summary.CustomData ?? DBNull.Value;
             cmd.Parameters.AddWithValue("@RunStarted", summary.RunStarted);
             cmd.Parameters.AddWithValue("@WarmupIterations", summary.WarmupIterations);


### PR DESCRIPTION
Capture the architecture that a run was performed on. Also adding logic
to upgrade an existing benchmark database to add the required column if
not present.