### PR TITLE
[small] :bug: Validate property without CLR type set

### DIFF
--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/PropertyMappingValidationConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/PropertyMappingValidationConvention.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
 
             foreach (var entityType in modelBuilder.Metadata.GetEntityTypes())
             {
-                var unmappedProperty = entityType.GetProperties().FirstOrDefault(p => !IsMappedPrimitiveProperty(p.ClrType));
+                var unmappedProperty = entityType.GetProperties().FirstOrDefault(p => !IsMappedPrimitiveProperty(((IProperty)p).ClrType));
                 if (unmappedProperty != null)
                 {
                     throw new InvalidOperationException(CoreStrings.PropertyNotMapped(unmappedProperty.Name, entityType.Name));

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/PropertyMappingValidationConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/PropertyMappingValidationConventionTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Metadata.Conventions;
@@ -102,6 +101,16 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
         {
             var modelBuilder = new InternalModelBuilder(new Model(), new ConventionSet());
             var entityTypeBuilder = modelBuilder.Entity(typeof(NonCandidatePropertyEntity), ConfigurationSource.Convention);
+
+            new PropertyMappingValidationConvention().Apply(modelBuilder);
+        }
+
+        [Fact]
+        public void Does_not_throw_when_clr_type_is_not_set_for_shadow_property()
+        {
+            var modelBuilder = new InternalModelBuilder(new Model(), new ConventionSet());
+            var entityTypeBuilder = modelBuilder.Entity(typeof(NavigationAsProperty), ConfigurationSource.Convention);
+            entityTypeBuilder.Property("ShadowPropertyOfNullType", ConfigurationSource.Convention);
 
             new PropertyMappingValidationConvention().Apply(modelBuilder);
         }

--- a/test/EntityFramework.Relational.Tests/Metadata/Conventions/Internal/RelationalPropertyMappingValidationConventionTest.cs
+++ b/test/EntityFramework.Relational.Tests/Metadata/Conventions/Internal/RelationalPropertyMappingValidationConventionTest.cs
@@ -117,6 +117,16 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Conventions.Internal
             new RelationalPropertyMappingValidationConvention(new TestRelationalTypeMapper()).Apply(modelBuilder);
         }
 
+        [Fact]
+        public void Does_not_throw_when_clr_type_is_not_set_for_shadow_property()
+        {
+            var modelBuilder = new InternalModelBuilder(new Model(), new ConventionSet());
+            var entityTypeBuilder = modelBuilder.Entity(typeof(NavigationAsProperty), ConfigurationSource.Convention);
+            entityTypeBuilder.Property("ShadowPropertyOfNullType", ConfigurationSource.Convention);
+
+            new RelationalPropertyMappingValidationConvention(new TestRelationalTypeMapper()).Apply(modelBuilder);
+        }
+
         private class NonPrimitiveAsPropertyEntity
         {
             public NavigationAsProperty Property { get; set; }

--- a/test/EntityFramework.Relational.Tests/TestRelationalTypeMapper.cs
+++ b/test/EntityFramework.Relational.Tests/TestRelationalTypeMapper.cs
@@ -26,7 +26,8 @@ namespace Microsoft.Data.Entity.Tests
         protected override IReadOnlyDictionary<Type, RelationalTypeMapping> SimpleMappings { get; }
             = new Dictionary<Type, RelationalTypeMapping>
                 {
-                        { typeof(int), _defaultIntMapping }
+                        { typeof(int), _defaultIntMapping },
+                        { typeof(string), _string }
                 };
 
         protected override IReadOnlyDictionary<string, RelationalTypeMapping> SimpleNameMappings { get; }


### PR DESCRIPTION
The PropertyMappingValidation threw an exception if there is property without CLR type set is present in the model. Converted to use `IProperty.ClrType` so that we use the default value for clr type.