### PR TITLE
[TINY] Remove initialNodeState from ChangeTracker.TrackGraph

### DIFF
--- a/src/EntityFramework.Core/ChangeTracking/ChangeTracker.cs
+++ b/src/EntityFramework.Core/ChangeTracking/ChangeTracker.cs
@@ -153,11 +153,9 @@ namespace Microsoft.Data.Entity.ChangeTracking
         ///     An action to configure the change tracking information for each entity. For the entity to begin being tracked,
         ///     the <see cref="EntityEntry.State" /> must be set.
         /// </param>
-        /// <param name="initialNodeState">An optional object containing state information that will be passed to the callback.</param>
         public virtual void TrackGraph(
             [NotNull] object rootEntity,
-            [NotNull] Action<EntityEntryGraphNode> callback,
-            [CanBeNull] object initialNodeState = null)
+            [NotNull] Action<EntityEntryGraphNode> callback)
         {
             Check.NotNull(rootEntity, nameof(rootEntity));
             Check.NotNull(callback, nameof(callback));
@@ -165,7 +163,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
             var rootEntry = _stateManager.GetOrCreateEntry(rootEntity);
 
             _graphIterator.TraverseGraph(
-                new EntityEntryGraphNode(_context, rootEntry, null) { NodeState = initialNodeState },
+                new EntityEntryGraphNode(_context, rootEntry, null),
                 n =>
                     {
                         if (n.Entry.State != EntityState.Detached)


### PR DESCRIPTION
Discussed with @ajcvickers and concluded that this is a pretty advanced
concept and can be removed from this top level API. It is still present
in the EntityGraphNode and EntityGraphIterator. You can also use it with
TrackGraph if you want to, you just need to check for a null state and
set it within the callback.