### PR TITLE
Improvements to SQLite metadata reader

### DIFF
--- a/src/EntityFramework.MicrosoftSqlServer.Design/Properties/SqlServerDesignStrings.Designer.cs
+++ b/src/EntityFramework.MicrosoftSqlServer.Design/Properties/SqlServerDesignStrings.Designer.cs
@@ -29,14 +29,6 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
-        /// For column {columnId}. Could not find type mapping for SQL Server type {sqlServerDataType}. Skipping column.
-        /// </summary>
-        public static string CannotFindTypeMappingForColumn([CanBeNull] object columnId, [CanBeNull] object sqlServerDataType)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("CannotFindTypeMappingForColumn", "columnId", "sqlServerDataType"), columnId, sqlServerDataType);
-        }
-
-        /// <summary>
         /// Unable to interpret the string {sqlServerStringLiteral} as a SQLServer string literal.
         /// </summary>
         public static string CannotInterpretSqlServerStringLiteral([CanBeNull] object sqlServerStringLiteral)

--- a/src/EntityFramework.MicrosoftSqlServer.Design/Properties/SqlServerDesignStrings.resx
+++ b/src/EntityFramework.MicrosoftSqlServer.Design/Properties/SqlServerDesignStrings.resx
@@ -123,9 +123,6 @@
   <data name="CannotFindRelationalPropertyForColumnId" xml:space="preserve">
     <value>For foreign key ConstraintId {constraintId}, could not find relational property mapped to ToColumn {toColumnId}. Skipping generation of ForeignKey.</value>
   </data>
-  <data name="CannotFindTypeMappingForColumn" xml:space="preserve">
-    <value>For column {columnId}. Could not find type mapping for SQL Server type {sqlServerDataType}. Skipping column.</value>
-  </data>
   <data name="CannotInterpretSqlServerStringLiteral" xml:space="preserve">
     <value>Unable to interpret the string {sqlServerStringLiteral} as a SQLServer string literal.</value>
   </data>

--- a/src/EntityFramework.MicrosoftSqlServer.Design/ReverseEngineering/SqlServerMetadataModelProvider.cs
+++ b/src/EntityFramework.MicrosoftSqlServer.Design/ReverseEngineering/SqlServerMetadataModelProvider.cs
@@ -223,7 +223,7 @@ namespace Microsoft.Data.Entity.SqlServer.Design.ReverseEngineering
                 if (clrPropertyType == null)
                 {
                     Logger.LogWarning(
-                        SqlServerDesignStrings.CannotFindTypeMappingForColumn(tc.Id, tc.DataType));
+                        RelationalDesignStrings.CannotFindTypeMappingForColumn(tc.Id, tc.DataType));
                     continue;
                 }
 

--- a/src/EntityFramework.Relational.Design/Model/Column.cs
+++ b/src/EntityFramework.Relational.Design/Model/Column.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Data.Entity.Relational.Design.Model
     {
         public virtual Table Table { get; [param: NotNull] set; }
         public virtual string Name { get; [param: NotNull] set; }
-        public virtual bool IsPrimaryKey { get; [param: NotNull] set; }
+        public virtual int? PrimaryKeyOrdinal { get; [param: NotNull] set; }
         public virtual int Ordinal { get; [param: NotNull] set; }
         public virtual bool IsNullable { get; [param: NotNull] set; }
 
@@ -23,6 +23,7 @@ namespace Microsoft.Data.Entity.Relational.Design.Model
         public virtual int? Precision { get; [param: CanBeNull] set; }
         public virtual int? Scale { get; [param: CanBeNull] set; }
         public virtual bool? IsStoreGenerated { get; [param: CanBeNull] set; }
+        public virtual bool? IsComputed { get; [param: CanBeNull] set; }
         // SQL Server
         public virtual bool? IsIdentity { get; [param: CanBeNull] set; }
     }

--- a/src/EntityFramework.Relational.Design/Properties/RelationalDesignStrings.Designer.cs
+++ b/src/EntityFramework.Relational.Design/Properties/RelationalDesignStrings.Designer.cs
@@ -13,6 +13,14 @@ namespace Microsoft.Data.Entity.Internal
             = new ResourceManager("EntityFramework.Relational.Design.RelationalDesignStrings", typeof(RelationalDesignStrings).GetTypeInfo().Assembly);
 
         /// <summary>
+        /// Could not find type mapping for column {columnName} width data type {dateType}. Skipping column.
+        /// </summary>
+        public static string CannotFindTypeMappingForColumn([CanBeNull] object columnName, [CanBeNull] object dateType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("CannotFindTypeMappingForColumn", "columnName", "dateType"), columnName, dateType);
+        }
+
+        /// <summary>
         /// ConnectionString is required to generate code.
         /// </summary>
         public static string ConnectionStringRequired

--- a/src/EntityFramework.Relational.Design/Properties/RelationalDesignStrings.resx
+++ b/src/EntityFramework.Relational.Design/Properties/RelationalDesignStrings.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="CannotFindTypeMappingForColumn" xml:space="preserve">
+    <value>Could not find type mapping for column {columnName} with data type {dateType}. Skipping column.</value>
+  </data>
   <data name="ConnectionStringRequired" xml:space="preserve">
     <value>ConnectionString is required to generate code.</value>
   </data>

--- a/src/EntityFramework.Relational.Design/ReverseEngineering/ReverseEngineeringGenerator.cs
+++ b/src/EntityFramework.Relational.Design/ReverseEngineering/ReverseEngineeringGenerator.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
-using Microsoft.Data.Entity.Relational.Design.ReverseEngineering.Configuration;
 using Microsoft.Data.Entity.Relational.Design.Utilities;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Extensions.Logging;

--- a/src/EntityFramework.Relational/Storage/RelationalTypeMapping.cs
+++ b/src/EntityFramework.Relational/Storage/RelationalTypeMapping.cs
@@ -13,20 +13,25 @@ namespace Microsoft.Data.Entity.Storage
     {
         public static readonly RelationalTypeMapping NullMapping = new RelationalTypeMapping("NULL");
 
+        public RelationalTypeMapping([NotNull] string defaultTypeName, [NotNull] Type clrType, [CanBeNull] DbType? storeType)
+            : this(defaultTypeName, clrType)
+        {
+            StoreType = storeType;
+        }
+
+        public RelationalTypeMapping([NotNull] string defaultTypeName, [NotNull] Type clrType)
+            : this(defaultTypeName)
+        {
+            Check.NotNull(clrType, nameof(clrType));
+
+            ClrType = clrType;
+        }
+
         private RelationalTypeMapping([NotNull] string defaultTypeName)
         {
             Check.NotEmpty(defaultTypeName, nameof(defaultTypeName));
 
             DefaultTypeName = defaultTypeName;
-        }
-
-        public RelationalTypeMapping([NotNull] string defaultTypeName, [NotNull] Type clrType, DbType? storeType = null)
-            : this(defaultTypeName)
-        {
-            Check.NotNull(clrType, nameof(clrType));
-
-            StoreType = storeType;
-            ClrType = clrType;
         }
 
         public virtual string DefaultTypeName { get; }

--- a/src/EntityFramework.Sqlite.Design/EntityFramework.Sqlite.Design.csproj
+++ b/src/EntityFramework.Sqlite.Design/EntityFramework.Sqlite.Design.csproj
@@ -56,6 +56,8 @@
       <DependentUpon>Resources.tt</DependentUpon>
     </Compile>
     <Compile Include="ReverseEngineering\Configuration\SqliteModelConfiguration.cs" />
+    <Compile Include="ReverseEngineering\CSharpUniqueNamer.cs" />
+    <Compile Include="ReverseEngineering\CSharpNamer.cs" />
     <Compile Include="ReverseEngineering\SqliteConfigurationFactory.cs" />
     <Compile Include="ReverseEngineering\TableSelectionSetSqliteExtensions.cs" />
     <Compile Include="SqliteDesignTimeServices.cs" />

--- a/src/EntityFramework.Sqlite.Design/ReverseEngineering/CSharpNamer.cs
+++ b/src/EntityFramework.Sqlite.Design/ReverseEngineering/CSharpNamer.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Relational.Design.Utilities;
+using Microsoft.Data.Entity.Utilities;
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Data.Entity.Sqlite.Design.ReverseEngineering
+{
+    public class CSharpNamer<T>
+    {
+        private readonly Func<T, string> _nameGetter;
+        private Dictionary<T, string> _nameCache = new Dictionary<T, string>();
+
+        public CSharpNamer([NotNull] Func<T, string> nameGetter)
+        {
+            Check.NotNull(nameGetter, nameof(nameGetter));
+
+            _nameGetter = nameGetter;
+        }
+
+        public virtual string GetName([NotNull] T item)
+        {
+            Check.NotNull(item, nameof(item));
+
+            if (_nameCache.ContainsKey(item))
+            {
+                return _nameCache[item];
+            }
+
+            var name = CSharpUtilities.Instance.GenerateCSharpIdentifier(GenerateName(item), null);
+            _nameCache.Add(item, name);
+            return name;
+        }
+
+        protected virtual string GenerateName([NotNull] T item)
+            => _nameGetter(item);
+    }
+}

--- a/src/EntityFramework.Sqlite.Design/ReverseEngineering/CSharpUniqueNamer.cs
+++ b/src/EntityFramework.Sqlite.Design/ReverseEngineering/CSharpUniqueNamer.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Data.Entity.Sqlite.Design.ReverseEngineering
+{
+    public class CSharpUniqueNamer<T> : CSharpNamer<T>
+    {
+        private HashSet<string> _usedNames = new HashSet<string>();
+
+        public CSharpUniqueNamer([NotNull] Func<T, string> nameGetter)
+            :base(nameGetter)
+        {
+        }
+
+        protected override string GenerateName([NotNull] T item)
+        {
+            var input = base.GenerateName(item);
+            var name = input;
+            var suffix = 1;
+
+            while (_usedNames.Contains(name))
+            {
+                name = input + (suffix++);
+            }
+
+            _usedNames.Add(name);
+            return name;
+        }
+    }
+}

--- a/src/EntityFramework.Sqlite.Design/ReverseEngineering/SqliteMetadataReader.cs
+++ b/src/EntityFramework.Sqlite.Design/ReverseEngineering/SqliteMetadataReader.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Data.Entity.Sqlite.Design.ReverseEngineering
                             Table = table,
                             Name = reader.GetString((int)TableInfoColumns.Name),
                             DataType = typeName,
-                            IsPrimaryKey = reader.GetBoolean((int)TableInfoColumns.Pk),
+                            PrimaryKeyOrdinal = isPk ? reader.GetInt32((int)TableInfoColumns.Pk) : default(int?),
                             IsNullable = !notNull,
                             DefaultValue = reader.GetValue((int)TableInfoColumns.DefaultValue) as string,
                             Ordinal = ordinal++

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/SqlServerE2ETests.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/SqlServerE2ETests.cs
@@ -144,13 +144,13 @@ namespace Microsoft.Data.Entity.SqlServer.Design.FunctionalTests.ReverseEngineer
             {
                 Warn =
                         {
-                            @"For column [dbo][AllDataTypes][hierarchyidColumn]. Could not find type mapping for SQL Server type hierarchyid. Skipping column.",
-                            @"For column [dbo][AllDataTypes][sql_variantColumn]. Could not find type mapping for SQL Server type sql_variant. Skipping column.",
-                            @"For column [dbo][AllDataTypes][xmlColumn]. Could not find type mapping for SQL Server type xml. Skipping column.",
-                            @"For column [dbo][AllDataTypes][geographyColumn]. Could not find type mapping for SQL Server type geography. Skipping column.",
-                            @"For column [dbo][AllDataTypes][geometryColumn]. Could not find type mapping for SQL Server type geometry. Skipping column.",
+                            @"Could not find type mapping for column [dbo][AllDataTypes][hierarchyidColumn] with data type hierarchyid. Skipping column.",
+                            @"Could not find type mapping for column [dbo][AllDataTypes][sql_variantColumn] with data type sql_variant. Skipping column.",
+                            @"Could not find type mapping for column [dbo][AllDataTypes][xmlColumn] with data type xml. Skipping column.",
+                            @"Could not find type mapping for column [dbo][AllDataTypes][geographyColumn] with data type geography. Skipping column.",
+                            @"Could not find type mapping for column [dbo][AllDataTypes][geometryColumn] with data type geometry. Skipping column.",
                             @"For column [dbo][PropertyConfiguration][PropertyConfigurationID]. This column is set up as an Identity column, but the SQL Server data type is tinyint. This will be mapped to CLR type byte which does not allow the SqlServerValueGenerationStrategy.IdentityColumn setting. Generating a matching Property but ignoring the Identity setting.",
-                            @"For column [dbo][TableWithUnmappablePrimaryKeyColumn][TableWithUnmappablePrimaryKeyColumnID]. Could not find type mapping for SQL Server type hierarchyid. Skipping column.",
+                            @"Could not find type mapping for column [dbo][TableWithUnmappablePrimaryKeyColumn][TableWithUnmappablePrimaryKeyColumnID] with data type hierarchyid. Skipping column.",
                             @"Unable to identify any primary key columns in the underlying SQL Server table [dbo].[TableWithUnmappablePrimaryKeyColumn]."
                         }
             });
@@ -191,13 +191,13 @@ namespace Microsoft.Data.Entity.SqlServer.Design.FunctionalTests.ReverseEngineer
             {
                 Warn =
                         {
-                            @"For column [dbo][AllDataTypes][hierarchyidColumn]. Could not find type mapping for SQL Server type hierarchyid. Skipping column.",
-                            @"For column [dbo][AllDataTypes][sql_variantColumn]. Could not find type mapping for SQL Server type sql_variant. Skipping column.",
-                            @"For column [dbo][AllDataTypes][xmlColumn]. Could not find type mapping for SQL Server type xml. Skipping column.",
-                            @"For column [dbo][AllDataTypes][geographyColumn]. Could not find type mapping for SQL Server type geography. Skipping column.",
-                            @"For column [dbo][AllDataTypes][geometryColumn]. Could not find type mapping for SQL Server type geometry. Skipping column.",
+                            @"Could not find type mapping for column [dbo][AllDataTypes][hierarchyidColumn] with data type hierarchyid. Skipping column.",
+                            @"Could not find type mapping for column [dbo][AllDataTypes][sql_variantColumn] with data type sql_variant. Skipping column.",
+                            @"Could not find type mapping for column [dbo][AllDataTypes][xmlColumn] with data type xml. Skipping column.",
+                            @"Could not find type mapping for column [dbo][AllDataTypes][geographyColumn] with data type geography. Skipping column.",
+                            @"Could not find type mapping for column [dbo][AllDataTypes][geometryColumn] with data type geometry. Skipping column.",
                             @"For column [dbo][PropertyConfiguration][PropertyConfigurationID]. This column is set up as an Identity column, but the SQL Server data type is tinyint. This will be mapped to CLR type byte which does not allow the SqlServerValueGenerationStrategy.IdentityColumn setting. Generating a matching Property but ignoring the Identity setting.",
-                            @"For column [dbo][TableWithUnmappablePrimaryKeyColumn][TableWithUnmappablePrimaryKeyColumnID]. Could not find type mapping for SQL Server type hierarchyid. Skipping column.",
+                            @"Could not find type mapping for column [dbo][TableWithUnmappablePrimaryKeyColumn][TableWithUnmappablePrimaryKeyColumnID] with data type hierarchyid. Skipping column.",
                             @"Unable to identify any primary key columns in the underlying SQL Server table [dbo].[TableWithUnmappablePrimaryKeyColumn]."
                         }
             });

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/SqlServerMetadataReaderTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/SqlServerMetadataReaderTest.cs
@@ -67,8 +67,8 @@ CREATE TABLE [dbo].[Denali] ( id int );";
             Assert.Equal("Mountains", fk.Table.Name);
             Assert.Equal("dbo", fk.PrincipalTable.SchemaName);
             Assert.Equal("Ranges", fk.PrincipalTable.Name);
-            Assert.Equal(new [] { "RangeId", "RangeAltId"}, fk.From.Select(c=>c.Name).ToArray());
-            Assert.Equal(new [] { "Id", "AltId"}, fk.To.Select(c=>c.Name).ToArray());
+            Assert.Equal(new[] { "RangeId", "RangeAltId" }, fk.From.Select(c => c.Name).ToArray());
+            Assert.Equal(new[] { "Id", "AltId" }, fk.To.Select(c => c.Name).ToArray());
         }
 
         [Fact]
@@ -104,9 +104,12 @@ CREATE TABLE [dbo].[Denali] ( id int );";
         {
             var sql = @"
 CREATE TABLE [dbo].[Mountains] (
-    Id int PRIMARY KEY,
+    Id int,
     Name nvarchar(100) NOT NULL,
-    Latitude decimal( 5, 2 ) DEFAULT 0.0
+    Latitude decimal( 5, 2 ) DEFAULT 0.0,
+    Created datetime2(6),
+    Sum AS Latitude + 1.0,
+    Primary Key (Name, Id)
 );";
             var dbInfo = GetDatabaseInfo(sql);
 
@@ -123,7 +126,7 @@ CREATE TABLE [dbo].[Mountains] (
                     {
                         Assert.Equal("Id", id.Name);
                         Assert.Equal("int", id.DataType);
-                        Assert.True(id.IsPrimaryKey);
+                        Assert.Equal(2, id.PrimaryKeyOrdinal);
                         Assert.False(id.IsNullable);
                         Assert.Equal(0, id.Ordinal);
                         Assert.Null(id.DefaultValue);
@@ -132,7 +135,7 @@ CREATE TABLE [dbo].[Mountains] (
                     {
                         Assert.Equal("Name", name.Name);
                         Assert.Equal("nvarchar", name.DataType);
-                        Assert.False(name.IsPrimaryKey);
+                        Assert.Equal(1, name.PrimaryKeyOrdinal);
                         Assert.False(name.IsNullable);
                         Assert.Equal(1, name.Ordinal);
                         Assert.Null(name.DefaultValue);
@@ -142,12 +145,23 @@ CREATE TABLE [dbo].[Mountains] (
                     {
                         Assert.Equal("Latitude", lat.Name);
                         Assert.Equal("decimal", lat.DataType);
-                        Assert.False(lat.IsPrimaryKey);
+                        Assert.Null(lat.PrimaryKeyOrdinal);
                         Assert.True(lat.IsNullable);
                         Assert.Equal(2, lat.Ordinal);
                         Assert.Equal("((0.0))", lat.DefaultValue);
                         Assert.Equal(5, lat.Precision);
                         Assert.Equal(2, lat.Scale);
+                        Assert.Null(lat.MaxLength);
+                    },
+                created =>
+                    {
+                        Assert.Equal("Created", created.Name);
+                        Assert.Equal(6, created.Scale);
+                    },
+                sum =>
+                    {
+                        Assert.Equal("Sum", sum.Name);
+                        Assert.True(sum.IsComputed);
                     });
         }
 

--- a/test/EntityFramework.Relational.Design.Tests/EntityFramework.Relational.Design.Tests.csproj
+++ b/test/EntityFramework.Relational.Design.Tests/EntityFramework.Relational.Design.Tests.csproj
@@ -46,6 +46,10 @@
       <Project>{7028a7e3-0ad8-4606-a922-8189c8a704e0}</Project>
       <Name>EntityFramework.Relational.Design</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\src\EntityFramework.Relational\EntityFramework.Relational.csproj">
+      <Project>{75c5a774-a3f3-43eb-97d3-dbe0cf2825d8}</Project>
+      <Name>EntityFramework.Relational</Name>
+    </ProjectReference>
     <ProjectReference Include="..\EntityFramework.Core.Tests\EntityFramework.Core.Tests.csproj">
       <Project>{ef361118-7d0d-453e-ada4-2f24fbee196c}</Project>
       <Name>EntityFramework.Core.Tests</Name>

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/FkToAltKey/FkToAltKeyContext.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/FkToAltKey/FkToAltKeyContext.expected
@@ -14,22 +14,12 @@ namespace E2E.Sqlite
         {
             modelBuilder.Entity<Comment>(entity =>
             {
-                entity.Property(e => e.Id).HasColumnType("INTEGER");
-
-                entity.Property(e => e.Contents).HasColumnType("TEXT");
-
-                entity.Property(e => e.UserAltId).HasColumnType("INTEGER");
-
                 entity.HasOne(d => d.UserAlt).WithMany(p => p.Comment).HasPrincipalKey(p => p.AltId).HasForeignKey(d => d.UserAltId);
             });
 
             modelBuilder.Entity<User>(entity =>
             {
                 entity.HasAlternateKey(e => e.AltId);
-
-                entity.Property(e => e.Id).HasColumnType("INTEGER");
-
-                entity.Property(e => e.AltId).HasColumnType("INTEGER");
             });
         }
 

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/OneToMany/OneToManyFluentApiContext.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/OneToMany/OneToManyFluentApiContext.expected
@@ -39,9 +39,7 @@ namespace E2E.Sqlite
 
                 entity.Property(e => e.OneToManyPrincipalID2).HasColumnType("INT");
 
-                entity.Property(e => e.Other)
-                    .IsRequired()
-                    .HasColumnType("TEXT");
+                entity.Property(e => e.Other).IsRequired();
             });
         }
 

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/OneToOne/OneToOneFluentApiContext.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/OneToOne/OneToOneFluentApiContext.expected
@@ -22,11 +22,6 @@ namespace E2E.Sqlite
 
                 entity.HasOne(d => d.Principal).WithOne(p => p.Dependent).HasForeignKey<Dependent>(d => d.PrincipalId);
             });
-
-            modelBuilder.Entity<Principal>(entity =>
-            {
-                entity.Property(e => e.Id).HasColumnType("INTEGER");
-            });
         }
 
         public virtual DbSet<Dependent> Dependent { get; set; }

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/SelfRef/SelfRefFluentApiContext.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/SelfRef/SelfRefFluentApiContext.expected
@@ -14,10 +14,6 @@ namespace E2E.Sqlite
         {
             modelBuilder.Entity<SelfRef>(entity =>
             {
-                entity.Property(e => e.Id).HasColumnType("INTEGER");
-
-                entity.Property(e => e.SelfForeignKey).HasColumnType("INTEGER");
-
                 entity.HasOne(d => d.SelfForeignKeyNavigation).WithMany(p => p.InverseSelfForeignKeyNavigation).HasForeignKey(d => d.SelfForeignKey);
             });
         }

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/FkToAltKey/FkToAltKeyContext.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/FkToAltKey/FkToAltKeyContext.expected
@@ -14,22 +14,12 @@ namespace E2E.Sqlite
         {
             modelBuilder.Entity<Comment>(entity =>
             {
-                entity.Property(e => e.Id).HasColumnType("INTEGER");
-
-                entity.Property(e => e.Contents).HasColumnType("TEXT");
-
-                entity.Property(e => e.UserAltId).HasColumnType("INTEGER");
-
                 entity.HasOne(d => d.UserAlt).WithMany(p => p.Comment).HasPrincipalKey(p => p.AltId).HasForeignKey(d => d.UserAltId);
             });
 
             modelBuilder.Entity<User>(entity =>
             {
                 entity.HasAlternateKey(e => e.AltId);
-
-                entity.Property(e => e.Id).HasColumnType("INTEGER");
-
-                entity.Property(e => e.AltId).HasColumnType("INTEGER");
             });
         }
 

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/OneToMany/OneToManyAttributesContext.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/OneToMany/OneToManyAttributesContext.expected
@@ -34,8 +34,6 @@ namespace E2E.Sqlite
                 entity.Property(e => e.OneToManyPrincipalID1).HasColumnType("INT");
 
                 entity.Property(e => e.OneToManyPrincipalID2).HasColumnType("INT");
-
-                entity.Property(e => e.Other).HasColumnType("TEXT");
             });
         }
 

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/OneToOne/OneToOneAttributesContext.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/OneToOne/OneToOneAttributesContext.expected
@@ -20,11 +20,6 @@ namespace E2E.Sqlite
 
                 entity.Property(e => e.PrincipalId).HasColumnType("INT");
             });
-
-            modelBuilder.Entity<Principal>(entity =>
-            {
-                entity.Property(e => e.Id).HasColumnType("INTEGER");
-            });
         }
 
         public virtual DbSet<Dependent> Dependent { get; set; }

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/SelfRef/SelfRefAttributesContext.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/SelfRef/SelfRefAttributesContext.expected
@@ -12,12 +12,6 @@ namespace E2E.Sqlite
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.Entity<SelfRef>(entity =>
-            {
-                entity.Property(e => e.Id).HasColumnType("INTEGER");
-
-                entity.Property(e => e.SelfForeignKey).HasColumnType("INTEGER");
-            });
         }
 
         public virtual DbSet<SelfRef> SelfRef { get; set; }

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/SqliteMetadataModelProviderTest.cs
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/SqliteMetadataModelProviderTest.cs
@@ -17,6 +17,7 @@ using Microsoft.Data.Entity.Sqlite.FunctionalTests;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Xunit;
+using Microsoft.Data.Entity.Relational.Design.ReverseEngineering.Internal;
 
 namespace EntityFramework.Sqlite.Design.FunctionalTests
 {
@@ -52,7 +53,7 @@ namespace EntityFramework.Sqlite.Design.FunctionalTests
             var entityType = GetModel(@"CREATE TABLE ""Column Types"" (
                                         col1 text,
                                         col2 unsigned big int );")
-                .GetEntityType("Column Types");
+                .GetEntityType("Column_Types");
 
             Assert.NotNull(entityType);
             Assert.Equal("Column Types", entityType.Sqlite().TableName);
@@ -128,7 +129,7 @@ namespace EntityFramework.Sqlite.Design.FunctionalTests
                 columns,
                 idx.Properties.Select(c => c.Sqlite().ColumnName).ToArray());
 
-            var props = columns.Select(c => entityType.GetProperty(c)).ToArray();
+            var props = columns.Select(c => entityType.GetProperties().First(p=>p.Sqlite().ColumnName == c)).ToArray();
             var key = entityType.FindKey(props);
 
             Assert.NotNull(key);
@@ -313,7 +314,7 @@ CREATE TABLE Gum ( A, B,
         private IModel GetModel(string createSql)
         {
             _testStore.ExecuteNonQuery(createSql);
-            return _metadataModelProvider.ConstructRelationalModel(_testStore.Connection.ConnectionString);
+            return _metadataModelProvider.GenerateMetadataModel(_testStore.Connection.ConnectionString, TableSelectionSet.InclusiveAll);
         }
     }
 

--- a/test/EntityFramework.Sqlite.Design.Tests/CSharpNamerTest.cs
+++ b/test/EntityFramework.Sqlite.Design.Tests/CSharpNamerTest.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Sqlite.Design.ReverseEngineering;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Sqlite.Design
+{
+    public class CSharpNamerTest
+    {
+        [Theory]
+        [InlineData("Name with space", "Name_with_space")]
+        [InlineData("namespace", "_namespace")]
+        [InlineData("@namespace", "@namespace")]
+        [InlineData("8ball", "_8ball")]
+        public void Sanitizes_name(string input, string output)
+        {
+            Assert.Equal(output, new CSharpNamer<string>(s => s).GetName(input));
+        }
+    }
+}

--- a/test/EntityFramework.Sqlite.Design.Tests/CSharpUniqueNamerTest.cs
+++ b/test/EntityFramework.Sqlite.Design.Tests/CSharpUniqueNamerTest.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Relational.Design.Model;
+using Microsoft.Data.Entity.Sqlite.Design.ReverseEngineering;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Sqlite.Design
+{
+    public class CSharpUniqueNamerTest
+    {
+        [Fact]
+        public void Returns_unique_name_for_type()
+        {
+            var namer = new CSharpUniqueNamer<Column>(s => s.Name);
+            var input1 = new Column
+            {
+                Name = "Id"
+            };
+            var input2 = new Column
+            {
+                Name = "Id"
+            };
+
+            Assert.Equal("Id", namer.GetName(input1));
+            Assert.Equal("Id", namer.GetName(input1));
+
+            Assert.Equal("Id1", namer.GetName(input2));
+        }
+    }
+}

--- a/test/EntityFramework.Sqlite.Design.Tests/EntityFramework.Sqlite.Design.Tests.csproj
+++ b/test/EntityFramework.Sqlite.Design.Tests/EntityFramework.Sqlite.Design.Tests.csproj
@@ -42,12 +42,24 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ApiConsistencyTest.cs" />
+    <Compile Include="CSharpUniqueNamerTest.cs" />
+    <Compile Include="CSharpNamerTest.cs" />
+    <Compile Include="RelationalMetadataModelProviderTest.cs" />
     <Compile Include="SqliteDmlParserTest.cs" />
+    <Compile Include="TestLogger.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\src\EntityFramework.Core\EntityFramework.Core.csproj">
+      <Project>{71415cec-8111-4c73-8751-512d22f10602}</Project>
+      <Name>EntityFramework.Core</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\EntityFramework.Relational.Design\EntityFramework.Relational.Design.csproj">
       <Project>{7028A7E3-0AD8-4606-A922-8189C8A704E0}</Project>
       <Name>EntityFramework.Relational.Design</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\EntityFramework.Relational\EntityFramework.Relational.csproj">
+      <Project>{75c5a774-a3f3-43eb-97d3-dbe0cf2825d8}</Project>
+      <Name>EntityFramework.Relational</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\src\EntityFramework.Sqlite.Design\EntityFramework.Sqlite.Design.csproj">
       <Project>{2fa76686-11eb-4a4c-b3e2-1fdaf29e4a62}</Project>

--- a/test/EntityFramework.Sqlite.Design.Tests/RelationalMetadataModelProviderTest.cs
+++ b/test/EntityFramework.Sqlite.Design.Tests/RelationalMetadataModelProviderTest.cs
@@ -1,0 +1,568 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Internal;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Relational.Design;
+using Microsoft.Data.Entity.Relational.Design.Model;
+using Microsoft.Data.Entity.Relational.Design.ReverseEngineering.Internal;
+using Microsoft.Data.Entity.Relational.Design.Utilities;
+using Microsoft.Data.Entity.Sqlite.Design.ReverseEngineering;
+using Microsoft.Data.Entity.Storage;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using ForeignKey = Microsoft.Data.Entity.Relational.Design.Model.ForeignKey;
+using Index = Microsoft.Data.Entity.Relational.Design.Model.Index;
+
+namespace Microsoft.Data.Entity.Sqlite.Design
+{
+    public class RelationalMetadataModelProviderTest
+    {
+        private readonly FakeMetadataModelProvider _provider;
+        private readonly TestLogger _logger;
+
+        public RelationalMetadataModelProviderTest()
+        {
+            var factory = new TestLoggerFactory();
+            _logger = factory.Logger;
+
+            _provider = new FakeMetadataModelProvider(factory);
+        }
+
+        [Fact]
+        public void Creates_entity_types()
+        {
+            var info = new SchemaInfo
+            {
+                Tables =
+                {
+                    new Table { Name = "tableWithSchema", SchemaName = "public" },
+                    new Table { Name = "noSchema" }
+                }
+            };
+            var model = _provider.GetModel(info);
+            Assert.Collection(model.EntityTypes.OrderBy(t => t.Name).Cast<EntityType>(),
+                table =>
+                    {
+                        Assert.Equal("noSchema", table.Relational().TableName);
+                        Assert.Null(table.Relational().Schema);
+                    },
+                pgtable =>
+                    {
+                        Assert.Equal("tableWithSchema", pgtable.Relational().TableName);
+                        Assert.Equal("public", pgtable.Relational().Schema);
+                    }
+                );
+        }
+
+        [Fact]
+        public void Loads_column_types()
+        {
+            var info = new SchemaInfo
+            {
+                Tables =
+                {
+                    new Table
+                    {
+                        Name = "Jobs",
+                        Columns =
+                        {
+                            new Column
+                            {
+                                Name = "occupation",
+                                DataType = "string",
+                                DefaultValue = "\"dev\"",
+                            },
+                            new Column
+                            {
+                                Name = "salary",
+                                DataType = "long",
+                                IsNullable = true,
+                                MaxLength = 100,
+
+                            },
+                            new Column
+                            {
+                                Name = "modified",
+                                DataType = "string",
+                                IsNullable = false,
+                                IsComputed = true,
+                            },
+                            new Column
+                            {
+                                Name = "created",
+                                DataType = "string",
+                                IsStoreGenerated = true
+                            }
+                        }
+                    }
+                }
+            };
+
+            var entityType = (EntityType)_provider.GetModel(info).GetEntityType("Jobs");
+
+            Assert.Collection(entityType.Properties,
+                col4 =>
+                    {
+                        Assert.Equal("created", col4.Relational().ColumnName);
+                        Assert.Equal(ValueGenerated.OnAdd, col4.ValueGenerated);
+                    },
+                col3 =>
+                    {
+                        Assert.Equal("modified", col3.Relational().ColumnName);
+                        Assert.Equal(ValueGenerated.OnAddOrUpdate, col3.ValueGenerated);
+                    },
+                col1 =>
+                    {
+                        Assert.Equal("occupation", col1.Relational().ColumnName);
+                        Assert.Equal(typeof(string), col1.ClrType);
+                        Assert.False(col1.IsColumnNullable());
+                        Assert.Null(col1.GetMaxLength());
+                        Assert.Equal("\"dev\"", col1.Relational().GeneratedValueSql);
+                    },
+                col2 =>
+                    {
+                        Assert.Equal(typeof(long?), col2.ClrType);
+                        Assert.True(col2.IsColumnNullable());
+                        Assert.Equal(100, col2.GetMaxLength());
+                        Assert.Null(col2.Relational().DefaultValue);
+                    });
+
+            Assert.Contains(SqliteDesignStrings.MissingPrimaryKey("Jobs"), _logger.FullLog);
+        }
+
+        [Theory]
+        [InlineData("string", null)]
+        [InlineData("alias for string", "alias for string")]
+        public void Column_type_annotation(string dataType, string expectedColumnType)
+        {
+            var info = new SchemaInfo
+            {
+                Tables =
+                {
+                    new Table
+                    {
+                        Name = "A",
+                        Columns =
+                        {
+                            new Column
+                            {
+                                Name = "Col",
+                                DataType = dataType
+                            }
+                        }
+                    }
+                }
+            };
+            var property = (Property)_provider.GetModel(info).GetEntityType("A").GetProperty("Col");
+            Assert.Equal(expectedColumnType, property.Relational().ColumnType);
+        }
+
+        [Theory]
+        [InlineData("cheese")]
+        [InlineData(null)]
+        public void Unmappable_column_type(string dataType)
+        {
+            var info = new SchemaInfo { Tables = { new Table { Name = "E" } } };
+            info.Tables[0].Columns.Add(new Column
+            {
+                Table = info.Tables[0],
+                Name = "Coli",
+                DataType = dataType
+            });
+            Assert.Empty(_provider.GetModel(info).GetEntityType("E").GetProperties());
+            Assert.Contains(RelationalDesignStrings.CannotFindTypeMappingForColumn("E.Coli", dataType), _logger.FullLog);
+        }
+
+        [Theory]
+        [InlineData(new[] { "Id" }, 1)]
+        [InlineData(new[] { "Id", "AltId" }, 2)]
+        public void Primary_key(string[] keyProps, int length)
+
+        {
+            var ordinal = 3;
+            var info = new SchemaInfo
+            {
+                Tables =
+                {
+                    new Table
+                    {
+                        Name = "PkTable",
+                        Columns = keyProps.Select(k => new Column { PrimaryKeyOrdinal = ordinal++, Name = k, DataType = "long" }).ToList()
+                    }
+                }
+            };
+            var model = (EntityType)_provider.GetModel(info).EntityTypes.Single();
+
+            Assert.Equal(keyProps, model.GetPrimaryKey().Properties.Select(p => p.Relational().ColumnName).ToArray());
+        }
+
+        [Fact]
+        public void Indexes_and_alternate_keys()
+        {
+            var table = new Table
+            {
+                Name = "T",
+                Columns =
+                {
+                    new Column { Name = "C1", DataType = "long" },
+                    new Column { Name = "C2", DataType = "long" },
+                    new Column { Name = "C3", DataType = "long" }
+                }
+            };
+            table.Indexes.Add(new Index { Name = "IDX_C1", Columns = { table.Columns[0] }, IsUnique = false });
+            table.Indexes.Add(new Index { Name = "UNQ_C2", Columns = { table.Columns[1] }, IsUnique = true });
+            table.Indexes.Add(new Index { Name = "IDX_C2_C1", Columns = { table.Columns[1], table.Columns[0] }, IsUnique = false });
+            table.Indexes.Add(new Index { /*Name ="UNQ_C3_C1",*/ Columns = { table.Columns[2], table.Columns[0] }, IsUnique = true });
+            var info = new SchemaInfo { Tables = { table } };
+
+            var entityType = (EntityType)_provider.GetModel(info).EntityTypes.Single();
+
+            Assert.Collection(entityType.Indexes,
+                indexColumn1 =>
+                    {
+                        Assert.False(indexColumn1.IsUnique);
+                        Assert.Equal("IDX_C1", indexColumn1.Relational().Name);
+                        Assert.Same(entityType.GetProperty("C1"), indexColumn1.Properties.Single());
+                    },
+                uniqueColumn2 =>
+                    {
+                        Assert.True(uniqueColumn2.IsUnique);
+                        Assert.Same(entityType.GetProperty("C2"), uniqueColumn2.Properties.Single());
+                    },
+                indexColumn2Column1 =>
+                    {
+                        Assert.False(indexColumn2Column1.IsUnique);
+                        Assert.Equal(new[] { "C2", "C1" }, indexColumn2Column1.Properties.Select(c => c.Name).ToArray());
+                    },
+                uniqueColumn3Column1 =>
+                    {
+                        Assert.True(uniqueColumn3Column1.IsUnique);
+                        Assert.Equal(new[] { "C3", "C1" }, uniqueColumn3Column1.Properties.Select(c => c.Name).ToArray());
+                    }
+                );
+
+            Assert.Collection(entityType.GetKeys(),
+                single =>
+                    {
+                        Assert.Equal("UNQ_C2", single.Relational().Name);
+                        Assert.Same(entityType.GetProperty("C2"), single.Properties.Single());
+                    },
+                composite =>
+                    {
+                        Assert.Equal(new[] { "C3", "C1" }, composite.Properties.Select(c => c.Name).ToArray());
+                    });
+        }
+
+        [Fact]
+        public void Foreign_key()
+
+        {
+            var parentTable = new Table { Name = "Parent", Columns = { new Column { Name = "Id", DataType = "long", PrimaryKeyOrdinal = 1 } } };
+            var childrenTable = new Table
+            {
+                Name = "Children",
+                Columns =
+                {
+                    new Column { Name = "Id", DataType = "long", PrimaryKeyOrdinal = 1 },
+                    new Column { Name = "ParentId", DataType = "long", IsNullable = true }
+                }
+            };
+            childrenTable.ForeignKeys.Add(new ForeignKey
+            {
+                Table = childrenTable,
+                From = { childrenTable.Columns[1] },
+                PrincipalTable = parentTable,
+                To = { parentTable.Columns[0] }
+            });
+
+            var model = _provider.GetModel(new SchemaInfo { Tables = { parentTable, childrenTable } });
+
+            var parent = (EntityType)model.GetEntityType("Parent");
+
+            var children = (EntityType)model.GetEntityType("Children");
+
+            Assert.NotEmpty(parent.FindReferencingForeignKeys());
+            var fk = Assert.Single(children.GetForeignKeys());
+            Assert.False(fk.IsUnique);
+
+            var principalKey = fk.PrincipalKey;
+
+            Assert.Same(parent, principalKey.DeclaringEntityType);
+            Assert.Same(parent.Properties.First(), principalKey.Properties[0]);
+        }
+
+        [Fact]
+        public void Unique_foreign_key()
+
+        {
+            var parentTable = new Table { Name = "Parent", Columns = { new Column { Name = "Id", DataType = "long", PrimaryKeyOrdinal = 1 } } };
+            var childrenTable = new Table
+            {
+                Name = "Children",
+                Columns =
+                {
+                    new Column { Name = "Id", DataType = "long", PrimaryKeyOrdinal = 1 },
+                }
+            };
+            childrenTable.ForeignKeys.Add(new ForeignKey
+            {
+                Table = childrenTable,
+                From = { childrenTable.Columns[0] },
+                PrincipalTable = parentTable,
+                To = { parentTable.Columns[0] }
+            });
+
+            var model = _provider.GetModel(new SchemaInfo { Tables = { parentTable, childrenTable } });
+
+            var children = (EntityType)model.GetEntityType("Children");
+
+            var fk = Assert.Single(children.GetForeignKeys());
+            Assert.True(fk.IsUnique);
+        }
+
+        [Fact]
+        public void Composite_foreign_key()
+
+        {
+            var parentTable = new Table
+            {
+                Name = "Parent",
+                Columns =
+            {
+                new Column { Name = "Id_A", DataType = "long", PrimaryKeyOrdinal = 1 },
+                new Column { Name = "Id_B", DataType = "long", PrimaryKeyOrdinal = 2 }
+            }
+            };
+            var childrenTable = new Table
+            {
+                Name = "Children",
+                Columns =
+                {
+                    new Column { Name = "Id", DataType = "long", PrimaryKeyOrdinal = 1 },
+                    new Column { Name = "ParentId_A", DataType = "long" },
+                    new Column { Name = "ParentId_B", DataType = "long" }
+                }
+            };
+            childrenTable.ForeignKeys.Add(new ForeignKey
+            {
+                Table = childrenTable,
+                From = { childrenTable.Columns[1], childrenTable.Columns[2] },
+                PrincipalTable = parentTable,
+                To = { parentTable.Columns[0], parentTable.Columns[1] }
+            });
+
+            var model = _provider.GetModel(new SchemaInfo { Tables = { parentTable, childrenTable } });
+
+            var parent = (EntityType)model.GetEntityType("Parent");
+
+            var children = (EntityType)model.GetEntityType("Children");
+
+            Assert.NotEmpty(parent.FindReferencingForeignKeys());
+
+            var fk = Assert.Single(children.GetForeignKeys());
+            Assert.False(fk.IsUnique);
+
+            var principalKey = fk.PrincipalKey;
+
+            Assert.Equal("Parent", principalKey.DeclaringEntityType.Name);
+            Assert.Equal("Id_A", principalKey.Properties[0].Name);
+            Assert.Equal("Id_B", principalKey.Properties[1].Name);
+        }
+
+        [Fact]
+        public void It_loads_self_referencing_foreign_key()
+
+        {
+            var table = new Table
+            {
+                Name = "ItemsList",
+                Columns =
+                {
+                    new Column { Name = "Id", DataType = "long", PrimaryKeyOrdinal = 1 },
+                    new Column { Name = "ParentId", DataType = "long", IsNullable = false }
+                }
+            };
+            table.ForeignKeys.Add(new ForeignKey
+            {
+                Table = table,
+                From = { table.Columns[1] },
+                PrincipalTable = table,
+                To = { table.Columns[0] }
+            });
+
+            var model = _provider.GetModel(new SchemaInfo { Tables = { table } });
+            var list = model.GetEntityType("ItemsList");
+
+            Assert.NotEmpty(list.FindReferencingForeignKeys());
+            Assert.NotEmpty(list.GetForeignKeys());
+
+            var principalKey = list.GetForeignKey(list.FindProperty("ParentId")).PrincipalKey;
+            Assert.Equal("ItemsList", principalKey.EntityType.Name);
+            Assert.Equal("Id", principalKey.Properties[0].Name);
+        }
+
+        [Fact]
+        public void It_logs_warning_for_bad_foreign_key()
+        {
+            var parentTable = new Table
+            {
+                Name = "Parent",
+                Columns =
+            {
+                new Column { Name = "NotPkId", DataType = "long", PrimaryKeyOrdinal = null }
+            }
+            };
+            var childrenTable = new Table
+            {
+                Name = "Children",
+                Columns =
+                {
+                    new Column { Name = "Id", DataType = "long", PrimaryKeyOrdinal = 1 },
+                    new Column { Name = "ParentId", DataType = "long" },
+                }
+            };
+            childrenTable.ForeignKeys.Add(new ForeignKey
+            {
+                Table = childrenTable,
+                From = { childrenTable.Columns[1] },
+                PrincipalTable = parentTable,
+                To = { parentTable.Columns[0] }
+            });
+
+            _provider.GetModel(new SchemaInfo { Tables = { parentTable, childrenTable } });
+
+            Assert.Contains("Warning: " + SqliteDesignStrings.ForeignKeyScaffoldError("Children", "ParentId"), _logger.FullLog);
+        }
+
+        [Fact]
+        public void Unique_index_foreign_key()
+        {
+            var table = new Table
+            {
+                Name = "Friends",
+                Columns =
+                {
+                    new Column { Name = "Id", DataType = "long", PrimaryKeyOrdinal = 1 },
+                    new Column { Name = "BuddyId", DataType = "long", IsNullable = false }
+                }
+            };
+            table.Indexes.Add(new Index { Columns = { table.Columns[1] }, IsUnique = true });
+            table.ForeignKeys.Add(new ForeignKey
+            {
+                Table = table,
+                From = { table.Columns[1] },
+                PrincipalTable = table,
+                To = { table.Columns[0] }
+            });
+
+            var model = _provider.GetModel(new SchemaInfo { Tables = { table } }).GetEntityType("Friends");
+
+            var fk = Assert.Single(model.GetForeignKeys());
+
+            Assert.True(fk.IsUnique);
+            Assert.Equal(model.GetPrimaryKey(), fk.PrincipalKey);
+        }
+
+        [Fact]
+        public void Unique_index_composite_foreign_key()
+        {
+            var parentTable = new Table
+            {
+                Name = "Parent",
+                Columns =
+            {
+                new Column { Name = "Id_A", DataType = "long", PrimaryKeyOrdinal = 1 },
+                new Column { Name = "Id_B", DataType = "long", PrimaryKeyOrdinal = 2 }
+            }
+            };
+            var childrenTable = new Table
+            {
+                Name = "Children",
+                Columns =
+                {
+                    new Column { Name = "Id", DataType = "long", PrimaryKeyOrdinal = 1 },
+                    new Column { Name = "ParentId_A", DataType = "long" },
+                    new Column { Name = "ParentId_B", DataType = "long" }
+                }
+            };
+            childrenTable.Indexes.Add(new Index { IsUnique = true, Columns = { childrenTable.Columns[1], childrenTable.Columns[2] } });
+            childrenTable.ForeignKeys.Add(new ForeignKey
+            {
+                Table = childrenTable,
+                From = { childrenTable.Columns[1], childrenTable.Columns[2] },
+                PrincipalTable = parentTable,
+                To = { parentTable.Columns[0], parentTable.Columns[1] }
+            });
+
+            var model = _provider.GetModel(new SchemaInfo { Tables = { parentTable, childrenTable } });
+            var parent = model.GetEntityType("Parent");
+            var children = model.GetEntityType("Children");
+
+            var fk = Assert.Single(children.GetForeignKeys());
+
+            Assert.True(fk.IsUnique);
+            Assert.Equal(parent.GetPrimaryKey(), fk.PrincipalKey);
+        }
+    }
+
+    public class FakeMetadataModelProvider : SqliteMetadataModelProvider
+    {
+        protected override IRelationalAnnotationProvider ExtensionsProvider { get; }
+
+        public new IModel GetModel(SchemaInfo schemaInfo)
+        {
+            return base.GetModel(schemaInfo);
+        }
+
+        public override IModel ConstructRelationalModel(string connectionString)
+        {
+            throw new NotImplementedException();
+        }
+
+        public FakeMetadataModelProvider(
+            [NotNull] ILoggerFactory loggerFactory)
+            : base(new TestTypeMapper(),
+                  loggerFactory,
+                  new ModelUtilities(),
+                  new CSharpUtilities(),
+                  new FakeMetadataReader())
+        {
+        }
+    }
+
+    public class FakeMetadataReader : IMetadataReader
+    {
+        public SchemaInfo GetSchema(string connectionString, TableSelectionSet tableSelectionSet)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public class TestTypeMapper : RelationalTypeMapper
+    {
+        private static readonly RelationalTypeMapping _string = new RelationalTypeMapping("string", typeof(string));
+        private static readonly RelationalTypeMapping _long = new RelationalTypeMapping("long", typeof(long));
+
+        protected override IReadOnlyDictionary<Type, RelationalTypeMapping> SimpleMappings { get; }
+            = new Dictionary<Type, RelationalTypeMapping>
+            {
+                { typeof(string), _string },
+                { typeof(long), _long }
+            };
+
+        protected override IReadOnlyDictionary<string, RelationalTypeMapping> SimpleNameMappings { get; }
+            = new Dictionary<string, RelationalTypeMapping>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "string", _string },
+                { "alias for string", _string },
+                { "long", _long }
+            };
+
+        protected override string GetColumnType(IProperty property) => ((Property)property).Relational().ColumnType;
+    }
+}

--- a/test/EntityFramework.Sqlite.Design.Tests/TestLogger.cs
+++ b/test/EntityFramework.Sqlite.Design.Tests/TestLogger.cs
@@ -1,0 +1,59 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Data.Entity.Sqlite.Design
+{
+    public class TestLoggerFactory : LoggerFactory
+    {
+        public TestLoggerFactory()
+        {
+            Logger = new TestLogger();
+            AddProvider(new TestLoggerProvider(Logger));
+        }
+
+        public TestLogger Logger { get; }
+    }
+    public class TestLoggerProvider : ILoggerProvider
+    {
+        private readonly ILogger _logger;
+
+        public TestLoggerProvider(ILogger logger)
+        {
+            _logger = logger;
+        }
+
+        public ILogger CreateLogger(string name) => _logger;
+
+        public void Dispose()
+        {
+        }
+    }
+
+    public class TestLogger : ILogger
+    {
+        public IDisposable BeginScopeImpl(object state) => new NullScope();
+        public string FullLog => _sb.ToString();
+        private readonly StringBuilder _sb = new StringBuilder();
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log(LogLevel logLevel, int eventId, object state, Exception exception, Func<object, Exception, string> formatter)
+        {
+            _sb.Append(logLevel)
+                .Append(": ")
+                .Append(formatter(state, exception));
+        }
+
+        public class NullScope : IDisposable
+        {
+            public void Dispose()
+            {
+                // intentionally does nothing
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fix bug in primary key ordering.

SQLite reverse typemapping only adds ColumnType annotation if it has a custom type, instead of adding for every type.

Note:
Once approved, will merge into dev after #3367 is merged.

Fixes #3404 
