### PR TITLE
[SMALL] RevEng: No longer output AlternateKey() Fluent API.

### DIFF
--- a/src/EntityFramework.Relational.Design/Internal/Configuration/KeyFluentApiConfiguration.cs
+++ b/src/EntityFramework.Relational.Design/Internal/Configuration/KeyFluentApiConfiguration.cs
@@ -26,14 +26,13 @@ namespace Microsoft.Data.Entity.Scaffolding.Internal.Configuration
             _properties = new List<Property>(properties);
         }
 
-        public virtual bool IsPrimaryKey { get; set; }
         public virtual bool HasAttributeEquivalent { get; set; }
         public virtual string For { get; }
 
         public virtual string FluentApi => string.Format(
                 CultureInfo.InvariantCulture,
                 "{0}({1} => {2})",
-                IsPrimaryKey ? nameof(EntityTypeBuilder.HasKey) : nameof(EntityTypeBuilder.HasAlternateKey),
+                nameof(EntityTypeBuilder.HasKey),
                 _lambdaIdentifier,
                 new ModelUtilities().GenerateLambdaToKey(_properties, _lambdaIdentifier));
     }

--- a/src/EntityFramework.Relational.Design/Internal/Configuration/ModelConfiguration.cs
+++ b/src/EntityFramework.Relational.Design/Internal/Configuration/ModelConfiguration.cs
@@ -174,12 +174,10 @@ namespace Microsoft.Data.Entity.Scaffolding.Internal.Configuration
                     continue;
                 }
 
-                var keyFluentApi = _configurationFactory
-                    .CreateKeyFluentApiConfiguration("e", key.Properties);
-
                 if(key.IsPrimaryKey())
                 {
-                    keyFluentApi.IsPrimaryKey = true;
+                    var keyFluentApi = _configurationFactory
+                        .CreateKeyFluentApiConfiguration("e", key.Properties);
 
                     if (key.Properties.Count == 1)
                     {
@@ -191,9 +189,9 @@ namespace Microsoft.Data.Entity.Scaffolding.Internal.Configuration
                         propertyConfiguration.AttributeConfigurations.Add(
                             _configurationFactory.CreateAttributeConfiguration(nameof(KeyAttribute)));
                     }
-                }
 
-                entityConfiguration.FluentApiConfigurations.Add(keyFluentApi);
+                    entityConfiguration.FluentApiConfigurations.Add(keyFluentApi);
+                }
             }
         }
 

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/SqlServerReverseEngineerTestE2EContext.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/SqlServerReverseEngineerTestE2EContext.expected
@@ -100,8 +100,6 @@ namespace E2ETest.Namespace
 
             modelBuilder.Entity<OneToOneFKToUniqueKeyDependent>(entity =>
             {
-                entity.HasAlternateKey(e => new { e.OneToOneFKToUniqueKeyDependentFK1, e.OneToOneFKToUniqueKeyDependentFK2 });
-
                 entity.HasKey(e => new { e.OneToOneFKToUniqueKeyDependentID1, e.OneToOneFKToUniqueKeyDependentID2 });
 
                 entity.Property(e => e.SomeColumn)
@@ -114,8 +112,6 @@ namespace E2ETest.Namespace
             modelBuilder.Entity<OneToOneFKToUniqueKeyPrincipal>(entity =>
             {
                 entity.HasKey(e => new { e.OneToOneFKToUniqueKeyPrincipalID1, e.OneToOneFKToUniqueKeyPrincipalID2 });
-
-                entity.HasAlternateKey(e => new { e.OneToOneFKToUniqueKeyPrincipalUniqueKey1, e.OneToOneFKToUniqueKeyPrincipalUniqueKey2 });
 
                 entity.Property(e => e.SomePrincipalColumn)
                     .IsRequired()
@@ -133,8 +129,6 @@ namespace E2ETest.Namespace
 
             modelBuilder.Entity<OneToOneSeparateFKDependent>(entity =>
             {
-                entity.HasAlternateKey(e => new { e.OneToOneSeparateFKDependentFK1, e.OneToOneSeparateFKDependentFK2 });
-
                 entity.HasKey(e => new { e.OneToOneSeparateFKDependentID1, e.OneToOneSeparateFKDependentID2 });
 
                 entity.Property(e => e.SomeDependentEndColumn)

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/AttributesContext.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/AttributesContext.expected
@@ -72,8 +72,6 @@ namespace E2ETest.Namespace
 
             modelBuilder.Entity<OneToOneFKToUniqueKeyDependent>(entity =>
             {
-                entity.HasAlternateKey(e => new { e.OneToOneFKToUniqueKeyDependentFK1, e.OneToOneFKToUniqueKeyDependentFK2 });
-
                 entity.HasKey(e => new { e.OneToOneFKToUniqueKeyDependentID1, e.OneToOneFKToUniqueKeyDependentID2 });
 
                 entity.HasOne(d => d.OneToOneFKToUniqueKeyDependentFK).WithOne(p => p.OneToOneFKToUniqueKeyDependent).HasPrincipalKey<OneToOneFKToUniqueKeyPrincipal>(p => new { p.OneToOneFKToUniqueKeyPrincipalUniqueKey1, p.OneToOneFKToUniqueKeyPrincipalUniqueKey2 }).HasForeignKey<OneToOneFKToUniqueKeyDependent>(d => new { d.OneToOneFKToUniqueKeyDependentFK1, d.OneToOneFKToUniqueKeyDependentFK2 });
@@ -82,8 +80,6 @@ namespace E2ETest.Namespace
             modelBuilder.Entity<OneToOneFKToUniqueKeyPrincipal>(entity =>
             {
                 entity.HasKey(e => new { e.OneToOneFKToUniqueKeyPrincipalID1, e.OneToOneFKToUniqueKeyPrincipalID2 });
-
-                entity.HasAlternateKey(e => new { e.OneToOneFKToUniqueKeyPrincipalUniqueKey1, e.OneToOneFKToUniqueKeyPrincipalUniqueKey2 });
             });
 
             modelBuilder.Entity<OneToOnePrincipal>(entity =>
@@ -93,8 +89,6 @@ namespace E2ETest.Namespace
 
             modelBuilder.Entity<OneToOneSeparateFKDependent>(entity =>
             {
-                entity.HasAlternateKey(e => new { e.OneToOneSeparateFKDependentFK1, e.OneToOneSeparateFKDependentFK2 });
-
                 entity.HasKey(e => new { e.OneToOneSeparateFKDependentID1, e.OneToOneSeparateFKDependentID2 });
             });
 

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/FkToAltKey/FkToAltKeyContext.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/FkToAltKey/FkToAltKeyContext.expected
@@ -16,11 +16,6 @@ namespace E2E.Sqlite
             {
                 entity.HasOne(d => d.UserAlt).WithMany(p => p.Comment).HasPrincipalKey(p => p.AltId).HasForeignKey(d => d.UserAltId).OnDelete(DeleteBehavior.Restrict);
             });
-
-            modelBuilder.Entity<User>(entity =>
-            {
-                entity.HasAlternateKey(e => e.AltId);
-            });
         }
 
         public virtual DbSet<Comment> Comment { get; set; }

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/ManyToMany/ManyToManyFluentApiContext.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/ManyToMany/ManyToManyFluentApiContext.expected
@@ -14,8 +14,6 @@ namespace E2E.Sqlite
         {
             modelBuilder.Entity<Users_Groups>(entity =>
             {
-                entity.HasAlternateKey(e => new { e.UserId, e.GroupId });
-
                 entity.HasOne(d => d.Group).WithMany(p => p.Users_Groups).HasForeignKey(d => d.GroupId);
 
                 entity.HasOne(d => d.User).WithMany(p => p.Users_Groups).HasForeignKey(d => d.UserId);

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/OneToOne/OneToOneFluentApiContext.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/OneToOne/OneToOneFluentApiContext.expected
@@ -14,8 +14,6 @@ namespace E2E.Sqlite
         {
             modelBuilder.Entity<Dependent>(entity =>
             {
-                entity.HasAlternateKey(e => e.PrincipalId);
-
                 entity.Property(e => e.Id).HasColumnType("INT");
 
                 entity.Property(e => e.PrincipalId).HasColumnType("INT");

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/FkToAltKey/FkToAltKeyContext.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/FkToAltKey/FkToAltKeyContext.expected
@@ -16,11 +16,6 @@ namespace E2E.Sqlite
             {
                 entity.HasOne(d => d.UserAlt).WithMany(p => p.Comment).HasPrincipalKey(p => p.AltId).HasForeignKey(d => d.UserAltId).OnDelete(DeleteBehavior.Restrict);
             });
-
-            modelBuilder.Entity<User>(entity =>
-            {
-                entity.HasAlternateKey(e => e.AltId);
-            });
         }
 
         public virtual DbSet<Comment> Comment { get; set; }

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/ManyToMany/ManyToManyAttributesContext.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/ManyToMany/ManyToManyAttributesContext.expected
@@ -12,10 +12,6 @@ namespace E2E.Sqlite
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.Entity<Users_Groups>(entity =>
-            {
-                entity.HasAlternateKey(e => new { e.UserId, e.GroupId });
-            });
         }
 
         public virtual DbSet<Groups> Groups { get; set; }

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/OneToOne/OneToOneAttributesContext.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/OneToOne/OneToOneAttributesContext.expected
@@ -14,8 +14,6 @@ namespace E2E.Sqlite
         {
             modelBuilder.Entity<Dependent>(entity =>
             {
-                entity.HasAlternateKey(e => e.PrincipalId);
-
                 entity.Property(e => e.Id).HasColumnType("INT");
 
                 entity.Property(e => e.PrincipalId).HasColumnType("INT");


### PR DESCRIPTION
Partial fix for #2840.

One output from the meeting on 10/21/15 was that we should no longer output the HasAlternateKey() fluent API. This PR fixes that.