### PR TITLE
[SMALL] RevEng: Fixing missing character in namespace…

### DIFF
--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/SqlServerE2ETests.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/SqlServerE2ETests.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Data.Entity.SqlServer.Design.FunctionalTests.ReverseEngineer
             {
                 ConnectionString = _connectionString,
                 ContextClassName = "AttributesContext",
-                ProjectPath = TestProjectDir,
+                ProjectPath = TestProjectDir + Path.DirectorySeparatorChar, // tests that ending DirectorySeparatorChar does not affect namespace
                 ProjectRootNamespace = TestNamespace,
                 OutputPath = TestSubDir,
                 TableSelectionSet = Filter,


### PR DESCRIPTION
...when defining  output directory through Powershell.

Fixes #3228. Problem was that Powershell sends the project path with trailing "\" and we were expecting without.