### PR TITLE
Block CLR types which are not mapped by TypeMapper or cannot be added…

### DIFF
--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/PropertyMappingValidationConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/PropertyMappingValidationConvention.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
 
             foreach (var entityType in modelBuilder.Metadata.EntityTypes)
             {
-                var unmappedProperty = entityType.Properties.FirstOrDefault(p => !IsMappedPrimitiveProperty(p));
+                var unmappedProperty = entityType.Properties.FirstOrDefault(p => !IsMappedPrimitiveProperty(p.ClrType));
                 if (unmappedProperty != null)
                 {
                     throw new InvalidOperationException(CoreStrings.PropertyNotMapped(unmappedProperty.Name, entityType.Name));
@@ -66,11 +66,11 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
             return modelBuilder;
         }
 
-        public virtual bool IsMappedPrimitiveProperty([NotNull] IProperty property)
+        public virtual bool IsMappedPrimitiveProperty([NotNull] Type clrType)
         {
-            Check.NotNull(property, nameof(property));
+            Check.NotNull(clrType, nameof(clrType));
 
-            return property.ClrType.IsPrimitive();
+            return clrType.IsPrimitive();
         }
 
         public virtual Type FindCandidateNavigationPropertyType([NotNull] PropertyInfo propertyInfo)

--- a/src/EntityFramework.Relational/Metadata/Conventions/Internal/RelationalPropertyMappingValidationConvention.cs
+++ b/src/EntityFramework.Relational/Metadata/Conventions/Internal/RelationalPropertyMappingValidationConvention.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
             _typeMapper = typeMapper;
         }
 
-        public override bool IsMappedPrimitiveProperty(IProperty property) => _typeMapper.IsPropertyMapped(property);
+        public override bool IsMappedPrimitiveProperty(Type clrType) => _typeMapper.IsTypeMapped(clrType);
 
         public override Type FindCandidateNavigationPropertyType(PropertyInfo propertyInfo)
         {

--- a/src/EntityFramework.Relational/Storage/IRelationalTypeMapper.cs
+++ b/src/EntityFramework.Relational/Storage/IRelationalTypeMapper.cs
@@ -12,7 +12,6 @@ namespace Microsoft.Data.Entity.Storage
         RelationalTypeMapping GetMapping([NotNull] IProperty property);
         RelationalTypeMapping GetMapping([NotNull] Type clrType);
         RelationalTypeMapping GetMapping([NotNull] string typeName);
-        bool IsPropertyMapped([NotNull] IProperty property);
         bool IsTypeMapped([NotNull] Type clrType);
     }
 }

--- a/src/EntityFramework.Relational/Storage/RelationalTypeMapper.cs
+++ b/src/EntityFramework.Relational/Storage/RelationalTypeMapper.cs
@@ -96,8 +96,6 @@ namespace Microsoft.Data.Entity.Storage
 
         public virtual bool IsTypeMapped(Type clrType) => FindMapping(clrType) != null;
 
-        public virtual bool IsPropertyMapped(IProperty property) => FindMapping(property) != null;
-
         protected virtual RelationalTypeMapping FindCustomMapping([NotNull] IProperty property) => null;
 
         protected virtual RelationalTypeMapping GetCustomMapping([NotNull] IProperty property)

--- a/src/Shared/PropertyInfoExtensions.cs
+++ b/src/Shared/PropertyInfoExtensions.cs
@@ -16,9 +16,7 @@ namespace System.Reflection
         public static bool IsCandidateProperty(this PropertyInfo propertyInfo)
             => !propertyInfo.IsStatic()
                 && propertyInfo.GetIndexParameters().Length == 0
-                && propertyInfo.CanRead
-                && propertyInfo.CanWrite
-                && !propertyInfo.GetTargetType().GetTypeInfo().IsInterface;
+                && propertyInfo.CanRead;
 
         public static Type FindCandidateNavigationPropertyType(this PropertyInfo propertyInfo, Func<Type, bool> isPrimitiveProperty)
         {
@@ -27,22 +25,16 @@ namespace System.Reflection
                 return null;
             }
 
-            var targetType = propertyInfo.GetTargetType();
+            var targetType = propertyInfo.PropertyType;
+            targetType = targetType.TryGetSequenceType() ?? targetType;
+            targetType = targetType.UnwrapNullableType();
 
             if (isPrimitiveProperty(targetType)
+                || targetType.GetTypeInfo().IsInterface
                 || targetType.GetTypeInfo().IsValueType)
             {
                 return null;
             }
-
-            return targetType;
-        }
-
-        public static Type GetTargetType(this PropertyInfo propertyInfo)
-        {
-            var targetType = propertyInfo.PropertyType;
-            targetType = targetType.TryGetSequenceType() ?? targetType;
-            targetType = targetType.UnwrapNullableType();
 
             return targetType;
         }

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/ConcurrencyModel/Sponsor.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/ConcurrencyModel/Sponsor.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Microsoft.Data.Entity.FunctionalTests.TestModels.ConcurrencyModel
 {
@@ -15,6 +16,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.ConcurrencyModel
         public int Id { get; set; }
         public string Name { get; set; }
 
+        [NotMapped]
         public virtual ICollection<Team> Teams
         {
             get { return _teams; }

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/ConcurrencyModel/Team.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/ConcurrencyModel/Team.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Microsoft.Data.Entity.FunctionalTests.TestModels.ConcurrencyModel
 {
@@ -35,6 +36,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.ConcurrencyModel
             get { return _drivers; }
         }
 
+        [NotMapped]
         public virtual ICollection<Sponsor> Sponsors
         {
             get { return _sponsors; }

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/GearsOfWarModel/Gear.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/GearsOfWarModel/Gear.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel
         public string LeaderNickname { get; set; }
         public int LeaderSquadId { get; set; }
 
+        [NotMapped]
         public bool IsMarcus => Nickname == "Marcus";
     }
 }

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/MonsterContext`.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/MonsterContext`.cs
@@ -257,6 +257,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
                     b.HasMany(e => (IEnumerable<TProductPhoto>)e.Photos).WithOne();
                     b.HasOne(e => (TProductDetail)e.Detail).WithOne(e => (TProduct)e.Product)
                         .HasForeignKey<TProductDetail>(e => e.ProductId);
+                    b.Ignore(e => e.Suppliers);
                 });
 
             modelBuilder.Entity<TOrderLine>(b =>
@@ -266,7 +267,11 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
                     b.HasOne(e => (TProduct)e.Product).WithMany().HasForeignKey(e => e.ProductId);
                 });
 
-            modelBuilder.Entity<TSupplier>().HasOne(e => (TSupplierLogo)e.Logo).WithOne().HasForeignKey<TSupplierLogo>(e => e.SupplierId);
+            modelBuilder.Entity<TSupplier>(b =>
+                {
+                    b.HasOne(e => (TSupplierLogo)e.Logo).WithOne().HasForeignKey<TSupplierLogo>(e => e.SupplierId);
+                    b.Ignore(e => e.Products);
+                });
 
             modelBuilder.Entity<TCustomer>(b =>
                 {

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/Northwind/Customer.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/Northwind/Customer.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Microsoft.Data.Entity.FunctionalTests.TestModels.Northwind
 {
@@ -21,6 +22,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.Northwind
 
         public virtual ICollection<Order> Orders { get; set; }
 
+        [NotMapped]
         public bool IsLondon => City == "London";
 
         protected bool Equals(Customer other) => string.Equals(CustomerID, other.CustomerID);

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/PropertyDiscoveryConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/PropertyDiscoveryConventionTest.cs
@@ -23,11 +23,6 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
                 set { }
             }
 
-            public int ReadOnly
-            {
-                get { return 0; }
-            }
-
             public int this[int index]
             {
                 get { return 0; }

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/PropertyMappingValidationConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/PropertyMappingValidationConventionTest.cs
@@ -98,10 +98,10 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
         }
 
         [Fact]
-        public void Does_not_throw_when_interface_or_non_candidate_property_is_not_added()
+        public void Does_not_throw_when_non_candidate_property_is_not_added()
         {
             var modelBuilder = new InternalModelBuilder(new Model(), new ConventionSet());
-            var entityTypeBuilder = modelBuilder.Entity(typeof(InterfacePropertyEntity), ConfigurationSource.Convention);
+            var entityTypeBuilder = modelBuilder.Entity(typeof(NonCandidatePropertyEntity), ConfigurationSource.Convention);
 
             new PropertyMappingValidationConvention().Apply(modelBuilder);
         }
@@ -123,18 +123,17 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
         private class NavigationEntity
         {
             public PrimitivePropertyEntity Navigation { get; set; }
-
         }
 
-        private class InterfacePropertyEntity
+        private class NonCandidatePropertyEntity
         {
-            public IProperty InterfaceProperty { get; set; }
-
-            public List<IProperty> InterfacePropertyList { get; set; }
-
-            public int ReadOnlyProperty { get; }
-
             public static int StaticProperty { get; set; }
+
+            public int _writeOnlyField = 1;
+            public int WriteOnlyProperty
+            {
+                set { _writeOnlyField = value; }
+            }
         }
     }
 }

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/RelationshipDiscoveryConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/RelationshipDiscoveryConventionTest.cs
@@ -314,11 +314,6 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
                 set { }
             }
 
-            public OneToManyDependent ReadOnly
-            {
-                get { return null; }
-            }
-
             public OneToManyDependent this[int index]
             {
                 get { return null; }


### PR DESCRIPTION
… as navigation

Implements #3443 
As decided in the meeting,
Candidate properties are the properties which have getter & are not static.
Interfaces are not valid navigations.
If any candidate property is not added to model, exception will be thrown.
For scalar properties, CLR type must be mapped by TypeMapper regardless of the column type.