### PR TITLE
Fix to #3103 - Must be reducible node exception when performing Join

### DIFF
--- a/src/EntityFramework.Core/Query/EntityQueryModelVisitor.cs
+++ b/src/EntityFramework.Core/Query/EntityQueryModelVisitor.cs
@@ -678,9 +678,12 @@ namespace Microsoft.Data.Entity.Query
             {
                 innerElementType = innerSequenceType.GetTypeInfo().GenericTypeArguments[0];
 
-                querySourceMapping.AddMapping(
-                    joinClause,
-                    QueryResultScope.GetResult(innerItemParameter, joinClause, innerElementType));
+                if (!querySourceMapping.ContainsMapping(joinClause))
+                {
+                    querySourceMapping.AddMapping(
+                        joinClause,
+                        QueryResultScope.GetResult(innerItemParameter, joinClause, innerElementType));
+                }
             }
             else
             {

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -129,6 +129,116 @@ ORDER BY [c0].[DefaultText], [c0].[DefaultText0]",
                 Sql);
         }
 
+        public override void Join_navigation_translated_to_FK()
+        {
+            base.Join_navigation_translated_to_FK();
+
+            Assert.Equal(
+                @"SELECT [e1].[Id], [e2].[Id]
+FROM [Level1] AS [e1]
+INNER JOIN [Level2] AS [e2] ON [e1].[Id] = [e2].[OneToOne_Optional_PK_InverseId]", Sql);
+        }
+
+        public override void Join_navigation_in_outer_selector_translated_to_extra_join()
+        {
+            base.Join_navigation_in_outer_selector_translated_to_extra_join();
+
+            Assert.Equal(
+                @"SELECT [e1].[Id], [e2].[Id]
+FROM [Level1] AS [e1]
+INNER JOIN [Level2] AS [e1.OneToOne_Optional_FK] ON [e1].[Id] = [e1.OneToOne_Optional_FK].[Level1_Optional_Id]
+INNER JOIN [Level2] AS [e2] ON [e1.OneToOne_Optional_FK].[Id] = [e2].[Id]",
+                Sql);
+        }
+
+        public override void Join_navigation_in_outer_selector_translated_to_extra_join_nested()
+        {
+            base.Join_navigation_in_outer_selector_translated_to_extra_join_nested();
+
+            Assert.Equal(
+                @"SELECT [e1].[Id], [e3].[Id]
+FROM [Level1] AS [e1]
+INNER JOIN [Level2] AS [e1.OneToOne_Required_FK] ON [e1].[Id] = [e1.OneToOne_Required_FK].[Level1_Required_Id]
+INNER JOIN [Level3] AS [e1.OneToOne_Required_FK.OneToOne_Optional_FK] ON [e1.OneToOne_Required_FK].[Id] = [e1.OneToOne_Required_FK.OneToOne_Optional_FK].[Level2_Optional_Id]
+INNER JOIN [Level3] AS [e3] ON [e1.OneToOne_Required_FK.OneToOne_Optional_FK].[Id] = [e3].[Id]",
+                Sql);
+        }
+
+
+        public override void Join_navigation_in_inner_selector_translated_to_subquery()
+        {
+            base.Join_navigation_in_inner_selector_translated_to_subquery();
+
+            Assert.Equal(
+                @"SELECT [e2].[Id], [e1].[Id]
+FROM [Level2] AS [e2]
+INNER JOIN [Level1] AS [e1] ON [e2].[Id] = (
+    SELECT TOP(1) [subQuery0].[Id]
+    FROM [Level2] AS [subQuery0]
+    WHERE [subQuery0].[Level1_Optional_Id] = [e1].[Id]
+)",
+                Sql);
+        }
+
+        public override void Join_navigation_translated_to_subquery_non_key_join()
+        {
+            base.Join_navigation_translated_to_subquery_non_key_join();
+
+            Assert.Equal(
+                @"SELECT [e2].[Id], [e2].[Name], [e1].[Id], [e1].[Name]
+FROM [Level2] AS [e2]
+INNER JOIN [Level1] AS [e1] ON [e2].[Name] = (
+    SELECT TOP(1) [subQuery0].[Name]
+    FROM [Level2] AS [subQuery0]
+    WHERE [subQuery0].[Level1_Optional_Id] = [e1].[Id]
+)",
+                Sql);
+        }
+
+        public override void Join_navigation_translated_to_subquery_self_ref()
+        {
+            base.Join_navigation_translated_to_subquery_self_ref();
+
+            Assert.Equal(
+                @"SELECT [e1].[Id], [e2].[Id]
+FROM [Level1] AS [e1]
+INNER JOIN [Level1] AS [e2] ON [e1].[Id] = [e2].[OneToMany_Optional_Self_InverseId]",
+                Sql);
+        }
+
+        public override void Join_navigation_translated_to_subquery_nested()
+        {
+            base.Join_navigation_translated_to_subquery_nested();
+
+            Assert.Equal(
+                @"SELECT [e3].[Id], [e1].[Id]
+FROM [Level3] AS [e3]
+INNER JOIN [Level1] AS [e1] ON [e3].[Id] = (
+    SELECT TOP(1) [subQuery0.OneToOne_Optional_FK].[Id]
+    FROM [Level2] AS [subQuery0]
+    INNER JOIN [Level3] AS [subQuery0.OneToOne_Optional_FK] ON [subQuery0].[Id] = [subQuery0.OneToOne_Optional_FK].[Level2_Optional_Id]
+    WHERE [subQuery0].[Level1_Required_Id] = [e1].[Id]
+)",
+                Sql);
+        }
+
+        public override void Join_navigation_translated_to_subquery_deeply_nested_non_key_join()
+        {
+            base.Join_navigation_translated_to_subquery_deeply_nested_non_key_join();
+
+            Assert.Equal(
+                @"SELECT [e4].[Id], [e4].[Name], [e1].[Id], [e1].[Name]
+FROM [Level4] AS [e4]
+INNER JOIN [Level1] AS [e1] ON [e4].[Name] = (
+    SELECT TOP(1) [subQuery0.OneToOne_Optional_FK.OneToOne_Required_PK].[Name]
+    FROM [Level2] AS [subQuery0]
+    INNER JOIN [Level3] AS [subQuery0.OneToOne_Optional_FK] ON [subQuery0].[Id] = [subQuery0.OneToOne_Optional_FK].[Level2_Optional_Id]
+    INNER JOIN [Level4] AS [subQuery0.OneToOne_Optional_FK.OneToOne_Required_PK] ON [subQuery0.OneToOne_Optional_FK].[Id] = [subQuery0.OneToOne_Optional_FK.OneToOne_Required_PK].[Id]
+    WHERE [subQuery0].[Level1_Required_Id] = [e1].[Id]
+)",
+                Sql);
+        }
+
         private static string Sql => TestSqlLoggerFactory.Sql;
     }
 }

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -597,6 +597,21 @@ ORDER BY [ct].[GearNickName], [ct].[GearSquadId]",
                 Sql);
         }
 
+        public override void Join_navigation_translated_to_subquery_composite_key()
+        {
+            base.Join_navigation_translated_to_subquery_composite_key();
+
+            Assert.Equal(
+                @"SELECT [g].[FullName], [t].[Note]
+FROM [Gear] AS [g]
+INNER JOIN [CogTag] AS [t] ON [g].[FullName] = (
+    SELECT TOP(1) [subQuery0].[FullName]
+    FROM [Gear] AS [subQuery0]
+    WHERE ([subQuery0].[Nickname] = [t].[GearNickName]) AND ([subQuery0].[SquadId] = [t].[GearSquadId])
+)",
+                Sql);
+        }
+
         public GearsOfWarQuerySqlServerTest(GearsOfWarQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {


### PR DESCRIPTION
Problem:
We were incorrectly expanding navigations that appeared in the inner key selector of a join expression (right side).
Normally we expand nav props into additional join. E.g.:

from p in ctx.Payouts
join a in ctx.Assets on p.Good.Id equals a.Id
select p

converts to:

from p in ctx.Payouts
join g from ctx.Goods on p.Id equals g.Id
join a in ctx.Assets on g.Id equals a.Id
select p

However if navigation propery is in the inner key selector, like so:

from p in ctx.Payouts
join a in ctx.Assets on p.Id equals a.Good.Id
select p

we encounter chicken-and-egg problem:

from p in ctx.Payouts
join g in ctx.Good on a.Id equals g.Id // invalid, because a was not declared yet
join a in ctx.Assets on g.Id equals a.Id

or

from p in ctx.Payouts
join a in ctx.Assets on g.Id equals a.Id // invalid, because g was not declared yet
join g in ctx.Good on a.Id equals g.Id

Solution:

Some navigation properties can be translated into FKs, which removes the problem:

from c in Customers
join d in Details on c.Id equals d.Customer.Id
select c

can be translated into:

from c in Customers
join d in Details on c.Id equals c.CustomerId
select c

This can only be done for a subset of queries - join needs to be based on key property, FK must be pointing the right way, and key must not be composite.

For all other cases we translate this into a subquery:

from c in Customers
join d in Details on c.Id equals
(from c2 in Customers
 where c2.CustomerId equals d.Id
 select c2.Id).FirstOrDefault()

In case of nested navigation property we expand the first one into a subquery, and add extra joins to the subquery, just like we did originally. Only the first navigation is "problematic", the following ones can be safely translated to joins