### PR TITLE
Fix #2891 - Promote transaction API to core

### DIFF
--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -355,6 +355,7 @@
     <Compile Include="Query\Internal\IQueryBuffer.cs" />
     <Compile Include="Storage\DatabaseErrorLogState.cs" />
     <Compile Include="Storage\DatabaseProviderServices.cs" />
+    <Compile Include="Storage\IDbContextTransactionManager.cs" />
     <Compile Include="Storage\IDatabase.cs" />
     <Compile Include="Extensions\EntityTypeExtensions.cs" />
     <Compile Include="Metadata\IIndex.cs" />
@@ -401,6 +402,7 @@
     <Compile Include="Metadata\INavigation.cs" />
     <Compile Include="Metadata\IProperty.cs" />
     <Compile Include="Metadata\IPropertyBase.cs" />
+    <Compile Include="Storage\IDbContextTransaction.cs" />
     <Compile Include="Storage\ValueBuffer.cs" />
     <Compile Include="Metadata\Internal\Key.cs" />
     <Compile Include="Metadata\Internal\MemberMapper.cs" />

--- a/src/EntityFramework.Core/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/EntityFramework.Core/EntityFrameworkServiceCollectionExtensions.cs
@@ -3,7 +3,6 @@
 
 using System;
 using JetBrains.Annotations;
-using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Internal;
@@ -18,7 +17,6 @@ using Microsoft.Data.Entity.Utilities;
 using Microsoft.Data.Entity.ValueGeneration;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Logging;
 using Remotion.Linq.Parsing.Structure.NodeTypeProviders;
 
 // ReSharper disable once CheckNamespace
@@ -116,6 +114,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddScoped(p => GetContextServices(p).ContextOptions)
                 .AddScoped(p => GetContextServices(p).DatabaseProviderServices)
                 .AddScoped(p => GetProviderServices(p).Database)
+                .AddScoped(p => GetProviderServices(p).TransactionManager)
                 .AddScoped(p => GetProviderServices(p).ValueGeneratorSelector)
                 .AddScoped(p => GetProviderServices(p).Creator)
                 .AddScoped(p => GetProviderServices(p).ConventionSetBuilder)

--- a/src/EntityFramework.Core/Infrastructure/DatabaseFacade.cs
+++ b/src/EntityFramework.Core/Infrastructure/DatabaseFacade.cs
@@ -85,6 +85,38 @@ namespace Microsoft.Data.Entity.Infrastructure
             => this.GetService<IDatabaseCreator>().EnsureDeletedAsync(cancellationToken);
 
         /// <summary>
+        ///     Starts a new transaction.
+        /// </summary>
+        /// <returns>
+        ///     A <see cref="IDbContextTransaction"/> that represents the started transaction.
+        /// </returns>
+        public virtual IDbContextTransaction BeginTransaction()
+            => this.GetService<IDbContextTransactionManager>().BeginTransaction();
+
+        /// <summary>
+        ///     Asynchronously starts a new transaction.
+        /// </summary>
+        /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>
+        ///     A task that represents the asynchronus transaction initialization. The task result contains a <see cref="IDbContextTransaction"/>
+        ///     that represents the started transaction.
+        /// </returns>
+        public virtual Task<IDbContextTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default(CancellationToken))
+            => this.GetService<IDbContextTransactionManager>().BeginTransactionAsync(cancellationToken);
+
+        /// <summary>
+        ///     Applies the outstanding operations in the current transaction to the database.
+        /// </summary>
+        public virtual void CommitTransaction()
+            => this.GetService<IDbContextTransactionManager>().CommitTransaction();
+
+        /// <summary>
+        ///     Discards the outstanding operations in the current transaction.
+        /// </summary>
+        public virtual void RollbackTransaction()
+            => this.GetService<IDbContextTransactionManager>().RollbackTransaction();
+
+        /// <summary>
         ///     <para>
         ///         Gets the scoped <see cref="IServiceProvider" /> being used to resolve services.
         ///     </para>

--- a/src/EntityFramework.Core/Storage/DatabaseProviderServices.cs
+++ b/src/EntityFramework.Core/Storage/DatabaseProviderServices.cs
@@ -117,6 +117,11 @@ namespace Microsoft.Data.Entity.Storage
         public abstract IDatabase Database { get; }
 
         /// <summary>
+        ///     Gets the <see cref="IDbContextTransactionManager"/> for the database provider.
+        /// </summary>
+        public abstract IDbContextTransactionManager TransactionManager { get; }
+
+        /// <summary>
         ///     Gets the <see cref="IDatabaseCreator"/> for the database provider.
         /// </summary>
         public abstract IDatabaseCreator Creator { get; }

--- a/src/EntityFramework.Core/Storage/IDatabaseProviderServices.cs
+++ b/src/EntityFramework.Core/Storage/IDatabaseProviderServices.cs
@@ -34,6 +34,11 @@ namespace Microsoft.Data.Entity.Storage
         IDatabase Database { get; }
 
         /// <summary>
+        ///     Gets the <see cref="IDbContextTransactionManager"/> for the database provider.
+        /// </summary>
+        IDbContextTransactionManager TransactionManager { get; }
+
+        /// <summary>
         ///     Gets the <see cref="IDatabaseCreator"/> for the database provider.
         /// </summary>
         IDatabaseCreator Creator { get; }

--- a/src/EntityFramework.Core/Storage/IDbContextTransaction.cs
+++ b/src/EntityFramework.Core/Storage/IDbContextTransaction.cs
@@ -2,14 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Data.Common;
-using Microsoft.Data.Entity.Infrastructure;
 
 namespace Microsoft.Data.Entity.Storage
 {
-    public interface IRelationalTransaction : IDisposable, IInfrastructure<DbTransaction>
+    public interface IDbContextTransaction : IDisposable
     {
-        IRelationalConnection Connection { get; }
         void Commit();
         void Rollback();
     }

--- a/src/EntityFramework.Core/Storage/IDbContextTransactionManager.cs
+++ b/src/EntityFramework.Core/Storage/IDbContextTransactionManager.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Data.Entity.Storage
+{
+    public interface IDbContextTransactionManager
+    {
+        IDbContextTransaction BeginTransaction();
+
+        Task<IDbContextTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default(CancellationToken));
+
+        void CommitTransaction();
+
+        void RollbackTransaction();
+    }
+}

--- a/src/EntityFramework.InMemory/EntityFramework.InMemory.csproj
+++ b/src/EntityFramework.InMemory/EntityFramework.InMemory.csproj
@@ -46,6 +46,7 @@
       <Link>Utilities\LoggingExtensions.cs</Link>
     </Compile>
     <Compile Include="Extensions\Internal\InMemoryLoggerExtensions.cs" />
+    <Compile Include="Infrastructure\InMemoryDbContextOptionsBuilder.cs" />
     <Compile Include="Infrastructure\Internal\InMemoryModelSource.cs" />
     <Compile Include="Infrastructure\Internal\InMemoryOptionsExtension.cs" />
     <Compile Include="Infrastructure\InMemoryLoggingEventId.cs" />
@@ -77,6 +78,8 @@
     <Compile Include="Query\Internal\InMemoryQueryModelVisitor.cs" />
     <Compile Include="Query\Internal\InMemoryQueryModelVisitorFactory.cs" />
     <Compile Include="Query\Internal\MaterializerFactory.cs" />
+    <Compile Include="Storage\InMemoryTransactionManager.cs" />
+    <Compile Include="Storage\InMemoryTransaction.cs" />
     <Compile Include="Storage\Internal\IInMemoryDatabase.cs" />
     <Compile Include="Storage\Internal\IInMemoryStore.cs" />
     <Compile Include="Storage\Internal\InMemoryDatabase.cs" />

--- a/src/EntityFramework.InMemory/Extensions/InMemoryDbContextOptionsExtensions.cs
+++ b/src/EntityFramework.InMemory/Extensions/InMemoryDbContextOptionsExtensions.cs
@@ -12,9 +12,13 @@ namespace Microsoft.Data.Entity
 {
     public static class InMemoryDbContextOptionsExtensions
     {
-        public static void UseInMemoryDatabase([NotNull] this DbContextOptionsBuilder optionsBuilder)
-            => ((IDbContextOptionsBuilderInfrastructure)Check.NotNull(optionsBuilder, nameof(optionsBuilder)))
-                .AddOrUpdateExtension(
-                    new InMemoryOptionsExtension());
+        public static InMemoryDbContextOptionsBuilder UseInMemoryDatabase([NotNull] this DbContextOptionsBuilder optionsBuilder)
+        {
+            Check.NotNull(optionsBuilder, nameof(optionsBuilder));
+
+            ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(new InMemoryOptionsExtension());
+
+            return new InMemoryDbContextOptionsBuilder(optionsBuilder);
+        }
     }
 }

--- a/src/EntityFramework.InMemory/Extensions/InMemoryEntityFrameworkServicesBuilderExtensions.cs
+++ b/src/EntityFramework.InMemory/Extensions/InMemoryEntityFrameworkServicesBuilderExtensions.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddScoped<InMemoryValueGeneratorSelector>()
                 .AddScoped<InMemoryDatabaseProviderServices>()
                 .AddScoped<IInMemoryDatabase, InMemoryDatabase>()
+                .AddScoped<InMemoryTransactionManager>()
                 .AddScoped<InMemoryDatabaseCreator>()
                 .AddQuery());
 

--- a/src/EntityFramework.InMemory/Infrastructure/InMemoryDbContextOptionsBuilder.cs
+++ b/src/EntityFramework.InMemory/Infrastructure/InMemoryDbContextOptionsBuilder.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure.Internal;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Infrastructure
+{
+    public class InMemoryDbContextOptionsBuilder
+    {
+        public InMemoryDbContextOptionsBuilder([NotNull] DbContextOptionsBuilder optionsBuilder)
+        {
+            Check.NotNull(optionsBuilder, nameof(optionsBuilder));
+
+            OptionsBuilder = optionsBuilder;
+        }
+
+        protected virtual DbContextOptionsBuilder OptionsBuilder { get; }
+
+        public virtual InMemoryDbContextOptionsBuilder IgnoreTransactions()
+            => SetOption(e => e.IgnoreTransactions = true);
+
+        protected virtual InMemoryDbContextOptionsBuilder SetOption([NotNull] Action<InMemoryOptionsExtension> setAction)
+        {
+            Check.NotNull(setAction, nameof(setAction));
+
+            var extension = new InMemoryOptionsExtension(OptionsBuilder.Options.GetExtension<InMemoryOptionsExtension>());
+
+            setAction(extension);
+
+            ((IDbContextOptionsBuilderInfrastructure)OptionsBuilder).AddOrUpdateExtension(extension);
+
+            return this;
+        }
+    }
+}

--- a/src/EntityFramework.InMemory/Infrastructure/Internal/InMemoryOptionsExtension.cs
+++ b/src/EntityFramework.InMemory/Infrastructure/Internal/InMemoryOptionsExtension.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using JetBrains.Annotations;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -8,6 +9,23 @@ namespace Microsoft.Data.Entity.Infrastructure.Internal
 {
     public class InMemoryOptionsExtension : IDbContextOptionsExtension
     {
+        private bool _ignoreTransactions;
+
+        public InMemoryOptionsExtension()
+        {
+        }
+
+        public InMemoryOptionsExtension([NotNull] InMemoryOptionsExtension copyFrom)
+        {
+            _ignoreTransactions = copyFrom._ignoreTransactions;
+        }
+
+        public virtual bool IgnoreTransactions
+        {
+            get { return _ignoreTransactions; }
+            set { _ignoreTransactions = value; }
+        }
+
         public virtual void ApplyServices(EntityFrameworkServicesBuilder builder)
         {
             Check.NotNull(builder, nameof(builder));

--- a/src/EntityFramework.InMemory/Properties/InMemoryStrings.Designer.cs
+++ b/src/EntityFramework.InMemory/Properties/InMemoryStrings.Designer.cs
@@ -29,6 +29,14 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
+        /// Transactions are not supported by the in-memory store. To suppress this Exception call IgnoreTransactions() when overriding DbContext.OnConfiguring.
+        /// </summary>
+        public static string TransactionsNotSupported
+        {
+            get { return GetString("TransactionsNotSupported"); }
+        }
+
+        /// <summary>
         /// In-Memory-specific methods can only be used when the context is using an In-Memory database.
         /// </summary>
         public static string InMemoryNotInUse

--- a/src/EntityFramework.InMemory/Properties/InMemoryStrings.resx
+++ b/src/EntityFramework.InMemory/Properties/InMemoryStrings.resx
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <root>
-    <!-- 
+  <!-- 
     Microsoft ResX Schema 
     
     Version 2.0
@@ -60,77 +59,74 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-    <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-        <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
-        <xsd:element name="root" msdata:IsDataSet="true">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
             <xsd:complexType>
-                <xsd:choice maxOccurs="unbounded">
-                    <xsd:element name="metadata">
-                        <xsd:complexType>
-                            <xsd:sequence>
-                                <xsd:element name="value" type="xsd:string" minOccurs="0" />
-                            </xsd:sequence>
-                            <xsd:attribute name="name" use="required" type="xsd:string" />
-                            <xsd:attribute name="type" type="xsd:string" />
-                            <xsd:attribute name="mimetype" type="xsd:string" />
-                            <xsd:attribute ref="xml:space" />
-                        </xsd:complexType>
-                    </xsd:element>
-                    <xsd:element name="assembly">
-                        <xsd:complexType>
-                            <xsd:attribute name="alias" type="xsd:string" />
-                            <xsd:attribute name="name" type="xsd:string" />
-                        </xsd:complexType>
-                    </xsd:element>
-                    <xsd:element name="data">
-                        <xsd:complexType>
-                            <xsd:sequence>
-                                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-                                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-                            </xsd:sequence>
-                            <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
-                            <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-                            <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-                            <xsd:attribute ref="xml:space" />
-                        </xsd:complexType>
-                    </xsd:element>
-                    <xsd:element name="resheader">
-                        <xsd:complexType>
-                            <xsd:sequence>
-                                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-                            </xsd:sequence>
-                            <xsd:attribute name="name" type="xsd:string" use="required" />
-                        </xsd:complexType>
-                    </xsd:element>
-                </xsd:choice>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
-        </xsd:element>
-    </xsd:schema>
-    <resheader name="resmimetype">
-        <value>text/microsoft-resx</value>
-    </resheader>
-    <resheader name="version">
-        <value>2.0</value>
-    </resheader>
-    <resheader name="reader">
-        <value>
-            System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral,
-            PublicKeyToken=b77a5c561934e089
-        </value>
-    </resheader>
-    <resheader name="writer">
-        <value>
-            System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral,
-            PublicKeyToken=b77a5c561934e089
-        </value>
-    </resheader>
-    <data name="InvalidEnumValue" xml:space="preserve">
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="InvalidEnumValue" xml:space="preserve">
     <value>The value provided for argument '{argumentName}' must be a valid value of enum type '{enumType}'.</value>
   </data>
-    <data name="LogSavedChanges" xml:space="preserve">
+  <data name="LogSavedChanges" xml:space="preserve">
     <value>Saved {count} entities to in-memory store.</value>
   </data>
-    <data name="InMemoryNotInUse" xml:space="preserve">
+  <data name="InMemoryNotInUse" xml:space="preserve">
     <value>In-Memory-specific methods can only be used when the context is using an In-Memory database.</value>
+  </data>
+  <data name="TransactionsNotSupported" xml:space="preserve">
+    <value>Transactions are not supported by the in-memory store. To suppress this Exception call IgnoreTransactions() when overriding DbContext.OnConfiguring.</value>
   </data>
 </root>

--- a/src/EntityFramework.InMemory/Storage/InMemoryTransaction.cs
+++ b/src/EntityFramework.InMemory/Storage/InMemoryTransaction.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Data.Entity.Storage
+{
+    public class InMemoryTransaction : IDbContextTransaction
+    {
+        public virtual void Commit()
+        {
+        }
+
+        public virtual void Rollback()
+        {
+        }
+
+        public virtual void Dispose()
+        {
+        }
+    }
+}

--- a/src/EntityFramework.InMemory/Storage/InMemoryTransactionManager.cs
+++ b/src/EntityFramework.InMemory/Storage/InMemoryTransactionManager.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Infrastructure.Internal;
+using Microsoft.Data.Entity.Internal;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Storage
+{
+    public class InMemoryTransactionManager : IDbContextTransactionManager
+    {
+        private readonly bool _ignoreTransactions;
+
+        public InMemoryTransactionManager([NotNull] IDbContextOptions options)
+        {
+            Check.NotNull(options, nameof(options));
+
+            var optionsExtension = options.Extensions.OfType<InMemoryOptionsExtension>().FirstOrDefault();
+            if (optionsExtension != null)
+            {
+                _ignoreTransactions = optionsExtension.IgnoreTransactions;
+            }
+        }
+
+        public virtual IDbContextTransaction BeginTransaction()
+        {
+            if (!_ignoreTransactions)
+            {
+                throw new InvalidOperationException(InMemoryStrings.TransactionsNotSupported);
+            }
+            return new InMemoryTransaction();
+        }
+
+        public virtual Task<IDbContextTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (!_ignoreTransactions)
+            {
+                throw new InvalidOperationException(InMemoryStrings.TransactionsNotSupported);
+            }
+
+            return Task.FromResult<IDbContextTransaction>(new InMemoryTransaction());
+        }
+
+        public virtual void CommitTransaction()
+        {
+            if (!_ignoreTransactions)
+            {
+                throw new InvalidOperationException(InMemoryStrings.TransactionsNotSupported);
+            }
+        }
+
+        public virtual void RollbackTransaction()
+        {
+            if (!_ignoreTransactions)
+            {
+                throw new InvalidOperationException(InMemoryStrings.TransactionsNotSupported);
+            }
+        }
+    }
+}

--- a/src/EntityFramework.InMemory/Storage/Internal/InMemoryDatabaseProviderServices.cs
+++ b/src/EntityFramework.InMemory/Storage/Internal/InMemoryDatabaseProviderServices.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Data.Entity.Storage.Internal
 
         public override string InvariantName => GetType().GetTypeInfo().Assembly.GetName().Name;
         public override IDatabase Database => GetService<IInMemoryDatabase>();
+        public override IDbContextTransactionManager TransactionManager => GetService<InMemoryTransactionManager>();
         public override IQueryContextFactory QueryContextFactory => GetService<InMemoryQueryContextFactory>();
         public override IDatabaseCreator Creator => GetService<InMemoryDatabaseCreator>();
         public override IValueGeneratorSelector ValueGeneratorSelector => GetService<InMemoryValueGeneratorSelector>();

--- a/src/EntityFramework.Relational/EntityFramework.Relational.csproj
+++ b/src/EntityFramework.Relational/EntityFramework.Relational.csproj
@@ -221,6 +221,7 @@
     <Compile Include="Migrations\MigrationsSqlGenerator.cs" />
     <Compile Include="Migrations\Internal\MigrationsModelDiffer.cs" />
     <Compile Include="Query\Expressions\SqlFunctionExpression.cs" />
+    <Compile Include="Storage\DbContextTransactionExtensions.cs" />
     <Compile Include="Storage\Internal\RemappingUntypedRelationalValueBufferFactory.cs" />
     <Compile Include="Storage\Internal\TypedRelationalValueBufferFactory.cs" />
     <Compile Include="Storage\Internal\UntypedRelationalValueBufferFactory.cs" />
@@ -231,7 +232,7 @@
     <Compile Include="Storage\IRelationalDatabaseCreator.cs" />
     <Compile Include="Storage\IRelationalDatabaseProviderServices.cs" />
     <Compile Include="Infrastructure\RelationalSqlExecutor.cs" />
-    <Compile Include="Storage\IRelationalTransaction.cs" />
+    <Compile Include="Storage\IRelationalTransactionManager.cs" />
     <Compile Include="Storage\IRelationalTypeMapper.cs" />
     <Compile Include="Storage\IRelationalValueBufferFactory.cs" />
     <Compile Include="Storage\IRelationalValueBufferFactoryFactory.cs" />

--- a/src/EntityFramework.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EntityFramework.Relational/Properties/RelationalStrings.Designer.cs
@@ -101,6 +101,15 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
+        /// The connection does not have any active transactions.
+        /// </summary>
+        public static string NoActiveTransaction
+        {
+            get { return GetString("NoActiveTransaction"); }
+        }
+
+
+        /// <summary>
         /// The specified transaction is not associated with the current connection. Only transactions associated with the current connection may be used.
         /// </summary>
         public static string TransactionAssociatedWithDifferentConnection

--- a/src/EntityFramework.Relational/Properties/RelationalStrings.resx
+++ b/src/EntityFramework.Relational/Properties/RelationalStrings.resx
@@ -298,4 +298,7 @@
   <data name="DuplicateColumnName" xml:space="preserve">
     <value>Cannot use column name '{columnName}' in entity '{entityType}' for property '{property}' since it is being used for another property.</value>
   </data>
+  <data name="NoActiveTransaction" xml:space="preserve">
+    <value>The connection does not have any active transactions.</value>
+  </data>
 </root>

--- a/src/EntityFramework.Relational/Storage/DbContextTransactionExtensions.cs
+++ b/src/EntityFramework.Relational/Storage/DbContextTransactionExtensions.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Data.Common;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Internal;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Storage
+{
+    public static class DbContextTransactionExtensions
+    {
+        public static DbTransaction GetDbTransaction([NotNull] this IDbContextTransaction dbContextTransaction)
+        {
+            Check.NotNull(dbContextTransaction, nameof(dbContextTransaction));
+
+            var accessor = dbContextTransaction as IInfrastructure<DbTransaction>;
+
+            if (accessor == null)
+            {
+                throw new InvalidOperationException(RelationalStrings.RelationalNotInUse);
+            }
+
+            return accessor.GetInfrastructure();
+        }
+    }
+}

--- a/src/EntityFramework.Relational/Storage/IRelationalConnection.cs
+++ b/src/EntityFramework.Relational/Storage/IRelationalConnection.cs
@@ -2,35 +2,21 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Data;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
-using JetBrains.Annotations;
 
 namespace Microsoft.Data.Entity.Storage
 {
-    public interface IRelationalConnection : IDisposable
+    public interface IRelationalConnection : IRelationalTransactionManager, IDisposable
     {
         string ConnectionString { get; }
 
         DbConnection DbConnection { get; }
 
-        IRelationalTransaction Transaction { get; }
+        IDbContextTransaction CurrentTransaction { get; }
 
         int? CommandTimeout { get; set; }
-
-        DbTransaction DbTransaction { get; }
-
-        IRelationalTransaction BeginTransaction();
-
-        Task<IRelationalTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default(CancellationToken));
-
-        IRelationalTransaction BeginTransaction(IsolationLevel isolationLevel);
-
-        Task<IRelationalTransaction> BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken = default(CancellationToken));
-
-        IRelationalTransaction UseTransaction([CanBeNull] DbTransaction transaction);
 
         void Open();
 

--- a/src/EntityFramework.Relational/Storage/IRelationalTransactionManager.cs
+++ b/src/EntityFramework.Relational/Storage/IRelationalTransactionManager.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+
+namespace Microsoft.Data.Entity.Storage
+{
+    public interface IRelationalTransactionManager : IDbContextTransactionManager
+    {
+        IDbContextTransaction BeginTransaction(IsolationLevel isolationLevel);
+
+        Task<IDbContextTransaction> BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken = default(CancellationToken));
+
+        IDbContextTransaction UseTransaction([CanBeNull] DbTransaction transaction);
+    }
+}

--- a/src/EntityFramework.Relational/Storage/Internal/RelationalCommand.cs
+++ b/src/EntityFramework.Relational/Storage/Internal/RelationalCommand.cs
@@ -328,9 +328,9 @@ namespace Microsoft.Data.Entity.Storage.Internal
 
             command.CommandText = CommandText;
 
-            if (connection.Transaction != null)
+            if (connection.CurrentTransaction != null)
             {
-                command.Transaction = connection.Transaction.GetInfrastructure();
+                command.Transaction = connection.CurrentTransaction.GetDbTransaction();
             }
 
             if (connection.CommandTimeout != null)

--- a/src/EntityFramework.Relational/Storage/RelationalDatabaseProviderServices.cs
+++ b/src/EntityFramework.Relational/Storage/RelationalDatabaseProviderServices.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Data.Entity.Storage
         }
 
         public override IDatabase Database => GetService<RelationalDatabase>();
+        public override IDbContextTransactionManager TransactionManager => GetService<IRelationalConnection>();
         public override IModelValidator ModelValidator => GetService<RelationalModelValidator>();
         public override ICompiledQueryCacheKeyGenerator CompiledQueryCacheKeyGenerator => GetService<RelationalCompiledQueryCacheKeyGenerator>();
         public override IValueGeneratorSelector ValueGeneratorSelector => GetService<RelationalValueGeneratorSelector>();

--- a/src/EntityFramework.Relational/Storage/RelationalTransaction.cs
+++ b/src/EntityFramework.Relational/Storage/RelationalTransaction.cs
@@ -12,9 +12,10 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Data.Entity.Storage
 {
-    public class RelationalTransaction : IRelationalTransaction
+    public class RelationalTransaction : IDbContextTransaction, IInfrastructure<DbTransaction>
     {
-        private readonly DbTransaction _transaction;
+        private readonly IRelationalConnection _relationalConnection;
+        private readonly DbTransaction _dbTransaction;
         private readonly ILogger _logger;
         private readonly bool _transactionOwned;
 
@@ -35,14 +36,12 @@ namespace Microsoft.Data.Entity.Storage
                 throw new InvalidOperationException(RelationalStrings.TransactionAssociatedWithDifferentConnection);
             }
 
-            Connection = connection;
+            _relationalConnection = connection;
 
-            _transaction = transaction;
+            _dbTransaction = transaction;
             _logger = logger;
             _transactionOwned = transactionOwned;
         }
-
-        public virtual IRelationalConnection Connection { get; }
 
         public virtual void Commit()
         {
@@ -50,7 +49,7 @@ namespace Microsoft.Data.Entity.Storage
                 RelationalLoggingEventId.CommittingTransaction,
                 () => RelationalStrings.RelationalLoggerCommittingTransaction);
 
-            _transaction.Commit();
+            _dbTransaction.Commit();
 
             ClearTransaction();
         }
@@ -61,7 +60,7 @@ namespace Microsoft.Data.Entity.Storage
                 RelationalLoggingEventId.RollingbackTransaction,
                 () => RelationalStrings.RelationalLoggerRollingbackTransaction);
 
-            _transaction.Rollback();
+            _dbTransaction.Rollback();
 
             ClearTransaction();
         }
@@ -74,7 +73,7 @@ namespace Microsoft.Data.Entity.Storage
 
                 if (_transactionOwned)
                 {
-                    _transaction.Dispose();
+                    _dbTransaction.Dispose();
                 }
 
                 ClearTransaction();
@@ -83,11 +82,11 @@ namespace Microsoft.Data.Entity.Storage
 
         private void ClearTransaction()
         {
-            Debug.Assert(Connection.Transaction == null || Connection.Transaction == this);
+            Debug.Assert(_relationalConnection.CurrentTransaction == null || _relationalConnection.CurrentTransaction == this);
 
-            Connection.UseTransaction(null);
+            _relationalConnection.UseTransaction(null);
         }
 
-        DbTransaction IInfrastructure<DbTransaction>.Instance => _transaction;
+        DbTransaction IInfrastructure<DbTransaction>.Instance => _dbTransaction;
     }
 }

--- a/src/EntityFramework.Relational/Update/Internal/BatchExecutor.cs
+++ b/src/EntityFramework.Relational/Update/Internal/BatchExecutor.cs
@@ -16,10 +16,10 @@ namespace Microsoft.Data.Entity.Update.Internal
         {
             var rowsAffected = 0;
             connection.Open();
-            IRelationalTransaction startedTransaction = null;
+            IDbContextTransaction startedTransaction = null;
             try
             {
-                if (connection.Transaction == null)
+                if (connection.CurrentTransaction == null)
                 {
                     startedTransaction = connection.BeginTransaction();
                 }
@@ -48,10 +48,10 @@ namespace Microsoft.Data.Entity.Update.Internal
         {
             var rowsAffected = 0;
             await connection.OpenAsync(cancellationToken);
-            IRelationalTransaction startedTransaction = null;
+            IDbContextTransaction startedTransaction = null;
             try
             {
-                if (connection.Transaction == null)
+                if (connection.CurrentTransaction == null)
                 {
                     startedTransaction = connection.BeginTransaction();
                 }

--- a/test/EntityFramework.Commands.Tests/Migrations/Design/MigrationScaffolderTest.cs
+++ b/test/EntityFramework.Commands.Tests/Migrations/Design/MigrationScaffolderTest.cs
@@ -97,6 +97,7 @@ namespace Microsoft.Data.Entity.Migrations.Design
         {
             public string InvariantName => "Mock.Provider";
             public IDatabase Database => null;
+            public IDbContextTransactionManager TransactionManager => null;
             public IDatabaseCreator Creator => null;
             public IValueGeneratorSelector ValueGeneratorSelector => null;
             public IConventionSetBuilder ConventionSetBuilder => null;

--- a/test/EntityFramework.Core.Tests/DatabaseFacadeTest.cs
+++ b/test/EntityFramework.Core.Tests/DatabaseFacadeTest.cs
@@ -83,6 +83,69 @@ namespace Microsoft.Data.Entity.Tests
         }
 
         [Fact]
+        public void Can_begin_transaction()
+        {
+            var transactionManagerMock = new Mock<IDbContextTransactionManager>();
+            var transaction = Mock.Of<IDbContextTransaction>();
+
+            transactionManagerMock.Setup(m => m.BeginTransaction()).Returns(transaction);
+
+            var context = TestHelpers.Instance.CreateContext(
+                new ServiceCollection().AddInstance(transactionManagerMock.Object));
+
+            Assert.Same(transaction, context.Database.BeginTransaction());
+
+            transactionManagerMock.Verify(m => m.BeginTransaction(), Times.Once);
+        }
+
+        [Fact]
+        public void Can_begin_transaction_async()
+        {
+            var transactionManagerMock = new Mock<IDbContextTransactionManager>();
+            var transaction = Mock.Of<IDbContextTransaction>();
+
+            var transactionTask = new Task<IDbContextTransaction>(() => transaction);
+
+            transactionManagerMock.Setup(m => m.BeginTransactionAsync(It.IsAny<CancellationToken>()))
+                .Returns(transactionTask);
+
+            var context = TestHelpers.Instance.CreateContext(
+                new ServiceCollection().AddInstance(transactionManagerMock.Object));
+
+            var cancellationToken = new CancellationToken();
+
+            Assert.Same(transactionTask, context.Database.BeginTransactionAsync(cancellationToken));
+
+            transactionManagerMock.Verify(m => m.BeginTransactionAsync(cancellationToken), Times.Once);
+        }
+
+        [Fact]
+        public void Can_commit_transaction()
+        {
+            var transactionManagerMock = new Mock<IDbContextTransactionManager>();
+
+            var context = TestHelpers.Instance.CreateContext(
+                new ServiceCollection().AddInstance(transactionManagerMock.Object));
+
+            context.Database.CommitTransaction();
+
+            transactionManagerMock.Verify(m => m.CommitTransaction(), Times.Once);
+        }
+
+        [Fact]
+        public void Can_roll_back_transaction()
+        {
+            var transactionManagerMock = new Mock<IDbContextTransactionManager>();
+
+            var context = TestHelpers.Instance.CreateContext(
+                new ServiceCollection().AddInstance(transactionManagerMock.Object));
+
+            context.Database.RollbackTransaction();
+
+            transactionManagerMock.Verify(m => m.RollbackTransaction(), Times.Once);
+        }
+
+        [Fact]
         public void Cannot_use_DatabaseFacade_after_dispose()
         {
             var context = TestHelpers.Instance.CreateContext();

--- a/test/EntityFramework.InMemory.Tests/EntityFramework.InMemory.Tests.csproj
+++ b/test/EntityFramework.InMemory.Tests/EntityFramework.InMemory.Tests.csproj
@@ -32,12 +32,14 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ApiConsistencyTest.cs" />
+    <Compile Include="InMemoryDbContextOptionsExtensionsTest.cs" />
     <Compile Include="InMemoryIntegerValueGeneratorFactoryTest.cs" />
     <Compile Include="InMemoryOptionsExtensionTest.cs" />
     <Compile Include="InMemoryDatabaseCreatorTest.cs" />
     <Compile Include="InMemoryDatabaseProviderTest.cs" />
     <Compile Include="InMemoryDatabaseTest.cs" />
     <Compile Include="InMemoryEntityFrameworkServicesBuilderExtensionsTest.cs" />
+    <Compile Include="InMemoryTransactionManagerTest.cs" />
     <Compile Include="InMemoryValueGeneratorSelectorTest.cs" />
     <Compile Include="InMemoryIntegerValueGeneratorTest.cs" />
     <None Include="project.json" />

--- a/test/EntityFramework.InMemory.Tests/InMemoryDbContextOptionsExtensionsTest.cs
+++ b/test/EntityFramework.InMemory.Tests/InMemoryDbContextOptionsExtensionsTest.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.Data.Entity.Infrastructure.Internal;
+using Xunit;
+
+namespace Microsoft.Data.Entity.InMemory
+{
+    public class InMemoryDbContextOptionsExtensionsTest
+    {
+        [Fact]
+        public void Can_add_extension_with_transactions_ignored()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder();
+            optionsBuilder.UseInMemoryDatabase().IgnoreTransactions();
+
+            var extension = optionsBuilder.Options.Extensions.OfType<InMemoryOptionsExtension>().Single();
+
+            Assert.Equal(true, extension.IgnoreTransactions);
+        }
+    }
+}

--- a/test/EntityFramework.InMemory.Tests/InMemoryTransactionManagerTest.cs
+++ b/test/EntityFramework.InMemory.Tests/InMemoryTransactionManagerTest.cs
@@ -1,0 +1,126 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Data.Entity.Internal;
+using Microsoft.Data.Entity.Storage;
+using Xunit;
+
+namespace Microsoft.Data.Entity.InMemory
+{
+    public class InMemoryTransactionManagerTest
+    {
+        [Fact]
+        public void Throws_on_BeginTransaction()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder();
+            optionsBuilder.UseInMemoryDatabase();
+
+            var transactionManager = new InMemoryTransactionManager(optionsBuilder.Options);
+
+            Assert.Equal(
+                InMemoryStrings.TransactionsNotSupported,
+                Assert.Throws<InvalidOperationException>(
+                    () => transactionManager.BeginTransaction()).Message);
+        }
+
+        [Fact]
+        public async Task Throws_on_BeginTransactionAsync()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder();
+            optionsBuilder.UseInMemoryDatabase();
+
+            var transactionManager = new InMemoryTransactionManager(optionsBuilder.Options);
+
+            Assert.Equal(
+                InMemoryStrings.TransactionsNotSupported,
+                (await Assert.ThrowsAsync<InvalidOperationException>(
+                    async () => await transactionManager.BeginTransactionAsync())).Message);
+        }
+
+        [Fact]
+        public void Throws_on_CommitTransaction()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder();
+            optionsBuilder.UseInMemoryDatabase();
+
+            var transactionManager = new InMemoryTransactionManager(optionsBuilder.Options);
+
+            Assert.Equal(
+                InMemoryStrings.TransactionsNotSupported,
+                Assert.Throws<InvalidOperationException>(
+                    () => transactionManager.CommitTransaction()).Message);
+        }
+
+        [Fact]
+        public void Throws_on_RollbackTransaction()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder();
+            optionsBuilder.UseInMemoryDatabase();
+
+            var transactionManager = new InMemoryTransactionManager(optionsBuilder.Options);
+
+            Assert.Equal(
+                InMemoryStrings.TransactionsNotSupported,
+                Assert.Throws<InvalidOperationException>(
+                    () => transactionManager.RollbackTransaction()).Message);
+        }
+
+        [Fact]
+        public void Does_not_throw_on_BeginTransaction_when_transactions_ignored()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder();
+            optionsBuilder.UseInMemoryDatabase()
+                .IgnoreTransactions();
+
+            var transactionManager = new InMemoryTransactionManager(optionsBuilder.Options);
+
+            using (var transaction = transactionManager.BeginTransaction())
+            {
+                transaction.Commit();
+                transaction.Rollback();
+            }
+        }
+
+        [Fact]
+        public async Task Does_not_throw_on_BeginTransactionAsync_when_transactions_ignored()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder();
+            optionsBuilder.UseInMemoryDatabase()
+                .IgnoreTransactions();
+
+            var transactionManager = new InMemoryTransactionManager(optionsBuilder.Options);
+
+            using (var transaction = await transactionManager.BeginTransactionAsync())
+            {
+                transaction.Commit();
+                transaction.Rollback();
+            }
+        }
+
+        [Fact]
+        public void Does_not_throw_on_CommitTransaction_when_transactions_ignored()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder();
+            optionsBuilder.UseInMemoryDatabase()
+                .IgnoreTransactions();
+
+            var transactionManager = new InMemoryTransactionManager(optionsBuilder.Options);
+
+            transactionManager.CommitTransaction();
+        }
+
+        [Fact]
+        public void Does_not_throw_on_RollbackTransaction_when_transactions_ignored()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder();
+            optionsBuilder.UseInMemoryDatabase()
+                .IgnoreTransactions();
+
+            var transactionManager = new InMemoryTransactionManager(optionsBuilder.Options);
+
+            transactionManager.RollbackTransaction();
+        }
+    }
+}

--- a/test/EntityFramework.Relational.FunctionalTests/RelationalTestHelpers.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/RelationalTestHelpers.cs
@@ -18,6 +18,6 @@ namespace Microsoft.Data.Entity.Tests
             => builder.AddInMemoryDatabase().AddRelational();
 
         protected override void UseProviderOptions(DbContextOptionsBuilder optionsBuilder)
-            => optionsBuilder.UseInMemoryDatabase();
+            => optionsBuilder.UseInMemoryDatabase().IgnoreTransactions();
     }
 }

--- a/test/EntityFramework.Relational.FunctionalTests/TransactionTestBase.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/TransactionTestBase.cs
@@ -157,7 +157,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
                     Assert.Equal(EntityState.Deleted, firstEntry.State);
                     Assert.Equal(EntityState.Added, lastEntry.State);
-                    Assert.NotNull(transaction.GetInfrastructure().Connection);
+                    Assert.NotNull(transaction.GetDbTransaction().Connection);
                 }
             }
         }
@@ -184,7 +184,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
                     Assert.Equal(EntityState.Deleted, firstEntry.State);
                     Assert.Equal(EntityState.Added, lastEntry.State);
-                    Assert.NotNull(transaction.GetInfrastructure().Connection);
+                    Assert.NotNull(transaction.GetDbTransaction().Connection);
                 }
             }
         }
@@ -290,7 +290,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
                     using (var innerContext = CreateContext(context.Database.GetDbConnection()))
                     {
-                        innerContext.Database.UseTransaction(transaction.GetInfrastructure());
+                        innerContext.Database.UseTransaction(transaction.GetDbTransaction());
                         Assert.Equal(Fixture.Customers.Count - 1, innerContext.Set<TransactionCustomer>().Count());
                     }
                 }
@@ -328,7 +328,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
                     using (var innerContext = CreateContext(context.Database.GetDbConnection()))
                     {
-                        innerContext.Database.UseTransaction(transaction.GetInfrastructure());
+                        innerContext.Database.UseTransaction(transaction.GetDbTransaction());
                         Assert.Equal(Fixture.Customers.Count - 1, await innerContext.Set<TransactionCustomer>().CountAsync());
                     }
                 }

--- a/test/EntityFramework.Relational.Tests/EntityFramework.Relational.Tests.csproj
+++ b/test/EntityFramework.Relational.Tests/EntityFramework.Relational.Tests.csproj
@@ -52,6 +52,7 @@
     <Compile Include="Migrations\MigrationSqlGeneratorTest.cs" />
     <Compile Include="Migrations\MigrationSqlGeneratorTestBase.cs" />
     <Compile Include="Storage\RelationalCommandTest.cs" />
+    <Compile Include="Storage\RelationalTransactionExtensionsTest.cs" />
     <Compile Include="Storage\RelationalTypeMappingTest.cs" />
     <Compile Include="Metadata\RelationalBuilderExtensionsTest.cs" />
     <Compile Include="RelationalConnectionTest.cs" />

--- a/test/EntityFramework.Relational.Tests/Storage/RelationalCommandTest.cs
+++ b/test/EntityFramework.Relational.Tests/Storage/RelationalCommandTest.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Data.Entity.Storage
 
             var command = fakeConnection.DbConnections[0].DbCommands[0];
 
-            Assert.Same(relationalTransaction.GetInfrastructure(), command.Transaction);
+            Assert.Same(relationalTransaction.GetDbTransaction(), command.Transaction);
         }
 
         [Fact]

--- a/test/EntityFramework.Relational.Tests/Storage/RelationalTransactionExtensionsTest.cs
+++ b/test/EntityFramework.Relational.Tests/Storage/RelationalTransactionExtensionsTest.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Internal;
+using Microsoft.Data.Entity.Tests.TestUtilities;
+using Microsoft.Data.Entity.TestUtilities.FakeProvider;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Storage
+{
+    public class RelationalTransactionExtensionsTest
+    {
+        [Fact]
+        public void GetDbTransaction_returns_the_DbTransaction()
+        {
+            var dbConnection = new FakeDbConnection(ConnectionString);
+            var dbTransaction = new FakeDbTransaction(dbConnection);
+
+            var connection = new FakeRelationalConnection(
+                CreateOptions(new FakeRelationalOptionsExtension { Connection = dbConnection }));
+
+            var transaction = new RelationalTransaction(
+                connection,
+                dbTransaction,
+                new ListLogger(new List<Tuple<LogLevel, string>>()),
+                false);
+
+            Assert.Equal(dbTransaction, transaction.GetDbTransaction());
+        }
+
+        [Fact]
+        public void GetDbTransaction_throws_on_non_relational_provider()
+        {
+            var transaction = new NonRelationalTransaction();
+
+            Assert.Equal(
+                RelationalStrings.RelationalNotInUse,
+                Assert.Throws<InvalidOperationException>(
+                    () => transaction.GetDbTransaction()).Message);
+        }
+
+        private class NonRelationalTransaction : IDbContextTransaction
+        {
+            public void Commit()
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Dispose()
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Rollback()
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private const string ConnectionString = "Fake Connection String";
+
+        public static IDbContextOptions CreateOptions(
+            FakeRelationalOptionsExtension optionsExtension = null)
+        {
+            var optionsBuilder = new DbContextOptionsBuilder();
+
+            ((IDbContextOptionsBuilderInfrastructure)optionsBuilder)
+                .AddOrUpdateExtension(optionsExtension ?? new FakeRelationalOptionsExtension { ConnectionString = ConnectionString });
+
+            return optionsBuilder.Options;
+        }
+    }
+}

--- a/test/EntityFramework.Relational.Tests/TestUtilities/FakeProvider/FakeDbConnection.cs
+++ b/test/EntityFramework.Relational.Tests/TestUtilities/FakeProvider/FakeDbConnection.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Data.Entity.TestUtilities.FakeProvider
 
         private ConnectionState _state;
         private readonly List<FakeDbCommand> _dbCommands = new List<FakeDbCommand>();
+        private readonly List<FakeDbTransaction> _dbTransactions = new List<FakeDbTransaction>();
 
         public FakeDbConnection(
             string connectionString,
@@ -98,9 +99,15 @@ namespace Microsoft.Data.Entity.TestUtilities.FakeProvider
             return command;
         }
 
+        public IReadOnlyList<FakeDbTransaction> DbTransactions => _dbTransactions;
+
         protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel)
         {
-            return new FakeDbTransaction(this);
+            var transaction =  new FakeDbTransaction(this, isolationLevel);
+
+            _dbTransactions.Add(transaction);
+
+            return transaction;
         }
 
         public int DisposeCount { get; private set; }

--- a/test/EntityFramework.Relational.Tests/TestUtilities/FakeProvider/FakeDbTransaction.cs
+++ b/test/EntityFramework.Relational.Tests/TestUtilities/FakeProvider/FakeDbTransaction.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Data;
 using System.Data.Common;
 
@@ -9,29 +8,40 @@ namespace Microsoft.Data.Entity.TestUtilities.FakeProvider
 {
     public class FakeDbTransaction : DbTransaction
     {
-        public FakeDbTransaction(FakeDbConnection connection)
+        public FakeDbTransaction(FakeDbConnection connection, IsolationLevel isolationLevel = IsolationLevel.Unspecified)
         {
             DbConnection = connection;
+            IsolationLevel = isolationLevel;
         }
 
         protected override DbConnection DbConnection { get; }
 
-        public override IsolationLevel IsolationLevel
-        {
-            get
-            {
-                throw new NotImplementedException();
-            }
-        }
+        public override IsolationLevel IsolationLevel { get; }
+
+        public int CommitCount { get; private set; }
 
         public override void Commit()
         {
-            throw new NotImplementedException();
+            CommitCount++;
         }
+
+        public int RollbackCount { get; private set; }
 
         public override void Rollback()
         {
-            throw new NotImplementedException();
+            RollbackCount++;
+        }
+
+        public int DisposeCount { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                DisposeCount++;
+            }
+
+            base.Dispose(disposing);
         }
     }
 }

--- a/test/EntityFramework.Relational.Tests/Update/BatchExecutorTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/BatchExecutorTest.cs
@@ -20,11 +20,11 @@ namespace Microsoft.Data.Entity.Tests.Update
             mockModificationCommandBatch.Setup(m => m.ModificationCommands.Count).Returns(1);
 
             var mockRelationalConnection = new Mock<IRelationalConnection>();
-            var transactionMock = new Mock<IRelationalTransaction>();
+            var transactionMock = new Mock<IDbContextTransaction>();
 
-            IRelationalTransaction currentTransaction = null;
+            IDbContextTransaction currentTransaction = null;
             mockRelationalConnection.Setup(m => m.BeginTransaction()).Returns(() => currentTransaction = transactionMock.Object);
-            mockRelationalConnection.Setup(m => m.Transaction).Returns(() => currentTransaction);
+            mockRelationalConnection.Setup(m => m.CurrentTransaction).Returns(() => currentTransaction);
 
             var cancellationToken = new CancellationTokenSource().Token;
 
@@ -48,8 +48,8 @@ namespace Microsoft.Data.Entity.Tests.Update
             mockModificationCommandBatch.Setup(m => m.ModificationCommands.Count).Returns(1);
 
             var mockRelationalConnection = new Mock<IRelationalConnection>();
-            var transactionMock = new Mock<IRelationalTransaction>();
-            mockRelationalConnection.Setup(m => m.Transaction).Returns(transactionMock.Object);
+            var transactionMock = new Mock<IDbContextTransaction>();
+            mockRelationalConnection.Setup(m => m.CurrentTransaction).Returns(transactionMock.Object);
 
             var cancellationToken = new CancellationTokenSource().Token;
 


### PR DESCRIPTION
Adding concept of transactions to `DatabaseFacade` in core