### PR TITLE
Move SqlStatementExecutor functionality into RelationalCommand

### DIFF
--- a/src/EntityFramework.MicrosoftSqlServer/Query/Internal/SqlServerQueryCompilationContext.cs
+++ b/src/EntityFramework.MicrosoftSqlServer/Query/Internal/SqlServerQueryCompilationContext.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics.Tracing;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Query.ExpressionVisitors;
@@ -12,26 +11,22 @@ namespace Microsoft.Data.Entity.Query.Internal
 {
     public class SqlServerQueryCompilationContext : RelationalQueryCompilationContext
     {
-#pragma warning disable 0618
         public SqlServerQueryCompilationContext(
             [NotNull] ISensitiveDataLogger logger,
             [NotNull] IEntityQueryModelVisitorFactory entityQueryModelVisitorFactory,
             [NotNull] IRequiresMaterializationExpressionVisitorFactory requiresMaterializationExpressionVisitorFactory,
             [NotNull] ILinqOperatorProvider linqOpeartorProvider,
             [NotNull] IQueryMethodProvider queryMethodProvider,
-            [NotNull] Type contextType,
-            [NotNull] TelemetrySource telemetrySource)
+            [NotNull] Type contextType)
             : base(
                 Check.NotNull(logger, nameof(logger)),
                 Check.NotNull(entityQueryModelVisitorFactory, nameof(entityQueryModelVisitorFactory)),
                 Check.NotNull(requiresMaterializationExpressionVisitorFactory, nameof(requiresMaterializationExpressionVisitorFactory)),
                 Check.NotNull(linqOpeartorProvider, nameof(linqOpeartorProvider)),
                 Check.NotNull(queryMethodProvider, nameof(queryMethodProvider)),
-                Check.NotNull(contextType, nameof(contextType)),
-                Check.NotNull(telemetrySource, nameof(telemetrySource)))
+                Check.NotNull(contextType, nameof(contextType)))
         {
         }
-#pragma warning restore 0618
 
         public override bool IsLateralJoinSupported => true;
     }

--- a/src/EntityFramework.MicrosoftSqlServer/Query/Internal/SqlServerQueryCompilationContextFactory.cs
+++ b/src/EntityFramework.MicrosoftSqlServer/Query/Internal/SqlServerQueryCompilationContextFactory.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Diagnostics.Tracing;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Query.ExpressionVisitors;
@@ -11,21 +10,17 @@ namespace Microsoft.Data.Entity.Query.Internal
 {
     public class SqlServerQueryCompilationContextFactory : RelationalQueryCompilationContextFactory
     {
-#pragma warning disable 0618
         public SqlServerQueryCompilationContextFactory(
             [NotNull] ISensitiveDataLogger<SqlServerQueryCompilationContextFactory> logger,
             [NotNull] IEntityQueryModelVisitorFactory entityQueryModelVisitorFactory,
             [NotNull] IRequiresMaterializationExpressionVisitorFactory requiresMaterializationExpressionVisitorFactory,
-            [NotNull] DbContext context,
-            [NotNull] TelemetrySource telemetrySource)
+            [NotNull] DbContext context)
             : base(Check.NotNull(logger, nameof(logger)),
                 Check.NotNull(entityQueryModelVisitorFactory, nameof(entityQueryModelVisitorFactory)),
                 Check.NotNull(requiresMaterializationExpressionVisitorFactory, nameof(requiresMaterializationExpressionVisitorFactory)),
-                Check.NotNull(context, nameof(context)),
-                Check.NotNull(telemetrySource, nameof(telemetrySource)))
+                Check.NotNull(context, nameof(context)))
         {
         }
-#pragma warning restore 0618
 
         public override QueryCompilationContext Create(bool async)
             => async
@@ -35,15 +30,13 @@ namespace Microsoft.Data.Entity.Query.Internal
                     RequiresMaterializationExpressionVisitorFactory,
                     new AsyncLinqOperatorProvider(),
                     new AsyncQueryMethodProvider(),
-                    ContextType,
-                    TelemetrySource)
+                    ContextType)
                 : new SqlServerQueryCompilationContext(
                     (ISensitiveDataLogger)Logger,
                     EntityQueryModelVisitorFactory,
                     RequiresMaterializationExpressionVisitorFactory,
                     new LinqOperatorProvider(),
                     new QueryMethodProvider(),
-                    ContextType,
-                    TelemetrySource);
+                    ContextType);
     }
 }

--- a/src/EntityFramework.MicrosoftSqlServer/Update/Internal/SqlServerModificationCommandBatch.cs
+++ b/src/EntityFramework.MicrosoftSqlServer/Update/Internal/SqlServerModificationCommandBatch.cs
@@ -3,11 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.Tracing;
 using System.Linq;
 using System.Text;
 using JetBrains.Annotations;
-using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Storage;
 
@@ -24,22 +22,17 @@ namespace Microsoft.Data.Entity.Update.Internal
         private readonly List<ModificationCommand> _bulkInsertCommands = new List<ModificationCommand>();
         private int _commandsLeftToLengthCheck = 50;
 
-#pragma warning disable 0618
         public SqlServerModificationCommandBatch(
             [NotNull] IRelationalCommandBuilderFactory commandBuilderFactory,
             [NotNull] ISqlGenerator sqlGenerator,
             [NotNull] ISqlServerUpdateSqlGenerator updateSqlGenerator,
             [NotNull] IRelationalValueBufferFactoryFactory valueBufferFactoryFactory,
-            [NotNull] ISensitiveDataLogger logger,
-            [NotNull] TelemetrySource telemetrySource,
             [CanBeNull] int? maxBatchSize)
             : base(
                 commandBuilderFactory,
                 sqlGenerator,
                 updateSqlGenerator,
-                valueBufferFactoryFactory,
-                logger,
-                telemetrySource)
+                valueBufferFactoryFactory)
         {
             if (maxBatchSize.HasValue
                 && maxBatchSize.Value <= 0)
@@ -49,7 +42,6 @@ namespace Microsoft.Data.Entity.Update.Internal
 
             _maxBatchSize = Math.Min(maxBatchSize ?? Int32.MaxValue, MaxRowCount);
         }
-#pragma warning restore 0618
 
         protected override bool CanAddCommand(ModificationCommand modificationCommand)
         {

--- a/src/EntityFramework.MicrosoftSqlServer/Update/Internal/SqlServerModificationCommandBatchFactory.cs
+++ b/src/EntityFramework.MicrosoftSqlServer/Update/Internal/SqlServerModificationCommandBatchFactory.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Diagnostics.Tracing;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
@@ -18,36 +17,26 @@ namespace Microsoft.Data.Entity.Update.Internal
         private readonly ISqlServerUpdateSqlGenerator _updateSqlGenerator;
         private readonly IRelationalValueBufferFactoryFactory _valueBufferFactoryFactory;
         private readonly IDbContextOptions _options;
-        private readonly ISensitiveDataLogger<SqlServerModificationCommandBatchFactory> _logger;
-#pragma warning disable 0618
-        private readonly TelemetrySource _telemetrySource;
 
         public SqlServerModificationCommandBatchFactory(
             [NotNull] IRelationalCommandBuilderFactory commandBuilderFactory,
             [NotNull] ISqlGenerator sqlGenerator,
             [NotNull] ISqlServerUpdateSqlGenerator updateSqlGenerator,
             [NotNull] IRelationalValueBufferFactoryFactory valueBufferFactoryFactory,
-            [NotNull] IDbContextOptions options,
-            [NotNull] ISensitiveDataLogger<SqlServerModificationCommandBatchFactory> logger,
-            [NotNull] TelemetrySource telemetrySource)
+            [NotNull] IDbContextOptions options)
         {
             Check.NotNull(commandBuilderFactory, nameof(commandBuilderFactory));
             Check.NotNull(sqlGenerator, nameof(sqlGenerator));
             Check.NotNull(updateSqlGenerator, nameof(updateSqlGenerator));
             Check.NotNull(valueBufferFactoryFactory, nameof(valueBufferFactoryFactory));
             Check.NotNull(options, nameof(options));
-            Check.NotNull(logger, nameof(logger));
-            Check.NotNull(telemetrySource, nameof(telemetrySource));
 
             _commandBuilderFactory = commandBuilderFactory;
             _sqlGenerator = sqlGenerator;
             _updateSqlGenerator = updateSqlGenerator;
             _valueBufferFactoryFactory = valueBufferFactoryFactory;
             _options = options;
-            _logger = logger;
-            _telemetrySource = telemetrySource;
         }
-#pragma warning restore 0618
 
         public virtual ModificationCommandBatch Create()
         {
@@ -58,8 +47,6 @@ namespace Microsoft.Data.Entity.Update.Internal
                 _sqlGenerator,
                 _updateSqlGenerator,
                 _valueBufferFactoryFactory,
-                _logger,
-                _telemetrySource,
                 optionsExtension?.MaxBatchSize);
         }
     }

--- a/src/EntityFramework.Relational/EntityFramework.Relational.csproj
+++ b/src/EntityFramework.Relational/EntityFramework.Relational.csproj
@@ -231,6 +231,7 @@
     <Compile Include="Storage\RelationalDatabase.cs" />
     <Compile Include="Storage\RelationalDatabaseCreator.cs" />
     <Compile Include="Storage\RelationalDatabaseProviderServices.cs" />
+    <Compile Include="Storage\RelationalDataReader.cs" />
     <Compile Include="Storage\RelationalParameter.cs" />
     <Compile Include="Storage\RelationalSizedTypeMapping.cs" />
     <Compile Include="Storage\RelationalSqlGenerator.cs" />

--- a/src/EntityFramework.Relational/Query/AsyncQueryMethodProvider.cs
+++ b/src/EntityFramework.Relational/Query/AsyncQueryMethodProvider.cs
@@ -10,11 +10,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
-using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Query.Internal;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Extensions.Logging;
 using Remotion.Linq.Clauses;
 
 namespace Microsoft.Data.Entity.Query
@@ -143,19 +141,14 @@ namespace Microsoft.Data.Entity.Query
             = typeof(AsyncQueryMethodProvider).GetTypeInfo()
                 .GetDeclaredMethod(nameof(_ShapedQuery));
 
-#pragma warning disable 0618
         [UsedImplicitly]
         private static IAsyncEnumerable<T> _ShapedQuery<T>(
             QueryContext queryContext,
             CommandBuilder commandBuilder,
-            ISensitiveDataLogger logger,
-            TelemetrySource telemetrySource,
             Func<ValueBuffer, T> shaper)
             => new AsyncQueryingEnumerable(
                 ((RelationalQueryContext)queryContext),
                 commandBuilder,
-                logger,
-                telemetrySource,
                 queryIndex: null)
                 .Select(shaper);
 
@@ -169,16 +162,11 @@ namespace Microsoft.Data.Entity.Query
         private static IAsyncEnumerable<ValueBuffer> _Query(
             QueryContext queryContext,
             CommandBuilder commandBuilder,
-            ISensitiveDataLogger logger,
-            TelemetrySource telemetrySource,
             int? queryIndex)
             => new AsyncQueryingEnumerable(
                 ((RelationalQueryContext)queryContext),
                 commandBuilder,
-                logger,
-                telemetrySource,
                 queryIndex);
-#pragma warning restore 0618
 
         public virtual MethodInfo IncludeMethod => _includeMethodInfo;
 

--- a/src/EntityFramework.Relational/Query/ExpressionVisitors/IncludeExpressionVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionVisitors/IncludeExpressionVisitor.cs
@@ -264,8 +264,6 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
                                         _commandBuilderFactory.Create(
                                             () => _sqlQueryGeneratorFactory
                                                 .CreateGenerator(targetSelectExpression))),
-                                    Expression.Constant(_queryCompilationContext.Logger),
-                                    Expression.Constant(_queryCompilationContext.TelemetrySource),
                                     Expression.Constant(queryIndex, typeof(int?))),
                                 materializer));
                 }

--- a/src/EntityFramework.Relational/Query/ExpressionVisitors/QueryFlatteningExpressionVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionVisitors/QueryFlatteningExpressionVisitor.cs
@@ -62,9 +62,7 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
                             newExpression.Method,
                             newExpression.Arguments[0],
                             _outerCommandBuilder,
-                            newExpression.Arguments[2],
-                            newExpression.Arguments[3],
-                            newExpression.Arguments[4]);
+                            newExpression.Arguments[2]);
                 }
             }
 

--- a/src/EntityFramework.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
@@ -246,8 +246,6 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
                     .MakeGenericMethod(queryMethodInfo.ReturnType),
                 EntityQueryModelVisitor.QueryContextParameter,
                 Expression.Constant(_commandBuilderFactory.Create(sqlQueryGeneratorFunc)),
-                Expression.Constant(QueryModelVisitor.QueryCompilationContext.Logger),
-                Expression.Constant(QueryModelVisitor.QueryCompilationContext.TelemetrySource),
                 Expression.Lambda(
                     Expression.Call(queryMethodInfo, queryMethodArguments),
                     _valueBufferParameter));

--- a/src/EntityFramework.Relational/Query/QueryMethodProvider.cs
+++ b/src/EntityFramework.Relational/Query/QueryMethodProvider.cs
@@ -8,11 +8,9 @@ using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
-using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Query.Internal;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Extensions.Logging;
 using Remotion.Linq.Clauses;
 
 namespace Microsoft.Data.Entity.Query
@@ -97,19 +95,14 @@ namespace Microsoft.Data.Entity.Query
             = typeof(QueryMethodProvider).GetTypeInfo()
                 .GetDeclaredMethod(nameof(_ShapedQuery));
 
-#pragma warning disable 0618
         [UsedImplicitly]
         private static IEnumerable<T> _ShapedQuery<T>(
             QueryContext queryContext,
             CommandBuilder commandBuilder,
-            ISensitiveDataLogger logger,
-            TelemetrySource telemetrySource,
             Func<ValueBuffer, T> shaper)
             => new QueryingEnumerable(
                 (RelationalQueryContext)queryContext,
                 commandBuilder,
-                logger,
-                telemetrySource,
                 queryIndex: null)
                 .Select(shaper);
 
@@ -123,16 +116,11 @@ namespace Microsoft.Data.Entity.Query
         private static IEnumerable<ValueBuffer> _Query(
             QueryContext queryContext,
             CommandBuilder commandBuilder,
-            ISensitiveDataLogger logger,
-            TelemetrySource telemetrySource,
             int? queryIndex)
             => new QueryingEnumerable(
                 ((RelationalQueryContext)queryContext),
                 commandBuilder,
-                logger,
-                telemetrySource,
                 queryIndex);
-#pragma warning restore 0618
 
         public virtual MethodInfo IncludeMethod => _includeMethodInfo;
 

--- a/src/EntityFramework.Relational/Query/RelationalQueryCompilationContext.cs
+++ b/src/EntityFramework.Relational/Query/RelationalQueryCompilationContext.cs
@@ -10,7 +10,6 @@ using Microsoft.Data.Entity.Query.Expressions;
 using Microsoft.Data.Entity.Query.ExpressionVisitors;
 using Microsoft.Data.Entity.Utilities;
 using Remotion.Linq.Clauses;
-using System.Diagnostics.Tracing;
 
 namespace Microsoft.Data.Entity.Query
 {
@@ -19,15 +18,13 @@ namespace Microsoft.Data.Entity.Query
         private readonly List<RelationalQueryModelVisitor> _relationalQueryModelVisitors
             = new List<RelationalQueryModelVisitor>();
 
-#pragma warning disable 0618
         public RelationalQueryCompilationContext(
             [NotNull] ISensitiveDataLogger logger,
             [NotNull] IEntityQueryModelVisitorFactory entityQueryModelVisitorFactory,
             [NotNull] IRequiresMaterializationExpressionVisitorFactory requiresMaterializationExpressionVisitorFactory,
             [NotNull] ILinqOperatorProvider linqOperatorProvider,
             [NotNull] IQueryMethodProvider queryMethodProvider,
-            [NotNull] Type contextType,
-            [NotNull] TelemetrySource telemetrySource)
+            [NotNull] Type contextType)
             : base(
                 Check.NotNull(logger, nameof(logger)),
                 Check.NotNull(entityQueryModelVisitorFactory, nameof(entityQueryModelVisitorFactory)),
@@ -36,15 +33,11 @@ namespace Microsoft.Data.Entity.Query
                 Check.NotNull(contextType, nameof(contextType)))
         {
             Check.NotNull(queryMethodProvider, nameof(queryMethodProvider));
-            Check.NotNull(telemetrySource, nameof(telemetrySource));
 
             QueryMethodProvider = queryMethodProvider;
-            TelemetrySource = telemetrySource;
         }
 
         public virtual IQueryMethodProvider QueryMethodProvider { get; }
-        public virtual TelemetrySource TelemetrySource { get; }
-#pragma warning restore 0618
 
         public override EntityQueryModelVisitor CreateQueryModelVisitor()
         {

--- a/src/EntityFramework.Relational/Query/RelationalQueryCompilationContextFactory.cs
+++ b/src/EntityFramework.Relational/Query/RelationalQueryCompilationContextFactory.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Diagnostics.Tracing;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Query.ExpressionVisitors;
@@ -12,24 +11,18 @@ namespace Microsoft.Data.Entity.Query
 {
     public class RelationalQueryCompilationContextFactory : QueryCompilationContextFactory
     {
-#pragma warning disable 0618
         public RelationalQueryCompilationContextFactory(
             [NotNull] ISensitiveDataLogger<RelationalQueryCompilationContextFactory> logger,
             [NotNull] IEntityQueryModelVisitorFactory entityQueryModelVisitorFactory,
             [NotNull] IRequiresMaterializationExpressionVisitorFactory requiresMaterializationExpressionVisitorFactory,
-            [NotNull] DbContext context,
-            [NotNull] TelemetrySource telemetrySource)
+            [NotNull] DbContext context)
             : base(
                 Check.NotNull(logger, nameof(logger)),
                 Check.NotNull(entityQueryModelVisitorFactory, nameof(entityQueryModelVisitorFactory)),
                 Check.NotNull(requiresMaterializationExpressionVisitorFactory, nameof(requiresMaterializationExpressionVisitorFactory)),
                 Check.NotNull(context, nameof(context)))
         {
-            TelemetrySource = telemetrySource;
         }
-
-        protected virtual TelemetrySource TelemetrySource { get; }
-#pragma warning restore 0618
 
         public override QueryCompilationContext Create(bool async)
             => async
@@ -39,15 +32,13 @@ namespace Microsoft.Data.Entity.Query
                     RequiresMaterializationExpressionVisitorFactory,
                     new AsyncLinqOperatorProvider(),
                     new AsyncQueryMethodProvider(),
-                    ContextType,
-                    TelemetrySource)
+                    ContextType)
                 : new RelationalQueryCompilationContext(
                     (ISensitiveDataLogger)Logger,
                     EntityQueryModelVisitorFactory,
                     RequiresMaterializationExpressionVisitorFactory,
                     new LinqOperatorProvider(),
                     new QueryMethodProvider(),
-                    ContextType,
-                    TelemetrySource);
+                    ContextType);
     }
 }

--- a/src/EntityFramework.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EntityFramework.Relational/Query/RelationalQueryModelVisitor.cs
@@ -581,7 +581,7 @@ namespace Microsoft.Data.Entity.Query
                         .Create(QueryCompilationContext)
                         .Find(subQueryModelVisitor.Expression);
 
-                var shaperLambda = (LambdaExpression)shapedQueryMethodExpression.Arguments[4];
+                var shaperLambda = (LambdaExpression)shapedQueryMethodExpression.Arguments[2];
                 var shaperMethodCall = (MethodCallExpression)shaperLambda.Body;
 
                 var shaperMethod = shaperMethodCall.Method;
@@ -641,8 +641,6 @@ namespace Microsoft.Data.Entity.Query
                         .MakeGenericMethod(shaperMethod.ReturnType),
                     shapedQueryMethodExpression.Arguments[0],
                     shapedQueryMethodExpression.Arguments[1],
-                    shapedQueryMethodExpression.Arguments[2],
-                    shapedQueryMethodExpression.Arguments[3],
                     Expression.Lambda(
                         Expression.Call(shaperMethod, shaperMethodArgs),
                         shaperLambda.Parameters[0]));

--- a/src/EntityFramework.Relational/Storage/IRelationalCommand.cs
+++ b/src/EntityFramework.Relational/Storage/IRelationalCommand.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Generic;
 using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 
 namespace Microsoft.Data.Entity.Storage
@@ -12,6 +14,24 @@ namespace Microsoft.Data.Entity.Storage
         string CommandText { get; }
 
         IReadOnlyList<RelationalParameter> Parameters { get; }
+
+        void ExecuteNonQuery([NotNull] IRelationalConnection connection);
+
+        Task ExecuteNonQueryAsync(
+            [NotNull] IRelationalConnection connection,
+            CancellationToken cancellationToken = default(CancellationToken));
+
+        object ExecuteScalar([NotNull] IRelationalConnection connection);
+
+        Task<object> ExecuteScalarAsync(
+            [NotNull] IRelationalConnection connection,
+            CancellationToken cancellationToken = default(CancellationToken));
+
+        RelationalDataReader ExecuteReader([NotNull] IRelationalConnection connection);
+
+        Task<RelationalDataReader> ExecuteReaderAsync(
+            [NotNull] IRelationalConnection connection,
+            CancellationToken cancellationToken = default(CancellationToken));
 
         DbCommand CreateCommand([NotNull] IRelationalConnection connection);
     }

--- a/src/EntityFramework.Relational/Storage/Internal/RelationalCommand.cs
+++ b/src/EntityFramework.Relational/Storage/Internal/RelationalCommand.cs
@@ -1,30 +1,229 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Data.Common;
+using System.Diagnostics.Tracing;
+using System.Threading;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Storage.Internal
 {
     public class RelationalCommand : IRelationalCommand
     {
+#pragma warning disable 0618
         public RelationalCommand(
+            [NotNull] ISensitiveDataLogger logger,
+            [NotNull] TelemetrySource telemetrySource,
             [NotNull] string commandText,
             [NotNull] IReadOnlyList<RelationalParameter> parameters)
         {
+            Check.NotNull(logger, nameof(logger));
+            Check.NotNull(telemetrySource, nameof(telemetrySource));
             Check.NotNull(commandText, nameof(commandText));
             Check.NotNull(parameters, nameof(parameters));
 
+            Logger = logger;
+            TelemetrySource = telemetrySource;
             CommandText = commandText;
             Parameters = parameters;
         }
 
+        protected virtual ISensitiveDataLogger Logger { get; }
+
+        protected virtual TelemetrySource TelemetrySource { get; }
+#pragma warning restore 0618
+
         public virtual string CommandText { get; }
 
         public virtual IReadOnlyList<RelationalParameter> Parameters { get; }
+
+
+        public virtual void ExecuteNonQuery([NotNull] IRelationalConnection connection)
+            => Execute(
+                Check.NotNull(connection, nameof(connection)),
+                c =>
+                {
+                    using (c)
+                    {
+                        return c.ExecuteNonQuery();
+                    }
+                },
+                RelationalTelemetry.ExecuteMethod.ExecuteNonQuery);
+
+        public virtual async Task ExecuteNonQueryAsync(
+            [NotNull] IRelationalConnection connection,
+            CancellationToken cancellationToken = default(CancellationToken))
+            => await ExecuteAsync(
+                Check.NotNull(connection, nameof(connection)),
+                async (c, ct) =>
+                {
+                    using (c)
+                    {
+                        return await c.ExecuteNonQueryAsync(ct);
+                    }
+                },
+                RelationalTelemetry.ExecuteMethod.ExecuteNonQuery,
+                cancellationToken);
+
+        public virtual object ExecuteScalar([NotNull] IRelationalConnection connection)
+            => Execute(
+                Check.NotNull(connection, nameof(connection)),
+                c =>
+                {
+                    using (c)
+                    {
+                        return c.ExecuteScalar();
+                    }
+                },
+                RelationalTelemetry.ExecuteMethod.ExecuteScalar);
+
+        public virtual async Task<object> ExecuteScalarAsync(
+            [NotNull] IRelationalConnection connection,
+            CancellationToken cancellationToken = default(CancellationToken))
+            => await ExecuteAsync(
+                Check.NotNull(connection, nameof(connection)),
+                async (c, ct) =>
+                {
+                    using (c)
+                    {
+                        return await c.ExecuteScalarAsync(ct);
+                    }
+                },
+                RelationalTelemetry.ExecuteMethod.ExecuteScalar,
+                cancellationToken);
+
+        public virtual RelationalDataReader ExecuteReader([NotNull] IRelationalConnection connection)
+            => Execute(
+                Check.NotNull(connection, nameof(connection)),
+                c =>
+                {
+                    try
+                    {
+                        return new RelationalDataReader(c, c.ExecuteReader());
+                    }
+                    catch
+                    {
+                        c.Dispose();
+                        throw;
+                    }
+                },
+                RelationalTelemetry.ExecuteMethod.ExecuteReader);
+
+        public virtual async Task<RelationalDataReader> ExecuteReaderAsync(
+            [NotNull] IRelationalConnection connection,
+            CancellationToken cancellationToken = default(CancellationToken))
+            => await ExecuteAsync(
+                Check.NotNull(connection, nameof(connection)),
+                async (c, ct) =>
+                {
+                    try
+                    {
+                        return new RelationalDataReader(c, await c.ExecuteReaderAsync(ct));
+                    }
+                    catch
+                    {
+                        c.Dispose();
+                        throw;
+                    }
+                },
+                RelationalTelemetry.ExecuteMethod.ExecuteReader,
+                cancellationToken);
+
+        protected virtual T Execute<T>(
+            [NotNull] IRelationalConnection connection,
+            [NotNull] Func<DbCommand, T> action,
+            [NotNull] string executeMethod)
+        {
+            var dbCommand = CreateCommand(connection);
+
+            WriteTelemetry(
+                RelationalTelemetry.BeforeExecuteCommand,
+                dbCommand,
+                executeMethod);
+
+            T result;
+
+            try
+            {
+                result = action(dbCommand);
+            }
+            catch (Exception exception)
+            {
+                TelemetrySource
+                    .WriteCommandError(
+                        dbCommand,
+                        executeMethod,
+                        async: false,
+                        exception: exception);
+
+                throw;
+            }
+
+            WriteTelemetry(
+                RelationalTelemetry.AfterExecuteCommand,
+                dbCommand,
+                executeMethod);
+
+            return result;
+        }
+
+        protected virtual async Task<T> ExecuteAsync<T>(
+            [NotNull] IRelationalConnection connection,
+            [NotNull] Func<DbCommand, CancellationToken, Task<T>> action,
+            [NotNull] string executeMethod,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var dbCommand = CreateCommand(connection);
+
+            WriteTelemetry(
+                RelationalTelemetry.BeforeExecuteCommand,
+                dbCommand,
+                executeMethod,
+                async: true);
+
+            T result;
+
+            try
+            {
+                result = await action(dbCommand, cancellationToken);
+            }
+            catch (Exception exception)
+            {
+                TelemetrySource
+                    .WriteCommandError(
+                        dbCommand,
+                        executeMethod,
+                        async: true,
+                        exception: exception);
+
+                throw;
+            }
+
+            WriteTelemetry(
+                RelationalTelemetry.AfterExecuteCommand,
+                dbCommand,
+                executeMethod,
+                async: true);
+
+            return result;
+        }
+
+        private void WriteTelemetry(
+            string name,
+            DbCommand command,
+            string executeMethod,
+            bool async = false)
+            => TelemetrySource.WriteCommand(
+                name,
+                command,
+                executeMethod,
+                async: async);
 
         public virtual DbCommand CreateCommand([NotNull] IRelationalConnection connection)
         {
@@ -52,6 +251,8 @@ namespace Microsoft.Data.Entity.Storage.Internal
                         parameter.Value,
                         parameter.Nullable));
             }
+
+            Logger.LogCommand(command);
 
             return command;
         }

--- a/src/EntityFramework.Relational/Storage/Internal/RelationalCommandBuilder.cs
+++ b/src/EntityFramework.Relational/Storage/Internal/RelationalCommandBuilder.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.Tracing;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Utilities;
 
@@ -11,13 +13,22 @@ namespace Microsoft.Data.Entity.Storage.Internal
 {
     public class RelationalCommandBuilder : IRelationalCommandBuilder
     {
+        private readonly ISensitiveDataLogger _logger;
+        private readonly TelemetrySource _telemetrySource;
         private readonly IRelationalTypeMapper _typeMapper;
         private readonly List<RelationalParameter> _parameters = new List<RelationalParameter>();
 
-        public RelationalCommandBuilder([NotNull] IRelationalTypeMapper typeMapper)
+        public RelationalCommandBuilder(
+            [NotNull] ISensitiveDataLogger logger,
+            [NotNull] TelemetrySource telemetrySource,
+            [NotNull] IRelationalTypeMapper typeMapper)
         {
+            Check.NotNull(logger, nameof(logger));
+            Check.NotNull(telemetrySource, nameof(telemetrySource));
             Check.NotNull(typeMapper, nameof(typeMapper));
 
+            _logger = logger;
+            _telemetrySource = telemetrySource;
             _typeMapper = typeMapper;
         }
 
@@ -44,6 +55,8 @@ namespace Microsoft.Data.Entity.Storage.Internal
 
         public virtual IRelationalCommand BuildRelationalCommand()
                 => new RelationalCommand(
+                    _logger,
+                    _telemetrySource,
                     CommandTextBuilder.ToString(),
                     _parameters);
 

--- a/src/EntityFramework.Relational/Storage/Internal/RelationalCommandBuilderFactory.cs
+++ b/src/EntityFramework.Relational/Storage/Internal/RelationalCommandBuilderFactory.cs
@@ -1,23 +1,37 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Diagnostics.Tracing;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Storage.Internal
 {
     public class RelationalCommandBuilderFactory : IRelationalCommandBuilderFactory
     {
+        private readonly ISensitiveDataLogger _logger;
+        private readonly TelemetrySource _telemetrySource;
         private readonly IRelationalTypeMapper _typeMapper;
 
-        public RelationalCommandBuilderFactory([NotNull] IRelationalTypeMapper typeMapper)
+        public RelationalCommandBuilderFactory(
+            [NotNull] ISensitiveDataLogger<RelationalCommandBuilderFactory> logger,
+            [NotNull] TelemetrySource telemetrySource,
+            [NotNull] IRelationalTypeMapper typeMapper)
         {
+            Check.NotNull(logger, nameof(logger));
+            Check.NotNull(telemetrySource, nameof(telemetrySource));
             Check.NotNull(typeMapper, nameof(typeMapper));
 
+            _logger = logger;
+            _telemetrySource = telemetrySource;
             _typeMapper = typeMapper;
         }
 
         public virtual IRelationalCommandBuilder Create()
-            => new RelationalCommandBuilder(_typeMapper);
+            => new RelationalCommandBuilder(
+                _logger,
+                _telemetrySource,
+                _typeMapper);
     }
 }

--- a/src/EntityFramework.Relational/Storage/RelationalDataReader.cs
+++ b/src/EntityFramework.Relational/Storage/RelationalDataReader.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Data.Common;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Storage
+{
+    public class RelationalDataReader : IDisposable
+    {
+        private readonly DbCommand _command;
+        private readonly DbDataReader _reader;
+
+        private bool _disposed;
+
+        public RelationalDataReader(
+            [NotNull] DbCommand command,
+            [NotNull] DbDataReader reader)
+        {
+            Check.NotNull(command, nameof(command));
+            Check.NotNull(reader, nameof(reader));
+
+            _command = command;
+            _reader = reader;
+        }
+
+        public virtual DbDataReader DbDataReader => _reader;
+
+        public virtual void Dispose()
+        {
+            if (!_disposed)
+            {
+                _reader.Dispose();
+                _command.Dispose();
+
+                _disposed = true;
+            }
+        }
+    }
+}

--- a/src/EntityFramework.Relational/Update/AffectedCountModificationCommandBatch.cs
+++ b/src/EntityFramework.Relational/Update/AffectedCountModificationCommandBatch.cs
@@ -5,16 +5,13 @@ using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Diagnostics;
-using System.Diagnostics.Tracing;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
-using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Update
 {
@@ -26,18 +23,14 @@ namespace Microsoft.Data.Entity.Update
     {
         private readonly List<bool> _resultSetEnd = new List<bool>();
 
-#pragma warning disable 0618
         protected AffectedCountModificationCommandBatch(
             [NotNull] IRelationalCommandBuilderFactory commandBuilderFactory,
             [NotNull] ISqlGenerator sqlGenerator,
             [NotNull] IUpdateSqlGenerator updateSqlGenerator,
-            [NotNull] IRelationalValueBufferFactoryFactory valueBufferFactoryFactory,
-            [NotNull] ISensitiveDataLogger logger,
-            [NotNull] TelemetrySource telemetrySource)
-            : base(commandBuilderFactory, sqlGenerator, updateSqlGenerator, valueBufferFactoryFactory, logger, telemetrySource)
+            [NotNull] IRelationalValueBufferFactoryFactory valueBufferFactoryFactory)
+            : base(commandBuilderFactory, sqlGenerator, updateSqlGenerator, valueBufferFactoryFactory)
         {
         }
-#pragma warning restore 0618
 
         // contains true if the command at the corresponding index is the last command in its result set
         // the last value will not be read

--- a/src/EntityFramework.Relational/Update/Internal/BatchExecutor.cs
+++ b/src/EntityFramework.Relational/Update/Internal/BatchExecutor.cs
@@ -4,22 +4,12 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using JetBrains.Annotations;
-using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Storage;
 
 namespace Microsoft.Data.Entity.Update.Internal
 {
     public class BatchExecutor : IBatchExecutor
     {
-        private readonly ISensitiveDataLogger _logger;
-
-        // ReSharper disable once SuggestBaseTypeForParameter
-        public BatchExecutor([NotNull] ISensitiveDataLogger<BatchExecutor> logger)
-        {
-            _logger = logger;
-        }
-
         public virtual int Execute(
             IEnumerable<ModificationCommandBatch> commandBatches,
             IRelationalConnection connection)

--- a/src/EntityFramework.Relational/Update/ModificationCommandBatch.cs
+++ b/src/EntityFramework.Relational/Update/ModificationCommandBatch.cs
@@ -6,7 +6,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Data.Entity.Update
 {

--- a/src/EntityFramework.Relational/Update/SingularModificationCommandBatch.cs
+++ b/src/EntityFramework.Relational/Update/SingularModificationCommandBatch.cs
@@ -1,33 +1,25 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Diagnostics.Tracing;
 using JetBrains.Annotations;
-using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Storage;
 
 namespace Microsoft.Data.Entity.Update
 {
     public class SingularModificationCommandBatch : AffectedCountModificationCommandBatch
     {
-#pragma warning disable 0618
         public SingularModificationCommandBatch(
             [NotNull] IRelationalCommandBuilderFactory commandBuilderFactory,
             [NotNull] ISqlGenerator sqlGenerator,
             [NotNull] IUpdateSqlGenerator updateSqlGenerator,
-            [NotNull] IRelationalValueBufferFactoryFactory valueBufferFactoryFactory,
-            [NotNull] ISensitiveDataLogger logger,
-            [NotNull] TelemetrySource telemetrySource)
+            [NotNull] IRelationalValueBufferFactoryFactory valueBufferFactoryFactory)
             : base(
-                commandBuilderFactory, 
-                sqlGenerator, 
-                updateSqlGenerator, 
-                valueBufferFactoryFactory, 
-                logger,
-                telemetrySource)
+                  commandBuilderFactory,
+                  sqlGenerator,
+                  updateSqlGenerator,
+                  valueBufferFactoryFactory)
         {
         }
-#pragma warning restore 0618
 
         protected override bool CanAddCommand(ModificationCommand modificationCommand)
             => ModificationCommands.Count == 0;

--- a/src/EntityFramework.Sqlite/Update/Internal/SqliteModificationCommandBatchFactory.cs
+++ b/src/EntityFramework.Sqlite/Update/Internal/SqliteModificationCommandBatchFactory.cs
@@ -1,9 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Diagnostics.Tracing;
 using JetBrains.Annotations;
-using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Utilities;
 
@@ -15,41 +13,29 @@ namespace Microsoft.Data.Entity.Update.Internal
         private readonly ISqlGenerator _sqlGenerator;
         private readonly IUpdateSqlGenerator _updateSqlGenerator;
         private readonly IRelationalValueBufferFactoryFactory _valueBufferFactoryFactory;
-        private readonly ISensitiveDataLogger<SqliteModificationCommandBatchFactory> _logger;
-#pragma warning disable 0618
-        private readonly TelemetrySource _telemetrySource;
 
         public SqliteModificationCommandBatchFactory(
             [NotNull] IRelationalCommandBuilderFactory commandBuilderFactory,
             [NotNull] ISqlGenerator sqlGenerator,
             [NotNull] IUpdateSqlGenerator updateSqlGenerator,
-            [NotNull] IRelationalValueBufferFactoryFactory valueBufferFactoryFactory,
-            [NotNull] ISensitiveDataLogger<SqliteModificationCommandBatchFactory> logger,
-            [NotNull] TelemetrySource telemetrySource)
+            [NotNull] IRelationalValueBufferFactoryFactory valueBufferFactoryFactory)
         {
             Check.NotNull(commandBuilderFactory, nameof(commandBuilderFactory));
             Check.NotNull(sqlGenerator, nameof(sqlGenerator));
             Check.NotNull(updateSqlGenerator, nameof(updateSqlGenerator));
             Check.NotNull(valueBufferFactoryFactory, nameof(valueBufferFactoryFactory));
-            Check.NotNull(logger, nameof(logger));
-            Check.NotNull(telemetrySource, nameof(telemetrySource));
 
             _commandBuilderFactory = commandBuilderFactory;
             _sqlGenerator = sqlGenerator;
             _updateSqlGenerator = updateSqlGenerator;
             _valueBufferFactoryFactory = valueBufferFactoryFactory;
-            _logger = logger;
-            _telemetrySource = telemetrySource;
         }
-#pragma warning restore 0618
 
         public virtual ModificationCommandBatch Create()
             => new SingularModificationCommandBatch(
                 _commandBuilderFactory,
                 _sqlGenerator,
                 _updateSqlGenerator,
-                _valueBufferFactoryFactory,
-                _logger,
-                _telemetrySource);
+                _valueBufferFactoryFactory);
     }
 }

--- a/test/EntityFramework.Core.Tests/EntityFramework.Core.Tests.csproj
+++ b/test/EntityFramework.Core.Tests/EntityFramework.Core.Tests.csproj
@@ -137,6 +137,7 @@
     <Compile Include="Storage\DatabaseProviderSelectorTest.cs" />
     <Compile Include="TestUtilities\ListLogger.cs" />
     <Compile Include="TestUtilities\ListLoggerFactory.cs" />
+    <Compile Include="TestUtilities\ListLogger`.cs" />
     <Compile Include="Utilities\CheckTest.cs" />
     <Compile Include="Utilities\EnumerableExtensionsTest.cs" />
     <Compile Include="Utilities\ExpressionExtensionsTest.cs" />

--- a/test/EntityFramework.Core.Tests/TestUtilities/ListLogger`.cs
+++ b/test/EntityFramework.Core.Tests/TestUtilities/ListLogger`.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Data.Entity.Tests.TestUtilities
+{
+    public class ListLogger<T> : ListLogger, ILogger<T>
+    {
+        public ListLogger(List<Tuple<LogLevel, string>> logMessages)
+            : base(logMessages)
+        {
+        }
+    }
+}

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/CommandConfigurationTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/CommandConfigurationTest.cs
@@ -2,16 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Data.Entity.FunctionalTests;
 using Microsoft.Data.Entity.FunctionalTests.TestUtilities.Xunit;
-using Microsoft.Data.Entity.Infrastructure;
-using Microsoft.Data.Entity.Query.Expressions;
-using Microsoft.Data.Entity.Query.Internal;
-using Microsoft.Data.Entity.Query.Sql.Internal;
-using Microsoft.Data.Entity.Storage;
-using Microsoft.Data.Entity.Storage.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Xunit;
@@ -60,95 +53,12 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         }
 
         [Fact]
-        public void Constructed_select_query_uses_default_when_commandTimeout_not_configured_and_can_be_changed()
-        {
-            using (var context = new ChipsContext(_fixture.ServiceProvider))
-            {
-                var commandBuilder = setupCommandBuilder();
-
-                var command = commandBuilder.Build(context.GetService<IRelationalConnection>(), new Dictionary<string, object>());
-
-                Assert.Equal(30, command.CommandTimeout);
-
-                context.Database.SetCommandTimeout(77);
-                var command2 = commandBuilder.Build(context.GetService<IRelationalConnection>(), new Dictionary<string, object>());
-
-                Assert.Equal(77, command2.CommandTimeout);
-            }
-        }
-
-        [Fact]
-        public void Constructed_select_query_honors_configured_commandTimeout_configured_in_context()
-        {
-            using (var context = new ConfiguredChipsContext(_fixture.ServiceProvider))
-            {
-                var commandBuilder = setupCommandBuilder();
-
-                var command = commandBuilder.Build(context.GetService<IRelationalConnection>(), new Dictionary<string, object>());
-
-                Assert.Equal(77, command.CommandTimeout);
-            }
-        }
-
-        [Fact]
-        public void Constructed_select_query_honors_latest_configured_commandTimeout_configured_in_context()
-        {
-            using (var context = new ConfiguredChipsContext(_fixture.ServiceProvider))
-            {
-                var commandBuilder = setupCommandBuilder();
-
-                context.Database.SetCommandTimeout(88);
-                var command = commandBuilder.Build(context.GetService<IRelationalConnection>(), new Dictionary<string, object>());
-
-                Assert.Equal(88, command.CommandTimeout);
-
-                context.Database.SetCommandTimeout(99);
-                var command2 = commandBuilder.Build(context.GetService<IRelationalConnection>(), new Dictionary<string, object>());
-
-                Assert.Equal(99, command2.CommandTimeout);
-            }
-        }
-
-        [Fact]
         public void Constructed_select_query_CommandBuilder_throws_when_negative_CommandTimeout_is_used()
         {
             using (var context = new ConfiguredChipsContext(_fixture.ServiceProvider))
             {
                 Assert.Throws<ArgumentException>(() => context.Database.SetCommandTimeout(-5));
             }
-        }
-
-        [Fact]
-        public void Constructed_select_query_CommandBuilder_uses_default_when_null()
-        {
-            using (var context = new ConfiguredChipsContext(_fixture.ServiceProvider))
-            {
-                var commandBuilder = setupCommandBuilder();
-
-                context.Database.SetCommandTimeout(null);
-                var command = commandBuilder.Build(context.GetService<IRelationalConnection>(), new Dictionary<string, object>());
-
-                Assert.Equal(30, command.CommandTimeout);
-            }
-        }
-
-        private CommandBuilder setupCommandBuilder()
-        {
-            var commandBuilderFactory = new RelationalCommandBuilderFactory(new SqlServerTypeMapper());
-            var parameterNameGeneratorFactory = new ParameterNameGeneratorFactory();
-
-            return new CommandBuilder(
-                new UntypedRelationalValueBufferFactoryFactory(),
-                new SelectExpression(
-                    new SqlServerQuerySqlGeneratorFactory(
-                        commandBuilderFactory,
-                        new RelationalSqlGenerator(),
-                        parameterNameGeneratorFactory,
-                        new SqlCommandBuilder(
-                            commandBuilderFactory,
-                            new SqlServerSqlGenerator(),
-                            parameterNameGeneratorFactory)))
-                    .CreateGenerator);
         }
 
         [ConditionalTheory]

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/QueryLoggingSqlServerTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/QueryLoggingSqlServerTest.cs
@@ -42,8 +42,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
                 FROM [Customers] AS [c]
             , 
-            logger: SensitiveDataLogger`1, 
-            telemetrySource: Microsoft.Data.Entity, 
             shaper: (ValueBuffer prm2) => QueryResultScope<Customer> CreateEntity(
                 querySource: from Customer <generated>_0 in value(EntityQueryable`1[FunctionalTests.TestModels.Northwind.Customer]), 
                 queryContext: prm0, 
@@ -134,8 +132,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                     FROM [Customers] AS [c]
                     ORDER BY [c].[CustomerID]
                 , 
-                logger: SensitiveDataLogger`1, 
-                telemetrySource: Microsoft.Data.Entity, 
                 shaper: (ValueBuffer prm2) => QueryResultScope<Customer> CreateEntity(
                     querySource: from Customer c in value(EntityQueryable`1[FunctionalTests.TestModels.Northwind.Customer]), 
                     queryContext: prm0, 
@@ -182,8 +178,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                             ) AS [c] ON [o].[CustomerID] = [c].[CustomerID]
                             ORDER BY [c].[CustomerID]
                         , 
-                        logger: SensitiveDataLogger`1, 
-                        telemetrySource: Microsoft.Data.Entity, 
                         queryIndex: 1
                     )
                     , 

--- a/test/EntityFramework.MicrosoftSqlServer.Tests/Migrations/SqlServerHistoryRepositoryTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.Tests/Migrations/SqlServerHistoryRepositoryTest.cs
@@ -3,12 +3,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.Tracing;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Migrations.Internal;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Storage.Internal;
+using Microsoft.Data.Entity.TestUtilities;
 using Moq;
 using Xunit;
 
@@ -107,6 +109,8 @@ namespace Microsoft.Data.Entity.Migrations
             var typeMapper = new SqlServerTypeMapper();
 
             var commandBuilderFactory = new RelationalCommandBuilderFactory(
+                new FakeSensitiveDataLogger<RelationalCommandBuilderFactory>(),
+                new TelemetryListener("Fake"),
                 typeMapper);
 
             return new SqlServerHistoryRepository(

--- a/test/EntityFramework.MicrosoftSqlServer.Tests/Migrations/SqlServerMigrationSqlGeneratorTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.Tests/Migrations/SqlServerMigrationSqlGeneratorTest.cs
@@ -1,11 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Diagnostics.Tracing;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Migrations.Operations;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Storage.Internal;
+using Microsoft.Data.Entity.TestUtilities;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Migrations
@@ -19,7 +21,10 @@ namespace Microsoft.Data.Entity.Migrations
                 var typeMapper = new SqlServerTypeMapper();
 
                 return new SqlServerMigrationsSqlGenerator(
-                    new RelationalCommandBuilderFactory(typeMapper),
+                    new RelationalCommandBuilderFactory(
+                        new FakeSensitiveDataLogger<RelationalCommandBuilderFactory>(),
+                        new TelemetryListener("Fake"),
+                        typeMapper),
                     new SqlServerSqlGenerator(),
                     typeMapper,
                     new SqlServerAnnotationProvider());

--- a/test/EntityFramework.MicrosoftSqlServer.Tests/SqlServerDatabaseCreatorTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.Tests/SqlServerDatabaseCreatorTest.cs
@@ -157,9 +157,8 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         private class FakeSqlStatementExecutor : SqlStatementExecutor
         {
             public FakeSqlStatementExecutor(
-                IRelationalCommandBuilderFactory commandBuilderFactory,
-                ISensitiveDataLogger<FakeSqlStatementExecutor> logger)
-                : base(commandBuilderFactory, logger, new TelemetryListener("Fake"))
+                IRelationalCommandBuilderFactory commandBuilderFactory)
+                : base(commandBuilderFactory)
             {
             }
 

--- a/test/EntityFramework.MicrosoftSqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
@@ -8,15 +8,14 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Storage.Internal;
 using Microsoft.Data.Entity.Tests;
+using Microsoft.Data.Entity.TestUtilities;
 using Microsoft.Data.Entity.Update.Internal;
 using Microsoft.Data.Entity.ValueGeneration.Internal;
 using Microsoft.Extensions.DependencyInjection;
-using Moq;
 using Xunit;
 
 namespace Microsoft.Data.Entity.SqlServer.Tests
@@ -164,9 +163,10 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
 
             public FakeSqlStatementExecutor(int blockSize)
                 : base(
-                    new RelationalCommandBuilderFactory(new SqlServerTypeMapper()),
-                    new Mock<ISensitiveDataLogger<SqlStatementExecutor>>().Object,
-                    new TelemetryListener("Fake"))
+                    new RelationalCommandBuilderFactory(
+                        new FakeSensitiveDataLogger<RelationalCommandBuilderFactory>(),
+                        new TelemetryListener("Fake"),
+                        new SqlServerTypeMapper()))
             {
                 _blockSize = blockSize;
                 _current = -blockSize + 1;

--- a/test/EntityFramework.MicrosoftSqlServer.Tests/Update/SqlServerModificationCommandBatchFactoryTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.Tests/Update/SqlServerModificationCommandBatchFactoryTest.cs
@@ -2,12 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Diagnostics.Tracing;
-using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Storage.Internal;
+using Microsoft.Data.Entity.TestUtilities;
 using Microsoft.Data.Entity.Update;
 using Microsoft.Data.Entity.Update.Internal;
-using Moq;
 using Xunit;
 
 namespace Microsoft.Data.Entity.SqlServer.Tests.Update
@@ -21,13 +20,14 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Update
             optionsBuilder.UseSqlServer("Database=Crunchie").MaxBatchSize(1);
 
             var factory = new SqlServerModificationCommandBatchFactory(
-                new RelationalCommandBuilderFactory(new SqlServerTypeMapper()),
+                new RelationalCommandBuilderFactory(
+                    new FakeSensitiveDataLogger<RelationalCommandBuilderFactory>(),
+                    new TelemetryListener("Fake"),
+                    new SqlServerTypeMapper()),
                 new SqlServerSqlGenerator(),
                 new SqlServerUpdateSqlGenerator(new SqlServerSqlGenerator()),
                 new UntypedRelationalValueBufferFactoryFactory(),
-                optionsBuilder.Options,
-                new Mock<ISensitiveDataLogger<SqlServerModificationCommandBatchFactory>>().Object,
-                new TelemetryListener("Fake"));
+                optionsBuilder.Options);
 
             var batch = factory.Create();
 
@@ -42,13 +42,14 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Update
             optionsBuilder.UseSqlServer("Database=Crunchie");
 
             var factory = new SqlServerModificationCommandBatchFactory(
-                new RelationalCommandBuilderFactory(new SqlServerTypeMapper()),
+                new RelationalCommandBuilderFactory(
+                    new FakeSensitiveDataLogger<RelationalCommandBuilderFactory>(),
+                    new TelemetryListener("Fake"),
+                    new SqlServerTypeMapper()),
                 new SqlServerSqlGenerator(),
                 new SqlServerUpdateSqlGenerator(new SqlServerSqlGenerator()),
                 new UntypedRelationalValueBufferFactoryFactory(),
-                optionsBuilder.Options,
-                new Mock<ISensitiveDataLogger<SqlServerModificationCommandBatchFactory>>().Object,
-                new TelemetryListener("Fake"));
+                optionsBuilder.Options);
 
             var batch = factory.Create();
 

--- a/test/EntityFramework.MicrosoftSqlServer.Tests/Update/SqlServerModificationCommandBatchTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.Tests/Update/SqlServerModificationCommandBatchTest.cs
@@ -2,12 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Diagnostics.Tracing;
-using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Storage.Internal;
+using Microsoft.Data.Entity.TestUtilities;
 using Microsoft.Data.Entity.Update;
 using Microsoft.Data.Entity.Update.Internal;
-using Moq;
 using Xunit;
 
 namespace Microsoft.Data.Entity.SqlServer.Tests.Update
@@ -18,12 +17,13 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Update
         public void AddCommand_returns_false_when_max_batch_size_is_reached()
         {
             var batch = new SqlServerModificationCommandBatch(
-                new RelationalCommandBuilderFactory(new SqlServerTypeMapper()),
+                new RelationalCommandBuilderFactory(
+                    new FakeSensitiveDataLogger<RelationalCommandBuilderFactory>(),
+                    new TelemetryListener("Fake"),
+                    new SqlServerTypeMapper()),
                 new SqlServerSqlGenerator(),
                 new SqlServerUpdateSqlGenerator(new SqlServerSqlGenerator()),
                 new UntypedRelationalValueBufferFactoryFactory(),
-                new Mock<ISensitiveDataLogger>().Object,
-                new TelemetryListener("Fake"), 
                 1);
 
             Assert.True(batch.AddCommand(new ModificationCommand("T1", null, new ParameterNameGenerator(), p => p.SqlServer())));

--- a/test/EntityFramework.Relational.Tests/EntityFramework.Relational.Tests.csproj
+++ b/test/EntityFramework.Relational.Tests/EntityFramework.Relational.Tests.csproj
@@ -31,6 +31,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Data" />
@@ -49,6 +50,7 @@
     <Compile Include="Migrations\Internal\MigrationsAssemblyTest.cs" />
     <Compile Include="Migrations\MigrationSqlGeneratorTest.cs" />
     <Compile Include="Migrations\MigrationSqlGeneratorTestBase.cs" />
+    <Compile Include="Storage\RelationalCommandTest.cs" />
     <Compile Include="Storage\RelationalTypeMappingTest.cs" />
     <Compile Include="Metadata\RelationalBuilderExtensionsTest.cs" />
     <Compile Include="RelationalConnectionTest.cs" />
@@ -62,6 +64,21 @@
     <Compile Include="Storage\SqlCommandBuilderTest.cs" />
     <Compile Include="Storage\SqlGeneratorTestBase.cs" />
     <Compile Include="TestUtilities\FakeProvider\FakeRelationalTypeMapper.cs" />
+    <Compile Include="TestUtilities\FakeProvider\FakeCommandExecutor.cs" />
+    <Compile Include="TestUtilities\FakeProvider\FakeDbCommand.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Include="TestUtilities\FakeProvider\FakeDbConnection.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Include="TestUtilities\FakeProvider\FakeDbDataReader.cs" />
+    <Compile Include="TestUtilities\FakeProvider\FakeDbParameter.cs" />
+    <Compile Include="TestUtilities\FakeProvider\FakeDbParameterCollection.cs" />
+    <Compile Include="TestUtilities\FakeProvider\FakeDbTransaction.cs" />
+    <Compile Include="TestUtilities\FakeProvider\FakeRelationalConnection.cs" />
+    <Compile Include="TestUtilities\FakeProvider\FakeRelationalOptionsExtension.cs" />
+    <Compile Include="TestUtilities\FakeSensitiveDataLogger`.cs" />
+    <Compile Include="TestUtilities\ListTelemetrySource.cs" />
     <Compile Include="Update\UpdateSqlGeneratorTest.cs" />
     <Compile Include="Update\UpdateSqlGeneratorTestBase.cs" />
     <Compile Include="Storage\RelationalTypeMapperTest.cs" />

--- a/test/EntityFramework.Relational.Tests/Migrations/MigrationSqlGeneratorTest.cs
+++ b/test/EntityFramework.Relational.Tests/Migrations/MigrationSqlGeneratorTest.cs
@@ -3,12 +3,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.Tracing;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Migrations.Operations;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Storage.Internal;
 using Microsoft.Data.Entity.Tests;
+using Microsoft.Data.Entity.TestUtilities;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Migrations
@@ -22,7 +24,10 @@ namespace Microsoft.Data.Entity.Migrations
                 var typeMapper = new ConcreteRelationalTypeMapper();
 
                 return new ConcreteMigrationSqlGenerator(
-                    new RelationalCommandBuilderFactory(typeMapper),
+                    new RelationalCommandBuilderFactory(
+                        new FakeSensitiveDataLogger<RelationalCommandBuilderFactory>(),
+                        new TelemetryListener("Fake"),
+                        typeMapper),
                     new RelationalSqlGenerator(),
                     typeMapper,
                     new TestAnnotationProvider());

--- a/test/EntityFramework.Relational.Tests/SqlBatchBuilderTest.cs
+++ b/test/EntityFramework.Relational.Tests/SqlBatchBuilderTest.cs
@@ -4,11 +4,13 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Diagnostics.Tracing;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Storage.Internal;
 using Microsoft.Data.Entity.Tests;
+using Microsoft.Data.Entity.TestUtilities;
 using Xunit;
 
 namespace Microsoft.Data.Entity
@@ -92,6 +94,8 @@ Statement3
         private RelationalCommandListBuilder CreateBuilder()
             => new RelationalCommandListBuilder(
                 new RelationalCommandBuilderFactory(
+                    new FakeSensitiveDataLogger<RelationalCommandBuilderFactory>(),
+                    new TelemetryListener("Fake"),
                     new TestRelationalTypeMapper()));
 
         private class TestRelationalTypeMapper : RelationalTypeMapper

--- a/test/EntityFramework.Relational.Tests/Storage/RelationalCommandTest.cs
+++ b/test/EntityFramework.Relational.Tests/Storage/RelationalCommandTest.cs
@@ -1,0 +1,769 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Diagnostics.Tracing;
+using System.Threading.Tasks;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Internal;
+using Microsoft.Data.Entity.Storage.Internal;
+using Microsoft.Data.Entity.Tests.TestUtilities;
+using Microsoft.Data.Entity.TestUtilities;
+using Microsoft.Data.Entity.TestUtilities.FakeProvider;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Storage
+{
+    public class RelationalCommandTest
+    {
+        [Fact]
+        public void Configures_DbCommand()
+        {
+            var fakeConnection = CreateConnection();
+
+            var relationalCommand = new RelationalCommand(
+                new FakeSensitiveDataLogger<RelationalCommand>(),
+                new TelemetryListener("Fake"),
+                "CommandText",
+                new RelationalParameter[0]);
+
+            relationalCommand.ExecuteNonQuery(fakeConnection);
+
+            Assert.Equal(1, fakeConnection.DbConnections.Count);
+            Assert.Equal(1, fakeConnection.DbConnections[0].DbCommands.Count);
+
+            var command = fakeConnection.DbConnections[0].DbCommands[0];
+
+            Assert.Equal("CommandText", command.CommandText);
+            Assert.Null(command.Transaction);
+            Assert.Equal(FakeDbCommand.DefaultCommandTimeout, command.CommandTimeout);
+        }
+
+        [Fact]
+        public void Configures_DbCommand_with_transaction()
+        {
+            var fakeConnection = CreateConnection();
+
+            var relationalTransaction = fakeConnection.BeginTransaction();
+
+            var relationalCommand = new RelationalCommand(
+                new FakeSensitiveDataLogger<RelationalCommand>(),
+                new TelemetryListener("Fake"),
+                "CommandText",
+                new RelationalParameter[0]);
+
+            relationalCommand.ExecuteNonQuery(fakeConnection);
+
+            Assert.Equal(1, fakeConnection.DbConnections.Count);
+            Assert.Equal(1, fakeConnection.DbConnections[0].DbCommands.Count);
+
+            var command = fakeConnection.DbConnections[0].DbCommands[0];
+
+            Assert.Same(relationalTransaction.GetService(), command.Transaction);
+        }
+
+        [Fact]
+        public void Configures_DbCommand_with_timeout()
+        {
+            var optionsExtension = new FakeRelationalOptionsExtension
+            {
+                ConnectionString = ConnectionString,
+                CommandTimeout = 42
+            };
+
+            var fakeConnection = CreateConnection(CreateOptions(optionsExtension));
+
+            var relationalCommand = new RelationalCommand(
+                new FakeSensitiveDataLogger<RelationalCommand>(),
+                new TelemetryListener("Fake"),
+                "CommandText",
+                new RelationalParameter[0]);
+
+            relationalCommand.ExecuteNonQuery(fakeConnection);
+
+            Assert.Equal(1, fakeConnection.DbConnections.Count);
+            Assert.Equal(1, fakeConnection.DbConnections[0].DbCommands.Count);
+
+            var command = fakeConnection.DbConnections[0].DbCommands[0];
+
+            Assert.Equal(42, command.CommandTimeout);
+        }
+
+        [Fact]
+        public void Configures_DbCommand_with_parameters()
+        {
+            var fakeConnection = CreateConnection();
+
+            var relationalCommand = new RelationalCommand(
+                new FakeSensitiveDataLogger<RelationalCommand>(),
+                new TelemetryListener("Fake"),
+                "CommandText",
+                new[]
+                {
+                    new RelationalParameter("FirstParameter", 17, new RelationalTypeMapping("int", DbType.Int32), false),
+                    new RelationalParameter("SecondParameter", 18L,  new RelationalTypeMapping("long", DbType.Int64), true),
+                    new RelationalParameter("ThirdParameter", null,  new RelationalTypeMapping("null", FakeDbParameter.DefaultDbType), null)
+                });
+
+            relationalCommand.ExecuteNonQuery(fakeConnection);
+
+            Assert.Equal(1, fakeConnection.DbConnections.Count);
+            Assert.Equal(1, fakeConnection.DbConnections[0].DbCommands.Count);
+            Assert.Equal(3, fakeConnection.DbConnections[0].DbCommands[0].Parameters.Count);
+
+            var parameter = fakeConnection.DbConnections[0].DbCommands[0].Parameters[0];
+
+            Assert.Equal("FirstParameter", parameter.ParameterName);
+            Assert.Equal(17, parameter.Value);
+            Assert.Equal(ParameterDirection.Input, parameter.Direction);
+            Assert.Equal(false, parameter.IsNullable);
+            Assert.Equal(DbType.Int32, parameter.DbType);
+
+            parameter = fakeConnection.DbConnections[0].DbCommands[0].Parameters[1];
+
+            Assert.Equal("SecondParameter", parameter.ParameterName);
+            Assert.Equal(18L, parameter.Value);
+            Assert.Equal(ParameterDirection.Input, parameter.Direction);
+            Assert.Equal(true, parameter.IsNullable);
+            Assert.Equal(DbType.Int64, parameter.DbType);
+
+            parameter = fakeConnection.DbConnections[0].DbCommands[0].Parameters[2];
+
+            Assert.Equal("ThirdParameter", parameter.ParameterName);
+            Assert.Equal(DBNull.Value, parameter.Value);
+            Assert.Equal(ParameterDirection.Input, parameter.Direction);
+            Assert.Equal(FakeDbParameter.DefaultDbType, parameter.DbType);
+        }
+
+        [Fact]
+        public void Can_ExecuteNonQuery()
+        {
+            var executeNonQueryCount = 0;
+            var disposeCount = -1;
+
+            var fakeDbConnection = new FakeDbConnection(
+                ConnectionString,
+                new FakeCommandExecutor(
+                    executeNonQuery: c =>
+                    {
+                        executeNonQueryCount++;
+                        disposeCount = c.DisposeCount;
+                        return 1;
+                    }));
+
+            var optionsExtension = new FakeRelationalOptionsExtension { Connection = fakeDbConnection };
+
+            var options = CreateOptions(optionsExtension);
+
+            var fakeConnection = new FakeRelationalConnection(options);
+
+            var relationalCommand = new RelationalCommand(
+                new FakeSensitiveDataLogger<RelationalCommand>(),
+                new TelemetryListener("Fake"),
+                "ExecuteNonQuery Command",
+                new RelationalParameter[0]);
+
+            relationalCommand.ExecuteNonQuery(fakeConnection);
+
+            // Durring command execution
+            Assert.Equal(1, executeNonQueryCount);
+            Assert.Equal(0, disposeCount);
+
+            // After command execution
+            Assert.Equal(1, fakeDbConnection.DbCommands[0].DisposeCount);
+        }
+
+        [Fact]
+        public virtual async Task Can_ExecuteNonQueryAsync()
+        {
+            var executeNonQueryCount = 0;
+            var disposeCount = -1;
+
+            var fakeDbConnection = new FakeDbConnection(
+                ConnectionString,
+                new FakeCommandExecutor(
+                    executeNonQueryAsync: (c, ct) =>
+                    {
+                        executeNonQueryCount++;
+                        disposeCount = c.DisposeCount;
+                        return Task.FromResult(1);
+                    }));
+
+            var optionsExtension = new FakeRelationalOptionsExtension { Connection = fakeDbConnection };
+
+            var options = CreateOptions(optionsExtension);
+
+            var fakeConnection = new FakeRelationalConnection(options);
+
+            var relationalCommand = new RelationalCommand(
+                new FakeSensitiveDataLogger<RelationalCommand>(),
+                new TelemetryListener("Fake"),
+                "ExecuteNonQuery Command",
+                new RelationalParameter[0]);
+
+            await relationalCommand.ExecuteNonQueryAsync(fakeConnection);
+
+            // Durring command execution
+            Assert.Equal(1, executeNonQueryCount);
+            Assert.Equal(0, disposeCount);
+
+            // After command execution
+            Assert.Equal(1, fakeDbConnection.DbCommands[0].DisposeCount);
+        }
+
+        [Fact]
+        public void Can_ExecuteScalar()
+        {
+            var executeScalarCount = 0;
+            var disposeCount = -1;
+
+            var fakeDbConnection = new FakeDbConnection(
+                ConnectionString,
+                new FakeCommandExecutor(
+                    executeScalar: c =>
+                    {
+                        executeScalarCount++;
+                        disposeCount = c.DisposeCount;
+                        return "ExecuteScalar Result";
+                    }));
+
+            var optionsExtension = new FakeRelationalOptionsExtension { Connection = fakeDbConnection };
+
+            var options = CreateOptions(optionsExtension);
+
+            var fakeConnection = new FakeRelationalConnection(options);
+
+            var relationalCommand = new RelationalCommand(
+                new FakeSensitiveDataLogger<RelationalCommand>(),
+                new TelemetryListener("Fake"),
+                "ExecuteScalar Command",
+                new RelationalParameter[0]);
+
+            var result = (string)relationalCommand.ExecuteScalar(fakeConnection);
+
+            Assert.Equal("ExecuteScalar Result", result);
+
+            // Durring command execution
+            Assert.Equal(1, executeScalarCount);
+            Assert.Equal(0, disposeCount);
+
+            // After command execution
+            Assert.Equal(1, fakeDbConnection.DbCommands[0].DisposeCount);
+        }
+
+        [Fact]
+        public async Task Can_ExecuteScalarAsync()
+        {
+            var executeScalarCount = 0;
+            var disposeCount = -1;
+
+            var fakeDbConnection = new FakeDbConnection(
+                ConnectionString,
+                new FakeCommandExecutor(
+                    executeScalarAsync: (c, ct) =>
+                    {
+                        executeScalarCount++;
+                        disposeCount = c.DisposeCount;
+                        return Task.FromResult<object>("ExecuteScalar Result");
+                    }));
+
+            var optionsExtension = new FakeRelationalOptionsExtension { Connection = fakeDbConnection };
+
+            var options = CreateOptions(optionsExtension);
+
+            var fakeConnection = new FakeRelationalConnection(options);
+
+            var relationalCommand = new RelationalCommand(
+                new FakeSensitiveDataLogger<RelationalCommand>(),
+                new TelemetryListener("Fake"),
+                "ExecuteScalar Command",
+                new RelationalParameter[0]);
+
+            var result = (string)await relationalCommand.ExecuteScalarAsync(fakeConnection);
+
+            Assert.Equal("ExecuteScalar Result", result);
+
+            // Durring command execution
+            Assert.Equal(1, executeScalarCount);
+            Assert.Equal(0, disposeCount);
+
+            // After command execution
+            Assert.Equal(1, fakeDbConnection.DbCommands[0].DisposeCount);
+        }
+
+        [Fact]
+        public void Can_ExecuteReader()
+        {
+            var executeReaderCount = 0;
+            var disposeCount = -1;
+
+            var dbDataReader = new FakeDbDataReader();
+
+            var fakeDbConnection = new FakeDbConnection(
+                ConnectionString,
+                new FakeCommandExecutor(
+                    executeReader: (c, b) =>
+                    {
+                        executeReaderCount++;
+                        disposeCount = c.DisposeCount;
+                        return dbDataReader;
+                    }));
+
+            var optionsExtension = new FakeRelationalOptionsExtension { Connection = fakeDbConnection };
+
+            var options = CreateOptions(optionsExtension);
+
+            var fakeConnection = new FakeRelationalConnection(options);
+
+            var relationalCommand = new RelationalCommand(
+                new FakeSensitiveDataLogger<RelationalCommand>(),
+                new TelemetryListener("Fake"),
+                "ExecuteReader Command",
+                new RelationalParameter[0]);
+
+            var result = relationalCommand.ExecuteReader(fakeConnection);
+
+            Assert.Same(dbDataReader, result.DbDataReader);
+
+            // Durring command execution
+            Assert.Equal(1, executeReaderCount);
+            Assert.Equal(0, disposeCount);
+
+            // After command execution
+            Assert.Equal(0, dbDataReader.DisposeCount);
+            Assert.Equal(0, fakeDbConnection.DbCommands[0].DisposeCount);
+
+            // After reader dispose
+            result.Dispose();
+            Assert.Equal(1, dbDataReader.DisposeCount);
+            Assert.Equal(1, fakeDbConnection.DbCommands[0].DisposeCount);
+        }
+
+        [Fact]
+        public async Task Can_ExecuteReaderAsync()
+        {
+            var executeReaderCount = 0;
+            var disposeCount = -1;
+
+            var dbDataReader = new FakeDbDataReader();
+
+            var fakeDbConnection = new FakeDbConnection(
+                ConnectionString,
+                new FakeCommandExecutor(
+                    executeReaderAsync: (c, b, ct) =>
+                    {
+                        executeReaderCount++;
+                        disposeCount = c.DisposeCount;
+                        return Task.FromResult<DbDataReader>(dbDataReader);
+                    }));
+
+            var optionsExtension = new FakeRelationalOptionsExtension { Connection = fakeDbConnection };
+
+            var options = CreateOptions(optionsExtension);
+
+            var fakeConnection = new FakeRelationalConnection(options);
+
+            var relationalCommand = new RelationalCommand(
+                new FakeSensitiveDataLogger<RelationalCommand>(),
+                new TelemetryListener("Fake"),
+                "ExecuteReader Command",
+                new RelationalParameter[0]);
+
+            var result = await relationalCommand.ExecuteReaderAsync(fakeConnection);
+
+            Assert.Same(dbDataReader, result.DbDataReader);
+
+            // Durring command execution
+            Assert.Equal(1, executeReaderCount);
+            Assert.Equal(0, disposeCount);
+
+            // After command execution
+            Assert.Equal(0, dbDataReader.DisposeCount);
+            Assert.Equal(0, fakeDbConnection.DbCommands[0].DisposeCount);
+
+            // After reader dispose
+            result.Dispose();
+            Assert.Equal(1, dbDataReader.DisposeCount);
+            Assert.Equal(1, fakeDbConnection.DbCommands[0].DisposeCount);
+        }
+
+        [Fact]
+        public void ExecuteReader_disposes_command_on_exception()
+        {
+            var fakeDbConnection = new FakeDbConnection(
+                ConnectionString,
+                new FakeCommandExecutor(
+                    executeReader: (c, b) =>
+                    {
+                        throw new DbUpdateException("ExecuteReader Exception", new InvalidOperationException());
+                    }));
+
+            var optionsExtension = new FakeRelationalOptionsExtension { Connection = fakeDbConnection };
+
+            var options = CreateOptions(optionsExtension);
+
+            var fakeConnection = new FakeRelationalConnection(options);
+
+            var relationalCommand = new RelationalCommand(
+                new FakeSensitiveDataLogger<RelationalCommand>(),
+                new TelemetryListener("Fake"),
+                "ExecuteReader Command",
+                new RelationalParameter[0]);
+
+            Assert.Throws<DbUpdateException>(() => relationalCommand.ExecuteReader(fakeConnection));
+            Assert.Equal(1, fakeDbConnection.DbCommands[0].DisposeCount);
+        }
+
+        [Fact]
+        public async Task ExecuteReaderAsync_disposes_command_on_exception()
+        {
+            var fakeDbConnection = new FakeDbConnection(
+                ConnectionString,
+                new FakeCommandExecutor(
+                    executeReaderAsync: (c, b, ct) =>
+                    {
+                        throw new DbUpdateException("ExecuteReader Exception", new InvalidOperationException());
+                    }));
+
+            var optionsExtension = new FakeRelationalOptionsExtension { Connection = fakeDbConnection };
+
+            var options = CreateOptions(optionsExtension);
+
+            var fakeConnection = new FakeRelationalConnection(options);
+
+            var relationalCommand = new RelationalCommand(
+                new FakeSensitiveDataLogger<RelationalCommand>(),
+                new TelemetryListener("Fake"),
+                "ExecuteReader Command",
+                new RelationalParameter[0]);
+
+            await Assert.ThrowsAsync<DbUpdateException>(() => relationalCommand.ExecuteReaderAsync(fakeConnection));
+            Assert.Equal(1, fakeDbConnection.DbCommands[0].DisposeCount);
+        }
+
+        public static TheoryData CommandActions
+            => new TheoryData<Delegate, string, bool>
+                {
+                    {
+                        new Action<RelationalCommand, IRelationalConnection>( (command, connection) => command.ExecuteNonQuery(connection)),
+                        RelationalTelemetry.ExecuteMethod.ExecuteNonQuery,
+                        false
+                    },
+                    {
+                        new Action<RelationalCommand, IRelationalConnection>( (command, connection) => command.ExecuteScalar(connection)),
+                        RelationalTelemetry.ExecuteMethod.ExecuteScalar,
+                        false
+                    },
+                    {
+                        new Action<RelationalCommand, IRelationalConnection>( (command, connection) => command.ExecuteReader(connection)),
+                        RelationalTelemetry.ExecuteMethod.ExecuteReader,
+                        false
+                    },
+                    {
+                        new Func<RelationalCommand, IRelationalConnection, Task>( (command, connection) => command.ExecuteNonQueryAsync(connection)),
+                        RelationalTelemetry.ExecuteMethod.ExecuteNonQuery,
+                        true
+                    },
+                    {
+                        new Func<RelationalCommand, IRelationalConnection, Task>( (command, connection) => command.ExecuteScalarAsync(connection)),
+                        RelationalTelemetry.ExecuteMethod.ExecuteScalar,
+                        true
+                    },
+                    {
+                        new Func<RelationalCommand, IRelationalConnection, Task>( (command, connection) => command.ExecuteReaderAsync(connection)),
+                        RelationalTelemetry.ExecuteMethod.ExecuteReader,
+                        true
+                    }
+                };
+
+        [Theory]
+        [MemberData(nameof(CommandActions))]
+        public async Task Logs_commands_without_parameter_values(
+            Delegate commandDelegate,
+            string telemetryName,
+            bool async)
+        {
+            var options = CreateOptions();
+
+            var fakeConnection = new FakeRelationalConnection(options);
+
+            var log = new List<Tuple<LogLevel, string>>();
+
+            var relationalCommand = new RelationalCommand(
+                new SensitiveDataLogger<RelationalCommand>(
+                    new ListLogger<RelationalCommand>(log),
+                    options),
+                new TelemetryListener("Fake"),
+                "Command Text",
+                new[]
+                {
+                    new RelationalParameter("FirstParameter", 17, new RelationalTypeMapping("int", DbType.Int32), false)
+                });
+
+            if (async)
+            {
+                await ((Func<RelationalCommand, IRelationalConnection, Task>)commandDelegate)(relationalCommand, fakeConnection);
+            }
+            else
+            {
+                ((Action<RelationalCommand, IRelationalConnection>)commandDelegate)(relationalCommand, fakeConnection);
+            }
+
+            Assert.Equal(1, log.Count);
+            Assert.Equal(LogLevel.Information, log[0].Item1);
+            Assert.Equal(
+                @"Executing DbCommand: [Parameters=[FirstParameter='?'], CommandType='0', CommandTimeout='30']
+
+Command Text
+",
+                log[0].Item2);
+        }
+
+        [Theory]
+        [MemberData(nameof(CommandActions))]
+        public async Task Logs_commands_parameter_values(
+            Delegate commandDelegate,
+            string telemetryName,
+            bool async)
+        {
+            var optionsExtension = new FakeRelationalOptionsExtension
+            {
+                ConnectionString = ConnectionString,
+                LogSqlParameterValues = true,
+                LogSqlParameterValuesWarned = false
+            };
+
+            var options = CreateOptions(optionsExtension);
+
+            var fakeConnection = new FakeRelationalConnection(options);
+
+            var log = new List<Tuple<LogLevel, string>>();
+
+            var relationalCommand = new RelationalCommand(
+                new SensitiveDataLogger<RelationalCommand>(
+                    new ListLogger<RelationalCommand>(log),
+                    options),
+                new TelemetryListener("Fake"),
+                "Command Text",
+                new[]
+                {
+                    new RelationalParameter("FirstParameter", 17, new RelationalTypeMapping("int", DbType.Int32), false)
+                });
+
+            if (async)
+            {
+                await ((Func<RelationalCommand, IRelationalConnection, Task>)commandDelegate)(relationalCommand, fakeConnection);
+            }
+            else
+            {
+                ((Action<RelationalCommand, IRelationalConnection>)commandDelegate)(relationalCommand, fakeConnection);
+            }
+
+            Assert.Equal(2, log.Count);
+            Assert.Equal(LogLevel.Warning, log[0].Item1);
+            Assert.Equal(
+@"SQL parameter value logging is enabled. As SQL parameter values may include sensitive application data, this mode should only be enabled during development.",
+                log[0].Item2);
+
+            Assert.Equal(LogLevel.Information, log[1].Item1);
+            Assert.Equal(
+                @"Executing DbCommand: [Parameters=[FirstParameter='17'], CommandType='0', CommandTimeout='30']
+
+Command Text
+",
+                log[1].Item2);
+        }
+
+        [Theory]
+        [MemberData(nameof(CommandActions))]
+        public async Task Logs_commands_parameter_values_and_warnings(
+            Delegate commandDelegate,
+            string telemetryName,
+            bool async)
+        {
+            var optionsExtension = new FakeRelationalOptionsExtension
+            {
+                ConnectionString = ConnectionString,
+                LogSqlParameterValues = true
+            };
+
+            var options = CreateOptions(optionsExtension);
+
+            var fakeConnection = new FakeRelationalConnection(options);
+
+            var log = new List<Tuple<LogLevel, string>>();
+
+            var relationalCommand = new RelationalCommand(
+                new SensitiveDataLogger<RelationalCommand>(
+                    new ListLogger<RelationalCommand>(log),
+                    options),
+                new TelemetryListener("Fake"),
+                "Command Text",
+                new[]
+                {
+                    new RelationalParameter("FirstParameter", 17, new RelationalTypeMapping("int", DbType.Int32), false)
+                });
+
+            if (async)
+            {
+                await ((Func<RelationalCommand, IRelationalConnection, Task>)commandDelegate)(relationalCommand, fakeConnection);
+            }
+            else
+            {
+                ((Action<RelationalCommand, IRelationalConnection>)commandDelegate)(relationalCommand, fakeConnection);
+            }
+
+            Assert.Equal(2, log.Count);
+            Assert.Equal(LogLevel.Warning, log[0].Item1);
+            Assert.Equal(
+@"SQL parameter value logging is enabled. As SQL parameter values may include sensitive application data, this mode should only be enabled during development.",
+                log[0].Item2);
+
+            Assert.Equal(LogLevel.Information, log[1].Item1);
+            Assert.Equal(
+                @"Executing DbCommand: [Parameters=[FirstParameter='17'], CommandType='0', CommandTimeout='30']
+
+Command Text
+",
+                log[1].Item2);
+        }
+
+        [Theory]
+        [MemberData(nameof(CommandActions))]
+        public async Task Reports_command_telemetry(
+            Delegate commandDelegate,
+            string telemetryName,
+            bool async)
+        {
+            var options = CreateOptions();
+
+            var fakeConnection = new FakeRelationalConnection(options);
+
+            var telemetry = new List<Tuple<string, object>>();
+
+            var relationalCommand = new RelationalCommand(
+                new SensitiveDataLogger<RelationalCommand>(
+                    new FakeSensitiveDataLogger<RelationalCommand>(),
+                    options),
+                new ListTelemetrySource(telemetry),
+                "Command Text",
+                new[]
+                {
+                    new RelationalParameter("FirstParameter", 17, new RelationalTypeMapping("int", DbType.Int32), false)
+                });
+
+            if (async)
+            {
+                await ((Func<RelationalCommand, IRelationalConnection, Task>)commandDelegate)(relationalCommand, fakeConnection);
+            }
+            else
+            {
+                ((Action<RelationalCommand, IRelationalConnection>)commandDelegate)(relationalCommand, fakeConnection);
+            }
+
+            Assert.Equal(2, telemetry.Count);
+            Assert.Equal(RelationalTelemetry.BeforeExecuteCommand, telemetry[0].Item1);
+            Assert.Equal(RelationalTelemetry.AfterExecuteCommand, telemetry[1].Item1);
+
+            dynamic beforeData = telemetry[0].Item2;
+            dynamic afterData = telemetry[1].Item2;
+
+            Assert.Equal(fakeConnection.DbConnections[0].DbCommands[0], beforeData.Command);
+            Assert.Equal(fakeConnection.DbConnections[0].DbCommands[0], afterData.Command);
+
+            Assert.Equal(telemetryName, beforeData.ExecuteMethod);
+            Assert.Equal(telemetryName, afterData.ExecuteMethod);
+
+            Assert.Equal(async, beforeData.IsAsync);
+            Assert.Equal(async, afterData.IsAsync);
+        }
+
+        [Theory]
+        [MemberData(nameof(CommandActions))]
+        public async Task Reports_command_telemetry_on_exception(
+            Delegate commandDelegate,
+            string telemetryName,
+            bool async)
+        {
+            var exception = new InvalidOperationException();
+
+            var fakeDbConnection = new FakeDbConnection(
+                ConnectionString,
+                new FakeCommandExecutor(
+                    (c) => { throw exception; },
+                    (c) => { throw exception; },
+                    (c, cb) => { throw exception; },
+                    (c, ct) => { throw exception; },
+                    (c, ct) => { throw exception; },
+                    (c, cb, ct) => { throw exception; }));
+
+            var optionsExtension = new FakeRelationalOptionsExtension { Connection = fakeDbConnection };
+
+            var options = CreateOptions(optionsExtension);
+
+            var fakeConnection = new FakeRelationalConnection(options);
+
+            var telemetry = new List<Tuple<string, object>>();
+
+            var relationalCommand = new RelationalCommand(
+                new SensitiveDataLogger<RelationalCommand>(
+                    new FakeSensitiveDataLogger<RelationalCommand>(),
+                    options),
+                new ListTelemetrySource(telemetry),
+                "Command Text",
+                new[]
+                {
+                    new RelationalParameter("FirstParameter", 17, new RelationalTypeMapping("int", DbType.Int32), false)
+                });
+
+            if (async)
+            {
+                await Assert.ThrowsAsync<InvalidOperationException>(
+                    async ()
+                        => await ((Func<RelationalCommand, IRelationalConnection, Task>)commandDelegate)(relationalCommand, fakeConnection));
+            }
+            else
+            {
+                Assert.Throws<InvalidOperationException>(()
+                    => ((Action<RelationalCommand, IRelationalConnection>)commandDelegate)(relationalCommand, fakeConnection));
+            }
+
+            Assert.Equal(2, telemetry.Count);
+            Assert.Equal(RelationalTelemetry.BeforeExecuteCommand, telemetry[0].Item1);
+            Assert.Equal(RelationalTelemetry.CommandExecutionError, telemetry[1].Item1);
+
+            dynamic beforeData = telemetry[0].Item2;
+            dynamic afterData = telemetry[1].Item2;
+
+            Assert.Equal(fakeDbConnection.DbCommands[0], beforeData.Command);
+            Assert.Equal(fakeDbConnection.DbCommands[0], afterData.Command);
+
+            Assert.Equal(telemetryName, beforeData.ExecuteMethod);
+            Assert.Equal(telemetryName, afterData.ExecuteMethod);
+
+            Assert.Equal(async, beforeData.IsAsync);
+            Assert.Equal(async, afterData.IsAsync);
+
+            Assert.Equal(exception, afterData.Exception);
+        }
+
+        private const string ConnectionString = "Fake Connection String";
+
+        private static FakeRelationalConnection CreateConnection(IDbContextOptions options = null)
+            => new FakeRelationalConnection(options ?? CreateOptions());
+
+        public static IDbContextOptions CreateOptions(FakeRelationalOptionsExtension optionsExtension = null)
+        {
+            var optionsBuilder = new DbContextOptionsBuilder();
+
+            ((IDbContextOptionsBuilderInfrastructure)optionsBuilder)
+                .AddOrUpdateExtension(optionsExtension ?? new FakeRelationalOptionsExtension { ConnectionString = ConnectionString });
+
+            return optionsBuilder.Options;
+        }
+    }
+}

--- a/test/EntityFramework.Relational.Tests/Storage/SqlCommandBuilderTest.cs
+++ b/test/EntityFramework.Relational.Tests/Storage/SqlCommandBuilderTest.cs
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Data;
+using System.Diagnostics.Tracing;
 using Microsoft.Data.Entity.Storage.Internal;
+using Microsoft.Data.Entity.TestUtilities;
 using Microsoft.Data.Entity.TestUtilities.FakeProvider;
 using Xunit;
 
@@ -15,6 +17,8 @@ namespace Microsoft.Data.Entity.Storage
         {
             var builder = new SqlCommandBuilder(
                 new RelationalCommandBuilderFactory(
+                    new FakeSensitiveDataLogger<RelationalCommandBuilderFactory>(),
+                    new TelemetryListener("Fake"),
                     new FakeRelationalTypeMapper()),
                 new RelationalSqlGenerator(),
                 new ParameterNameGeneratorFactory());
@@ -30,6 +34,8 @@ namespace Microsoft.Data.Entity.Storage
         {
             var builder = new SqlCommandBuilder(
                 new RelationalCommandBuilderFactory(
+                    new FakeSensitiveDataLogger<RelationalCommandBuilderFactory>(),
+                    new TelemetryListener("Fake"),
                     new FakeRelationalTypeMapper()),
                 new RelationalSqlGenerator(),
                 new ParameterNameGeneratorFactory());
@@ -45,6 +51,8 @@ namespace Microsoft.Data.Entity.Storage
         {
             var builder = new SqlCommandBuilder(
                 new RelationalCommandBuilderFactory(
+                    new FakeSensitiveDataLogger<RelationalCommandBuilderFactory>(),
+                    new TelemetryListener("Fake"),
                     new FakeRelationalTypeMapper()),
                 new RelationalSqlGenerator(),
                 new ParameterNameGeneratorFactory());

--- a/test/EntityFramework.Relational.Tests/TestUtilities/FakeProvider/FakeCommandExecutor.cs
+++ b/test/EntityFramework.Relational.Tests/TestUtilities/FakeProvider/FakeCommandExecutor.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Data.Entity.TestUtilities.FakeProvider
+{
+    public class FakeCommandExecutor
+    {
+        private readonly Func<FakeDbCommand, int> _executeNonQuery;
+        private readonly Func<FakeDbCommand, object> _executeScalar;
+        private readonly Func<FakeDbCommand, CommandBehavior, DbDataReader> _executeReader;
+        private readonly Func<FakeDbCommand, CancellationToken, Task<int>> _executeNonQueryAsync;
+        private readonly Func<FakeDbCommand, CancellationToken, Task<object>> _executeScalarAsync;
+        private readonly Func<FakeDbCommand, CommandBehavior, CancellationToken, Task<DbDataReader>> _executeReaderAsync;
+
+        public FakeCommandExecutor(
+            Func<FakeDbCommand, int> executeNonQuery = null,
+            Func<FakeDbCommand, object> executeScalar = null,
+            Func<FakeDbCommand, CommandBehavior, DbDataReader> executeReader = null,
+            Func<FakeDbCommand, CancellationToken, Task<int>> executeNonQueryAsync = null,
+            Func<FakeDbCommand, CancellationToken, Task<object>> executeScalarAsync = null,
+            Func<FakeDbCommand, CommandBehavior, CancellationToken, Task<DbDataReader>> executeReaderAsync = null)
+        {
+            _executeNonQuery = executeNonQuery
+                ?? new Func<FakeDbCommand, int>(c => -1);
+
+            _executeScalar = executeScalar
+                ?? new Func<FakeDbCommand, object>(c => null);
+
+            _executeReader = executeReader
+                ?? new Func<FakeDbCommand, CommandBehavior, DbDataReader>((c, b) => new FakeDbDataReader());
+
+            _executeNonQueryAsync = executeNonQueryAsync
+                ?? new Func<FakeDbCommand, CancellationToken, Task<int>>((c, ct) => Task.FromResult(-1));
+
+            _executeScalarAsync = executeScalarAsync
+                ?? new Func<FakeDbCommand, CancellationToken, Task<object>>((c, ct) => Task.FromResult<object>(null));
+
+            _executeReaderAsync = executeReaderAsync
+                ?? new Func<FakeDbCommand, CommandBehavior, CancellationToken, Task<DbDataReader>>((c, ct, b) => Task.FromResult<DbDataReader>(new FakeDbDataReader()));
+        }
+
+        public virtual int ExecuteNonQuery(FakeDbCommand command) => _executeNonQuery(command);
+
+        public virtual object ExecuteScalar(FakeDbCommand command) => _executeScalar(command);
+
+        public virtual DbDataReader ExecuteReader(FakeDbCommand command, CommandBehavior behavior)
+            => _executeReader(command, behavior);
+
+        public Task<int> ExecuteNonQueryAsync(FakeDbCommand command, CancellationToken cancellationToken)
+            => _executeNonQueryAsync(command, cancellationToken);
+
+        public Task<object> ExecuteScalarAsync(FakeDbCommand command, CancellationToken cancellationToken)
+            => _executeScalarAsync(command, cancellationToken);
+
+        public Task<DbDataReader> ExecuteReaderAsync(FakeDbCommand command, CommandBehavior behavior, CancellationToken cancellationToken)
+            => _executeReaderAsync(command, behavior, cancellationToken);
+    }
+}

--- a/test/EntityFramework.Relational.Tests/TestUtilities/FakeProvider/FakeDbCommand.cs
+++ b/test/EntityFramework.Relational.Tests/TestUtilities/FakeProvider/FakeDbCommand.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Data.Entity.TestUtilities.FakeProvider
+{
+    public class FakeDbCommand : DbCommand
+    {
+        private FakeCommandExecutor _commandExecutor;
+
+        public FakeDbCommand(
+            FakeDbConnection connection,
+            FakeCommandExecutor commandExecutor)
+        {
+            DbConnection = connection;
+            _commandExecutor = commandExecutor;
+        }
+
+        protected override DbConnection DbConnection { get; set; }
+
+        protected override DbTransaction DbTransaction { get; set; }
+
+        public override void Cancel()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override string CommandText { get; set; }
+
+        public static int DefaultCommandTimeout = 30;
+
+        public override int CommandTimeout { get; set; } = DefaultCommandTimeout;
+
+        public override CommandType CommandType { get; set; }
+
+        protected override DbParameter CreateDbParameter()
+            => new FakeDbParameter();
+
+        protected override DbParameterCollection DbParameterCollection { get; }
+            = new FakeDbParameterCollection();
+
+        public override void Prepare()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int ExecuteNonQuery()
+            => _commandExecutor.ExecuteNonQuery(this);
+
+        public override object ExecuteScalar()
+            => _commandExecutor.ExecuteScalar(this);
+
+        protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
+            => _commandExecutor.ExecuteReader(this, behavior);
+
+        public override Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
+            => _commandExecutor.ExecuteNonQueryAsync(this, cancellationToken);
+
+        public override Task<object> ExecuteScalarAsync(CancellationToken cancellationToken)
+            => _commandExecutor.ExecuteScalarAsync(this, cancellationToken);
+
+        protected override Task<DbDataReader> ExecuteDbDataReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
+            => _commandExecutor.ExecuteReaderAsync(this, behavior, cancellationToken);
+
+        public override bool DesignTimeVisible
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+            set
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public override UpdateRowSource UpdatedRowSource
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+            set
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public int DisposeCount { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                DisposeCount++;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/test/EntityFramework.Relational.Tests/TestUtilities/FakeProvider/FakeDbConnection.cs
+++ b/test/EntityFramework.Relational.Tests/TestUtilities/FakeProvider/FakeDbConnection.cs
@@ -1,0 +1,115 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Data.Entity.TestUtilities.FakeProvider
+{
+    public class FakeDbConnection : DbConnection
+    {
+        private readonly FakeCommandExecutor _commandExecutor;
+
+        private ConnectionState _state;
+        private readonly List<FakeDbCommand> _dbCommands = new List<FakeDbCommand>();
+
+        public FakeDbConnection(
+            string connectionString,
+            FakeCommandExecutor commandExecutor = null,
+            ConnectionState state = ConnectionState.Closed)
+        {
+            ConnectionString = connectionString;
+            _commandExecutor = commandExecutor ?? new FakeCommandExecutor();
+            _state = state;
+        }
+
+        public override ConnectionState State => _state;
+
+        public IReadOnlyList<FakeDbCommand> DbCommands => _dbCommands;
+
+        public override string ConnectionString { get; set; }
+
+        public override string Database
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public override string DataSource
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public override string ServerVersion
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public override void ChangeDatabase(string databaseName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int OpenCount { get; private set; }
+
+        public override void Open()
+        {
+            OpenCount++;
+            _state = ConnectionState.Open;
+        }
+
+        public int OpenAsyncCount { get; private set; }
+
+        public override Task OpenAsync(CancellationToken cancellationToken)
+        {
+            OpenAsyncCount++;
+            return base.OpenAsync(cancellationToken);
+        }
+
+        public int CloseCount { get; private set; }
+
+        public override void Close()
+        {
+            CloseCount++;
+            _state = ConnectionState.Closed;
+        }
+
+        protected override DbCommand CreateDbCommand()
+        {
+            var command = new FakeDbCommand(this, _commandExecutor);
+
+            _dbCommands.Add(command);
+
+            return command;
+        }
+
+        protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel)
+        {
+            return new FakeDbTransaction(this);
+        }
+
+        public int DisposeCount { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                DisposeCount++;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/test/EntityFramework.Relational.Tests/TestUtilities/FakeProvider/FakeDbDataReader.cs
+++ b/test/EntityFramework.Relational.Tests/TestUtilities/FakeProvider/FakeDbDataReader.cs
@@ -1,0 +1,237 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Data.Entity.TestUtilities.FakeProvider
+{
+    public class FakeDbDataReader : DbDataReader
+    {
+        private readonly string[] _columnNames;
+        private readonly IList<object[]> _results;
+
+        private object[] _currentRow;
+        private int _rowIndex = 0;
+
+        public FakeDbDataReader(string[] columnNames = null, IList<object[]> results = null)
+        {
+            _columnNames = columnNames ?? new string[0];
+            _results = results ?? new List<object[]>();
+        }
+
+        public int ReadCount { get; private set; }
+
+        public override bool Read()
+        {
+            _currentRow = _rowIndex < _results.Count
+                ? _results[_rowIndex++]
+                : null;
+
+            return _currentRow != null;
+        }
+
+        public int ReadAsyncCount { get; private set; }
+
+        public override Task<bool> ReadAsync(CancellationToken cancellationToken)
+        {
+            ReadAsyncCount++;
+
+            _currentRow = _rowIndex < _results.Count
+                ? _results[_rowIndex++]
+                : null;
+
+            return Task.FromResult(_currentRow != null);
+        }
+
+        public int CloseCount { get; private set; }
+        public override void Close()
+        {
+            CloseCount++;
+        }
+
+        public int DisposeCount { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                DisposeCount++;
+
+                base.Dispose(disposing);
+            }
+        }
+
+        public override int FieldCount => _columnNames.Length;
+
+        public override string GetName(int ordinal) => _columnNames[ordinal];
+
+        public override bool IsDBNull(int ordinal) => _currentRow[ordinal] == DBNull.Value;
+
+        public override object GetValue(int ordinal) => _currentRow[ordinal];
+
+        public int GetInt32Count { get; private set; }
+
+        public override int GetInt32(int ordinal)
+        {
+            GetInt32Count++;
+
+            return (Int32)_currentRow[ordinal];
+        }
+
+        public override object this[string name]
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public override object this[int ordinal]
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public override int Depth
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+
+
+        public override bool HasRows
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public override bool IsClosed
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public override int RecordsAffected
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public override bool GetBoolean(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override byte GetByte(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override long GetBytes(int ordinal, long dataOffset, byte[] buffer, int bufferOffset, int length)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override char GetChar(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override long GetChars(int ordinal, long dataOffset, char[] buffer, int bufferOffset, int length)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override string GetDataTypeName(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override DateTime GetDateTime(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override decimal GetDecimal(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override double GetDouble(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override IEnumerator GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Type GetFieldType(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override float GetFloat(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Guid GetGuid(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override short GetInt16(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override long GetInt64(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int GetOrdinal(string name)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override DataTable GetSchemaTable()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override string GetString(int ordinal)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int GetValues(object[] values)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override bool NextResult()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/test/EntityFramework.Relational.Tests/TestUtilities/FakeProvider/FakeDbParameter.cs
+++ b/test/EntityFramework.Relational.Tests/TestUtilities/FakeProvider/FakeDbParameter.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Data;
+using System.Data.Common;
+
+namespace Microsoft.Data.Entity.TestUtilities.FakeProvider
+{
+    public class FakeDbParameter : DbParameter
+    {
+        public override string ParameterName { get; set; }
+
+        public override object Value { get; set; }
+
+        public override ParameterDirection Direction { get; set; }
+
+        public override bool IsNullable { get; set; }
+
+        public static DbType DefaultDbType = DbType.AnsiString;
+        public override DbType DbType { get; set; } = DefaultDbType;
+
+        public override int Size
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+
+            set
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public override string SourceColumn
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+
+            set
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public override bool SourceColumnNullMapping
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+
+            set
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public override DataRowVersion SourceVersion
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+
+            set
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public override void ResetDbType()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/test/EntityFramework.Relational.Tests/TestUtilities/FakeProvider/FakeDbParameterCollection.cs
+++ b/test/EntityFramework.Relational.Tests/TestUtilities/FakeProvider/FakeDbParameterCollection.cs
@@ -1,0 +1,132 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Data.Common;
+
+namespace Microsoft.Data.Entity.TestUtilities.FakeProvider
+{
+    public class FakeDbParameterCollection : DbParameterCollection
+    {
+        private List<object> _parameters = new List<object>();
+
+        public override int Count => _parameters.Count;
+
+        public override int Add(object value)
+        {
+            _parameters.Add(value);
+
+            return _parameters.Count - 1;
+        }
+
+        protected override DbParameter GetParameter(int index)
+            => (DbParameter)_parameters[index];
+
+        public override IEnumerator GetEnumerator()
+            => _parameters.GetEnumerator();
+
+        public override bool IsSynchronized
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public override bool IsFixedSize
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public override bool IsReadOnly
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public override object SyncRoot
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public override void AddRange(Array values)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Clear()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override bool Contains(string value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override bool Contains(object value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void CopyTo(Array array, int index)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int IndexOf(string parameterName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int IndexOf(object value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Insert(int index, object value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Remove(object value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void RemoveAt(string parameterName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void RemoveAt(int index)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override DbParameter GetParameter(string parameterName)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override void SetParameter(string parameterName, DbParameter value)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override void SetParameter(int index, DbParameter value)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/test/EntityFramework.Relational.Tests/TestUtilities/FakeProvider/FakeDbTransaction.cs
+++ b/test/EntityFramework.Relational.Tests/TestUtilities/FakeProvider/FakeDbTransaction.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Data;
+using System.Data.Common;
+
+namespace Microsoft.Data.Entity.TestUtilities.FakeProvider
+{
+    public class FakeDbTransaction : DbTransaction
+    {
+        public FakeDbTransaction(FakeDbConnection connection)
+        {
+            DbConnection = connection;
+        }
+
+        protected override DbConnection DbConnection { get; }
+
+        public override IsolationLevel IsolationLevel
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public override void Commit()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Rollback()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/test/EntityFramework.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalConnection.cs
+++ b/test/EntityFramework.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalConnection.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Data.Common;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Storage;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Data.Entity.TestUtilities.FakeProvider
+{
+    public class FakeRelationalConnection : RelationalConnection
+    {
+        private readonly List<FakeDbConnection> _dbConnections = new List<FakeDbConnection>();
+
+        public FakeRelationalConnection(IDbContextOptions options)
+            : base(options, new Logger<FakeRelationalConnection>(new LoggerFactory()))
+        {
+        }
+
+        public IReadOnlyList<FakeDbConnection> DbConnections => _dbConnections;
+
+        protected override DbConnection CreateDbConnection()
+        {
+            var connection = new FakeDbConnection(ConnectionString);
+
+            _dbConnections.Add(connection);
+
+            return connection;
+        }
+    }
+}

--- a/test/EntityFramework.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalOptionsExtension.cs
+++ b/test/EntityFramework.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalOptionsExtension.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Data.Entity.Infrastructure;
+
+namespace Microsoft.Data.Entity.TestUtilities.FakeProvider
+{
+    public class FakeRelationalOptionsExtension : RelationalOptionsExtension
+    {
+        public FakeRelationalOptionsExtension()
+        {
+        }
+
+        public FakeRelationalOptionsExtension(FakeRelationalOptionsExtension copyFrom)
+            : base(copyFrom)
+        {
+        }
+
+        public override void ApplyServices(EntityFrameworkServicesBuilder builder)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/test/EntityFramework.Relational.Tests/TestUtilities/FakeSensitiveDataLogger`.cs
+++ b/test/EntityFramework.Relational.Tests/TestUtilities/FakeSensitiveDataLogger`.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Data.Entity.TestUtilities
+{
+    public class FakeSensitiveDataLogger<T> : ISensitiveDataLogger<T>
+
+    {
+        public bool LogSensitiveData { get; }
+
+        public void Log(LogLevel logLevel, int eventId, object state, Exception exception, Func<object, Exception, string> formatter)
+        {
+        }
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public IDisposable BeginScope(object state)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IDisposable BeginScopeImpl(object state) => null;
+    }
+}

--- a/test/EntityFramework.Relational.Tests/TestUtilities/ListTelemetrySource.cs
+++ b/test/EntityFramework.Relational.Tests/TestUtilities/ListTelemetrySource.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+
+namespace Microsoft.Data.Entity.TestUtilities
+{
+    public class ListTelemetrySource : TelemetrySource
+    {
+        public ListTelemetrySource(List<Tuple<string, object>> telemetryList)
+        {
+            TelemetryList = telemetryList;
+        }
+
+        public List<Tuple<string, object>> TelemetryList { get; }
+
+        public override void WriteTelemetry(string telemetryName, object parameters)
+        {
+            TelemetryList?.Add(new Tuple<string, object>(telemetryName, parameters));
+        }
+
+        public override bool IsEnabled(string telemetryName) => true;
+    }
+}

--- a/test/EntityFramework.Relational.Tests/Update/BatchExecutorTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/BatchExecutorTest.cs
@@ -3,11 +3,9 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Update;
 using Microsoft.Data.Entity.Update.Internal;
-using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
 
@@ -30,7 +28,7 @@ namespace Microsoft.Data.Entity.Tests.Update
 
             var cancellationToken = new CancellationTokenSource().Token;
 
-            var batchExecutor = new BatchExecutorForTest();
+            var batchExecutor = new BatchExecutor();
 
             await batchExecutor.ExecuteAsync(new[] { mockModificationCommandBatch.Object }, mockRelationalConnection.Object, cancellationToken);
 
@@ -55,7 +53,7 @@ namespace Microsoft.Data.Entity.Tests.Update
 
             var cancellationToken = new CancellationTokenSource().Token;
 
-            var batchExecutor = new BatchExecutorForTest();
+            var batchExecutor = new BatchExecutor();
 
             await batchExecutor.ExecuteAsync(new[] { mockModificationCommandBatch.Object }, mockRelationalConnection.Object, cancellationToken);
 
@@ -66,14 +64,6 @@ namespace Microsoft.Data.Entity.Tests.Update
             mockModificationCommandBatch.Verify(mcb => mcb.ExecuteAsync(
                 It.IsAny<IRelationalConnection>(),
                 cancellationToken));
-        }
-
-        private class BatchExecutorForTest : BatchExecutor
-        {
-            public BatchExecutorForTest()
-                : base(new Mock<ISensitiveDataLogger<BatchExecutor>>().Object)
-            {
-            }
         }
     }
 }

--- a/test/EntityFramework.Relational.Tests/Update/CommandBatchPreparerTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/CommandBatchPreparerTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics.Tracing;
 using System.Linq;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Infrastructure;
@@ -369,9 +368,7 @@ namespace Microsoft.Data.Entity.Tests.Update
                     _commandBuilderFactory,
                     _sqlGenerator,
                     _updateSqlGenerator,
-                    _valueBufferFactoryFactory,
-                    new Mock<ISensitiveDataLogger>().Object,
-                    new TelemetryListener("Fake"));
+                    _valueBufferFactoryFactory);
         }
     }
 }

--- a/test/EntityFramework.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
@@ -622,12 +622,13 @@ namespace Microsoft.Data.Entity.Tests.Update
 
             public ModificationCommandBatchFake(IUpdateSqlGenerator sqlGenerator = null)
                 : base(
-                    new RelationalCommandBuilderFactory(new ConcreteTypeMapper()),
+                    new RelationalCommandBuilderFactory(
+                        Mock.Of<ISensitiveDataLogger<RelationalCommandBuilderFactory>>(),
+                        new TelemetryListener("Fake"),
+                        new ConcreteTypeMapper()),
                     new RelationalSqlGenerator(),
                     sqlGenerator ?? new FakeSqlGenerator(),
-                    new TypedRelationalValueBufferFactoryFactory(),
-                    new Mock<ISensitiveDataLogger>().Object,
-                    new TelemetryListener("Fake"))
+                    new TypedRelationalValueBufferFactoryFactory())
             {
                 ShouldAddCommand = true;
                 ShouldValidateSql = true;
@@ -635,12 +636,13 @@ namespace Microsoft.Data.Entity.Tests.Update
 
             public ModificationCommandBatchFake(DbDataReader reader, IUpdateSqlGenerator sqlGenerator = null)
                 : base(
-                    new RelationalCommandBuilderFactory(new ConcreteTypeMapper()),
+                    new RelationalCommandBuilderFactory(
+                        Mock.Of<ISensitiveDataLogger<RelationalCommandBuilderFactory>>(),
+                        new TelemetryListener("Fake"),
+                        new ConcreteTypeMapper()),
                     new RelationalSqlGenerator(),
                     sqlGenerator ?? new FakeSqlGenerator(),
-                    new TypedRelationalValueBufferFactoryFactory(),
-                    new Mock<ISensitiveDataLogger>().Object,
-                    new TelemetryListener("Fake"))
+                    new TypedRelationalValueBufferFactoryFactory())
             {
                 _reader = reader;
                 ShouldAddCommand = true;

--- a/test/EntityFramework.Sqlite.FunctionalTests/CommandConfigurationTest.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/CommandConfigurationTest.cs
@@ -2,15 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using Microsoft.Data.Entity.FunctionalTests;
-using Microsoft.Data.Entity.Infrastructure;
-using Microsoft.Data.Entity.Query.Expressions;
-using Microsoft.Data.Entity.Query.Internal;
-using Microsoft.Data.Entity.Query.Sql;
-using Microsoft.Data.Entity.Storage;
-using Microsoft.Data.Entity.Storage.Internal;
-using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -57,82 +49,12 @@ namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
         }
 
         [Fact]
-        public void Constructed_select_query_uses_default_when_CommandTimeout_not_configured_and_can_be_changed()
-        {
-            using (var context = new ChipsContext(_fixture.ServiceProvider))
-            {
-                var commandBuilder = SetupCommandBuilder();
-
-                var command = commandBuilder.Build(context.GetService<IRelationalConnection>(), new Dictionary<string, object>());
-
-                Assert.Equal(new SqliteCommand().CommandTimeout, command.CommandTimeout);
-
-                context.Database.SetCommandTimeout(77);
-                var command2 = commandBuilder.Build(context.GetService<IRelationalConnection>(), new Dictionary<string, object>());
-
-                Assert.Equal(77, command2.CommandTimeout);
-            }
-        }
-
-        [Fact]
-        public void Constructed_select_query_honors_latest_configured_CommandTimeout_configured_in_context()
-        {
-            using (var context = new ConfiguredChipsContext(_fixture.ServiceProvider))
-            {
-                var commandBuilder = SetupCommandBuilder();
-
-                context.Database.SetCommandTimeout(88);
-                var command = commandBuilder.Build(context.GetService<IRelationalConnection>(), new Dictionary<string, object>());
-
-                Assert.Equal(88, command.CommandTimeout);
-
-                context.Database.SetCommandTimeout(99);
-                var command2 = commandBuilder.Build(context.GetService<IRelationalConnection>(), new Dictionary<string, object>());
-
-                Assert.Equal(99, command2.CommandTimeout);
-            }
-        }
-
-        [Fact]
         public void Constructed_select_query_CommandBuilder_throws_when_negative_CommandTimeout_is_used()
         {
             using (var context = new ConfiguredChipsContext(_fixture.ServiceProvider))
             {
                 Assert.Throws<ArgumentException>(() => context.Database.SetCommandTimeout(-5));
             }
-        }
-
-        [Fact]
-        public void Constructed_select_query_CommandBuilder_uses_default_when_null()
-        {
-            using (var context = new ConfiguredChipsContext(_fixture.ServiceProvider))
-            {
-                var commandBuilder = SetupCommandBuilder();
-
-                context.Database.SetCommandTimeout(null);
-                var command = commandBuilder.Build(context.GetService<IRelationalConnection>(), new Dictionary<string, object>());
-
-                Assert.Equal(new SqliteCommand().CommandTimeout, command.CommandTimeout);
-            }
-        }
-
-        private CommandBuilder SetupCommandBuilder()
-        {
-            var commandBuilderFactory = new RelationalCommandBuilderFactory(new SqliteTypeMapper());
-            var parameterNameGeneratorFactory = new ParameterNameGeneratorFactory();
-
-            return new CommandBuilder(
-                new UntypedRelationalValueBufferFactoryFactory(),
-                new SelectExpression(
-                    new SqliteQuerySqlGeneratorFactory(
-                        commandBuilderFactory,
-                        new RelationalSqlGenerator(),
-                        parameterNameGeneratorFactory,
-                        new SqlCommandBuilder(
-                            commandBuilderFactory,
-                            new SqliteSqlGenerator(),
-                            parameterNameGeneratorFactory)))
-                    .CreateGenerator);
         }
 
         private class ChipsContext : DbContext

--- a/test/EntityFramework.Sqlite.FunctionalTests/ComplexNavigationsQuerySqliteFixture.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/ComplexNavigationsQuerySqliteFixture.cs
@@ -52,7 +52,8 @@ namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
         public override ComplexNavigationsContext CreateContext(SqliteTestStore testStore)
         {
             var optionsBuilder = new DbContextOptionsBuilder();
-            optionsBuilder.UseSqlite(testStore.Connection);
+            optionsBuilder.UseSqlite(testStore.Connection)
+                .SuppressForeignKeyEnforcement();
 
             var context = new ComplexNavigationsContext(_serviceProvider, optionsBuilder.Options);
             context.Database.UseTransaction(testStore.Transaction);

--- a/test/EntityFramework.Sqlite.FunctionalTests/DataAnnotationSqliteFixture.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/DataAnnotationSqliteFixture.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
 
             optionsBuilder
                 .UseSqlite(testStore.Connection)
+                .SuppressForeignKeyEnforcement()
                 .LogSqlParameterValues();
 
             var context = new DataAnnotationContext(_serviceProvider, optionsBuilder.Options);

--- a/test/EntityFramework.Sqlite.FunctionalTests/MappingQuerySqliteFixture.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/MappingQuerySqliteFixture.cs
@@ -28,7 +28,8 @@ namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
             _testDatabase = SqliteNorthwindContext.GetSharedStore();
 
             var optionsBuilder = new DbContextOptionsBuilder().UseModel(CreateModel());
-            optionsBuilder.UseSqlite(_testDatabase.Connection.ConnectionString);
+            optionsBuilder.UseSqlite(_testDatabase.Connection.ConnectionString)
+                .SuppressForeignKeyEnforcement();
             _options = optionsBuilder.Options;
         }
 

--- a/test/EntityFramework.Sqlite.FunctionalTests/NorthwindQuerySqliteFixture.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/NorthwindQuerySqliteFixture.cs
@@ -41,7 +41,8 @@ namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
             var optionsBuilder = new DbContextOptionsBuilder();
 
             var sqliteDbContextOptionsBuilder
-                = optionsBuilder.UseSqlite(_testStore.Connection.ConnectionString);
+                = optionsBuilder.UseSqlite(_testStore.Connection.ConnectionString)
+                    .SuppressForeignKeyEnforcement();
 
             ConfigureOptions(sqliteDbContextOptionsBuilder);
 

--- a/test/EntityFramework.Sqlite.Tests/Migrations/SqliteHistoryRepositoryTest.cs
+++ b/test/EntityFramework.Sqlite.Tests/Migrations/SqliteHistoryRepositoryTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.Tracing;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Infrastructure.Internal;
 using Microsoft.Data.Entity.Internal;
@@ -10,6 +11,7 @@ using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Migrations.Internal;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Storage.Internal;
+using Microsoft.Data.Entity.TestUtilities;
 using Moq;
 using Xunit;
 
@@ -114,7 +116,10 @@ namespace Microsoft.Data.Entity.Migrations
                     annotationsProvider,
                     new SqliteMigrationsAnnotationProvider()),
                 new SqliteMigrationsSqlGenerator(
-                    new RelationalCommandBuilderFactory(typeMapper),
+                    new RelationalCommandBuilderFactory(
+                        new FakeSensitiveDataLogger<RelationalCommandBuilderFactory>(),
+                        new TelemetryListener("Fake"),
+                        typeMapper),
                     new SqliteSqlGenerator(),
                     typeMapper,
                     annotationsProvider),

--- a/test/EntityFramework.Sqlite.Tests/Migrations/SqliteMigrationSqlGeneratorTest.cs
+++ b/test/EntityFramework.Sqlite.Tests/Migrations/SqliteMigrationSqlGeneratorTest.cs
@@ -2,11 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics.Tracing;
 using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Migrations.Operations;
-using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Storage.Internal;
+using Microsoft.Data.Entity.TestUtilities;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Migrations
@@ -20,7 +21,10 @@ namespace Microsoft.Data.Entity.Migrations
                 var typeMapper = new SqliteTypeMapper();
 
                 return new SqliteMigrationsSqlGenerator(
-                    new RelationalCommandBuilderFactory(typeMapper),
+                    new RelationalCommandBuilderFactory(
+                        new FakeSensitiveDataLogger<RelationalCommandBuilderFactory>(),
+                        new TelemetryListener("Fake"),
+                        typeMapper),
                     new SqliteSqlGenerator(),
                     typeMapper,
                     new SqliteAnnotationProvider());


### PR DESCRIPTION
Incremental change for #3110 
Fix #3205 - `SqliteRelationalConnection`

Additional work to be done relates to fixing calls on `SqlStatementExecutor.ExecuteReader` which currently do not dispose `DbCommands`, removing `CreateDbCommand` from the public interface of `IRelationalCommand`, and general cleanup to consumers of the new API