### PR TITLE
Create non-internal state entry interface for consuming by SaveChanges

### DIFF
--- a/src/EntityFramework.Core/ChangeTracking/Internal/ArraySidecar.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/ArraySidecar.cs
@@ -22,7 +22,11 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
         public override bool CanStoreValue(IPropertyBase property) => Index(property) != -1;
 
-        protected override object ReadValue(IPropertyBase property) => _values[IndexChecked(property)];
+        protected override object ReadValue(IPropertyBase property)
+        {
+            var index = Index(property);
+            return index != -1 ? _values[index] : null;
+        }
 
         protected override void WriteValue(IPropertyBase property, object value) => _values[IndexChecked(property)] = value;
 

--- a/src/EntityFramework.Core/ChangeTracking/Internal/CompositeKeyValue.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/CompositeKeyValue.cs
@@ -10,11 +10,11 @@ using Microsoft.Data.Entity.Metadata;
 namespace Microsoft.Data.Entity.ChangeTracking.Internal
 {
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
-    public class CompositeEntityKey : EntityKey
+    public class CompositeKeyValue : KeyValue
     {
         private readonly object[] _keyValueParts;
 
-        public CompositeEntityKey([NotNull] IKey key, [NotNull] object[] keyValueParts)
+        public CompositeKeyValue([NotNull] IKey key, [NotNull] object[] keyValueParts)
             : base(key)
         {
             _keyValueParts = keyValueParts;
@@ -24,7 +24,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
         protected override object GetValue() => _keyValueParts;
 
-        private bool Equals(CompositeEntityKey other)
+        private bool Equals(CompositeKeyValue other)
         {
             if (Key != other.Key)
             {
@@ -60,7 +60,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
             return ReferenceEquals(this, obj)
                    || obj.GetType() == GetType()
-                   && Equals((CompositeEntityKey)obj);
+                   && Equals((CompositeKeyValue)obj);
         }
 
         public override int GetHashCode()

--- a/src/EntityFramework.Core/ChangeTracking/Internal/CompositeKeyValueFactory.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/CompositeKeyValueFactory.cs
@@ -4,25 +4,26 @@
 using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
 
 namespace Microsoft.Data.Entity.ChangeTracking.Internal
 {
-    public class CompositeEntityKeyFactory : EntityKeyFactory
+    public class CompositeKeyValueFactory : KeyValueFactory
     {
-        public CompositeEntityKeyFactory([NotNull] IKey key)
+        public CompositeKeyValueFactory([NotNull] IKey key)
             : base(key)
         {
         }
 
-        public override EntityKey Create(IReadOnlyList<IProperty> properties, ValueBuffer valueBuffer)
+        public override IKeyValue Create(IReadOnlyList<IProperty> properties, ValueBuffer valueBuffer)
             => Create(properties, p => valueBuffer[p.Index]);
 
-        public override EntityKey Create(IReadOnlyList<IProperty> properties, IPropertyAccessor propertyAccessor)
+        public override IKeyValue Create(IReadOnlyList<IProperty> properties, IPropertyAccessor propertyAccessor)
             => Create(properties, p => propertyAccessor[p]);
 
-        private EntityKey Create(IReadOnlyList<IProperty> properties, Func<IProperty, object> reader)
+        private KeyValue Create(IReadOnlyList<IProperty> properties, Func<IProperty, object> reader)
         {
             var components = new object[properties.Count];
 
@@ -32,13 +33,13 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
                 if (value == null)
                 {
-                    return EntityKey.InvalidEntityKey;
+                    return KeyValue.InvalidKeyValue;
                 }
 
                 components[i] = value;
             }
 
-            return new CompositeEntityKey(Key, components);
+            return new CompositeKeyValue(Key, components);
         }
     }
 }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/EntityEntryMetadataServices.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/EntityEntryMetadataServices.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Metadata.Internal;
 
@@ -15,7 +16,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         private readonly IOriginalValuesFactory _originalValuesFactory;
         private readonly IRelationshipsSnapshotFactory _relationshipsSnapshotFactory;
         private readonly IStoreGeneratedValuesFactory _storeGeneratedValuesFactory;
-        private readonly IEntityKeyFactorySource _entityKeyFactorySource;
+        private readonly IKeyValueFactorySource _keyValueFactorySource;
 
         public EntityEntryMetadataServices(
             [NotNull] IClrAccessorSource<IClrPropertyGetter> getterSource,
@@ -23,14 +24,14 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
             [NotNull] IOriginalValuesFactory originalValuesFactory,
             [NotNull] IRelationshipsSnapshotFactory relationshipsSnapshotFactory,
             [NotNull] IStoreGeneratedValuesFactory storeGeneratedValuesFactory,
-            [NotNull] IEntityKeyFactorySource entityKeyFactorySource)
+            [NotNull] IKeyValueFactorySource keyValueFactorySource)
         {
             _getterSource = getterSource;
             _setterSource = setterSource;
             _originalValuesFactory = originalValuesFactory;
             _relationshipsSnapshotFactory = relationshipsSnapshotFactory;
             _storeGeneratedValuesFactory = storeGeneratedValuesFactory;
-            _entityKeyFactorySource = entityKeyFactorySource;
+            _keyValueFactorySource = keyValueFactorySource;
         }
 
         public virtual object ReadValue(object entity, IPropertyBase propertyBase)
@@ -48,8 +49,8 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         public virtual Sidecar CreateStoreGeneratedValues(InternalEntityEntry entry, IReadOnlyList<IProperty> properties)
             => _storeGeneratedValuesFactory.Create(entry, properties);
 
-        public virtual EntityKey CreateKey(IKey key, IReadOnlyList<IProperty> properties, IPropertyAccessor propertyAccessor)
-            => _entityKeyFactorySource
+        public virtual IKeyValue CreateKey(IKey key, IReadOnlyList<IProperty> properties, IPropertyAccessor propertyAccessor)
+            => _keyValueFactorySource
                 .GetKeyFactory(key)
                 .Create(properties, propertyAccessor);
     }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/IEntityEntryMetadataServices.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/IEntityEntryMetadataServices.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 
 namespace Microsoft.Data.Entity.ChangeTracking.Internal
@@ -15,7 +16,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         Sidecar CreateRelationshipSnapshot([NotNull] InternalEntityEntry entry);
         Sidecar CreateStoreGeneratedValues([NotNull] InternalEntityEntry entry, [NotNull] IReadOnlyList<IProperty> properties);
 
-        EntityKey CreateKey(
+        IKeyValue CreateKey(
             [NotNull] IKey key,
             [NotNull] IReadOnlyList<IProperty> properties,
             [NotNull] IPropertyAccessor propertyAccessor);

--- a/src/EntityFramework.Core/ChangeTracking/Internal/IKeyValueFactorySource.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/IKeyValueFactorySource.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+
+namespace Microsoft.Data.Entity.ChangeTracking.Internal
+{
+    public interface IKeyValueFactorySource
+    {
+        KeyValueFactory GetKeyFactory([NotNull] IKey key);
+    }
+}

--- a/src/EntityFramework.Core/ChangeTracking/Internal/IStateManager.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/IStateManager.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
 
@@ -18,11 +19,11 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
         InternalEntityEntry StartTracking(
             [NotNull] IEntityType entityType,
-            [NotNull] EntityKey entityKey,
+            [NotNull] IKeyValue keyValue,
             [NotNull] object entity,
             ValueBuffer valueBuffer);
 
-        InternalEntityEntry TryGetEntry([NotNull] EntityKey keyValue);
+        InternalEntityEntry TryGetEntry([NotNull] IKeyValue keyValueValue);
 
         InternalEntityEntry TryGetEntry([NotNull] object entity);
 
@@ -38,9 +39,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
         InternalEntityEntry GetPrincipal([NotNull] IPropertyAccessor dependentEntry, [NotNull] IForeignKey foreignKey);
 
-        void UpdateIdentityMap([NotNull] InternalEntityEntry entry, [NotNull] EntityKey oldKey, [NotNull] IKey principalKey);
+        void UpdateIdentityMap([NotNull] InternalEntityEntry entry, [NotNull] IKeyValue oldKeyValue, [NotNull] IKey principalKey);
 
-        void UpdateDependentMap([NotNull] InternalEntityEntry entry, [NotNull] EntityKey oldKey, [NotNull] IForeignKey foreignKey);
+        void UpdateDependentMap([NotNull] InternalEntityEntry entry, [NotNull] IKeyValue oldKeyValue, [NotNull] IForeignKey foreignKey);
 
         IEnumerable<InternalEntityEntry> GetDependents([NotNull] InternalEntityEntry principalEntry, [NotNull] IForeignKey foreignKey);
 
@@ -49,5 +50,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         Task<int> SaveChangesAsync(bool acceptAllChangesOnSuccess, CancellationToken cancellationToken = default(CancellationToken));
 
         void AcceptAllChanges();
+
+        DbContext Context { get; }
     }
 }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/KeyValue.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/KeyValue.cs
@@ -2,19 +2,20 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 
 namespace Microsoft.Data.Entity.ChangeTracking.Internal
 {
-    public abstract class EntityKey
+    public abstract class KeyValue : IKeyValue
     {
-        public static readonly EntityKey InvalidEntityKey = new InvalidEntityKeySentinel();
+        public static readonly KeyValue InvalidKeyValue = new InvalidKeyValueSentinel();
 
-        private EntityKey()
+        private KeyValue()
         {
         }
 
-        protected EntityKey([NotNull] IKey key)
+        protected KeyValue([NotNull] IKey key)
         {
             Key = key;
         }
@@ -25,7 +26,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
         protected abstract object GetValue();
 
-        private sealed class InvalidEntityKeySentinel : EntityKey
+        private sealed class InvalidKeyValueSentinel : KeyValue
         {
             protected override object GetValue() => null;
 

--- a/src/EntityFramework.Core/ChangeTracking/Internal/KeyValueFactory.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/KeyValueFactory.cs
@@ -3,25 +3,26 @@
 
 using System.Collections.Generic;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
 
 namespace Microsoft.Data.Entity.ChangeTracking.Internal
 {
-    public abstract class EntityKeyFactory
+    public abstract class KeyValueFactory
     {
-        protected EntityKeyFactory([NotNull] IKey key)
+        protected KeyValueFactory([NotNull] IKey key)
         {
             Key = key;
         }
 
         public virtual IKey Key { get; }
 
-        public abstract EntityKey Create(
+        public abstract IKeyValue Create(
             [NotNull] IReadOnlyList<IProperty> properties,
             ValueBuffer valueBuffer);
 
-        public abstract EntityKey Create(
+        public abstract IKeyValue Create(
             [NotNull] IReadOnlyList<IProperty> properties,
             [NotNull] IPropertyAccessor propertyAccessor);
     }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/KeyValueFactorySource.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/KeyValueFactorySource.cs
@@ -9,12 +9,12 @@ using Microsoft.Data.Entity.Metadata;
 
 namespace Microsoft.Data.Entity.ChangeTracking.Internal
 {
-    public class EntityKeyFactorySource : IEntityKeyFactorySource
+    public class KeyValueFactorySource : IKeyValueFactorySource
     {
-        private readonly ThreadSafeDictionaryCache<IKey, EntityKeyFactory> _cache
-            = new ThreadSafeDictionaryCache<IKey, EntityKeyFactory>(ReferenceEqualityComparer.Instance);
+        private readonly ThreadSafeDictionaryCache<IKey, KeyValueFactory> _cache
+            = new ThreadSafeDictionaryCache<IKey, KeyValueFactory>(ReferenceEqualityComparer.Instance);
 
-        public virtual EntityKeyFactory GetKeyFactory(IKey key)
+        public virtual KeyValueFactory GetKeyFactory(IKey key)
             => _cache.GetOrAdd(
                 key,
                 k =>
@@ -29,12 +29,12 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
                             // advantages of the simple key don't really apply anyway.
                             if (!typeof(IStructuralEquatable).GetTypeInfo().IsAssignableFrom(keyType.GetTypeInfo()))
                             {
-                                return (EntityKeyFactory)(Activator.CreateInstance(
-                                    typeof(SimpleEntityKeyFactory<>).MakeGenericType(keyType.UnwrapNullableType()), k));
+                                return (KeyValueFactory)(Activator.CreateInstance(
+                                    typeof(SimpleKeyValueFactory<>).MakeGenericType(keyType.UnwrapNullableType()), k));
                             }
                         }
 
-                        return new CompositeEntityKeyFactory(k);
+                        return new CompositeKeyValueFactory(k);
                     });
     }
 }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/NavigationFixer.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
                 var newKeyValues = foreignKey.PrincipalKey.Properties.Select(p => entry[p]).ToList();
 
                 var oldKey = entry.RelationshipsSnapshot.GetPrincipalKeyValue(foreignKey);
-                if (oldKey != EntityKey.InvalidEntityKey)
+                if (oldKey != KeyValue.InvalidKeyValue)
                 {
                     foreach (var dependent in entry.StateManager.Entries.Where(
                         e => foreignKey.DeclaringEntityType.IsAssignableFrom(e.EntityType)

--- a/src/EntityFramework.Core/ChangeTracking/Internal/PropertyAccessorExtensions.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/PropertyAccessorExtensions.cs
@@ -2,24 +2,25 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 
 namespace Microsoft.Data.Entity.ChangeTracking.Internal
 {
     public static class PropertyAccessorExtensions
     {
-        public static EntityKey GetDependentKeyValue([NotNull] this IPropertyAccessor propertyAccessor, [NotNull] IForeignKey foreignKey)
+        public static IKeyValue GetDependentKeyValue([NotNull] this IPropertyAccessor propertyAccessor, [NotNull] IForeignKey foreignKey)
             => propertyAccessor.InternalEntityEntry.CreateKey(
                 foreignKey.PrincipalKey, foreignKey.Properties, propertyAccessor);
 
-        public static EntityKey GetPrincipalKeyValue([NotNull] this IPropertyAccessor propertyAccessor, [NotNull] IForeignKey foreignKey)
+        public static IKeyValue GetPrincipalKeyValue([NotNull] this IPropertyAccessor propertyAccessor, [NotNull] IForeignKey foreignKey)
             => propertyAccessor.GetPrincipalKeyValue(foreignKey.PrincipalKey);
 
-        public static EntityKey GetPrincipalKeyValue([NotNull] this IPropertyAccessor propertyAccessor, [NotNull] IKey key)
+        public static IKeyValue GetPrincipalKeyValue([NotNull] this IPropertyAccessor propertyAccessor, [NotNull] IKey key)
             => propertyAccessor.InternalEntityEntry.CreateKey(
                 key, key.Properties, propertyAccessor);
 
-        public static EntityKey GetPrimaryKeyValue([NotNull] this IPropertyAccessor propertyAccessor)
+        public static IKeyValue GetPrimaryKeyValue([NotNull] this IPropertyAccessor propertyAccessor)
         {
             var key = propertyAccessor.InternalEntityEntry.EntityType.GetPrimaryKey();
             return propertyAccessor.InternalEntityEntry.CreateKey(key, key.Properties, propertyAccessor);

--- a/src/EntityFramework.Core/ChangeTracking/Internal/SimpleKeyValue.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/SimpleKeyValue.cs
@@ -10,13 +10,13 @@ using Microsoft.Data.Entity.Metadata;
 namespace Microsoft.Data.Entity.ChangeTracking.Internal
 {
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
-    public class SimpleEntityKey<TKey> : EntityKey
+    public class SimpleKeyValue<TKey> : KeyValue
     {
         private static readonly IEqualityComparer _equalityComparer = EqualityComparer<TKey>.Default;
 
         private readonly TKey _keyValue;
 
-        public SimpleEntityKey([NotNull] IKey key, [CanBeNull] TKey keyValue)
+        public SimpleKeyValue([NotNull] IKey key, [CanBeNull] TKey keyValue)
             : base(key)
         {
             _keyValue = keyValue;
@@ -30,9 +30,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
             => !ReferenceEquals(null, obj)
                && (ReferenceEquals(this, obj)
                    || (obj.GetType() == GetType()
-                       && Equals((SimpleEntityKey<TKey>)obj)));
+                       && Equals((SimpleKeyValue<TKey>)obj)));
 
-        private bool Equals(SimpleEntityKey<TKey> other)
+        private bool Equals(SimpleKeyValue<TKey> other)
             => Key == other.Key
                && _equalityComparer.Equals(_keyValue, other._keyValue);
 

--- a/src/EntityFramework.Core/ChangeTracking/Internal/SimpleKeyValueFactory.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/SimpleKeyValueFactory.cs
@@ -3,29 +3,30 @@
 
 using System.Collections.Generic;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
 
 namespace Microsoft.Data.Entity.ChangeTracking.Internal
 {
-    public class SimpleEntityKeyFactory<TKey> : EntityKeyFactory
+    public class SimpleKeyValueFactory<TKey> : KeyValueFactory
     {
-        public SimpleEntityKeyFactory([NotNull] IKey key)
+        public SimpleKeyValueFactory([NotNull] IKey key)
             : base(key)
         {
         }
 
-        public override EntityKey Create(
+        public override IKeyValue Create(
             IReadOnlyList<IProperty> properties, ValueBuffer valueBuffer)
             => Create(valueBuffer[properties[0].Index]);
 
-        public override EntityKey Create(
+        public override IKeyValue Create(
             IReadOnlyList<IProperty> properties, IPropertyAccessor propertyAccessor)
             => Create(propertyAccessor[properties[0]]);
 
-        private EntityKey Create(object value)
+        private KeyValue Create(object value)
             => value != null
-                ? new SimpleEntityKey<TKey>(Key, (TKey)value)
-                : EntityKey.InvalidEntityKey;
+                ? new SimpleKeyValue<TKey>(Key, (TKey)value)
+                : KeyValue.InvalidKeyValue;
     }
 }

--- a/src/EntityFramework.Core/ChangeTracking/PropertyEntry.cs
+++ b/src/EntityFramework.Core/ChangeTracking/PropertyEntry.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
         /// </summary>
         public virtual bool IsModified
         {
-            get { return _internalEntry.IsPropertyModified(Metadata); }
+            get { return _internalEntry.IsModified(Metadata); }
             set { _internalEntry.SetPropertyModified(Metadata, value); }
         }
 

--- a/src/EntityFramework.Core/DbUpdateConcurrencyException.cs
+++ b/src/EntityFramework.Core/DbUpdateConcurrencyException.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
+using Microsoft.Data.Entity.Update;
 
 namespace Microsoft.Data.Entity
 {
@@ -11,7 +12,7 @@ namespace Microsoft.Data.Entity
     {
         public DbUpdateConcurrencyException(
             [NotNull] string message,
-            [NotNull] IReadOnlyList<InternalEntityEntry> entries)
+            [NotNull] IReadOnlyList<IUpdateEntry> entries)
             : base(message, entries)
         {
         }

--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -64,7 +64,7 @@
     <Compile Include="ChangeTracking\Internal\EntityGraphAttacher.cs" />
     <Compile Include="ChangeTracking\Internal\IChangeTrackerFactory.cs" />
     <Compile Include="ChangeTracking\Internal\IEntityGraphAttacher.cs" />
-    <Compile Include="ChangeTracking\Internal\SimpleEntityKeyFactory.cs" />
+    <Compile Include="ChangeTracking\Internal\SimpleKeyValueFactory.cs" />
     <Compile Include="ChangeTracking\Internal\ValueBufferOriginalValues.cs" />
     <Compile Include="ChangeTracking\Internal\ValueBufferSidecar.cs" />
     <Compile Include="DbUpdateConcurrencyException.cs" />
@@ -76,6 +76,7 @@
     <Compile Include="Infrastructure\AccessorExtensions.cs" />
     <Compile Include="Infrastructure\DbContextAttribute.cs" />
     <Compile Include="Infrastructure\IDbContextFactory.cs" />
+    <Compile Include="Infrastructure\IKeyValue.cs" />
     <Compile Include="Infrastructure\ModelSource.cs" />
     <Compile Include="Infrastructure\CoreLoggingEventId.cs" />
     <Compile Include="Internal\DatabaseProviderSelector.cs" />
@@ -111,7 +112,7 @@
     <Compile Include="ChangeTracking\Internal\IChangeDetector.cs" />
     <Compile Include="ChangeTracking\Internal\IEntityEntryGraphIterator.cs" />
     <Compile Include="ChangeTracking\Internal\IEntityEntryMetadataServices.cs" />
-    <Compile Include="ChangeTracking\Internal\IEntityKeyFactorySource.cs" />
+    <Compile Include="ChangeTracking\Internal\IKeyValueFactorySource.cs" />
     <Compile Include="ChangeTracking\Internal\IInternalEntityEntryFactory.cs" />
     <Compile Include="ChangeTracking\Internal\IInternalEntityEntryNotifier.cs" />
     <Compile Include="ChangeTracking\Internal\IInternalEntityEntrySubscriber.cs" />
@@ -126,13 +127,13 @@
     <Compile Include="ChangeTracking\Internal\IKeyListener.cs" />
     <Compile Include="ChangeTracking\Internal\INavigationListener.cs" />
     <Compile Include="ChangeTracking\Internal\InternalClrEntityEntry.cs" />
-    <Compile Include="ChangeTracking\Internal\CompositeEntityKey.cs" />
-    <Compile Include="ChangeTracking\Internal\CompositeEntityKeyFactory.cs" />
+    <Compile Include="ChangeTracking\Internal\CompositeKeyValue.cs" />
+    <Compile Include="ChangeTracking\Internal\CompositeKeyValueFactory.cs" />
     <Compile Include="ChangeTracking\Internal\DictionarySidecar.cs" />
     <Compile Include="ChangeTracking\Internal\EntityEntryGraphIterator.cs" />
-    <Compile Include="ChangeTracking\Internal\EntityKey.cs" />
-    <Compile Include="ChangeTracking\Internal\EntityKeyFactory.cs" />
-    <Compile Include="ChangeTracking\Internal\EntityKeyFactorySource.cs" />
+    <Compile Include="ChangeTracking\Internal\KeyValue.cs" />
+    <Compile Include="ChangeTracking\Internal\KeyValueFactory.cs" />
+    <Compile Include="ChangeTracking\Internal\KeyValueFactorySource.cs" />
     <Compile Include="ChangeTracking\Internal\IEntityStateListener.cs" />
     <Compile Include="ChangeTracking\Internal\IPropertyAccessor.cs" />
     <Compile Include="ChangeTracking\Internal\IPropertyListener.cs" />
@@ -146,7 +147,7 @@
     <Compile Include="ChangeTracking\Internal\RelationshipsSnapshotFactory.cs" />
     <Compile Include="ChangeTracking\Internal\InternalShadowEntityEntry.cs" />
     <Compile Include="ChangeTracking\Internal\Sidecar.cs" />
-    <Compile Include="ChangeTracking\Internal\SimpleEntityKey.cs" />
+    <Compile Include="ChangeTracking\Internal\SimpleKeyValue.cs" />
     <Compile Include="ChangeTracking\Internal\StateData.cs" />
     <Compile Include="ChangeTracking\Internal\InternalEntityEntry.cs" />
     <Compile Include="ChangeTracking\Internal\InternalEntityEntryFactory.cs" />
@@ -414,6 +415,7 @@
     <Compile Include="..\Shared\SharedTypeExtensions.cs">
       <Link>Extensions\Internal\SharedTypeExtensions.cs</Link>
     </Compile>
+    <Compile Include="Update\IUpdateEntry.cs" />
     <Compile Include="ValueGeneration\GuidValueGenerator.cs" />
     <Compile Include="ValueGeneration\HiLoValueGeneratorState.cs" />
     <Compile Include="ValueGeneration\HiLoValueGenerator.cs" />

--- a/src/EntityFramework.Core/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/EntityFramework.Core/EntityFrameworkServiceCollectionExtensions.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddSingleton<IDbSetFinder, DbSetFinder>()
                 .AddSingleton<IDbSetInitializer, DbSetInitializer>()
                 .AddSingleton<IDbSetSource, DbSetSource>()
-                .AddSingleton<IEntityKeyFactorySource, EntityKeyFactorySource>()
+                .AddSingleton<IKeyValueFactorySource, KeyValueFactorySource>()
                 .AddSingleton<IClrAccessorSource<IClrPropertyGetter>, ClrPropertyGetterSource>()
                 .AddSingleton<IClrAccessorSource<IClrPropertySetter>, ClrPropertySetterSource>()
                 .AddSingleton<IClrCollectionAccessorSource, ClrCollectionAccessorSource>()

--- a/src/EntityFramework.Core/Infrastructure/IKeyValue.cs
+++ b/src/EntityFramework.Core/Infrastructure/IKeyValue.cs
@@ -1,13 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using JetBrains.Annotations;
 using Microsoft.Data.Entity.Metadata;
 
-namespace Microsoft.Data.Entity.ChangeTracking.Internal
+namespace Microsoft.Data.Entity.Infrastructure
 {
-    public interface IEntityKeyFactorySource
+    public interface IKeyValue
     {
-        EntityKeyFactory GetKeyFactory([NotNull] IKey key);
+        IKey Key { get; }
+        object Value { get; }
     }
 }

--- a/src/EntityFramework.Core/Query/IQueryBuffer.cs
+++ b/src/EntityFramework.Core/Query/IQueryBuffer.cs
@@ -7,22 +7,23 @@ using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
 
 namespace Microsoft.Data.Entity.Query
 {
     public delegate IEnumerable<EntityLoadInfo> RelatedEntitiesLoader(
-        EntityKey primaryKey, Func<ValueBuffer, EntityKey> foreignKeyFactory);
+        IKeyValue primaryKeyValue, Func<ValueBuffer, IKeyValue> foreignKeyFactory);
 
     public delegate IAsyncEnumerable<EntityLoadInfo> AsyncRelatedEntitiesLoader(
-        EntityKey primaryKey, Func<ValueBuffer, EntityKey> foreignKeyFactory);
+        IKeyValue primaryKeyValue, Func<ValueBuffer, IKeyValue> foreignKeyFactory);
 
     public interface IQueryBuffer
     {
         object GetEntity(
             [NotNull] IEntityType entityType,
-            [NotNull] EntityKey entityKey,
+            [NotNull] IKeyValue keyValue,
             EntityLoadInfo entityLoadInfo,
             bool queryStateManager);
 

--- a/src/EntityFramework.Core/Query/Internal/EntityTrackingInfoFactory.cs
+++ b/src/EntityFramework.Core/Query/Internal/EntityTrackingInfoFactory.cs
@@ -11,14 +11,14 @@ namespace Microsoft.Data.Entity.Query.Internal
 {
     public class EntityTrackingInfoFactory : IEntityTrackingInfoFactory
     {
-        private readonly IEntityKeyFactorySource _entityKeyFactorySource;
+        private readonly IKeyValueFactorySource _keyValueFactorySource;
         private readonly IClrAccessorSource<IClrPropertyGetter> _clrPropertyGetterSource;
 
         public EntityTrackingInfoFactory(
-            [NotNull] IEntityKeyFactorySource entityKeyFactorySource,
+            [NotNull] IKeyValueFactorySource keyValueFactorySource,
             [NotNull] IClrAccessorSource<IClrPropertyGetter> clrPropertyGetterSource)
         {
-            _entityKeyFactorySource = entityKeyFactorySource;
+            _keyValueFactorySource = keyValueFactorySource;
             _clrPropertyGetterSource = clrPropertyGetterSource;
         }
 
@@ -28,7 +28,7 @@ namespace Microsoft.Data.Entity.Query.Internal
             IEntityType entityType)
         {
             var trackingInfo = new EntityTrackingInfo(
-                _entityKeyFactorySource,
+                _keyValueFactorySource,
                 _clrPropertyGetterSource,
                 queryCompilationContext,
                 querySourceReferenceExpression,

--- a/src/EntityFramework.Core/Query/QueryContextFactory.cs
+++ b/src/EntityFramework.Core/Query/QueryContextFactory.cs
@@ -14,27 +14,27 @@ namespace Microsoft.Data.Entity.Query
         private readonly IStateManager _stateManager;
         private readonly IClrCollectionAccessorSource _collectionAccessorSource;
         private readonly IClrAccessorSource<IClrPropertySetter> _propertySetterSource;
-        private readonly IEntityKeyFactorySource _entityKeyFactorySource;
+        private readonly IKeyValueFactorySource _keyValueFactorySource;
 
         protected QueryContextFactory(
             [NotNull] IStateManager stateManager,
-            [NotNull] IEntityKeyFactorySource entityKeyFactorySource,
+            [NotNull] IKeyValueFactorySource keyValueFactorySource,
             [NotNull] IClrCollectionAccessorSource collectionAccessorSource,
             [NotNull] IClrAccessorSource<IClrPropertySetter> propertySetterSource)
         {
             Check.NotNull(stateManager, nameof(stateManager));
-            Check.NotNull(entityKeyFactorySource, nameof(entityKeyFactorySource));
+            Check.NotNull(keyValueFactorySource, nameof(keyValueFactorySource));
             Check.NotNull(collectionAccessorSource, nameof(collectionAccessorSource));
             Check.NotNull(propertySetterSource, nameof(propertySetterSource));
 
             _stateManager = stateManager;
-            _entityKeyFactorySource = entityKeyFactorySource;
+            _keyValueFactorySource = keyValueFactorySource;
             _collectionAccessorSource = collectionAccessorSource;
             _propertySetterSource = propertySetterSource;
         }
 
         protected virtual IQueryBuffer CreateQueryBuffer()
-            => new QueryBuffer(_stateManager, _entityKeyFactorySource, _collectionAccessorSource, _propertySetterSource);
+            => new QueryBuffer(_stateManager, _keyValueFactorySource, _collectionAccessorSource, _propertySetterSource);
 
         public abstract QueryContext Create();
     }

--- a/src/EntityFramework.Core/Storage/Database.cs
+++ b/src/EntityFramework.Core/Storage/Database.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Query;
+using Microsoft.Data.Entity.Update;
 using Microsoft.Data.Entity.Utilities;
 using Remotion.Linq;
 
@@ -24,10 +25,10 @@ namespace Microsoft.Data.Entity.Storage
             _queryCompilationContextFactory = queryCompilationContextFactory;
         }
 
-        public abstract int SaveChanges(IReadOnlyList<InternalEntityEntry> entries);
+        public abstract int SaveChanges(IReadOnlyList<IUpdateEntry> entries);
 
         public abstract Task<int> SaveChangesAsync(
-            IReadOnlyList<InternalEntityEntry> entries,
+            IReadOnlyList<IUpdateEntry> entries,
             CancellationToken cancellationToken = default(CancellationToken));
 
         public virtual Func<QueryContext, IEnumerable<TResult>> CompileQuery<TResult>(QueryModel queryModel)

--- a/src/EntityFramework.Core/Storage/IDatabase.cs
+++ b/src/EntityFramework.Core/Storage/IDatabase.cs
@@ -8,16 +8,17 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Query;
+using Microsoft.Data.Entity.Update;
 using Remotion.Linq;
 
 namespace Microsoft.Data.Entity.Storage
 {
     public interface IDatabase
     {
-        int SaveChanges([NotNull] IReadOnlyList<InternalEntityEntry> entries);
+        int SaveChanges([NotNull] IReadOnlyList<IUpdateEntry> entries);
 
         Task<int> SaveChangesAsync(
-            [NotNull] IReadOnlyList<InternalEntityEntry> entries,
+            [NotNull] IReadOnlyList<IUpdateEntry> entries,
             CancellationToken cancellationToken = default(CancellationToken));
 
         Func<QueryContext, IEnumerable<TResult>> CompileQuery<TResult>([NotNull] QueryModel queryModel);

--- a/src/EntityFramework.Core/Update/IUpdateEntry.cs
+++ b/src/EntityFramework.Core/Update/IUpdateEntry.cs
@@ -1,0 +1,26 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.ChangeTracking;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
+
+namespace Microsoft.Data.Entity.Update
+{
+    public interface IUpdateEntry
+    {
+        IEntityType EntityType { get; }
+        EntityState EntityState { get; }
+        bool IsModified([NotNull] IProperty property);
+        bool IsStoreGenerated([NotNull] IProperty property);
+        object GetOriginalValue([NotNull] IProperty property);
+        object this[[NotNull] IPropertyBase propertyBase] { get; [param: CanBeNull] set; }
+
+        IKeyValue GetPrimaryKeyValue(bool originalValue = false);
+        IKeyValue GetPrincipalKeyValue([NotNull] IForeignKey foreignKey, bool originalValue = false);
+        IKeyValue GetDependentKeyValue([NotNull] IForeignKey foreignKey, bool originalValue = false);
+
+        EntityEntry ToEntityEntry();
+    }
+}

--- a/src/EntityFramework.InMemory/Query/ExpressionVisitors/Internal/InMemoryEntityQueryableExpressionVisitor.cs
+++ b/src/EntityFramework.InMemory/Query/ExpressionVisitors/Internal/InMemoryEntityQueryableExpressionVisitor.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Query.Internal;
 using Microsoft.Data.Entity.Storage;
@@ -16,26 +17,26 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors.Internal
     public class InMemoryEntityQueryableExpressionVisitor : EntityQueryableExpressionVisitor
     {
         private readonly IModel _model;
-        private readonly IEntityKeyFactorySource _entityKeyFactorySource;
+        private readonly IKeyValueFactorySource _keyValueFactorySource;
         private readonly IMaterializerFactory _materializerFactory;
 
         private IQuerySource _querySource;
 
         public InMemoryEntityQueryableExpressionVisitor(
             [NotNull] IModel model,
-            [NotNull] IEntityKeyFactorySource entityKeyFactorySource,
+            [NotNull] IKeyValueFactorySource keyValueFactorySource,
             [NotNull] IMaterializerFactory materializerFactory,
             [NotNull] EntityQueryModelVisitor entityQueryModelVisitor,
             [NotNull] IQuerySource querySource)
             : base(Check.NotNull(entityQueryModelVisitor, nameof(entityQueryModelVisitor)))
         {
             Check.NotNull(model, nameof(model));
-            Check.NotNull(entityKeyFactorySource, nameof(entityKeyFactorySource));
+            Check.NotNull(keyValueFactorySource, nameof(keyValueFactorySource));
             Check.NotNull(materializerFactory, nameof(materializerFactory));
             Check.NotNull(querySource, nameof(querySource));
 
             _model = model;
-            _entityKeyFactorySource = entityKeyFactorySource;
+            _keyValueFactorySource = keyValueFactorySource;
             _materializerFactory = materializerFactory;
             _querySource = querySource;
         }
@@ -51,9 +52,9 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors.Internal
             var keyProperties
                 = entityType.GetPrimaryKey().Properties;
 
-            var keyFactory = _entityKeyFactorySource.GetKeyFactory(entityType.GetPrimaryKey());
+            var keyFactory = _keyValueFactorySource.GetKeyFactory(entityType.GetPrimaryKey());
 
-            Func<ValueBuffer, EntityKey> entityKeyFactory
+            Func<ValueBuffer, IKeyValue> keyValueFactory
                 = vr => keyFactory.Create(keyProperties, vr);
 
             if (QueryModelVisitor.QueryCompilationContext
@@ -65,7 +66,7 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors.Internal
                     InMemoryQueryModelVisitor.EntityQueryMethodInfo.MakeGenericMethod(elementType),
                     EntityQueryModelVisitor.QueryContextParameter,
                     Expression.Constant(entityType),
-                    Expression.Constant(entityKeyFactory),
+                    Expression.Constant(keyValueFactory),
                     materializer,
                     Expression.Constant(QueryModelVisitor.QuerySourceRequiresTracking(_querySource)));
             }

--- a/src/EntityFramework.InMemory/Query/ExpressionVisitors/Internal/InMemoryEntityQueryableExpressionVisitorFactory.cs
+++ b/src/EntityFramework.InMemory/Query/ExpressionVisitors/Internal/InMemoryEntityQueryableExpressionVisitorFactory.cs
@@ -14,20 +14,20 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors.Internal
     public class InMemoryEntityQueryableExpressionVisitorFactory : IEntityQueryableExpressionVisitorFactory
     {
         private readonly IModel _model;
-        private readonly IEntityKeyFactorySource _entityKeyFactorySource;
+        private readonly IKeyValueFactorySource _keyValueFactorySource;
         private readonly IMaterializerFactory _materializerFactory;
 
         public InMemoryEntityQueryableExpressionVisitorFactory(
             [NotNull] IModel model,
-            [NotNull] IEntityKeyFactorySource entityKeyFactorySource,
+            [NotNull] IKeyValueFactorySource keyValueFactorySource,
             [NotNull] IMaterializerFactory materializerFactory)
         {
             Check.NotNull(model, nameof(model));
-            Check.NotNull(entityKeyFactorySource, nameof(entityKeyFactorySource));
+            Check.NotNull(keyValueFactorySource, nameof(keyValueFactorySource));
             Check.NotNull(materializerFactory, nameof(materializerFactory));
 
             _model = model;
-            _entityKeyFactorySource = entityKeyFactorySource;
+            _keyValueFactorySource = keyValueFactorySource;
             _materializerFactory = materializerFactory;
         }
 
@@ -36,7 +36,7 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors.Internal
             [NotNull] IQuerySource querySource)
             => new InMemoryEntityQueryableExpressionVisitor(
                 _model,
-                _entityKeyFactorySource,
+                _keyValueFactorySource,
                 _materializerFactory,
                 Check.NotNull(queryModelVisitor, nameof(queryModelVisitor)),
                 Check.NotNull(querySource, nameof(querySource)));

--- a/src/EntityFramework.InMemory/Query/Internal/InMemoryQueryContextFactory.cs
+++ b/src/EntityFramework.InMemory/Query/Internal/InMemoryQueryContextFactory.cs
@@ -15,11 +15,11 @@ namespace Microsoft.Data.Entity.Query.Internal
 
         public InMemoryQueryContextFactory(
             [NotNull] IStateManager stateManager,
-            [NotNull] IEntityKeyFactorySource entityKeyFactorySource,
+            [NotNull] IKeyValueFactorySource keyValueFactorySource,
             [NotNull] IClrCollectionAccessorSource collectionAccessorSource,
             [NotNull] IClrAccessorSource<IClrPropertySetter> propertySetterSource,
             [NotNull] IInMemoryDatabase database)
-            : base(stateManager, entityKeyFactorySource, collectionAccessorSource, propertySetterSource)
+            : base(stateManager, keyValueFactorySource, collectionAccessorSource, propertySetterSource)
         {
             Check.NotNull(database, nameof(database));
 

--- a/src/EntityFramework.InMemory/Storage/Internal/IInMemoryStore.cs
+++ b/src/EntityFramework.InMemory/Storage/Internal/IInMemoryStore.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Update;
 
 namespace Microsoft.Data.Entity.Storage.Internal
 {
@@ -22,6 +23,6 @@ namespace Microsoft.Data.Entity.Storage.Internal
 
         IEnumerable<InMemoryStore.InMemoryTable> GetTables([NotNull] IEntityType entityType);
 
-        int ExecuteTransaction([NotNull] IEnumerable<InternalEntityEntry> entries);
+        int ExecuteTransaction([NotNull] IEnumerable<IUpdateEntry> entries);
     }
 }

--- a/src/EntityFramework.InMemory/Storage/Internal/InMemoryDatabase.cs
+++ b/src/EntityFramework.InMemory/Storage/Internal/InMemoryDatabase.cs
@@ -11,6 +11,7 @@ using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Query;
+using Microsoft.Data.Entity.Update;
 using Microsoft.Data.Entity.Utilities;
 using Remotion.Linq;
 
@@ -35,11 +36,11 @@ namespace Microsoft.Data.Entity.Storage.Internal
 
         public virtual IInMemoryStore Store => _database;
 
-        public override int SaveChanges(IReadOnlyList<InternalEntityEntry> entries)
+        public override int SaveChanges(IReadOnlyList<IUpdateEntry> entries)
             => _database.ExecuteTransaction(Check.NotNull(entries, nameof(entries)));
 
         public override Task<int> SaveChangesAsync(
-            IReadOnlyList<InternalEntityEntry> entries,
+            IReadOnlyList<IUpdateEntry> entries,
             CancellationToken cancellationToken = default(CancellationToken))
             => Task.FromResult(_database.ExecuteTransaction(Check.NotNull(entries, nameof(entries))));
 

--- a/src/EntityFramework.Relational/Query/AsyncQueryMethodProvider.cs
+++ b/src/EntityFramework.Relational/Query/AsyncQueryMethodProvider.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Query.Internal;
 using Microsoft.Data.Entity.Storage;
@@ -257,7 +258,7 @@ namespace Microsoft.Data.Entity.Query
                 _materializer = materializer;
             }
 
-            public IAsyncEnumerable<EntityLoadInfo> GetRelatedValues(EntityKey key, Func<ValueBuffer, EntityKey> keyFactory)
+            public IAsyncEnumerable<EntityLoadInfo> GetRelatedValues(IKeyValue keyValue, Func<ValueBuffer, IKeyValue> keyFactory)
             {
                 var valueBuffer = _queryContext.GetIncludeValueBuffer(_queryIndex).WithOffset(_valueBufferOffset);
 
@@ -337,10 +338,10 @@ namespace Microsoft.Data.Entity.Query
                     = new AsyncIncludeCollectionIterator(relatedValueBuffers.GetEnumerator());
             }
 
-            public IAsyncEnumerable<EntityLoadInfo> GetRelatedValues(EntityKey key, Func<ValueBuffer, EntityKey> keyFactory)
+            public IAsyncEnumerable<EntityLoadInfo> GetRelatedValues(IKeyValue keyValue, Func<ValueBuffer, IKeyValue> keyFactory)
             {
                 return _includeCollectionIterator
-                    .GetRelatedValues(key, keyFactory)
+                    .GetRelatedValues(keyValue, keyFactory)
                     .Select(vr => new EntityLoadInfo(vr, _materializer));
             }
 

--- a/src/EntityFramework.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
             = Expression.Parameter(typeof(ValueBuffer));
 
         private readonly IModel _model;
-        private readonly IEntityKeyFactorySource _entityKeyFactorySource;
+        private readonly IKeyValueFactorySource _keyValueFactorySource;
         private readonly ISelectExpressionFactory _selectExpressionFactory;
         private readonly IMaterializerFactory _materializerFactory;
         private readonly ICommandBuilderFactory _commandBuilderFactory;
@@ -35,7 +35,7 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
 
         public RelationalEntityQueryableExpressionVisitor(
             [NotNull] IModel model,
-            [NotNull] IEntityKeyFactorySource entityKeyFactorySource,
+            [NotNull] IKeyValueFactorySource keyValueFactorySource,
             [NotNull] ISelectExpressionFactory selectExpressionFactory,
             [NotNull] IMaterializerFactory materializerFactory,
             [NotNull] ICommandBuilderFactory commandBuilderFactory,
@@ -45,7 +45,7 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
             : base(Check.NotNull(queryModelVisitor, nameof(queryModelVisitor)))
         {
             Check.NotNull(model, nameof(model));
-            Check.NotNull(entityKeyFactorySource, nameof(entityKeyFactorySource));
+            Check.NotNull(keyValueFactorySource, nameof(keyValueFactorySource));
             Check.NotNull(selectExpressionFactory, nameof(selectExpressionFactory));
             Check.NotNull(materializerFactory, nameof(materializerFactory));
             Check.NotNull(commandBuilderFactory, nameof(commandBuilderFactory));
@@ -53,7 +53,7 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
             Check.NotNull(querySource, nameof(querySource));
 
             _model = model;
-            _entityKeyFactorySource = entityKeyFactorySource;
+            _keyValueFactorySource = keyValueFactorySource;
             _selectExpressionFactory = selectExpressionFactory;
             _materializerFactory = materializerFactory;
             _commandBuilderFactory = commandBuilderFactory;
@@ -211,7 +211,7 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
                     = CreateEntityMethodInfo.MakeGenericMethod(elementType);
 
                 var keyFactory
-                    = _entityKeyFactorySource
+                    = _keyValueFactorySource
                         .GetKeyFactory(entityType.GetPrimaryKey());
 
                 queryMethodArguments.AddRange(
@@ -280,7 +280,7 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
             int valueBufferOffset,
             IEntityType entityType,
             bool queryStateManager,
-            EntityKeyFactory entityKeyFactory,
+            KeyValueFactory keyValueFactory,
             IReadOnlyList<IProperty> keyProperties,
             Func<ValueBuffer, object> materializer,
             bool allowNullResult)
@@ -288,12 +288,12 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
         {
             valueBuffer = valueBuffer.WithOffset(valueBufferOffset);
 
-            var entityKey
-                = entityKeyFactory.Create(keyProperties, valueBuffer);
+            var keyValue
+                = keyValueFactory.Create(keyProperties, valueBuffer);
 
             TEntity entity = null;
 
-            if (entityKey == EntityKey.InvalidEntityKey)
+            if (keyValue == KeyValue.InvalidKeyValue)
             {
                 if (!allowNullResult)
                 {
@@ -306,7 +306,7 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
                     = (TEntity)queryContext.QueryBuffer
                         .GetEntity(
                             entityType,
-                            entityKey,
+                            keyValue,
                             new EntityLoadInfo(valueBuffer, materializer),
                             queryStateManager);
             }

--- a/src/EntityFramework.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitorFactory.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitorFactory.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
     public class RelationalEntityQueryableExpressionVisitorFactory : IEntityQueryableExpressionVisitorFactory
     {
         private readonly IModel _model;
-        private readonly IEntityKeyFactorySource _entityKeyFactorySource;
+        private readonly IKeyValueFactorySource _keyValueFactorySource;
         private readonly ISelectExpressionFactory _selectExpressionFactory;
         private readonly IMaterializerFactory _materializerFactory;
         private readonly ICommandBuilderFactory _commandBuilderFactory;
@@ -22,21 +22,21 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
 
         public RelationalEntityQueryableExpressionVisitorFactory(
             [NotNull] IModel model,
-            [NotNull] IEntityKeyFactorySource entityKeyFactorySource,
+            [NotNull] IKeyValueFactorySource keyValueFactorySource,
             [NotNull] ISelectExpressionFactory selectExpressionFactory,
             [NotNull] IMaterializerFactory materializerFactory,
             [NotNull] ICommandBuilderFactory commandBuilderFactory,
             [NotNull] IRelationalAnnotationProvider relationalAnnotationProvider)
         {
             Check.NotNull(model, nameof(model));
-            Check.NotNull(entityKeyFactorySource, nameof(entityKeyFactorySource));
+            Check.NotNull(keyValueFactorySource, nameof(keyValueFactorySource));
             Check.NotNull(selectExpressionFactory, nameof(selectExpressionFactory));
             Check.NotNull(materializerFactory, nameof(materializerFactory));
             Check.NotNull(commandBuilderFactory, nameof(commandBuilderFactory));
             Check.NotNull(relationalAnnotationProvider, nameof(relationalAnnotationProvider));
 
             _model = model;
-            _entityKeyFactorySource = entityKeyFactorySource;
+            _keyValueFactorySource = keyValueFactorySource;
             _selectExpressionFactory = selectExpressionFactory;
             _materializerFactory = materializerFactory;
             _commandBuilderFactory = commandBuilderFactory;
@@ -48,7 +48,7 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
             [NotNull] IQuerySource querySource)
             => new RelationalEntityQueryableExpressionVisitor(
                 _model,
-                _entityKeyFactorySource,
+                _keyValueFactorySource,
                 _selectExpressionFactory,
                 _materializerFactory,
                 _commandBuilderFactory,

--- a/src/EntityFramework.Relational/Query/IAsyncIncludeRelatedValuesStrategy.cs
+++ b/src/EntityFramework.Relational/Query/IAsyncIncludeRelatedValuesStrategy.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Storage;
 
 namespace Microsoft.Data.Entity.Query
@@ -12,6 +13,6 @@ namespace Microsoft.Data.Entity.Query
     public interface IAsyncIncludeRelatedValuesStrategy : IDisposable
     {
         IAsyncEnumerable<EntityLoadInfo> GetRelatedValues(
-            [NotNull] EntityKey key, [NotNull] Func<ValueBuffer, EntityKey> keyFactory);
+            [NotNull] IKeyValue keyValue, [NotNull] Func<ValueBuffer, IKeyValue> keyFactory);
     }
 }

--- a/src/EntityFramework.Relational/Query/IIncludeRelatedValuesStrategy.cs
+++ b/src/EntityFramework.Relational/Query/IIncludeRelatedValuesStrategy.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Storage;
 
 namespace Microsoft.Data.Entity.Query
@@ -12,6 +13,6 @@ namespace Microsoft.Data.Entity.Query
     public interface IIncludeRelatedValuesStrategy : IDisposable
     {
         IEnumerable<EntityLoadInfo> GetRelatedValues(
-            [NotNull] EntityKey key, [NotNull] Func<ValueBuffer, EntityKey> keyFactory);
+            [NotNull] IKeyValue keyValue, [NotNull] Func<ValueBuffer, IKeyValue> keyFactory);
     }
 }

--- a/src/EntityFramework.Relational/Query/Internal/AsyncIncludeCollectionIterator.cs
+++ b/src/EntityFramework.Relational/Query/Internal/AsyncIncludeCollectionIterator.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Storage;
 
 namespace Microsoft.Data.Entity.Query.Internal
@@ -25,23 +26,23 @@ namespace Microsoft.Data.Entity.Query.Internal
         }
 
         public virtual IAsyncEnumerable<ValueBuffer> GetRelatedValues(
-            [NotNull] EntityKey primaryKey,
-            [NotNull] Func<ValueBuffer, EntityKey> relatedKeyFactory)
-            => new RelatedValuesEnumerable(this, primaryKey, relatedKeyFactory);
+            [NotNull] IKeyValue primaryKeyValue,
+            [NotNull] Func<ValueBuffer, IKeyValue> relatedKeyFactory)
+            => new RelatedValuesEnumerable(this, primaryKeyValue, relatedKeyFactory);
 
         private sealed class RelatedValuesEnumerable : IAsyncEnumerable<ValueBuffer>
         {
             private readonly AsyncIncludeCollectionIterator _iterator;
-            private readonly EntityKey _primaryKey;
-            private readonly Func<ValueBuffer, EntityKey> _relatedKeyFactory;
+            private readonly IKeyValue _primaryKeyValue;
+            private readonly Func<ValueBuffer, IKeyValue> _relatedKeyFactory;
 
             public RelatedValuesEnumerable(
                 AsyncIncludeCollectionIterator iterator,
-                EntityKey primaryKey,
-                Func<ValueBuffer, EntityKey> relatedKeyFactory)
+                IKeyValue primaryKeyValue,
+                Func<ValueBuffer, IKeyValue> relatedKeyFactory)
             {
                 _iterator = iterator;
-                _primaryKey = primaryKey;
+                _primaryKeyValue = primaryKeyValue;
                 _relatedKeyFactory = relatedKeyFactory;
             }
 
@@ -71,7 +72,7 @@ namespace Microsoft.Data.Entity.Query.Internal
                     if (_relatedValuesEnumerable._iterator._hasRemainingRows
                         && _relatedValuesEnumerable._relatedKeyFactory(
                             _relatedValuesEnumerable._iterator._relatedValuesEnumerator.Current)
-                            .Equals(_relatedValuesEnumerable._primaryKey))
+                            .Equals(_relatedValuesEnumerable._primaryKeyValue))
                     {
                         Current = _relatedValuesEnumerable._iterator._relatedValuesEnumerator.Current;
 

--- a/src/EntityFramework.Relational/Query/Internal/IncludeCollectionIterator.cs
+++ b/src/EntityFramework.Relational/Query/Internal/IncludeCollectionIterator.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Storage;
 
 namespace Microsoft.Data.Entity.Query.Internal
@@ -22,8 +23,8 @@ namespace Microsoft.Data.Entity.Query.Internal
         }
 
         public virtual IEnumerable<ValueBuffer> GetRelatedValues(
-            [NotNull] EntityKey primaryKey,
-            [NotNull] Func<ValueBuffer, EntityKey> relatedKeyFactory)
+            [NotNull] IKeyValue primaryKeyValue,
+            [NotNull] Func<ValueBuffer, IKeyValue> relatedKeyFactory)
         {
             if (!_initialized)
             {
@@ -32,7 +33,7 @@ namespace Microsoft.Data.Entity.Query.Internal
             }
 
             while (_hasRemainingRows
-                   && relatedKeyFactory(_relatedValuesEnumerator.Current).Equals(primaryKey))
+                   && relatedKeyFactory(_relatedValuesEnumerator.Current).Equals(primaryKeyValue))
             {
                 yield return _relatedValuesEnumerator.Current;
 

--- a/src/EntityFramework.Relational/Query/Internal/RelationalQueryContextFactory.cs
+++ b/src/EntityFramework.Relational/Query/Internal/RelationalQueryContextFactory.cs
@@ -14,11 +14,11 @@ namespace Microsoft.Data.Entity.Query.Internal
 
         public RelationalQueryContextFactory(
             [NotNull] IStateManager stateManager,
-            [NotNull] IEntityKeyFactorySource entityKeyFactorySource,
+            [NotNull] IKeyValueFactorySource keyValueFactorySource,
             [NotNull] IClrCollectionAccessorSource collectionAccessorSource,
             [NotNull] IClrAccessorSource<IClrPropertySetter> propertySetterSource,
             [NotNull] IRelationalConnection connection)
-            : base(stateManager, entityKeyFactorySource, collectionAccessorSource, propertySetterSource)
+            : base(stateManager, keyValueFactorySource, collectionAccessorSource, propertySetterSource)
         {
             _connection = connection;
         }

--- a/src/EntityFramework.Relational/Query/QueryMethodProvider.cs
+++ b/src/EntityFramework.Relational/Query/QueryMethodProvider.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Query.Internal;
 using Microsoft.Data.Entity.Storage;
@@ -209,7 +210,7 @@ namespace Microsoft.Data.Entity.Query
                 _materializer = materializer;
             }
 
-            public IEnumerable<EntityLoadInfo> GetRelatedValues(EntityKey key, Func<ValueBuffer, EntityKey> keyFactory)
+            public IEnumerable<EntityLoadInfo> GetRelatedValues(IKeyValue keyValue, Func<ValueBuffer, IKeyValue> keyFactory)
             {
                 var valueBuffer = _queryContext.GetIncludeValueBuffer(_queryIndex).WithOffset(_valueBufferOffset);
 
@@ -247,11 +248,11 @@ namespace Microsoft.Data.Entity.Query
                     = new IncludeCollectionIterator(relatedValueBuffers.GetEnumerator());
             }
 
-            public IEnumerable<EntityLoadInfo> GetRelatedValues(EntityKey key, Func<ValueBuffer, EntityKey> keyFactory)
+            public IEnumerable<EntityLoadInfo> GetRelatedValues(IKeyValue keyValue, Func<ValueBuffer, IKeyValue> keyFactory)
             {
                 return
                     _includeCollectionIterator
-                        .GetRelatedValues(key, keyFactory)
+                        .GetRelatedValues(keyValue, keyFactory)
                         .Select(vr => new EntityLoadInfo(vr, _materializer));
             }
 

--- a/src/EntityFramework.Relational/Storage/RelationalDatabase.cs
+++ b/src/EntityFramework.Relational/Storage/RelationalDatabase.cs
@@ -35,14 +35,14 @@ namespace Microsoft.Data.Entity.Storage
         }
 
         public override int SaveChanges(
-            IReadOnlyList<InternalEntityEntry> entries)
+            IReadOnlyList<IUpdateEntry> entries)
             => _batchExecutor.Execute(
                 _batchPreparer.BatchCommands(
                     Check.NotNull(entries, nameof(entries))),
                 _connection);
 
         public override Task<int> SaveChangesAsync(
-            IReadOnlyList<InternalEntityEntry> entries,
+            IReadOnlyList<IUpdateEntry> entries,
             CancellationToken cancellationToken = default(CancellationToken))
             => _batchExecutor.ExecuteAsync(
                 _batchPreparer.BatchCommands(

--- a/src/EntityFramework.Relational/Update/AffectedCountModificationCommandBatch.cs
+++ b/src/EntityFramework.Relational/Update/AffectedCountModificationCommandBatch.cs
@@ -247,9 +247,9 @@ namespace Microsoft.Data.Entity.Update
             return commandIndex;
         }
 
-        private IReadOnlyList<InternalEntityEntry> AggregateEntries(int endIndex, int commandCount)
+        private IReadOnlyList<IUpdateEntry> AggregateEntries(int endIndex, int commandCount)
         {
-            var entries = new List<InternalEntityEntry>();
+            var entries = new List<IUpdateEntry>();
             for (var i = endIndex - commandCount; i < endIndex; i++)
             {
                 entries.AddRange(ModificationCommands[i].Entries);

--- a/src/EntityFramework.Relational/Update/ColumnModification.cs
+++ b/src/EntityFramework.Relational/Update/ColumnModification.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Data.Entity.Update
         private readonly LazyRef<string> _outputParameterName;
 
         public ColumnModification(
-            [NotNull] InternalEntityEntry entry,
+            [NotNull] IUpdateEntry entry,
             [NotNull] IProperty property,
             [NotNull] IRelationalPropertyAnnotations propertyAnnotations,
             [NotNull] ParameterNameGenerator parameterNameGenerator,
@@ -51,7 +51,7 @@ namespace Microsoft.Data.Entity.Update
             IsCondition = isCondition;
         }
 
-        public virtual InternalEntityEntry Entry { get; }
+        public virtual IUpdateEntry Entry { get; }
 
         public virtual IProperty Property { get; }
 
@@ -74,8 +74,7 @@ namespace Microsoft.Data.Entity.Update
 
         public virtual string ColumnName { get; }
 
-        public virtual object OriginalValue
-            => Entry.OriginalValues.CanStoreValue(Property) ? Entry.OriginalValues[Property] : Value;
+        public virtual object OriginalValue => Entry.GetOriginalValue(Property);
 
         public virtual object Value
         {

--- a/src/EntityFramework.Relational/Update/ICommandBatchPreparer.cs
+++ b/src/EntityFramework.Relational/Update/ICommandBatchPreparer.cs
@@ -9,6 +9,6 @@ namespace Microsoft.Data.Entity.Update
 {
     public interface ICommandBatchPreparer
     {
-        IEnumerable<ModificationCommandBatch> BatchCommands([NotNull] IReadOnlyList<InternalEntityEntry> entries);
+        IEnumerable<ModificationCommandBatch> BatchCommands([NotNull] IReadOnlyList<IUpdateEntry> entries);
     }
 }

--- a/src/EntityFramework.Relational/Update/ModificationCommand.cs
+++ b/src/EntityFramework.Relational/Update/ModificationCommand.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Data.Entity.Update
         private readonly Func<IProperty, IRelationalPropertyAnnotations> _getPropertyExtensions;
         private readonly ParameterNameGenerator _parameterNameGenerator;
 
-        private readonly List<InternalEntityEntry> _entries = new List<InternalEntityEntry>();
+        private readonly List<IUpdateEntry> _entries = new List<IUpdateEntry>();
 
         private readonly LazyRef<IReadOnlyList<ColumnModification>> _columnModifications
             = new LazyRef<IReadOnlyList<ColumnModification>>(() => new ColumnModification[0]);
@@ -45,7 +45,7 @@ namespace Microsoft.Data.Entity.Update
 
         public virtual string Schema { get; }
 
-        public virtual IReadOnlyList<InternalEntityEntry> Entries => _entries;
+        public virtual IReadOnlyList<IUpdateEntry> Entries => _entries;
 
         public virtual EntityState EntityState => _entries.FirstOrDefault()?.EntityState ?? EntityState.Detached;
 
@@ -61,7 +61,7 @@ namespace Microsoft.Data.Entity.Update
             }
         }
 
-        public virtual void AddEntry([NotNull] InternalEntityEntry entry)
+        public virtual void AddEntry([NotNull] IUpdateEntry entry)
         {
             Check.NotNull(entry, nameof(entry));
 
@@ -99,8 +99,8 @@ namespace Microsoft.Data.Entity.Update
                 {
                     var isKey = property.IsPrimaryKey();
                     var isCondition = !adding && (isKey || property.IsConcurrencyToken);
-                    var readValue = entry.StoreMustGenerateValue(property);
-                    var writeValue = !readValue && (adding || entry.IsPropertyModified(property));
+                    var readValue = entry.IsStoreGenerated(property);
+                    var writeValue = !readValue && (adding || entry.IsModified(property));
 
                     if (readValue
                         || writeValue

--- a/test/EntityFramework.Core.FunctionalTests/FixupTest.cs
+++ b/test/EntityFramework.Core.FunctionalTests/FixupTest.cs
@@ -60,30 +60,30 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
                 var stateManager = context.ChangeTracker.GetService();
 
-                stateManager.StartTracking(categoryType, new SimpleEntityKey<int>(categoryType.FindPrimaryKey(), 11), new Category { Id = 11 }, new ValueBuffer(new object[] { 11 }));
-                stateManager.StartTracking(categoryType, new SimpleEntityKey<int>(categoryType.FindPrimaryKey(), 12), new Category { Id = 12 }, new ValueBuffer(new object[] { 12 }));
-                stateManager.StartTracking(categoryType, new SimpleEntityKey<int>(categoryType.FindPrimaryKey(), 13), new Category { Id = 13 }, new ValueBuffer(new object[] { 13 }));
+                stateManager.StartTracking(categoryType, new SimpleKeyValue<int>(categoryType.FindPrimaryKey(), 11), new Category { Id = 11 }, new ValueBuffer(new object[] { 11 }));
+                stateManager.StartTracking(categoryType, new SimpleKeyValue<int>(categoryType.FindPrimaryKey(), 12), new Category { Id = 12 }, new ValueBuffer(new object[] { 12 }));
+                stateManager.StartTracking(categoryType, new SimpleKeyValue<int>(categoryType.FindPrimaryKey(), 13), new Category { Id = 13 }, new ValueBuffer(new object[] { 13 }));
 
-                stateManager.StartTracking(productType, new SimpleEntityKey<int>(productType.FindPrimaryKey(), 21), new Product { Id = 21, CategoryId = 11 }, new ValueBuffer(new object[] { 21, 11 }));
+                stateManager.StartTracking(productType, new SimpleKeyValue<int>(productType.FindPrimaryKey(), 21), new Product { Id = 21, CategoryId = 11 }, new ValueBuffer(new object[] { 21, 11 }));
                 AssertAllFixedUp(context);
-                stateManager.StartTracking(productType, new SimpleEntityKey<int>(productType.FindPrimaryKey(), 22), new Product { Id = 22, CategoryId = 11 }, new ValueBuffer(new object[] { 22, 11 }));
+                stateManager.StartTracking(productType, new SimpleKeyValue<int>(productType.FindPrimaryKey(), 22), new Product { Id = 22, CategoryId = 11 }, new ValueBuffer(new object[] { 22, 11 }));
                 AssertAllFixedUp(context);
-                stateManager.StartTracking(productType, new SimpleEntityKey<int>(productType.FindPrimaryKey(), 23), new Product { Id = 23, CategoryId = 11 }, new ValueBuffer(new object[] { 23, 11 }));
+                stateManager.StartTracking(productType, new SimpleKeyValue<int>(productType.FindPrimaryKey(), 23), new Product { Id = 23, CategoryId = 11 }, new ValueBuffer(new object[] { 23, 11 }));
                 AssertAllFixedUp(context);
-                stateManager.StartTracking(productType, new SimpleEntityKey<int>(productType.FindPrimaryKey(), 24), new Product { Id = 24, CategoryId = 12 }, new ValueBuffer(new object[] { 24, 12 }));
+                stateManager.StartTracking(productType, new SimpleKeyValue<int>(productType.FindPrimaryKey(), 24), new Product { Id = 24, CategoryId = 12 }, new ValueBuffer(new object[] { 24, 12 }));
                 AssertAllFixedUp(context);
-                stateManager.StartTracking(productType, new SimpleEntityKey<int>(productType.FindPrimaryKey(), 25), new Product { Id = 25, CategoryId = 12 }, new ValueBuffer(new object[] { 25, 12 }));
+                stateManager.StartTracking(productType, new SimpleKeyValue<int>(productType.FindPrimaryKey(), 25), new Product { Id = 25, CategoryId = 12 }, new ValueBuffer(new object[] { 25, 12 }));
                 AssertAllFixedUp(context);
 
-                stateManager.StartTracking(offerType, new SimpleEntityKey<int>(offerType.FindPrimaryKey(), 31), new SpecialOffer { Id = 31, ProductId = 22 }, new ValueBuffer(new object[] { 31, 22 }));
+                stateManager.StartTracking(offerType, new SimpleKeyValue<int>(offerType.FindPrimaryKey(), 31), new SpecialOffer { Id = 31, ProductId = 22 }, new ValueBuffer(new object[] { 31, 22 }));
                 AssertAllFixedUp(context);
-                stateManager.StartTracking(offerType, new SimpleEntityKey<int>(offerType.FindPrimaryKey(), 32), new SpecialOffer { Id = 32, ProductId = 22 }, new ValueBuffer(new object[] { 32, 22 }));
+                stateManager.StartTracking(offerType, new SimpleKeyValue<int>(offerType.FindPrimaryKey(), 32), new SpecialOffer { Id = 32, ProductId = 22 }, new ValueBuffer(new object[] { 32, 22 }));
                 AssertAllFixedUp(context);
-                stateManager.StartTracking(offerType, new SimpleEntityKey<int>(offerType.FindPrimaryKey(), 33), new SpecialOffer { Id = 33, ProductId = 24 }, new ValueBuffer(new object[] { 33, 24 }));
+                stateManager.StartTracking(offerType, new SimpleKeyValue<int>(offerType.FindPrimaryKey(), 33), new SpecialOffer { Id = 33, ProductId = 24 }, new ValueBuffer(new object[] { 33, 24 }));
                 AssertAllFixedUp(context);
-                stateManager.StartTracking(offerType, new SimpleEntityKey<int>(offerType.FindPrimaryKey(), 34), new SpecialOffer { Id = 34, ProductId = 24 }, new ValueBuffer(new object[] { 34, 24 }));
+                stateManager.StartTracking(offerType, new SimpleKeyValue<int>(offerType.FindPrimaryKey(), 34), new SpecialOffer { Id = 34, ProductId = 24 }, new ValueBuffer(new object[] { 34, 24 }));
                 AssertAllFixedUp(context);
-                stateManager.StartTracking(offerType, new SimpleEntityKey<int>(offerType.FindPrimaryKey(), 35), new SpecialOffer { Id = 35, ProductId = 24 }, new ValueBuffer(new object[] { 35, 24 }));
+                stateManager.StartTracking(offerType, new SimpleKeyValue<int>(offerType.FindPrimaryKey(), 35), new SpecialOffer { Id = 35, ProductId = 24 }, new ValueBuffer(new object[] { 35, 24 }));
 
                 AssertAllFixedUp(context);
 

--- a/test/EntityFramework.Core.FunctionalTests/ThrowingMonsterStateManager.cs
+++ b/test/EntityFramework.Core.FunctionalTests/ThrowingMonsterStateManager.cs
@@ -19,8 +19,9 @@ namespace Microsoft.Data.Entity.FunctionalTests
             IInternalEntityEntryNotifier notifier,
             IValueGenerationManager valueGeneration,
             IModel model,
-            IDatabase database)
-            : base(factory, subscriber, notifier, valueGeneration, model, database)
+            IDatabase database,
+            DbContext context)
+            : base(factory, subscriber, notifier, valueGeneration, model, database, context)
         {
         }
 

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             changeDetector.DetectChanges(entry);
 
             Assert.Equal(EntityState.Modified, entry.EntityState);
-            Assert.True(entry.IsPropertyModified(entry.EntityType.GetProperty("Name")));
+            Assert.True(entry.IsModified(entry.EntityType.GetProperty("Name")));
         }
 
         [Fact]
@@ -170,7 +170,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             changeDetector.DetectChanges(entry);
 
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
-            Assert.False(entry.IsPropertyModified(entry.EntityType.GetProperty("Name")));
+            Assert.False(entry.IsModified(entry.EntityType.GetProperty("Name")));
         }
 
         [Fact]
@@ -185,14 +185,14 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entry = stateManager.GetOrCreateEntry(category);
             entry.SetEntityState(EntityState.Added);
 
-            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType.GetPrimaryKey(), -1)));
+            Assert.Same(entry, stateManager.TryGetEntry(new SimpleKeyValue<int>(entry.EntityType.GetPrimaryKey(), -1)));
 
             category.PrincipalId = 78;
 
             changeDetector.DetectChanges(entry);
 
             Assert.Equal(78, entry.RelationshipsSnapshot[entry.EntityType.GetProperty("PrincipalId")]);
-            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType.GetPrimaryKey(), -1)));
+            Assert.Same(entry, stateManager.TryGetEntry(new SimpleKeyValue<int>(entry.EntityType.GetPrimaryKey(), -1)));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -293,14 +293,14 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entry = stateManager.GetOrCreateEntry(category);
             entry.SetEntityState(EntityState.Added);
 
-            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType.GetPrimaryKey(), -1)));
+            Assert.Same(entry, stateManager.TryGetEntry(new SimpleKeyValue<int>(entry.EntityType.GetPrimaryKey(), -1)));
 
             category.Id = 78;
 
             changeDetector.DetectChanges(entry);
 
             Assert.Equal(78, entry.RelationshipsSnapshot[entry.EntityType.GetProperty("Id")]);
-            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType.GetPrimaryKey(), 78)));
+            Assert.Same(entry, stateManager.TryGetEntry(new SimpleKeyValue<int>(entry.EntityType.GetPrimaryKey(), 78)));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -329,7 +329,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entry = stateManager.GetOrCreateEntry(category);
             entry.SetEntityState(EntityState.Added);
 
-            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType.GetPrimaryKey(), -1)));
+            Assert.Same(entry, stateManager.TryGetEntry(new SimpleKeyValue<int>(entry.EntityType.GetPrimaryKey(), -1)));
 
             var property = entry.EntityType.GetProperty("Id");
             var sidecar = entry.AddSidecar(storeGeneratedValuesFactory.Create(entry, entry.EntityType.GetProperties()));
@@ -341,7 +341,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             Assert.Equal(78, entry.RelationshipsSnapshot[property]);
 
-            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType.GetPrimaryKey(), 78)));
+            Assert.Same(entry, stateManager.TryGetEntry(new SimpleKeyValue<int>(entry.EntityType.GetPrimaryKey(), 78)));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -369,14 +369,14 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entry = stateManager.GetOrCreateEntry(category);
             entry.SetEntityState(EntityState.Added);
 
-            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType.GetPrimaryKey(), -1)));
+            Assert.Same(entry, stateManager.TryGetEntry(new SimpleKeyValue<int>(entry.EntityType.GetPrimaryKey(), -1)));
 
             category.PrincipalId = 77;
 
             changeDetector.DetectChanges(entry);
 
             Assert.Equal(77, entry.RelationshipsSnapshot[entry.EntityType.GetProperty("PrincipalId")]);
-            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType.GetPrimaryKey(), -1)));
+            Assert.Same(entry, stateManager.TryGetEntry(new SimpleKeyValue<int>(entry.EntityType.GetPrimaryKey(), -1)));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -835,14 +835,14 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entry = stateManager.GetOrCreateEntry(product);
             entry.SetEntityState(EntityState.Added);
 
-            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType.GetPrimaryKey(), 77)));
+            Assert.Same(entry, stateManager.TryGetEntry(new SimpleKeyValue<int>(entry.EntityType.GetPrimaryKey(), 77)));
 
             product.Id = 78;
 
             changeDetector.DetectChanges(entry);
 
             Assert.Equal(77, entry.RelationshipsSnapshot[entry.EntityType.GetProperty("Id")]);
-            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType.GetPrimaryKey(), 77)));
+            Assert.Same(entry, stateManager.TryGetEntry(new SimpleKeyValue<int>(entry.EntityType.GetPrimaryKey(), 77)));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -1198,12 +1198,12 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entry = stateManager.GetOrCreateEntry(category);
             entry.SetEntityState(EntityState.Added);
 
-            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType.GetPrimaryKey(), -1)));
+            Assert.Same(entry, stateManager.TryGetEntry(new SimpleKeyValue<int>(entry.EntityType.GetPrimaryKey(), -1)));
 
             category.PrincipalId = 78;
 
             Assert.Equal(78, entry.RelationshipsSnapshot[entry.EntityType.GetProperty("PrincipalId")]);
-            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType.GetPrimaryKey(), -1)));
+            Assert.Same(entry, stateManager.TryGetEntry(new SimpleKeyValue<int>(entry.EntityType.GetPrimaryKey(), -1)));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -1262,12 +1262,12 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entry = stateManager.GetOrCreateEntry(category);
             entry.SetEntityState(EntityState.Added);
 
-            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType.GetPrimaryKey(), -1)));
+            Assert.Same(entry, stateManager.TryGetEntry(new SimpleKeyValue<int>(entry.EntityType.GetPrimaryKey(), -1)));
 
             category.Id = 78;
 
             Assert.Equal(78, entry.RelationshipsSnapshot[entry.EntityType.GetProperty("Id")]);
-            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType.GetPrimaryKey(), 78)));
+            Assert.Same(entry, stateManager.TryGetEntry(new SimpleKeyValue<int>(entry.EntityType.GetPrimaryKey(), 78)));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -1295,12 +1295,12 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entry = stateManager.GetOrCreateEntry(category);
             entry.SetEntityState(EntityState.Added);
 
-            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType.GetPrimaryKey(), -1)));
+            Assert.Same(entry, stateManager.TryGetEntry(new SimpleKeyValue<int>(entry.EntityType.GetPrimaryKey(), -1)));
 
             category.PrincipalId = 77;
 
             Assert.Equal(77, entry.RelationshipsSnapshot[entry.EntityType.GetProperty("PrincipalId")]);
-            Assert.Same(entry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entry.EntityType.GetPrimaryKey(), -1)));
+            Assert.Same(entry, stateManager.TryGetEntry(new SimpleKeyValue<int>(entry.EntityType.GetPrimaryKey(), -1)));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/CompositeEntityKeyFactoryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/CompositeEntityKeyFactoryTest.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             var entry = stateManager.GetOrCreateEntry(entity);
 
-            var key = (CompositeEntityKey)new CompositeEntityKeyFactory(
+            var key = (CompositeKeyValue)new CompositeKeyValueFactory(
                 type.GetPrimaryKey())
                 .Create(type.GetPrimaryKey().Properties, entry);
 
@@ -43,7 +43,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             var entry = stateManager.GetOrCreateEntry(entity);
 
-            var key = (CompositeEntityKey)new CompositeEntityKeyFactory(
+            var key = (CompositeKeyValue)new CompositeKeyValueFactory(
                 type.GetPrimaryKey())
                 .Create(new[] { type.GetProperty("P6"), type.GetProperty("P5") }, entry);
 
@@ -65,7 +65,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var sidecar = new RelationshipsSnapshot(entry);
             sidecar[type.GetProperty("P4")] = 77;
 
-            var key = (CompositeEntityKey)new CompositeEntityKeyFactory(
+            var key = (CompositeKeyValue)new CompositeKeyValueFactory(
                 type.GetPrimaryKey())
                 .Create(new[] { type.GetProperty("P6"), type.GetProperty("P4"), type.GetProperty("P5") }, sidecar);
 
@@ -85,8 +85,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entry = stateManager.GetOrCreateEntry(entity);
 
             Assert.Equal(
-                EntityKey.InvalidEntityKey,
-                new CompositeEntityKeyFactory(
+                KeyValue.InvalidKeyValue,
+                new CompositeKeyValueFactory(
                     type.GetPrimaryKey())
                     .Create(type.GetPrimaryKey().Properties, entry));
         }
@@ -99,7 +99,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             var random = new Random();
 
-            var key = (CompositeEntityKey)new CompositeEntityKeyFactory(
+            var key = (CompositeKeyValue)new CompositeKeyValueFactory(
                 type.GetPrimaryKey())
                 .Create(type.GetPrimaryKey().Properties, new ValueBuffer(new object[] { 7, "Ate", random }));
 
@@ -114,7 +114,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             var random = new Random();
 
-            var key = (CompositeEntityKey)new CompositeEntityKeyFactory(
+            var key = (CompositeKeyValue)new CompositeKeyValueFactory(
                 type.GetPrimaryKey())
                 .Create(
                     new[] { type.GetProperty("P6"), type.GetProperty("P5") },
@@ -131,13 +131,13 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             var random = new Random();
 
-            var key = new CompositeEntityKeyFactory(
+            var key = new CompositeKeyValueFactory(
                 type.GetPrimaryKey())
                 .Create(
                     new[] { type.GetProperty("P6"), type.GetProperty("P5") },
                     new ValueBuffer(new object[] { 7, "Ate", random, 77, null, random }));
 
-            Assert.Equal(EntityKey.InvalidEntityKey, key);
+            Assert.Equal(KeyValue.InvalidKeyValue, key);
         }
 
         private static Model BuildModel()

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/CompositeEntityKeyTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/CompositeEntityKeyTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Moq;
 using Xunit;
@@ -14,16 +15,16 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Value_property_is_strongly_typed()
         {
-            Assert.IsType<object[]>(new CompositeEntityKey(new Mock<IKey>().Object, new object[] { 77, "Kake" }).Value);
+            Assert.IsType<object[]>(new CompositeKeyValue(new Mock<IKey>().Object, new object[] { 77, "Kake" }).Value);
         }
 
         [Fact]
         public void Base_class_value_property_returns_same_as_strongly_typed_value_property()
         {
-            var key = new CompositeEntityKey(new Mock<IKey>().Object, new object[] { 77, "Kake" });
+            var key = new CompositeKeyValue(new Mock<IKey>().Object, new object[] { 77, "Kake" });
 
             Assert.Equal(new object[] { 77, "Kake" }, key.Value);
-            Assert.Equal(new object[] { 77, "Kake" }, (object[])((EntityKey)key).Value);
+            Assert.Equal(new object[] { 77, "Kake" }, (object[])((IKeyValue)key).Value);
         }
 
         [Fact]
@@ -32,15 +33,15 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var key1 = new Mock<IKey>().Object;
             var key2 = new Mock<IKey>().Object;
 
-            Assert.True(new CompositeEntityKey(key1, new object[] { 77, "Kake" }).Equals(new CompositeEntityKey(key1, new object[] { 77, "Kake" })));
-            Assert.False(new CompositeEntityKey(key1, new object[] { 77, "Kake" }).Equals(null));
-            Assert.False(new CompositeEntityKey(key1, new object[] { 77 }).Equals(new SimpleEntityKey<int>(key1, 77)));
-            Assert.False(new CompositeEntityKey(key1, new object[] { 77, "Kake" }).Equals(new CompositeEntityKey(key1, new object[] { 77, "Lie" })));
-            Assert.False(new CompositeEntityKey(key1, new object[] { 77, "Kake" }).Equals(new CompositeEntityKey(key1, new object[] { 77L, "Kake" })));
-            Assert.False(new CompositeEntityKey(key1, new object[] { 77, "Kake" }).Equals(new CompositeEntityKey(key1, new object[] { null, "Kake" })));
-            Assert.False(new CompositeEntityKey(key1, new object[] { 77, "Kake" }).Equals(new CompositeEntityKey(key1, new object[] { 77, "Kake", 42 })));
-            Assert.False(new CompositeEntityKey(key1, new object[] { 77, "Kake" }).Equals(new CompositeEntityKey(key1, new object[] { 88, "Kake" })));
-            Assert.False(new CompositeEntityKey(key1, new object[] { 77, "Kake" }).Equals(new CompositeEntityKey(key2, new object[] { 77, "Kake" })));
+            Assert.True(new CompositeKeyValue(key1, new object[] { 77, "Kake" }).Equals(new CompositeKeyValue(key1, new object[] { 77, "Kake" })));
+            Assert.False(new CompositeKeyValue(key1, new object[] { 77, "Kake" }).Equals(null));
+            Assert.False(new CompositeKeyValue(key1, new object[] { 77 }).Equals(new SimpleKeyValue<int>(key1, 77)));
+            Assert.False(new CompositeKeyValue(key1, new object[] { 77, "Kake" }).Equals(new CompositeKeyValue(key1, new object[] { 77, "Lie" })));
+            Assert.False(new CompositeKeyValue(key1, new object[] { 77, "Kake" }).Equals(new CompositeKeyValue(key1, new object[] { 77L, "Kake" })));
+            Assert.False(new CompositeKeyValue(key1, new object[] { 77, "Kake" }).Equals(new CompositeKeyValue(key1, new object[] { null, "Kake" })));
+            Assert.False(new CompositeKeyValue(key1, new object[] { 77, "Kake" }).Equals(new CompositeKeyValue(key1, new object[] { 77, "Kake", 42 })));
+            Assert.False(new CompositeKeyValue(key1, new object[] { 77, "Kake" }).Equals(new CompositeKeyValue(key1, new object[] { 88, "Kake" })));
+            Assert.False(new CompositeKeyValue(key1, new object[] { 77, "Kake" }).Equals(new CompositeKeyValue(key2, new object[] { 77, "Kake" })));
         }
 
         [Fact]
@@ -49,12 +50,12 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var key1 = new Mock<IKey>().Object;
             var key2 = new Mock<IKey>().Object;
 
-            Assert.Equal(new CompositeEntityKey(key1, new object[] { 77, "Kake" }).GetHashCode(), new CompositeEntityKey(key1, new object[] { 77, "Kake" }).GetHashCode());
-            Assert.NotEqual(new CompositeEntityKey(key1, new object[] { 77, "Kake" }).GetHashCode(), new CompositeEntityKey(key1, new object[] { 77, "Lie" }).GetHashCode());
-            Assert.NotEqual(new CompositeEntityKey(key1, new object[] { 77, "Kake" }).GetHashCode(), new CompositeEntityKey(key1, new object[] { null, "Kake" }).GetHashCode());
-            Assert.NotEqual(new CompositeEntityKey(key1, new object[] { 77, "Kake" }).GetHashCode(), new CompositeEntityKey(key1, new object[] { 77, "Kake", 42 }).GetHashCode());
-            Assert.NotEqual(new CompositeEntityKey(key1, new object[] { 77, "Kake" }).GetHashCode(), new CompositeEntityKey(key1, new object[] { 88, "Kake" }).GetHashCode());
-            Assert.NotEqual(new CompositeEntityKey(key1, new object[] { 77, "Kake" }).GetHashCode(), new CompositeEntityKey(key2, new object[] { 77, "Kake" }).GetHashCode());
+            Assert.Equal(new CompositeKeyValue(key1, new object[] { 77, "Kake" }).GetHashCode(), new CompositeKeyValue(key1, new object[] { 77, "Kake" }).GetHashCode());
+            Assert.NotEqual(new CompositeKeyValue(key1, new object[] { 77, "Kake" }).GetHashCode(), new CompositeKeyValue(key1, new object[] { 77, "Lie" }).GetHashCode());
+            Assert.NotEqual(new CompositeKeyValue(key1, new object[] { 77, "Kake" }).GetHashCode(), new CompositeKeyValue(key1, new object[] { null, "Kake" }).GetHashCode());
+            Assert.NotEqual(new CompositeKeyValue(key1, new object[] { 77, "Kake" }).GetHashCode(), new CompositeKeyValue(key1, new object[] { 77, "Kake", 42 }).GetHashCode());
+            Assert.NotEqual(new CompositeKeyValue(key1, new object[] { 77, "Kake" }).GetHashCode(), new CompositeKeyValue(key1, new object[] { 88, "Kake" }).GetHashCode());
+            Assert.NotEqual(new CompositeKeyValue(key1, new object[] { 77, "Kake" }).GetHashCode(), new CompositeKeyValue(key2, new object[] { 77, "Kake" }).GetHashCode());
         }
 
         [Fact]
@@ -62,8 +63,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         {
             var key = new Mock<IKey>().Object;
 
-            Assert.True(new CompositeEntityKey(key, new object[] { new Byte[] { 1, 2, 3 } }).Equals(new CompositeEntityKey(key, new object[] { new Byte[] { 1, 2, 3 } })));
-            Assert.False(new CompositeEntityKey(key, new object[] { new Byte[] { 1, 2, 3 } }).Equals(new CompositeEntityKey(key, new object[] { new Byte[] { 3, 2, 3 } })));
+            Assert.True(new CompositeKeyValue(key, new object[] { new Byte[] { 1, 2, 3 } }).Equals(new CompositeKeyValue(key, new object[] { new Byte[] { 1, 2, 3 } })));
+            Assert.False(new CompositeKeyValue(key, new object[] { new Byte[] { 1, 2, 3 } }).Equals(new CompositeKeyValue(key, new object[] { new Byte[] { 3, 2, 3 } })));
         }
 
         [Fact]
@@ -71,8 +72,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         {
             var key = new Mock<IKey>().Object;
 
-            Assert.Equal(new CompositeEntityKey(key, new object[] { new Byte[] { 1, 2, 3 } }).GetHashCode(), new CompositeEntityKey(key, new object[] { new Byte[] { 1, 2, 3 } }).GetHashCode());
-            Assert.NotEqual(new CompositeEntityKey(key, new object[] { new Byte[] { 1, 2, 3 } }).GetHashCode(), new CompositeEntityKey(key, new object[] { new Byte[] { 3, 2, 3 } }).GetHashCode());
+            Assert.Equal(new CompositeKeyValue(key, new object[] { new Byte[] { 1, 2, 3 } }).GetHashCode(), new CompositeKeyValue(key, new object[] { new Byte[] { 1, 2, 3 } }).GetHashCode());
+            Assert.NotEqual(new CompositeKeyValue(key, new object[] { new Byte[] { 1, 2, 3 } }).GetHashCode(), new CompositeKeyValue(key, new object[] { new Byte[] { 3, 2, 3 } }).GetHashCode());
         }
     }
 }

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/EntityKeyFactorySourceTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/EntityKeyFactorySourceTest.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         {
             var key = GetEntityType().GetPrimaryKey();
 
-            Assert.IsType<SimpleEntityKeyFactory<int>>(CreateKeyFactorySource().GetKeyFactory(key));
+            Assert.IsType<SimpleKeyValueFactory<int>>(CreateKeyFactorySource().GetKeyFactory(key));
         }
 
         [Fact]
@@ -24,7 +24,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entityType = GetEntityType();
             var key = entityType.GetKey(entityType.GetProperty("NullableInt"));
 
-            Assert.IsType<SimpleEntityKeyFactory<int>>(CreateKeyFactorySource().GetKeyFactory(key));
+            Assert.IsType<SimpleKeyValueFactory<int>>(CreateKeyFactorySource().GetKeyFactory(key));
         }
 
         [Fact]
@@ -65,7 +65,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entityType = GetEntityType();
             var key = entityType.GetKey(new[] { entityType.GetProperty("Id"), entityType.GetProperty("String") });
 
-            Assert.IsType<CompositeEntityKeyFactory>(
+            Assert.IsType<CompositeKeyValueFactory>(
                 CreateKeyFactorySource().GetKeyFactory(key));
         }
 
@@ -86,7 +86,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entityType = GetEntityType();
             var key = entityType.GetKey(entityType.GetProperty("String"));
 
-            Assert.IsType<SimpleEntityKeyFactory<string>>(CreateKeyFactorySource().GetKeyFactory(key));
+            Assert.IsType<SimpleKeyValueFactory<string>>(CreateKeyFactorySource().GetKeyFactory(key));
         }
 
         [Fact]
@@ -95,7 +95,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entityType = GetEntityType();
             var key = entityType.GetKey(entityType.GetProperty("ByteArray"));
 
-            Assert.IsType<CompositeEntityKeyFactory>(CreateKeyFactorySource().GetKeyFactory(key));
+            Assert.IsType<CompositeKeyValueFactory>(CreateKeyFactorySource().GetKeyFactory(key));
         }
 
         [Fact]
@@ -108,7 +108,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             Assert.Same(factorySource.GetKeyFactory(key), factorySource.GetKeyFactory(key));
         }
 
-        private static IEntityKeyFactorySource CreateKeyFactorySource() => new EntityKeyFactorySource();
+        private static IKeyValueFactorySource CreateKeyFactorySource() => new KeyValueFactorySource();
 
         private static IEntityType GetEntityType()
         {

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/EntityKeyTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/EntityKeyTest.cs
@@ -12,12 +12,12 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Value_property_calls_template_method()
         {
-            Assert.Equal("Kake", new ConcreteKey(null).Value);
+            Assert.Equal("Kake", new ConcreteKeyValue(null).Value);
         }
 
-        public class ConcreteKey : EntityKey
+        public class ConcreteKeyValue : KeyValue
         {
-            public ConcreteKey(IKey key)
+            public ConcreteKeyValue(IKey key)
                 : base(key)
             {
             }

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalClrEntityEntryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalClrEntityEntryTest.cs
@@ -110,15 +110,17 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var idProperty = entityType.GetProperty("Id");
             var configuration = TestHelpers.Instance.CreateContextServices(model);
 
-            var entry = CreateInternalEntry(configuration, entityType, new ValueBuffer(new object[] { 1, "Kool" }));
+            var entry = CreateInternalEntry(
+                configuration, 
+                entityType, 
+                new FullNotificationEntity { Id = 1, Name = "Kool" }, 
+                new ValueBuffer(new object[] { 1, "Kool" }));
 
             Assert.Equal(
                 CoreStrings.OriginalValueNotTracked("Id", typeof(FullNotificationEntity).FullName),
                 Assert.Throws<InvalidOperationException>(() => entry.OriginalValues[idProperty] = 1).Message);
 
-            Assert.Equal(
-                CoreStrings.OriginalValueNotTracked("Id", typeof(FullNotificationEntity).FullName),
-                Assert.Throws<InvalidOperationException>(() => entry.OriginalValues[idProperty]).Message);
+            Assert.Equal(1, entry.OriginalValues[idProperty]);
         }
 
         [Fact]

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntityEntryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntityEntryTest.cs
@@ -11,6 +11,7 @@ using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.ValueGeneration;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
+using Microsoft.Data.Entity.Update;
 using Microsoft.Data.Entity.ValueGeneration.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
@@ -88,24 +89,24 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var entry = CreateInternalEntry(configuration, entityType, new SomeEntity());
             entry[keyProperty] = 1;
 
-            Assert.False(entry.IsPropertyModified(keyProperty));
-            Assert.False(entry.IsPropertyModified(nonKeyProperty));
+            Assert.False(entry.IsModified(keyProperty));
+            Assert.False(entry.IsModified(nonKeyProperty));
 
             entry.SetEntityState(EntityState.Modified);
 
-            Assert.False(entry.IsPropertyModified(keyProperty));
-            Assert.True(entry.IsPropertyModified(nonKeyProperty));
+            Assert.False(entry.IsModified(keyProperty));
+            Assert.True(entry.IsModified(nonKeyProperty));
 
             entry.SetEntityState(EntityState.Unchanged, true);
 
-            Assert.False(entry.IsPropertyModified(keyProperty));
-            Assert.False(entry.IsPropertyModified(nonKeyProperty));
+            Assert.False(entry.IsModified(keyProperty));
+            Assert.False(entry.IsModified(nonKeyProperty));
 
             entry.SetPropertyModified(nonKeyProperty);
 
             Assert.Equal(EntityState.Modified, entry.EntityState);
-            Assert.False(entry.IsPropertyModified(keyProperty));
-            Assert.True(entry.IsPropertyModified(nonKeyProperty));
+            Assert.False(entry.IsModified(keyProperty));
+            Assert.True(entry.IsModified(nonKeyProperty));
         }
 
         [Fact]
@@ -155,15 +156,15 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             entry.SetEntityState(EntityState.Modified);
 
-            Assert.False(entry.IsPropertyModified(nonKeyProperty));
+            Assert.False(entry.IsModified(nonKeyProperty));
 
             entry.SetEntityState(EntityState.Unchanged, true);
 
-            Assert.False(entry.IsPropertyModified(nonKeyProperty));
+            Assert.False(entry.IsModified(nonKeyProperty));
 
             entry.SetPropertyModified(nonKeyProperty);
 
-            Assert.True(entry.IsPropertyModified(nonKeyProperty));
+            Assert.True(entry.IsModified(nonKeyProperty));
 
             Assert.Equal(
                 CoreStrings.PropertyReadOnlyAfterSave("Name", typeof(SomeEntity).Name),
@@ -173,7 +174,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             entry[nonKeyProperty] = "Beanjilly";
 
-            Assert.True(entry.IsPropertyModified(nonKeyProperty));
+            Assert.True(entry.IsModified(nonKeyProperty));
 
             Assert.Equal(
                 CoreStrings.PropertyReadOnlyAfterSave("Name", typeof(SomeEntity).Name),
@@ -194,18 +195,18 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             entry.SetEntityState(EntityState.Modified);
 
-            Assert.False(entry.IsPropertyModified(keyProperty));
+            Assert.False(entry.IsModified(keyProperty));
 
             entry.SetEntityState(EntityState.Unchanged, true);
 
-            Assert.False(entry.IsPropertyModified(keyProperty));
+            Assert.False(entry.IsModified(keyProperty));
 
             Assert.Equal(
                 CoreStrings.KeyReadOnly("Id", typeof(SomeEntity).Name),
                 Assert.Throws<NotSupportedException>(() => entry.SetPropertyModified(keyProperty)).Message);
 
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
-            Assert.False(entry.IsPropertyModified(keyProperty));
+            Assert.False(entry.IsModified(keyProperty));
 
             Assert.Equal(
                 CoreStrings.KeyReadOnly("Id", typeof(SomeEntity).Name),
@@ -213,7 +214,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
 
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
-            Assert.False(entry.IsPropertyModified(keyProperty));
+            Assert.False(entry.IsModified(keyProperty));
         }
 
         [Fact]
@@ -230,30 +231,30 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             Assert.False(entry.HasTemporaryValue(keyProperty));
             Assert.False(entry.HasTemporaryValue(nonKeyProperty));
-            Assert.False(entry.IsPropertyModified(keyProperty));
-            Assert.False(entry.IsPropertyModified(nonKeyProperty));
+            Assert.False(entry.IsModified(keyProperty));
+            Assert.False(entry.IsModified(nonKeyProperty));
 
             entry.SetEntityState(EntityState.Added);
 
             Assert.False(entry.HasTemporaryValue(keyProperty));
             Assert.False(entry.HasTemporaryValue(nonKeyProperty));
-            Assert.False(entry.IsPropertyModified(keyProperty));
-            Assert.False(entry.IsPropertyModified(nonKeyProperty));
+            Assert.False(entry.IsModified(keyProperty));
+            Assert.False(entry.IsModified(nonKeyProperty));
 
             entry.MarkAsTemporary(keyProperty);
 
             Assert.True(entry.HasTemporaryValue(keyProperty));
             Assert.False(entry.HasTemporaryValue(nonKeyProperty));
-            Assert.False(entry.IsPropertyModified(keyProperty));
-            Assert.False(entry.IsPropertyModified(nonKeyProperty));
+            Assert.False(entry.IsModified(keyProperty));
+            Assert.False(entry.IsModified(nonKeyProperty));
 
             entry.MarkAsTemporary(nonKeyProperty);
             entry.MarkAsTemporary(keyProperty, isTemporary: false);
 
             Assert.False(entry.HasTemporaryValue(keyProperty));
             Assert.True(entry.HasTemporaryValue(nonKeyProperty));
-            Assert.False(entry.IsPropertyModified(keyProperty));
-            Assert.False(entry.IsPropertyModified(nonKeyProperty));
+            Assert.False(entry.IsModified(keyProperty));
+            Assert.False(entry.IsModified(nonKeyProperty));
 
             entry[nonKeyProperty] = "I Am A Real Person!";
 
@@ -261,23 +262,23 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             Assert.False(entry.HasTemporaryValue(keyProperty));
             Assert.False(entry.HasTemporaryValue(nonKeyProperty));
-            Assert.False(entry.IsPropertyModified(keyProperty));
-            Assert.False(entry.IsPropertyModified(nonKeyProperty));
+            Assert.False(entry.IsModified(keyProperty));
+            Assert.False(entry.IsModified(nonKeyProperty));
 
             entry.MarkAsTemporary(keyProperty);
             entry.MarkAsTemporary(nonKeyProperty);
 
             Assert.False(entry.HasTemporaryValue(keyProperty));
             Assert.False(entry.HasTemporaryValue(nonKeyProperty));
-            Assert.False(entry.IsPropertyModified(keyProperty));
-            Assert.False(entry.IsPropertyModified(nonKeyProperty));
+            Assert.False(entry.IsModified(keyProperty));
+            Assert.False(entry.IsModified(nonKeyProperty));
 
             entry.SetEntityState(EntityState.Added);
 
             Assert.False(entry.HasTemporaryValue(keyProperty));
             Assert.False(entry.HasTemporaryValue(nonKeyProperty));
-            Assert.False(entry.IsPropertyModified(keyProperty));
-            Assert.False(entry.IsPropertyModified(nonKeyProperty));
+            Assert.False(entry.IsModified(keyProperty));
+            Assert.False(entry.IsModified(nonKeyProperty));
         }
 
         [Theory]
@@ -471,7 +472,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             entry[keyProperty] = 77;
 
             var keyValue = entry.GetPrimaryKeyValue();
-            Assert.IsType<SimpleEntityKey<int>>(keyValue);
+            Assert.IsType<SimpleKeyValue<int>>(keyValue);
             Assert.Equal(77, keyValue.Value);
             Assert.Same(entityType.GetPrimaryKey(), keyValue.Key);
         }
@@ -488,7 +489,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             entry[keyProperties[0]] = 77;
             entry[keyProperties[1]] = "SmokeyBacon";
 
-            var keyValue = (CompositeEntityKey)entry.GetPrimaryKeyValue();
+            var keyValue = (CompositeKeyValue)entry.GetPrimaryKeyValue();
             Assert.Equal(77, keyValue.Value[0]);
             Assert.Equal("SmokeyBacon", keyValue.Value[1]);
             Assert.Same(entityType.GetPrimaryKey(), keyValue.Key);
@@ -508,7 +509,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             entry.RelationshipsSnapshot[fkProperty] = 78;
 
             var keyValue = entry.GetDependentKeyValue(fk);
-            Assert.IsType<SimpleEntityKey<int>>(keyValue);
+            Assert.IsType<SimpleKeyValue<int>>(keyValue);
             Assert.Equal(77, keyValue.Value);
             Assert.Same(fk.PrincipalEntityType.GetPrimaryKey(), keyValue.Key);
         }
@@ -527,7 +528,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             entry.RelationshipsSnapshot[fkProperty] = 78;
 
             var keyValue = entry.RelationshipsSnapshot.GetDependentKeyValue(fk);
-            Assert.IsType<SimpleEntityKey<int>>(keyValue);
+            Assert.IsType<SimpleKeyValue<int>>(keyValue);
             Assert.Equal(78, keyValue.Value);
             Assert.Same(fk.PrincipalEntityType.GetPrimaryKey(), keyValue.Key);
         }
@@ -545,7 +546,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             entry[fkProperty] = 77;
 
             var keyValue = entry.RelationshipsSnapshot.GetDependentKeyValue(fk);
-            Assert.IsType<SimpleEntityKey<int>>(keyValue);
+            Assert.IsType<SimpleKeyValue<int>>(keyValue);
             Assert.Equal(77, keyValue.Value);
             Assert.Same(fk.PrincipalEntityType.GetPrimaryKey(), keyValue.Key);
         }
@@ -565,7 +566,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             entry[fkProperty] = 79;
 
             var keyValue = entry.RelationshipsSnapshot.GetDependentKeyValue(entityType.GetForeignKeys().Single());
-            Assert.IsType<SimpleEntityKey<int>>(keyValue);
+            Assert.IsType<SimpleKeyValue<int>>(keyValue);
             Assert.Equal(79, keyValue.Value);
         }
 
@@ -584,7 +585,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             entry[fkProperty] = 77;
 
             var keyValue = entry.RelationshipsSnapshot.GetDependentKeyValue(entityType.GetForeignKeys().Single());
-            Assert.IsType<SimpleEntityKey<int>>(keyValue);
+            Assert.IsType<SimpleKeyValue<int>>(keyValue);
             Assert.Equal(78, keyValue.Value);
         }
 
@@ -602,7 +603,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var fk = dependentType.GetForeignKeys().Single();
             var keyValue = entry.GetPrincipalKeyValue(fk);
-            Assert.IsType<SimpleEntityKey<int>>(keyValue);
+            Assert.IsType<SimpleKeyValue<int>>(keyValue);
             Assert.Equal(77, keyValue.Value);
             Assert.Same(fk.PrincipalEntityType.GetPrimaryKey(), keyValue.Key);
         }
@@ -619,7 +620,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             entry[fk.Properties[0]] = 77;
             entry[fk.Properties[1]] = "CheeseAndOnion";
 
-            var keyValue = (CompositeEntityKey)entry.GetDependentKeyValue(fk);
+            var keyValue = (CompositeKeyValue)entry.GetDependentKeyValue(fk);
             Assert.Equal(77, keyValue.Value[0]);
             Assert.Equal("CheeseAndOnion", keyValue.Value[1]);
             Assert.Same(fk.PrincipalEntityType.GetPrimaryKey(), keyValue.Key);
@@ -638,7 +639,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             entry[keyProperties[0]] = 77;
             entry[keyProperties[1]] = "PrawnCocktail";
 
-            var keyValue = (CompositeEntityKey)entry.GetPrincipalKeyValue(dependentType.GetForeignKeys().Single());
+            var keyValue = (CompositeKeyValue)entry.GetPrincipalKeyValue(dependentType.GetForeignKeys().Single());
             Assert.Equal(77, keyValue.Value[0]);
             Assert.Equal("PrawnCocktail", keyValue.Value[1]);
             Assert.Same(principalType.GetPrimaryKey(), keyValue.Key);
@@ -659,7 +660,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var fk = dependentType.GetForeignKeys().Single();
             var keyValue = entry.GetPrincipalKeyValue(fk);
-            Assert.Same(EntityKey.InvalidEntityKey, keyValue);
+            Assert.Same(KeyValue.InvalidKeyValue, keyValue);
             Assert.Null(keyValue.Key);
         }
 
@@ -730,8 +731,11 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             entry[keyProperty] = 77;
             entry[nonKeyProperty] = "Magic Tree House";
 
-            Assert.Equal(new object[] { 77, "Magic Tree House" }, entry.GetValueBuffer());
+            Assert.Equal(new object[] { 77, "Magic Tree House" }, CreateValueBuffer(entry));
         }
+
+        private static object[] CreateValueBuffer(IUpdateEntry entry)
+            => entry.EntityType.GetProperties().Select(p => entry[p]).ToArray();
 
         [Fact]
         public void All_original_values_can_be_accessed_for_entity_that_does_full_change_tracking_if_eager_values_on()
@@ -888,21 +892,21 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var entry = CreateInternalEntry(configuration, entityType, entity, new ValueBuffer(new object[] { 1, "Kool" }));
             entry.SetEntityState(EntityState.Unchanged);
 
-            Assert.False(entry.IsPropertyModified(idProperty));
-            Assert.False(entry.IsPropertyModified(nameProperty));
+            Assert.False(entry.IsModified(idProperty));
+            Assert.False(entry.IsModified(nameProperty));
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
 
             entry[idProperty] = 1;
             entry[nameProperty] = "Kool";
 
-            Assert.False(entry.IsPropertyModified(idProperty));
-            Assert.False(entry.IsPropertyModified(nameProperty));
+            Assert.False(entry.IsModified(idProperty));
+            Assert.False(entry.IsModified(nameProperty));
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
 
             entry[nameProperty] = "Beans";
 
-            Assert.False(entry.IsPropertyModified(idProperty));
-            Assert.True(entry.IsPropertyModified(nameProperty));
+            Assert.False(entry.IsModified(idProperty));
+            Assert.True(entry.IsModified(nameProperty));
             Assert.Equal(EntityState.Modified, entry.EntityState);
         }
 
@@ -917,25 +921,25 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var entry = CreateInternalEntry(configuration, entityType, entity, new ValueBuffer(new object[] { 1, "Kool" }));
             entry.SetEntityState(EntityState.Unchanged);
 
-            Assert.False(entry.IsPropertyModified(nameProperty));
+            Assert.False(entry.IsModified(nameProperty));
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
 
             entity.Name = "Kool";
 
-            Assert.False(entry.IsPropertyModified(nameProperty));
+            Assert.False(entry.IsModified(nameProperty));
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
 
             entity.Name = "Beans";
 
             if (needsDetectChanges)
             {
-                Assert.False(entry.IsPropertyModified(nameProperty));
+                Assert.False(entry.IsModified(nameProperty));
                 Assert.Equal(EntityState.Unchanged, entry.EntityState);
 
                 configuration.GetRequiredService<IChangeDetector>().DetectChanges(entry);
             }
 
-            Assert.True(entry.IsPropertyModified(nameProperty));
+            Assert.True(entry.IsModified(nameProperty));
             Assert.Equal(EntityState.Modified, entry.EntityState);
         }
 

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalMixedEntityEntryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalMixedEntityEntryTest.cs
@@ -108,15 +108,17 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var idProperty = entityType.GetProperty("Id");
             var configuration = TestHelpers.Instance.CreateContextServices(model);
 
-            var entry = CreateInternalEntry(configuration, entityType, new ValueBuffer(new object[] { 1, "Kool" }));
+            var entry = CreateInternalEntry(
+                configuration, 
+                entityType, 
+                new FullNotificationEntity { Id = 1, Name = "Kool" }, 
+                new ValueBuffer(new object[] { 1, "Kool" }));
 
             Assert.Equal(
                 CoreStrings.OriginalValueNotTracked("Id", typeof(FullNotificationEntity).FullName),
                 Assert.Throws<InvalidOperationException>(() => entry.OriginalValues[idProperty] = 1).Message);
 
-            Assert.Equal(
-                CoreStrings.OriginalValueNotTracked("Id", typeof(FullNotificationEntity).FullName),
-                Assert.Throws<InvalidOperationException>(() => entry.OriginalValues[idProperty]).Message);
+            Assert.Equal(1, entry.OriginalValues[idProperty]);
         }
 
         protected override Model BuildModel()

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalShadowEntityEntryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalShadowEntityEntryTest.cs
@@ -34,15 +34,17 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var idProperty = entityType.GetProperty("Id");
             var configuration = TestHelpers.Instance.CreateContextServices(model);
 
-            var entry = CreateInternalEntry(configuration, entityType, new ValueBuffer(new object[] { 1, "Kool" }));
+            var entry = CreateInternalEntry(
+                configuration, 
+                entityType,
+                new SomeEntity { Id = 1, Name = "Kool" },
+                new ValueBuffer(new object[] { 1, "Kool" }));
 
             Assert.Equal(
                 CoreStrings.OriginalValueNotTracked("Id", typeof(SomeEntity).FullName),
                 Assert.Throws<InvalidOperationException>(() => entry.OriginalValues[idProperty] = 1).Message);
 
-            Assert.Equal(
-                CoreStrings.OriginalValueNotTracked("Id", typeof(SomeEntity).FullName),
-                Assert.Throws<InvalidOperationException>(() => entry.OriginalValues[idProperty]).Message);
+            Assert.Equal(1, entry.OriginalValues[idProperty]);
         }
 
         protected override Model BuildModel()

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/OriginalValuesTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/OriginalValuesTest.cs
@@ -27,11 +27,9 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         }
 
         [Fact]
-        public void Throws_on_attempt_to_read_when_original_value_cannot_be_stored()
+        public void Returns_current_value_when_original_value_not_stored()
         {
-            Assert.Equal(
-                CoreStrings.OriginalValueNotTracked("Name", typeof(Banana).FullName),
-                Assert.Throws<InvalidOperationException>(() => CreateSidecar()[NameProperty]).Message);
+            Assert.Equal("Stand", CreateSidecar()[NameProperty]);
         }
 
         [Fact]

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/SidecarTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/SidecarTest.cs
@@ -304,7 +304,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             sidecar[foreignKey.Properties.Single()] = 42;
 
             var keyValue = sidecar.GetDependentKeyValue(foreignKey);
-            Assert.IsType<SimpleEntityKey<int>>(keyValue);
+            Assert.IsType<SimpleKeyValue<int>>(keyValue);
             Assert.Equal(42, keyValue.Value);
         }
 
@@ -319,7 +319,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             sidecar[foreignKey.PrincipalKey.Properties.Single()] = 42;
 
             var keyValue = sidecar.GetPrincipalKeyValue(foreignKey);
-            Assert.IsType<SimpleEntityKey<int>>(keyValue);
+            Assert.IsType<SimpleKeyValue<int>>(keyValue);
             Assert.Equal(42, keyValue.Value);
         }
 
@@ -331,7 +331,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             sidecar[IdProperty] = 42;
 
             var keyValue = sidecar.GetPrimaryKeyValue();
-            Assert.IsType<SimpleEntityKey<int>>(keyValue);
+            Assert.IsType<SimpleKeyValue<int>>(keyValue);
             Assert.Equal(42, keyValue.Value);
         }
 
@@ -346,7 +346,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             sidecar[foreignKey.Properties[0]] = 77;
             sidecar[foreignKey.Properties[1]] = "CheeseAndOnion";
 
-            var keyValue = (CompositeEntityKey)sidecar.GetDependentKeyValue(foreignKey);
+            var keyValue = (CompositeKeyValue)sidecar.GetDependentKeyValue(foreignKey);
             Assert.Equal(77, keyValue.Value[0]);
             Assert.Equal("CheeseAndOnion", keyValue.Value[1]);
         }
@@ -362,7 +362,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             sidecar[foreignKey.PrincipalKey.Properties[0]] = 77;
             sidecar[foreignKey.PrincipalKey.Properties[1]] = "PrawnCocktail";
 
-            var keyValue = (CompositeEntityKey)sidecar.GetPrincipalKeyValue(foreignKey);
+            var keyValue = (CompositeKeyValue)sidecar.GetPrincipalKeyValue(foreignKey);
             Assert.Equal(77, keyValue.Value[0]);
             Assert.Equal("PrawnCocktail", keyValue.Value[1]);
         }

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/SimpleEntityKeyFactoryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/SimpleEntityKeyFactoryTest.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entity = new Banana { P1 = 7, P2 = 8 };
             var entry = stateManager.GetOrCreateEntry(entity);
 
-            var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>(type.GetPrimaryKey())
+            var key = (SimpleKeyValue<int>)new SimpleKeyValueFactory<int>(type.GetPrimaryKey())
                 .Create(type.GetPrimaryKey().Properties, entry);
 
             Assert.Equal(7, key.Value);
@@ -37,7 +37,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entity = new Banana { P1 = 7, P2 = 8 };
             var entry = stateManager.GetOrCreateEntry(entity);
 
-            var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>(type.GetPrimaryKey())
+            var key = (SimpleKeyValue<int>)new SimpleKeyValueFactory<int>(type.GetPrimaryKey())
                 .Create(new[] { type.GetProperty("P2") }, entry);
 
             Assert.Equal(8, key.Value);
@@ -53,7 +53,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entity = new Banana { P1 = 7, P2 = null };
             var entry = stateManager.GetOrCreateEntry(entity);
 
-            Assert.Equal(EntityKey.InvalidEntityKey, new SimpleEntityKeyFactory<int>(type.GetPrimaryKey())
+            Assert.Equal(KeyValue.InvalidKeyValue, new SimpleKeyValueFactory<int>(type.GetPrimaryKey())
                 .Create(new[] { type.GetProperty("P2") }, entry));
         }
 
@@ -67,7 +67,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entity = new Banana { P1 = 7, P2 = 0 };
             var entry = stateManager.GetOrCreateEntry(entity);
 
-            var key = (SimpleEntityKey<int?>)new SimpleEntityKeyFactory<int?>(type.GetPrimaryKey())
+            var key = (SimpleKeyValue<int?>)new SimpleKeyValueFactory<int?>(type.GetPrimaryKey())
                 .Create(new[] { type.GetProperty("P2") }, entry);
 
             Assert.Equal(0, key.Value);
@@ -78,7 +78,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         {
             var type = BuildModel().GetEntityType(typeof(Banana));
 
-            var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>(type.GetPrimaryKey())
+            var key = (SimpleKeyValue<int>)new SimpleKeyValueFactory<int>(type.GetPrimaryKey())
                 .Create(type.GetPrimaryKey().Properties, new ValueBuffer(new object[] { 7, "Ate" }));
 
             Assert.Equal(7, key.Value);
@@ -89,7 +89,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         {
             var type = BuildModel().GetEntityType(typeof(Banana));
 
-            var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>(type.GetPrimaryKey())
+            var key = (SimpleKeyValue<int>)new SimpleKeyValueFactory<int>(type.GetPrimaryKey())
                 .Create(new[] { type.GetProperty("P2") }, new ValueBuffer(new object[] { 7, 8 }));
 
             Assert.Equal(8, key.Value);
@@ -100,7 +100,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         {
             var type = BuildModel().GetEntityType(typeof(Kiwi));
 
-            var key = (SimpleEntityKey<string>)new SimpleEntityKeyFactory<string>(type.GetPrimaryKey())
+            var key = (SimpleKeyValue<string>)new SimpleKeyValueFactory<string>(type.GetPrimaryKey())
                 .Create(type.GetPrimaryKey().Properties, new ValueBuffer(new object[] { "7", "Ate" }));
 
             Assert.Equal("7", key.Value);
@@ -111,7 +111,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         {
             var type = BuildModel().GetEntityType(typeof(Kiwi));
 
-            var key = (SimpleEntityKey<string>)new SimpleEntityKeyFactory<string>(type.GetPrimaryKey())
+            var key = (SimpleKeyValue<string>)new SimpleKeyValueFactory<string>(type.GetPrimaryKey())
                 .Create(new[] { type.GetProperty("P2") }, new ValueBuffer(new object[] { "7", "Ate" }));
 
             Assert.Equal("Ate", key.Value);
@@ -122,7 +122,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         {
             var type = BuildModel().GetEntityType(typeof(Banana));
 
-            var key = (SimpleEntityKey<int?>)new SimpleEntityKeyFactory<int?>(type.GetPrimaryKey())
+            var key = (SimpleKeyValue<int?>)new SimpleKeyValueFactory<int?>(type.GetPrimaryKey())
                 .Create(new[] { type.GetProperty("P2") }, new ValueBuffer(new object[] { 7, 0 }));
 
             Assert.Equal(0, key.Value);
@@ -133,7 +133,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         {
             var type = BuildModel().GetEntityType(typeof(Banana));
 
-            var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>(type.GetPrimaryKey())
+            var key = (SimpleKeyValue<int>)new SimpleKeyValueFactory<int>(type.GetPrimaryKey())
                 .Create(new[] { type.GetProperty("P1") }, new ValueBuffer(new object[] { 0, 8 }));
 
             Assert.Equal(0, key.Value);
@@ -152,7 +152,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var sidecar = new RelationshipsSnapshot(entry);
             sidecar[type.GetProperty("P2")] = "Eaten";
 
-            var key = (SimpleEntityKey<string>)new SimpleEntityKeyFactory<string>(type.GetPrimaryKey())
+            var key = (SimpleKeyValue<string>)new SimpleKeyValueFactory<string>(type.GetPrimaryKey())
                 .Create(new[] { type.GetProperty("P2") }, sidecar);
 
             Assert.Equal("Eaten", key.Value);
@@ -170,7 +170,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             var sidecar = new RelationshipsSnapshot(entry);
 
-            var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>(type.GetPrimaryKey())
+            var key = (SimpleKeyValue<int>)new SimpleKeyValueFactory<int>(type.GetPrimaryKey())
                 .Create(new[] { type.GetProperty("P2") }, sidecar);
 
             Assert.Equal(8, key.Value);

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/SimpleEntityKeyTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/SimpleEntityKeyTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Data.Entity.ChangeTracking.Internal;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Moq;
 using Xunit;
@@ -13,16 +14,16 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
         [Fact]
         public void Value_property_is_strongly_typed()
         {
-            Assert.IsType<int>(new SimpleEntityKey<int>(new Mock<IKey>().Object, 77).Value);
+            Assert.IsType<int>(new SimpleKeyValue<int>(new Mock<IKey>().Object, 77).Value);
         }
 
         [Fact]
         public void Base_class_value_property_returns_same_as_strongly_typed_value_property()
         {
-            var key = new SimpleEntityKey<int>(new Mock<IKey>().Object, 77);
+            var key = new SimpleKeyValue<int>(new Mock<IKey>().Object, 77);
 
             Assert.Equal(77, key.Value);
-            Assert.Equal(77, ((EntityKey)key).Value);
+            Assert.Equal(77, ((IKeyValue)key).Value);
         }
 
         [Fact]
@@ -31,12 +32,12 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var key1 = new Mock<IKey>().Object;
             var key2 = new Mock<IKey>().Object;
 
-            Assert.True(new SimpleEntityKey<int>(key1, 77).Equals(new SimpleEntityKey<int>(key1, 77)));
-            Assert.False(new SimpleEntityKey<int>(key1, 77).Equals(null));
-            Assert.False(new SimpleEntityKey<int>(key1, 77).Equals(new CompositeEntityKey(key1, new object[] { 77 })));
-            Assert.False(new SimpleEntityKey<int>(key1, 77).Equals(new SimpleEntityKey<int>(key1, 88)));
-            Assert.False(new SimpleEntityKey<int>(key1, 77).Equals(new SimpleEntityKey<long>(key1, 77)));
-            Assert.False(new SimpleEntityKey<int>(key1, 77).Equals(new SimpleEntityKey<int>(key2, 77)));
+            Assert.True(new SimpleKeyValue<int>(key1, 77).Equals(new SimpleKeyValue<int>(key1, 77)));
+            Assert.False(new SimpleKeyValue<int>(key1, 77).Equals(null));
+            Assert.False(new SimpleKeyValue<int>(key1, 77).Equals(new CompositeKeyValue(key1, new object[] { 77 })));
+            Assert.False(new SimpleKeyValue<int>(key1, 77).Equals(new SimpleKeyValue<int>(key1, 88)));
+            Assert.False(new SimpleKeyValue<int>(key1, 77).Equals(new SimpleKeyValue<long>(key1, 77)));
+            Assert.False(new SimpleKeyValue<int>(key1, 77).Equals(new SimpleKeyValue<int>(key2, 77)));
         }
 
         [Fact]
@@ -45,9 +46,9 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var key1 = new Mock<IKey>().Object;
             var key2 = new Mock<IKey>().Object;
 
-            Assert.Equal(new SimpleEntityKey<int>(key1, 77).GetHashCode(), new SimpleEntityKey<int>(key1, 77).GetHashCode());
-            Assert.NotEqual(new SimpleEntityKey<int>(key1, 77).GetHashCode(), new SimpleEntityKey<int>(key1, 88).GetHashCode());
-            Assert.NotEqual(new SimpleEntityKey<int>(key1, 77).GetHashCode(), new SimpleEntityKey<int>(key2, 77).GetHashCode());
+            Assert.Equal(new SimpleKeyValue<int>(key1, 77).GetHashCode(), new SimpleKeyValue<int>(key1, 77).GetHashCode());
+            Assert.NotEqual(new SimpleKeyValue<int>(key1, 77).GetHashCode(), new SimpleKeyValue<int>(key1, 88).GetHashCode());
+            Assert.NotEqual(new SimpleKeyValue<int>(key1, 77).GetHashCode(), new SimpleKeyValue<int>(key2, 77).GetHashCode());
         }
     }
 }

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/SimpleNullableEntityKeyFactoryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/SimpleNullableEntityKeyFactoryTest.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entity = new Banana { P1 = 7 };
             var entry = stateManager.GetOrCreateEntry(entity);
 
-            var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>(type.GetPrimaryKey())
+            var key = (SimpleKeyValue<int>)new SimpleKeyValueFactory<int>(type.GetPrimaryKey())
                 .Create(type.GetPrimaryKey().Properties, entry);
 
             Assert.Equal(7, key.Value);
@@ -38,7 +38,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entity = new Banana { P1 = 7, P2 = null };
             var entry = stateManager.GetOrCreateEntry(entity);
 
-            Assert.Equal(EntityKey.InvalidEntityKey, new SimpleEntityKeyFactory<int>(type.GetPrimaryKey())
+            Assert.Equal(KeyValue.InvalidKeyValue, new SimpleKeyValueFactory<int>(type.GetPrimaryKey())
                 .Create(new[] { type.GetProperty("P2") }, entry));
         }
 
@@ -48,7 +48,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var model = BuildModel();
             var type = model.GetEntityType(typeof(Banana));
 
-            var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>(type.GetPrimaryKey())
+            var key = (SimpleKeyValue<int>)new SimpleKeyValueFactory<int>(type.GetPrimaryKey())
                 .Create(new[] { type.GetProperty("P2") }, new ValueBuffer(new object[] { 7, 77 }));
 
             Assert.Equal(77, key.Value);
@@ -61,8 +61,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var type = model.GetEntityType(typeof(Banana));
 
             Assert.Equal(
-                EntityKey.InvalidEntityKey,
-                new SimpleEntityKeyFactory<int>(type.GetPrimaryKey())
+                KeyValue.InvalidKeyValue,
+                new SimpleKeyValueFactory<int>(type.GetPrimaryKey())
                 .Create(new[] { type.GetProperty("P2") }, new ValueBuffer(new object[] { 7, null })));
         }
 
@@ -79,7 +79,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var sidecar = new RelationshipsSnapshot(entry);
             sidecar[type.GetProperty("P2")] = 78;
 
-            var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>(type.GetPrimaryKey())
+            var key = (SimpleKeyValue<int>)new SimpleKeyValueFactory<int>(type.GetPrimaryKey())
                 .Create(new[] { type.GetProperty("P2") }, sidecar);
 
             Assert.Equal(78, key.Value);
@@ -97,7 +97,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             var sidecar = new RelationshipsSnapshot(entry);
 
-            var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>(type.GetPrimaryKey())
+            var key = (SimpleKeyValue<int>)new SimpleKeyValueFactory<int>(type.GetPrimaryKey())
                 .Create(new[] { type.GetProperty("P2") }, sidecar);
 
             Assert.Equal(77, key.Value);

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/StateManagerTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/StateManagerTest.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var categoryType = model.GetEntityType(typeof(Category));
             var stateManager = CreateStateManager(model);
 
-            var entityKey = new SimpleEntityKey<int>(categoryType.GetPrimaryKey(), 77);
+            var entityKey = new SimpleKeyValue<int>(categoryType.GetPrimaryKey(), 77);
             var valueBuffer = new ValueBuffer(new object[] { 77, "Bjork", null });
 
             stateManager.StartTracking(categoryType, entityKey, new Category { Id = 77 }, valueBuffer);
@@ -59,7 +59,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var stateManager = CreateStateManager(model);
 
             var category = new Category { Id = 77 };
-            var entityKey = new SimpleEntityKey<int>(categoryType.GetPrimaryKey(), 77);
+            var entityKey = new SimpleKeyValue<int>(categoryType.GetPrimaryKey(), 77);
             var valueBuffer = new ValueBuffer(new object[] { 77, "Bjork", null });
 
             var entry = stateManager.StartTracking(categoryType, entityKey, category, valueBuffer);
@@ -79,7 +79,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             Assert.Equal(
                 CoreStrings.InvalidPrimaryKey("Category"),
                 Assert.Throws<InvalidOperationException>(
-                    () => stateManager.StartTracking(categoryType, EntityKey.InvalidEntityKey, new Category { Id = 0 }, valueBuffer)).Message);
+                    () => stateManager.StartTracking(categoryType, KeyValue.InvalidKeyValue, new Category { Id = 0 }, valueBuffer)).Message);
         }
 
         [Fact]

--- a/test/EntityFramework.Core.Tests/DbContextTest.cs
+++ b/test/EntityFramework.Core.Tests/DbContextTest.cs
@@ -15,6 +15,7 @@ using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Metadata.Conventions.Internal;
 using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Storage;
+using Microsoft.Data.Entity.Update;
 using Microsoft.Data.Entity.ValueGeneration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -217,12 +218,12 @@ namespace Microsoft.Data.Entity.Tests
             public bool SaveChangesCalled { get; set; }
             public bool SaveChangesAsyncCalled { get; set; }
 
-            public void UpdateIdentityMap(InternalEntityEntry entry, EntityKey oldKey, IKey principalKey)
+            public void UpdateIdentityMap(InternalEntityEntry entry, IKeyValue oldKeyValue, IKey principalKey)
             {
                 throw new NotImplementedException();
             }
 
-            public void UpdateDependentMap(InternalEntityEntry entry, EntityKey oldKey, IForeignKey foreignKey)
+            public void UpdateDependentMap(InternalEntityEntry entry, IKeyValue oldKeyValue, IForeignKey foreignKey)
             {
                 throw new NotImplementedException();
             }
@@ -259,12 +260,12 @@ namespace Microsoft.Data.Entity.Tests
                 throw new NotImplementedException();
             }
 
-            public InternalEntityEntry StartTracking(IEntityType entityType, EntityKey entityKey, object entity, ValueBuffer valueBuffer)
+            public InternalEntityEntry StartTracking(IEntityType entityType, IKeyValue keyValue, object entity, ValueBuffer valueBuffer)
             {
                 throw new NotImplementedException();
             }
 
-            public InternalEntityEntry TryGetEntry(EntityKey keyValue)
+            public InternalEntityEntry TryGetEntry(IKeyValue keyValueValue)
             {
                 throw new NotImplementedException();
             }
@@ -299,6 +300,11 @@ namespace Microsoft.Data.Entity.Tests
             public InternalEntityEntry GetPrincipal(IPropertyAccessor dependentEntry, IForeignKey foreignKey)
             {
                 throw new NotImplementedException();
+            }
+
+            public DbContext Context
+            {
+                get { throw new NotImplementedException(); }
             }
         }
 
@@ -1631,10 +1637,10 @@ namespace Microsoft.Data.Entity.Tests
         [Fact]
         public void SaveChanges_only_passes_dirty_entries_to_Database()
         {
-            var passedEntries = new List<InternalEntityEntry>();
+            var passedEntries = new List<IUpdateEntry>();
             var database = new Mock<IDatabase>();
-            database.Setup(s => s.SaveChanges(It.IsAny<IReadOnlyList<InternalEntityEntry>>()))
-                .Callback<IEnumerable<InternalEntityEntry>>(passedEntries.AddRange)
+            database.Setup(s => s.SaveChanges(It.IsAny<IReadOnlyList<IUpdateEntry>>()))
+                .Callback<IEnumerable<IUpdateEntry>>(passedEntries.AddRange)
                 .Returns(3);
 
             var valueGenMock = new Mock<IValueGeneratorSelector>();
@@ -1679,10 +1685,10 @@ namespace Microsoft.Data.Entity.Tests
         [Fact]
         public async Task SaveChangesAsync_only_passes_dirty_entries_to_Database()
         {
-            var passedEntries = new List<InternalEntityEntry>();
+            var passedEntries = new List<IUpdateEntry>();
             var database = new Mock<IDatabase>();
-            database.Setup(s => s.SaveChangesAsync(It.IsAny<IReadOnlyList<InternalEntityEntry>>(), It.IsAny<CancellationToken>()))
-                .Callback<IEnumerable<InternalEntityEntry>, CancellationToken>((e, c) => passedEntries.AddRange(e))
+            database.Setup(s => s.SaveChangesAsync(It.IsAny<IReadOnlyList<IUpdateEntry>>(), It.IsAny<CancellationToken>()))
+                .Callback<IEnumerable<IUpdateEntry>, CancellationToken>((e, c) => passedEntries.AddRange(e))
                 .Returns(Task.FromResult(3));
 
             var valueGenMock = new Mock<IValueGeneratorSelector>();
@@ -1729,7 +1735,7 @@ namespace Microsoft.Data.Entity.Tests
         {
             using (var context = new EarlyLearningCenter())
             {
-                Assert.IsType<EntityKeyFactorySource>(context.GetService<IEntityKeyFactorySource>());
+                Assert.IsType<KeyValueFactorySource>(context.GetService<IKeyValueFactorySource>());
             }
         }
 

--- a/test/EntityFramework.Core.Tests/EntityFrameworkServiceCollectionExtensionsTest.cs
+++ b/test/EntityFramework.Core.Tests/EntityFrameworkServiceCollectionExtensionsTest.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Data.Entity.Tests
             VerifySingleton<IDbSetFinder>();
             VerifySingleton<IDbSetInitializer>();
             VerifySingleton<IDbSetSource>();
-            VerifySingleton<IEntityKeyFactorySource>();
+            VerifySingleton<IKeyValueFactorySource>();
             VerifySingleton<IClrAccessorSource<IClrPropertyGetter>>();
             VerifySingleton<IClrAccessorSource<IClrPropertySetter>>();
             VerifySingleton<IClrCollectionAccessorSource>();

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/QueryLoggingSqlServerTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/QueryLoggingSqlServerTest.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 valueBufferOffset: 0, 
                 entityType: FunctionalTests.TestModels.Northwind.Customer, 
                 queryStateManager: True, 
-                entityKeyFactory: SimpleEntityKeyFactory`1, 
+                keyValueFactory: SimpleKeyValueFactory`1, 
                 keyProperties: List<Property> { Customer.CustomerID, }, 
                 materializer: (ValueBuffer prm3) => 
                 {
@@ -140,7 +140,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                     valueBufferOffset: 0, 
                     entityType: FunctionalTests.TestModels.Northwind.Customer, 
                     queryStateManager: True, 
-                    entityKeyFactory: SimpleEntityKeyFactory`1, 
+                    keyValueFactory: SimpleKeyValueFactory`1, 
                     keyProperties: List<Property> { Customer.CustomerID, }, 
                     materializer: (ValueBuffer prm3) => 
                     {

--- a/test/EntityFramework.Relational.Tests/Update/ColumnModificationTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/ColumnModificationTest.cs
@@ -36,52 +36,6 @@ namespace Microsoft.Data.Entity.Tests.Update
         }
 
         [Fact]
-        public void Get_OriginalValue_delegates_to_OriginalValues_if_possible()
-        {
-            var internalEntryMock = CreateInternalEntryMock(Mock.Of<IProperty>());
-            var originalValuesMock = new Mock<Sidecar>(internalEntryMock.Object);
-            originalValuesMock.Setup(m => m.CanStoreValue(It.IsAny<IPropertyBase>())).Returns(true);
-            internalEntryMock.Setup(m => m.OriginalValues).Returns(originalValuesMock.Object);
-            var columnModification = new ColumnModification(
-                internalEntryMock.Object,
-                new Mock<IProperty>().Object,
-                new Mock<IRelationalPropertyAnnotations>().Object,
-                new ParameterNameGenerator(),
-                isRead: false,
-                isWrite: false,
-                isKey: false,
-                isCondition: false);
-
-            var value = columnModification.OriginalValue;
-
-            originalValuesMock.Verify(m => m[It.IsAny<IPropertyBase>()], Times.Once);
-            internalEntryMock.Verify(m => m[It.IsAny<IPropertyBase>()], Times.Never);
-        }
-
-        [Fact]
-        public void Get_OriginalValue_delegates_to_Entry_if_OriginalValues_if_unavailable()
-        {
-            var internalEntryMock = CreateInternalEntryMock(Mock.Of<IProperty>());
-            var originalValuesMock = new Mock<Sidecar>(internalEntryMock.Object);
-            originalValuesMock.Setup(m => m.CanStoreValue(It.IsAny<IPropertyBase>())).Returns(false);
-            internalEntryMock.Setup(m => m.OriginalValues).Returns(originalValuesMock.Object);
-            var columnModification = new ColumnModification(
-                internalEntryMock.Object,
-                new Mock<IProperty>().Object,
-                new Mock<IRelationalPropertyAnnotations>().Object,
-                new ParameterNameGenerator(),
-                isRead: false,
-                isWrite: false,
-                isKey: false,
-                isCondition: false);
-
-            var value = columnModification.OriginalValue;
-
-            internalEntryMock.Verify(m => m[It.IsAny<IPropertyBase>()], Times.Once);
-            originalValuesMock.Verify(m => m[It.IsAny<IPropertyBase>()], Times.Never);
-        }
-
-        [Fact]
         public void Get_Value_delegates_to_Entry()
         {
             var internalEntryMock = CreateInternalEntryMock(Mock.Of<IProperty>());


### PR DESCRIPTION
Issue #2495.

The new interface is IUpdateEntry. An interface has been extracted from EntityKey and called IKeyValue, and this has also been made public. Also, a ToEntityEntry method allows update exceptions to provide access back to the original public EntityEntry objects.