### PR TITLE
Need a discuss and review, couple fixes and changes

### DIFF
--- a/src/EntityFramework.Core/Query/EntityQueryModelVisitor.cs
+++ b/src/EntityFramework.Core/Query/EntityQueryModelVisitor.cs
@@ -378,7 +378,7 @@ namespace Microsoft.Data.Entity.Query
                     var navigation = Model.FindEntityType(navigationType)?.FindNavigation(propertyInfo.Name);
                     if (navigation == null)
                     {
-                        throw new Exception($"Cannot find navigation {propertyInfo}.");
+                        return null;
                     }
 
                     boundChainedNavigations.Add(navigation);

--- a/src/EntityFramework.Core/Query/EntityQueryModelVisitor.cs
+++ b/src/EntityFramework.Core/Query/EntityQueryModelVisitor.cs
@@ -367,7 +367,7 @@ namespace Microsoft.Data.Entity.Query
             Expression navigationPropertyPath)
         {
             var boundChainedNavigations = new List<INavigation>();
-            var navigationType = navigationPropertyPath.Type.TryGetElementType(typeof(ICollection<>)) ??
+            var navigationType = navigationPropertyPath.Type.TryGetElementType(typeof (ICollection<>)) ??
                                  navigationPropertyPath.Type;
             if (chainedNavigationProperties != null)
             {
@@ -375,7 +375,9 @@ namespace Microsoft.Data.Entity.Query
                     var propertyInfo in
                         chainedNavigationProperties)
                 {
-                    var navigation = Model.FindEntityType(navigationType)?.FindNavigation(propertyInfo.Name);
+                    var navigation =
+                        Model.FindEntityType(propertyInfo.DeclaringType)?.FindNavigation(propertyInfo.Name) ??
+                        Model.FindEntityType(navigationType)?.FindNavigation(propertyInfo.Name);
                     if (navigation == null)
                     {
                         return null;
@@ -383,7 +385,7 @@ namespace Microsoft.Data.Entity.Query
 
                     boundChainedNavigations.Add(navigation);
 
-                    navigationType = propertyInfo.PropertyType.TryGetElementType(typeof(ICollection<>)) ??
+                    navigationType = propertyInfo.PropertyType.TryGetElementType(typeof (ICollection<>)) ??
                                      propertyInfo.PropertyType;
                 }
             }

--- a/src/EntityFramework.Core/Query/ExpressionVisitors/NavigationRewritingExpressionVisitor.cs
+++ b/src/EntityFramework.Core/Query/ExpressionVisitors/NavigationRewritingExpressionVisitor.cs
@@ -388,10 +388,10 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
                         new WhereClause(
                             Expression.Equal(
                                 CreateKeyAccessExpression(
-                                    querySourceReferenceExpression,
+                                    innerQuerySourceReferenceExpression,
                                     navigation.ForeignKey.Properties),
                                 CreateKeyAccessExpression(
-                                    innerQuerySourceReferenceExpression,
+                                    querySourceReferenceExpression,
                                     navigation.ForeignKey.PrincipalKey.Properties))));
 
                     return _queryModel.MainFromClause.FromExpression;

--- a/src/EntityFramework.Relational/Extensions/ExpressionExtensions.cs
+++ b/src/EntityFramework.Relational/Extensions/ExpressionExtensions.cs
@@ -41,5 +41,12 @@ namespace System.Linq.Expressions
                    || unwrappedExpression is LiteralExpression
                    || unwrappedExpression.IsAliasWithColumnExpression();
         }
+
+        public static bool IsSelectExpression([NotNull] this Expression expression)
+        {
+            var unwrappedExpression = expression.RemoveConvert();
+
+            return unwrappedExpression is SelectExpression;
+        }
     }
 }

--- a/src/EntityFramework.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/EntityFramework.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -723,7 +723,7 @@ namespace Microsoft.Data.Entity.Query.Sql
                 }
 
                 if (binaryExpression.IsLogicalOperation()
-                    && binaryExpression.Left.IsSimpleExpression())
+                    && (binaryExpression.Left.IsSimpleExpression() || binaryExpression.Left.IsSelectExpression()))
                 {
                     _sql.Append(" = ");
                     _sql.Append(TrueLiteral);
@@ -761,7 +761,7 @@ namespace Microsoft.Data.Entity.Query.Sql
                 }
 
                 if (binaryExpression.IsLogicalOperation()
-                    && binaryExpression.Right.IsSimpleExpression())
+                    && (binaryExpression.Right.IsSimpleExpression() || binaryExpression.Right.IsSelectExpression()))
                 {
                     _sql.Append(" = ");
                     _sql.Append(TrueLiteral);


### PR DESCRIPTION
#3235 fix - more than a fix, actually we could allow to use types as base types without strict declaration of base on model for example if we want separated tables with the same base entity and  ignore keys/properties from base type in child.

#3317 fix - select statement in SQL couldn't result in a bool, so just check the expression if it's select on binary expression and add " = 1"
Also MSSQL tests does have some missed parts on SQL generation if we have different FK/PK names and result SQL query was contain wrong table reference values because of small mistake. That was fixed in this commit.