### PR TITLE
Fix #3382 - Moves sensitive data logging option to core.

### DIFF
--- a/src/EntityFramework.Core/DbContextOptionsBuilder.cs
+++ b/src/EntityFramework.Core/DbContextOptionsBuilder.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
@@ -33,16 +34,37 @@ namespace Microsoft.Data.Entity
         {
             Check.NotNull(model, nameof(model));
 
-            ((IDbContextOptionsBuilderInfrastructure)this).AddOrUpdateExtension(new CoreOptionsExtension { Model = model });
+            SetOption(e => e.Model = model);
 
             return this;
         }
+
+        public virtual DbContextOptionsBuilder EnableSensitiveDataLogging()
+            => SetOption(e => e.IsSensitiveDataLoggingEnabled = true);
 
         void IDbContextOptionsBuilderInfrastructure.AddOrUpdateExtension<TExtension>(TExtension extension)
         {
             Check.NotNull(extension, nameof(extension));
 
             _options = _options.WithExtension(extension);
+        }
+
+        private DbContextOptionsBuilder SetOption([NotNull] Action<CoreOptionsExtension> setAction)
+        {
+            Check.NotNull(setAction, nameof(setAction));
+
+            var existingExtension = Options.FindExtension<CoreOptionsExtension>();
+            
+            var extension 
+                = existingExtension != null 
+                    ? new CoreOptionsExtension(existingExtension)
+                    : new CoreOptionsExtension();
+
+            setAction(extension);
+
+            ((IDbContextOptionsBuilderInfrastructure)this).AddOrUpdateExtension(extension);
+
+            return this;
         }
     }
 }

--- a/src/EntityFramework.Core/Infrastructure/CoreOptionsExtension.cs
+++ b/src/EntityFramework.Core/Infrastructure/CoreOptionsExtension.cs
@@ -8,7 +8,32 @@ namespace Microsoft.Data.Entity.Infrastructure
 {
     public class CoreOptionsExtension : IDbContextOptionsExtension
     {
-        public virtual IModel Model { get; [param: CanBeNull] set; }
+        private IModel _model;
+        private bool _isSensitiveDataLoggingEnabled;
+
+        public CoreOptionsExtension()
+        {
+        }
+
+        public CoreOptionsExtension([NotNull] CoreOptionsExtension copyFrom)
+        {
+            _isSensitiveDataLoggingEnabled = copyFrom.IsSensitiveDataLoggingEnabled;
+            _model = copyFrom.Model;
+        }
+
+        public virtual bool IsSensitiveDataLoggingEnabled
+        {
+            get { return _isSensitiveDataLoggingEnabled; }
+            set { _isSensitiveDataLoggingEnabled = value; }
+        }
+
+        public virtual bool SensitiveDataLoggingWarned { get; set; }
+
+        public virtual IModel Model
+        {
+            get { return _model; }
+            [param: CanBeNull] set { _model = value; }
+        }
 
         public virtual void ApplyServices(EntityFrameworkServicesBuilder builder)
         {

--- a/src/EntityFramework.Relational/Infrastructure/RelationalDbContextOptionsBuilder.cs
+++ b/src/EntityFramework.Relational/Infrastructure/RelationalDbContextOptionsBuilder.cs
@@ -53,9 +53,6 @@ namespace Microsoft.Data.Entity.Infrastructure
         public virtual TBuilder DisableQueryClientEvaluation()
             => SetOption(e => e.IsQueryClientEvaluationEnabled = false);
         
-        public virtual TBuilder LogSqlParameterValues()
-            => SetOption(e => e.LogSqlParameterValues = true);
-
         protected virtual TBuilder SetOption([NotNull] Action<TExtension> setAction)
         {
             Check.NotNull(setAction, nameof(setAction));

--- a/src/EntityFramework.Relational/Infrastructure/RelationalOptionsExtension.cs
+++ b/src/EntityFramework.Relational/Infrastructure/RelationalOptionsExtension.cs
@@ -18,7 +18,6 @@ namespace Microsoft.Data.Entity.Infrastructure
         private int? _maxBatchSize;
         private bool _useRelationalNulls;
         private bool _queryClientEvaluationEnabled = true;
-        private bool _logSqlParameterValues;
         private bool? _throwOnAmbientTransaction;
         private string _migrationsAssembly;
         private string _migrationsHistoryTableName;
@@ -40,7 +39,6 @@ namespace Microsoft.Data.Entity.Infrastructure
             _maxBatchSize = copyFrom._maxBatchSize;
             _useRelationalNulls = copyFrom._useRelationalNulls;
             _queryClientEvaluationEnabled = copyFrom._queryClientEvaluationEnabled;
-            _logSqlParameterValues = copyFrom._logSqlParameterValues;
             _throwOnAmbientTransaction = copyFrom._throwOnAmbientTransaction;
             _migrationsAssembly = copyFrom._migrationsAssembly;
             _migrationsHistoryTableName = copyFrom._migrationsHistoryTableName;
@@ -114,14 +112,6 @@ namespace Microsoft.Data.Entity.Infrastructure
             get { return _queryClientEvaluationEnabled; }
             set { _queryClientEvaluationEnabled = value; }
         }
-
-        public virtual bool LogSqlParameterValues
-        {
-            get { return _logSqlParameterValues; }
-            set { _logSqlParameterValues = value; }
-        }
-
-        internal bool LogSqlParameterValuesWarned { get; set; }
 
         public virtual bool? ThrowOnAmbientTransaction
         {

--- a/src/EntityFramework.Relational/Infrastructure/SensitiveDataLogger.cs
+++ b/src/EntityFramework.Relational/Infrastructure/SensitiveDataLogger.cs
@@ -12,16 +12,16 @@ namespace Microsoft.Data.Entity.Infrastructure
     public class SensitiveDataLogger<T> : ISensitiveDataLogger<T>
     {
         private readonly ILogger<T> _logger;
-        private readonly RelationalOptionsExtension _relationalOptionsExtension;
+        private readonly CoreOptionsExtension _coreOptionsExtension;
 
         public SensitiveDataLogger(
             [NotNull] ILogger<T> logger, [CanBeNull] IDbContextOptions contextOptions)
         {
             _logger = logger;
 
-            _relationalOptionsExtension
+            _coreOptionsExtension
                 = contextOptions?.Extensions
-                    .OfType<RelationalOptionsExtension>()
+                    .OfType<CoreOptionsExtension>()
                     .FirstOrDefault();
         }
 
@@ -29,20 +29,20 @@ namespace Microsoft.Data.Entity.Infrastructure
         {
             get
             {
-                if (_relationalOptionsExtension == null)
+                if (_coreOptionsExtension == null)
                 {
                     return false;
                 }
 
-                if (_relationalOptionsExtension.LogSqlParameterValues
-                    && !_relationalOptionsExtension.LogSqlParameterValuesWarned)
+                if (_coreOptionsExtension.IsSensitiveDataLoggingEnabled
+                    && !_coreOptionsExtension.SensitiveDataLoggingWarned)
                 {
                     _logger.LogWarning(RelationalStrings.ParameterLoggingEnabled);
 
-                    _relationalOptionsExtension.LogSqlParameterValuesWarned = true;
+                    _coreOptionsExtension.SensitiveDataLoggingWarned = true;
                 }
 
-                return _relationalOptionsExtension.LogSqlParameterValues;
+                return _coreOptionsExtension.IsSensitiveDataLoggingEnabled;
             }
         }
 

--- a/test/EntityFramework.Core.Tests/DbContextOptionsTest.cs
+++ b/test/EntityFramework.Core.Tests/DbContextOptionsTest.cs
@@ -21,6 +21,17 @@ namespace Microsoft.Data.Entity.Tests
         }
 
         [Fact]
+        public void Sensitive_data_logging_can_be_set_explicitly_in_options()
+        {
+            var model = new Model();
+
+            var optionsBuilder = new DbContextOptionsBuilder().UseModel(model).EnableSensitiveDataLogging();
+
+            Assert.Same(model, optionsBuilder.Options.FindExtension<CoreOptionsExtension>().Model);
+            Assert.True(optionsBuilder.Options.FindExtension<CoreOptionsExtension>().IsSensitiveDataLoggingEnabled);
+        }
+
+        [Fact]
         public void Extensions_can_be_added_to_options()
         {
             var optionsBuilder = new DbContextOptionsBuilder();

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/DataAnnotationSqlServerFixture.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/DataAnnotationSqlServerFixture.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         public override DataAnnotationContext CreateContext(SqlServerTestStore testStore)
         {
             var optionsBuilder = new DbContextOptionsBuilder();
-            optionsBuilder.UseSqlServer(testStore.Connection).LogSqlParameterValues();
+            optionsBuilder.EnableSensitiveDataLogging().UseSqlServer(testStore.Connection);
 
             var context = new DataAnnotationContext(_serviceProvider, optionsBuilder.Options);
             context.Database.UseTransaction(testStore.Transaction);

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/GearsOfWarQuerySqlServerFixture.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/GearsOfWarQuerySqlServerFixture.cs
@@ -54,8 +54,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             var optionsBuilder = new DbContextOptionsBuilder();
 
             optionsBuilder
-                .UseSqlServer(testStore.Connection)
-                .LogSqlParameterValues();
+                .EnableSensitiveDataLogging()
+                .UseSqlServer(testStore.Connection);
 
             var context = new GearsOfWarContext(_serviceProvider, optionsBuilder.Options);
             

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/InheritanceSqlServerFixture.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/InheritanceSqlServerFixture.cs
@@ -31,8 +31,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             var optionsBuilder = new DbContextOptionsBuilder();
 
             optionsBuilder
-                .UseSqlServer(testStore.Connection)
-                .LogSqlParameterValues();
+                .EnableSensitiveDataLogging()
+                .UseSqlServer(testStore.Connection);
 
             _options = optionsBuilder.Options;
 

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/NorthwindQuerySqlServerFixture.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/NorthwindQuerySqlServerFixture.cs
@@ -39,9 +39,9 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             var optionsBuilder = new DbContextOptionsBuilder();
 
             var sqlServerDbContextOptionsBuilder
-                = optionsBuilder.UseSqlServer(_testStore.Connection.ConnectionString);
-
-            sqlServerDbContextOptionsBuilder.LogSqlParameterValues();
+                = optionsBuilder
+                    .EnableSensitiveDataLogging()
+                    .UseSqlServer(_testStore.Connection.ConnectionString);
 
             ConfigureOptions(sqlServerDbContextOptionsBuilder);
 

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/NorthwindSprocQuerySqlServerFixture.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/NorthwindSprocQuerySqlServerFixture.cs
@@ -32,8 +32,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             var optionsBuilder = new DbContextOptionsBuilder();
 
             optionsBuilder
-                .UseSqlServer(_testStore.Connection.ConnectionString)
-                .LogSqlParameterValues();
+                .EnableSensitiveDataLogging()
+                .UseSqlServer(_testStore.Connection.ConnectionString);
 
             _options = optionsBuilder.Options;
 

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/NullSemanticsQuerySqlServerFixture.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/NullSemanticsQuerySqlServerFixture.cs
@@ -54,9 +54,10 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         {
             var optionsBuilder = new DbContextOptionsBuilder();
 
-            var sqlServerOptions = optionsBuilder.UseSqlServer(testStore.Connection);
-
-            sqlServerOptions.LogSqlParameterValues();
+            var sqlServerOptions
+                = optionsBuilder
+                    .EnableSensitiveDataLogging()
+                    .UseSqlServer(testStore.Connection);
 
             if (useRelationalNulls)
             {

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/QueryBugsTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/QueryBugsTest.cs
@@ -242,8 +242,8 @@ LEFT JOIN [Customer] AS [c] ON ([o].[CustomerFirstName] = [c].[FirstName]) AND (
 
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
                 => optionsBuilder
-                    .UseSqlServer(SqlServerTestStore.CreateConnectionString("Repro925"))
-                    .LogSqlParameterValues();
+                    .EnableSensitiveDataLogging()
+                    .UseSqlServer(SqlServerTestStore.CreateConnectionString("Repro925"));
 
             protected override void OnModelCreating(ModelBuilder modelBuilder)
             {

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/SqlServerEndToEndTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/SqlServerEndToEndTest.cs
@@ -113,8 +113,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 var optionsBuilder = new DbContextOptionsBuilder();
 
                 optionsBuilder
-                    .UseSqlServer(testDatabase.Connection.ConnectionString)
-                    .LogSqlParameterValues();
+                    .EnableSensitiveDataLogging()
+                    .UseSqlServer(testDatabase.Connection.ConnectionString);
 
                 using (var db = new BloggingContext(_fixture.ServiceProvider, optionsBuilder.Options))
                 {

--- a/test/EntityFramework.Relational.Tests/Storage/RelationalCommandTest.cs
+++ b/test/EntityFramework.Relational.Tests/Storage/RelationalCommandTest.cs
@@ -532,12 +532,10 @@ Command Text
         {
             var optionsExtension = new FakeRelationalOptionsExtension
             {
-                ConnectionString = ConnectionString,
-                LogSqlParameterValues = true,
-                LogSqlParameterValuesWarned = false
+                ConnectionString = ConnectionString
             };
 
-            var options = CreateOptions(optionsExtension);
+            var options = CreateOptions(optionsExtension, logParameters: true);
 
             var fakeConnection = new FakeRelationalConnection(options);
 
@@ -587,11 +585,10 @@ Command Text
         {
             var optionsExtension = new FakeRelationalOptionsExtension
             {
-                ConnectionString = ConnectionString,
-                LogSqlParameterValues = true
+                ConnectionString = ConnectionString
             };
 
-            var options = CreateOptions(optionsExtension);
+            var options = CreateOptions(optionsExtension, logParameters: true);
 
             var fakeConnection = new FakeRelationalConnection(options);
 
@@ -756,9 +753,15 @@ Command Text
         private static FakeRelationalConnection CreateConnection(IDbContextOptions options = null)
             => new FakeRelationalConnection(options ?? CreateOptions());
 
-        public static IDbContextOptions CreateOptions(FakeRelationalOptionsExtension optionsExtension = null)
+        public static IDbContextOptions CreateOptions(
+            FakeRelationalOptionsExtension optionsExtension = null, bool logParameters = false)
         {
             var optionsBuilder = new DbContextOptionsBuilder();
+
+            if (logParameters)
+            {
+                optionsBuilder.EnableSensitiveDataLogging();
+            }
 
             ((IDbContextOptionsBuilderInfrastructure)optionsBuilder)
                 .AddOrUpdateExtension(optionsExtension ?? new FakeRelationalOptionsExtension { ConnectionString = ConnectionString });

--- a/test/EntityFramework.Sqlite.FunctionalTests/DataAnnotationSqliteFixture.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/DataAnnotationSqliteFixture.cs
@@ -53,9 +53,9 @@ namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
             var optionsBuilder = new DbContextOptionsBuilder();
 
             optionsBuilder
+                .EnableSensitiveDataLogging()
                 .UseSqlite(testStore.Connection)
-                .SuppressForeignKeyEnforcement()
-                .LogSqlParameterValues();
+                .SuppressForeignKeyEnforcement();
 
             var context = new DataAnnotationContext(_serviceProvider, optionsBuilder.Options);
             context.Database.UseTransaction(testStore.Transaction);


### PR DESCRIPTION
The new API is DbContextOptionsBuilder.EnableSensitiveDataLogging.