### PR TITLE
[SMALL] Fix to #3180 - A column has been specified more than once in the order by list. Columns in the order by list must be unique.

### DIFF
--- a/src/EntityFramework.Core/Query/EntityQueryModelVisitor.cs
+++ b/src/EntityFramework.Core/Query/EntityQueryModelVisitor.cs
@@ -316,9 +316,14 @@ namespace Microsoft.Data.Entity.Query
                                     CoreStrings.IncludeNonBindableExpression(annotation.NavigationPropertyPath));
                             }
 
-                            return new IncludeSpecification(annotation.QuerySource, navigationPath);
+                            return new
+                            {
+                                specification = new IncludeSpecification(annotation.QuerySource, navigationPath),
+                                order = string.Concat(navigationPath.Select(n => n.IsCollection() ? "1" : "0"))
+                            };
                         })
-                    .OrderBy(a => a.NavigationPath.First().PointsToPrincipal())
+                    .OrderByDescending(e => e.order).ThenBy(e => e.specification.NavigationPath.First().PointsToPrincipal())
+                    .Select(e => e.specification)
                     .ToList();
 
             IncludeNavigations(queryModel, includeSpecifications);

--- a/test/EntityFramework.Core.FunctionalTests/ComplexNavigationsQueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/ComplexNavigationsQueryTestBase.cs
@@ -492,5 +492,133 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 }
             }
         }
+
+        // issue #3180
+        [Fact]
+        public virtual void Multiple_complex_includes()
+        {
+            List<Level1> levelOnes;
+            List<Level2> levelTwos;
+            using (var context = CreateContext())
+            {
+                levelOnes = context.LevelOne
+                    .Include(e => e.OneToOne_Optional_FK)
+                    .Include(e => e.OneToMany_Optional).ToList();
+
+                levelTwos = context.LevelTwo
+                    .Include(e => e.OneToMany_Optional)
+                    .Include(e => e.OneToOne_Optional_FK).ToList();
+            }
+
+            ClearLog();
+
+            using (var context = CreateContext())
+            {
+                var query = context.LevelOne
+                    .Include(e => e.OneToOne_Optional_FK)
+                        .ThenInclude(e => e.OneToMany_Optional)
+                    .Include(e => e.OneToMany_Optional)
+                        .ThenInclude(e => e.OneToOne_Optional_FK);
+
+                var result = query.ToList();
+
+                Assert.Equal(levelOnes.Count, result.Count);
+                foreach (var resultItem in result)
+                {
+                    var expectedLevel1 = levelOnes.Where(e => e.Id == resultItem.Id).Single();
+                    Assert.Equal(expectedLevel1.OneToOne_Optional_FK?.Id, resultItem.OneToOne_Optional_FK?.Id);
+                    Assert.Equal(expectedLevel1.OneToMany_Optional?.Count, resultItem.OneToMany_Optional?.Count);
+
+                    var oneToOne_Optional_FK = resultItem.OneToOne_Optional_FK;
+                    if (oneToOne_Optional_FK != null)
+                    {
+                        var expectedReferenceLevel2 = levelTwos.Where(e => e.Id == oneToOne_Optional_FK.Id).Single();
+                        Assert.Equal(expectedReferenceLevel2.OneToMany_Optional?.Count, oneToOne_Optional_FK.OneToMany_Optional?.Count);
+                    }
+                }
+            }
+        }
+
+        // issue #3180
+        [Fact]
+        public virtual void Multiple_complex_includes_self_ref()
+        {
+            List<Level1> levelOnes1;
+            List<Level1> levelOnes2;
+            using (var context = CreateContext())
+            {
+                levelOnes1 = context.LevelOne.Include(e => e.OneToOne_Optional_Self).ToList();
+                levelOnes2 = context.LevelOne.Include(e => e.OneToMany_Optional_Self).ToList();
+            }
+
+            ClearLog();
+
+            using (var context = CreateContext())
+            {
+                var query = context.LevelOne
+                    .Include(e => e.OneToOne_Optional_Self)
+                        .ThenInclude(e => e.OneToMany_Optional_Self)
+                    .Include(e => e.OneToMany_Optional_Self)
+                        .ThenInclude(e => e.OneToOne_Optional_Self);
+
+                var result = query.ToList();
+
+                foreach (var resultItem in result)
+                {
+                    var expected1 = levelOnes1.Where(e => e.Id == resultItem.Id).Single();
+                    var expected2 = levelOnes2.Where(e => e.Id == resultItem.Id).Single();
+
+                    Assert.Equal(expected1.OneToOne_Optional_Self?.Id, resultItem.OneToOne_Optional_Self?.Id);
+                    Assert.Equal(expected2.OneToMany_Optional_Self?.Count, resultItem.OneToMany_Optional_Self?.Count);
+                }
+            }
+        }
+
+        [Fact]
+        public virtual void Multiple_complex_include_select()
+        {
+            List<Level1> levelOnes;
+            List<Level2> levelTwos;
+            using (var context = CreateContext())
+            {
+                levelOnes = context.LevelOne
+                    .Include(e => e.OneToOne_Optional_FK)
+                    .Include(e => e.OneToMany_Optional).ToList();
+
+                levelTwos = context.LevelTwo
+                    .Include(e => e.OneToMany_Optional)
+                    .Include(e => e.OneToOne_Optional_FK).ToList();
+            }
+
+            ClearLog();
+
+            using (var context = CreateContext())
+            {
+                var query = context.LevelOne
+                    .Select(e => e)
+                    .Include(e => e.OneToOne_Optional_FK)
+                        .ThenInclude(e => e.OneToMany_Optional)
+                    .Select(e => e)
+                    .Include(e => e.OneToMany_Optional)
+                        .ThenInclude(e => e.OneToOne_Optional_FK);
+
+                var result = query.ToList();
+
+                Assert.Equal(levelOnes.Count, result.Count);
+                foreach (var resultItem in result)
+                {
+                    var expectedLevel1 = levelOnes.Where(e => e.Id == resultItem.Id).Single();
+                    Assert.Equal(expectedLevel1.OneToOne_Optional_FK?.Id, resultItem.OneToOne_Optional_FK?.Id);
+                    Assert.Equal(expectedLevel1.OneToMany_Optional?.Count, resultItem.OneToMany_Optional?.Count);
+
+                    var oneToOne_Optional_FK = resultItem.OneToOne_Optional_FK;
+                    if (oneToOne_Optional_FK != null)
+                    {
+                        var expectedReferenceLevel2 = levelTwos.Where(e => e.Id == oneToOne_Optional_FK.Id).Single();
+                        Assert.Equal(expectedReferenceLevel2.OneToMany_Optional?.Count, oneToOne_Optional_FK.OneToMany_Optional?.Count);
+                    }
+                }
+            }
+        }
     }
 }

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Linq;
 using Microsoft.Data.Entity.FunctionalTests;
 using Xunit;
 
@@ -236,6 +237,116 @@ INNER JOIN [Level1] AS [e1] ON [e4].[Name] = (
     INNER JOIN [Level4] AS [subQuery0.OneToOne_Optional_FK.OneToOne_Required_PK] ON [subQuery0.OneToOne_Optional_FK].[Id] = [subQuery0.OneToOne_Optional_FK.OneToOne_Required_PK].[Id]
     WHERE [subQuery0].[Level1_Required_Id] = [e1].[Id]
 )",
+                Sql);
+        }
+
+        public override void Multiple_complex_includes()
+        {
+            base.Multiple_complex_includes();
+
+            Assert.Equal(
+                @"SELECT [e].[Id], [e].[Name], [e].[OneToMany_Optional_Self_InverseId], [e].[OneToMany_Required_Self_InverseId], [e].[OneToOne_Optional_SelfId], [l].[Id], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Name], [l].[OneToMany_Optional_InverseId], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_PK_InverseId], [l].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [e]
+LEFT JOIN [Level2] AS [l] ON [l].[Level1_Optional_Id] = [e].[Id]
+ORDER BY [e].[Id], [l].[Id]
+
+SELECT [l].[Id], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Name], [l].[OneToMany_Optional_InverseId], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_PK_InverseId], [l].[OneToOne_Optional_SelfId], [l0].[Id], [l0].[Level2_Optional_Id], [l0].[Level2_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_InverseId], [l0].[OneToMany_Optional_Self_InverseId], [l0].[OneToMany_Required_InverseId], [l0].[OneToMany_Required_Self_InverseId], [l0].[OneToOne_Optional_PK_InverseId], [l0].[OneToOne_Optional_SelfId]
+FROM [Level2] AS [l]
+INNER JOIN (
+    SELECT DISTINCT [e].[Id]
+    FROM [Level1] AS [e]
+) AS [e] ON [l].[OneToMany_Optional_InverseId] = [e].[Id]
+LEFT JOIN [Level3] AS [l0] ON [l0].[Level2_Optional_Id] = [l].[Id]
+ORDER BY [e].[Id]
+
+SELECT [l].[Id], [l].[Level2_Optional_Id], [l].[Level2_Required_Id], [l].[Name], [l].[OneToMany_Optional_InverseId], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_PK_InverseId], [l].[OneToOne_Optional_SelfId]
+FROM [Level3] AS [l]
+INNER JOIN (
+    SELECT DISTINCT [e].[Id], [l].[Id] AS [Id0]
+    FROM [Level1] AS [e]
+    LEFT JOIN [Level2] AS [l] ON [l].[Level1_Optional_Id] = [e].[Id]
+) AS [l0] ON [l].[OneToMany_Optional_InverseId] = [l0].[Id0]
+ORDER BY [l0].[Id], [l0].[Id0]",
+                Sql);
+        }
+
+        public override void Multiple_complex_includes_self_ref()
+        {
+            base.Multiple_complex_includes_self_ref();
+
+            Assert.Equal(
+                @"SELECT [e].[Id], [e].[Name], [e].[OneToMany_Optional_Self_InverseId], [e].[OneToMany_Required_Self_InverseId], [e].[OneToOne_Optional_SelfId], [l].[Id], [l].[Name], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [e]
+LEFT JOIN [Level1] AS [l] ON [e].[OneToOne_Optional_SelfId] = [l].[Id]
+ORDER BY [e].[Id], [l].[Id]
+
+SELECT [l].[Id], [l].[Name], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l]
+INNER JOIN (
+    SELECT DISTINCT [e].[Id], [l].[Id] AS [Id0]
+    FROM [Level1] AS [e]
+    LEFT JOIN [Level1] AS [l] ON [e].[OneToOne_Optional_SelfId] = [l].[Id]
+) AS [l0] ON [l].[OneToMany_Optional_Self_InverseId] = [l0].[Id0]
+ORDER BY [l0].[Id], [l0].[Id0]
+
+SELECT [l].[Id], [l].[Name], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_SelfId], [l0].[Id], [l0].[Name], [l0].[OneToMany_Optional_Self_InverseId], [l0].[OneToMany_Required_Self_InverseId], [l0].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l]
+INNER JOIN (
+    SELECT DISTINCT [e].[Id]
+    FROM [Level1] AS [e]
+) AS [e] ON [l].[OneToMany_Optional_Self_InverseId] = [e].[Id]
+LEFT JOIN [Level1] AS [l0] ON [l].[OneToOne_Optional_SelfId] = [l0].[Id]
+ORDER BY [e].[Id]",
+                Sql);
+        }
+
+        public override void Multiple_complex_include_select()
+        {
+            base.Multiple_complex_include_select();
+
+            Assert.Equal(
+                @"SELECT [e].[Id], [e].[Name], [e].[OneToMany_Optional_Self_InverseId], [e].[OneToMany_Required_Self_InverseId], [e].[OneToOne_Optional_SelfId], [l].[Id], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Name], [l].[OneToMany_Optional_InverseId], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_PK_InverseId], [l].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [e]
+LEFT JOIN [Level2] AS [l] ON [l].[Level1_Optional_Id] = [e].[Id]
+ORDER BY [e].[Id], [l].[Id]
+
+SELECT [l].[Id], [l].[Level1_Optional_Id], [l].[Level1_Required_Id], [l].[Name], [l].[OneToMany_Optional_InverseId], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_PK_InverseId], [l].[OneToOne_Optional_SelfId], [l0].[Id], [l0].[Level2_Optional_Id], [l0].[Level2_Required_Id], [l0].[Name], [l0].[OneToMany_Optional_InverseId], [l0].[OneToMany_Optional_Self_InverseId], [l0].[OneToMany_Required_InverseId], [l0].[OneToMany_Required_Self_InverseId], [l0].[OneToOne_Optional_PK_InverseId], [l0].[OneToOne_Optional_SelfId]
+FROM [Level2] AS [l]
+INNER JOIN (
+    SELECT DISTINCT [e].[Id]
+    FROM [Level1] AS [e]
+) AS [e] ON [l].[OneToMany_Optional_InverseId] = [e].[Id]
+LEFT JOIN [Level3] AS [l0] ON [l0].[Level2_Optional_Id] = [l].[Id]
+ORDER BY [e].[Id]
+
+SELECT [l].[Id], [l].[Level2_Optional_Id], [l].[Level2_Required_Id], [l].[Name], [l].[OneToMany_Optional_InverseId], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_PK_InverseId], [l].[OneToOne_Optional_SelfId]
+FROM [Level3] AS [l]
+INNER JOIN (
+    SELECT DISTINCT [e].[Id], [l].[Id] AS [Id0]
+    FROM [Level1] AS [e]
+    LEFT JOIN [Level2] AS [l] ON [l].[Level1_Optional_Id] = [e].[Id]
+) AS [l0] ON [l].[OneToMany_Optional_InverseId] = [l0].[Id0]
+ORDER BY [l0].[Id], [l0].[Id0]",
+                Sql);
+        }
+
+        // issue #3491
+        //[Fact]
+        public virtual void Multiple_complex_includes_from_sql()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.LevelOne.FromSql("SELECT * FROM [Level1]")
+                    .Include(e => e.OneToOne_Optional_FK)
+                    .ThenInclude(e => e.OneToMany_Optional)
+                    .Include(e => e.OneToMany_Optional)
+                    .ThenInclude(e => e.OneToOne_Optional_FK);
+
+                var result = query.ToList();
+            }
+
+            Assert.Equal(
+                @"",
                 Sql);
         }
 

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/IncludeSqlServerTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/IncludeSqlServerTest.cs
@@ -104,11 +104,11 @@ INNER JOIN [Products] AS [p] ON [od].[ProductID] = [p].[ProductID]",
             base.Include_multiple_references_multi_level_reverse();
 
             Assert.Equal(
-                @"SELECT [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice], [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitsInStock], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+                @"SELECT [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice], [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate], [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitsInStock]
 FROM [Order Details] AS [od]
-INNER JOIN [Products] AS [p] ON [od].[ProductID] = [p].[ProductID]
 INNER JOIN [Orders] AS [o] ON [od].[OrderID] = [o].[OrderID]
-LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]",
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+INNER JOIN [Products] AS [p] ON [od].[ProductID] = [p].[ProductID]",
                 Sql);
         }
 

--- a/test/EntityFramework.Sqlite.FunctionalTests/IncludeSqliteTest.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/IncludeSqliteTest.cs
@@ -84,11 +84,11 @@ INNER JOIN ""Products"" AS ""p"" ON ""od"".""ProductID"" = ""p"".""ProductID""",
             base.Include_multiple_references_multi_level_reverse();
 
             Assert.Equal(
-                @"SELECT ""od"".""OrderID"", ""od"".""ProductID"", ""od"".""Discount"", ""od"".""Quantity"", ""od"".""UnitPrice"", ""p"".""ProductID"", ""p"".""Discontinued"", ""p"".""ProductName"", ""p"".""UnitsInStock"", ""o"".""OrderID"", ""o"".""CustomerID"", ""o"".""EmployeeID"", ""o"".""OrderDate"", ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
+                @"SELECT ""od"".""OrderID"", ""od"".""ProductID"", ""od"".""Discount"", ""od"".""Quantity"", ""od"".""UnitPrice"", ""o"".""OrderID"", ""o"".""CustomerID"", ""o"".""EmployeeID"", ""o"".""OrderDate"", ""c"".""CustomerID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region"", ""p"".""ProductID"", ""p"".""Discontinued"", ""p"".""ProductName"", ""p"".""UnitsInStock""
 FROM ""Order Details"" AS ""od""
-INNER JOIN ""Products"" AS ""p"" ON ""od"".""ProductID"" = ""p"".""ProductID""
 INNER JOIN ""Orders"" AS ""o"" ON ""od"".""OrderID"" = ""o"".""OrderID""
-LEFT JOIN ""Customers"" AS ""c"" ON ""o"".""CustomerID"" = ""c"".""CustomerID""",
+LEFT JOIN ""Customers"" AS ""c"" ON ""o"".""CustomerID"" = ""c"".""CustomerID""
+INNER JOIN ""Products"" AS ""p"" ON ""od"".""ProductID"" = ""p"".""ProductID""",
                 Sql);
         }
 


### PR DESCRIPTION
Problem happens for specific combination of nested include statements. When we include reference we add a JOIN on the table that is being included. Issue is that QuerySource of the new table is copied from it's parent table. When include collection, we introduce a new query, but also add order by on the previous query. We determine which table to order based on the query source, but since query sources are the same, the choice is ambiguous. This may lead to queries that try to sort the same column twice, or trying to sort based on column that doesn't exist.

Fix is to always apply includes in a deterministic order that would prevent this situation from happening - first include collections, and only then references.