### PR TITLE
Change service provider cache for better performance

### DIFF
--- a/src/EntityFramework.Core/Internal/ServiceProviderCache.cs
+++ b/src/EntityFramework.Core/Internal/ServiceProviderCache.cs
@@ -18,28 +18,26 @@ namespace Microsoft.Data.Entity.Internal
 
         public virtual IServiceProvider GetOrAdd([NotNull] IDbContextOptions options)
         {
-            var services = new ServiceCollection();
-            var builder = services.AddEntityFramework();
-
-            foreach (var extension in options.Extensions)
-            {
-                extension.ApplyServices(builder);
-            }
-
             // Decided that this hashing algorithm is robust enough. See issue #762.
             unchecked
             {
-                var key = services.Aggregate(0, (t, d) => (t * 397) ^ CalculateHash(d).GetHashCode());
+                var key = options.Extensions.Aggregate(0, (t, e) => (t * 397) ^ e.GetType().GetHashCode());
 
-                return _configurations.GetOrAdd(key, k => services.BuildServiceProvider());
+                return _configurations.GetOrAdd(
+                    key,
+                    k =>
+                        {
+                            var services = new ServiceCollection();
+                            var builder = services.AddEntityFramework();
+
+                            foreach (var extension in options.Extensions)
+                            {
+                                extension.ApplyServices(builder);
+                            }
+
+                            return services.BuildServiceProvider();
+                        });
             }
         }
-
-        private static long CalculateHash(ServiceDescriptor descriptor)
-            => ((((long)descriptor.Lifetime * 397)
-                 ^ descriptor.ServiceType.GetHashCode()) * 397)
-               ^ (descriptor.ImplementationInstance?.GetType()
-                  ?? descriptor.ImplementationType
-                  ?? (object)descriptor.ImplementationFactory).GetHashCode();
     }
 }

--- a/test/EntityFramework.Core.Tests/ServiceProviderCacheTest.cs
+++ b/test/EntityFramework.Core.Tests/ServiceProviderCacheTest.cs
@@ -1,10 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Internal;
-using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Tests
@@ -12,23 +10,10 @@ namespace Microsoft.Data.Entity.Tests
     public class ServiceProviderCacheTest
     {
         [Fact]
-        public void Returns_same_provider_for_same_set_of_configured_services()
+        public void Returns_same_provider_for_same_tyoe_of_configured_extensions()
         {
-            var serviceInstance = new FakeService4();
-
-            var config1 = CreateOptions(b =>
-                {
-                    b.GetService().AddSingleton<IFakeServiceA, FakeService1>();
-                    b.GetService().AddSingleton<FakeService3>();
-                    b.GetService().AddInstance(serviceInstance);
-                });
-
-            var config2 = CreateOptions(b =>
-                {
-                    b.GetService().AddSingleton<IFakeServiceA, FakeService1>();
-                    b.GetService().AddSingleton<FakeService3>();
-                    b.GetService().AddInstance(serviceInstance);
-                });
+            var config1 = CreateOptions(new FakeDbContextOptionsExtension1());
+            var config2 = CreateOptions(new FakeDbContextOptionsExtension1());
 
             var cache = new ServiceProviderCache();
 
@@ -36,138 +21,36 @@ namespace Microsoft.Data.Entity.Tests
         }
 
         [Fact]
-        public void Returns_same_provider_for_configured_services_differing_by_instance()
+        public void Returns_different_provider_for_different_tyoe_of_configured_extensions()
         {
-            var config1 = CreateOptions(b =>
-                {
-                    b.GetService().AddSingleton<IFakeServiceA, FakeService1>();
-                    b.GetService().AddSingleton<FakeService3>();
-                    b.GetService().AddInstance(new FakeService4());
-                });
-
-            var config2 = CreateOptions(b =>
-                {
-                    b.GetService().AddSingleton<IFakeServiceA, FakeService1>();
-                    b.GetService().AddSingleton<FakeService3>();
-                    b.GetService().AddInstance(new FakeService4());
-                });
-
-            var cache = new ServiceProviderCache();
-
-            Assert.Same(cache.GetOrAdd(config1), cache.GetOrAdd(config2));
-        }
-
-        [Fact]
-        public void Returns_different_provider_for_configured_services_differing_by_type()
-        {
-            var serviceInstance = new FakeService4();
-
-            var config1 = CreateOptions(b =>
-                {
-                    b.GetService().AddSingleton<IFakeServiceA, FakeService1>();
-                    b.GetService().AddSingleton<FakeService3>();
-                    b.GetService().AddInstance(serviceInstance);
-                });
-
-            var config2 = CreateOptions(b =>
-                {
-                    b.GetService().AddSingleton<IFakeServiceA, FakeService2>();
-                    b.GetService().AddSingleton<FakeService3>();
-                    b.GetService().AddInstance(serviceInstance);
-                });
+            var config1 = CreateOptions(new FakeDbContextOptionsExtension1());
+            var config2 = CreateOptions(new FakeDbContextOptionsExtension2());
 
             var cache = new ServiceProviderCache();
 
             Assert.NotSame(cache.GetOrAdd(config1), cache.GetOrAdd(config2));
         }
 
-        [Fact]
-        public void Returns_different_provider_for_configured_services_differing_by_lifetime()
-        {
-            var serviceInstance = new FakeService4();
-
-            var config1 = CreateOptions(b =>
-                {
-                    b.GetService().AddSingleton<IFakeServiceA, FakeService1>();
-                    b.GetService().AddSingleton<FakeService3>();
-                    b.GetService().AddInstance(serviceInstance);
-                });
-
-            var config2 = CreateOptions(b =>
-                {
-                    b.GetService().AddSingleton<IFakeServiceA, FakeService1>();
-                    b.GetService().AddScoped<FakeService3>();
-                    b.GetService().AddInstance(serviceInstance);
-                });
-
-            var cache = new ServiceProviderCache();
-
-            Assert.NotSame(cache.GetOrAdd(config1), cache.GetOrAdd(config2));
-        }
-
-        [Fact]
-        public void Returns_different_provider_for_configured_services_differing_by_services_provided()
-        {
-            var serviceInstance = new FakeService4();
-
-            var config1 = CreateOptions(b =>
-                {
-                    b.GetService().AddSingleton<IFakeServiceA, FakeService1>();
-                    b.GetService().AddSingleton<FakeService3>();
-                    b.GetService().AddInstance(serviceInstance);
-                });
-
-            var config2 = CreateOptions(b =>
-                {
-                    b.GetService().AddSingleton<IFakeServiceB, FakeService1>();
-                    b.GetService().AddSingleton<FakeService3>();
-                    b.GetService().AddInstance(serviceInstance);
-                });
-
-            var cache = new ServiceProviderCache();
-
-            Assert.NotSame(cache.GetOrAdd(config1), cache.GetOrAdd(config2));
-        }
-
-        private static DbContextOptions CreateOptions(Action<EntityFrameworkServicesBuilder> builderAction)
+        private static DbContextOptions CreateOptions(IDbContextOptionsExtension extension)
         {
             var optionsBuilder = new DbContextOptionsBuilder();
-            ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(new FakeDbContextOptionsExtension { BuilderAction = builderAction });
+            ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
+
             return optionsBuilder.Options;
         }
 
-        private class FakeDbContextOptionsExtension : IDbContextOptionsExtension
+        private class FakeDbContextOptionsExtension1 : IDbContextOptionsExtension
         {
-            public Action<EntityFrameworkServicesBuilder> BuilderAction { get; set; }
-
             public virtual void ApplyServices(EntityFrameworkServicesBuilder builder)
             {
-                BuilderAction(builder);
             }
         }
 
-        private interface IFakeServiceA
+        private class FakeDbContextOptionsExtension2 : IDbContextOptionsExtension
         {
-        }
-
-        private interface IFakeServiceB
-        {
-        }
-
-        private class FakeService1 : IFakeServiceA, IFakeServiceB
-        {
-        }
-
-        private class FakeService2 : IFakeServiceA, IFakeServiceB
-        {
-        }
-
-        private class FakeService3
-        {
-        }
-
-        private class FakeService4
-        {
+            public virtual void ApplyServices(EntityFrameworkServicesBuilder builder)
+            {
+            }
         }
     }
 }


### PR DESCRIPTION
Previously we would build a cache key based on all the services. Now we just look at which extensions have been added and use that. This should have the same behavior based on the following assumptions:
- This is only used when we are building the service provider internally, and there are no hooks to modify services in this case. If such a hook is added, then it will need to be able to influence the cache key creation
- Each provider adds unchanging set of services--i.e. there is no logic which says sometimes add this service, sometimes don't.