### PR TITLE
Refactor update surface to use RelationalCommand instead of DbCommand

### DIFF
--- a/test/EntityFramework.Relational.Tests/TestUtilities/FakeProvider/FakeDbCommand.cs
+++ b/test/EntityFramework.Relational.Tests/TestUtilities/FakeProvider/FakeDbCommand.cs
@@ -13,6 +13,10 @@ namespace Microsoft.Data.Entity.TestUtilities.FakeProvider
     {
         private FakeCommandExecutor _commandExecutor;
 
+        public FakeDbCommand()
+        {
+        }
+
         public FakeDbCommand(
             FakeDbConnection connection,
             FakeCommandExecutor commandExecutor)


### PR DESCRIPTION
Factoring change to remove raw DbCommand use from Update
@AndriySvyryd @ajcvickers 