### PR TITLE
[SMALL] Fix to Issue #3452 - Error when return complex linq to json object The EF.Property<T> method may only be used within LINQ queries.

### DIFF
--- a/test/EntityFramework.Core.FunctionalTests/ComplexNavigationsQueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/ComplexNavigationsQueryTestBase.cs
@@ -620,5 +620,33 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 }
             }
         }
+
+        [Fact]
+        public virtual void Select_nav_prop_collection_one_to_many_required()
+        {
+            List<List<int>> expected;
+            using (var context = CreateContext())
+            {
+                expected = context.LevelOne
+                    .Include(e => e.OneToMany_Required)
+                    .ToList()
+                    .OrderBy(e => e.Id)
+                    .Select(e => e.OneToMany_Required?.Select(i => i.Id).ToList()).ToList();
+            }
+
+            ClearLog();
+
+            using (var context = CreateContext())
+            {
+                var query = context.LevelOne.OrderBy(e => e.Id).Select(e => e.OneToMany_Required.Select(i => i.Id));
+                var result = query.ToList();
+
+                Assert.Equal(expected.Count, result.Count);
+                for (int i = 0; i < result.Count; i++)
+                {
+                    Assert.Equal(expected[i].Count, result[i].Count());
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Problem was that we incorrectly that relationship would flow in one direction always assigning foreign key property to the outer key selector and primary key to the inner selector for the comparison.
Fix is to check the direction of the navigation and correctly construct the MemberExpressions. Also making sure we compensate for differences in nullabilities between keys, when necessary.