### PR TITLE
Inheritance conventions

### DIFF
--- a/src/EntityFramework.Core/ChangeTracking/Internal/ValueGenerationManager.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/ValueGenerationManager.cs
@@ -38,7 +38,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
                     }
                     else
                     {
-                        var valueGenerator = _valueGeneratorSelector.Select(property, entry.EntityType);
+                        var valueGenerator = _valueGeneratorSelector.Select(property, property.IsKey()
+                            ? property.DeclaringEntityType
+                            : entry.EntityType);
 
                         Debug.Assert(valueGenerator != null);
 

--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -164,6 +164,8 @@
     <Compile Include="DbContextOptionsBuilder`.cs" />
     <Compile Include="Metadata\Builders\ReferenceReferenceBuilder`.cs" />
     <Compile Include="Metadata\Conventions\ConventionSet.cs" />
+    <Compile Include="Metadata\Conventions\Internal\BaseTypeDiscoveryConvention.cs" />
+    <Compile Include="Metadata\Conventions\Internal\DerivedTypeDiscoveryConvention.cs" />
     <Compile Include="Metadata\Conventions\Internal\CascadeDeleteConvention.cs" />
     <Compile Include="Metadata\Conventions\Internal\INavigationRemovedConvention.cs" />
     <Compile Include="Metadata\Conventions\Internal\IPropertyNullableConvention.cs" />
@@ -172,6 +174,7 @@
     <Compile Include="Metadata\Conventions\Internal\ForeignKeyAttributeConvention.cs" />
     <Compile Include="Metadata\Conventions\Internal\IEntityTypeMemberIgnoredConvention.cs" />
     <Compile Include="Metadata\Conventions\Internal\INavigationConvention.cs" />
+    <Compile Include="Metadata\Conventions\Internal\InheritanceDiscoveryConventionBase.cs" />
     <Compile Include="Metadata\Conventions\Internal\InversePropertyAttributeConvention.cs" />
     <Compile Include="Metadata\Conventions\Internal\IPrimaryKeyConvention.cs" />
     <Compile Include="Metadata\Conventions\Internal\NavigationAttributeNavigationConvention.cs" />

--- a/src/EntityFramework.Core/Internal/ModelValidator.cs
+++ b/src/EntityFramework.Core/Internal/ModelValidator.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Data.Entity.Internal
             EnsureNoShadowEntities(model);
             EnsureNoShadowKeys(model);
             EnsureNonNullPrimaryKeys(model);
-            EnsureClrPropertyTypesMatch(model);
         }
 
         protected virtual void EnsureNoShadowEntities([NotNull] IModel model)
@@ -69,33 +68,6 @@ namespace Microsoft.Data.Entity.Internal
             if (entityTypeWithNullPk != null)
             {
                 ShowError(CoreStrings.EntityRequiresKey(entityTypeWithNullPk.Name));
-            }
-        }
-
-        protected virtual void EnsureClrPropertyTypesMatch([NotNull] IModel model)
-        {
-            foreach (var entityType in model.EntityTypes)
-            {
-                foreach (var property in entityType.GetDeclaredProperties())
-                {
-                    if (property.IsShadowProperty
-                        || !entityType.HasClrType())
-                    {
-                        continue;
-                    }
-
-                    var clrProperty = entityType.ClrType.GetPropertiesInHierarchy(property.Name).FirstOrDefault();
-                    if (clrProperty == null)
-                    {
-                        ShowError(CoreStrings.NoClrProperty(property.Name, entityType.Name));
-                        continue;
-                    }
-
-                    if (property.ClrType != clrProperty.PropertyType)
-                    {
-                        ShowError(CoreStrings.PropertyWrongClrType(property.Name, entityType.Name));
-                    }
-                }
             }
         }
 

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/BaseTypeDiscoveryConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/BaseTypeDiscoveryConvention.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Metadata.Internal;
+
+namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
+{
+    public class BaseTypeDiscoveryConvention : InheritanceDiscoveryConventionBase, IEntityTypeConvention
+    {
+        public virtual InternalEntityTypeBuilder Apply(InternalEntityTypeBuilder entityTypeBuilder)
+        {
+            var entityType = entityTypeBuilder.Metadata;
+            var clrType = entityType.ClrType;
+            if (clrType == null)
+            {
+                return entityTypeBuilder;
+            }
+
+            var baseEntityType = FindClosestBaseType(entityType);
+            return entityTypeBuilder.HasBaseType(baseEntityType, ConfigurationSource.Convention);
+        }
+    }
+}

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/ConventionDispatcher.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/ConventionDispatcher.cs
@@ -177,14 +177,17 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
         }
 
         public virtual void OnNavigationRemoved(
-            [NotNull] InternalRelationshipBuilder relationshipBuilder, [NotNull] string navigationName, bool pointsToPrincipal)
+            [NotNull] InternalEntityTypeBuilder sourceEntityTypeBuilder,
+            [NotNull] InternalEntityTypeBuilder targetEntityTypeBuilder,
+            [NotNull] string navigationName)
         {
-            Check.NotNull(relationshipBuilder, nameof(relationshipBuilder));
+            Check.NotNull(sourceEntityTypeBuilder, nameof(sourceEntityTypeBuilder));
+            Check.NotNull(targetEntityTypeBuilder, nameof(targetEntityTypeBuilder));
             Check.NotNull(navigationName, nameof(navigationName));
 
             foreach (var navigationConvention in _conventionSet.NavigationRemovedConventions)
             {
-                if (!navigationConvention.Apply(relationshipBuilder, navigationName, pointsToPrincipal))
+                if (!navigationConvention.Apply(sourceEntityTypeBuilder, targetEntityTypeBuilder, navigationName))
                 {
                     break;
                 }

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
@@ -9,20 +9,26 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
         {
             var conventionSet = new ConventionSet();
 
-            var relationshipDiscoveryConvention = new RelationshipDiscoveryConvention();
+            var propertyDiscoveryConvention = new PropertyDiscoveryConvention();
             var keyDiscoveryConvention = new KeyDiscoveryConvention();
+            var relationshipDiscoveryConvention = new RelationshipDiscoveryConvention();
             conventionSet.EntityTypeAddedConventions.Add(new NotMappedEntityTypeAttributeConvention());
             conventionSet.EntityTypeAddedConventions.Add(new NotMappedMemberAttributeConvention());
-            conventionSet.EntityTypeAddedConventions.Add(new PropertyDiscoveryConvention());
+            conventionSet.EntityTypeAddedConventions.Add(new BaseTypeDiscoveryConvention());
+            conventionSet.EntityTypeAddedConventions.Add(propertyDiscoveryConvention);
             conventionSet.EntityTypeAddedConventions.Add(keyDiscoveryConvention);
             conventionSet.EntityTypeAddedConventions.Add(new InversePropertyAttributeConvention());
             conventionSet.EntityTypeAddedConventions.Add(relationshipDiscoveryConvention);
+            conventionSet.EntityTypeAddedConventions.Add(new DerivedTypeDiscoveryConvention());
 
+            conventionSet.BaseEntityTypeSetConventions.Add(propertyDiscoveryConvention);
+            conventionSet.BaseEntityTypeSetConventions.Add(keyDiscoveryConvention);
             conventionSet.BaseEntityTypeSetConventions.Add(relationshipDiscoveryConvention);
 
             // An ambiguity might have been resolved
             conventionSet.EntityTypeMemberIgnoredConventions.Add(relationshipDiscoveryConvention);
 
+            var keyAttributeConvention = new KeyAttributeConvention();
             var foreignKeyPropertyDiscoveryConvention = new ForeignKeyPropertyDiscoveryConvention();
             conventionSet.PropertyAddedConventions.Add(new ConcurrencyCheckAttributeConvention());
             conventionSet.PropertyAddedConventions.Add(new DatabaseGeneratedAttributeConvention());
@@ -32,8 +38,6 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
             conventionSet.PropertyAddedConventions.Add(new TimestampAttributeConvention());
             conventionSet.PropertyAddedConventions.Add(keyDiscoveryConvention);
             conventionSet.PropertyAddedConventions.Add(foreignKeyPropertyDiscoveryConvention);
-
-            var keyAttributeConvention = new KeyAttributeConvention();
             conventionSet.PropertyAddedConventions.Add(keyAttributeConvention);
 
             var keyConvention = new KeyConvention();
@@ -44,6 +48,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
             var cascadeDeleteConvention = new CascadeDeleteConvention();
             conventionSet.ForeignKeyAddedConventions.Add(new ForeignKeyAttributeConvention());
             conventionSet.ForeignKeyAddedConventions.Add(foreignKeyPropertyDiscoveryConvention);
+            conventionSet.ForeignKeyAddedConventions.Add(keyConvention);
             conventionSet.ForeignKeyAddedConventions.Add(cascadeDeleteConvention);
 
             conventionSet.ForeignKeyRemovedConventions.Add(keyConvention);

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/DerivedTypeDiscoveryConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/DerivedTypeDiscoveryConvention.cs
@@ -1,0 +1,34 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.Data.Entity.Metadata.Internal;
+
+namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
+{
+    public class DerivedTypeDiscoveryConvention : InheritanceDiscoveryConventionBase, IEntityTypeConvention
+    {
+        public virtual InternalEntityTypeBuilder Apply(InternalEntityTypeBuilder entityTypeBuilder)
+        {
+            var entityType = entityTypeBuilder.Metadata;
+            var clrType = entityType.ClrType;
+            if (clrType == null)
+            {
+                return entityTypeBuilder;
+            }
+
+            var directlyDerivedTypes = entityType.Model.EntityTypes.Where(t =>
+                t.BaseType == entityType.BaseType
+                && t.HasClrType
+                && FindClosestBaseType(t) == entityType);
+
+            foreach (var directlyDerivedType in directlyDerivedTypes)
+            {
+                entityTypeBuilder.ModelBuilder.Entity(directlyDerivedType.ClrType, ConfigurationSource.Convention)
+                    .HasBaseType(entityType, ConfigurationSource.Convention);
+            }
+
+            return entityTypeBuilder;
+        }
+    }
+}

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/ForeignKeyPropertyDiscoveryConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/ForeignKeyPropertyDiscoveryConvention.cs
@@ -27,22 +27,9 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
                 var candidatePropertiesOnPrincipal = FindCandidateForeignKeyProperties(
                     relationshipBuilder.Metadata, onDependent: false);
 
-                bool shouldInvert;
                 if (ShouldInvert(relationshipBuilder.Metadata, foreignKeyProperties, candidatePropertiesOnPrincipal)
-                    && relationshipBuilder.CanSet(relationshipBuilder.Metadata.DeclaringEntityType,
-                        relationshipBuilder.Metadata.PrincipalEntityType,
-                        null,
-                        null,
-                        /*dependentProperties:*/ candidatePropertiesOnPrincipal,
-                        null,
-                        null,
-                        null,
-                        null,
-                        /*strictPrincipal:*/ true,
-                        ConfigurationSource.Convention,
-                        out shouldInvert))
+                    && relationshipBuilder.CanInvert(candidatePropertiesOnPrincipal, ConfigurationSource.Convention))
                 {
-                    Debug.Assert(shouldInvert);
                     relationshipBuilder = relationshipBuilder.DependentEntityType(relationshipBuilder.Metadata.PrincipalEntityType, ConfigurationSource.Convention);
 
                     if (candidatePropertiesOnPrincipal != null)

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/INavigationRemovedConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/INavigationRemovedConvention.cs
@@ -8,6 +8,9 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
 {
     public interface INavigationRemovedConvention
     {
-        bool Apply([NotNull] InternalRelationshipBuilder relationshipBuilder, [NotNull] string navigationName, bool pointsToPrincipal);
+        bool Apply(
+            [NotNull] InternalEntityTypeBuilder sourceEntityTypeBuilder,
+            [NotNull] InternalEntityTypeBuilder targetEntityTypeBuilder,
+            [NotNull] string navigationName);
     }
 }

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/InheritanceDiscoveryConventionBase.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/InheritanceDiscoveryConventionBase.cs
@@ -1,0 +1,31 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
+{
+    public class InheritanceDiscoveryConventionBase
+    {
+        protected virtual EntityType FindClosestBaseType([NotNull] EntityType entityType)
+        {
+            Check.NotNull(entityType, nameof(entityType));
+
+            var clrType = entityType.ClrType;
+            Check.NotNull(clrType, nameof(entityType.ClrType));
+
+            var baseType = clrType.GetTypeInfo().BaseType;
+            EntityType baseEntityType = null;
+
+            while (baseType != null
+                   && baseEntityType == null)
+            {
+                baseEntityType = entityType.Model.FindEntityType(baseType);
+                baseType = baseType.GetTypeInfo().BaseType;
+            }
+            return baseEntityType;
+        }
+    }
+}

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/KeyDiscoveryConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/KeyDiscoveryConvention.cs
@@ -10,7 +10,7 @@ using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
 {
-    public class KeyDiscoveryConvention : IEntityTypeConvention, IPropertyConvention
+    public class KeyDiscoveryConvention : IEntityTypeConvention, IPropertyConvention, IBaseTypeConvention
     {
         private const string KeySuffix = "Id";
 
@@ -54,6 +54,9 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
 
             return keyProperties;
         }
+
+        public virtual bool Apply(InternalEntityTypeBuilder entityTypeBuilder, EntityType oldBaseType)
+            => Apply(entityTypeBuilder) != null;
 
         public virtual InternalPropertyBuilder Apply(InternalPropertyBuilder propertyBuilder)
         {

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/PropertyDiscoveryConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/PropertyDiscoveryConvention.cs
@@ -10,7 +10,7 @@ using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
 {
-    public class PropertyDiscoveryConvention : IEntityTypeConvention
+    public class PropertyDiscoveryConvention : IEntityTypeConvention, IBaseTypeConvention
     {
         public virtual InternalEntityTypeBuilder Apply(InternalEntityTypeBuilder entityTypeBuilder)
         {
@@ -35,5 +35,8 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
 
             return propertyInfo.IsCandidateProperty() && propertyInfo.PropertyType.IsPrimitive();
         }
+
+        public virtual bool Apply(InternalEntityTypeBuilder entityTypeBuilder, EntityType oldBaseType)
+            => Apply(entityTypeBuilder) != null;
     }
 }

--- a/src/EntityFramework.Core/Metadata/EntityType.cs
+++ b/src/EntityFramework.Core/Metadata/EntityType.cs
@@ -70,7 +70,14 @@ namespace Microsoft.Data.Entity.Metadata
             Model = model;
 
             _properties = new SortedDictionary<string, Property>(new PropertyComparer(this));
+#if DEBUG
+            DebugName = DisplayName();
+#endif
         }
+
+#if DEBUG
+        private string DebugName { get; set; }
+#endif
 
         public virtual Type ClrType => _typeOrName as Type;
 

--- a/src/EntityFramework.Core/Metadata/EntityTypeExtensions.cs
+++ b/src/EntityFramework.Core/Metadata/EntityTypeExtensions.cs
@@ -121,6 +121,15 @@ namespace Microsoft.Data.Entity.Metadata
             return false;
         }
 
+        public static bool IsSameHierarchy([NotNull] this IEntityType firstEntityType, [NotNull] IEntityType secondEntityType)
+        {
+            Check.NotNull(firstEntityType, nameof(firstEntityType));
+            Check.NotNull(secondEntityType, nameof(secondEntityType));
+
+            return firstEntityType.IsAssignableFrom(secondEntityType)
+                   || secondEntityType.IsAssignableFrom(firstEntityType);
+        }
+
         public static bool IsAbstract([NotNull] this IEntityType entityType)
         {
             Check.NotNull(entityType, nameof(entityType));

--- a/src/EntityFramework.Core/Metadata/ForeignKeyExtensions.cs
+++ b/src/EntityFramework.Core/Metadata/ForeignKeyExtensions.cs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Utilities;
@@ -38,8 +36,7 @@ namespace Microsoft.Data.Entity.Metadata
         {
             Check.NotNull(foreignKey, nameof(foreignKey));
 
-            return foreignKey.DeclaringEntityType.IsAssignableFrom(foreignKey.PrincipalEntityType)
-                   || foreignKey.PrincipalEntityType.IsAssignableFrom(foreignKey.DeclaringEntityType);
+            return foreignKey.DeclaringEntityType.IsSameHierarchy(foreignKey.PrincipalEntityType);
         }
 
         public static bool IsSelfPrimaryKeyReferencing([NotNull] this IForeignKey foreignKey)
@@ -54,19 +51,20 @@ namespace Microsoft.Data.Entity.Metadata
             Check.NotNull(foreignKey, nameof(foreignKey));
             Check.NotNull(entityType, nameof(entityType));
 
-            if (!foreignKey.DeclaringEntityType.IsAssignableFrom(entityType)
-                && !foreignKey.PrincipalEntityType.IsAssignableFrom(entityType))
+            if (foreignKey.DeclaringEntityType != entityType
+                && foreignKey.PrincipalEntityType != entityType)
             {
-                throw new ArgumentException(CoreStrings.EntityTypeNotInRelationship(
-                    entityType.Name, foreignKey.DeclaringEntityType.Name, foreignKey.PrincipalEntityType.Name));
+                throw new ArgumentException(CoreStrings.EntityTypeNotInRelationshipStrict(
+                    entityType.DisplayName(), foreignKey.DeclaringEntityType.DisplayName(), foreignKey.PrincipalEntityType.DisplayName()));
             }
 
-            if (foreignKey.IsIntraHierarchical())
+            if (foreignKey.IsSelfReferencing())
             {
-                throw new InvalidOperationException(CoreStrings.IntraHierarchicalAmbiguousNavigation(entityType.Name, Property.Format(foreignKey.Properties), foreignKey.PrincipalEntityType, foreignKey.DeclaringEntityType));
+                throw new InvalidOperationException(CoreStrings.SelfReferencingAmbiguousNavigation(
+                    entityType.DisplayName(), Property.Format(foreignKey.Properties)));
             }
 
-            return foreignKey.DeclaringEntityType.IsAssignableFrom(entityType)
+            return foreignKey.DeclaringEntityType == entityType
                 ? foreignKey.DependentToPrincipal
                 : foreignKey.PrincipalToDependent;
         }
@@ -74,7 +72,7 @@ namespace Microsoft.Data.Entity.Metadata
         public static Navigation FindNavigationFrom([NotNull] this ForeignKey foreignKey, [NotNull] EntityType entityType)
             => (Navigation)((IForeignKey)foreignKey).FindNavigationFrom(entityType);
 
-        public static INavigation FindNavigationTo([NotNull] this IForeignKey foreignKey, [NotNull] IEntityType entityType)
+        public static INavigation FindNavigationFromInHierarchy([NotNull] this IForeignKey foreignKey, [NotNull] IEntityType entityType)
         {
             Check.NotNull(foreignKey, nameof(foreignKey));
             Check.NotNull(entityType, nameof(entityType));
@@ -83,15 +81,47 @@ namespace Microsoft.Data.Entity.Metadata
                 && !foreignKey.PrincipalEntityType.IsAssignableFrom(entityType))
             {
                 throw new ArgumentException(CoreStrings.EntityTypeNotInRelationship(
-                    entityType.Name, foreignKey.DeclaringEntityType.Name, foreignKey.PrincipalEntityType.Name));
+                    entityType.DisplayName(), foreignKey.DeclaringEntityType.DisplayName(), foreignKey.PrincipalEntityType.DisplayName()));
             }
 
             if (foreignKey.IsIntraHierarchical())
             {
-                throw new InvalidOperationException(CoreStrings.IntraHierarchicalAmbiguousNavigation(entityType.Name, Property.Format(foreignKey.Properties), foreignKey.PrincipalEntityType, foreignKey.DeclaringEntityType));
+                throw new InvalidOperationException(CoreStrings.IntraHierarchicalAmbiguousNavigation(
+                    entityType.DisplayName(),
+                    Property.Format(foreignKey.Properties),
+                    foreignKey.PrincipalEntityType.DisplayName(),
+                    foreignKey.DeclaringEntityType.DisplayName()));
             }
 
             return foreignKey.DeclaringEntityType.IsAssignableFrom(entityType)
+                ? foreignKey.DependentToPrincipal
+                : foreignKey.PrincipalToDependent;
+        }
+
+        public static Navigation FindNavigationFromInHierarchy([NotNull] this ForeignKey foreignKey, [NotNull] EntityType entityType)
+            => (Navigation)((IForeignKey)foreignKey).FindNavigationFromInHierarchy(entityType);
+
+        public static INavigation FindNavigationTo([NotNull] this IForeignKey foreignKey, [NotNull] IEntityType entityType)
+        {
+            Check.NotNull(foreignKey, nameof(foreignKey));
+            Check.NotNull(entityType, nameof(entityType));
+
+            if (foreignKey.DeclaringEntityType != entityType
+                && foreignKey.PrincipalEntityType != entityType)
+            {
+                throw new ArgumentException(CoreStrings.EntityTypeNotInRelationshipStrict(
+                    entityType.DisplayName(),
+                    foreignKey.DeclaringEntityType.DisplayName(),
+                    foreignKey.PrincipalEntityType.DisplayName()));
+            }
+
+            if (foreignKey.IsSelfReferencing())
+            {
+                throw new InvalidOperationException(CoreStrings.SelfReferencingAmbiguousNavigation(
+                    entityType.DisplayName(), Property.Format(foreignKey.Properties)));
+            }
+
+            return foreignKey.DeclaringEntityType == entityType
                 ? foreignKey.PrincipalToDependent
                 : foreignKey.DependentToPrincipal;
         }
@@ -99,7 +129,7 @@ namespace Microsoft.Data.Entity.Metadata
         public static Navigation FindNavigationTo([NotNull] this ForeignKey foreignKey, [NotNull] EntityType entityType)
             => (Navigation)((IForeignKey)foreignKey).FindNavigationTo(entityType);
 
-        public static IEntityType ResolveOtherEntityType([NotNull] this IForeignKey foreignKey, [NotNull] IEntityType entityType)
+        public static INavigation FindNavigationToInHierarchy([NotNull] this IForeignKey foreignKey, [NotNull] IEntityType entityType)
         {
             Check.NotNull(foreignKey, nameof(foreignKey));
             Check.NotNull(entityType, nameof(entityType));
@@ -108,15 +138,41 @@ namespace Microsoft.Data.Entity.Metadata
                 && !foreignKey.PrincipalEntityType.IsAssignableFrom(entityType))
             {
                 throw new ArgumentException(CoreStrings.EntityTypeNotInRelationship(
-                    entityType.Name, foreignKey.DeclaringEntityType.Name, foreignKey.PrincipalEntityType.Name));
+                    entityType.DisplayName(), foreignKey.DeclaringEntityType.DisplayName(), foreignKey.PrincipalEntityType.DisplayName()));
             }
 
             if (foreignKey.IsIntraHierarchical())
             {
-                throw new InvalidOperationException(CoreStrings.IntraHierarchicalAmbiguousTargetEntityType(entityType.Name, Property.Format(foreignKey.Properties)));
+                throw new InvalidOperationException(CoreStrings.IntraHierarchicalAmbiguousNavigation(
+                    entityType.DisplayName(),
+                    Property.Format(foreignKey.Properties),
+                    foreignKey.PrincipalEntityType.DisplayName(),
+                    foreignKey.DeclaringEntityType.DisplayName()));
             }
 
             return foreignKey.DeclaringEntityType.IsAssignableFrom(entityType)
+                ? foreignKey.PrincipalToDependent
+                : foreignKey.DependentToPrincipal;
+        }
+
+        public static Navigation FindNavigationToInHierarchy([NotNull] this ForeignKey foreignKey, [NotNull] EntityType entityType)
+            => (Navigation)((IForeignKey)foreignKey).FindNavigationToInHierarchy(entityType);
+
+        public static IEntityType ResolveOtherEntityType([NotNull] this IForeignKey foreignKey, [NotNull] IEntityType entityType)
+        {
+            Check.NotNull(foreignKey, nameof(foreignKey));
+            Check.NotNull(entityType, nameof(entityType));
+
+            if (foreignKey.DeclaringEntityType != entityType
+                && foreignKey.PrincipalEntityType != entityType)
+            {
+                throw new ArgumentException(CoreStrings.EntityTypeNotInRelationshipStrict(
+                    entityType.DisplayName(),
+                    foreignKey.DeclaringEntityType.DisplayName(),
+                    foreignKey.PrincipalEntityType.DisplayName()));
+            }
+
+            return foreignKey.DeclaringEntityType == entityType
                 ? foreignKey.PrincipalEntityType
                 : foreignKey.DeclaringEntityType;
         }
@@ -124,7 +180,8 @@ namespace Microsoft.Data.Entity.Metadata
         public static EntityType ResolveOtherEntityType([NotNull] this ForeignKey foreignKey, [NotNull] EntityType entityType)
             => (EntityType)((IForeignKey)foreignKey).ResolveOtherEntityType(entityType);
 
-        public static IEntityType ResolveEntityType([NotNull] this IForeignKey foreignKey, [NotNull] IEntityType entityType)
+        public static IEntityType ResolveOtherEntityTypeInHierarchy(
+            [NotNull] this IForeignKey foreignKey, [NotNull] IEntityType entityType)
         {
             Check.NotNull(foreignKey, nameof(foreignKey));
             Check.NotNull(entityType, nameof(entityType));
@@ -133,12 +190,48 @@ namespace Microsoft.Data.Entity.Metadata
                 && !foreignKey.PrincipalEntityType.IsAssignableFrom(entityType))
             {
                 throw new ArgumentException(CoreStrings.EntityTypeNotInRelationship(
-                    entityType.Name, foreignKey.DeclaringEntityType.Name, foreignKey.PrincipalEntityType.Name));
+                    entityType.DisplayName(),
+                    foreignKey.DeclaringEntityType.DisplayName(),
+                    foreignKey.PrincipalEntityType.DisplayName()));
             }
 
             if (foreignKey.IsIntraHierarchical())
             {
-                throw new InvalidOperationException(CoreStrings.IntraHierarchicalAmbiguousTargetEntityType(entityType.Name, Property.Format(foreignKey.Properties)));
+                throw new InvalidOperationException(CoreStrings.IntraHierarchicalAmbiguousTargetEntityType(
+                    entityType.DisplayName(),
+                    Property.Format(foreignKey.Properties),
+                    foreignKey.PrincipalEntityType.DisplayName(),
+                    foreignKey.DeclaringEntityType.DisplayName()));
+            }
+
+            return foreignKey.DeclaringEntityType.IsAssignableFrom(entityType)
+                ? foreignKey.PrincipalEntityType
+                : foreignKey.DeclaringEntityType;
+        }
+
+        public static EntityType ResolveOtherEntityTypeInHierarchy([NotNull] this ForeignKey foreignKey, [NotNull] EntityType entityType)
+            => (EntityType)((IForeignKey)foreignKey).ResolveOtherEntityTypeInHierarchy(entityType);
+
+        public static IEntityType ResolveEntityTypeInHierarchy([NotNull] this IForeignKey foreignKey, [NotNull] IEntityType entityType)
+        {
+            Check.NotNull(foreignKey, nameof(foreignKey));
+            Check.NotNull(entityType, nameof(entityType));
+
+            if (!foreignKey.DeclaringEntityType.IsAssignableFrom(entityType)
+                && !foreignKey.PrincipalEntityType.IsAssignableFrom(entityType))
+            {
+                throw new ArgumentException(CoreStrings.EntityTypeNotInRelationship(
+                    entityType.DisplayName(),
+                    foreignKey.DeclaringEntityType.DisplayName(),
+                    foreignKey.PrincipalEntityType.DisplayName()));
+            }
+
+            if (foreignKey.IsIntraHierarchical())
+            {
+                throw new InvalidOperationException(CoreStrings.IntraHierarchicalAmbiguousTargetEntityType(
+                    entityType.DisplayName(), Property.Format(foreignKey.Properties),
+                    foreignKey.PrincipalEntityType.DisplayName(),
+                    foreignKey.DeclaringEntityType.DisplayName()));
             }
 
             return foreignKey.DeclaringEntityType.IsAssignableFrom(entityType)
@@ -146,7 +239,7 @@ namespace Microsoft.Data.Entity.Metadata
                 : foreignKey.PrincipalEntityType;
         }
 
-        public static EntityType ResolveEntityType([NotNull] this ForeignKey foreignKey, [NotNull] EntityType entityType)
-            => (EntityType)((IForeignKey)foreignKey).ResolveEntityType(entityType);
+        public static EntityType ResolveEntityTypeInHierarchy([NotNull] this ForeignKey foreignKey, [NotNull] EntityType entityType)
+            => (EntityType)((IForeignKey)foreignKey).ResolveEntityTypeInHierarchy(entityType);
     }
 }

--- a/src/EntityFramework.Core/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -167,8 +167,13 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 var existingProperty = Metadata.FindProperty(propertyName);
                 if (existingProperty == null)
                 {
-                    var derivedProperties = Metadata.FindDerivedProperties(propertyName).ToList();
+                    var derivedProperties = Metadata.FindDerivedProperties(propertyName);
                     detachedProperties = DetachProperties(derivedProperties);
+                }
+                else if (existingProperty.DeclaringEntityType != Metadata)
+                {
+                    return ModelBuilder.Entity(existingProperty.DeclaringEntityType.Name, ConfigurationSource.Convention)
+                        .InternalProperty(clrProperty, configurationSource);
                 }
 
                 var builder = _propertyBuilders.GetOrAdd(
@@ -196,8 +201,13 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 var existingProperty = Metadata.FindProperty(propertyName);
                 if (existingProperty == null)
                 {
-                    var derivedProperties = Metadata.FindDerivedProperties(propertyName).ToList();
+                    var derivedProperties = Metadata.FindDerivedProperties(propertyName);
                     detachedProperties = DetachProperties(derivedProperties);
+                }
+                else if(existingProperty.DeclaringEntityType != Metadata)
+                {
+                    return ModelBuilder.Entity(existingProperty.DeclaringEntityType.Name, ConfigurationSource.Convention)
+                        .InternalProperty(propertyName, propertyType, configurationSource);
                 }
 
                 var builder = _propertyBuilders.GetOrAdd(
@@ -215,10 +225,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                     ModelBuilder.ConventionDispatcher.OnPropertyAdded,
                     configurationSource);
 
-                if (detachedProperties != null)
-                {
-                    detachedProperties.Attach(this);
-                }
+                detachedProperties?.Attach(this);
 
                 return ConfigureProperty(builder, propertyType, /*shadowProperty:*/ null, configurationSource);
             }
@@ -339,27 +346,13 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var navigation = Metadata.FindNavigationsInHierarchy(memberName).SingleOrDefault();
             if (navigation != null)
             {
-                var oldNavigationToPrincipalName = navigation.ForeignKey.DependentToPrincipal?.Name;
-                var oldNavigationToDependentName = navigation.ForeignKey.PrincipalToDependent?.Name;
-
                 var ownerBuilder = ModelBuilder.Entity(navigation.ForeignKey.DeclaringEntityType.Name, ConfigurationSource.Convention);
-                var relationshipBuilder = ownerBuilder.Relationship(navigation.ForeignKey, ConfigurationSource.Convention);
                 var removedConfigurationSource = ownerBuilder.RemoveForeignKey(navigation.ForeignKey, configurationSource);
 
                 if (removedConfigurationSource == null)
                 {
                     _ignoredMembers.Value.Remove(memberName);
                     return false;
-                }
-
-                if (oldNavigationToPrincipalName != null)
-                {
-                    ModelBuilder.ConventionDispatcher.OnNavigationRemoved(relationshipBuilder, oldNavigationToPrincipalName, true);
-                }
-
-                if (oldNavigationToDependentName != null)
-                {
-                    ModelBuilder.ConventionDispatcher.OnNavigationRemoved(relationshipBuilder, oldNavigationToDependentName, false);
                 }
             }
 
@@ -434,8 +427,8 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
             var detachedRelationships = new HashSet<RelationshipBuilderSnapshot>();
             PropertyBuildersSnapshot detachedProperties = null;
-            var baseRelationshipsToBeRemoved = new HashSet<ForeignKey>();
 
+            IReadOnlyList<RelationshipSnapshot> relationshipsToBeRemoved = new List<RelationshipSnapshot>();
             if (baseEntityType != null)
             {
                 if (Metadata.GetKeys().Any(k => !_keyBuilders.CanRemove(k, configurationSource, canOverrideSameSource: true)))
@@ -445,38 +438,15 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                     return null;
                 }
 
-                // TODO: Find conflicting navigations if different principal end
-                var relationshipsToBeRemoved = new HashSet<ForeignKey>();
-                FindConflictingRelationships(baseEntityType, baseRelationshipsToBeRemoved, relationshipsToBeRemoved, whereDependent: true);
-                FindConflictingRelationships(baseEntityType, baseRelationshipsToBeRemoved, relationshipsToBeRemoved, whereDependent: false);
-
-                // TODO: Try to remove on derived if this fails
-                if (baseRelationshipsToBeRemoved.Any(relationshipToBeRemoved =>
-                    !CanRemove(relationshipToBeRemoved, configurationSource)))
+                relationshipsToBeRemoved = FindConflictingRelationships(baseEntityType, configurationSource);
+                if (relationshipsToBeRemoved == null)
                 {
-                    Debug.Assert(configurationSource != ConfigurationSource.Explicit);
-
                     return null;
-                }
-
-                // TODO: Try to remove on base if this fails
-                if (relationshipsToBeRemoved.Any(relationshipToBeRemoved =>
-                    !CanRemove(relationshipToBeRemoved, configurationSource)))
-                {
-                    Debug.Assert(configurationSource != ConfigurationSource.Explicit);
-
-                    return null;
-                }
-
-                foreach (var relationshipToBeRemoved in baseRelationshipsToBeRemoved)
-                {
-                    var removedConfigurationSource = RemoveForeignKey(relationshipToBeRemoved, configurationSource);
-                    Debug.Assert(removedConfigurationSource.HasValue);
                 }
 
                 foreach (var relationshipToBeRemoved in relationshipsToBeRemoved)
                 {
-                    var removedConfigurationSource = RemoveForeignKey(relationshipToBeRemoved, configurationSource);
+                    var removedConfigurationSource = RemoveForeignKey(relationshipToBeRemoved.ForeignKey, configurationSource, runConventions: false);
                     Debug.Assert(removedConfigurationSource.HasValue);
                 }
 
@@ -498,9 +468,9 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
                 var duplicatedProperties = baseEntityType.Properties
                     .Select(p => Metadata.FindDeclaredProperty(p.Name))
-                    .Where(p => p != null)
-                    .ToList();
+                    .Where(p => p != null);
 
+                // TODO: Detach base property if shadow and derived non-shadow
                 detachedProperties = DetachProperties(duplicatedProperties);
 
                 ModelBuilder.Entity(baseEntityType.Name, configurationSource);
@@ -510,45 +480,32 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var originalBaseType = Metadata.BaseType;
             Metadata.BaseType = baseEntityType;
 
-            if (detachedProperties != null)
-            {
-                detachedProperties.Attach(this);
-            }
+            detachedProperties?.Attach(this);
 
             foreach (var detachedRelationship in detachedRelationships)
             {
                 detachedRelationship.Attach();
             }
 
-            if (baseRelationshipsToBeRemoved.Any())
+            foreach (var relationshipToBeRemoved in relationshipsToBeRemoved)
             {
-                // Try to readd the removed relationships to the derived types
-                var basestType = baseEntityType;
-                foreach (var baseTypeFromRelationship in baseRelationshipsToBeRemoved.Select(r => r.ResolveEntityType(baseEntityType)))
+                var dependentEntityType = ModelBuilder.Entity(
+                    relationshipToBeRemoved.ForeignKey.DeclaringEntityType.Name, ConfigurationSource.Convention);
+                var principalEntityType = ModelBuilder.Entity(
+                    relationshipToBeRemoved.ForeignKey.PrincipalEntityType.Name, ConfigurationSource.Convention);
+                var source = relationshipToBeRemoved.IsDependent ? dependentEntityType : principalEntityType;
+                var target = relationshipToBeRemoved.IsDependent ? principalEntityType : dependentEntityType;
+
+                if (relationshipToBeRemoved.NavigationFrom != null)
                 {
-                    if (baseTypeFromRelationship.IsAssignableFrom(baseEntityType))
-                    {
-                        basestType = baseTypeFromRelationship;
-                    }
-                    Debug.Assert(baseEntityType.IsAssignableFrom(baseTypeFromRelationship));
+                    ModelBuilder.ConventionDispatcher.OnNavigationRemoved(source, target, relationshipToBeRemoved.NavigationFrom.Name);
+                }
+                if (relationshipToBeRemoved.NavigationTo != null)
+                {
+                    ModelBuilder.ConventionDispatcher.OnNavigationRemoved(target, source, relationshipToBeRemoved.NavigationTo.Name);
                 }
 
-                var affectedDerivedTypes = new Queue<EntityType>();
-                affectedDerivedTypes.Enqueue(basestType);
-                while (affectedDerivedTypes.Count > 0)
-                {
-                    var affectedDerivedType = affectedDerivedTypes.Dequeue();
-                    foreach (var moreDerivedType in affectedDerivedType.GetDirectlyDerivedTypes().Where(t => t != Metadata))
-                    {
-                        affectedDerivedTypes.Enqueue(moreDerivedType);
-                    }
-                    if (affectedDerivedType != baseEntityType)
-                    {
-                        ModelBuilder.ConventionDispatcher.OnBaseEntityTypeSet(
-                            ModelBuilder.Entity(affectedDerivedType.Name, ConfigurationSource.Convention),
-                            affectedDerivedType.BaseType);
-                    }
-                }
+                ModelBuilder.ConventionDispatcher.OnForeignKeyRemoved(dependentEntityType, relationshipToBeRemoved.ForeignKey);
             }
 
             ModelBuilder.ConventionDispatcher.OnBaseEntityTypeSet(this, originalBaseType);
@@ -556,11 +513,16 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             return this;
         }
 
-        private PropertyBuildersSnapshot DetachProperties(
-            IReadOnlyList<Property> propertiesToDetach)
+        private PropertyBuildersSnapshot DetachProperties(IEnumerable<Property> propertiesToDetach)
         {
+            var propertiesToDetachList = propertiesToDetach.ToList();
+            if (propertiesToDetachList.Count == 0)
+            {
+                return null;
+            }
+
             var detachedRelationships = new List<RelationshipBuilderSnapshot>();
-            foreach (var propertyToDetach in propertiesToDetach)
+            foreach (var propertyToDetach in propertiesToDetachList)
             {
                 foreach (var relationship in propertyToDetach.FindContainingForeignKeysInHierarchy().ToList())
                 {
@@ -575,7 +537,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             // Issue #2514
 
             var detachedProperties = new List<Tuple<InternalPropertyBuilder, ConfigurationSource>>();
-            foreach (var propertyToDetach in propertiesToDetach)
+            foreach (var propertyToDetach in propertiesToDetachList)
             {
                 var property = propertyToDetach.DeclaringEntityType.FindDeclaredProperty(propertyToDetach.Name);
                 if (property != null)
@@ -619,14 +581,13 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             }
         }
 
-        private void FindConflictingRelationships(
+        private IReadOnlyList<RelationshipSnapshot> FindConflictingRelationships(
             EntityType baseEntityType,
-            HashSet<ForeignKey> baseRelationshipsToBeRemoved,
-            HashSet<ForeignKey> relationshipsToBeRemoved,
-            bool whereDependent)
+            ConfigurationSource configurationSource)
         {
-            var baseRelationshipsByTargetType = GroupForeignKeysByTargetType(baseEntityType, whereDependent);
-            var relationshipsByTargetType = GroupForeignKeysByTargetType(Metadata, whereDependent);
+            var relationshipsToBeRemoved = new List<RelationshipSnapshot>();
+            var baseRelationshipsByTargetType = GroupRelationshipsByTargetType(baseEntityType);
+            var relationshipsByTargetType = GroupRelationshipsByTargetType(Metadata);
 
             foreach (var relatedEntityType in relationshipsByTargetType.Keys)
             {
@@ -639,40 +600,51 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 {
                     foreach (var relationship in relationshipsByTargetType[relatedEntityType])
                     {
-                        if ((whereDependent
+                        if ((baseRelationship.IsDependent
+                             && relationship.IsDependent
                              && PropertyListComparer.Instance.Equals(
                                  baseRelationship.ForeignKey.Properties,
                                  relationship.ForeignKey.Properties))
                             || (relationship.NavigationFrom != null
                                 && baseRelationship.NavigationFrom?.Name == relationship.NavigationFrom.Name))
                         {
-                            if (baseRelationship.NavigationTo == null
-                                && relationship.NavigationTo != null)
+                            if (CanRemove(relationship.ForeignKey, configurationSource))
                             {
-                                baseRelationshipsToBeRemoved.Add(baseRelationship.ForeignKey);
+                                relationshipsToBeRemoved.Add(relationship);
+                            }
+                            else if (CanRemove(baseRelationship.ForeignKey, configurationSource))
+                            {
+                                relationshipsToBeRemoved.Add(baseRelationship);
                             }
                             else
                             {
-                                relationshipsToBeRemoved.Add(relationship.ForeignKey);
+                                return null;
                             }
                         }
                     }
                 }
             }
+
+            return relationshipsToBeRemoved;
         }
 
-        private Dictionary<EntityType, List<RelationshipSnapshot>> GroupForeignKeysByTargetType(EntityType entityType, bool whereDependent)
-        {
-            var foreignKeys = whereDependent
-                ? entityType.GetForeignKeys()
-                : entityType.FindReferencingForeignKeys().Where(foreignKey => !foreignKey.IsSelfReferencing());
-            return foreignKeys
-                .GroupBy(foreignKey => whereDependent ? foreignKey.PrincipalEntityType : foreignKey.DeclaringEntityType)
-                .ToDictionary(g => g.Key, g => g.Select(foreignKey =>
+        private Dictionary<EntityType, List<RelationshipSnapshot>> GroupRelationshipsByTargetType(EntityType entityType)
+            => entityType.GetForeignKeys()
+                .Select(foreignKey =>
                     new RelationshipSnapshot(foreignKey,
-                        whereDependent ? foreignKey.DependentToPrincipal : foreignKey.PrincipalToDependent,
-                        whereDependent ? foreignKey.PrincipalToDependent : foreignKey.DependentToPrincipal)).ToList());
-        }
+                        foreignKey.DependentToPrincipal,
+                        foreignKey.PrincipalToDependent,
+                        isDependent: true))
+                .Concat(entityType.FindReferencingForeignKeys().Where(foreignKey => !foreignKey.IsSelfReferencing())
+                    .Select(foreignKey =>
+                        new RelationshipSnapshot(foreignKey,
+                            foreignKey.PrincipalToDependent,
+                            foreignKey.DependentToPrincipal,
+                            isDependent: false)))
+                .GroupBy(relationship => relationship.IsDependent
+                    ? relationship.ForeignKey.PrincipalEntityType
+                    : relationship.ForeignKey.DeclaringEntityType)
+                .ToDictionary(g => g.Key, g => g.ToList());
 
         private ConfigurationSource? RemoveProperty(
             Property property, ConfigurationSource configurationSource, bool canOverrideSameSource = true)
@@ -720,18 +692,21 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var navigationToDependentName = foreignKey.PrincipalToDependent?.Name;
             var relationship = ModelBuilder.Entity(foreignKey.DeclaringEntityType.Name, ConfigurationSource.Convention)
                 .Relationship(foreignKey, ConfigurationSource.Convention);
-            var relationshipConfigurationSource = RemoveForeignKey(foreignKey, ConfigurationSource.Explicit);
+            var relationshipConfigurationSource = RemoveForeignKey(foreignKey, ConfigurationSource.Explicit, runConventions: false);
             Debug.Assert(relationshipConfigurationSource != null);
 
             return new RelationshipBuilderSnapshot(relationship, navigationToPrincipalName, navigationToDependentName, relationshipConfigurationSource.Value);
         }
 
         public virtual ConfigurationSource? RemoveForeignKey([NotNull] ForeignKey foreignKey, ConfigurationSource configurationSource)
+            => RemoveForeignKey(foreignKey, configurationSource, runConventions: true);
+
+        public virtual ConfigurationSource? RemoveForeignKey([NotNull] ForeignKey foreignKey, ConfigurationSource configurationSource, bool runConventions)
         {
             if (foreignKey.DeclaringEntityType != Metadata)
             {
                 return ModelBuilder.Entity(foreignKey.DeclaringEntityType.Name, ConfigurationSource.Convention)
-                    .RemoveForeignKey(foreignKey, configurationSource);
+                    .RemoveForeignKey(foreignKey, configurationSource, runConventions);
             }
 
             var removedConfigurationSource = _relationshipBuilders.Value.Remove(foreignKey, configurationSource);
@@ -751,10 +726,28 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var removedForeignKey = Metadata.RemoveForeignKey(foreignKey);
             Debug.Assert(removedForeignKey == foreignKey);
 
-            ModelBuilder.ConventionDispatcher.OnForeignKeyRemoved(this, foreignKey);
             RemoveShadowPropertiesIfUnused(foreignKey.Properties);
             ModelBuilder.Entity(foreignKey.PrincipalEntityType.Name, ConfigurationSource.Convention)
                 ?.RemoveKeyIfUnused(foreignKey.PrincipalKey);
+
+            if (runConventions)
+            {
+                var principalEntityBuilder = ModelBuilder.Entity(foreignKey.PrincipalEntityType.Name, ConfigurationSource.Convention);
+                if (principalEntityBuilder != null)
+                {
+                    if (navigationToPrincipal != null)
+                    {
+                        ModelBuilder.ConventionDispatcher.OnNavigationRemoved(this, principalEntityBuilder, navigationToPrincipal.Name);
+                    }
+
+                    if (navigationToDependent != null)
+                    {
+                        ModelBuilder.ConventionDispatcher.OnNavigationRemoved(principalEntityBuilder, this, navigationToDependent.Name);
+                    }
+                }
+
+                ModelBuilder.ConventionDispatcher.OnForeignKeyRemoved(this, foreignKey);
+            }
 
             return removedConfigurationSource;
         }
@@ -908,25 +901,27 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             }
 
             InternalRelationshipBuilder relationship;
+            InternalRelationshipBuilder newRelationship = null;
             var existingForeignKey = Metadata.FindForeignKeysInHierarchy(dependentProperties).FirstOrDefault();
-            if (existingForeignKey == null)
+            if (existingForeignKey == null
+                || existingForeignKey.DeclaringEntityType != Metadata)
             {
-                relationship = CreateForeignKey(
-                    principalEntityTypeBuilder,
-                    dependentProperties,
-                    null,
-                    null,
-                    null,
-                    configurationSource);
+                newRelationship = Relationship(principalEntityTypeBuilder, configurationSource);
+                relationship = newRelationship;
             }
             else
             {
-                relationship = existingForeignKey.DeclaringEntityType == Metadata
-                    ? Relationship(existingForeignKey, configurationSource)
-                    : Relationship(principalEntityTypeBuilder, configurationSource);
+                relationship = Relationship(existingForeignKey, configurationSource);
             }
 
-            return relationship.HasForeignKey(dependentProperties, configurationSource);
+            relationship = relationship.HasForeignKey(dependentProperties, configurationSource);
+            if (relationship == null
+                && newRelationship != null)
+            {
+                RemoveForeignKey(newRelationship.Metadata, configurationSource);
+            }
+
+            return relationship;
         }
 
         public virtual InternalRelationshipBuilder Relationship(
@@ -980,25 +975,16 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             EntityType principalType,
             IReadOnlyList<Property> dependentProperties,
             Key principalKey,
-            ConfigurationSource configurationSource)
-        {
-            var relationship = _relationshipBuilders.Value.GetOrAdd(
+            ConfigurationSource configurationSource,
+            bool runConventions)
+            => _relationshipBuilders.Value.GetOrAdd(
                 () => null,
                 () => Metadata.AddForeignKey(dependentProperties, principalKey, principalType),
                 fk => new InternalRelationshipBuilder(fk, ModelBuilder, null),
+                runConventions
+                    ? ModelBuilder.ConventionDispatcher.OnForeignKeyAdded
+                    : (Func<InternalRelationshipBuilder, InternalRelationshipBuilder>)null,
                 configurationSource);
-
-            foreach (var foreignKeyProperty in dependentProperties)
-            {
-                var propertyBuilder = ModelBuilder.Entity(foreignKeyProperty.DeclaringEntityType.Name, ConfigurationSource.Convention)
-                    .Property(foreignKeyProperty.Name, ConfigurationSource.Convention);
-
-                propertyBuilder.UseValueGenerator(null, ConfigurationSource.Convention);
-                propertyBuilder.ValueGenerated(null, ConfigurationSource.Convention);
-            }
-
-            return relationship;
-        }
 
         public virtual InternalRelationshipBuilder Relationship(
             [NotNull] InternalEntityTypeBuilder targetEntityTypeBuilder,
@@ -1163,7 +1149,8 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 null,
                 null,
                 null,
-                configurationSource);
+                configurationSource,
+                runConventions: true);
 
         public virtual InternalRelationshipBuilder CreateForeignKey(
             [NotNull] InternalEntityTypeBuilder principalEntityTypeBuilder,
@@ -1171,7 +1158,8 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             [CanBeNull] IReadOnlyList<Property> principalProperties,
             [CanBeNull] string navigationToPrincipalName,
             bool? isRequired,
-            ConfigurationSource configurationSource)
+            ConfigurationSource configurationSource,
+            bool runConventions)
         {
             var principalType = principalEntityTypeBuilder.Metadata;
             Debug.Assert(dependentProperties == null
@@ -1193,7 +1181,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             {
                 dependentProperties = GetOrCreateProperties(dependentProperties, ConfigurationSource.Convention);
                 if (principalKey == null
-                    || !Entity.Metadata.ForeignKey.AreCompatible(
+                    || !ForeignKey.AreCompatible(
                         principalKey.Properties,
                         dependentProperties,
                         principalType,
@@ -1244,7 +1232,8 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 dependentProperties = fkProperties;
             }
 
-            return CreateRelationshipBuilder(principalType, dependentProperties, principalKey, configurationSource);
+            ModelBuilder.Entity(principalType.Name, configurationSource);
+            return CreateRelationshipBuilder(principalType, dependentProperties, principalKey, configurationSource, runConventions);
         }
 
         private Property CreateUniqueProperty(string baseName, Type propertyType, InternalEntityTypeBuilder entityTypeBuilder, bool? isRequired = null)
@@ -1255,17 +1244,14 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 var name = baseName + (++index > 0 ? index.ToString() : "");
                 var entityType = entityTypeBuilder.Metadata;
                 if (entityType.FindPropertiesInHierarchy(name).Any()
-                    || (entityType.ClrType?.GetRuntimeProperty(name) != null))
+                    || (entityType.ClrType?.GetRuntimeProperties().FirstOrDefault(p => p.Name == name) != null))
                 {
                     continue;
                 }
 
-                var propertyBuilder = entityTypeBuilder.Property(name, ConfigurationSource.Convention);
+                var propertyBuilder = entityTypeBuilder.Property(name, propertyType, ConfigurationSource.Convention);
                 if (propertyBuilder != null)
                 {
-                    var clrTypeSet = propertyBuilder.ClrType(propertyType, ConfigurationSource.Convention);
-                    Debug.Assert(clrTypeSet);
-
                     if (isRequired.HasValue
                         && propertyType.IsNullableType())
                     {
@@ -1367,8 +1353,8 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             [NotNull] InternalModelBuilder modelBuilder,
             [NotNull] IEnumerable<Property> properties,
             ConfigurationSource configurationSource)
-            => properties.Select(property =>
-                modelBuilder.Entity(property.DeclaringEntityType.Name, configurationSource)
+            => properties.Where(property => property.DeclaringEntityType.FindProperty(property.Name) != null)
+                .Select(property => modelBuilder.Entity(property.DeclaringEntityType.Name, configurationSource)
                     ?.Property(property.Name, configurationSource));
 
         private struct RelationshipSnapshot
@@ -1376,12 +1362,14 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             public readonly ForeignKey ForeignKey;
             public readonly Navigation NavigationFrom;
             public readonly Navigation NavigationTo;
+            public readonly bool IsDependent;
 
-            public RelationshipSnapshot(ForeignKey foreignKey, Navigation navigationFrom, Navigation navigationTo)
+            public RelationshipSnapshot(ForeignKey foreignKey, Navigation navigationFrom, Navigation navigationTo, bool isDependent)
             {
                 ForeignKey = foreignKey;
                 NavigationFrom = navigationFrom;
                 NavigationTo = navigationTo;
+                IsDependent = isDependent;
             }
         }
 

--- a/src/EntityFramework.Core/Metadata/Internal/InternalModelBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/InternalModelBuilder.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
         private readonly LazyRef<Dictionary<string, ConfigurationSource>> _ignoredEntityTypeNames =
             new LazyRef<Dictionary<string, ConfigurationSource>>(() => new Dictionary<string, ConfigurationSource>());
-        
+
         public InternalModelBuilder([NotNull] Model metadata, [NotNull] ConventionSet conventions)
             : base(metadata)
         {
@@ -101,9 +101,14 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 return true;
             }
 
-            _ignoredEntityTypeNames.Value[name] = configurationSource;
-
             var entityType = Metadata.FindEntityType(name);
+
+            return Ignore(entityType, name, configurationSource);
+        }
+
+        private bool Ignore(EntityType entityType, string name, ConfigurationSource configurationSource)
+        {
+            _ignoredEntityTypeNames.Value[name] = configurationSource;
             if (entityType != null)
             {
                 if (!Remove(entityType, configurationSource))
@@ -124,28 +129,37 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 return false;
             }
 
-            foreach (var foreignKey in entityType.GetForeignKeys().ToList())
+            foreach (var foreignKey in entityType.GetDeclaredForeignKeys().ToList())
+            {
+                var removed = entityTypeBuilder.RemoveForeignKey(foreignKey, configurationSource, runConventions: false);
+                Debug.Assert(removed.HasValue);
+            }
+
+            foreach (var foreignKey in Metadata.FindDeclaredReferencingForeignKeys(entityType).ToList())
             {
                 var removed = entityTypeBuilder.RemoveForeignKey(foreignKey, configurationSource);
                 Debug.Assert(removed.HasValue);
             }
 
-            foreach (var foreignKey in Metadata.FindReferencingForeignKeys(entityType).ToList())
+            foreach (var directlyDerivedType in entityType.GetDirectlyDerivedTypes().ToList())
             {
-                var removed = entityTypeBuilder.RemoveForeignKey(foreignKey, configurationSource);
-                Debug.Assert(removed.HasValue);
+                var removed = Entity(directlyDerivedType.Name, ConfigurationSource.Convention)
+                    .HasBaseType(entityType.BaseType, configurationSource);
+                Debug.Assert(removed != null);
             }
 
             Metadata.RemoveEntityType(entityType);
 
             return true;
         }
-        
+
         public virtual void RemoveEntityTypesUnreachableByNavigations(ConfigurationSource configurationSource)
         {
-            foreach (var orphan in new ModelNavigationsGraphAdapter(Metadata).GetUnreachableVertices(GetRoots(configurationSource)))
+            var rootEntityTypes = GetRoots(configurationSource);
+            foreach (var orphan in new ModelNavigationsGraphAdapter(Metadata).GetUnreachableVertices(rootEntityTypes))
             {
-                Remove(orphan, configurationSource);
+                // Ignoring the type prevents it from being rediscovered by conventions that run as part of the removal
+                Ignore(orphan, orphan.Name, configurationSource);
             }
         }
 

--- a/src/EntityFramework.Core/Metadata/ModelExtensions.cs
+++ b/src/EntityFramework.Core/Metadata/ModelExtensions.cs
@@ -34,6 +34,17 @@ namespace Microsoft.Data.Entity.Metadata
             model[CoreAnnotationNames.ProductVersionAnnotation] = value;
         }
         
+        public static IEnumerable<IForeignKey> FindDeclaredReferencingForeignKeys([NotNull] this IModel model, [NotNull] IEntityType entityType)
+        {
+            Check.NotNull(model, nameof(model));
+            Check.NotNull(entityType, nameof(entityType));
+
+            // TODO: Perf: Add additional indexes so that this isn't a linear lookup
+            // Issue #1179
+            return model.EntityTypes.SelectMany(et => et.GetDeclaredForeignKeys())
+                .Where(fk => fk.PrincipalEntityType == entityType);
+        }
+
         public static IEnumerable<IForeignKey> FindReferencingForeignKeys([NotNull] this IModel model, [NotNull] IEntityType entityType)
         {
             Check.NotNull(model, nameof(model));

--- a/src/EntityFramework.Core/Properties/CoreStrings.Designer.cs
+++ b/src/EntityFramework.Core/Properties/CoreStrings.Designer.cs
@@ -757,11 +757,11 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
-        /// The entity type '{entityType}' cannot be removed because it is being referenced from a foreign key. All referencing foreign keys must be removed or redefined before the entity type can be removed.
+        /// The entity type '{entityType}' cannot be removed because it is being referenced by foreign key {foreignKey} on '{referencingEntityType}'. All referencing foreign keys must be removed or redefined before the entity type can be removed.
         /// </summary>
-        public static string EntityTypeInUse([CanBeNull] object entityType)
+        public static string EntityTypeInUseByForeignKey([CanBeNull] object entityType, [CanBeNull] object foreignKey, [CanBeNull] object referencingEntityType)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("EntityTypeInUse", "entityType"), entityType);
+            return string.Format(CultureInfo.CurrentCulture, GetString("EntityTypeInUseByForeignKey", "entityType", "foreignKey", "referencingEntityType"), entityType, foreignKey, referencingEntityType);
         }
 
         /// <summary>
@@ -1021,11 +1021,11 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
-        /// The entity type related to '{entityType}' cannot be determined because the specified foreign key {foreignKey} references an entity type that it is in the same hierarchy as the entity type that it is declared on.
+        /// The entity type related to '{entityType}' cannot be determined because the specified foreign key {foreignKey} references entity type '{principalEntityType}' that it is in the same hierarchy as the entity type that it is declared on '{dependentEntityType}'.
         /// </summary>
-        public static string IntraHierarchicalAmbiguousTargetEntityType([CanBeNull] object entityType, [CanBeNull] object foreignKey)
+        public static string IntraHierarchicalAmbiguousTargetEntityType([CanBeNull] object entityType, [CanBeNull] object foreignKey, [CanBeNull] object principalEntityType, [CanBeNull] object dependentEntityType)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("IntraHierarchicalAmbiguousTargetEntityType", "entityType", "foreignKey"), entityType, foreignKey);
+            return string.Format(CultureInfo.CurrentCulture, GetString("IntraHierarchicalAmbiguousTargetEntityType", "entityType", "foreignKey", "principalEntityType", "dependentEntityType"), entityType, foreignKey, principalEntityType, dependentEntityType);
         }
 
         /// <summary>
@@ -1154,6 +1154,30 @@ namespace Microsoft.Data.Entity.Internal
         public static string ConflictingProperty([CanBeNull] object navigation, [CanBeNull] object entityType, [CanBeNull] object duplicateEntityType)
         {
             return string.Format(CultureInfo.CurrentCulture, GetString("ConflictingProperty", "navigation", "entityType", "duplicateEntityType"), navigation, entityType, duplicateEntityType);
+        }
+
+        /// <summary>
+        /// The specified entity type '{entityType}' is invalid. It should be either the dependent entity type '{dependentType}' or the principal entity type '{principalType}'.
+        /// </summary>
+        public static string EntityTypeNotInRelationshipStrict([CanBeNull] object entityType, [CanBeNull] object dependentType, [CanBeNull] object principalType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("EntityTypeNotInRelationshipStrict", "entityType", "dependentType", "principalType"), entityType, dependentType, principalType);
+        }
+
+        /// <summary>
+        /// The navigation property corresponding to '{entityType}' cannot be determined because the principal entity type for foreign key {foreignKey} is the same as the dependent entity type.
+        /// </summary>
+        public static string SelfReferencingAmbiguousNavigation([CanBeNull] object entityType, [CanBeNull] object foreignKey)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("SelfReferencingAmbiguousNavigation", "entityType", "foreignKey"), entityType, foreignKey);
+        }
+
+        /// <summary>
+        /// The entity type '{entityType}' cannot be removed because '{derivedEntityType}' is derived from it. All derived entity types must be removed or redefined before the entity type can be removed.
+        /// </summary>
+        public static string EntityTypeInUseByDerived([CanBeNull] object entityType, [CanBeNull] object derivedEntityType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("EntityTypeInUseByDerived", "entityType", "derivedEntityType"), entityType, derivedEntityType);
         }
 
         /// <summary>

--- a/src/EntityFramework.Core/Properties/CoreStrings.resx
+++ b/src/EntityFramework.Core/Properties/CoreStrings.resx
@@ -396,8 +396,8 @@
   <data name="RecursiveOnConfiguring" xml:space="preserve">
     <value>An attempt was made to use the context while it is being configured. A DbContext instance cannot be used inside OnConfiguring since it is still being configured at this point.</value>
   </data>
-  <data name="EntityTypeInUse" xml:space="preserve">
-    <value>The entity type '{entityType}' cannot be removed because it is being referenced from a foreign key. All referencing foreign keys must be removed or redefined before the entity type can be removed.</value>
+  <data name="EntityTypeInUseByForeignKey" xml:space="preserve">
+    <value>The entity type '{entityType}' cannot be removed because it is being referenced by foreign key {foreignKey} on '{referencingEntityType}'. All referencing foreign keys must be removed or redefined before the entity type can be removed.</value>
   </data>
   <data name="ArgumentPropertyNull" xml:space="preserve">
     <value>The property '{property}' of the argument '{argument}' cannot be null.</value>
@@ -496,7 +496,7 @@
     <value>The block size used for Hi-Lo value generation must be positive. When the Hi-Lo generator is backed by a SQL sequence this means that the sequence increment must be positive.</value>
   </data>
   <data name="IntraHierarchicalAmbiguousTargetEntityType" xml:space="preserve">
-    <value>The entity type related to '{entityType}' cannot be determined because the specified foreign key {foreignKey} references an entity type that it is in the same hierarchy as the entity type that it is declared on.</value>
+    <value>The entity type related to '{entityType}' cannot be determined because the specified foreign key {foreignKey} references entity type '{principalEntityType}' that it is in the same hierarchy as the entity type that it is declared on '{dependentEntityType}'.</value>
   </data>
   <data name="NonClrBaseType" xml:space="preserve">
     <value>The entity type '{entityType}' cannot inherit from '{baseEntityType}' because '{baseEntityType}' is a shadow state entity type while '{entityType}' is not.</value>
@@ -545,6 +545,15 @@
   </data>
   <data name="ConflictingProperty" xml:space="preserve">
     <value>The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because a property with the same name already exists on entity type '{duplicateEntityType}'.</value>
+  </data>
+  <data name="EntityTypeNotInRelationshipStrict" xml:space="preserve">
+    <value>The specified entity type '{entityType}' is invalid. It should be either the dependent entity type '{dependentType}' or the principal entity type '{principalType}'.</value>
+  </data>
+  <data name="SelfReferencingAmbiguousNavigation" xml:space="preserve">
+    <value>The navigation property corresponding to '{entityType}' cannot be determined because the principal entity type for foreign key {foreignKey} is the same as the dependent entity type.</value>
+  </data>
+  <data name="EntityTypeInUseByDerived" xml:space="preserve">
+    <value>The entity type '{entityType}' cannot be removed because '{derivedEntityType}' is derived from it. All derived entity types must be removed or redefined before the entity type can be removed.</value>
   </data>
   <data name="NavigationNotAdded" xml:space="preserve">
     <value>The navigation '{navigation}' on entity type '{entityType}' has not been added to the model, or ignored, or target entityType ignored.</value>

--- a/src/EntityFramework.Relational/Metadata/Builders/DiscriminatorBuilder.cs
+++ b/src/EntityFramework.Relational/Metadata/Builders/DiscriminatorBuilder.cs
@@ -25,13 +25,13 @@ namespace Microsoft.Data.Entity.Metadata.Builders
 
         public virtual DiscriminatorBuilder HasValue([NotNull] Type entityType, [CanBeNull] object value)
         {
-            var entityTypeBuilder = AnnotationsBuilder.EntityTypeBuilder.ModelBuilder.Entity(entityType, ConfigurationSource.Convention);
+            var entityTypeBuilder = AnnotationsBuilder.EntityTypeBuilder.ModelBuilder.Entity(entityType, AnnotationsBuilder.Annotations.ConfigurationSource);
             return HasValue(entityTypeBuilder, value);
         }
 
         public virtual DiscriminatorBuilder HasValue([NotNull] string entityTypeName, [CanBeNull] object value)
         {
-            var entityTypeBuilder = AnnotationsBuilder.EntityTypeBuilder.ModelBuilder.Entity(entityTypeName, ConfigurationSource.Convention);
+            var entityTypeBuilder = AnnotationsBuilder.EntityTypeBuilder.ModelBuilder.Entity(entityTypeName, AnnotationsBuilder.Annotations.ConfigurationSource);
             return HasValue(entityTypeBuilder, value);
         }
 

--- a/src/EntityFramework.Relational/RelationalEntityTypeBuilderExtensions.cs
+++ b/src/EntityFramework.Relational/RelationalEntityTypeBuilderExtensions.cs
@@ -5,7 +5,6 @@ using System;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
-using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Metadata.Builders;
 using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Utilities;

--- a/src/EntityFramework.Relational/Update/AffectedCountModificationCommandBatch.cs
+++ b/src/EntityFramework.Relational/Update/AffectedCountModificationCommandBatch.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Data.Entity.Update
 {
     /// <summary>
     ///     A <see cref="ReaderModificationCommandBatch" /> for providers which append an SQL query to find out
-    ///     how many rows were affected (see <see cref="SqlGenerator.AppendSelectAffectedCountCommand" />).
+    ///     how many rows were affected (see <see cref="UpdateSqlGenerator.AppendSelectAffectedCountCommand" />).
     /// </summary>
     public abstract class AffectedCountModificationCommandBatch : ReaderModificationCommandBatch
     {

--- a/src/EntityFramework.Relational/Update/UpdateSqlGenerator.cs
+++ b/src/EntityFramework.Relational/Update/UpdateSqlGenerator.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Data.Entity.Update
 {
     public abstract class UpdateSqlGenerator : IUpdateSqlGenerator
     {
-        public UpdateSqlGenerator([NotNull] ISqlGenerator sqlGenerator)
+        protected UpdateSqlGenerator([NotNull] ISqlGenerator sqlGenerator)
         {
             Check.NotNull(sqlGenerator, nameof(sqlGenerator));
 

--- a/test/EntityFramework.Core.FunctionalTests/F1FixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/F1FixtureBase.cs
@@ -84,8 +84,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 });
 
             modelBuilder.Entity<TestDriver>();
-
             modelBuilder.Entity<TitleSponsor>();
+
             // TODO: Complex type
             // .Property(t => t.Details);
 

--- a/test/EntityFramework.Core.FunctionalTests/InheritanceFixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/InheritanceFixtureBase.cs
@@ -9,15 +9,18 @@ namespace Microsoft.Data.Entity.FunctionalTests
     {
         public virtual void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.Entity<Kiwi>().HasBaseType<Bird>();
-            modelBuilder.Entity<Eagle>().HasBaseType<Bird>();
-            modelBuilder.Entity<Bird>().HasBaseType<Animal>();
+            modelBuilder.Entity<Kiwi>();
+            modelBuilder.Entity<Eagle>();
+            modelBuilder.Entity<Bird>();
             modelBuilder.Entity<Animal>().HasKey(e => e.Species);
-            modelBuilder.Entity<Rose>().HasBaseType<Flower>();
-            modelBuilder.Entity<Daisy>().HasBaseType<Flower>();
-            modelBuilder.Entity<Flower>().HasBaseType<Plant>();
+            modelBuilder.Entity<Rose>();
+            modelBuilder.Entity<Daisy>();
+            modelBuilder.Entity<Flower>();
             modelBuilder.Entity<Plant>().HasKey(e => e.Species);
             modelBuilder.Entity<Country>();
+
+            //#3282
+            modelBuilder.Entity<Eagle>().Property(e => e.EagleId).Metadata.RequiresValueGenerator = false;
         }
 
         public abstract InheritanceContext CreateContext();

--- a/test/EntityFramework.Core.FunctionalTests/InheritanceRelationshipsQueryFixtureBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/InheritanceRelationshipsQueryFixtureBase.cs
@@ -17,12 +17,12 @@ namespace Microsoft.Data.Entity.FunctionalTests
             modelBuilder.Entity<DerivedInheritanceRelationshipEntity>().HasBaseType<BaseInheritanceRelationshipEntity>();
             modelBuilder.Entity<BaseInheritanceRelationshipEntity>().HasKey(e => e.Id);
 
-            modelBuilder.Entity<NestedReferenceDerived>().HasBaseType<NestedReferenceBase>();
-            modelBuilder.Entity<NestedCollectionDerived>().HasBaseType<NestedCollectionBase>();
-            modelBuilder.Entity<DerivedReferenceOnBase>().HasBaseType<BaseReferenceOnBase>();
-            modelBuilder.Entity<DerivedCollectionOnBase>().HasBaseType<BaseCollectionOnBase>();
-            modelBuilder.Entity<DerivedReferenceOnDerived>().HasBaseType<BaseReferenceOnDerived>();
-            modelBuilder.Entity<DerivedCollectionOnDerived>().HasBaseType<BaseCollectionOnDerived>();
+            modelBuilder.Entity<NestedReferenceDerived>();
+            modelBuilder.Entity<NestedCollectionDerived>();
+            modelBuilder.Entity<DerivedReferenceOnBase>();
+            modelBuilder.Entity<DerivedCollectionOnBase>();
+            modelBuilder.Entity<DerivedReferenceOnDerived>();
+            modelBuilder.Entity<DerivedCollectionOnDerived>();
             modelBuilder.Entity<BaseReferenceOnBase>().HasKey(e => e.Id);
             modelBuilder.Entity<BaseReferenceOnDerived>().HasKey(e => e.Id);
             modelBuilder.Entity<BaseCollectionOnBase>().HasKey(e => e.Id);
@@ -62,12 +62,6 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 .HasForeignKey(e => e.ParentId)
                 .IsRequired(false);
 
-            modelBuilder.Entity<DerivedInheritanceRelationshipEntity>()
-                .HasOne(e => e.BaseReferenceOnDerived)
-                .WithOne(e => e.BaseParent)
-                .HasForeignKey<BaseReferenceOnDerived>(e => e.BaseParentId)
-                .IsRequired(false);
-
             //TODO: See issue #3289
             modelBuilder.Entity<DerivedReferenceOnDerived>().Property(typeof(int?), "DerivedInheritanceRelationshipEntityId");
 
@@ -99,6 +93,18 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 .HasMany(e => e.CollectionOnDerived)
                 .WithOne(e => e.Parent)
                 .HasForeignKey(e => e.ParentId)
+                .IsRequired(false);
+
+            modelBuilder.Entity<DerivedInheritanceRelationshipEntity>()
+                .HasMany(e => e.DerivedCollectionOnDerived)
+                .WithOne()
+                .HasForeignKey("DerivedInheritanceRelationshipEntityId")
+                .IsRequired(false);
+
+            modelBuilder.Entity<DerivedInheritanceRelationshipEntity>()
+                .HasOne(e => e.BaseReferenceOnDerived)
+                .WithOne(e => e.BaseParent)
+                .HasForeignKey<BaseReferenceOnDerived>(e => e.BaseParentId)
                 .IsRequired(false);
 
             modelBuilder.Entity<BaseReferenceOnBase>()

--- a/test/EntityFramework.Core.FunctionalTests/OptimisticConcurrencyTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/OptimisticConcurrencyTestBase.cs
@@ -547,21 +547,15 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
         [Fact]
         public virtual void Calling_Reload_on_a_Unchanged_entity_makes_the_entity_unchanged()
-        {
-            TestReloadPositive(EntityState.Unchanged);
-        }
+            => TestReloadPositive(EntityState.Unchanged);
 
         [Fact]
         public virtual void Calling_Reload_on_a_Modified_entity_makes_the_entity_unchanged()
-        {
-            TestReloadPositive(EntityState.Modified);
-        }
+            => TestReloadPositive(EntityState.Modified);
 
         [Fact]
         public virtual void Calling_Reload_on_a_Deleted_entity_makes_the_entity_unchanged()
-        {
-            TestReloadPositive(EntityState.Deleted);
-        }
+            => TestReloadPositive(EntityState.Deleted);
 
         private void TestReloadPositive(EntityState state)
         {
@@ -628,10 +622,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         /// </summary>
         private Task ConcurrencyTestAsync(
             Action<F1Context> change, Action<F1Context, DbUpdateException> resolver,
-            Action<F1Context> validator)
-        {
-            return ConcurrencyTestAsync(change, change, resolver, validator);
-        }
+            Action<F1Context> validator) => ConcurrencyTestAsync(change, change, resolver, validator);
 
         /// <summary>
         ///     Runs the two actions with two different contexts and calling

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/ConcurrencyModel/Team.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/ConcurrencyModel/Team.cs
@@ -31,16 +31,10 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.ConcurrencyModel
 
         public virtual Chassis Chassis { get; set; }
 
-        public virtual ICollection<Driver> Drivers
-        {
-            get { return _drivers; }
-        }
+        public virtual ICollection<Driver> Drivers => _drivers;
 
         [NotMapped]
-        public virtual ICollection<Sponsor> Sponsors
-        {
-            get { return _sponsors; }
-        }
+        public virtual ICollection<Sponsor> Sponsors => _sponsors;
 
         public int? GearboxId { get; set; }
         public virtual Gearbox Gearbox { get; set; } // Uni-directional

--- a/test/EntityFramework.Core.Tests/ApiConsistencyTest.cs
+++ b/test/EntityFramework.Core.Tests/ApiConsistencyTest.cs
@@ -12,10 +12,8 @@ namespace Microsoft.Data.Entity.Tests
 {
     public class ApiConsistencyTest : ApiConsistencyTestBase
     {
-
         public class SampleEntity
         {
-
         }
 
         [Fact]
@@ -51,9 +49,6 @@ namespace Microsoft.Data.Entity.Tests
             Assert.Equal("", string.Join(Environment.NewLine, voidMethods));
         }
 
-        protected override Assembly TargetAssembly
-        {
-            get { return typeof(EntityType).Assembly; }
-        }
+        protected override Assembly TargetAssembly => typeof(EntityType).Assembly;
     }
 }

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalClrEntityEntryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalClrEntityEntryTest.cs
@@ -4,14 +4,13 @@
 using System;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Internal;
-using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 {
-    public class InternalClrEntityEntryTest : InternalEntityEntryTest
+    public class InternalClrEntityEntryTest : InternalEntityEntryTestBase
     {
         [Fact]
         public void Can_get_entity()
@@ -86,21 +85,15 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
         [Fact]
         public void Setting_CLR_property_with_snapshot_change_tracking_requires_DetectChanges()
-        {
-            SetPropertyClrTest(new SomeEntity { Id = 1, Name = "Kool" }, needsDetectChanges: true);
-        }
+            => SetPropertyClrTest(new SomeEntity { Id = 1, Name = "Kool" }, needsDetectChanges: true);
 
         [Fact]
         public void Setting_CLR_property_with_changed_only_notifications_does_not_require_DetectChanges()
-        {
-            SetPropertyClrTest(new ChangedOnlyEntity { Id = 1, Name = "Kool" }, needsDetectChanges: false); 
-        }
+            => SetPropertyClrTest(new ChangedOnlyEntity { Id = 1, Name = "Kool" }, needsDetectChanges: false);
 
         [Fact]
         public void Setting_CLR_property_with_full_notifications_does_not_require_DetectChanges()
-        {
-            SetPropertyClrTest(new FullNotificationEntity { Id = 1, Name = "Kool" }, needsDetectChanges: false);
-        }
+            => SetPropertyClrTest(new FullNotificationEntity { Id = 1, Name = "Kool" }, needsDetectChanges: false);
 
         [Fact]
         public void Original_values_are_not_tracked_unless_needed_by_default_for_properties_of_full_notifications_entity()

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalMixedEntityEntryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalMixedEntityEntryTest.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 {
-    public class InternalMixedEntityEntryTest : InternalEntityEntryTest
+    public class InternalMixedEntityEntryTest : InternalEntityEntryTestBase
     {
         [Fact]
         public void Can_get_entity()

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalShadowEntityEntryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalShadowEntityEntryTest.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 {
-    public class InternalShadowEntityEntryTest : InternalEntityEntryTest
+    public class InternalShadowEntityEntryTest : InternalEntityEntryTestBase
     {
         [Fact]
         public void Entity_is_null()

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/SidecarTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/SidecarTest.cs
@@ -477,11 +477,9 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             }
 
             public override ValueGenerator Create(IProperty property, IEntityType entityType)
-            {
-                return property.ClrType == typeof(int)
+                => property.ClrType == typeof(int)
                     ? _inMemoryFactory.Create(property)
                     : base.Create(property, entityType);
-            }
         }
     }
 }

--- a/test/EntityFramework.Core.Tests/EntityFramework.Core.Tests.csproj
+++ b/test/EntityFramework.Core.Tests/EntityFramework.Core.Tests.csproj
@@ -57,7 +57,7 @@
     <Compile Include="ChangeTracking\Internal\StateDataTest.cs" />
     <Compile Include="ChangeTracking\Internal\InternalEntityEntryFactoryTest.cs" />
     <Compile Include="ChangeTracking\Internal\InternalEntryEntrySubscriberTest.cs" />
-    <Compile Include="ChangeTracking\Internal\InternalEntityEntryTest.cs" />
+    <Compile Include="ChangeTracking\Internal\InternalEntityEntryTestBase.cs" />
     <Compile Include="ChangeTracking\Internal\StateManagerTest.cs" />
     <Compile Include="ChangeTracking\Internal\StoreGeneratedValuesTest.cs" />
     <Compile Include="ContextConfigurationTest.cs" />
@@ -88,8 +88,10 @@
     <Compile Include="Metadata\Internal\InternalPropertyBuilderTest.cs" />
     <Compile Include="Metadata\Internal\InternalRelationshipBuilderTest.cs" />
     <Compile Include="Metadata\MetadataBuilderTest.cs" />
+    <Compile Include="Metadata\ModelConventions\BaseTypeDiscoveryConventionTest.cs" />
     <Compile Include="Metadata\ModelConventions\CascadeDeleteConventionTest.cs" />
     <Compile Include="Metadata\ModelConventions\ConventionDispatcherTest.cs" />
+    <Compile Include="Metadata\ModelConventions\DerivedTypeDiscoveryConventionTest.cs" />
     <Compile Include="Metadata\ModelConventions\ForeignKeyPropertyDiscoveryConventionTest.cs" />
     <Compile Include="Metadata\ModelConventions\KeyConventionTest.cs" />
     <Compile Include="Metadata\ModelConventions\EntityTypeAttributeConventionTest.cs" />

--- a/test/EntityFramework.Core.Tests/Metadata/ForeignKeyTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ForeignKeyTest.cs
@@ -606,14 +606,21 @@ namespace Microsoft.Data.Entity.Metadata.Tests
         {
             var fk = CreateOneToManyFK();
 
-            Assert.Same(fk.DeclaringEntityType, fk.ResolveEntityType(fk.DeclaringEntityType));
-            Assert.Same(fk.PrincipalEntityType, fk.ResolveEntityType(fk.PrincipalEntityType));
             Assert.Same(fk.PrincipalEntityType, fk.ResolveOtherEntityType(fk.DeclaringEntityType));
             Assert.Same(fk.DeclaringEntityType, fk.ResolveOtherEntityType(fk.PrincipalEntityType));
             Assert.Same(fk.PrincipalToDependent, fk.FindNavigationFrom(fk.PrincipalEntityType));
             Assert.Same(fk.DependentToPrincipal, fk.FindNavigationFrom(fk.DeclaringEntityType));
             Assert.Same(fk.DependentToPrincipal, fk.FindNavigationTo(fk.PrincipalEntityType));
             Assert.Same(fk.PrincipalToDependent, fk.FindNavigationTo(fk.DeclaringEntityType));
+
+            Assert.Same(fk.DeclaringEntityType, fk.ResolveEntityTypeInHierarchy(fk.DeclaringEntityType));
+            Assert.Same(fk.PrincipalEntityType, fk.ResolveEntityTypeInHierarchy(fk.PrincipalEntityType));
+            Assert.Same(fk.PrincipalEntityType, fk.ResolveOtherEntityTypeInHierarchy(fk.DeclaringEntityType));
+            Assert.Same(fk.DeclaringEntityType, fk.ResolveOtherEntityTypeInHierarchy(fk.PrincipalEntityType));
+            Assert.Same(fk.PrincipalToDependent, fk.FindNavigationFromInHierarchy(fk.PrincipalEntityType));
+            Assert.Same(fk.DependentToPrincipal, fk.FindNavigationFromInHierarchy(fk.DeclaringEntityType));
+            Assert.Same(fk.DependentToPrincipal, fk.FindNavigationToInHierarchy(fk.PrincipalEntityType));
+            Assert.Same(fk.PrincipalToDependent, fk.FindNavigationToInHierarchy(fk.DeclaringEntityType));
         }
 
         [Fact]
@@ -628,8 +635,6 @@ namespace Microsoft.Data.Entity.Metadata.Tests
             var derivedDependent = model.AddEntityType(typeof(DerivedOneToManyDependent));
             derivedDependent.BaseType = fk.DeclaringEntityType;
 
-            Assert.Same(fk.DeclaringEntityType, fk.ResolveEntityType(fk.DeclaringEntityType));
-            Assert.Same(fk.PrincipalEntityType, fk.ResolveEntityType(fk.PrincipalEntityType));
             Assert.Same(fk.PrincipalEntityType, fk.ResolveOtherEntityType(fk.DeclaringEntityType));
             Assert.Same(fk.DeclaringEntityType, fk.ResolveOtherEntityType(fk.PrincipalEntityType));
             Assert.Same(fk.PrincipalToDependent, fk.FindNavigationFrom(fk.PrincipalEntityType));
@@ -637,90 +642,158 @@ namespace Microsoft.Data.Entity.Metadata.Tests
             Assert.Same(fk.DependentToPrincipal, fk.FindNavigationTo(fk.PrincipalEntityType));
             Assert.Same(fk.PrincipalToDependent, fk.FindNavigationTo(fk.DeclaringEntityType));
 
-            Assert.Same(fk.DeclaringEntityType, fk.ResolveEntityType(derivedDependent));
-            Assert.Same(fk.PrincipalEntityType, fk.ResolveEntityType(derivedPrincipal));
-            Assert.Same(fk.PrincipalEntityType, fk.ResolveOtherEntityType(derivedDependent));
-            Assert.Same(fk.DeclaringEntityType, fk.ResolveOtherEntityType(derivedPrincipal));
-            Assert.Same(fk.PrincipalToDependent, fk.FindNavigationFrom(derivedPrincipal));
-            Assert.Same(fk.DependentToPrincipal, fk.FindNavigationFrom(derivedDependent));
-            Assert.Same(fk.DependentToPrincipal, fk.FindNavigationTo(derivedPrincipal));
-            Assert.Same(fk.PrincipalToDependent, fk.FindNavigationTo(derivedDependent));
+            Assert.Same(fk.DeclaringEntityType, fk.ResolveEntityTypeInHierarchy(fk.DeclaringEntityType));
+            Assert.Same(fk.PrincipalEntityType, fk.ResolveEntityTypeInHierarchy(fk.PrincipalEntityType));
+            Assert.Same(fk.PrincipalEntityType, fk.ResolveOtherEntityTypeInHierarchy(fk.DeclaringEntityType));
+            Assert.Same(fk.DeclaringEntityType, fk.ResolveOtherEntityTypeInHierarchy(fk.PrincipalEntityType));
+            Assert.Same(fk.PrincipalToDependent, fk.FindNavigationFromInHierarchy(fk.PrincipalEntityType));
+            Assert.Same(fk.DependentToPrincipal, fk.FindNavigationFromInHierarchy(fk.DeclaringEntityType));
+            Assert.Same(fk.DependentToPrincipal, fk.FindNavigationToInHierarchy(fk.PrincipalEntityType));
+            Assert.Same(fk.PrincipalToDependent, fk.FindNavigationToInHierarchy(fk.DeclaringEntityType));
+
+            Assert.Equal(
+                CoreStrings.EntityTypeNotInRelationshipStrict(derivedDependent.DisplayName(), fk.DeclaringEntityType.DisplayName(), fk.PrincipalEntityType.DisplayName()),
+                Assert.Throws<ArgumentException>(() => fk.ResolveOtherEntityType(derivedDependent)).Message);
+            Assert.Equal(
+                CoreStrings.EntityTypeNotInRelationshipStrict(derivedPrincipal.DisplayName(), fk.DeclaringEntityType.DisplayName(), fk.PrincipalEntityType.DisplayName()),
+                Assert.Throws<ArgumentException>(() => fk.ResolveOtherEntityType(derivedPrincipal)).Message);
+            Assert.Equal(
+                CoreStrings.EntityTypeNotInRelationshipStrict(derivedPrincipal.DisplayName(), fk.DeclaringEntityType.DisplayName(), fk.PrincipalEntityType.DisplayName()),
+                Assert.Throws<ArgumentException>(() => fk.FindNavigationFrom(derivedPrincipal)).Message);
+            Assert.Equal(
+                CoreStrings.EntityTypeNotInRelationshipStrict(derivedDependent.DisplayName(), fk.DeclaringEntityType.DisplayName(), fk.PrincipalEntityType.DisplayName()),
+                Assert.Throws<ArgumentException>(() => fk.FindNavigationFrom(derivedDependent)).Message);
+            Assert.Equal(
+                CoreStrings.EntityTypeNotInRelationshipStrict(derivedPrincipal.DisplayName(), fk.DeclaringEntityType.DisplayName(), fk.PrincipalEntityType.DisplayName()),
+                Assert.Throws<ArgumentException>(() => fk.FindNavigationTo(derivedPrincipal)).Message);
+            Assert.Equal(
+                CoreStrings.EntityTypeNotInRelationshipStrict(derivedDependent.DisplayName(), fk.DeclaringEntityType.DisplayName(), fk.PrincipalEntityType.DisplayName()),
+                Assert.Throws<ArgumentException>(() => fk.FindNavigationTo(derivedDependent)).Message);
+            
+            Assert.Same(fk.DeclaringEntityType, fk.ResolveEntityTypeInHierarchy(derivedDependent));
+            Assert.Same(fk.PrincipalEntityType, fk.ResolveEntityTypeInHierarchy(derivedPrincipal));
+            Assert.Same(fk.PrincipalEntityType, fk.ResolveOtherEntityTypeInHierarchy(derivedDependent));
+            Assert.Same(fk.DeclaringEntityType, fk.ResolveOtherEntityTypeInHierarchy(derivedPrincipal));
+            Assert.Same(fk.PrincipalToDependent, fk.FindNavigationFromInHierarchy(derivedPrincipal));
+            Assert.Same(fk.DependentToPrincipal, fk.FindNavigationFromInHierarchy(derivedDependent));
+            Assert.Same(fk.DependentToPrincipal, fk.FindNavigationToInHierarchy(derivedPrincipal));
+            Assert.Same(fk.PrincipalToDependent, fk.FindNavigationToInHierarchy(derivedDependent));
         }
 
         [Fact]
-        public void Finding_targets_throws_for_self_ref_foreign_keys()
+        public void Can_find_targets_for_self_ref_foreign_keys()
         {
             var fk = CreateSelfRefFK();
 
+            Assert.Same(fk.PrincipalEntityType, fk.ResolveOtherEntityType(fk.DeclaringEntityType));
+            Assert.Same(fk.DeclaringEntityType, fk.ResolveOtherEntityType(fk.PrincipalEntityType));
+            
             Assert.Equal(
-                CoreStrings.IntraHierarchicalAmbiguousTargetEntityType(fk.DeclaringEntityType.Name, Property.Format(fk.Properties)),
-                Assert.Throws<InvalidOperationException>(() => fk.ResolveEntityType(fk.DeclaringEntityType)).Message);
-            Assert.Equal(
-                CoreStrings.IntraHierarchicalAmbiguousTargetEntityType(fk.PrincipalEntityType.Name, Property.Format(fk.Properties)),
-                Assert.Throws<InvalidOperationException>(() => fk.ResolveEntityType(fk.PrincipalEntityType)).Message);
-
-            Assert.Equal(
-                CoreStrings.IntraHierarchicalAmbiguousTargetEntityType(fk.DeclaringEntityType.Name, Property.Format(fk.Properties)),
-                Assert.Throws<InvalidOperationException>(() => fk.ResolveOtherEntityType(fk.DeclaringEntityType)).Message);
-            Assert.Equal(
-                CoreStrings.IntraHierarchicalAmbiguousTargetEntityType(fk.PrincipalEntityType.Name, Property.Format(fk.Properties)),
-                Assert.Throws<InvalidOperationException>(() => fk.ResolveOtherEntityType(fk.PrincipalEntityType)).Message);
-
-            Assert.Equal(
-                CoreStrings.IntraHierarchicalAmbiguousNavigation(fk.PrincipalEntityType.Name, Property.Format(fk.Properties),
-                    fk.PrincipalEntityType, fk.DeclaringEntityType),
+                CoreStrings.SelfReferencingAmbiguousNavigation(
+                    fk.PrincipalEntityType.DisplayName(), Property.Format(fk.Properties)),
                 Assert.Throws<InvalidOperationException>(() => fk.FindNavigationFrom(fk.PrincipalEntityType)).Message);
             Assert.Equal(
-                CoreStrings.IntraHierarchicalAmbiguousNavigation(fk.DeclaringEntityType.Name, Property.Format(fk.Properties),
-                    fk.PrincipalEntityType, fk.DeclaringEntityType),
+                CoreStrings.SelfReferencingAmbiguousNavigation(
+                    fk.DeclaringEntityType.DisplayName(), Property.Format(fk.Properties)),
                 Assert.Throws<InvalidOperationException>(() => fk.FindNavigationFrom(fk.DeclaringEntityType)).Message);
 
             Assert.Equal(
-                CoreStrings.IntraHierarchicalAmbiguousNavigation(fk.PrincipalEntityType.Name, Property.Format(fk.Properties),
-                    fk.PrincipalEntityType, fk.DeclaringEntityType),
+                CoreStrings.SelfReferencingAmbiguousNavigation(
+                    fk.PrincipalEntityType.DisplayName(), Property.Format(fk.Properties)),
                 Assert.Throws<InvalidOperationException>(() => fk.FindNavigationTo(fk.PrincipalEntityType)).Message);
             Assert.Equal(
-                CoreStrings.IntraHierarchicalAmbiguousNavigation(fk.DeclaringEntityType.Name, Property.Format(fk.Properties),
-                    fk.PrincipalEntityType, fk.DeclaringEntityType),
+                CoreStrings.SelfReferencingAmbiguousNavigation(
+                    fk.DeclaringEntityType.DisplayName(), Property.Format(fk.Properties)),
                 Assert.Throws<InvalidOperationException>(() => fk.FindNavigationTo(fk.DeclaringEntityType)).Message);
+
+            Assert.Equal(
+                CoreStrings.IntraHierarchicalAmbiguousTargetEntityType(
+                    fk.DeclaringEntityType.DisplayName(), Property.Format(fk.Properties),
+                    fk.PrincipalEntityType.DisplayName(), fk.DeclaringEntityType.DisplayName()),
+                Assert.Throws<InvalidOperationException>(() => fk.ResolveEntityTypeInHierarchy(fk.DeclaringEntityType)).Message);
+            Assert.Equal(
+                CoreStrings.IntraHierarchicalAmbiguousTargetEntityType(
+                    fk.PrincipalEntityType.DisplayName(), Property.Format(fk.Properties),
+                    fk.PrincipalEntityType.DisplayName(), fk.DeclaringEntityType.DisplayName()),
+                Assert.Throws<InvalidOperationException>(() => fk.ResolveEntityTypeInHierarchy(fk.PrincipalEntityType)).Message);
+
+            Assert.Equal(
+                CoreStrings.IntraHierarchicalAmbiguousTargetEntityType(
+                    fk.DeclaringEntityType.DisplayName(), Property.Format(fk.Properties),
+                    fk.PrincipalEntityType.DisplayName(), fk.DeclaringEntityType.DisplayName()),
+                Assert.Throws<InvalidOperationException>(() => fk.ResolveOtherEntityTypeInHierarchy(fk.DeclaringEntityType)).Message);
+            Assert.Equal(
+                CoreStrings.IntraHierarchicalAmbiguousTargetEntityType(
+                    fk.PrincipalEntityType.DisplayName(), Property.Format(fk.Properties),
+                    fk.PrincipalEntityType.DisplayName(), fk.DeclaringEntityType.DisplayName()),
+                Assert.Throws<InvalidOperationException>(() => fk.ResolveOtherEntityTypeInHierarchy(fk.PrincipalEntityType)).Message);
+
+            Assert.Equal(
+                CoreStrings.IntraHierarchicalAmbiguousNavigation(
+                    fk.PrincipalEntityType.DisplayName(), Property.Format(fk.Properties),
+                    fk.PrincipalEntityType.DisplayName(), fk.DeclaringEntityType.DisplayName()),
+                Assert.Throws<InvalidOperationException>(() => fk.FindNavigationFromInHierarchy(fk.PrincipalEntityType)).Message);
+            Assert.Equal(
+                CoreStrings.IntraHierarchicalAmbiguousNavigation(
+                    fk.DeclaringEntityType.DisplayName(), Property.Format(fk.Properties),
+                    fk.PrincipalEntityType.DisplayName(), fk.DeclaringEntityType.DisplayName()),
+                Assert.Throws<InvalidOperationException>(() => fk.FindNavigationFromInHierarchy(fk.DeclaringEntityType)).Message);
+
+            Assert.Equal(
+                CoreStrings.IntraHierarchicalAmbiguousNavigation(
+                    fk.PrincipalEntityType.DisplayName(), Property.Format(fk.Properties),
+                    fk.PrincipalEntityType.DisplayName(), fk.DeclaringEntityType.DisplayName()),
+                Assert.Throws<InvalidOperationException>(() => fk.FindNavigationToInHierarchy(fk.PrincipalEntityType)).Message);
+            Assert.Equal(
+                CoreStrings.IntraHierarchicalAmbiguousNavigation(
+                    fk.DeclaringEntityType.DisplayName(), Property.Format(fk.Properties),
+                    fk.PrincipalEntityType.DisplayName(), fk.DeclaringEntityType.DisplayName()),
+                Assert.Throws<InvalidOperationException>(() => fk.FindNavigationToInHierarchy(fk.DeclaringEntityType)).Message);
         }
 
         [Fact]
-        public void Finding_targets_throws_for_same_hierarchy_foreign_keys()
+        public void Can_finding_targets_for_same_hierarchy_foreign_keys()
         {
             var fk = CreateOneToManySameHierarchyFK();
 
+            Assert.Same(fk.PrincipalEntityType, fk.ResolveOtherEntityType(fk.DeclaringEntityType));
+            Assert.Same(fk.DeclaringEntityType, fk.ResolveOtherEntityType(fk.PrincipalEntityType));
+            Assert.Same(fk.PrincipalToDependent, fk.FindNavigationFrom(fk.PrincipalEntityType));
+            Assert.Same(fk.DependentToPrincipal, fk.FindNavigationFrom(fk.DeclaringEntityType));
+            Assert.Same(fk.DependentToPrincipal, fk.FindNavigationTo(fk.PrincipalEntityType));
+            Assert.Same(fk.PrincipalToDependent, fk.FindNavigationTo(fk.DeclaringEntityType));
+            
             Assert.Equal(
-                CoreStrings.IntraHierarchicalAmbiguousTargetEntityType(fk.DeclaringEntityType.Name, Property.Format(fk.Properties)),
-                Assert.Throws<InvalidOperationException>(() => fk.ResolveEntityType(fk.DeclaringEntityType)).Message);
+                CoreStrings.IntraHierarchicalAmbiguousTargetEntityType(fk.DeclaringEntityType.DisplayName(), Property.Format(fk.Properties), fk.PrincipalEntityType.DisplayName(), fk.DeclaringEntityType.DisplayName()),
+                Assert.Throws<InvalidOperationException>(() => fk.ResolveEntityTypeInHierarchy(fk.DeclaringEntityType)).Message);
             Assert.Equal(
-                CoreStrings.IntraHierarchicalAmbiguousTargetEntityType(fk.PrincipalEntityType.Name, Property.Format(fk.Properties)),
-                Assert.Throws<InvalidOperationException>(() => fk.ResolveEntityType(fk.PrincipalEntityType)).Message);
+                CoreStrings.IntraHierarchicalAmbiguousTargetEntityType(fk.PrincipalEntityType.DisplayName(), Property.Format(fk.Properties), fk.PrincipalEntityType.DisplayName(), fk.DeclaringEntityType.DisplayName()),
+                Assert.Throws<InvalidOperationException>(() => fk.ResolveEntityTypeInHierarchy(fk.PrincipalEntityType)).Message);
 
             Assert.Equal(
-                CoreStrings.IntraHierarchicalAmbiguousTargetEntityType(fk.DeclaringEntityType.Name, Property.Format(fk.Properties)),
-                Assert.Throws<InvalidOperationException>(() => fk.ResolveOtherEntityType(fk.DeclaringEntityType)).Message);
+                CoreStrings.IntraHierarchicalAmbiguousTargetEntityType(fk.DeclaringEntityType.DisplayName(), Property.Format(fk.Properties), fk.PrincipalEntityType.DisplayName(), fk.DeclaringEntityType.DisplayName()),
+                Assert.Throws<InvalidOperationException>(() => fk.ResolveOtherEntityTypeInHierarchy(fk.DeclaringEntityType)).Message);
             Assert.Equal(
-                CoreStrings.IntraHierarchicalAmbiguousTargetEntityType(fk.PrincipalEntityType.Name, Property.Format(fk.Properties)),
-                Assert.Throws<InvalidOperationException>(() => fk.ResolveOtherEntityType(fk.PrincipalEntityType)).Message);
+                CoreStrings.IntraHierarchicalAmbiguousTargetEntityType(fk.PrincipalEntityType.DisplayName(), Property.Format(fk.Properties), fk.PrincipalEntityType.DisplayName(), fk.DeclaringEntityType.DisplayName()),
+                Assert.Throws<InvalidOperationException>(() => fk.ResolveOtherEntityTypeInHierarchy(fk.PrincipalEntityType)).Message);
 
             Assert.Equal(
-                CoreStrings.IntraHierarchicalAmbiguousNavigation(fk.PrincipalEntityType.Name, Property.Format(fk.Properties),
-                    fk.PrincipalEntityType, fk.DeclaringEntityType),
-                Assert.Throws<InvalidOperationException>(() => fk.FindNavigationFrom(fk.PrincipalEntityType)).Message);
+                CoreStrings.IntraHierarchicalAmbiguousNavigation(fk.PrincipalEntityType.DisplayName(), Property.Format(fk.Properties),
+                    fk.PrincipalEntityType.DisplayName(), fk.DeclaringEntityType.DisplayName()),
+                Assert.Throws<InvalidOperationException>(() => fk.FindNavigationFromInHierarchy(fk.PrincipalEntityType)).Message);
             Assert.Equal(
-                CoreStrings.IntraHierarchicalAmbiguousNavigation(fk.DeclaringEntityType.Name, Property.Format(fk.Properties),
-                    fk.PrincipalEntityType, fk.DeclaringEntityType),
-                Assert.Throws<InvalidOperationException>(() => fk.FindNavigationFrom(fk.DeclaringEntityType)).Message);
+                CoreStrings.IntraHierarchicalAmbiguousNavigation(fk.DeclaringEntityType.DisplayName(), Property.Format(fk.Properties),
+                    fk.PrincipalEntityType.DisplayName(), fk.DeclaringEntityType.DisplayName()),
+                Assert.Throws<InvalidOperationException>(() => fk.FindNavigationFromInHierarchy(fk.DeclaringEntityType)).Message);
 
             Assert.Equal(
-                CoreStrings.IntraHierarchicalAmbiguousNavigation(fk.PrincipalEntityType.Name, Property.Format(fk.Properties),
-                    fk.PrincipalEntityType, fk.DeclaringEntityType),
-                Assert.Throws<InvalidOperationException>(() => fk.FindNavigationTo(fk.PrincipalEntityType)).Message);
+                CoreStrings.IntraHierarchicalAmbiguousNavigation(fk.PrincipalEntityType.DisplayName(), Property.Format(fk.Properties),
+                    fk.PrincipalEntityType.DisplayName(), fk.DeclaringEntityType.DisplayName()),
+                Assert.Throws<InvalidOperationException>(() => fk.FindNavigationToInHierarchy(fk.PrincipalEntityType)).Message);
             Assert.Equal(
-                CoreStrings.IntraHierarchicalAmbiguousNavigation(fk.DeclaringEntityType.Name, Property.Format(fk.Properties),
-                    fk.PrincipalEntityType, fk.DeclaringEntityType),
-                Assert.Throws<InvalidOperationException>(() => fk.FindNavigationTo(fk.DeclaringEntityType)).Message);
+                CoreStrings.IntraHierarchicalAmbiguousNavigation(fk.DeclaringEntityType.DisplayName(), Property.Format(fk.Properties),
+                    fk.PrincipalEntityType.DisplayName(), fk.DeclaringEntityType.DisplayName()),
+                Assert.Throws<InvalidOperationException>(() => fk.FindNavigationToInHierarchy(fk.DeclaringEntityType)).Message);
         }
 
         [Fact]
@@ -730,32 +803,53 @@ namespace Microsoft.Data.Entity.Metadata.Tests
             var unrelatedType = fk.DeclaringEntityType.Model.AddEntityType(typeof(NavigationBase));
 
             Assert.Equal(
-                CoreStrings.EntityTypeNotInRelationship(unrelatedType.Name, fk.DeclaringEntityType.Name, fk.PrincipalEntityType.Name),
-                Assert.Throws<ArgumentException>(() => fk.ResolveEntityType(unrelatedType)).Message);
-            Assert.Equal(
-                CoreStrings.EntityTypeNotInRelationship(unrelatedType.Name, fk.DeclaringEntityType.Name, fk.PrincipalEntityType.Name),
-                Assert.Throws<ArgumentException>(() => fk.ResolveEntityType(unrelatedType)).Message);
-
-            Assert.Equal(
-                CoreStrings.EntityTypeNotInRelationship(unrelatedType.Name, fk.DeclaringEntityType.Name, fk.PrincipalEntityType.Name),
+                CoreStrings.EntityTypeNotInRelationshipStrict(unrelatedType.DisplayName(), fk.DeclaringEntityType.DisplayName(), fk.PrincipalEntityType.DisplayName()),
                 Assert.Throws<ArgumentException>(() => fk.ResolveOtherEntityType(unrelatedType)).Message);
             Assert.Equal(
-                CoreStrings.EntityTypeNotInRelationship(unrelatedType.Name, fk.DeclaringEntityType.Name, fk.PrincipalEntityType.Name),
+                CoreStrings.EntityTypeNotInRelationshipStrict(unrelatedType.DisplayName(), fk.DeclaringEntityType.DisplayName(), fk.PrincipalEntityType.DisplayName()),
                 Assert.Throws<ArgumentException>(() => fk.ResolveOtherEntityType(unrelatedType)).Message);
 
             Assert.Equal(
-                CoreStrings.EntityTypeNotInRelationship(unrelatedType.Name, fk.DeclaringEntityType.Name, fk.PrincipalEntityType.Name),
+                CoreStrings.EntityTypeNotInRelationshipStrict(unrelatedType.DisplayName(), fk.DeclaringEntityType.DisplayName(), fk.PrincipalEntityType.DisplayName()),
                 Assert.Throws<ArgumentException>(() => fk.FindNavigationFrom(unrelatedType)).Message);
             Assert.Equal(
-                CoreStrings.EntityTypeNotInRelationship(unrelatedType.Name, fk.DeclaringEntityType.Name, fk.PrincipalEntityType.Name),
+                CoreStrings.EntityTypeNotInRelationshipStrict(unrelatedType.DisplayName(), fk.DeclaringEntityType.DisplayName(), fk.PrincipalEntityType.DisplayName()),
                 Assert.Throws<ArgumentException>(() => fk.FindNavigationFrom(unrelatedType)).Message);
 
             Assert.Equal(
-                CoreStrings.EntityTypeNotInRelationship(unrelatedType.Name, fk.DeclaringEntityType.Name, fk.PrincipalEntityType.Name),
+                CoreStrings.EntityTypeNotInRelationshipStrict(unrelatedType.DisplayName(), fk.DeclaringEntityType.DisplayName(), fk.PrincipalEntityType.DisplayName()),
                 Assert.Throws<ArgumentException>(() => fk.FindNavigationTo(unrelatedType)).Message);
             Assert.Equal(
-                CoreStrings.EntityTypeNotInRelationship(unrelatedType.Name, fk.DeclaringEntityType.Name, fk.PrincipalEntityType.Name),
+                CoreStrings.EntityTypeNotInRelationshipStrict(unrelatedType.DisplayName(), fk.DeclaringEntityType.DisplayName(), fk.PrincipalEntityType.DisplayName()),
                 Assert.Throws<ArgumentException>(() => fk.FindNavigationTo(unrelatedType)).Message);
+
+            Assert.Equal(
+                CoreStrings.EntityTypeNotInRelationship(unrelatedType.DisplayName(), fk.DeclaringEntityType.DisplayName(), fk.PrincipalEntityType.DisplayName()),
+                Assert.Throws<ArgumentException>(() => fk.ResolveEntityTypeInHierarchy(unrelatedType)).Message);
+            Assert.Equal(
+                CoreStrings.EntityTypeNotInRelationship(unrelatedType.DisplayName(), fk.DeclaringEntityType.DisplayName(), fk.PrincipalEntityType.DisplayName()),
+                Assert.Throws<ArgumentException>(() => fk.ResolveEntityTypeInHierarchy(unrelatedType)).Message);
+
+            Assert.Equal(
+                CoreStrings.EntityTypeNotInRelationship(unrelatedType.DisplayName(), fk.DeclaringEntityType.DisplayName(), fk.PrincipalEntityType.DisplayName()),
+                Assert.Throws<ArgumentException>(() => fk.ResolveOtherEntityTypeInHierarchy(unrelatedType)).Message);
+            Assert.Equal(
+                CoreStrings.EntityTypeNotInRelationship(unrelatedType.DisplayName(), fk.DeclaringEntityType.DisplayName(), fk.PrincipalEntityType.DisplayName()),
+                Assert.Throws<ArgumentException>(() => fk.ResolveOtherEntityTypeInHierarchy(unrelatedType)).Message);
+
+            Assert.Equal(
+                CoreStrings.EntityTypeNotInRelationship(unrelatedType.DisplayName(), fk.DeclaringEntityType.DisplayName(), fk.PrincipalEntityType.DisplayName()),
+                Assert.Throws<ArgumentException>(() => fk.FindNavigationFromInHierarchy(unrelatedType)).Message);
+            Assert.Equal(
+                CoreStrings.EntityTypeNotInRelationship(unrelatedType.DisplayName(), fk.DeclaringEntityType.DisplayName(), fk.PrincipalEntityType.DisplayName()),
+                Assert.Throws<ArgumentException>(() => fk.FindNavigationFromInHierarchy(unrelatedType)).Message);
+
+            Assert.Equal(
+                CoreStrings.EntityTypeNotInRelationship(unrelatedType.DisplayName(), fk.DeclaringEntityType.DisplayName(), fk.PrincipalEntityType.DisplayName()),
+                Assert.Throws<ArgumentException>(() => fk.FindNavigationToInHierarchy(unrelatedType)).Message);
+            Assert.Equal(
+                CoreStrings.EntityTypeNotInRelationship(unrelatedType.DisplayName(), fk.DeclaringEntityType.DisplayName(), fk.PrincipalEntityType.DisplayName()),
+                Assert.Throws<ArgumentException>(() => fk.FindNavigationToInHierarchy(unrelatedType)).Message);
         }
     }
 }

--- a/test/EntityFramework.Core.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
@@ -91,7 +91,53 @@ namespace Microsoft.Data.Entity.Metadata.Internal
         }
 
         [Fact]
-        public void Can_promote_relationship_to_base()
+        public void Replaces_derived_foreign_key_of_lower_or_equal_source()
+        {
+            var modelBuilder = CreateModelBuilder();
+            var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
+            principalEntityBuilder.PrimaryKey(new[] { nameof(Customer.Id) }, ConfigurationSource.Convention);
+            var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+            var derivedEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
+            derivedEntityBuilder.HasBaseType(entityBuilder.Metadata, ConfigurationSource.Convention);
+            derivedEntityBuilder.Property(Order.IdProperty, ConfigurationSource.Convention);
+            derivedEntityBuilder.HasForeignKey(principalEntityBuilder.Metadata.Name, new[] { Order.IdProperty.Name }, ConfigurationSource.DataAnnotation);
+
+            Assert.Null(entityBuilder.HasForeignKey(principalEntityBuilder.Metadata.Name, new[] { Order.IdProperty.Name }, ConfigurationSource.Convention));
+            var foreignKeyBuilder = entityBuilder.HasForeignKey(principalEntityBuilder.Metadata.Name, new[] { Order.IdProperty.Name }, ConfigurationSource.DataAnnotation);
+
+            Assert.Same(foreignKeyBuilder.Metadata.Properties.Single(), entityBuilder.Metadata.FindProperty(Order.IdProperty.Name));
+            Assert.Same(foreignKeyBuilder.Metadata, entityBuilder.Metadata.GetForeignKeys().Single());
+            Assert.Empty(derivedEntityBuilder.Metadata.GetDeclaredForeignKeys());
+        }
+
+        [Fact]
+        public void Replaces_inherited_foreign_key_of_lower_or_equal_source()
+        {
+            var modelBuilder = CreateModelBuilder();
+            var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
+            var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+            dependentEntityBuilder.Property(Order.IdProperty.Name, typeof(int), ConfigurationSource.Convention);
+            dependentEntityBuilder.HasForeignKey(
+                principalEntityBuilder.Metadata.Name, new[] { Order.IdProperty.Name }, ConfigurationSource.DataAnnotation);
+
+            var derivedDependentEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
+            derivedDependentEntityBuilder.HasBaseType(dependentEntityBuilder.Metadata, ConfigurationSource.Convention);
+
+            Assert.Null(derivedDependentEntityBuilder.HasForeignKey(
+                principalEntityBuilder.Metadata.Name, new[] { Order.IdProperty.Name }, ConfigurationSource.Convention));
+            var relationshipBuilder = derivedDependentEntityBuilder.HasForeignKey(
+                principalEntityBuilder.Metadata.Name, new[] { Order.IdProperty.Name }, ConfigurationSource.DataAnnotation);
+
+            Assert.Same(derivedDependentEntityBuilder.Metadata.GetDeclaredForeignKeys().Single(), relationshipBuilder.Metadata);
+            relationshipBuilder = relationshipBuilder.IsUnique(true, ConfigurationSource.Convention);
+            Assert.True(relationshipBuilder.Metadata.IsUnique);
+            Assert.Null(relationshipBuilder.HasForeignKey(
+                new[] { dependentEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention).Metadata },
+                ConfigurationSource.Convention));
+        }
+        
+        [Fact]
+        public void Replaces_derived_relationship_of_lower_or_equal_source()
         {
             var modelBuilder = CreateModelBuilder();
             var principalEntityBuilder = modelBuilder.Entity(typeof(SpecialCustomer), ConfigurationSource.Explicit);
@@ -110,11 +156,17 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
             Assert.Empty(baseDependentEntityBuilder.Metadata.GetForeignKeys());
 
+            Assert.Null(baseDependentEntityBuilder.Relationship(
+                basePrincipalEntityBuilder,
+                Order.CustomerProperty.Name,
+                Customer.OrdersProperty.Name,
+                ConfigurationSource.Convention));
+
             var relationship = baseDependentEntityBuilder.Relationship(
                 basePrincipalEntityBuilder,
                 Order.CustomerProperty.Name,
                 Customer.OrdersProperty.Name,
-                ConfigurationSource.Convention);
+                ConfigurationSource.DataAnnotation);
 
             Assert.Same(relationship.Metadata, dependentEntityBuilder.Metadata.GetForeignKeys().Single());
             Assert.Same(relationship.Metadata, principalEntityBuilder.Metadata.Navigations.Single().ForeignKey);
@@ -123,49 +175,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
         }
 
         [Fact]
-        public void Can_promote_foreignKey_to_base()
-        {
-            var modelBuilder = CreateModelBuilder();
-            var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-            principalEntityBuilder.PrimaryKey(new[] { nameof(Customer.Id) }, ConfigurationSource.Convention);
-            var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-            var derivedEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
-            derivedEntityBuilder.HasBaseType(entityBuilder.Metadata, ConfigurationSource.Convention);
-            derivedEntityBuilder.Property(Order.IdProperty, ConfigurationSource.Convention);
-            derivedEntityBuilder.HasForeignKey(principalEntityBuilder.Metadata.Name, new[] { Order.IdProperty.Name }, ConfigurationSource.DataAnnotation);
-
-            var foreignKeyBuilder = entityBuilder.HasForeignKey(principalEntityBuilder.Metadata.Name, new[] { Order.IdProperty.Name }, ConfigurationSource.Convention);
-            Assert.Same(foreignKeyBuilder.Metadata.Properties.Single(), entityBuilder.Metadata.FindProperty(Order.IdProperty.Name));
-            Assert.Same(foreignKeyBuilder.Metadata, entityBuilder.Metadata.GetForeignKeys().Single());
-            Assert.Empty(derivedEntityBuilder.Metadata.GetDeclaredForeignKeys());
-        }
-
-        [Fact]
-        public void Can_configure_inherited_foreignKey()
-        {
-            var modelBuilder = CreateModelBuilder();
-            var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-            var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-            dependentEntityBuilder.Property(Order.IdProperty.Name, typeof(int), ConfigurationSource.Convention);
-            dependentEntityBuilder.HasForeignKey(
-                principalEntityBuilder.Metadata.Name, new[] { Order.IdProperty.Name }, ConfigurationSource.Explicit);
-
-            var derivedDependentEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
-            derivedDependentEntityBuilder.HasBaseType(dependentEntityBuilder.Metadata, ConfigurationSource.Convention);
-
-            var relationshipBuilder = derivedDependentEntityBuilder.HasForeignKey(
-                principalEntityBuilder.Metadata.Name, new[] { Order.IdProperty.Name }, ConfigurationSource.Convention);
-            Assert.Same(dependentEntityBuilder.Metadata.GetForeignKeys().Single(), relationshipBuilder.Metadata);
-
-            relationshipBuilder = relationshipBuilder.IsUnique(true, ConfigurationSource.Convention);
-            Assert.True(relationshipBuilder.Metadata.IsUnique);
-            Assert.Null(relationshipBuilder.HasForeignKey(
-                new[] { dependentEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention).Metadata },
-                ConfigurationSource.Convention));
-        }
-
-        [Fact]
-        public void Can_configure_relationship_on_inherited_navigation()
+        public void Replaces_inherited_relationship_of_lower_or_equal_source()
         {
             var modelBuilder = CreateModelBuilder();
             var principalEntityBuilder = modelBuilder.Entity(typeof(SpecialCustomer), ConfigurationSource.Explicit);
@@ -179,15 +189,21 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 basePrincipalEntityBuilder,
                 Order.CustomerProperty.Name,
                 Customer.OrdersProperty.Name,
-                ConfigurationSource.Convention);
+                ConfigurationSource.DataAnnotation);
+
+            Assert.Null(dependentEntityBuilder.Relationship(
+                principalEntityBuilder,
+                Order.CustomerProperty.Name,
+                null,
+                ConfigurationSource.Convention));
 
             var relationshipBuilder = dependentEntityBuilder.Relationship(
                 principalEntityBuilder,
                 Order.CustomerProperty.Name,
                 null,
-                ConfigurationSource.Convention);
+                ConfigurationSource.DataAnnotation);
 
-            Assert.Same(baseDependentEntityBuilder.Metadata, relationshipBuilder.Metadata.DeclaringEntityType);
+            Assert.Same(dependentEntityBuilder.Metadata, relationshipBuilder.Metadata.DeclaringEntityType);
             Assert.Null(relationshipBuilder.Metadata.PrincipalToDependent);
             Assert.Equal(Order.CustomerProperty.Name, relationshipBuilder.Metadata.DependentToPrincipal.Name);
             Assert.Empty(principalEntityBuilder.Metadata.Navigations);
@@ -886,7 +902,8 @@ namespace Microsoft.Data.Entity.Metadata.Internal
         {
             var modelBuilder = CreateModelBuilder();
             var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-            entityBuilder.Property(Order.IdProperty.Name, typeof(int), ConfigurationSource.Explicit);
+            entityBuilder.Property(Order.IdProperty.Name, typeof(int), ConfigurationSource.Explicit)
+                .IsConcurrencyToken(false, ConfigurationSource.Convention);
 
             var derivedEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
             derivedEntityBuilder.HasBaseType(entityBuilder.Metadata, ConfigurationSource.Convention);
@@ -1270,7 +1287,6 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var property1 = dependentEntityBuilder.Metadata.AddProperty(Order.CustomerIdProperty.Name, typeof(int));
             property1.IsShadowProperty = false;
             var property2 = dependentEntityBuilder.Metadata.AddProperty(Order.CustomerUniqueProperty.Name, typeof(Guid));
-            property2.IsShadowProperty = false;
             var foreignKey = dependentEntityBuilder.Metadata.AddForeignKey(
                 new[]
                 {
@@ -1361,6 +1377,28 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
             Assert.Equal(Customer.OrdersProperty.Name, foreignKeyBuilder.Metadata.PrincipalToDependent.Name);
             Assert.Equal(Order.CustomerProperty.Name, foreignKeyBuilder.Metadata.DependentToPrincipal.Name);
+        }
+
+        [Fact]
+        public void Can_merge_with_intrahierarchal_relationship_of_higher_source()
+        {
+            var modelBuilder = CreateModelBuilder();
+            var baseEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
+            var derivedEntityBuilder = modelBuilder.Entity(typeof(SpecialCustomer), ConfigurationSource.Explicit);
+            derivedEntityBuilder.HasBaseType(baseEntityBuilder.Metadata, ConfigurationSource.Convention);
+
+            baseEntityBuilder.Relationship(derivedEntityBuilder, ConfigurationSource.Explicit)
+                .DependentToPrincipal(nameof(Customer.SpecialCustomer), ConfigurationSource.Explicit);
+
+            var derivedRelationship = derivedEntityBuilder.Relationship(baseEntityBuilder, ConfigurationSource.Convention)
+                .DependentToPrincipal(nameof(SpecialCustomer.Customer), ConfigurationSource.Convention)
+                .PrincipalToDependent(nameof(Customer.SpecialCustomer), ConfigurationSource.Convention);
+
+            Assert.NotNull(derivedRelationship);
+
+            var baseNavigation = baseEntityBuilder.Metadata.Navigations.Single();
+            Assert.Equal(nameof(Customer.SpecialCustomer), baseNavigation.Name);
+            Assert.Equal(nameof(SpecialCustomer.Customer), baseNavigation.FindInverse()?.Name);
         }
 
         [Fact]
@@ -1622,7 +1660,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 derivedEntityBuilder.HasBaseType((Type)null, ConfigurationSource.DataAnnotation));
             Assert.Same(derivedEntityBuilder,
                 derivedEntityBuilder.HasBaseType(entityBuilder.Metadata, ConfigurationSource.Explicit));
-            Assert.Null(derivedEntityBuilder.HasBaseType((Type)null, ConfigurationSource.Convention));
+            Assert.Null(derivedEntityBuilder.HasBaseType((string)null, ConfigurationSource.Convention));
             Assert.Same(entityBuilder.Metadata, derivedEntityBuilder.Metadata.BaseType);
         }
 
@@ -1679,18 +1717,13 @@ namespace Microsoft.Data.Entity.Metadata.Internal
         {
             var modelBuilder = CreateModelBuilder();
             var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-            principalEntityBuilder.PrimaryKey(new[] { Customer.IdProperty, Customer.UniqueProperty }, ConfigurationSource.Explicit);
             var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-            dependentEntityBuilder.HasForeignKey(typeof(Customer).FullName, new[] { Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name }, ConfigurationSource.DataAnnotation)
-                .DependentToPrincipal(Order.CustomerProperty.Name, ConfigurationSource.DataAnnotation);
+            dependentEntityBuilder.Relationship(
+                principalEntityBuilder, Order.CustomerProperty.Name, null, ConfigurationSource.DataAnnotation);
 
             var derivedDependentEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
-            var derivedIdProperty = derivedDependentEntityBuilder.Property(Order.IdProperty, ConfigurationSource.Convention).Metadata;
-
-            derivedDependentEntityBuilder.HasForeignKey(
-                principalEntityBuilder, new[] { derivedIdProperty }, ConfigurationSource.DataAnnotation)
-                .DependentToPrincipal(Order.CustomerProperty.Name,
-                    ConfigurationSource.DataAnnotation);
+            derivedDependentEntityBuilder.Relationship(
+                principalEntityBuilder, Order.CustomerProperty.Name, null, ConfigurationSource.DataAnnotation);
 
             Assert.Null(derivedDependentEntityBuilder.HasBaseType(dependentEntityBuilder.Metadata, ConfigurationSource.Convention));
             Assert.Null(derivedDependentEntityBuilder.Metadata.BaseType);
@@ -1708,17 +1741,15 @@ namespace Microsoft.Data.Entity.Metadata.Internal
         {
             var modelBuilder = CreateModelBuilder();
             var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-            principalEntityBuilder.PrimaryKey(new[] { Customer.IdProperty, Customer.UniqueProperty }, ConfigurationSource.Explicit);
             var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-            dependentEntityBuilder.HasForeignKey(typeof(Customer).FullName, new[] { Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name }, ConfigurationSource.DataAnnotation)
-                .DependentToPrincipal(Order.CustomerProperty.Name, ConfigurationSource.DataAnnotation);
+            dependentEntityBuilder.Relationship(
+                principalEntityBuilder, Order.CustomerProperty.Name, null, ConfigurationSource.DataAnnotation)
+                .DependentEntityType(dependentEntityBuilder, ConfigurationSource.DataAnnotation);
 
             var derivedDependentEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
-            var derivedIdProperty = derivedDependentEntityBuilder.Property(Order.IdProperty, ConfigurationSource.Convention).Metadata;
-
-            derivedDependentEntityBuilder.HasForeignKey(
-                principalEntityBuilder, new[] { derivedIdProperty }, ConfigurationSource.DataAnnotation)
-                .Navigations(Order.CustomerProperty.Name, Customer.SpecialOrdersProperty.Name, ConfigurationSource.DataAnnotation);
+            derivedDependentEntityBuilder.Relationship(
+                principalEntityBuilder, Order.CustomerProperty.Name, null, ConfigurationSource.Explicit)
+                .PrincipalEntityType(derivedDependentEntityBuilder, ConfigurationSource.Explicit);
 
             Assert.Null(derivedDependentEntityBuilder.HasBaseType(dependentEntityBuilder.Metadata, ConfigurationSource.Convention));
             Assert.Null(derivedDependentEntityBuilder.Metadata.BaseType);
@@ -1735,17 +1766,11 @@ namespace Microsoft.Data.Entity.Metadata.Internal
         public void Can_only_set_base_type_if_relationship_with_conflicting_foreign_key_of_lower_or_equal_source()
         {
             var modelBuilder = CreateModelBuilder();
-            var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-            principalEntityBuilder.PrimaryKey(new[] { Customer.IdProperty }, ConfigurationSource.Explicit);
             var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
             dependentEntityBuilder.HasForeignKey(typeof(Customer).FullName, new[] { Order.CustomerIdProperty.Name }, ConfigurationSource.DataAnnotation);
 
             var derivedDependentEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
-            var derivedIdProperty = derivedDependentEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention).Metadata;
-
-            derivedDependentEntityBuilder.Relationship(
-                principalEntityBuilder, Order.CustomerProperty.Name, null, ConfigurationSource.DataAnnotation)
-                .HasForeignKey(new[] { derivedIdProperty }, ConfigurationSource.DataAnnotation);
+            derivedDependentEntityBuilder.HasForeignKey(typeof(Customer).FullName, new[] { Order.CustomerIdProperty.Name }, ConfigurationSource.DataAnnotation);
 
             Assert.Null(derivedDependentEntityBuilder.HasBaseType(dependentEntityBuilder.Metadata, ConfigurationSource.Convention));
             Assert.Null(derivedDependentEntityBuilder.Metadata.BaseType);
@@ -1762,17 +1787,11 @@ namespace Microsoft.Data.Entity.Metadata.Internal
         public void Can_only_set_base_type_if_relationship_with_conflicting_foreign_key_of_lower_or_equal_source_on_base_type()
         {
             var modelBuilder = CreateModelBuilder();
-            var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-            principalEntityBuilder.PrimaryKey(new[] { Customer.IdProperty }, ConfigurationSource.Explicit);
             var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
             dependentEntityBuilder.HasForeignKey(typeof(Customer).FullName, new[] { Order.CustomerIdProperty.Name }, ConfigurationSource.DataAnnotation);
 
             var derivedDependentEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
-            var derivedIdProperty = derivedDependentEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention).Metadata;
-
-            derivedDependentEntityBuilder.Relationship(
-                principalEntityBuilder, null, Customer.SpecialOrdersProperty.Name, ConfigurationSource.DataAnnotation)
-                .HasForeignKey(new[] { derivedIdProperty }, ConfigurationSource.DataAnnotation);
+            derivedDependentEntityBuilder.HasForeignKey(typeof(Customer).FullName, new[] { Order.CustomerIdProperty.Name }, ConfigurationSource.Explicit);
 
             Assert.Null(derivedDependentEntityBuilder.HasBaseType(dependentEntityBuilder.Metadata, ConfigurationSource.Convention));
             Assert.Null(derivedDependentEntityBuilder.Metadata.BaseType);
@@ -1890,10 +1909,12 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             public SpecialOrder AmbiguousOrder { get; set; }
             public IEnumerable<Order> EnumerableOrders { get; set; }
             public Order NotCollectionOrders { get; set; }
+            internal SpecialCustomer SpecialCustomer { get; set; }
         }
 
         private class SpecialCustomer : Customer
         {
+            internal Customer Customer { get; set; }
         }
     }
 }

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/BaseTypeDiscoveryConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/BaseTypeDiscoveryConventionTest.cs
@@ -1,0 +1,68 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Metadata.Internal;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
+{
+    public class BaseTypeDiscoveryConventionTest
+    {
+        [Fact]
+        public void Discovers_parent_type()
+        {
+            var entityBuilderA = CreateInternalEntityTypeBuilder<A>();
+            var entityBuilderB = entityBuilderA.ModelBuilder.Entity(typeof(B), ConfigurationSource.Explicit);
+            var entityBuilderC = entityBuilderA.ModelBuilder.Entity(typeof(C), ConfigurationSource.Explicit);
+            Assert.Null(entityBuilderC.Metadata.BaseType);
+
+            new BaseTypeDiscoveryConvention().Apply(entityBuilderC);
+
+            Assert.Same(entityBuilderB.Metadata, entityBuilderC.Metadata.BaseType);
+        }
+
+        [Fact]
+        public void Discovers_grandparent_type()
+        {
+            var entityBuilderA = CreateInternalEntityTypeBuilder<A>();
+            var entityBuilderC = entityBuilderA.ModelBuilder.Entity(typeof(C), ConfigurationSource.Explicit);
+            Assert.Null(entityBuilderC.Metadata.BaseType);
+
+            new BaseTypeDiscoveryConvention().Apply(entityBuilderC);
+
+            Assert.Same(entityBuilderA.Metadata, entityBuilderC.Metadata.BaseType);
+        }
+
+        [Fact]
+        public void Discovers_parent_type_if_base_type_set()
+        {
+            var entityBuilderA = CreateInternalEntityTypeBuilder<A>();
+            var entityBuilderB = entityBuilderA.ModelBuilder.Entity(typeof(B), ConfigurationSource.Explicit);
+            var entityBuilderC = entityBuilderA.ModelBuilder.Entity(typeof(C), ConfigurationSource.Explicit);
+            entityBuilderC.HasBaseType(entityBuilderA.Metadata, ConfigurationSource.Convention);
+
+            new BaseTypeDiscoveryConvention().Apply(entityBuilderC);
+
+            Assert.Same(entityBuilderB.Metadata, entityBuilderC.Metadata.BaseType);
+        }
+
+        private class A
+        {
+        }
+
+        private class B : A
+        {
+        }
+
+        private class C : B
+        {
+        }
+
+        private InternalEntityTypeBuilder CreateInternalEntityTypeBuilder<T>()
+        {
+            var modelBuilder = new InternalModelBuilder(new Model(), new ConventionSet());
+
+            return modelBuilder.Entity(typeof(T), ConfigurationSource.Explicit);
+        }
+    }
+}

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/ConventionDispatcherTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/ConventionDispatcherTest.cs
@@ -104,31 +104,31 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             var convention = new Mock<IEntityTypeMemberIgnoredConvention>();
             convention.Setup(c => c.Apply(It.IsAny<InternalEntityTypeBuilder>(), It.IsAny<string>()))
                 .Returns<InternalEntityTypeBuilder, string>((b, t) =>
-                {
-                    Assert.NotNull(b);
-                    Assert.Equal("A", t);
-                    entityTypeBuilder = b;
-                    return true;
-                });
+                    {
+                        Assert.NotNull(b);
+                        Assert.Equal("A", t);
+                        entityTypeBuilder = b;
+                        return true;
+                    });
             conventions.EntityTypeMemberIgnoredConventions.Add(convention.Object);
 
             var nullConvention = new Mock<IEntityTypeMemberIgnoredConvention>();
             nullConvention.Setup(c => c.Apply(It.IsAny<InternalEntityTypeBuilder>(), It.IsAny<string>()))
                 .Returns<InternalEntityTypeBuilder, string>((b, t) =>
-                {
-                    Assert.Equal("A", t);
-                    Assert.Same(entityTypeBuilder, b);
-                    return false;
-                });
+                    {
+                        Assert.Equal("A", t);
+                        Assert.Same(entityTypeBuilder, b);
+                        return false;
+                    });
             conventions.EntityTypeMemberIgnoredConventions.Add(nullConvention.Object);
 
             var extraConvention = new Mock<IEntityTypeMemberIgnoredConvention>();
             extraConvention.Setup(c => c.Apply(It.IsAny<InternalEntityTypeBuilder>(), It.IsAny<string>()))
                 .Returns<InternalEntityTypeBuilder, string>((b, t) =>
-                {
-                    Assert.False(true);
-                    return false;
-                });
+                    {
+                        Assert.False(true);
+                        return false;
+                    });
             conventions.EntityTypeMemberIgnoredConventions.Add(extraConvention.Object);
 
             var builder = new InternalModelBuilder(new Model(), conventions).Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
@@ -258,10 +258,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
 
             var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Convention);
             entityBuilder.PrimaryKey(new[] { "OrderId" }, ConfigurationSource.Convention);
-            Assert.NotNull(entityBuilder.Relationship(entityBuilder, ConfigurationSource.Convention));
-
-            Assert.Null(entityBuilder.Relationship(entityBuilder, ConfigurationSource.Convention)
-                .HasForeignKey(new[] { nameof(Order.OrderId) }, ConfigurationSource.Convention ));
+            Assert.Null(entityBuilder.Relationship(entityBuilder, ConfigurationSource.Convention));
 
             Assert.NotNull(relationshipBuilder);
         }
@@ -435,19 +432,20 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
         {
             var conventions = new ConventionSet();
 
-            InternalRelationshipBuilder relationshipBuilderFromConvention = null;
+            InternalEntityTypeBuilder dependentEntityTypeBuilderFromConvention = null;
+            InternalEntityTypeBuilder principalEntityBuilderFromConvention = null;
             var convention = new Mock<INavigationRemovedConvention>();
-            convention.Setup(c => c.Apply(It.IsAny<InternalRelationshipBuilder>(), It.IsAny<string>(), It.IsAny<bool>())).Returns((InternalRelationshipBuilder b, string n, bool p) =>
+            convention.Setup(c => c.Apply(It.IsAny<InternalEntityTypeBuilder>(), It.IsAny<InternalEntityTypeBuilder>(), It.IsAny<string>())).Returns((InternalEntityTypeBuilder s, InternalEntityTypeBuilder t, string n) =>
                 {
-                    relationshipBuilderFromConvention = b;
+                    dependentEntityTypeBuilderFromConvention = s;
+                    principalEntityBuilderFromConvention = t;
                     Assert.Equal(nameof(OrderDetails.Order), n);
-                    Assert.True(p);
                     return false;
                 });
             conventions.NavigationRemovedConventions.Add(convention.Object);
 
             var extraConvention = new Mock<INavigationRemovedConvention>();
-            extraConvention.Setup(c => c.Apply(It.IsAny<InternalRelationshipBuilder>(), It.IsAny<string>(), It.IsAny<bool>())).Returns((InternalRelationshipBuilder b, string n, bool p) =>
+            extraConvention.Setup(c => c.Apply(It.IsAny<InternalEntityTypeBuilder>(), It.IsAny<InternalEntityTypeBuilder>(), It.IsAny<string>())).Returns((InternalEntityTypeBuilder s, InternalEntityTypeBuilder t, string n) =>
                 {
                     Assert.False(true);
                     return false;
@@ -455,15 +453,16 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             conventions.NavigationRemovedConventions.Add(extraConvention.Object);
 
             var builder = new InternalModelBuilder(new Model(), conventions);
-            
+
             var principalEntityBuilder = builder.Entity(typeof(Order), ConfigurationSource.Convention);
             var dependentEntityBuilder = builder.Entity(typeof(OrderDetails), ConfigurationSource.Convention);
-            
+
             var relationshipBuilder = dependentEntityBuilder.Relationship(principalEntityBuilder, nameof(OrderDetails.Order), nameof(Order.OrderDetails), ConfigurationSource.Convention);
             relationshipBuilder.DependentToPrincipal(null, ConfigurationSource.Convention);
 
             Assert.NotNull(relationshipBuilder);
-            Assert.Same(relationshipBuilderFromConvention, relationshipBuilder);
+            Assert.Same(dependentEntityTypeBuilderFromConvention, dependentEntityBuilder);
+            Assert.Same(principalEntityBuilderFromConvention, principalEntityBuilder);
         }
 
         [Fact]

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/DerivedTypeDiscoveryConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/DerivedTypeDiscoveryConventionTest.cs
@@ -1,0 +1,74 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Metadata.Conventions;
+using Microsoft.Data.Entity.Metadata.Internal;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
+{
+    public class DerivedTypeDiscoveryConventionTest
+    {
+        [Fact]
+        public void Discovers_child_types()
+        {
+            var entityBuilderA = CreateInternalEntityTypeBuilder<A>();
+            var entityBuilderB = entityBuilderA.ModelBuilder.Entity(typeof(B), ConfigurationSource.Explicit);
+            var entityBuilderC = entityBuilderA.ModelBuilder.Entity(typeof(C), ConfigurationSource.Explicit);
+            Assert.Null(entityBuilderB.Metadata.BaseType);
+            Assert.Null(entityBuilderC.Metadata.BaseType);
+
+            new DerivedTypeDiscoveryConvention().Apply(entityBuilderA);
+
+            Assert.Same(entityBuilderA.Metadata, entityBuilderB.Metadata.BaseType);
+            Assert.Null(entityBuilderC.Metadata.BaseType);
+        }
+
+        [Fact]
+        public void Discovers_child_type_when_grandchild_type_exists()
+        {
+            var entityBuilderA = CreateInternalEntityTypeBuilder<A>();
+            var entityBuilderB = entityBuilderA.ModelBuilder.Entity(typeof(B), ConfigurationSource.Explicit);
+            var entityBuilderC = entityBuilderA.ModelBuilder.Entity(typeof(C), ConfigurationSource.Explicit);
+            entityBuilderC.HasBaseType(entityBuilderB.Metadata, ConfigurationSource.DataAnnotation);
+
+            new DerivedTypeDiscoveryConvention().Apply(entityBuilderA);
+
+            Assert.Same(entityBuilderA.Metadata, entityBuilderB.Metadata.BaseType);
+            Assert.Same(entityBuilderB.Metadata, entityBuilderC.Metadata.BaseType);
+        }
+
+        [Fact]
+        public void Discovers_child_type_if_base_type_set()
+        {
+            var entityBuilderA = CreateInternalEntityTypeBuilder<A>();
+            var entityBuilderB = entityBuilderA.ModelBuilder.Entity(typeof(B), ConfigurationSource.Explicit);
+            entityBuilderB.HasBaseType(entityBuilderA.Metadata, ConfigurationSource.DataAnnotation);
+            var entityBuilderC = entityBuilderA.ModelBuilder.Entity(typeof(C), ConfigurationSource.Explicit);
+            entityBuilderC.HasBaseType(entityBuilderA.Metadata, ConfigurationSource.Convention);
+
+            new DerivedTypeDiscoveryConvention().Apply(entityBuilderB);
+            
+            Assert.Same(entityBuilderB.Metadata, entityBuilderC.Metadata.BaseType);
+        }
+
+        private class A
+        {
+        }
+
+        private class B : A
+        {
+        }
+
+        private class C : B
+        {
+        }
+
+        private InternalEntityTypeBuilder CreateInternalEntityTypeBuilder<T>()
+        {
+            var modelBuilder = new InternalModelBuilder(new Model(), new ConventionSet());
+
+            return modelBuilder.Entity(typeof(T), ConfigurationSource.Explicit);
+        }
+    }
+}

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/ForeignKeyPropertyDiscoveryConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/ForeignKeyPropertyDiscoveryConventionTest.cs
@@ -769,7 +769,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
         [Fact]
         public void Inverts_and_sets_foreign_key_if_matching_non_shadow_property_added_on_principal_type()
         {
-            var relationshipBuilder = PrincipalType.Relationship(DependentType, "InverseReferenceNav", "SomeNav", ConfigurationSource.Convention)
+            var relationshipBuilder = PrincipalType
+                .Relationship(DependentType, "InverseReferenceNav", "SomeNav", ConfigurationSource.Convention)
                 .IsUnique(true, ConfigurationSource.Convention);
 
             var fk = (IForeignKey)relationshipBuilder.Metadata;

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/KeyConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/KeyConventionTest.cs
@@ -177,14 +177,16 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
 
             var keyProperties = keyBuilder.Metadata.Properties;
 
-            Assert.True(keyProperties[0].RequiresValueGenerator);
+            Assert.True(((IProperty)keyProperties[0]).RequiresValueGenerator);
 
-            referencedEntityBuilder.HasForeignKey(
+            var foreignKeyBuilder = referencedEntityBuilder.HasForeignKey(
                 principalEntityBuilder,
                 referencedEntityBuilder.GetOrCreateProperties(properties, ConfigurationSource.Convention),
                 ConfigurationSource.Convention);
+            
+            Assert.Same(foreignKeyBuilder, new KeyConvention().Apply(foreignKeyBuilder));
 
-            Assert.Null(keyProperties[0].RequiresValueGenerator);
+            Assert.False(((IProperty)keyProperties[0]).RequiresValueGenerator);
         }
 
         [Fact]
@@ -213,11 +215,15 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
                 referencedEntityBuilder.GetOrCreateProperties(properties, ConfigurationSource.Convention),
                 ConfigurationSource.Convention);
 
-            Assert.Null(keyProperties[0].RequiresValueGenerator);
+            Assert.Same(relationshipBuilder, new KeyConvention().Apply(relationshipBuilder));
+
+            Assert.False(((IProperty)keyProperties[0]).RequiresValueGenerator);
 
             referencedEntityBuilder.RemoveForeignKey(relationshipBuilder.Metadata, ConfigurationSource.Convention);
 
-            Assert.True(keyProperties[0].RequiresValueGenerator);
+            new KeyConvention().Apply(referencedEntityBuilder, relationshipBuilder.Metadata);
+
+            Assert.True(((IProperty)keyProperties[0]).RequiresValueGenerator);
         }
 
         #endregion
@@ -266,8 +272,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
 
             var keyProperties = keyBuilder.Metadata.Properties;
 
-            Assert.Null(keyProperties[0].ValueGenerated);
-            Assert.Null(keyProperties[1].ValueGenerated);
+            Assert.Equal(ValueGenerated.Never, ((IProperty)keyProperties[0]).ValueGenerated);
+            Assert.Equal(ValueGenerated.Never, ((IProperty)keyProperties[1]).ValueGenerated);
         }
 
         [Fact]
@@ -308,8 +314,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             Assert.Same(idProperty, entityBuilder.Metadata.GetProperty("Id"));
             Assert.Same(numberProperty, entityBuilder.Metadata.GetProperty("Number"));
 
-            Assert.Null(idProperty.ValueGenerated);
-            Assert.Equal(ValueGenerated.OnAdd, numberProperty.ValueGenerated);
+            Assert.Equal(ValueGenerated.Never, ((IProperty)idProperty).ValueGenerated);
+            Assert.Equal(ValueGenerated.OnAdd, ((IProperty)numberProperty).ValueGenerated);
         }
 
         [Fact]
@@ -345,14 +351,16 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
 
             var property = keyBuilder.Metadata.Properties.First();
 
-            Assert.Equal(ValueGenerated.OnAdd, property.ValueGenerated);
+            Assert.Equal(ValueGenerated.OnAdd, ((IProperty)property).ValueGenerated);
 
-            referencedEntityBuilder.HasForeignKey(
+            var relationshipBuilder= referencedEntityBuilder.HasForeignKey(
                 principalEntityBuilder,
                 referencedEntityBuilder.GetOrCreateProperties(properties, ConfigurationSource.Convention),
                 ConfigurationSource.Convention);
 
-            Assert.Null(property.ValueGenerated);
+            Assert.Same(relationshipBuilder, new KeyConvention().Apply(relationshipBuilder));
+
+            Assert.Equal(ValueGenerated.Never, ((IProperty)property).ValueGenerated);
         }
 
         [Fact]
@@ -377,7 +385,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
                 referencedEntityBuilder.GetOrCreateProperties(properties, ConfigurationSource.Convention),
                 ConfigurationSource.Convention);
 
-            Assert.Null(property.ValueGenerated);
+            Assert.Same(relationshipBuilder, new KeyConvention().Apply(relationshipBuilder));
+
+            Assert.Equal(ValueGenerated.Never, ((IProperty)property).ValueGenerated);
 
             referencedEntityBuilder.RemoveForeignKey(relationshipBuilder.Metadata, ConfigurationSource.Convention);
 

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/RelationshipDiscoveryConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/RelationshipDiscoveryConventionTest.cs
@@ -17,26 +17,6 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
     public class RelationshipDiscoveryConventionTest
     {
         [Fact]
-        public void Entity_type_is_discovered_through_private_unidirectional_nonCollection_navigation_when_no_PK_on_principal()
-        {
-            var entityBuilder = CreateInternalEntityBuilder<OneToManyDependent>(OneToManyPrincipal.IgnoreNavigation);
-
-            Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
-
-            VerifyOneToManyDependent(entityBuilder, unidirectional: true, dependentHasPK: false);
-        }
-
-        [Fact]
-        public void Entity_type_is_discovered_through_unidirectional_collection_navigation_when_no_PK_on_principal()
-        {
-            var entityBuilder = CreateInternalEntityBuilder<OneToManyPrincipal>(OneToManyDependent.IgnoreNavigation);
-
-            Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
-
-            VerifyOneToManyPrincipal(entityBuilder, unidirectional: true, dependentHasPK: false);
-        }
-
-        [Fact]
         public void Entity_type_is_not_discovered_if_ignored()
         {
             var entityBuilder = CreateInternalEntityBuilder<OneToManyDependent>();
@@ -67,86 +47,168 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
         [Fact]
         public void One_to_one_bidirectional_is_discovered()
         {
-            var entityBuilder = CreateInternalEntityBuilder<OneToOnePrincipal>(ConfigureKeys);
+            var entityBuilder = CreateInternalEntityBuilder<OneToOnePrincipal>();
 
             Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
 
-            VerifyOneToOne(entityBuilder.Metadata.Model);
+            VerifyRelationship(entityBuilder.Metadata.Navigations.Single(), OneToOneDependent.NavigationProperty.Name, unique: true);
+            Assert.Equal(2, entityBuilder.Metadata.Model.EntityTypes.Count);
+        }
 
-            Assert.NotSame(entityBuilder, new RelationshipDiscoveryConvention().Apply(
-                entityBuilder.ModelBuilder.Entity(typeof(OneToOneDependent), ConfigurationSource.Convention)));
+        [Fact]
+        public void One_to_many_unidirectional_is_upgraded_to_one_to_one_bidirectional()
+        {
+            var principalEntityBuilder = CreateInternalEntityBuilder<OneToOnePrincipal>();
+            var dependentEntityBuilder = principalEntityBuilder.ModelBuilder.Entity(typeof(OneToOneDependent), ConfigurationSource.Convention);
 
-            VerifyOneToOne(entityBuilder.Metadata.Model);
+            dependentEntityBuilder.Relationship(principalEntityBuilder, null, OneToOnePrincipal.NavigationProperty, ConfigurationSource.Convention)
+                .IsUnique(false, ConfigurationSource.Convention);
+
+            Assert.Same(dependentEntityBuilder, new RelationshipDiscoveryConvention().Apply(dependentEntityBuilder));
+
+            VerifyRelationship(dependentEntityBuilder.Metadata.Navigations.Single(), OneToOnePrincipal.NavigationProperty.Name, unique: true);
+            Assert.Equal(2, principalEntityBuilder.Metadata.Model.EntityTypes.Count);
+        }
+
+        [Fact]
+        public void Two_one_to_many_unidirectional_are_upgraded_to_one_to_one_bidirectional()
+        {
+            var principalEntityBuilder = CreateInternalEntityBuilder<OneToOnePrincipal>();
+            var dependentEntityBuilder = principalEntityBuilder.ModelBuilder.Entity(typeof(OneToOneDependent), ConfigurationSource.Convention);
+
+            dependentEntityBuilder.Relationship(principalEntityBuilder, null, OneToOnePrincipal.NavigationProperty, ConfigurationSource.Convention)
+                .IsUnique(false, ConfigurationSource.Convention);
+
+            principalEntityBuilder.Relationship(dependentEntityBuilder, null, OneToOneDependent.NavigationProperty, ConfigurationSource.Convention)
+                .IsUnique(false, ConfigurationSource.Convention);
+
+            Assert.Same(dependentEntityBuilder, new RelationshipDiscoveryConvention().Apply(dependentEntityBuilder));
+
+            VerifyRelationship(dependentEntityBuilder.Metadata.Navigations.Single(), OneToOnePrincipal.NavigationProperty.Name, unique: true);
+            Assert.Equal(2, principalEntityBuilder.Metadata.Model.EntityTypes.Count);
+        }
+
+        [Fact]
+        public void One_to_many_unidirectional_is_not_upgraded_to_one_to_one_bidirectional_if_higher_source()
+        {
+            var principalEntityBuilder = CreateInternalEntityBuilder<OneToOnePrincipal>();
+            var dependentEntityBuilder = principalEntityBuilder.ModelBuilder.Entity(typeof(OneToOneDependent), ConfigurationSource.Convention);
+
+            dependentEntityBuilder.Relationship(principalEntityBuilder, null, OneToOnePrincipal.NavigationProperty, ConfigurationSource.Explicit)
+                .IsUnique(false, ConfigurationSource.Convention);
+
+            Assert.Same(dependentEntityBuilder, new RelationshipDiscoveryConvention().Apply(dependentEntityBuilder));
+            VerifyRelationship(principalEntityBuilder.Metadata.Navigations.Single(), null, unique: false, singleRelationship: false);
+            VerifyRelationship(dependentEntityBuilder.Metadata.Navigations.Single(), null, unique: false, singleRelationship: false);
+            Assert.Equal(2, principalEntityBuilder.Metadata.Model.EntityTypes.Count);
         }
 
         [Fact]
         public void One_to_many_unidirectional_is_discovered()
         {
-            var entityBuilder = CreateInternalEntityBuilder<OneToManyDependent>(
-                ConfigureKeys, OneToManyPrincipal.IgnoreNavigation);
+            var entityBuilder = CreateInternalEntityBuilder<OneToManyDependent>(OneToManyPrincipal.IgnoreNavigation);
 
             Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
 
-            VerifyOneToManyDependent(entityBuilder, unidirectional: true);
+            VerifyRelationship(entityBuilder.Metadata.Navigations.Single(), null, unique: false);
+            Assert.Equal(2, entityBuilder.Metadata.Model.EntityTypes.Count);
         }
 
         [Fact]
-        public void One_to_many_unidirectional_remains_unchanged_if_already_discovered()
+        public void One_to_many_unidirectional_is_upgraded_to_one_to_many_bidirectional()
         {
-            var entityBuilder = CreateInternalEntityBuilder<OneToManyDependent>(
-                ConfigureKeys, OneToManyPrincipal.IgnoreNavigation);
+            var principalEntityBuilder = CreateInternalEntityBuilder<OneToManyPrincipal>();
+            var dependentEntityBuilder = principalEntityBuilder.ModelBuilder.Entity(typeof(OneToManyDependent), ConfigurationSource.Convention);
 
-            Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
-            var entityType = entityBuilder.Metadata;
-            var fk = entityType.GetForeignKeys().Single();
-            Assert.Null(fk.IsRequired);
-            Assert.False(((IForeignKey)fk).IsUnique);
+            dependentEntityBuilder.Relationship(principalEntityBuilder, null, OneToManyPrincipal.NavigationProperty, ConfigurationSource.Convention);
 
-            fk.IsRequired = true;
-            fk.IsUnique = true;
+            Assert.Same(dependentEntityBuilder, new RelationshipDiscoveryConvention().Apply(dependentEntityBuilder));
 
-            Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
+            VerifyRelationship(dependentEntityBuilder.Metadata.Navigations.Single(), OneToManyPrincipal.NavigationProperty.Name, unique: false);
+            Assert.Equal(2, principalEntityBuilder.Metadata.Model.EntityTypes.Count);
+        }
 
-            var newFk = (IForeignKey)entityType.GetForeignKeys().Single();
-            Assert.True(newFk.IsRequired);
-            Assert.True(newFk.IsUnique);
+        [Fact]
+        public void One_to_many_unidirectional_is_not_upgraded_to_one_to_many_bidirectional_if_higher_source()
+        {
+            var principalEntityBuilder = CreateInternalEntityBuilder<OneToManyPrincipal>();
+            var dependentEntityBuilder = principalEntityBuilder.ModelBuilder.Entity(typeof(OneToManyDependent), ConfigurationSource.Convention);
+
+            dependentEntityBuilder.Relationship(principalEntityBuilder, null, OneToManyPrincipal.NavigationProperty, ConfigurationSource.Explicit);
+
+            Assert.Same(dependentEntityBuilder, new RelationshipDiscoveryConvention().Apply(dependentEntityBuilder));
+
+            VerifyRelationship(principalEntityBuilder.Metadata.Navigations.Single(), null, unique: false, singleRelationship: false);
+            VerifyRelationship(dependentEntityBuilder.Metadata.Navigations.Single(), null, unique: false, singleRelationship: false);
+            Assert.Equal(2, principalEntityBuilder.Metadata.Model.EntityTypes.Count);
         }
 
         [Fact]
         public void One_to_many_bidirectional_is_discovered()
         {
-            var entityBuilder = CreateInternalEntityBuilder<OneToManyDependent>(ConfigureKeys);
+            var entityBuilder = CreateInternalEntityBuilder<OneToManyDependent>();
 
             Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
 
-            VerifyOneToManyDependent(entityBuilder, unidirectional: false);
+            VerifyRelationship(entityBuilder.Metadata.Navigations.Single(), OneToManyPrincipal.NavigationProperty.Name, unique: false);
+            Assert.Equal(2, entityBuilder.Metadata.Model.EntityTypes.Count);
         }
 
         [Fact]
         public void Many_to_one_unidirectional_is_discovered()
         {
-            var entityBuilder = CreateInternalEntityBuilder<OneToManyPrincipal>(
-                ConfigureKeys, OneToManyDependent.IgnoreNavigation);
+            var entityBuilder = CreateInternalEntityBuilder<OneToManyPrincipal>(OneToManyDependent.IgnoreNavigation);
 
             Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
 
-            VerifyOneToManyPrincipal(entityBuilder, unidirectional: true);
+            VerifyRelationship(entityBuilder.Metadata.Navigations.Single(), null, unique: false);
+            Assert.Equal(2, entityBuilder.Metadata.Model.EntityTypes.Count);
+        }
+
+        [Fact]
+        public void Many_to_one_unidirectional_is_upgraded_to_many_to_one_bidirectional()
+        {
+            var principalEntityBuilder = CreateInternalEntityBuilder<OneToManyPrincipal>();
+            var dependentEntityBuilder = principalEntityBuilder.ModelBuilder.Entity(typeof(OneToManyDependent), ConfigurationSource.Convention);
+
+            dependentEntityBuilder.Relationship(principalEntityBuilder, OneToManyDependent.NavigationProperty, null, ConfigurationSource.Convention);
+
+            Assert.Same(principalEntityBuilder, new RelationshipDiscoveryConvention().Apply(principalEntityBuilder));
+
+            VerifyRelationship(principalEntityBuilder.Metadata.Navigations.Single(), OneToManyDependent.NavigationProperty.Name, unique: false);
+            Assert.Equal(2, principalEntityBuilder.Metadata.Model.EntityTypes.Count);
+        }
+
+        [Fact]
+        public void Many_to_one_unidirectional_is_not_upgraded_to_many_to_one_bidirectional_if_higher_source()
+        {
+            var principalEntityBuilder = CreateInternalEntityBuilder<OneToManyPrincipal>();
+            var dependentEntityBuilder = principalEntityBuilder.ModelBuilder.Entity(typeof(OneToManyDependent), ConfigurationSource.Convention);
+
+            dependentEntityBuilder.Relationship(principalEntityBuilder, OneToManyDependent.NavigationProperty, null, ConfigurationSource.Explicit);
+
+            Assert.Same(principalEntityBuilder, new RelationshipDiscoveryConvention().Apply(principalEntityBuilder));
+
+            VerifyRelationship(principalEntityBuilder.Metadata.Navigations.Single(), null, unique: false, singleRelationship: false);
+            VerifyRelationship(dependentEntityBuilder.Metadata.Navigations.Single(), null, unique: false, singleRelationship: false);
+            Assert.Equal(2, principalEntityBuilder.Metadata.Model.EntityTypes.Count);
         }
 
         [Fact]
         public void Many_to_one_bidirectional_is_discovered()
         {
-            var entityBuilder = CreateInternalEntityBuilder<OneToManyPrincipal>(ConfigureKeys);
+            var entityBuilder = CreateInternalEntityBuilder<OneToManyPrincipal>();
 
             Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
 
-            VerifyOneToManyPrincipal(entityBuilder, unidirectional: false);
+            VerifyRelationship(entityBuilder.Metadata.Navigations.Single(), OneToManyDependent.NavigationProperty.Name, unique: false);
+            Assert.Equal(2, entityBuilder.Metadata.Model.EntityTypes.Count);
         }
 
         [Fact]
         public void Many_to_many_bidirectional_is_not_discovered()
         {
-            var entityBuilder = CreateInternalEntityBuilder<ManyToManyFirst>(ConfigureKeys);
+            var entityBuilder = CreateInternalEntityBuilder<ManyToManyFirst>();
 
             Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
             new ModelCleanupConvention().Apply(entityBuilder.ModelBuilder);
@@ -159,36 +221,97 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
         [Fact]
         public void Ambiguous_navigations_are_not_discovered()
         {
-            var entityBuilder = CreateInternalEntityBuilder<MultipleNavigationsFirst>(
-                ConfigureKeys, MultipleNavigationsSecond.IgnoreCollectionNavigation);
+            var entityBuilder = CreateInternalEntityBuilder<MultipleNavigationsFirst>(MultipleNavigationsSecond.IgnoreCollectionNavigation);
 
             Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
-            new ModelCleanupConvention().Apply(entityBuilder.ModelBuilder);
 
             Assert.Empty(entityBuilder.Metadata.GetForeignKeys());
             Assert.Empty(entityBuilder.Metadata.Navigations);
-            Assert.Equal(1, entityBuilder.Metadata.Model.EntityTypes.Count);
+            Assert.Equal(2, entityBuilder.Metadata.Model.EntityTypes.Count);
         }
 
         [Fact]
-        public void Ambiguous_reverse_navigations_are_not_discovered()
+        public void Existing_relationship_is_removed_if_ambiguous()
         {
-            var entityBuilder = CreateInternalEntityBuilder<MultipleNavigationsSecond>(
-                ConfigureKeys, MultipleNavigationsSecond.IgnoreCollectionNavigation);
+            var entityBuilderFirst = CreateInternalEntityBuilder<MultipleNavigationsFirst>(MultipleNavigationsSecond.IgnoreCollectionNavigation);
+            var entityBuilderSecond = entityBuilderFirst.ModelBuilder.Entity(typeof(MultipleNavigationsSecond), ConfigurationSource.Convention);
 
-            Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
-            new ModelCleanupConvention().Apply(entityBuilder.ModelBuilder);
+            entityBuilderFirst.Relationship(entityBuilderSecond, MultipleNavigationsFirst.CollectionNavigationProperty, null, ConfigurationSource.Convention);
 
-            Assert.Empty(entityBuilder.Metadata.GetForeignKeys());
-            Assert.Empty(entityBuilder.Metadata.Navigations);
-            Assert.Equal(1, entityBuilder.Metadata.Model.EntityTypes.Count);
+            Assert.Same(entityBuilderFirst, new RelationshipDiscoveryConvention().Apply(entityBuilderFirst));
+
+            Assert.Empty(entityBuilderFirst.Metadata.GetForeignKeys());
+            Assert.Empty(entityBuilderFirst.Metadata.Navigations);
+            Assert.Empty(entityBuilderSecond.Metadata.Navigations);
+            Assert.Equal(2, entityBuilderFirst.Metadata.Model.EntityTypes.Count);
+        }
+
+        [Fact]
+        public void Existing_relationship_removes_ambiguity_if_higher_source()
+        {
+            var entityBuilderFirst = CreateInternalEntityBuilder<MultipleNavigationsFirst>(MultipleNavigationsSecond.IgnoreCollectionNavigation);
+            var entityBuilderSecond = entityBuilderFirst.ModelBuilder.Entity(typeof(MultipleNavigationsSecond), ConfigurationSource.Convention);
+
+            entityBuilderFirst.Relationship(entityBuilderSecond, MultipleNavigationsFirst.CollectionNavigationProperty, null, ConfigurationSource.DataAnnotation);
+
+            Assert.Same(entityBuilderFirst, new RelationshipDiscoveryConvention().Apply(entityBuilderFirst));
+
+            VerifyRelationship(entityBuilderFirst.Metadata.FindNavigation(MultipleNavigationsFirst.CollectionNavigationProperty.Name), null, unique: false, singleRelationship: false);
+            VerifyRelationship(entityBuilderFirst.Metadata.FindNavigation(MultipleNavigationsFirst.NonCollectionNavigationProperty.Name), nameof(MultipleNavigationsSecond.MultipleNavigationsFirst), unique: true, singleRelationship: false);
+            Assert.Equal(2, entityBuilderFirst.Metadata.Model.EntityTypes.Count);
+        }
+
+        [Fact]
+        public void Navigations_are_not_discovered_if_ambiguous_inverse()
+        {
+            var entityBuilderFirst = CreateInternalEntityBuilder<MultipleNavigationsSecond>(
+                MultipleNavigationsSecond.IgnoreCollectionNavigation);
+            var entityBuilderSecond = entityBuilderFirst.ModelBuilder.Entity(typeof(MultipleNavigationsSecond), ConfigurationSource.Convention);
+
+            Assert.Same(entityBuilderFirst, new RelationshipDiscoveryConvention().Apply(entityBuilderFirst));
+
+            Assert.Empty(entityBuilderFirst.Metadata.GetForeignKeys());
+            Assert.Empty(entityBuilderFirst.Metadata.Navigations);
+            Assert.Empty(entityBuilderSecond.Metadata.Navigations);
+            Assert.Equal(2, entityBuilderFirst.Metadata.Model.EntityTypes.Count);
+        }
+
+        [Fact]
+        public void Existing_relationship_is_removed_if_ambiguous_inverse()
+        {
+            var entityBuilderFirst = CreateInternalEntityBuilder<MultipleNavigationsFirst>(MultipleNavigationsSecond.IgnoreCollectionNavigation);
+            var entityBuilderSecond = entityBuilderFirst.ModelBuilder.Entity(typeof(MultipleNavigationsSecond), ConfigurationSource.Convention);
+
+            entityBuilderFirst.Relationship(entityBuilderSecond, MultipleNavigationsFirst.CollectionNavigationProperty, null, ConfigurationSource.Convention);
+
+            Assert.Same(entityBuilderSecond, new RelationshipDiscoveryConvention().Apply(entityBuilderSecond));
+
+            Assert.Empty(entityBuilderFirst.Metadata.GetForeignKeys());
+            Assert.Empty(entityBuilderFirst.Metadata.Navigations);
+            Assert.Empty(entityBuilderSecond.Metadata.Navigations);
+            Assert.Equal(2, entityBuilderFirst.Metadata.Model.EntityTypes.Count);
+        }
+
+        [Fact]
+        public void Existing_relationship_removes_ambiguity_in_inverse_if_higher_source()
+        {
+            var entityBuilderFirst = CreateInternalEntityBuilder<MultipleNavigationsFirst>(MultipleNavigationsSecond.IgnoreCollectionNavigation);
+            var entityBuilderSecond = entityBuilderFirst.ModelBuilder.Entity(typeof(MultipleNavigationsSecond), ConfigurationSource.Convention);
+
+            entityBuilderFirst.Relationship(entityBuilderSecond, MultipleNavigationsFirst.CollectionNavigationProperty, null, ConfigurationSource.DataAnnotation);
+
+            Assert.Same(entityBuilderSecond, new RelationshipDiscoveryConvention().Apply(entityBuilderSecond));
+
+            VerifyRelationship(entityBuilderFirst.Metadata.FindNavigation(MultipleNavigationsFirst.CollectionNavigationProperty.Name), null, unique: false, singleRelationship: false);
+            VerifyRelationship(entityBuilderFirst.Metadata.FindNavigation(MultipleNavigationsFirst.NonCollectionNavigationProperty.Name), nameof(MultipleNavigationsSecond.MultipleNavigationsFirst), unique: true, singleRelationship: false);
+            Assert.Equal(2, entityBuilderFirst.Metadata.Model.EntityTypes.Count);
         }
 
         [Fact]
         public void Multiple_navigations_to_same_entity_type_are_discovered()
         {
             var entityBuilder = CreateInternalEntityBuilder<MultipleNavigationsFirst>(
-                ConfigureKeys, MultipleNavigationsSecond.IgnoreCollectionNavigation, MultipleNavigationsSecond.IgnoreNonCollectionNavigation);
+                MultipleNavigationsSecond.IgnoreCollectionNavigation, MultipleNavigationsSecond.IgnoreNonCollectionNavigation);
 
             Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
 
@@ -215,9 +338,352 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
         }
 
         [Fact]
+        public void Navigations_to_base_and_derived_are_discovered()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<NavigationsToBaseAndDerived>(
+                NavigationsToBaseAndDerived.IgnoreDerivedTwoNavigation,
+                Base.IgnoreBaseNavigation,
+                DerivedOne.IgnoreDerivedNavigation);
+            var modelBuilder = entityBuilder.ModelBuilder;
+            var baseBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit);
+            var derivedBuilder = modelBuilder.Entity(typeof(DerivedOne), ConfigurationSource.Explicit);
+            derivedBuilder.HasBaseType(baseBuilder.Metadata, ConfigurationSource.Convention);
+
+            Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
+
+            var baseFk = entityBuilder.Metadata.Navigations
+                .Single(n => n.Name == nameof(NavigationsToBaseAndDerived.Base)).ForeignKey;
+            var derivedFk = entityBuilder.Metadata.Navigations
+                .Single(n => n.Name == nameof(NavigationsToBaseAndDerived.DerivedOne)).ForeignKey;
+            Assert.Null(baseFk.FindNavigationTo(entityBuilder.Metadata));
+            Assert.Null(derivedFk.FindNavigationTo(entityBuilder.Metadata));
+            Assert.Equal(2, entityBuilder.Metadata.Navigations.Count());
+            Assert.Equal(3, entityBuilder.Metadata.Model.EntityTypes.Count);
+        }
+
+        [Fact]
+        public void Navigations_to_base_and_derived_are_discovered_if_inverse_from_base()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<NavigationsToBaseAndDerived>(
+                NavigationsToBaseAndDerived.IgnoreDerivedTwoNavigation,
+                DerivedOne.IgnoreDerivedNavigation);
+            var modelBuilder = entityBuilder.ModelBuilder;
+            var baseBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit);
+            var derivedBuilder = modelBuilder.Entity(typeof(DerivedOne), ConfigurationSource.Explicit);
+            derivedBuilder.HasBaseType(baseBuilder.Metadata, ConfigurationSource.Convention);
+
+            Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
+
+            var baseFk = entityBuilder.Metadata.Navigations
+                .Single(n => n.Name == nameof(NavigationsToBaseAndDerived.Base)).ForeignKey;
+            var derivedFk = entityBuilder.Metadata.Navigations
+                .Single(n => n.Name == nameof(NavigationsToBaseAndDerived.DerivedOne)).ForeignKey;
+            Assert.Equal(nameof(Base.BaseNavigation), baseFk.FindNavigationTo(entityBuilder.Metadata).Name);
+            Assert.Null(derivedFk.FindNavigationTo(entityBuilder.Metadata));
+            Assert.Equal(2, entityBuilder.Metadata.Navigations.Count());
+            Assert.Equal(3, entityBuilder.Metadata.Model.EntityTypes.Count);
+        }
+
+        [Fact]
+        public void Navigations_to_derived_and_base_are_discovered_if_inverse_from_base()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<NavigationsToBaseAndDerived>(
+                NavigationsToBaseAndDerived.IgnoreDerivedOneNavigation,
+                DerivedTwo.IgnoreDerivedNavigation);
+            var modelBuilder = entityBuilder.ModelBuilder;
+            var baseBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit);
+            var derivedBuilder = modelBuilder.Entity(typeof(DerivedTwo), ConfigurationSource.Explicit);
+            derivedBuilder.HasBaseType(baseBuilder.Metadata, ConfigurationSource.Convention);
+
+            Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
+
+            var baseFk = entityBuilder.Metadata.Navigations
+                .Single(n => n.Name == nameof(NavigationsToBaseAndDerived.Base)).ForeignKey;
+            var derivedFk = entityBuilder.Metadata.Navigations
+                .Single(n => n.Name == nameof(NavigationsToBaseAndDerived.DerivedTwo)).ForeignKey;
+            Assert.Equal(nameof(Base.BaseNavigation), baseFk.FindNavigationTo(entityBuilder.Metadata).Name);
+            Assert.Null(derivedFk.FindNavigationTo(entityBuilder.Metadata));
+            Assert.Equal(2, entityBuilder.Metadata.Navigations.Count());
+            Assert.Equal(3, entityBuilder.Metadata.Model.EntityTypes.Count);
+        }
+
+        [Fact]
+        public void Navigations_to_base_and_derived_are_discovered_if_inverse_from_derived()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<NavigationsToBaseAndDerived>(
+                NavigationsToBaseAndDerived.IgnoreDerivedTwoNavigation,
+                Base.IgnoreBaseNavigation);
+            var modelBuilder = entityBuilder.ModelBuilder;
+            var baseBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit);
+            var derivedBuilder = modelBuilder.Entity(typeof(DerivedOne), ConfigurationSource.Explicit);
+            derivedBuilder.HasBaseType(baseBuilder.Metadata, ConfigurationSource.Convention);
+
+            Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
+
+            var baseFk = entityBuilder.Metadata.Navigations
+                .Single(n => n.Name == nameof(NavigationsToBaseAndDerived.Base)).ForeignKey;
+            var derivedFk = entityBuilder.Metadata.Navigations
+                .Single(n => n.Name == nameof(NavigationsToBaseAndDerived.DerivedOne)).ForeignKey;
+            Assert.Null(baseFk.FindNavigationTo(entityBuilder.Metadata));
+            Assert.Equal(nameof(DerivedOne.DerivedNavigation), derivedFk.FindNavigationTo(entityBuilder.Metadata).Name);
+            Assert.Equal(2, entityBuilder.Metadata.Navigations.Count());
+            Assert.Equal(3, entityBuilder.Metadata.Model.EntityTypes.Count);
+        }
+
+        [Fact]
+        public void Navigation_pairs_to_base_and_derived_are_discovered()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<NavigationsToBaseAndDerived>();
+            var modelBuilder = entityBuilder.ModelBuilder;
+            var baseBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit);
+            var derivedBuilder = modelBuilder.Entity(typeof(DerivedOne), ConfigurationSource.Explicit);
+            derivedBuilder.HasBaseType(baseBuilder.Metadata, ConfigurationSource.Convention);
+            var derivedBuilderTwo = modelBuilder.Entity(typeof(DerivedTwo), ConfigurationSource.Explicit);
+            derivedBuilderTwo.HasBaseType(baseBuilder.Metadata, ConfigurationSource.Convention);
+
+            Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
+
+            var baseFk = entityBuilder.Metadata.Navigations
+                .Single(n => n.Name == nameof(NavigationsToBaseAndDerived.Base)).ForeignKey;
+            var derivedFk = entityBuilder.Metadata.Navigations
+                .Single(n => n.Name == nameof(NavigationsToBaseAndDerived.DerivedOne)).ForeignKey;
+            Assert.Equal(nameof(Base.BaseNavigation), baseFk.FindNavigationTo(entityBuilder.Metadata).Name);
+            Assert.Equal(nameof(DerivedOne.DerivedNavigation), derivedFk.FindNavigationTo(entityBuilder.Metadata).Name);
+            Assert.Equal(3, entityBuilder.Metadata.Navigations.Count());
+            Assert.Equal(4, entityBuilder.Metadata.Model.EntityTypes.Count);
+        }
+
+        [Fact]
+        public void Navigation_to_base_is_discovered()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<NavigationsToBaseAndDerived>(
+                NavigationsToBaseAndDerived.IgnoreDerivedTwoNavigation,
+                NavigationsToBaseAndDerived.IgnoreDerivedOneNavigation);
+            var modelBuilder = entityBuilder.ModelBuilder;
+            modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit);
+
+            Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
+
+            VerifyRelationship(entityBuilder.Metadata.FindNavigation(nameof(NavigationsToBaseAndDerived.Base)),
+                expectedInverseName: nameof(Base.BaseNavigation), unique: true);
+            Assert.Equal(2, entityBuilder.Metadata.Model.EntityTypes.Count);
+        }
+
+        [Fact]
+        public void Existing_navigation_to_derived_is_promoted()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<NavigationsToBaseAndDerived>(
+                NavigationsToBaseAndDerived.IgnoreDerivedTwoNavigation,
+                NavigationsToBaseAndDerived.IgnoreDerivedOneNavigation);
+            var modelBuilder = entityBuilder.ModelBuilder;
+            modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit);
+            var baseBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit);
+            var derivedBuilder = modelBuilder.Entity(typeof(DerivedOne), ConfigurationSource.Explicit);
+            derivedBuilder.HasBaseType(baseBuilder.Metadata, ConfigurationSource.Convention);
+
+            derivedBuilder.Relationship(entityBuilder, nameof(Base.BaseNavigation), null, ConfigurationSource.Convention);
+
+            Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
+
+            VerifyRelationship(entityBuilder.Metadata.FindNavigation(nameof(NavigationsToBaseAndDerived.Base)),
+                expectedInverseName: nameof(Base.BaseNavigation), unique: true);
+            Assert.Empty(derivedBuilder.Metadata.GetDeclaredNavigations());
+            Assert.Equal(3, entityBuilder.Metadata.Model.EntityTypes.Count);
+        }
+
+        [Fact]
+        public void Existing_navigation_from_derived_is_promoted()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<NavigationsToBaseAndDerived>(
+                NavigationsToBaseAndDerived.IgnoreDerivedTwoNavigation,
+                NavigationsToBaseAndDerived.IgnoreDerivedOneNavigation);
+            var modelBuilder = entityBuilder.ModelBuilder;
+            modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit);
+            var baseBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit);
+            var derivedBuilder = modelBuilder.Entity(typeof(DerivedOne), ConfigurationSource.Explicit);
+            derivedBuilder.HasBaseType(baseBuilder.Metadata, ConfigurationSource.Convention);
+
+            derivedBuilder.Relationship(entityBuilder, nameof(Base.BaseNavigation), null, ConfigurationSource.Convention);
+
+            Assert.Same(baseBuilder, new RelationshipDiscoveryConvention().Apply(baseBuilder));
+
+            VerifyRelationship(baseBuilder.Metadata.FindNavigation(nameof(Base.BaseNavigation)),
+                expectedInverseName: nameof(NavigationsToBaseAndDerived.Base), unique: true);
+            Assert.Empty(derivedBuilder.Metadata.GetDeclaredNavigations());
+            Assert.Equal(3, entityBuilder.Metadata.Model.EntityTypes.Count);
+        }
+
+        [Fact]
+        public void Navigation_from_derived_is_not_discovered_if_ambiguous()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<NavigationsToBaseAndDerived>(
+                NavigationsToBaseAndDerived.IgnoreDerivedTwoNavigation,
+                NavigationsToBaseAndDerived.IgnoreBaseNavigation);
+            var modelBuilder = entityBuilder.ModelBuilder;
+            var baseBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit);
+            var derivedBuilder = modelBuilder.Entity(typeof(DerivedOne), ConfigurationSource.Explicit);
+            derivedBuilder.HasBaseType(baseBuilder.Metadata, ConfigurationSource.Convention);
+
+            Assert.Same(derivedBuilder, new RelationshipDiscoveryConvention().Apply(derivedBuilder));
+
+            Assert.Empty(entityBuilder.Metadata.Navigations);
+            Assert.Empty(entityBuilder.Metadata.GetForeignKeys());
+            Assert.Empty(derivedBuilder.Metadata.Navigations);
+            Assert.Empty(derivedBuilder.Metadata.GetForeignKeys());
+            Assert.Equal(3, entityBuilder.Metadata.Model.EntityTypes.Count);
+        }
+
+        [Fact]
+        public void Existing_relationship_to_base_removes_ambiguity()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<NavigationsToBaseAndDerived>(
+                NavigationsToBaseAndDerived.IgnoreDerivedTwoNavigation,
+                NavigationsToBaseAndDerived.IgnoreBaseNavigation);
+            var modelBuilder = entityBuilder.ModelBuilder;
+            var baseBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit);
+            var derivedBuilder = modelBuilder.Entity(typeof(DerivedOne), ConfigurationSource.Explicit);
+            derivedBuilder.HasBaseType(baseBuilder.Metadata, ConfigurationSource.Convention);
+
+            baseBuilder.Relationship(entityBuilder, nameof(Base.BaseNavigation), null, ConfigurationSource.Convention);
+
+            Assert.Same(derivedBuilder, new RelationshipDiscoveryConvention().Apply(derivedBuilder));
+
+            VerifyRelationship(baseBuilder.Metadata.Navigations.Single(), expectedInverseName: null, unique: false, singleRelationship: false);
+            VerifyRelationship(entityBuilder.Metadata.Navigations.Single(), nameof(DerivedOne.DerivedNavigation), unique: true, singleRelationship: false);
+            Assert.Equal(3, entityBuilder.Metadata.Model.EntityTypes.Count);
+        }
+
+        [Fact]
+        public void Navigation_to_derived_is_not_discovered_if_inverse_ambiguous()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<NavigationsToBaseAndDerived>(
+                NavigationsToBaseAndDerived.IgnoreDerivedTwoNavigation,
+                NavigationsToBaseAndDerived.IgnoreBaseNavigation);
+            var modelBuilder = entityBuilder.ModelBuilder;
+            var baseBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit);
+            var derivedBuilder = modelBuilder.Entity(typeof(DerivedOne), ConfigurationSource.Explicit);
+            derivedBuilder.HasBaseType(baseBuilder.Metadata, ConfigurationSource.Convention);
+
+            Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
+
+            Assert.Empty(entityBuilder.Metadata.Navigations);
+            Assert.Empty(entityBuilder.Metadata.GetForeignKeys());
+            Assert.Empty(derivedBuilder.Metadata.Navigations);
+            Assert.Empty(derivedBuilder.Metadata.GetForeignKeys());
+            Assert.Equal(3, entityBuilder.Metadata.Model.EntityTypes.Count);
+        }
+
+        [Fact]
+        public void Existing_relationship_to_base_removes_ambiguity_in_derived_inverse()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<NavigationsToBaseAndDerived>(
+                NavigationsToBaseAndDerived.IgnoreDerivedTwoNavigation,
+                NavigationsToBaseAndDerived.IgnoreBaseNavigation);
+            var modelBuilder = entityBuilder.ModelBuilder;
+            var baseBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit);
+            var derivedBuilder = modelBuilder.Entity(typeof(DerivedOne), ConfigurationSource.Explicit);
+            derivedBuilder.HasBaseType(baseBuilder.Metadata, ConfigurationSource.Convention);
+
+            entityBuilder.Relationship(baseBuilder, null, nameof(Base.BaseNavigation), ConfigurationSource.Convention);
+
+            Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
+
+            VerifyRelationship(baseBuilder.Metadata.Navigations.Single(), expectedInverseName: null, unique: false, singleRelationship: false);
+            VerifyRelationship(entityBuilder.Metadata.Navigations.Single(), nameof(DerivedOne.DerivedNavigation), unique: true, singleRelationship: false);
+            Assert.Equal(3, entityBuilder.Metadata.Model.EntityTypes.Count);
+        }
+
+        [Fact]
+        public void Navigation_to_derived_is_discovered()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<NavigationsToBaseAndDerived>(
+                NavigationsToBaseAndDerived.IgnoreDerivedTwoNavigation,
+                NavigationsToBaseAndDerived.IgnoreBaseNavigation,
+                Base.IgnoreBaseNavigation);
+            var modelBuilder = entityBuilder.ModelBuilder;
+            var baseBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit);
+            var derivedBuilder = modelBuilder.Entity(typeof(DerivedOne), ConfigurationSource.Explicit);
+            derivedBuilder.HasBaseType(baseBuilder.Metadata, ConfigurationSource.Convention);
+
+            Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
+
+            var derivedFk = entityBuilder.Metadata.Navigations
+                .Single(n => n.Name == nameof(NavigationsToBaseAndDerived.DerivedOne)).ForeignKey;
+            Assert.Equal(nameof(DerivedOne.DerivedNavigation), derivedFk.FindNavigationTo(entityBuilder.Metadata).Name);
+            Assert.Equal(1, entityBuilder.Metadata.Navigations.Count());
+            Assert.Equal(3, entityBuilder.Metadata.Model.EntityTypes.Count);
+        }
+
+        [Fact]
+        public void Navigation_to_derived_is_discovered_if_inverse_inherited()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<NavigationsToBaseAndDerived>(
+                NavigationsToBaseAndDerived.IgnoreDerivedTwoNavigation,
+                NavigationsToBaseAndDerived.IgnoreBaseNavigation,
+                DerivedOne.IgnoreDerivedNavigation);
+            var modelBuilder = entityBuilder.ModelBuilder;
+            var baseBuilder = modelBuilder.Entity(typeof(Base), ConfigurationSource.Explicit);
+            var derivedBuilder = modelBuilder.Entity(typeof(DerivedOne), ConfigurationSource.Explicit);
+            derivedBuilder.HasBaseType(baseBuilder.Metadata, ConfigurationSource.Convention);
+
+            Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
+
+            var derivedFk = entityBuilder.Metadata.Navigations
+                .Single(n => n.Name == nameof(NavigationsToBaseAndDerived.DerivedOne)).ForeignKey;
+            Assert.Equal(nameof(Base.BaseNavigation), derivedFk.FindNavigationTo(entityBuilder.Metadata).Name);
+            Assert.Equal(1, entityBuilder.Metadata.Navigations.Count());
+            Assert.Equal(3, entityBuilder.Metadata.Model.EntityTypes.Count);
+        }
+
+        [Fact]
+        public void Navigation_to_base_is_not_discovered_if_base_ignored()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<NavigationsToBaseAndDerived>(
+                NavigationsToBaseAndDerived.IgnoreDerivedTwoNavigation,
+                NavigationsToBaseAndDerived.IgnoreDerivedOneNavigation,
+                DerivedOne.IgnoreDerivedNavigation);
+            var modelBuilder = entityBuilder.ModelBuilder;
+            modelBuilder.Ignore(typeof(Base), ConfigurationSource.Explicit);
+            modelBuilder.Entity(typeof(DerivedOne), ConfigurationSource.Explicit);
+
+            Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
+
+            Assert.Empty(entityBuilder.Metadata.GetForeignKeys());
+            Assert.Empty(entityBuilder.Metadata.Navigations);
+            Assert.Equal(2, entityBuilder.Metadata.Model.EntityTypes.Count);
+        }
+
+        [Fact]
+        public void Navigation_to_derived_is_discovered_if_base_ignored()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<NavigationsToBaseAndDerived>(
+                NavigationsToBaseAndDerived.IgnoreDerivedTwoNavigation,
+                DerivedOne.IgnoreDerivedNavigation);
+            var modelBuilder = entityBuilder.ModelBuilder;
+            modelBuilder.Ignore(typeof(Base), ConfigurationSource.Explicit);
+            modelBuilder.Entity(typeof(DerivedOne), ConfigurationSource.Explicit);
+
+            Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
+
+            var derivedFk = entityBuilder.Metadata.FindNavigation(nameof(NavigationsToBaseAndDerived.DerivedOne)).ForeignKey;
+            Assert.Equal(nameof(DerivedOne.BaseNavigation), derivedFk.FindNavigationTo(entityBuilder.Metadata).Name);
+            Assert.Equal(1, entityBuilder.Metadata.Navigations.Count());
+            Assert.Equal(2, entityBuilder.Metadata.Model.EntityTypes.Count);
+        }
+
+        [Fact]
+        public void Does_not_throw_on_shadow_entity_types()
+        {
+            var entityBuilder = new InternalModelBuilder(new Model(), new ConventionSet())
+                .Entity("Shadow", ConfigurationSource.DataAnnotation);
+
+            Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
+        }
+
+        [Fact]
         public void Bidirectional_ambiguous_cardinality_is_discovered()
         {
-            var entityBuilder = CreateInternalEntityBuilder<AmbiguousCardinalityOne>(ConfigureKeys);
+            var entityBuilder = CreateInternalEntityBuilder<AmbiguousCardinalityOne>();
 
             Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
 
@@ -234,7 +700,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
         [Fact]
         public void Unidirectional_ambiguous_cardinality_is_discovered()
         {
-            var entityBuilder = CreateInternalEntityBuilder<AmbiguousCardinalityOne>(ConfigureKeys,
+            var entityBuilder = CreateInternalEntityBuilder<AmbiguousCardinalityOne>(
                 AmbiguousCardinalityTwo.IgnoreNavigation);
 
             Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
@@ -250,9 +716,54 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
         }
 
         [Fact]
-        public void Does_not_discover_nonNavigation_properties()
+        public void One_to_one_bidirectional_self_ref_is_discovered()
         {
-            var entityBuilder = CreateInternalEntityBuilder<EntityWithNoValidNavigations>();
+            var entityBuilder = CreateInternalEntityBuilder<SelfRef>(SelfRef.IgnoreNavigation3, SelfRef.IgnoreNavigation4);
+
+            Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
+
+            VerifySelfRef(entityBuilder.Metadata.FindNavigation(nameof(SelfRef.SelfRef1)), nameof(SelfRef.SelfRef2), unique: true);
+        }
+
+        [Fact]
+        public void One_to_many_unidirectional_self_ref_is_discovered()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<SelfRef>(SelfRef.IgnoreNavigation2, SelfRef.IgnoreNavigation3, SelfRef.IgnoreNavigation4);
+
+            Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
+
+            VerifySelfRef(entityBuilder.Metadata.FindNavigation(nameof(SelfRef.SelfRef1)), expectedInverseName: null, unique: false);
+        }
+
+        [Fact]
+        public void One_to_many_unidirectional_self_ref_is_upgraded_to_one_to_one_bidirectional()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<SelfRef>(SelfRef.IgnoreNavigation3, SelfRef.IgnoreNavigation4);
+
+            entityBuilder.Relationship(entityBuilder, nameof(SelfRef.SelfRef1), null, ConfigurationSource.Convention);
+
+            Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
+
+            VerifySelfRef(entityBuilder.Metadata.FindNavigation(nameof(SelfRef.SelfRef1)), nameof(SelfRef.SelfRef2), unique: true);
+        }
+
+        [Fact]
+        public void One_to_many_unidirectional_self_ref_is_not_upgraded_to_one_to_one_bidirectional_if_higher_source()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<SelfRef>(SelfRef.IgnoreNavigation3, SelfRef.IgnoreNavigation4);
+
+            entityBuilder.Relationship(entityBuilder, nameof(SelfRef.SelfRef1), null, ConfigurationSource.Explicit);
+
+            Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
+
+            VerifySelfRef(entityBuilder.Metadata.FindNavigation(nameof(SelfRef.SelfRef1)), expectedInverseName: null, unique: false, singleRelationship: false);
+            VerifySelfRef(entityBuilder.Metadata.FindNavigation(nameof(SelfRef.SelfRef2)), expectedInverseName: null, unique: false, singleRelationship: false);
+        }
+
+        [Fact]
+        public void Ambiguous_self_ref_is_not_discovered()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<SelfRef>(SelfRef.IgnoreNavigation4);
 
             Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
 
@@ -262,25 +773,57 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
         }
 
         [Fact]
-        public void One_to_one_bidirectional_self_ref_is_discovered()
+        public void Existing_unidirectional_self_ref_is_removed_if_ambiguous()
         {
-            var entityBuilder = CreateInternalEntityBuilder<SelfRef>(ConfigureKeys);
+            var entityBuilder = CreateInternalEntityBuilder<SelfRef>(SelfRef.IgnoreNavigation4);
+
+            entityBuilder.Relationship(entityBuilder, nameof(SelfRef.SelfRef1), null, ConfigurationSource.Convention);
 
             Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
 
-            IModel model = entityBuilder.Metadata.Model;
-            var entityType = model.EntityTypes.Single();
+            Assert.Empty(entityBuilder.Metadata.GetForeignKeys());
+            Assert.Empty(entityBuilder.Metadata.Navigations);
+            Assert.Empty(entityBuilder.Metadata.Properties);
+        }
 
-            Assert.Equal(2, entityType.GetProperties().Count());
-            Assert.Equal(1, entityType.GetKeys().Count());
+        [Fact]
+        public void Existing_unidirectional_self_ref_removes_ambiguity_if_higher_source()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<SelfRef>(SelfRef.IgnoreNavigation4);
 
-            var fk = entityType.GetForeignKeys().Single();
-            Assert.False(fk.IsRequired);
-            Assert.True(fk.IsUnique);
-            Assert.NotSame(fk.Properties.Single(), entityType.GetPrimaryKey().Properties.Single());
-            Assert.Equal(2, entityType.GetNavigations().Count());
-            Assert.Equal(SelfRef.SelfRef1NavigationProperty.Name, fk.PrincipalToDependent?.Name);
-            Assert.Equal(SelfRef.SelfRef2NavigationProperty.Name, fk.DependentToPrincipal?.Name);
+            entityBuilder.Relationship(entityBuilder, nameof(SelfRef.SelfRef1), null, ConfigurationSource.DataAnnotation);
+
+            Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
+
+            VerifySelfRef(entityBuilder.Metadata.FindNavigation(nameof(SelfRef.SelfRef1)), expectedInverseName: null, unique: false, singleRelationship: false);
+            VerifySelfRef(entityBuilder.Metadata.FindNavigation(nameof(SelfRef.SelfRef2)), expectedInverseName: nameof(SelfRef.SelfRef3), unique: false, singleRelationship: false);
+        }
+
+        [Fact]
+        public void Existing_bidirectional_self_ref_is_removed_if_ambiguous()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<SelfRef>();
+
+            entityBuilder.Relationship(entityBuilder, nameof(SelfRef.SelfRef1), nameof(SelfRef.SelfRef3), ConfigurationSource.Convention);
+
+            Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
+
+            Assert.Empty(entityBuilder.Metadata.GetForeignKeys());
+            Assert.Empty(entityBuilder.Metadata.Navigations);
+            Assert.Empty(entityBuilder.Metadata.Properties);
+        }
+
+        [Fact]
+        public void Existing_bidirectional_self_ref_removes_ambiguity_if_higher_source()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<SelfRef>();
+
+            entityBuilder.Relationship(entityBuilder, nameof(SelfRef.SelfRef1), nameof(SelfRef.SelfRef3), ConfigurationSource.DataAnnotation);
+
+            Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
+
+            VerifySelfRef(entityBuilder.Metadata.FindNavigation(nameof(SelfRef.SelfRef1)), expectedInverseName: nameof(SelfRef.SelfRef3), unique: false, singleRelationship: false);
+            VerifySelfRef(entityBuilder.Metadata.FindNavigation(nameof(SelfRef.SelfRef2)), expectedInverseName: nameof(SelfRef.SelfRef4), unique: false, singleRelationship: false);
         }
 
         [Fact]
@@ -297,10 +840,21 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             Assert.Equal(1, entityType.GetKeys().Count());
 
             var fk = entityType.GetForeignKeys().Single();
-            Assert.False(fk.IsRequired);
             Assert.False(fk.IsUnique);
             Assert.True(fk.PrincipalEntityType.ClrType.IsAbstract);
             Assert.Equal(1, entityType.GetNavigations().Count());
+        }
+
+        [Fact]
+        public void Does_not_discover_nonNavigation_properties()
+        {
+            var entityBuilder = CreateInternalEntityBuilder<EntityWithNoValidNavigations>();
+
+            Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
+
+            Assert.Empty(entityBuilder.Metadata.GetForeignKeys());
+            Assert.Empty(entityBuilder.Metadata.Navigations);
+            Assert.Empty(entityBuilder.Metadata.Properties);
         }
 
         private class EntityWithNoValidNavigations
@@ -340,70 +894,61 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             public AbstractClass Abstract { get; set; }
         }
 
-        private static void VerifyOneToOne(IModel model)
+        private static void VerifyRelationship(
+            Navigation navigation, string expectedInverseName, bool unique, bool singleRelationship = true)
         {
-            Assert.Equal(2, model.EntityTypes.Count);
-            var principalEntityType = model.EntityTypes.Single(e => e.ClrType == typeof(OneToOnePrincipal));
-            var dependentEntityType = model.EntityTypes.Single(e => e.ClrType == typeof(OneToOneDependent));
+            IForeignKey fk = navigation.ForeignKey;
+            Assert.Equal(expectedInverseName, navigation.FindInverse()?.Name);
+            Assert.Equal(unique, fk.IsUnique);
+            Assert.NotSame(fk.Properties.Single(), fk.PrincipalKey.Properties.Single());
+            Assert.NotEqual(fk.PrincipalToDependent?.Name, fk.DependentToPrincipal?.Name);
 
-            Assert.Equal(1, principalEntityType.GetProperties().Count());
-            Assert.Equal(1, principalEntityType.GetKeys().Count());
-            Assert.Empty(principalEntityType.GetForeignKeys());
-            Assert.Equal(OneToOnePrincipal.NavigationProperty.Name, principalEntityType.GetNavigations().Single().Name);
-
-            Assert.Equal(2, dependentEntityType.GetProperties().Count());
-            Assert.Equal(1, dependentEntityType.GetKeys().Count());
-            var fk = dependentEntityType.GetForeignKeys().Single();
-            Assert.False(fk.IsRequired);
-            Assert.True(fk.IsUnique);
-            Assert.NotSame(fk.Properties.Single(), dependentEntityType.GetPrimaryKey().Properties.Single());
-            Assert.Equal(OneToOneDependent.NavigationProperty.Name, dependentEntityType.GetNavigations().Single().Name);
-        }
-
-        private static void VerifyOneToManyPrincipal(InternalEntityTypeBuilder entityTypeBuilder, bool unidirectional, bool dependentHasPK = true)
-        {
-            VerifyOneToMany(entityTypeBuilder.Metadata.Model, dependentHasPK, hasNavigationToDependent: true, hasNavigationToPrincipal: !unidirectional);
-        }
-
-        private static void VerifyOneToManyDependent(InternalEntityTypeBuilder entityTypeBuilder, bool unidirectional, bool dependentHasPK = true)
-        {
-            VerifyOneToMany(entityTypeBuilder.Metadata.Model, dependentHasPK, hasNavigationToDependent: !unidirectional, hasNavigationToPrincipal: true);
-        }
-
-        private static void VerifyOneToMany(
-            IModel model,
-            bool dependentHasPK,
-            bool hasNavigationToDependent,
-            bool hasNavigationToPrincipal)
-        {
-            Assert.Equal(2, model.EntityTypes.Count);
-            var principalEntityType = model.EntityTypes.Single(e => e.ClrType == typeof(OneToManyPrincipal));
-            var dependentEntityType = model.EntityTypes.Single(e => e.ClrType == typeof(OneToManyDependent));
-
-            Assert.Equal(dependentHasPK ? 2 : 1, dependentEntityType.GetProperties().Count());
-            Assert.Equal(dependentHasPK ? 1 : 0, dependentEntityType.GetKeys().Count());
-            var fk = dependentEntityType.GetForeignKeys().Single();
-            Assert.False(fk.IsRequired);
-            Assert.False(fk.IsUnique);
-            if (hasNavigationToPrincipal)
+            if (singleRelationship)
             {
-                Assert.Equal(OneToManyDependent.NavigationProperty.Name, dependentEntityType.GetNavigations().Single().Name);
+                var principalEntityType = fk.PrincipalEntityType;
+                Assert.Equal(1, principalEntityType.GetDeclaredProperties().Count());
+                Assert.Equal(1, principalEntityType.GetKeys().Count());
+                Assert.Empty(principalEntityType.GetDeclaredForeignKeys());
+                if (expectedInverseName == null
+                    && navigation.PointsToPrincipal())
+                {
+                    Assert.Empty(principalEntityType.GetNavigations());
+                }
+
+                var dependentEntityType = fk.DeclaringEntityType;
+                Assert.Equal(1, dependentEntityType.GetDeclaredProperties().Count());
+                Assert.Equal(principalEntityType.IsAssignableFrom(dependentEntityType) ? 1 : 0, dependentEntityType.GetKeys().Count());
+                if (expectedInverseName == null
+                    && !navigation.PointsToPrincipal())
+                {
+                    Assert.Empty(dependentEntityType.GetNavigations());
+                }
+            }
+        }
+
+        private static void VerifySelfRef(
+            Navigation navigation, string expectedInverseName, bool unique, bool singleRelationship = true)
+        {
+            IForeignKey fk = navigation.ForeignKey;
+            Assert.Equal(1, fk.DeclaringEntityType.Model.EntityTypes.Count);
+            Assert.Equal(expectedInverseName, navigation.FindInverse()?.Name);
+            Assert.Equal(unique, fk.IsUnique);
+            Assert.NotSame(fk.Properties.Single(), fk.PrincipalKey.Properties.Single());
+            Assert.NotEqual(fk.PrincipalToDependent?.Name, fk.DependentToPrincipal?.Name);
+
+            var entityType = fk.DeclaringEntityType;
+            if (singleRelationship)
+            {
+                Assert.Equal(1, entityType.GetKeys().Count());
+                Assert.Equal(1, entityType.GetForeignKeys().Count());
+                Assert.Equal(2, entityType.GetProperties().Count());
+                Assert.Equal(expectedInverseName == null ? 1 : 2, entityType.GetNavigations().Count());
             }
             else
             {
-                Assert.Empty(dependentEntityType.GetNavigations());
-            }
-
-            Assert.Equal(1, principalEntityType.GetProperties().Count());
-            Assert.Equal(1, principalEntityType.GetKeys().Count());
-            Assert.Empty(principalEntityType.GetForeignKeys());
-            if (hasNavigationToDependent)
-            {
-                Assert.Equal(OneToManyPrincipal.NavigationProperty.Name, principalEntityType.GetNavigations().Single().Name);
-            }
-            else
-            {
-                Assert.Empty(principalEntityType.GetNavigations());
+                Assert.Equal(2, entityType.GetKeys().Count());
+                Assert.Equal(2, entityType.GetForeignKeys().Count());
+                Assert.Equal(4, entityType.GetProperties().Count());
             }
         }
 
@@ -418,11 +963,6 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             var entityBuilder = modelBuilder.Entity(typeof(T), ConfigurationSource.DataAnnotation);
 
             return entityBuilder;
-        }
-
-        private static void ConfigureKeys(InternalEntityTypeBuilder entityTypeBuilder)
-        {
-            entityTypeBuilder.PrimaryKey(new[] { "Id" }, ConfigurationSource.Convention);
         }
 
         private class TestModelChangeListener : IEntityTypeConvention
@@ -445,25 +985,41 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             }
         }
 
-        public class OneToOnePrincipal
+        private class OneToOnePrincipal
         {
             public static readonly PropertyInfo NavigationProperty =
                 typeof(OneToOnePrincipal).GetProperty("OneToOneDependent", BindingFlags.Public | BindingFlags.Instance);
 
             public int Id { get; set; }
             public OneToOneDependent OneToOneDependent { get; set; }
+
+            public static void IgnoreNavigation(InternalEntityTypeBuilder entityTypeBuilder)
+            {
+                if (entityTypeBuilder.Metadata.ClrType == typeof(OneToOnePrincipal))
+                {
+                    entityTypeBuilder.Ignore(nameof(OneToOneDependent), ConfigurationSource.DataAnnotation);
+                }
+            }
         }
 
-        public class OneToOneDependent
+        private class OneToOneDependent
         {
             public static readonly PropertyInfo NavigationProperty =
                 typeof(OneToOneDependent).GetProperty("OneToOnePrincipal", BindingFlags.Public | BindingFlags.Instance);
 
             public int Id { get; set; }
             public OneToOnePrincipal OneToOnePrincipal { get; set; }
+
+            public static void IgnoreNavigation(InternalEntityTypeBuilder entityTypeBuilder)
+            {
+                if (entityTypeBuilder.Metadata.ClrType == typeof(OneToOneDependent))
+                {
+                    entityTypeBuilder.Ignore(nameof(OneToOnePrincipal), ConfigurationSource.DataAnnotation);
+                }
+            }
         }
 
-        public class OneToManyPrincipal
+        private class OneToManyPrincipal
         {
             public static readonly PropertyInfo NavigationProperty =
                 typeof(OneToManyPrincipal).GetProperty("OneToManyDependents", BindingFlags.Public | BindingFlags.Instance);
@@ -481,7 +1037,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             }
         }
 
-        public class OneToManyDependent
+        private class OneToManyDependent
         {
             public static readonly PropertyInfo NavigationProperty =
                 typeof(OneToManyDependent).GetProperty("OneToManyPrincipal", BindingFlags.NonPublic | BindingFlags.Instance);
@@ -499,7 +1055,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             }
         }
 
-        public class ManyToManyFirst
+        private class ManyToManyFirst
         {
             public static readonly PropertyInfo NavigationProperty =
                 typeof(OneToManyPrincipal).GetProperty("ManyToManySeconds", BindingFlags.Public | BindingFlags.Instance);
@@ -508,7 +1064,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             public IEnumerable<ManyToManySecond> ManyToManySeconds { get; set; }
         }
 
-        public class ManyToManySecond
+        private class ManyToManySecond
         {
             public static readonly PropertyInfo NavigationProperty =
                 typeof(OneToManyPrincipal).GetProperty("ManyToManyFirsts", BindingFlags.Public | BindingFlags.Instance);
@@ -517,7 +1073,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             public IEnumerable<ManyToManyFirst> ManyToManyFirsts { get; set; }
         }
 
-        public class MultipleNavigationsFirst
+        private class MultipleNavigationsFirst
         {
             public static readonly PropertyInfo CollectionNavigationProperty =
                 typeof(MultipleNavigationsFirst).GetProperty("MultipleNavigationsSeconds", BindingFlags.Public | BindingFlags.Instance);
@@ -531,14 +1087,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             public MultipleNavigationsSecond MultipleNavigationsSecond { get; set; }
         }
 
-        public class MultipleNavigationsSecond
+        private class MultipleNavigationsSecond
         {
-            public static readonly PropertyInfo CollectionNavigationProperty =
-                typeof(MultipleNavigationsSecond).GetProperty("MultipleNavigationsFirsts", BindingFlags.Public | BindingFlags.Instance);
-
-            public static readonly PropertyInfo NonCollectionNavigationProperty =
-                typeof(MultipleNavigationsSecond).GetProperty("MultipleNavigationsFirst", BindingFlags.Public | BindingFlags.Instance);
-
             public int Id { get; set; }
 
             public IEnumerable<MultipleNavigationsFirst> MultipleNavigationsFirsts { get; set; }
@@ -548,7 +1098,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             {
                 if (entityTypeBuilder.Metadata.ClrType == typeof(MultipleNavigationsSecond))
                 {
-                    entityTypeBuilder.Ignore(CollectionNavigationProperty.Name, ConfigurationSource.DataAnnotation);
+                    entityTypeBuilder.Ignore(nameof(MultipleNavigationsFirsts), ConfigurationSource.DataAnnotation);
                 }
             }
 
@@ -556,23 +1106,117 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             {
                 if (entityTypeBuilder.Metadata.ClrType == typeof(MultipleNavigationsSecond))
                 {
-                    entityTypeBuilder.Ignore(NonCollectionNavigationProperty.Name, ConfigurationSource.DataAnnotation);
+                    entityTypeBuilder.Ignore(nameof(MultipleNavigationsFirst), ConfigurationSource.DataAnnotation);
+                }
+            }
+        }
+
+        private class NavigationsToBaseAndDerived
+        {
+            public int Id { get; set; }
+
+            public DerivedOne DerivedOne { get; set; }
+            public DerivedTwo DerivedTwo { get; set; }
+            public Base Base { get; set; }
+
+            public static void IgnoreDerivedOneNavigation(InternalEntityTypeBuilder entityTypeBuilder)
+            {
+                if (entityTypeBuilder.Metadata.ClrType == typeof(NavigationsToBaseAndDerived))
+                {
+                    entityTypeBuilder.Ignore(nameof(DerivedOne), ConfigurationSource.DataAnnotation);
+                }
+            }
+
+            public static void IgnoreDerivedTwoNavigation(InternalEntityTypeBuilder entityTypeBuilder)
+            {
+                if (entityTypeBuilder.Metadata.ClrType == typeof(NavigationsToBaseAndDerived))
+                {
+                    entityTypeBuilder.Ignore(nameof(DerivedTwo), ConfigurationSource.DataAnnotation);
+                }
+            }
+
+            public static void IgnoreBaseNavigation(InternalEntityTypeBuilder entityTypeBuilder)
+            {
+                if (entityTypeBuilder.Metadata.ClrType == typeof(NavigationsToBaseAndDerived))
+                {
+                    entityTypeBuilder.Ignore(nameof(Base), ConfigurationSource.DataAnnotation);
+                }
+            }
+        }
+
+        private class Base
+        {
+            public int Id { get; set; }
+
+            public NavigationsToBaseAndDerived BaseNavigation { get; set; }
+
+            public static void IgnoreBaseNavigation(InternalEntityTypeBuilder entityTypeBuilder)
+            {
+                if (entityTypeBuilder.Metadata.ClrType == typeof(Base))
+                {
+                    entityTypeBuilder.Ignore(nameof(BaseNavigation), ConfigurationSource.DataAnnotation);
+                }
+            }
+        }
+
+        private class DerivedOne : Base
+        {
+            public NavigationsToBaseAndDerived DerivedNavigation { get; set; }
+
+            public static void IgnoreDerivedNavigation(InternalEntityTypeBuilder entityTypeBuilder)
+            {
+                if (entityTypeBuilder.Metadata.ClrType == typeof(DerivedOne))
+                {
+                    entityTypeBuilder.Ignore(nameof(DerivedNavigation), ConfigurationSource.DataAnnotation);
+                }
+            }
+        }
+
+        private class DerivedTwo : Base
+        {
+            public NavigationsToBaseAndDerived DerivedNavigation { get; set; }
+
+            public static void IgnoreDerivedNavigation(InternalEntityTypeBuilder entityTypeBuilder)
+            {
+                if (entityTypeBuilder.Metadata.ClrType == typeof(DerivedTwo))
+                {
+                    entityTypeBuilder.Ignore(nameof(DerivedNavigation), ConfigurationSource.DataAnnotation);
                 }
             }
         }
 
         private class SelfRef
         {
-            public static readonly PropertyInfo SelfRef1NavigationProperty =
-                typeof(SelfRef).GetProperty("SelfRef1", BindingFlags.Public | BindingFlags.Instance);
-
-            public static readonly PropertyInfo SelfRef2NavigationProperty =
-                typeof(SelfRef).GetProperty("SelfRef2", BindingFlags.Public | BindingFlags.Instance);
-
             public int Id { get; set; }
             public SelfRef SelfRef1 { get; set; }
             public SelfRef SelfRef2 { get; set; }
+            public IEnumerable<SelfRef> SelfRef3 { get; set; }
+            public IEnumerable<SelfRef> SelfRef4 { get; set; }
             public int SelfRefId { get; set; }
+
+            public static void IgnoreNavigation2(InternalEntityTypeBuilder entityTypeBuilder)
+            {
+                if (entityTypeBuilder.Metadata.ClrType == typeof(SelfRef))
+                {
+                    entityTypeBuilder.Ignore(nameof(SelfRef2), ConfigurationSource.DataAnnotation);
+                }
+            }
+
+            public static void IgnoreNavigation3(InternalEntityTypeBuilder entityTypeBuilder)
+            {
+                if (entityTypeBuilder.Metadata.ClrType == typeof(SelfRef))
+                {
+                    entityTypeBuilder.Ignore(nameof(SelfRef3), ConfigurationSource.DataAnnotation);
+                }
+            }
+
+            public static void IgnoreNavigation4(InternalEntityTypeBuilder entityTypeBuilder)
+            {
+                if (entityTypeBuilder.Metadata.ClrType == typeof(SelfRef))
+                {
+                    entityTypeBuilder.Ignore(nameof(SelfRef4), ConfigurationSource.DataAnnotation);
+                }
+            }
         }
 
         public class AmbiguousCardinalityOne : IEnumerable<AmbiguousCardinalityOne>

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/DataAnnotationsTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/DataAnnotationsTestBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -27,6 +27,30 @@ namespace Microsoft.Data.Entity.Tests
             }
 
             [Fact]
+            public virtual void NotMappedAttribute_removes_ambiguity_in_conventional_relationship_building_with_base()
+            {
+                var model = new Model();
+                var modelBuilder = CreateModelBuilder(model);
+                modelBuilder.Entity<BookDetailsBase>();
+                modelBuilder.Entity<Book>();
+
+                Assert.Same(model.GetEntityType(typeof(BookDetailsBase)), model.GetEntityType(typeof(BookDetails)).BaseType);
+                Assert.Contains("Details", model.GetEntityType(typeof(Book)).Navigations.Select(nav => nav.Name));
+                Assert.Contains("AnotherBook", model.GetEntityType(typeof(BookDetailsBase)).Navigations.Select(nav => nav.Name));
+                Assert.Contains("AnotherBook", model.GetEntityType(typeof(BookDetails)).Navigations.Select(nav => nav.Name));
+                Assert.DoesNotContain("Book", model.GetEntityType(typeof(BookDetails)).Navigations.Select(nav => nav.Name));
+                
+                modelBuilder.Entity<BookDetails>().HasBaseType(null);
+                
+                Assert.Same(model.GetEntityType(typeof(BookDetails)),
+                    model.GetEntityType(typeof(Book)).Navigations.Single(n => n.Name == "Details").ForeignKey.DeclaringEntityType);
+                Assert.Contains("Details", model.GetEntityType(typeof(Book)).Navigations.Select(nav => nav.Name));
+                Assert.Contains("AnotherBook", model.GetEntityType(typeof(BookDetailsBase)).Navigations.Select(nav => nav.Name));
+                Assert.Contains("AnotherBook", model.GetEntityType(typeof(BookDetails)).Navigations.Select(nav => nav.Name));
+                Assert.DoesNotContain("Book", model.GetEntityType(typeof(BookDetails)).Navigations.Select(nav => nav.Name));
+            }
+
+            [Fact]
             public virtual void InversePropertyAttribute_removes_ambiguity_in_conventional_relationalship_building()
             {
                 var model = new Model();
@@ -37,6 +61,45 @@ namespace Microsoft.Data.Entity.Tests
                     model.GetEntityType(typeof(BookLabel)).FindNavigation("Book").FindInverse().Name);
                 
                 Assert.Null(model.GetEntityType(typeof(Book)).FindNavigation("AlternateLabel").FindInverse());
+            }
+
+            [Fact]
+            public virtual void InversePropertyAttribute_removes_ambiguity_in_conventional_relationalship_building_with_base()
+            {
+                var model = new Model();
+                var modelBuilder = CreateModelBuilder(model);
+                modelBuilder.Entity<SpecialBookLabel>();
+
+                Assert.Same(model.GetEntityType(typeof(BookLabel)), model.GetEntityType(typeof(SpecialBookLabel)).BaseType);
+                Assert.Empty(model.GetEntityType(typeof(SpecialBookLabel)).GetDeclaredNavigations());
+                Assert.Contains("Book", model.GetEntityType(typeof(BookLabel)).Navigations.Select(nav => nav.Name));
+                Assert.Equal("Label", model.GetEntityType(typeof(BookLabel)).FindNavigation("Book").ForeignKey.PrincipalToDependent.Name);
+                Assert.Contains("AlternateLabel", model.GetEntityType(typeof(Book)).Navigations.Select(nav => nav.Name));
+                Assert.Null(model.GetEntityType(typeof(Book)).FindNavigation("AlternateLabel").ForeignKey.PrincipalToDependent);
+                
+                modelBuilder.Entity<SpecialBookLabel>().HasBaseType(null);
+                
+                Assert.Null(model.GetEntityType(typeof(SpecialBookLabel)).Navigations.Single(n => n.Name == "Book").FindInverse());
+                Assert.Contains("Book", model.GetEntityType(typeof(BookLabel)).Navigations.Select(nav => nav.Name));
+                Assert.Equal("Label", model.GetEntityType(typeof(BookLabel)).FindNavigation("Book").ForeignKey.PrincipalToDependent.Name);
+                Assert.Contains("AlternateLabel", model.GetEntityType(typeof(Book)).Navigations.Select(nav => nav.Name));
+                Assert.Null(model.GetEntityType(typeof(Book)).FindNavigation("AlternateLabel").ForeignKey.PrincipalToDependent);
+            }
+
+            // TODO: Support base type ignore
+            //[Fact]
+            public virtual void InversePropertyAttribute_removes_ambiguity_in_conventional_relationalship_building_with_base_ignored()
+            {
+                var model = new Model();
+                var modelBuilder = CreateModelBuilder(model);
+                modelBuilder.Entity<SpecialBookLabel>().HasBaseType(null);
+                modelBuilder.Ignore<BookLabel>();
+
+                Assert.Null(model.FindEntityType(typeof(BookLabel)));
+                Assert.Contains("Book", model.GetEntityType(typeof(SpecialBookLabel)).Navigations.Select(nav => nav.Name));
+                Assert.Equal("Label", model.GetEntityType(typeof(SpecialBookLabel)).FindNavigation("Book").ForeignKey.PrincipalToDependent.Name);
+                Assert.Contains("AlternateLabel", model.GetEntityType(typeof(Book)).Navigations.Select(nav => nav.Name));
+                Assert.Null(model.GetEntityType(typeof(Book)).FindNavigation("AlternateLabel").ForeignKey.PrincipalToDependent);
             }
 
             [Fact]

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/InheritanceTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/InheritanceTestBase.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Data.Entity.FunctionalTests;
 using Microsoft.Data.Entity.FunctionalTests.TestUtilities;
@@ -15,96 +16,129 @@ namespace Microsoft.Data.Entity.Tests
         public abstract class InheritanceTestBase : ModelBuilderTestBase
         {
             [Fact]
-            public virtual void Can_set_switch_and_remove_base_type()
+            public virtual void Can_set_and_remove_base_type()
             {
                 var modelBuilder = CreateModelBuilder();
 
                 var pickleBuilder = modelBuilder.Entity<Pickle>();
+                pickleBuilder.HasOne(e => e.BigMak).WithMany(e => e.Pickles);
                 var pickle = pickleBuilder.Metadata;
-                var bigMakBuilder = modelBuilder.Entity<BigMak>();
+                // TODO: Remove this line
+                // Issue #2837
+                modelBuilder.Entity<BigMak>().Ignore(b => b.Bun);
 
                 Assert.Null(pickle.BaseType);
-                var modelClone = modelBuilder.Model.Clone();
-                var pickleClone = modelClone.GetEntityType(pickle.Name);
+                var pickleClone = modelBuilder.Model.Clone().GetEntityType(pickle.Name);
                 var initialProperties = pickleClone.GetProperties();
-                var initialIndexes = pickleClone.GetIndexes();
-                var initialForeignKey = pickleClone.GetForeignKeys();
-                var initialReferencingForeignKey = pickleClone.FindReferencingForeignKeys();
                 var initialKeys = pickleClone.GetKeys();
+                var initialIndexes = pickleClone.GetIndexes();
+                var initialForeignKeys = pickleClone.GetForeignKeys();
+                var initialReferencingForeignKeys = pickleClone.FindReferencingForeignKeys();
 
-                pickleBuilder.BaseType<Ingredient>();
+                pickleBuilder.HasBaseType<Ingredient>();
+                var ingredientBuilder = modelBuilder.Entity<Ingredient>();
+                var ingredient = ingredientBuilder.Metadata;
 
-                Assert.Same(pickle.BaseType.ClrType, typeof(Ingredient));
+                Assert.Same(typeof(Ingredient), pickle.BaseType.ClrType);
                 AssertEqual(initialProperties, pickle.Properties, new PropertyComparer(compareAnnotations: false));
                 AssertEqual(initialKeys, pickle.GetKeys());
                 AssertEqual(initialIndexes, pickle.Indexes);
-                AssertEqual(initialForeignKey, pickle.GetForeignKeys());
-                AssertEqual(initialReferencingForeignKey, pickle.FindReferencingForeignKeys());
+                AssertEqual(initialForeignKeys, pickle.GetForeignKeys());
+                AssertEqual(initialReferencingForeignKeys, pickle.FindReferencingForeignKeys());
 
-                /*
-                pickleBuilder.BaseEntity(null);
+                pickleBuilder.HasBaseType(null);
 
-                Assert.Null(pickle.HasBaseType);
-                AssertEqual(initialProperties.Select(p => p.Name), pickle.Properties.Select(p => p.Name));
-                AssertEqual(initialNavigations.Select(p => p.Name), pickle.Navigations.Select(p => p.Name));
-                AssertEqual(initialIndexes, pickle.Indexes);
-                AssertEqual(initialForeignKey, pickle.GetForeignKeys());
+                Assert.Null(pickle.BaseType);
+                AssertEqual(initialProperties, pickle.Properties, new PropertyComparer(compareAnnotations: false));
                 AssertEqual(initialKeys, pickle.GetKeys());
+                AssertEqual(initialIndexes, pickle.Indexes);
+                AssertEqual(initialForeignKeys, pickle.GetForeignKeys());
+                AssertEqual(initialReferencingForeignKeys, pickle.FindReferencingForeignKeys());
 
-                AssertEqual(initialProperties, ingredient.Properties);
-                AssertEqual(initialNavigations, ingredient.Navigations);
-                AssertEqual(initialIndexes, ingredient.Indexes);
-                AssertEqual(initialForeignKey, ingredient.GetForeignKeys());
+                AssertEqual(initialProperties, ingredient.Properties, new PropertyComparer(compareAnnotations: false));
                 AssertEqual(initialKeys, ingredient.GetKeys());
-                */
+                AssertEqual(initialIndexes, ingredient.Indexes);
+                Assert.Equal(initialForeignKeys.Count(), ingredient.GetForeignKeys().Count());
+                Assert.Equal(initialReferencingForeignKeys.Count(), ingredient.FindReferencingForeignKeys().Count());
             }
-
-            //[Fact]
-            public virtual void Setting_base_type_runs_conventions_on_other_derived_types()
+            
+            [Fact]
+            public virtual void Setting_base_type_to_null_fixes_relationships()
             {
                 var modelBuilder = CreateModelBuilder();
-                modelBuilder.Ignore<Customer>();
-                var principalEntityBuilder = modelBuilder.Entity<SpecialCustomer>();
-                principalEntityBuilder.Ignore(nameof(SpecialCustomer.Orders));
-
+                modelBuilder.Ignore<CustomerDetails>();
+                modelBuilder.Ignore<OrderDetails>();
+                var principalEntityBuilder = modelBuilder.Entity<Customer>();
+                principalEntityBuilder.Ignore(nameof(Customer.Orders));
+                var derivedPrincipalEntityBuilder = modelBuilder.Entity<SpecialCustomer>();
                 var dependentEntityBuilder = modelBuilder.Entity<Order>();
-                dependentEntityBuilder.Ignore(e => e.Details);
                 var derivedDependentEntityBuilder = modelBuilder.Entity<SpecialOrder>();
-                //derivedDependentEntityBuilder.BaseType(null);
-                derivedDependentEntityBuilder.Ignore(e => e.Details);
-                var otherDerivedDependentEntityBuilder = modelBuilder.Entity<BackOrder>();
-                //otherDerivedDependentEntityBuilder.BaseType(null);
-                otherDerivedDependentEntityBuilder.Ignore(e => e.Details);
 
-                var fk = dependentEntityBuilder.Metadata.GetDeclaredForeignKeys().Single();
+                Assert.Same(principalEntityBuilder.Metadata, derivedPrincipalEntityBuilder.Metadata.BaseType);
+                Assert.Same(dependentEntityBuilder.Metadata, derivedDependentEntityBuilder.Metadata.BaseType);
+
+                var fk = dependentEntityBuilder.Metadata.Navigations.Single().ForeignKey;
                 Assert.Equal(nameof(Order.Customer), fk.DependentToPrincipal.Name);
                 Assert.Null(fk.PrincipalToDependent);
-                Assert.Equal(nameof(Order.CustomerId), fk.Properties.Single().Name);
-
-                var derivedFk = derivedDependentEntityBuilder.Metadata.GetDeclaredForeignKeys().Single();
-                Assert.Equal(nameof(Order.Customer), derivedFk.DependentToPrincipal.Name);
+                Assert.Same(principalEntityBuilder.Metadata, fk.PrincipalEntityType);
+                var derivedFk = derivedPrincipalEntityBuilder.Metadata.Navigations.Single().ForeignKey;
+                Assert.Null(derivedFk.DependentToPrincipal);
                 Assert.Equal(nameof(SpecialCustomer.SpecialOrders), derivedFk.PrincipalToDependent.Name);
-                Assert.Equal(nameof(Order.CustomerId), derivedFk.Properties.Single().Name);
+                Assert.Empty(derivedDependentEntityBuilder.Metadata.GetDeclaredNavigations());
+                Assert.Empty(principalEntityBuilder.Metadata.Navigations);
 
-                var otherDerivedFk = otherDerivedDependentEntityBuilder.Metadata.GetDeclaredForeignKeys().Single();
-                Assert.Equal(nameof(Order.Customer), otherDerivedFk.DependentToPrincipal.Name);
-                Assert.Null(otherDerivedFk.PrincipalToDependent);
-                Assert.Equal(nameof(Order.CustomerId), otherDerivedFk.Properties.Single().Name);
+                derivedDependentEntityBuilder.HasBaseType(null);
 
-                otherDerivedDependentEntityBuilder.BaseType<Order>();
+                fk = dependentEntityBuilder.Metadata.Navigations.Single().ForeignKey;
+                Assert.Equal(nameof(Order.Customer), fk.DependentToPrincipal.Name);
+                Assert.Null(fk.PrincipalToDependent);
+                Assert.Same(principalEntityBuilder.Metadata, fk.PrincipalEntityType);
+                var newDerivedFk = derivedDependentEntityBuilder.Metadata.GetDeclaredNavigations().Single().ForeignKey;
+                Assert.Equal(nameof(Order.Customer), newDerivedFk.DependentToPrincipal.Name);
+                Assert.Equal(nameof(SpecialCustomer.SpecialOrders), newDerivedFk.PrincipalToDependent.Name);
+                Assert.Same(derivedPrincipalEntityBuilder.Metadata, newDerivedFk.PrincipalEntityType);
+                Assert.Empty(principalEntityBuilder.Metadata.Navigations);
+            }
 
-                Assert.Empty(otherDerivedDependentEntityBuilder.Metadata.GetDeclaredForeignKeys());
+            [Fact]
+            public virtual void Pulling_relationship_to_a_derived_type_creates_relationships_on_other_derived_types()
+            {
+                var modelBuilder = CreateModelBuilder();
+                modelBuilder.Ignore<CustomerDetails>();
+                modelBuilder.Ignore<OrderDetails>();
+                var principalEntityBuilder = modelBuilder.Entity<Customer>();
+                principalEntityBuilder.Ignore(nameof(Customer.Orders));
+                var derivedPrincipalEntityBuilder = modelBuilder.Entity<SpecialCustomer>();
+                var dependentEntityBuilder = modelBuilder.Entity<Order>();
+                var derivedDependentEntityBuilder = modelBuilder.Entity<SpecialOrder>();
+                var otherDerivedDependentEntityBuilder = modelBuilder.Entity<BackOrder>();
 
-                derivedDependentEntityBuilder.BaseType<Order>();
+                Assert.Same(principalEntityBuilder.Metadata, derivedPrincipalEntityBuilder.Metadata.BaseType);
+                Assert.Same(dependentEntityBuilder.Metadata, derivedDependentEntityBuilder.Metadata.BaseType);
+                Assert.Same(dependentEntityBuilder.Metadata, otherDerivedDependentEntityBuilder.Metadata.BaseType);
 
-                Assert.Equal(0, dependentEntityBuilder.Metadata.GetForeignKeys().Count());
-
-                derivedFk = derivedDependentEntityBuilder.Metadata.GetDeclaredForeignKeys().Single();
-                Assert.Equal(nameof(Order.Customer), derivedFk.DependentToPrincipal.Name);
+                var fk = dependentEntityBuilder.Metadata.Navigations.Single().ForeignKey;
+                Assert.Equal(nameof(Order.Customer), fk.DependentToPrincipal.Name);
+                Assert.Null(fk.PrincipalToDependent);
+                Assert.Same(principalEntityBuilder.Metadata, fk.PrincipalEntityType);
+                var derivedFk = derivedPrincipalEntityBuilder.Metadata.Navigations.Single().ForeignKey;
+                Assert.Null(derivedFk.DependentToPrincipal);
                 Assert.Equal(nameof(SpecialCustomer.SpecialOrders), derivedFk.PrincipalToDependent.Name);
-                Assert.Equal(nameof(Order.CustomerId), derivedFk.Properties.Single().Name);
+                Assert.Empty(derivedDependentEntityBuilder.Metadata.GetDeclaredNavigations());
+                Assert.Empty(otherDerivedDependentEntityBuilder.Metadata.GetDeclaredNavigations());
+                Assert.Empty(principalEntityBuilder.Metadata.Navigations);
 
-                otherDerivedFk = otherDerivedDependentEntityBuilder.Metadata.GetDeclaredForeignKeys().Single();
+                derivedDependentEntityBuilder
+                    .HasOne(e => (SpecialCustomer)e.Customer)
+                    .WithMany(e => e.SpecialOrders);
+                
+                Assert.Empty(dependentEntityBuilder.Metadata.GetForeignKeys());
+                Assert.Empty(dependentEntityBuilder.Metadata.Navigations);
+                var newFk = derivedDependentEntityBuilder.Metadata.GetDeclaredNavigations().Single().ForeignKey;
+                Assert.Equal(nameof(Order.Customer), newFk.DependentToPrincipal.Name);
+                Assert.Equal(nameof(SpecialCustomer.SpecialOrders), newFk.PrincipalToDependent.Name);
+                Assert.Same(derivedPrincipalEntityBuilder.Metadata, newFk.PrincipalEntityType);
+                var otherDerivedFk = otherDerivedDependentEntityBuilder.Metadata.GetDeclaredNavigations().Single().ForeignKey;
                 Assert.Equal(nameof(Order.Customer), otherDerivedFk.DependentToPrincipal.Name);
                 Assert.Null(otherDerivedFk.PrincipalToDependent);
                 Assert.Equal(nameof(Order.CustomerId), otherDerivedFk.Properties.Single().Name);

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderGenericTest.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderGenericTest.cs
@@ -132,10 +132,10 @@ namespace Microsoft.Data.Entity.Tests
             public override TestEntityTypeBuilder<TEntity> HasAnnotation(string annotation, object value)
                 => Wrap(EntityTypeBuilder.HasAnnotation(annotation, value));
 
-            public override TestEntityTypeBuilder<TEntity> BaseType<TBaseEntity>()
+            public override TestEntityTypeBuilder<TEntity> HasBaseType<TBaseEntity>()
                 => Wrap(EntityTypeBuilder.HasBaseType<TBaseEntity>());
 
-            public override TestEntityTypeBuilder<TEntity> BaseType(string baseEntityTypeName)
+            public override TestEntityTypeBuilder<TEntity> HasBaseType(string baseEntityTypeName)
                 => Wrap(EntityTypeBuilder.HasBaseType(baseEntityTypeName));
 
             public override TestKeyBuilder HasKey(Expression<Func<TEntity, object>> keyExpression)

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderNonGenericStringTest.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderNonGenericStringTest.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Data.Entity.Tests
             protected override NonGenericTestEntityTypeBuilder<TEntity> Wrap(EntityTypeBuilder entityTypeBuilder)
                 => new NonGenericStringTestEntityTypeBuilder<TEntity>(entityTypeBuilder);
 
-            public override TestEntityTypeBuilder<TEntity> BaseType<TBaseEntity>()
+            public override TestEntityTypeBuilder<TEntity> HasBaseType<TBaseEntity>()
                 => Wrap(EntityTypeBuilder.HasBaseType(typeof(TBaseEntity)));
 
             public override TestReferenceNavigationBuilder<TEntity, TRelatedEntity> HasOne<TRelatedEntity>(Expression<Func<TEntity, TRelatedEntity>> reference = null)

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderNonGenericTest.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderNonGenericTest.cs
@@ -118,10 +118,10 @@ namespace Microsoft.Data.Entity.Tests
             public override TestEntityTypeBuilder<TEntity> HasAnnotation(string annotation, object value)
                 => Wrap(EntityTypeBuilder.HasAnnotation(annotation, value));
 
-            public override TestEntityTypeBuilder<TEntity> BaseType<TBaseEntity>()
+            public override TestEntityTypeBuilder<TEntity> HasBaseType<TBaseEntity>()
                 => Wrap(EntityTypeBuilder.HasBaseType(typeof(TBaseEntity)));
 
-            public override TestEntityTypeBuilder<TEntity> BaseType(string baseEntityTypeName)
+            public override TestEntityTypeBuilder<TEntity> HasBaseType(string baseEntityTypeName)
                 => Wrap(EntityTypeBuilder.HasBaseType(baseEntityTypeName));
 
             public override TestKeyBuilder HasKey(Expression<Func<TEntity, object>> keyExpression)

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderTestBase.cs
@@ -125,10 +125,7 @@ namespace Microsoft.Data.Entity.Tests
             public abstract TestModelBuilder Ignore<TEntity>()
                 where TEntity : class;
 
-            public virtual TestModelBuilder Validate()
-            {                
-                return ModelBuilder.Validate() == null ? null : this;
-            }
+            public virtual TestModelBuilder Validate() => ModelBuilder.Validate() == null ? null : this;
         }
 
         public abstract class TestEntityTypeBuilder<TEntity>
@@ -137,10 +134,10 @@ namespace Microsoft.Data.Entity.Tests
             public abstract EntityType Metadata { get; }
             public abstract TestEntityTypeBuilder<TEntity> HasAnnotation(string annotation, object value);
 
-            public abstract TestEntityTypeBuilder<TEntity> BaseType<TBaseEntity>()
+            public abstract TestEntityTypeBuilder<TEntity> HasBaseType<TBaseEntity>()
                 where TBaseEntity : class;
 
-            public abstract TestEntityTypeBuilder<TEntity> BaseType(string baseEntityTypeName);
+            public abstract TestEntityTypeBuilder<TEntity> HasBaseType(string baseEntityTypeName);
             public abstract TestKeyBuilder HasKey(Expression<Func<TEntity, object>> keyExpression);
             public abstract TestKeyBuilder HasKey(params string[] propertyNames);
             public abstract TestKeyBuilder HasAlternateKey(Expression<Func<TEntity, object>> keyExpression);

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/NonRelationshipTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/NonRelationshipTestBase.cs
@@ -242,8 +242,8 @@ namespace Microsoft.Data.Entity.Tests
             [Fact]
             public virtual void Can_add_multiple_properties()
             {
-                var model = new Model();
-                var modelBuilder = CreateModelBuilder(model);
+                var modelBuilder = CreateModelBuilder(new Model());
+                modelBuilder.Ignore<CustomerDetails>();
 
                 modelBuilder.Entity<Customer>(b =>
                     {
@@ -252,7 +252,7 @@ namespace Microsoft.Data.Entity.Tests
                         b.Property(e => e.AlternateKey);
                     });
 
-                Assert.Equal(3, model.GetEntityType(typeof(Customer)).PropertyCount);
+                Assert.Equal(3, modelBuilder.Model.GetEntityType(typeof(Customer)).PropertyCount);
             }
 
             [Fact]

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/OneToManyTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/OneToManyTestBase.cs
@@ -1189,10 +1189,10 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Same(principalProperty, primaryPrincipalKey.Properties.Single());
                 Assert.Equal(2, principalType.GetKeys().Count());
                 Assert.True(principalType.GetKeys().Contains(nonPrimaryPrincipalKey));
-                var oldKeyProperty = principalType.GetProperty(nameof(BigMak.Id));
-                var newKeyProperty = principalType.GetProperty(nameof(BigMak.AlternateKey));
-                Assert.Null(oldKeyProperty.RequiresValueGenerator);
-                Assert.Null(oldKeyProperty.ValueGenerated);
+                var oldKeyProperty = (IProperty)principalType.GetProperty(nameof(BigMak.Id));
+                var newKeyProperty = (IProperty)principalType.GetProperty(nameof(BigMak.AlternateKey));
+                Assert.False(oldKeyProperty.RequiresValueGenerator);
+                Assert.Equal(ValueGenerated.Never, oldKeyProperty.ValueGenerated);
                 Assert.True(newKeyProperty.RequiresValueGenerator);
                 Assert.Equal(ValueGenerated.OnAdd, newKeyProperty.ValueGenerated);
                 Assert.Same(dependentKey, dependentType.GetKeys().SingleOrDefault());

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/TestModel.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/TestModel.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Data.Entity.Tests
 
         private class Ingredient
         {
-            public readonly static PropertyInfo BurgerIdProperty = typeof(Ingredient).GetProperty("BurgerId");
+            public static readonly PropertyInfo BurgerIdProperty = typeof(Ingredient).GetProperty("BurgerId");
 
             public int Id { get; set; }
             public int BurgerId { get; set; }
@@ -194,23 +194,30 @@ namespace Microsoft.Data.Entity.Tests
             public BookDetails Details { get; set; }
         }
 
-        private class BookDetails
+        private abstract class BookDetailsBase
         {
             public int Id { get; set; }
+            public Book AnotherBook { get; set; }
+        }
 
+        private class BookDetails : BookDetailsBase
+        {
             [NotMapped]
             public Book Book { get; set; }
-
-            public Book AnotherBook { get; set; }
         }
 
         private class BookLabel
         {
             public int Id { get; set; }
-            public int BookId { get; set; }
 
             [InverseProperty("Label")]
             public Book Book { get; set; }
+
+            public int BookId { get; set; }
+        }
+
+        private class SpecialBookLabel : BookLabel
+        {
         }
 
         private class Post
@@ -236,7 +243,6 @@ namespace Microsoft.Data.Entity.Tests
             public Post Post { get; set; }
         }
 
-
         private class Author
         {
             public int Id { get; set; }
@@ -257,7 +263,6 @@ namespace Microsoft.Data.Entity.Tests
 
             public Author Author { get; set; }
         }
-
 
         private class A
         {
@@ -296,7 +301,6 @@ namespace Microsoft.Data.Entity.Tests
             [ForeignKey("CId")]
             public C C { get; set; }
         }
-
         private class EntityWithoutId
         {
             public string Name { get; set; }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests.csproj
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="..\..\tools\EntityFramework.props" />

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
@@ -90,19 +90,21 @@ VALUES (@p0, @p1, @p2);",
         {
             base.RequiredAttribute_for_navigation_throws_while_inserting_null_value();
 
-            Assert.Equal(@"@p0: Book1
+            Assert.Equal(@"@p0: 0
+@p1: Book1
 
 SET NOCOUNT OFF;
-INSERT INTO [BookDetail] ([BookId])
-OUTPUT INSERTED.[Id]
-VALUES (@p0);
+INSERT INTO [BookDetail] ([Id], [BookId])
+VALUES (@p0, @p1);
+SELECT @@ROWCOUNT;
 
-@p0: 
+@p0: 0
+@p1: 
 
 SET NOCOUNT OFF;
-INSERT INTO [BookDetail] ([BookId])
-OUTPUT INSERTED.[Id]
-VALUES (@p0);",
+INSERT INTO [BookDetail] ([Id], [BookId])
+VALUES (@p0, @p1);
+SELECT @@ROWCOUNT;",
                 Sql);
         }
 

--- a/test/EntityFramework.Relational.FunctionalTests/F1RelationalFixture.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/F1RelationalFixture.cs
@@ -19,8 +19,6 @@ namespace Microsoft.Data.Entity.FunctionalTests
             modelBuilder.Entity<EngineSupplier>().ToTable("EngineSuppliers");
             modelBuilder.Entity<Gearbox>().ToTable("Gearboxes");
             modelBuilder.Entity<Sponsor>().ToTable("Sponsors");
-            modelBuilder.Entity<TestDriver>().ToTable("TestDrivers");
-            modelBuilder.Entity<TitleSponsor>().ToTable("TitleSponsors");
         }
     }
 }

--- a/test/EntityFramework.Relational.FunctionalTests/InheritanceRelationalFixture.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/InheritanceRelationalFixture.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Data.Entity.FunctionalTests.TestModels.Inheritance;

--- a/test/EntityFramework.Relational.Tests/Metadata/Conventions/Internal/DiscriminatorConventionTest.cs
+++ b/test/EntityFramework.Relational.Tests/Metadata/Conventions/Internal/DiscriminatorConventionTest.cs
@@ -21,8 +21,8 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Conventions.Internal
             Assert.Null(entityTypeBuilder.Metadata.Relational().DiscriminatorProperty);
             Assert.Null(entityTypeBuilder.Metadata.Relational().DiscriminatorValue);
 
-            var baseTypeBuilder = entityTypeBuilder.ModelBuilder.Entity(typeof(EntityBase), ConfigurationSource.Convention);
-            entityTypeBuilder.HasBaseType(baseTypeBuilder.Metadata, ConfigurationSource.Convention);
+            var baseTypeBuilder = entityTypeBuilder.ModelBuilder.Entity(typeof(EntityBase), ConfigurationSource.Explicit);
+            Assert.Same(entityTypeBuilder, entityTypeBuilder.HasBaseType(baseTypeBuilder.Metadata, ConfigurationSource.DataAnnotation));
 
             Assert.True(new DiscriminatorConvention().Apply(entityTypeBuilder, oldBaseType: null));
 
@@ -33,7 +33,7 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Conventions.Internal
             Assert.Equal(typeof(EntityBase).Name, baseTypeBuilder.Metadata.Relational().DiscriminatorValue);
             Assert.Equal(typeof(Entity).Name, entityTypeBuilder.Metadata.Relational().DiscriminatorValue);
             
-            entityTypeBuilder.HasBaseType((Type)null, ConfigurationSource.Convention);
+            Assert.NotNull(entityTypeBuilder.HasBaseType((Type)null, ConfigurationSource.DataAnnotation));
             Assert.True(new DiscriminatorConvention().Apply(entityTypeBuilder, oldBaseType: baseTypeBuilder.Metadata));
             Assert.Null(baseTypeBuilder.Metadata.Relational().DiscriminatorProperty);
             Assert.Null(entityTypeBuilder.Metadata.Relational().DiscriminatorProperty);
@@ -50,12 +50,12 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Conventions.Internal
             Assert.Null(entityTypeBuilder.Metadata.Relational().DiscriminatorValue);
 
             var baseTypeBuilder = entityTypeBuilder.ModelBuilder.Entity(typeof(EntityBase), ConfigurationSource.Explicit);
-            Assert.Same(entityTypeBuilder, entityTypeBuilder.HasBaseType(baseTypeBuilder.Metadata, ConfigurationSource.Convention));
+            Assert.Same(entityTypeBuilder, entityTypeBuilder.HasBaseType(baseTypeBuilder.Metadata, ConfigurationSource.DataAnnotation));
 
             Assert.True(new DiscriminatorConvention().Apply(entityTypeBuilder, oldBaseType: null));
 
             var derivedTypeBuilder = entityTypeBuilder.ModelBuilder.Entity(typeof(DerivedEntity), ConfigurationSource.Explicit);
-            Assert.Same(derivedTypeBuilder, derivedTypeBuilder.HasBaseType(entityTypeBuilder.Metadata, ConfigurationSource.Convention));
+            Assert.Same(derivedTypeBuilder, derivedTypeBuilder.HasBaseType(entityTypeBuilder.Metadata, ConfigurationSource.DataAnnotation));
             Assert.Same(derivedTypeBuilder.Metadata, entityTypeBuilder.ModelBuilder.Entity(typeof(DerivedEntity).FullName, ConfigurationSource.Convention).Metadata);
 
             Assert.True(new DiscriminatorConvention().Apply(derivedTypeBuilder, oldBaseType: null));
@@ -68,7 +68,7 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Conventions.Internal
             Assert.Equal(typeof(Entity).Name, entityTypeBuilder.Metadata.Relational().DiscriminatorValue);
             Assert.Equal(typeof(DerivedEntity).Name, derivedTypeBuilder.Metadata.Relational().DiscriminatorValue);
 
-            entityTypeBuilder.HasBaseType((Type)null, ConfigurationSource.Convention);
+            entityTypeBuilder.HasBaseType((Type)null, ConfigurationSource.DataAnnotation);
             Assert.True(new DiscriminatorConvention().Apply(entityTypeBuilder, oldBaseType: baseTypeBuilder.Metadata));
 
             Assert.Null(baseTypeBuilder.Metadata.Relational().DiscriminatorProperty);
@@ -104,8 +104,8 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Conventions.Internal
         {
             var entityTypeBuilder = CreateInternalEntityTypeBuilder<Entity>();
             
-            var baseTypeBuilder = entityTypeBuilder.ModelBuilder.Entity(typeof(EntityBase), ConfigurationSource.Convention);
-            entityTypeBuilder.HasBaseType(baseTypeBuilder.Metadata, ConfigurationSource.Convention);
+            var baseTypeBuilder = entityTypeBuilder.ModelBuilder.Entity(typeof(EntityBase), ConfigurationSource.DataAnnotation);
+            entityTypeBuilder.HasBaseType(baseTypeBuilder.Metadata, ConfigurationSource.DataAnnotation);
             baseTypeBuilder.Relational(ConfigurationSource.Explicit).HasDiscriminator("T", typeof(int));
 
             Assert.True(new DiscriminatorConvention().Apply(entityTypeBuilder, oldBaseType: null));
@@ -136,7 +136,7 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Conventions.Internal
             Assert.Null(baseTypeBuilder.Metadata.Relational().DiscriminatorValue);
             Assert.Null(entityTypeBuilder.Metadata.Relational().DiscriminatorValue);
 
-            entityTypeBuilder.HasBaseType((Type)null, ConfigurationSource.Convention);
+            entityTypeBuilder.HasBaseType((Type)null, ConfigurationSource.DataAnnotation);
             Assert.True(new DiscriminatorConvention().Apply(entityTypeBuilder, oldBaseType: baseTypeBuilder.Metadata));
 
             Assert.Null(baseTypeBuilder.Metadata.Relational().DiscriminatorProperty);

--- a/test/EntityFramework.Relational.Tests/Metadata/InternalRelationalMetadataBuilderExtensionsTest.cs
+++ b/test/EntityFramework.Relational.Tests/Metadata/InternalRelationalMetadataBuilderExtensionsTest.cs
@@ -234,7 +234,7 @@ namespace Microsoft.Data.Entity.Metadata
         {
             var typeBuilder = CreateBuilder().Entity("Splot", ConfigurationSource.Convention);
             var derivedTypeBuilder = typeBuilder.ModelBuilder.Entity("Splod", ConfigurationSource.Convention);
-            derivedTypeBuilder.HasBaseType(typeBuilder.Metadata, ConfigurationSource.Convention);
+            derivedTypeBuilder.HasBaseType(typeBuilder.Metadata, ConfigurationSource.DataAnnotation);
 
             Assert.NotNull(typeBuilder.Relational(ConfigurationSource.Convention).HasDiscriminator());
             Assert.Equal(1, typeBuilder.Metadata.GetDeclaredProperties().Count());

--- a/test/EntityFramework.Relational.Tests/RelationalModelValidatorTest.cs
+++ b/test/EntityFramework.Relational.Tests/RelationalModelValidatorTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Data.Entity.Internal;
-using Microsoft.Data.Entity.Metadata.Conventions;
 using Microsoft.Data.Entity.Metadata.Conventions.Internal;
 using Microsoft.Data.Entity.Tests.Infrastructure;
 using Microsoft.Data.Entity.Tests.TestUtilities;

--- a/test/EntityFramework.Sqlite.FunctionalTests/DataAnnotationSqliteTest.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/DataAnnotationSqliteTest.cs
@@ -77,21 +77,19 @@ WHERE changes() = 1 AND ""UniqueNo"" = last_insert_rowid();",
         {
             base.RequiredAttribute_for_navigation_throws_while_inserting_null_value();
 
-            Assert.Equal(@"@p0: Book1
+            Assert.Equal(@"@p0: 0
+@p1: Book1
 
-INSERT INTO ""BookDetail"" (""BookId"")
-VALUES (@p0);
-SELECT ""Id""
-FROM ""BookDetail""
-WHERE changes() = 1 AND ""Id"" = last_insert_rowid();
+INSERT INTO ""BookDetail"" (""Id"", ""BookId"")
+VALUES (@p0, @p1);
+SELECT changes();
 
-@p0: 
+@p0: 0
+@p1: 
 
-INSERT INTO ""BookDetail"" (""BookId"")
-VALUES (@p0);
-SELECT ""Id""
-FROM ""BookDetail""
-WHERE changes() = 1 AND ""Id"" = last_insert_rowid();",
+INSERT INTO ""BookDetail"" (""Id"", ""BookId"")
+VALUES (@p0, @p1);
+SELECT changes();",
                 Sql);
         }
 


### PR DESCRIPTION
Add conventions that discover base and derived types that are already in the model using the associated CLR type information
Adjust conventions to correctly handle inheritance
Allow setting the base type to null
Move non-shadow property validation to Property

Fixes #1704