### PR TITLE
Fix Commands.FunctionalTest failures in VS - correct diagnostic assembly name

### DIFF
--- a/test/EntityFramework.Commands.FunctionalTests/Design/OperationExecutorTest.cs
+++ b/test/EntityFramework.Commands.FunctionalTests/Design/OperationExecutorTest.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Data.Entity.Design.Internal
                         References =
                                 {
                                     BuildReference.ByName("System.Collections.Immutable", copyLocal: true),
-                                    BuildReference.ByName("System.Diagnostics", copyLocal: true),
+                                    BuildReference.ByName("System.Diagnostics.DiagnosticSource", copyLocal: true),
                                     BuildReference.ByName("System.Interactive.Async", copyLocal: true),
                                     BuildReference.ByName("System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"),
                                     BuildReference.ByName("EntityFramework.Core", copyLocal: true),
@@ -148,7 +148,7 @@ namespace Microsoft.Data.Entity.Design.Internal
                     References =
                             {
                                 BuildReference.ByName("System.Collections.Immutable", copyLocal: true),
-                                BuildReference.ByName("System.Diagnostics", copyLocal: true),
+                                BuildReference.ByName("System.Diagnostics.DiagnosticSource", copyLocal: true),
                                 BuildReference.ByName("System.Interactive.Async", copyLocal: true),
                                 BuildReference.ByName("System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"),
                                 BuildReference.ByName("EntityFramework.Core", copyLocal: true),
@@ -330,7 +330,7 @@ namespace Microsoft.Data.Entity.Design.Internal
                     References =
                                 {
                                     BuildReference.ByName("System.Collections.Immutable", copyLocal: true),
-                                    BuildReference.ByName("System.Diagnostics", copyLocal: true),
+                                    BuildReference.ByName("System.Diagnostics.DiagnosticSource", copyLocal: true),
                                     BuildReference.ByName("System.Interactive.Async", copyLocal: true),
                                     BuildReference.ByName("System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"),
                                     BuildReference.ByName("EntityFramework.Core", copyLocal: true),


### PR DESCRIPTION
Commands functional tests are failing in VS after 4de4695a931ad4943ba76ebb62ff26bbf7ba35d7, updated Assembly name appears to be incorrect.

cc @divega 