### PR TITLE
doc comments for root types in core

### DIFF
--- a/src/EntityFramework.Core/DbContext.cs
+++ b/src/EntityFramework.Core/DbContext.cs
@@ -243,11 +243,19 @@ namespace Microsoft.Data.Entity
         ///     This method is called for each instance of the context that is created.
         /// </summary>
         /// <remarks>
-        ///     If you passed an instance of <see cref="DbContextOptions" /> to the constructor of the context (or
-        ///     provided an <see cref="IServiceProvider" /> with <see cref="DbContextOptions" /> registered) then
-        ///     it is cloned before being passed to this method. This allows the options to be altered without
-        ///     affecting other context instances that are constructed with the same <see cref="DbContextOptions" />
-        ///     instance.
+        ///     <para>
+        ///         If you passed an instance of <see cref="DbContextOptions" /> to the constructor of the context (or
+        ///         provided an <see cref="IServiceProvider" /> with <see cref="DbContextOptions" /> registered) then
+        ///         it is cloned before being passed to this method. This allows the options to be altered without
+        ///         affecting other context instances that are constructed with the same <see cref="DbContextOptions" />
+        ///         instance.
+        ///     </para>
+        ///     <para>
+        ///         In situations where an instance of <see cref="DbContextOptions" /> may or may not have been passed
+        ///         to the constructor, you can use <see cref="DbContextOptionsBuilder.IsConfigured"/> to determine if 
+        ///         the options have already been set, and skip some or all of the logic in 
+        ///         <see cref="DbContext.OnConfiguring(DbContextOptionsBuilder)"/>.
+        ///     </para>
         /// </remarks>
         /// <param name="optionsBuilder">
         ///     A builder used to create or modify options for this context. Databases (and other extensions)
@@ -262,6 +270,10 @@ namespace Microsoft.Data.Entity
         ///     exposed in <see cref="DbSet{TEntity}" /> properties on your derived context. The resulting model may be cached
         ///     and re-used for subsequent instances of your derived context.
         /// </summary>
+        /// <remarks>
+        ///     If a model is explicitly set on the options for this context (via <see cref="DbContextOptionsBuilder.UseModel(IModel)"/>)
+        ///     then this method will not be run.
+        /// </remarks>
         /// <param name="modelBuilder">
         ///     The builder being used to construct the model for this context. Databases (and other extensions) typically
         ///     define extension methods on this object that allow you to configure aspects of the model that are specific

--- a/src/EntityFramework.Core/DbContextOptionsBuilder.cs
+++ b/src/EntityFramework.Core/DbContextOptionsBuilder.cs
@@ -10,15 +10,35 @@ using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity
 {
+    /// <summary>
+    ///     <para>
+    ///         Provides a simple API surface for configuring <see cref="DbContextOptions" />. Databases (and other extensions)
+    ///         typically define extension methods on this object that allow you to configure the database connection (and other 
+    ///         options) to be used for a context.
+    ///     </para>
+    ///     <para>
+    ///         You can use <see cref="DbContextOptionsBuilder" /> to configure a context by overriding
+    ///         <see cref="DbContext.OnConfiguring(DbContextOptionsBuilder)" /> or creating a <see cref="DbContextOptions" />
+    ///         externally and passing it to the context constructor.
+    ///     </para>
+    /// </summary>
     public class DbContextOptionsBuilder : IDbContextOptionsBuilderInfrastructure
     {
         private DbContextOptions _options;
 
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="DbContextOptionsBuilder" /> class with no options set.
+        /// </summary>
         public DbContextOptionsBuilder()
             : this(new DbContextOptions<DbContext>())
         {
         }
 
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="DbContextOptionsBuilder" /> class to further configure
+        ///     a given <see cref="DbContextOptions"/>.
+        /// </summary>
+        /// <param name="options"> The options to be configured. </param>
         public DbContextOptionsBuilder([NotNull] DbContextOptions options)
         {
             Check.NotNull(options, nameof(options));
@@ -26,10 +46,30 @@ namespace Microsoft.Data.Entity
             _options = options;
         }
 
+        /// <summary>
+        ///     Gets the options being configured.
+        /// </summary>
         public virtual DbContextOptions Options => _options;
 
+        /// <summary>
+        ///     <para>
+        ///         Gets a value indicating whether any options have been configured.
+        ///     </para>
+        ///     <para>
+        ///         This can be useful when you have overridden <see cref="DbContext.OnConfiguring(DbContextOptionsBuilder)"/> to configure
+        ///         the context, but in some cases you also externally provide options via the context constructor. This property can be
+        ///         used to determine if the options have already been set, and skip some or all of the logic in 
+        ///         <see cref="DbContext.OnConfiguring(DbContextOptionsBuilder)"/>.
+        ///     </para>
+        /// </summary>
         public virtual bool IsConfigured => _options.Extensions.Any();
 
+        /// <summary>
+        ///     Sets the model to be used for the context. If the model is set, then <see cref="DbContext.OnModelCreating(ModelBuilder)"/>
+        ///     will not be run.
+        /// </summary>
+        /// <param name="model"> The model to be used. </param>
+        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
         public virtual DbContextOptionsBuilder UseModel([NotNull] IModel model)
         {
             Check.NotNull(model, nameof(model));
@@ -39,9 +79,26 @@ namespace Microsoft.Data.Entity
             return this;
         }
 
+        /// <summary>
+        ///     Enables application data to be included in exception messages, logging, etc. This can include the values assigned to properties 
+        ///     of your entity instances, parameter values for commands being sent to the database, and other such data. You should only enable
+        ///     this flag if you have the appropriate security measures in place based on the sensitivity of this data.
+        /// </summary>
+        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
         public virtual DbContextOptionsBuilder EnableSensitiveDataLogging()
             => SetOption(e => e.IsSensitiveDataLoggingEnabled = true);
 
+        /// <summary>
+        ///     <para>
+        ///         Adds the given extension to the options. If an existing extension of the same type already exists, it will be replaced.
+        ///     </para>
+        ///     <para>
+        ///         This property is intended for use by extension methods to configure the context. It is not intended to be used in
+        ///         application code.
+        ///     </para>
+        /// </summary>
+        /// <typeparam name="TExtension"> The type of extension to be added. </typeparam>
+        /// <param name="extension"> The extension to be added. </param>
         void IDbContextOptionsBuilderInfrastructure.AddOrUpdateExtension<TExtension>(TExtension extension)
         {
             Check.NotNull(extension, nameof(extension));

--- a/src/EntityFramework.Core/DbContextOptionsBuilder`.cs
+++ b/src/EntityFramework.Core/DbContextOptionsBuilder`.cs
@@ -7,22 +7,52 @@ using Microsoft.Data.Entity.Metadata;
 
 namespace Microsoft.Data.Entity
 {
+    /// <summary>
+    ///     <para>
+    ///         Provides a simple API surface for configuring <see cref="DbContextOptions{TContext}" />. Databases (and other extensions)
+    ///         typically define extension methods on this object that allow you to configure the database connection (and other 
+    ///         options) to be used for a context.
+    ///     </para>
+    ///     <para>
+    ///         You can use <see cref="DbContextOptionsBuilder" /> to configure a context by overriding
+    ///         <see cref="DbContext.OnConfiguring(DbContextOptionsBuilder)" /> or creating a <see cref="DbContextOptions" />
+    ///         externally and passing it to the context constructor.
+    ///     </para>
+    /// </summary>
+    /// <typeparam name="TContext"> The type of context to be configured. </typeparam>
     public class DbContextOptionsBuilder<TContext> : DbContextOptionsBuilder
         where TContext : DbContext
     {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="DbContextOptionsBuilder{TContext}" /> class with no options set.
+        /// </summary>
         public DbContextOptionsBuilder()
             : this(new DbContextOptions<TContext>())
         {
         }
 
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="DbContextOptionsBuilder{TContext}" /> class to further configure
+        ///     a given <see cref="DbContextOptions"/>.
+        /// </summary>
+        /// <param name="options"> The options to be configured. </param>
         public DbContextOptionsBuilder([NotNull] DbContextOptions<TContext> options)
             : base(options)
         {
         }
 
+        /// <summary>
+        ///     Gets the options being configured.
+        /// </summary>
         public new virtual DbContextOptions<TContext> Options => (DbContextOptions<TContext>)base.Options;
 
-        public new virtual DbContextOptionsBuilder<TContext> UseModel([NotNull] IModel model) 
+        /// <summary>
+        ///     Sets the model to be used for the context. If the model is set, then <see cref="DbContext.OnModelCreating(ModelBuilder)"/>
+        ///     will not be run.
+        /// </summary>
+        /// <param name="model"> The model to be used. </param>
+        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
+        public new virtual DbContextOptionsBuilder<TContext> UseModel([NotNull] IModel model)
             => (DbContextOptionsBuilder<TContext>)base.UseModel(model);
     }
 }

--- a/src/EntityFramework.Core/DbUpdateConcurrencyException.cs
+++ b/src/EntityFramework.Core/DbUpdateConcurrencyException.cs
@@ -8,8 +8,18 @@ using Microsoft.Data.Entity.Update;
 
 namespace Microsoft.Data.Entity
 {
+    /// <summary>
+    ///     An exception that is thrown when a concurrency violation is encountered while saving to the database. A concurrency violation
+    ///     occurs when an unexpected number of rows are affected during save. This is usually because the data in the database has
+    ///     been modified since it was loaded into memory.
+    /// </summary>
     public class DbUpdateConcurrencyException : DbUpdateException
     {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="DbUpdateConcurrencyException" /> class.
+        /// </summary>
+        /// <param name="message"> The error message that explains the reason for the exception. </param>
+        /// <param name="entries"> The entries that were involved in the concurrency violation. </param>
         public DbUpdateConcurrencyException(
             [NotNull] string message,
             [NotNull] IReadOnlyList<IUpdateEntry> entries)

--- a/src/EntityFramework.Core/DbUpdateException.cs
+++ b/src/EntityFramework.Core/DbUpdateException.cs
@@ -12,16 +12,29 @@ using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity
 {
+    /// <summary>
+    ///     An exception that is thrown when an error is encountered while saving to the database.
+    /// </summary>
     public class DbUpdateException : Exception
     {
         private readonly LazyRef<IReadOnlyList<EntityEntry>> _entries;
 
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="DbUpdateException" /> class.
+        /// </summary>
+        /// <param name="message"> The error message that explains the reason for the exception. </param>
+        /// <param name="innerException"> The exception that is the cause of the current exception. </param>
         public DbUpdateException([NotNull] string message, [CanBeNull] Exception innerException)
             : base(message, innerException)
         {
             _entries = new LazyRef<IReadOnlyList<EntityEntry>>(() => new List<EntityEntry>());
         }
 
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="DbUpdateException" /> class.
+        /// </summary>
+        /// <param name="message"> The error message that explains the reason for the exception. </param>
+        /// <param name="entries"> The entries that were involved in the error. </param>
         public DbUpdateException(
             [NotNull] string message,
             [NotNull] IReadOnlyList<IUpdateEntry> entries)
@@ -29,6 +42,12 @@ namespace Microsoft.Data.Entity
         {
         }
 
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="DbUpdateException" /> class.
+        /// </summary>
+        /// <param name="message"> The error message that explains the reason for the exception. </param>
+        /// <param name="entries"> The entries that were involved in the error. </param>
+        /// <param name="innerException"> The exception that is the cause of the current exception. </param>
         public DbUpdateException(
             [NotNull] string message,
             [CanBeNull] Exception innerException,
@@ -40,6 +59,10 @@ namespace Microsoft.Data.Entity
             _entries = new LazyRef<IReadOnlyList<EntityEntry>>(() => entries.Select(e => e.ToEntityEntry()).ToList());
         }
 
+        /// <summary>
+        ///     Gets the entries that were involved in the error. Typically this is a single entry, but in some cases it
+        ///     may be zero or multiple entries.
+        /// </summary>
         public virtual IReadOnlyList<EntityEntry> Entries => _entries.Value;
     }
 }

--- a/src/EntityFramework.Core/EF.cs
+++ b/src/EntityFramework.Core/EF.cs
@@ -7,9 +7,29 @@ using Microsoft.Data.Entity.Internal;
 
 namespace Microsoft.Data.Entity
 {
+    /// <summary>
+    ///     Static methods that are useful in application code where there is not an EF type for the method to be accessed from. For example,
+    ///     referencing a shadow state property in a LINQ query.
+    /// </summary>
     // ReSharper disable once InconsistentNaming
     public static class EF
     {
+        /// <summary>
+        ///     Addresses a given property on an entity instance. This is useful when you want to reference a shadow state property in a
+        ///     LINQ query. Currently this method can only be used in LINQ queries and can not be used to access the value assigned to a
+        ///     property in other scenarios.
+        /// </summary>
+        /// <example>
+        ///     The following code performs a filter using the a LastUpdated shadow state property.
+        ///     <code>
+        ///         var blogs = context.Blogs
+        ///             .Where(b =&gt; EF.Property&lt;DateTime&gt;(b, "LastUpdated") > DateTime.Now.AddDays(-5))
+        ///     </code>
+        /// </example>
+        /// <typeparam name="TProperty"> The type of the property being referenced. </typeparam>
+        /// <param name="entity"> The entity to access the property on. </param>
+        /// <param name="propertyName"> The name of the property. </param>
+        /// <returns> The value assigned to the property. </returns>
         public static TProperty Property<TProperty>([NotNull] object entity, [NotNull] string propertyName)
         {
             throw new InvalidOperationException(CoreStrings.PropertyMethodInvoked);

--- a/src/EntityFramework.Core/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/EntityFramework.Core/EntityFrameworkServiceCollectionExtensions.cs
@@ -42,17 +42,29 @@ namespace Microsoft.Extensions.DependencyInjection
         ///     </para>
         ///     <para>
         ///         The database you are using will also define extension methods that can be called on the returned
-        ///         <see cref="EntityFrameworkServicesBuilder" /> to register the services for the database. For example,
-        ///         when using EntityFramework.MicrosoftSqlServer you would call
-        ///         <c>collection.AddEntityFramework().UseSqlServer(connectionString)</c>.
+        ///         <see cref="EntityFrameworkServicesBuilder" /> to register the services required by the database. 
+        ///         For example, when using EntityFramework.MicrosoftSqlServer you would call
+        ///         <c>collection.AddEntityFramework().AddSqlServer()</c>.
         ///     </para>
         ///     <para>
-        ///         For derived contexts to resolve their services from the <see cref="IServiceProvider" /> you must chain a call
-        ///         to the <see cref="EntityFrameworkServicesBuilder.AddDbContext{TContext}" /> method on the returned
+        ///         For derived contexts to be registered in the <see cref="IServiceProvider" /> and resolve their services 
+        ///         from the <see cref="IServiceProvider" /> you must chain a call to the 
+        ///         <see cref="EntityFrameworkServicesBuilder.AddDbContext{TContext}" /> method on the returned
         ///         <see cref="EntityFrameworkServicesBuilder" />.
-        ///         This will ensure services are resolved from the <see cref="IServiceProvider" />  will be honored.
         ///     </para>
         /// </remarks>
+        /// <example>
+        ///     <code>
+        ///         public void ConfigureServices(IServiceCollection services) 
+        ///         {
+        ///             var connectionString = "connection string to database";
+        /// 
+        ///             services.AddEntityFramework() 
+        ///                 .AddSqlServer()
+        ///                 .AddDbContext&lt;MyContext&gt;(options => options.UseSqlServer(connectionString)); 
+        ///         }
+        ///     </code>
+        /// </example>
         /// <param name="serviceCollection"> The <see cref="IServiceCollection" /> to add services to. </param>
         /// <returns>
         ///     A builder that allows further Entity Framework specific setup of the <see cref="IServiceCollection" />.

--- a/src/EntityFramework.Core/GraphBehavior.cs
+++ b/src/EntityFramework.Core/GraphBehavior.cs
@@ -3,9 +3,20 @@
 
 namespace Microsoft.Data.Entity
 {
+    /// <summary>
+    ///     Indicates how the navigation properties of an entity are traversed so that a given operation can be recursively
+    ///     performed on the entities that it is related to.
+    /// </summary>
     public enum GraphBehavior
     {
+        /// <summary>
+        ///     Navigation properties where the entity being acted on is the principal are traversed.
+        /// </summary>
         IncludeDependents,
+
+        /// <summary>
+        ///     Navigation properties are not traversed. The operation is only performed on the root entity.
+        /// </summary>
         SingleObject
     };
 }

--- a/src/EntityFramework.Core/ModelBuilder.cs
+++ b/src/EntityFramework.Core/ModelBuilder.cs
@@ -14,23 +14,18 @@ namespace Microsoft.Data.Entity
 {
     /// <summary>
     ///     <para>
-    ///         Provides a simple API surface for configuring a <see cref="Model" /> that defines the shape of your
-    ///         entities and how they map to the database.
+    ///         Provides a simple API surface for configuring a <see cref="Metadata.Model" /> that defines the shape of your
+    ///         entities, the relationships between them, and how they map to the database.
     ///     </para>
     ///     <para>
     ///         You can use <see cref="ModelBuilder" /> to construct a model for a context by overriding
-    ///         <see cref="DbContext.OnModelCreating(ModelBuilder)" /> or creating a <see cref="Model" />
-    ///         externally
-    ///         and setting it on a <see cref="DbContextOptions" /> instance that is passed to the context
-    ///         constructor.
+    ///         <see cref="DbContext.OnModelCreating(ModelBuilder)" /> on your derived context. Alternatively you can create the 
+    ///         model externally and set it on a <see cref="DbContextOptions" /> instance that is passed to the context constructor.
     ///     </para>
     /// </summary>
     public class ModelBuilder : IAccessor<InternalModelBuilder>
     {
         private readonly InternalModelBuilder _builder;
-
-        // TODO: Configure property facets, foreign keys & navigation properties
-        // Issue #213
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="ModelBuilder" /> class that will
@@ -88,7 +83,13 @@ namespace Microsoft.Data.Entity
         }
 
         /// <summary>
-        ///     The internal <see cref="ModelBuilder" /> being used to configure this model.
+        ///     <para>
+        ///         The internal <see cref="ModelBuilder" /> being used to configure this model.
+        ///     </para>
+        ///     <para>
+        ///         This property is intended for use by extension methods to configure the model. It is not intended to be used in
+        ///         application code.
+        ///     </para>
         /// </summary>
         InternalModelBuilder IAccessor<InternalModelBuilder>.Service => _builder;
 


### PR DESCRIPTION
Remaining types in the root namespace of EntityFramework.Core

The things I think it would be good to read over in detail are:
* EF.Property
* EntityFrameworkServiceCollectionExtensions.AddEntityFramework
* GraphBehavior
* DbContextOptionsBuilder.EnableSensitiveDataLogging