### PR TITLE
Fix to #3180 - A column has been specified more than once in the order by list. Columns in the order by list must be unique.

### DIFF
--- a/src/EntityFramework.Relational/Query/ExpressionVisitors/IncludeExpressionVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionVisitors/IncludeExpressionVisitor.cs
@@ -130,7 +130,8 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
                             targetTableName,
                             _relationalAnnotationProvider.For(targetEntityType).Schema,
                             targetTableAlias,
-                            querySource);
+                            querySource,
+                            targetEntityType);
 
                     var valueBufferOffset = selectExpression.Projection.Count;
 
@@ -194,14 +195,17 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
                 }
                 else
                 {
-                    var principalTable
-                        = selectExpression.Tables.Last(t => t.QuerySource == querySource);
-
                     foreach (var property in navigation.ForeignKey.PrincipalKey.Properties)
                     {
+                        var principalTable = selectExpression.Tables
+                            .Where(t =>
+                                t.QuerySource == querySource &&
+                                (t.EntityType == null || t.EntityType.RootType() == navigation.ForeignKey.PrincipalEntityType.RootType()))
+                            .Last();
+
                         selectExpression
                             .AddToOrderBy(
-                                _relationalAnnotationProvider.For(property).ColumnName,
+                                 _relationalAnnotationProvider.For(property).ColumnName,
                                 property,
                                 principalTable,
                                 OrderingDirection.Asc);
@@ -214,7 +218,8 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
                             targetTableName,
                             _relationalAnnotationProvider.For(targetEntityType).Schema,
                             targetTableAlias,
-                            querySource);
+                            querySource,
+                            targetEntityType);
 
                     targetSelectExpression.AddTable(targetTableExpression);
 

--- a/src/EntityFramework.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
@@ -141,7 +141,8 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
                         name,
                         _relationalAnnotationProvider.For(entityType).Schema,
                         tableAlias,
-                        _querySource));
+                        _querySource,
+                        entityType));
             }
             else
             {
@@ -153,7 +154,8 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
                         sqlString,
                         sqlParameters,
                         tableAlias,
-                        _querySource));
+                        _querySource,
+                        entityType));
 
                 var sqlStart = sqlString.SkipWhile(char.IsWhiteSpace).Take(7).ToArray();
 

--- a/src/EntityFramework.Relational/Query/Expressions/CrossJoinExpression.cs
+++ b/src/EntityFramework.Relational/Query/Expressions/CrossJoinExpression.cs
@@ -15,7 +15,8 @@ namespace Microsoft.Data.Entity.Query.Expressions
         public CrossJoinExpression([NotNull] TableExpressionBase tableExpression)
             : base(
                 Check.NotNull(tableExpression, nameof(tableExpression)).QuerySource,
-                tableExpression.Alias)
+                tableExpression.Alias,
+                tableExpression.EntityType)
         {
             _tableExpression = tableExpression;
         }

--- a/src/EntityFramework.Relational/Query/Expressions/JoinExpressionBase.cs
+++ b/src/EntityFramework.Relational/Query/Expressions/JoinExpressionBase.cs
@@ -15,7 +15,8 @@ namespace Microsoft.Data.Entity.Query.Expressions
         protected JoinExpressionBase([NotNull] TableExpressionBase tableExpression)
             : base(
                 Check.NotNull(tableExpression, nameof(tableExpression)).QuerySource,
-                tableExpression.Alias)
+                tableExpression.Alias,
+                tableExpression.EntityType)
         {
             _tableExpression = tableExpression;
         }

--- a/src/EntityFramework.Relational/Query/Expressions/LateralJoinExpression.cs
+++ b/src/EntityFramework.Relational/Query/Expressions/LateralJoinExpression.cs
@@ -15,7 +15,8 @@ namespace Microsoft.Data.Entity.Query.Expressions
         public LateralJoinExpression([NotNull] TableExpressionBase tableExpression)
             : base(
                 Check.NotNull(tableExpression, nameof(tableExpression)).QuerySource,
-                tableExpression.Alias)
+                tableExpression.Alias,
+                tableExpression.EntityType)
         {
             _tableExpression = tableExpression;
         }

--- a/src/EntityFramework.Relational/Query/Expressions/RawSqlDerivedTableExpression.cs
+++ b/src/EntityFramework.Relational/Query/Expressions/RawSqlDerivedTableExpression.cs
@@ -3,6 +3,7 @@
 
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Query.Sql;
 using Microsoft.Data.Entity.Utilities;
 using Remotion.Linq.Clauses;
@@ -15,10 +16,12 @@ namespace Microsoft.Data.Entity.Query.Expressions
             [NotNull] string sql,
             [NotNull] object[] parameters,
             [NotNull] string alias,
-            [NotNull] IQuerySource querySource)
+            [NotNull] IQuerySource querySource,
+            [NotNull] IEntityType entityType)
             : base(
                 Check.NotNull(querySource, nameof(querySource)),
-                Check.NotEmpty(alias, nameof(alias)))
+                Check.NotEmpty(alias, nameof(alias)),
+                Check.NotNull(entityType, nameof(entityType)))
         {
             Check.NotEmpty(sql, nameof(sql));
             Check.NotNull(parameters, nameof(parameters));

--- a/src/EntityFramework.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/EntityFramework.Relational/Query/Expressions/SelectExpression.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Data.Entity.Query.Expressions
         public virtual Expression Predicate { get; [param: CanBeNull] set; }
 
         public SelectExpression([NotNull] ISqlQueryGeneratorFactory sqlQueryGeneratorFactory)
-            : base(null, null)
+            : base(null, null, null)
         {
             Check.NotNull(sqlQueryGeneratorFactory, nameof(sqlQueryGeneratorFactory));
 
@@ -46,7 +46,7 @@ namespace Microsoft.Data.Entity.Query.Expressions
         public SelectExpression(
             [NotNull] ISqlQueryGeneratorFactory sqlQueryGeneratorFactory,
             [NotNull] string alias)
-            : base(null, Check.NotEmpty(alias, nameof(alias)))
+            : base(null, Check.NotEmpty(alias, nameof(alias)), null)
         {
             Check.NotNull(sqlQueryGeneratorFactory, nameof(sqlQueryGeneratorFactory));
 

--- a/src/EntityFramework.Relational/Query/Expressions/TableExpression.cs
+++ b/src/EntityFramework.Relational/Query/Expressions/TableExpression.cs
@@ -3,6 +3,7 @@
 
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Query.Sql;
 using Microsoft.Data.Entity.Utilities;
 using Remotion.Linq.Clauses;
@@ -15,10 +16,12 @@ namespace Microsoft.Data.Entity.Query.Expressions
             [NotNull] string table,
             [CanBeNull] string schema,
             [NotNull] string alias,
-            [NotNull] IQuerySource querySource)
+            [NotNull] IQuerySource querySource,
+            [CanBeNull] IEntityType entityType)
             : base(
                 Check.NotNull(querySource, nameof(querySource)),
-                Check.NotEmpty(alias, nameof(alias)))
+                Check.NotEmpty(alias, nameof(alias)),
+                entityType)
         {
             Check.NotEmpty(table, nameof(table));
 

--- a/src/EntityFramework.Relational/Query/Expressions/TableExpressionBase.cs
+++ b/src/EntityFramework.Relational/Query/Expressions/TableExpressionBase.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Utilities;
 using Remotion.Linq.Clauses;
 
@@ -13,17 +14,21 @@ namespace Microsoft.Data.Entity.Query.Expressions
     {
         private string _alias;
         private IQuerySource _querySource;
+        private IEntityType _entityType;
 
         protected TableExpressionBase(
-            [CanBeNull] IQuerySource querySource, [CanBeNull] string alias)
+            [CanBeNull] IQuerySource querySource, [CanBeNull] string alias, [CanBeNull] IEntityType entityType)
         {
             _querySource = querySource;
             _alias = alias;
+            _entityType = entityType;
         }
 
         public override ExpressionType NodeType => ExpressionType.Extension;
 
         public override Type Type => typeof(object);
+
+        public virtual IEntityType EntityType => _entityType;
 
         public virtual IQuerySource QuerySource
         {

--- a/test/EntityFramework.Core.FunctionalTests/ComplexNavigationsQueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/ComplexNavigationsQueryTestBase.cs
@@ -492,5 +492,133 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 }
             }
         }
+
+        // issue #3180
+        [Fact]
+        public virtual void Multiple_complex_includes()
+        {
+            List<Level1> levelOnes;
+            List<Level2> levelTwos;
+            using (var context = CreateContext())
+            {
+                levelOnes = context.LevelOne
+                    .Include(e => e.OneToOne_Optional_FK)
+                    .Include(e => e.OneToMany_Optional).ToList();
+
+                levelTwos = context.LevelTwo
+                    .Include(e => e.OneToMany_Optional)
+                    .Include(e => e.OneToOne_Optional_FK).ToList();
+            }
+
+            ClearLog();
+
+            using (var context = CreateContext())
+            {
+                var query = context.LevelOne
+                    .Include(e => e.OneToOne_Optional_FK)
+                        .ThenInclude(e => e.OneToMany_Optional)
+                    .Include(e => e.OneToMany_Optional)
+                        .ThenInclude(e => e.OneToOne_Optional_FK);
+
+                var result = query.ToList();
+
+                Assert.Equal(levelOnes.Count, result.Count);
+                foreach (var resultItem in result)
+                {
+                    var expectedLevel1 = levelOnes.Where(e => e.Id == resultItem.Id).Single();
+                    Assert.Equal(expectedLevel1.OneToOne_Optional_FK?.Id, resultItem.OneToOne_Optional_FK?.Id);
+                    Assert.Equal(expectedLevel1.OneToMany_Optional?.Count, resultItem.OneToMany_Optional?.Count);
+
+                    var oneToOne_Optional_FK = resultItem.OneToOne_Optional_FK;
+                    if (oneToOne_Optional_FK != null)
+                    {
+                        var expectedReferenceLevel2 = levelTwos.Where(e => e.Id == oneToOne_Optional_FK.Id).Single();
+                        Assert.Equal(expectedReferenceLevel2.OneToMany_Optional?.Count, oneToOne_Optional_FK.OneToMany_Optional?.Count);
+                    }
+                }
+            }
+        }
+
+        // issue #3180
+        [Fact]
+        public virtual void Multiple_complex_includes_self_ref()
+        {
+            List<Level1> levelOnes1;
+            List<Level1> levelOnes2;
+            using (var context = CreateContext())
+            {
+                levelOnes1 = context.LevelOne.Include(e => e.OneToOne_Optional_Self).ToList();
+                levelOnes2 = context.LevelOne.Include(e => e.OneToMany_Optional_Self).ToList();
+            }
+
+            ClearLog();
+
+            using (var context = CreateContext())
+            {
+                var query = context.LevelOne
+                    .Include(e => e.OneToOne_Optional_Self)
+                        .ThenInclude(e => e.OneToMany_Optional_Self)
+                    .Include(e => e.OneToMany_Optional_Self)
+                        .ThenInclude(e => e.OneToOne_Optional_Self);
+
+                var result = query.ToList();
+
+                foreach (var resultItem in result)
+                {
+                    var expected1 = levelOnes1.Where(e => e.Id == resultItem.Id).Single();
+                    var expected2 = levelOnes2.Where(e => e.Id == resultItem.Id).Single();
+
+                    Assert.Equal(expected1.OneToOne_Optional_Self?.Id, resultItem.OneToOne_Optional_Self?.Id);
+                    Assert.Equal(expected2.OneToMany_Optional_Self?.Count, resultItem.OneToMany_Optional_Self?.Count);
+                }
+            }
+        }
+
+        [Fact]
+        public virtual void Multiple_complex_include_select()
+        {
+            List<Level1> levelOnes;
+            List<Level2> levelTwos;
+            using (var context = CreateContext())
+            {
+                levelOnes = context.LevelOne
+                    .Include(e => e.OneToOne_Optional_FK)
+                    .Include(e => e.OneToMany_Optional).ToList();
+
+                levelTwos = context.LevelTwo
+                    .Include(e => e.OneToMany_Optional)
+                    .Include(e => e.OneToOne_Optional_FK).ToList();
+            }
+
+            ClearLog();
+
+            using (var context = CreateContext())
+            {
+                var query = context.LevelOne
+                    .Select(e => e)
+                    .Include(e => e.OneToOne_Optional_FK)
+                        .ThenInclude(e => e.OneToMany_Optional)
+                    .Select(e => e)
+                    .Include(e => e.OneToMany_Optional)
+                        .ThenInclude(e => e.OneToOne_Optional_FK);
+
+                var result = query.ToList();
+
+                Assert.Equal(levelOnes.Count, result.Count);
+                foreach (var resultItem in result)
+                {
+                    var expectedLevel1 = levelOnes.Where(e => e.Id == resultItem.Id).Single();
+                    Assert.Equal(expectedLevel1.OneToOne_Optional_FK?.Id, resultItem.OneToOne_Optional_FK?.Id);
+                    Assert.Equal(expectedLevel1.OneToMany_Optional?.Count, resultItem.OneToMany_Optional?.Count);
+
+                    var oneToOne_Optional_FK = resultItem.OneToOne_Optional_FK;
+                    if (oneToOne_Optional_FK != null)
+                    {
+                        var expectedReferenceLevel2 = levelTwos.Where(e => e.Id == oneToOne_Optional_FK.Id).Single();
+                        Assert.Equal(expectedReferenceLevel2.OneToMany_Optional?.Count, oneToOne_Optional_FK.OneToMany_Optional?.Count);
+                    }
+                }
+            }
+        }
     }
 }

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Linq;
 using Microsoft.Data.Entity.FunctionalTests;
 using Xunit;
 
@@ -238,6 +239,119 @@ INNER JOIN [Level1] AS [e1] ON [e4].[Name] = (
 )",
                 Sql);
         }
+
+        public override void Multiple_complex_includes()
+        {
+            base.Multiple_complex_includes();
+
+            Assert.Equal(
+                @"SELECT [e].[Id], [e].[Name], [e].[OneToMany_Optional_Self_InverseId], [e].[OneToMany_Required_Self_InverseId], [e].[OneToOne_Optional_SelfId], [l].[Id], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Name], [l].[OneToMany_Optional_InverseId], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_PK_InverseId], [l].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [e]
+LEFT JOIN [Level2] AS [l] ON [l].[Level1_Optional_Id] = [e].[Id]
+ORDER BY [l].[Id], [e].[Id]
+
+SELECT [l].[Id], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Name], [l].[OneToMany_Optional_InverseId], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_PK_InverseId], [l].[OneToOne_Optional_SelfId], [l0].[Id], [l0].[Level2_Optional_Id], [l0].[Level2_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_InverseId], [l0].[OneToMany_Optional_Self_InverseId], [l0].[OneToMany_Required_InverseId], [l0].[OneToMany_Required_Self_InverseId], [l0].[OneToOne_Optional_PK_InverseId], [l0].[OneToOne_Optional_SelfId]
+FROM [Level2] AS [l]
+INNER JOIN (
+    SELECT DISTINCT [l].[Id], [e].[Id] AS [Id0]
+    FROM [Level1] AS [e]
+    LEFT JOIN [Level2] AS [l] ON [l].[Level1_Optional_Id] = [e].[Id]
+) AS [e] ON [l].[OneToMany_Optional_InverseId] = [e].[Id0]
+LEFT JOIN [Level3] AS [l0] ON [l0].[Level2_Optional_Id] = [l].[Id]
+ORDER BY [e].[Id], [e].[Id0]
+
+SELECT [l].[Id], [l].[Level2_Optional_Id], [l].[Level2_Required_Id], [l].[Name], [l].[OneToMany_Optional_InverseId], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_PK_InverseId], [l].[OneToOne_Optional_SelfId]
+FROM [Level3] AS [l]
+INNER JOIN (
+    SELECT DISTINCT [l].[Id]
+    FROM [Level1] AS [e]
+    LEFT JOIN [Level2] AS [l] ON [l].[Level1_Optional_Id] = [e].[Id]
+) AS [l0] ON [l].[OneToMany_Optional_InverseId] = [l0].[Id]
+ORDER BY [l0].[Id]",
+                Sql);
+        }
+
+        public override void Multiple_complex_includes_self_ref()
+        {
+            base.Multiple_complex_includes_self_ref();
+
+            Assert.Equal(
+                @"SELECT [e].[Id], [e].[Name], [e].[OneToMany_Optional_Self_InverseId], [e].[OneToMany_Required_Self_InverseId], [e].[OneToOne_Optional_SelfId], [l].[Id], [l].[Name], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [e]
+LEFT JOIN [Level1] AS [l] ON [e].[OneToOne_Optional_SelfId] = [l].[Id]
+ORDER BY [e].[Id], [l].[Id]
+
+SELECT [l].[Id], [l].[Name], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l]
+INNER JOIN (
+    SELECT DISTINCT [e].[Id], [l].[Id] AS [Id0]
+    FROM [Level1] AS [e]
+    LEFT JOIN [Level1] AS [l] ON [e].[OneToOne_Optional_SelfId] = [l].[Id]
+) AS [l0] ON [l].[OneToMany_Optional_Self_InverseId] = [l0].[Id0]
+ORDER BY [l0].[Id], [l0].[Id0]
+
+SELECT [l].[Id], [l].[Name], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_SelfId], [l0].[Id], [l0].[Name], [l0].[OneToMany_Optional_Self_InverseId], [l0].[OneToMany_Required_Self_InverseId], [l0].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l]
+INNER JOIN (
+    SELECT DISTINCT [e].[Id]
+    FROM [Level1] AS [e]
+) AS [e] ON [l].[OneToMany_Optional_Self_InverseId] = [e].[Id]
+LEFT JOIN [Level1] AS [l0] ON [l].[OneToOne_Optional_SelfId] = [l0].[Id]
+ORDER BY [e].[Id]",
+                Sql);
+        }
+
+        public override void Multiple_complex_include_select()
+        {
+            base.Multiple_complex_include_select();
+
+            Assert.Equal(
+                @"SELECT [e].[Id], [e].[Name], [e].[OneToMany_Optional_Self_InverseId], [e].[OneToMany_Required_Self_InverseId], [e].[OneToOne_Optional_SelfId], [l].[Id], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Name], [l].[OneToMany_Optional_InverseId], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_PK_InverseId], [l].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [e]
+LEFT JOIN [Level2] AS [l] ON [l].[Level1_Optional_Id] = [e].[Id]
+ORDER BY [l].[Id], [e].[Id]
+
+SELECT [l].[Id], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Name], [l].[OneToMany_Optional_InverseId], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_PK_InverseId], [l].[OneToOne_Optional_SelfId], [l0].[Id], [l0].[Level2_Optional_Id], [l0].[Level2_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_InverseId], [l0].[OneToMany_Optional_Self_InverseId], [l0].[OneToMany_Required_InverseId], [l0].[OneToMany_Required_Self_InverseId], [l0].[OneToOne_Optional_PK_InverseId], [l0].[OneToOne_Optional_SelfId]
+FROM [Level2] AS [l]
+INNER JOIN (
+    SELECT DISTINCT [l].[Id], [e].[Id] AS [Id0]
+    FROM [Level1] AS [e]
+    LEFT JOIN [Level2] AS [l] ON [l].[Level1_Optional_Id] = [e].[Id]
+) AS [e] ON [l].[OneToMany_Optional_InverseId] = [e].[Id0]
+LEFT JOIN [Level3] AS [l0] ON [l0].[Level2_Optional_Id] = [l].[Id]
+ORDER BY [e].[Id], [e].[Id0]
+
+SELECT [l].[Id], [l].[Level2_Optional_Id], [l].[Level2_Required_Id], [l].[Name], [l].[OneToMany_Optional_InverseId], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_PK_InverseId], [l].[OneToOne_Optional_SelfId]
+FROM [Level3] AS [l]
+INNER JOIN (
+    SELECT DISTINCT [l].[Id]
+    FROM [Level1] AS [e]
+    LEFT JOIN [Level2] AS [l] ON [l].[Level1_Optional_Id] = [e].[Id]
+) AS [l0] ON [l].[OneToMany_Optional_InverseId] = [l0].[Id]
+ORDER BY [l0].[Id]",
+                Sql);
+        }
+
+        // issue #3491
+        //[Fact]
+        public virtual void Multiple_complex_includes_from_sql()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.LevelOne.FromSql("SELECT * FROM [Level1]")
+                    .Include(e => e.OneToOne_Optional_FK)
+                    .ThenInclude(e => e.OneToMany_Optional)
+                    .Include(e => e.OneToMany_Optional)
+                    .ThenInclude(e => e.OneToOne_Optional_FK);
+
+                var result = query.ToList();
+            }
+
+            Assert.Equal(
+                @"",
+                Sql);
+        }
+
 
         private static string Sql => TestSqlLoggerFactory.Sql;
     }

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Linq;
 using Microsoft.Data.Entity.FunctionalTests;
 using Xunit;
 using Xunit.Abstractions;


### PR DESCRIPTION
Problem happens for specific combination of nested include statements. When we include collection, we inject ORDER by clauses. We choose them based on the QuerySource of the tables in the select expression. If select expression has multiple tables, added by previous include reference, both tables have the same QuerySource. This makes the choice of order by table ambiguous and may lead to us ordering by the same column twice.

Fix is to add additional metadata to TableExpressionBase that represents the type of entity it is associated with.

The fix doesn't remove the issue entirely. It can still appear in some cases with self reference includes (where Tables have the same type), or if Includes are done on a subquery (which doesn't have IEntityType associated with it)