### PR TITLE
[SMALL] RevEng: ensure it understands default values for datetime columns…

### DIFF
--- a/src/EntityFramework.MicrosoftSqlServer.Design/Internal/SqlServerLiteralUtilities.cs
+++ b/src/EntityFramework.MicrosoftSqlServer.Design/Internal/SqlServerLiteralUtilities.cs
@@ -132,6 +132,14 @@ namespace Microsoft.Data.Entity.Scaffolding.Internal
 
             propertyType = propertyType.UnwrapNullableType();
 
+            if (typeof(DateTime) == propertyType)
+            {
+                return new DefaultExpressionOrValue
+                {
+                    DefaultExpression = sqlServerDefaultValue
+                };
+            }
+
             if (typeof(string) == propertyType)
             {
                 return new DefaultExpressionOrValue

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/E2E.sql
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/E2E.sql
@@ -139,6 +139,7 @@ GO
 CREATE TABLE "dbo"."PropertyConfiguration" (
 	"PropertyConfigurationID" "tinyint" IDENTITY(1, 1) PRIMARY KEY, -- tests error message about tinyint identity columns
 	"WithDateDefaultExpression" "datetime2" NOT NULL DEFAULT (getdate()),
+	"WithDateFixedDefault" "datetime2" NOT NULL DEFAULT ('October 20, 2015 11am'),
 	"WithDateNullDefault" "datetime2" NULL DEFAULT (NULL),
 	"WithGuidDefaultExpression" "uniqueidentifier" NOT NULL DEFAULT (newsequentialid()),
 	"WithVarcharNullDefaultValue" "varchar" NULL DEFAULT (NULL),

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/PropertyConfiguration.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/PropertyConfiguration.expected
@@ -11,6 +11,7 @@ namespace E2ETest.Namespace
         public byte[] RowversionColumn { get; set; }
         public int? SumOfAAndB { get; set; }
         public DateTime WithDateDefaultExpression { get; set; }
+        public DateTime WithDateFixedDefault { get; set; }
         public DateTime? WithDateNullDefault { get; set; }
         public int WithDefaultValue { get; set; }
         public Guid WithGuidDefaultExpression { get; set; }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/SqlServerReverseEngineerTestE2EContext.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/SqlServerReverseEngineerTestE2EContext.expected
@@ -164,6 +164,8 @@ namespace E2ETest.Namespace
 
                 entity.Property(e => e.WithDateDefaultExpression).HasDefaultValueSql("getdate()");
 
+                entity.Property(e => e.WithDateFixedDefault).HasDefaultValueSql("'October 20, 2015 11am'");
+
                 entity.Property(e => e.WithDefaultValue).HasDefaultValue(-1);
 
                 entity.Property(e => e.WithGuidDefaultExpression).HasDefaultValueSql("newsequentialid()");

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/AttributesContext.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/AttributesContext.expected
@@ -113,6 +113,8 @@ namespace E2ETest.Namespace
 
                 entity.Property(e => e.WithDateDefaultExpression).HasDefaultValueSql("getdate()");
 
+                entity.Property(e => e.WithDateFixedDefault).HasDefaultValueSql("'October 20, 2015 11am'");
+
                 entity.Property(e => e.WithDefaultValue).HasDefaultValue(-1);
 
                 entity.Property(e => e.WithGuidDefaultExpression).HasDefaultValueSql("newsequentialid()");

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/PropertyConfiguration.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/PropertyConfiguration.expected
@@ -14,6 +14,7 @@ namespace E2ETest.Namespace
         public byte[] RowversionColumn { get; set; }
         public int? SumOfAAndB { get; set; }
         public DateTime WithDateDefaultExpression { get; set; }
+        public DateTime WithDateFixedDefault { get; set; }
         public DateTime? WithDateNullDefault { get; set; }
         public int WithDefaultValue { get; set; }
         public Guid WithGuidDefaultExpression { get; set; }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/SqlServerDatabaseModelFactoryTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/SqlServerDatabaseModelFactoryTest.cs
@@ -110,7 +110,7 @@ CREATE TABLE [dbo].[Mountains] (
     Id int,
     Name nvarchar(100) NOT NULL,
     Latitude decimal( 5, 2 ) DEFAULT 0.0,
-    Created datetime2(6),
+    Created datetime2(6) DEFAULT('October 20, 2015 11am'),
     Sum AS Latitude + 1.0,
     Modified rowversion,
     Primary Key (Name, Id)
@@ -161,6 +161,7 @@ CREATE TABLE [dbo].[Mountains] (
                     {
                         Assert.Equal("Created", created.Name);
                         Assert.Equal(6, created.Scale);
+                        Assert.Equal("('October 20, 2015 11am')", created.DefaultValue);
                     },
                 sum =>
                     {


### PR DESCRIPTION
...which are fixed values.

Fixes #3250.