### PR TITLE
[SMALL] RevEng: Generate POCO classes as partial

### DIFF
--- a/src/EntityFramework.Relational.Design/ReverseEngineering/Internal/EntityTypeWriter.cs
+++ b/src/EntityFramework.Relational.Design/ReverseEngineering/Internal/EntityTypeWriter.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering.Internal
         public virtual void AddClass()
         {
             AddAttributes(_entity.AttributeConfigurations);
-            _sb.AppendLine("public class " + _entity.EntityType.Name);
+            _sb.AppendLine("public partial class " + _entity.EntityType.Name);
             _sb.AppendLine("{");
             using (_sb.Indent())
             {

--- a/src/EntityFramework.Relational.Design/ReverseEngineering/ReverseEngineeringGenerator.cs
+++ b/src/EntityFramework.Relational.Design/ReverseEngineering/ReverseEngineeringGenerator.cs
@@ -23,14 +23,12 @@ namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering
         public ReverseEngineeringGenerator(
             [NotNull] ILoggerFactory loggerFactory,
             [NotNull] IFileService fileService,
-            [NotNull] ModelUtilities modelUtilities,
             [NotNull] MetadataModelProvider metadataModelProvider,
             [NotNull] ConfigurationFactory configurationFactory,
             [NotNull] CodeWriter codeWriter)
         {
             Check.NotNull(loggerFactory, nameof(loggerFactory));
             Check.NotNull(fileService, nameof(fileService));
-            Check.NotNull(modelUtilities, nameof(modelUtilities));
             Check.NotNull(metadataModelProvider, nameof(metadataModelProvider));
             Check.NotNull(configurationFactory, nameof(configurationFactory));
             Check.NotNull(codeWriter, nameof(codeWriter));

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/AllDataTypes.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/AllDataTypes.expected
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace E2ETest.Namespace
 {
-    public class AllDataTypes
+    public partial class AllDataTypes
     {
         public int AllDataTypesID { get; set; }
         public long bigintColumn { get; set; }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/OneToManyDependent.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/OneToManyDependent.expected
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace E2ETest.Namespace
 {
-    public class OneToManyDependent
+    public partial class OneToManyDependent
     {
         public int OneToManyDependentID1 { get; set; }
         public int OneToManyDependentID2 { get; set; }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/OneToManyPrincipal.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/OneToManyPrincipal.expected
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace E2ETest.Namespace
 {
-    public class OneToManyPrincipal
+    public partial class OneToManyPrincipal
     {
         public OneToManyPrincipal()
         {

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/OneToOneDependent.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/OneToOneDependent.expected
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace E2ETest.Namespace
 {
-    public class OneToOneDependent
+    public partial class OneToOneDependent
     {
         public int OneToOneDependentID1 { get; set; }
         public int OneToOneDependentID2 { get; set; }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/OneToOneFKToUniqueKeyDependent.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/OneToOneFKToUniqueKeyDependent.expected
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace E2ETest.Namespace
 {
-    public class OneToOneFKToUniqueKeyDependent
+    public partial class OneToOneFKToUniqueKeyDependent
     {
         public int OneToOneFKToUniqueKeyDependentID1 { get; set; }
         public int OneToOneFKToUniqueKeyDependentID2 { get; set; }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/OneToOneFKToUniqueKeyPrincipal.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/OneToOneFKToUniqueKeyPrincipal.expected
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace E2ETest.Namespace
 {
-    public class OneToOneFKToUniqueKeyPrincipal
+    public partial class OneToOneFKToUniqueKeyPrincipal
     {
         public int OneToOneFKToUniqueKeyPrincipalID1 { get; set; }
         public int OneToOneFKToUniqueKeyPrincipalID2 { get; set; }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/OneToOnePrincipal.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/OneToOnePrincipal.expected
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace E2ETest.Namespace
 {
-    public class OneToOnePrincipal
+    public partial class OneToOnePrincipal
     {
         public int OneToOnePrincipalID1 { get; set; }
         public int OneToOnePrincipalID2 { get; set; }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/OneToOneSeparateFKDependent.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/OneToOneSeparateFKDependent.expected
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace E2ETest.Namespace
 {
-    public class OneToOneSeparateFKDependent
+    public partial class OneToOneSeparateFKDependent
     {
         public int OneToOneSeparateFKDependentID1 { get; set; }
         public int OneToOneSeparateFKDependentID2 { get; set; }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/OneToOneSeparateFKPrincipal.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/OneToOneSeparateFKPrincipal.expected
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace E2ETest.Namespace
 {
-    public class OneToOneSeparateFKPrincipal
+    public partial class OneToOneSeparateFKPrincipal
     {
         public int OneToOneSeparateFKPrincipalID1 { get; set; }
         public int OneToOneSeparateFKPrincipalID2 { get; set; }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/PropertyConfiguration.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/PropertyConfiguration.expected
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace E2ETest.Namespace
 {
-    public class PropertyConfiguration
+    public partial class PropertyConfiguration
     {
         public byte PropertyConfigurationID { get; set; }
         public int A { get; set; }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/ReferredToByTableWithUnmappablePrimaryKeyColumn.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/ReferredToByTableWithUnmappablePrimaryKeyColumn.expected
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace E2ETest.Namespace
 {
-    public class ReferredToByTableWithUnmappablePrimaryKeyColumn
+    public partial class ReferredToByTableWithUnmappablePrimaryKeyColumn
     {
         public int ReferredToByTableWithUnmappablePrimaryKeyColumnID { get; set; }
         public string AColumn { get; set; }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/SelfReferencing.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/SelfReferencing.expected
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace E2ETest.Namespace
 {
-    public class SelfReferencing
+    public partial class SelfReferencing
     {
         public int SelfReferencingID { get; set; }
         public string Description { get; set; }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/Test_Spaces_Keywords_Table.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/Test_Spaces_Keywords_Table.expected
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace E2ETest.Namespace
 {
-    public class Test_Spaces_Keywords_Table
+    public partial class Test_Spaces_Keywords_Table
     {
         public int Test_Spaces_Keywords_TableID { get; set; }
         public int? @AtSymbolAtStartOfColumn { get; set; }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/AllDataTypes.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/AllDataTypes.expected
@@ -5,7 +5,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace E2ETest.Namespace
 {
-    public class AllDataTypes
+    public partial class AllDataTypes
     {
         public int AllDataTypesID { get; set; }
         public long bigintColumn { get; set; }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/OneToManyDependent.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/OneToManyDependent.expected
@@ -5,7 +5,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace E2ETest.Namespace
 {
-    public class OneToManyDependent
+    public partial class OneToManyDependent
     {
         public int OneToManyDependentID1 { get; set; }
         public int OneToManyDependentID2 { get; set; }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/OneToManyPrincipal.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/OneToManyPrincipal.expected
@@ -5,7 +5,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace E2ETest.Namespace
 {
-    public class OneToManyPrincipal
+    public partial class OneToManyPrincipal
     {
         public OneToManyPrincipal()
         {

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/OneToOneDependent.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/OneToOneDependent.expected
@@ -5,7 +5,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace E2ETest.Namespace
 {
-    public class OneToOneDependent
+    public partial class OneToOneDependent
     {
         public int OneToOneDependentID1 { get; set; }
         public int OneToOneDependentID2 { get; set; }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/OneToOneFKToUniqueKeyDependent.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/OneToOneFKToUniqueKeyDependent.expected
@@ -5,7 +5,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace E2ETest.Namespace
 {
-    public class OneToOneFKToUniqueKeyDependent
+    public partial class OneToOneFKToUniqueKeyDependent
     {
         public int OneToOneFKToUniqueKeyDependentID1 { get; set; }
         public int OneToOneFKToUniqueKeyDependentID2 { get; set; }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/OneToOneFKToUniqueKeyPrincipal.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/OneToOneFKToUniqueKeyPrincipal.expected
@@ -5,7 +5,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace E2ETest.Namespace
 {
-    public class OneToOneFKToUniqueKeyPrincipal
+    public partial class OneToOneFKToUniqueKeyPrincipal
     {
         public int OneToOneFKToUniqueKeyPrincipalID1 { get; set; }
         public int OneToOneFKToUniqueKeyPrincipalID2 { get; set; }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/OneToOnePrincipal.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/OneToOnePrincipal.expected
@@ -5,7 +5,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace E2ETest.Namespace
 {
-    public class OneToOnePrincipal
+    public partial class OneToOnePrincipal
     {
         public int OneToOnePrincipalID1 { get; set; }
         public int OneToOnePrincipalID2 { get; set; }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/OneToOneSeparateFKDependent.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/OneToOneSeparateFKDependent.expected
@@ -5,7 +5,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace E2ETest.Namespace
 {
-    public class OneToOneSeparateFKDependent
+    public partial class OneToOneSeparateFKDependent
     {
         public int OneToOneSeparateFKDependentID1 { get; set; }
         public int OneToOneSeparateFKDependentID2 { get; set; }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/OneToOneSeparateFKPrincipal.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/OneToOneSeparateFKPrincipal.expected
@@ -5,7 +5,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace E2ETest.Namespace
 {
-    public class OneToOneSeparateFKPrincipal
+    public partial class OneToOneSeparateFKPrincipal
     {
         public int OneToOneSeparateFKPrincipalID1 { get; set; }
         public int OneToOneSeparateFKPrincipalID2 { get; set; }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/PropertyConfiguration.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/PropertyConfiguration.expected
@@ -5,7 +5,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace E2ETest.Namespace
 {
-    public class PropertyConfiguration
+    public partial class PropertyConfiguration
     {
         public byte PropertyConfigurationID { get; set; }
         public int A { get; set; }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/ReferredToByTableWithUnmappablePrimaryKeyColumn.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/ReferredToByTableWithUnmappablePrimaryKeyColumn.expected
@@ -5,7 +5,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace E2ETest.Namespace
 {
-    public class ReferredToByTableWithUnmappablePrimaryKeyColumn
+    public partial class ReferredToByTableWithUnmappablePrimaryKeyColumn
     {
         public int ReferredToByTableWithUnmappablePrimaryKeyColumnID { get; set; }
         [Required]

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/SelfReferencing.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/SelfReferencing.expected
@@ -5,7 +5,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace E2ETest.Namespace
 {
-    public class SelfReferencing
+    public partial class SelfReferencing
     {
         public int SelfReferencingID { get; set; }
         [Required]

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/Test_Spaces_Keywords_Table.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/Test_Spaces_Keywords_Table.expected
@@ -6,7 +6,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 namespace E2ETest.Namespace
 {
     [Table("Test Spaces Keywords Table")]
-    public class Test_Spaces_Keywords_Table
+    public partial class Test_Spaces_Keywords_Table
     {
         [Column("Test Spaces Keywords TableID")]
         public int Test_Spaces_Keywords_TableID { get; set; }

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/FkToAltKey/Comment.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/FkToAltKey/Comment.expected
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace E2E.Sqlite
 {
-    public class Comment
+    public partial class Comment
     {
         public long Id { get; set; }
         public string Contents { get; set; }

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/FkToAltKey/User.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/FkToAltKey/User.expected
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace E2E.Sqlite
 {
-    public class User
+    public partial class User
     {
         public User()
         {

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/ManyToMany/Groups.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/ManyToMany/Groups.expected
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace E2E.Sqlite
 {
-    public class Groups
+    public partial class Groups
     {
         public Groups()
         {

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/ManyToMany/Users.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/ManyToMany/Users.expected
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace E2E.Sqlite
 {
-    public class Users
+    public partial class Users
     {
         public Users()
         {

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/ManyToMany/Users_Groups.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/ManyToMany/Users_Groups.expected
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace E2E.Sqlite
 {
-    public class Users_Groups
+    public partial class Users_Groups
     {
         public string Id { get; set; }
         public string GroupId { get; set; }

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/NoPrincipalPk/Dependent.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/NoPrincipalPk/Dependent.expected
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace E2E.Sqlite
 {
-    public class Dependent
+    public partial class Dependent
     {
         public string Id { get; set; }
         public long? PrincipalId { get; set; }

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/OneToMany/OneToManyDependent.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/OneToMany/OneToManyDependent.expected
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace E2E.Sqlite
 {
-    public class OneToManyDependent
+    public partial class OneToManyDependent
     {
         public long OneToManyDependentID1 { get; set; }
         public long OneToManyDependentID2 { get; set; }

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/OneToMany/OneToManyPrincipal.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/OneToMany/OneToManyPrincipal.expected
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace E2E.Sqlite
 {
-    public class OneToManyPrincipal
+    public partial class OneToManyPrincipal
     {
         public OneToManyPrincipal()
         {

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/OneToOne/Dependent.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/OneToOne/Dependent.expected
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace E2E.Sqlite
 {
-    public class Dependent
+    public partial class Dependent
     {
         public long Id { get; set; }
         public long PrincipalId { get; set; }

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/OneToOne/Principal.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/OneToOne/Principal.expected
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace E2E.Sqlite
 {
-    public class Principal
+    public partial class Principal
     {
         public long Id { get; set; }
 

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/SelfRef/SelfRef.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/SelfRef/SelfRef.expected
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace E2E.Sqlite
 {
-    public class SelfRef
+    public partial class SelfRef
     {
         public long Id { get; set; }
         public long? SelfForeignKey { get; set; }

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/FkToAltKey/Comment.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/FkToAltKey/Comment.expected
@@ -5,7 +5,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace E2E.Sqlite
 {
-    public class Comment
+    public partial class Comment
     {
         public long Id { get; set; }
         public string Contents { get; set; }

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/FkToAltKey/User.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/FkToAltKey/User.expected
@@ -5,7 +5,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace E2E.Sqlite
 {
-    public class User
+    public partial class User
     {
         public User()
         {

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/ManyToMany/Groups.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/ManyToMany/Groups.expected
@@ -5,7 +5,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace E2E.Sqlite
 {
-    public class Groups
+    public partial class Groups
     {
         public Groups()
         {

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/ManyToMany/Users.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/ManyToMany/Users.expected
@@ -5,7 +5,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace E2E.Sqlite
 {
-    public class Users
+    public partial class Users
     {
         public Users()
         {

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/ManyToMany/Users_Groups.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/ManyToMany/Users_Groups.expected
@@ -5,7 +5,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace E2E.Sqlite
 {
-    public class Users_Groups
+    public partial class Users_Groups
     {
         public string Id { get; set; }
         public string GroupId { get; set; }

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/NoPrincipalPk/Dependent.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/NoPrincipalPk/Dependent.expected
@@ -5,7 +5,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace E2E.Sqlite
 {
-    public class Dependent
+    public partial class Dependent
     {
         public string Id { get; set; }
         public long? PrincipalId { get; set; }

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/OneToMany/OneToManyDependent.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/OneToMany/OneToManyDependent.expected
@@ -5,7 +5,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace E2E.Sqlite
 {
-    public class OneToManyDependent
+    public partial class OneToManyDependent
     {
         public long OneToManyDependentID1 { get; set; }
         public long OneToManyDependentID2 { get; set; }

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/OneToMany/OneToManyPrincipal.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/OneToMany/OneToManyPrincipal.expected
@@ -5,7 +5,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace E2E.Sqlite
 {
-    public class OneToManyPrincipal
+    public partial class OneToManyPrincipal
     {
         public OneToManyPrincipal()
         {

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/OneToOne/Dependent.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/OneToOne/Dependent.expected
@@ -5,7 +5,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace E2E.Sqlite
 {
-    public class Dependent
+    public partial class Dependent
     {
         public long Id { get; set; }
         public long PrincipalId { get; set; }

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/OneToOne/Principal.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/OneToOne/Principal.expected
@@ -5,7 +5,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace E2E.Sqlite
 {
-    public class Principal
+    public partial class Principal
     {
         public long Id { get; set; }
 

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/SelfRef/SelfRef.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/SelfRef/SelfRef.expected
@@ -5,7 +5,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace E2E.Sqlite
 {
-    public class SelfRef
+    public partial class SelfRef
     {
         public long Id { get; set; }
         public long? SelfForeignKey { get; set; }


### PR DESCRIPTION
Fixes #3428. (Fix looks large but it's mostly just the expected results files.)

Also removed an unused dependency on `ModeUtilities` in `ReverseEngineeringGenerator`.