### PR TITLE
Create shadow ForeignKey properties based on NavigationToPrincipal Name

### DIFF
--- a/src/EntityFramework.Core/Metadata/Builders/EntityTypeBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Builders/EntityTypeBuilder.cs
@@ -318,7 +318,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         protected virtual InternalRelationshipBuilder CollectionBuilder(
             [NotNull] EntityType relatedEntityType, [CanBeNull] string navigationName)
             => Builder.ModelBuilder.Entity(relatedEntityType.Name, ConfigurationSource.Explicit)
-                .Relationship(Builder, ConfigurationSource.Explicit)
+                .Relationship(Builder, null, ConfigurationSource.Explicit)
                 .DependentEntityType(relatedEntityType, ConfigurationSource.Explicit)
                 .IsUnique(false, ConfigurationSource.Explicit)
                 .PrincipalToDependent(navigationName, ConfigurationSource.Explicit);

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/ForeignKeyAttributeConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/ForeignKeyAttributeConvention.cs
@@ -131,11 +131,11 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
             var dependentEntityTypebuilder = relationshipBuilder.ModelBuilder.Entity(foreignKey.DeclaringEntityType.Name, ConfigurationSource.Convention);
             var principalEntityTypeBuilder = relationshipBuilder.ModelBuilder.Entity(foreignKey.PrincipalEntityType.Name, ConfigurationSource.Convention);
 
-            dependentEntityTypebuilder.Relationship(principalEntityTypeBuilder, ConfigurationSource.DataAnnotation)
+            dependentEntityTypebuilder.Relationship(principalEntityTypeBuilder, dependentToPrincipalNavigationName, ConfigurationSource.DataAnnotation)
                 .PrincipalToDependent(null, ConfigurationSource.DataAnnotation)
                 .DependentToPrincipal(dependentToPrincipalNavigationName, ConfigurationSource.DataAnnotation);
 
-            principalEntityTypeBuilder.Relationship(dependentEntityTypebuilder, ConfigurationSource.DataAnnotation)
+            principalEntityTypeBuilder.Relationship(dependentEntityTypebuilder, null, ConfigurationSource.DataAnnotation)
                 .PrincipalToDependent(null, ConfigurationSource.DataAnnotation)
                 .DependentToPrincipal(principalToDepedentNavigationName, ConfigurationSource.DataAnnotation);
         }

--- a/src/EntityFramework.Core/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -906,7 +906,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             if (existingForeignKey == null
                 || existingForeignKey.DeclaringEntityType != Metadata)
             {
-                newRelationship = Relationship(principalEntityTypeBuilder, configurationSource);
+                newRelationship = Relationship(principalEntityTypeBuilder, null, configurationSource);
                 relationship = newRelationship;
             }
             else
@@ -1027,7 +1027,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             {
                 if (navigationToTarget == null)
                 {
-                    return Relationship(targetEntityTypeBuilder, configurationSource)
+                    return Relationship(targetEntityTypeBuilder, null, configurationSource)
                         .Navigations(null, null, configurationSource);
                 }
 
@@ -1053,7 +1053,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 if (!toTargetCanBeUnique)
                 {
                     return Navigations(
-                        Relationship(targetEntityTypeBuilder, configurationSource)
+                        Relationship(targetEntityTypeBuilder, null, configurationSource)
                             .PrincipalEntityType(targetEntityTypeBuilder, configurationSource)
                             .IsUnique(false, configurationSource),
                         null,
@@ -1062,7 +1062,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 }
 
                 return Navigations(
-                    targetEntityTypeBuilder.Relationship(this, configurationSource),
+                    targetEntityTypeBuilder.Relationship(this, inverseNavigation.Name, configurationSource),
                     inverseNavigation.Name,
                     null,
                     configurationSource);
@@ -1087,7 +1087,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 }
 
                 return Navigations(
-                    Relationship(targetEntityTypeBuilder, configurationSource)
+                    Relationship(targetEntityTypeBuilder, navigationToTarget.Name, configurationSource)
                         .PrincipalEntityType(targetEntityTypeBuilder, configurationSource)
                         .IsUnique(false, configurationSource),
                     navigationToTarget.Name,
@@ -1098,7 +1098,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             if (!toSourceCanBeUnique)
             {
                 return Navigations(
-                    targetEntityTypeBuilder.Relationship(this, configurationSource)
+                    targetEntityTypeBuilder.Relationship(this, inverseNavigation.Name, configurationSource)
                         .PrincipalEntityType(this, configurationSource)
                         .IsUnique(false, configurationSource),
                     inverseNavigation.Name,
@@ -1106,7 +1106,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                     configurationSource);
             }
 
-            var relationship = Relationship(targetEntityTypeBuilder, configurationSource);
+            var relationship = Relationship(targetEntityTypeBuilder, null, configurationSource);
             if (!toTargetCanBeNonUnique
                 && !toSourceCanBeNonUnique)
             {
@@ -1138,16 +1138,17 @@ namespace Microsoft.Data.Entity.Metadata.Internal
         public virtual InternalRelationshipBuilder Relationship(
             [NotNull] EntityType principalEntityType,
             ConfigurationSource configurationSource)
-            => Relationship(ModelBuilder.Entity(principalEntityType.Name, configurationSource), configurationSource);
+            => Relationship(ModelBuilder.Entity(principalEntityType.Name, configurationSource), null, configurationSource);
 
         public virtual InternalRelationshipBuilder Relationship(
             [NotNull] InternalEntityTypeBuilder principalEntityTypeBuilder,
+            [CanBeNull] string navigationToPrincipalName,
             ConfigurationSource configurationSource)
             => CreateForeignKey(
                 principalEntityTypeBuilder,
                 null,
                 null,
-                null,
+                navigationToPrincipalName,
                 null,
                 configurationSource,
                 runConventions: true);

--- a/test/EntityFramework.Core.Tests/Metadata/CollectionTypeFactoryTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/CollectionTypeFactoryTest.cs
@@ -1,0 +1,99 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Metadata.Internal;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Tests.Metadata
+{
+    public class CollectionTypeFactoryTest
+    {
+        [Fact]
+        public void Returns_given_type_if_public_parameterless_constructor_available()
+        {
+            var factory = new CollectionTypeFactory();
+
+            Assert.Same(typeof(CustomHashSet), factory.TryFindTypeToInstantiate(typeof(CustomHashSet)));
+            Assert.Same(typeof(CustomList), factory.TryFindTypeToInstantiate(typeof(CustomList)));
+            Assert.Same(typeof(HashSet<Random>), factory.TryFindTypeToInstantiate(typeof(HashSet<Random>)));
+            Assert.Same(typeof(List<Random>), factory.TryFindTypeToInstantiate(typeof(List<Random>)));
+            Assert.Same(typeof(ObservableCollection<Random>), factory.TryFindTypeToInstantiate(typeof(ObservableCollection<Random>)));
+        }
+
+        [Fact]
+        public void Returns_HashSet_if_assignable()
+        {
+            var factory = new CollectionTypeFactory();
+
+            Assert.Same(typeof(HashSet<Random>), factory.TryFindTypeToInstantiate(typeof(ICollection<Random>)));
+
+            Assert.Same(typeof(HashSet<Random>), factory.TryFindTypeToInstantiate(typeof(ISet<Random>)));
+        }
+
+        [Fact]
+        public void Returns_List_if_assignable()
+        {
+            Assert.Same(typeof(List<Random>), new CollectionTypeFactory().TryFindTypeToInstantiate(typeof(IList<Random>)));
+        }
+
+        [Fact]
+        public void Returns_null_when_no_usable_concrete_type_found()
+        {
+            var factory = new CollectionTypeFactory();
+
+            Assert.Null(factory.TryFindTypeToInstantiate(typeof(PrivateConstructor)));
+            Assert.Null(factory.TryFindTypeToInstantiate(typeof(InternalConstructor)));
+            Assert.Null(factory.TryFindTypeToInstantiate(typeof(ProtectedConstructor)));
+            Assert.Null(factory.TryFindTypeToInstantiate(typeof(NoParameterlessConstructor)));
+            Assert.Null(factory.TryFindTypeToInstantiate(typeof(Abstract)));
+            Assert.Null(factory.TryFindTypeToInstantiate(typeof(object)));
+            Assert.Null(factory.TryFindTypeToInstantiate(typeof(Random)));
+            Assert.Null(factory.TryFindTypeToInstantiate(typeof(IEnumerable<Random>)));
+        }
+
+        private class CustomHashSet : HashSet<Random>
+        {
+        }
+
+        private class CustomList : List<Random>
+        {
+        }
+
+        private class PrivateConstructor : List<Random>
+        {
+            private PrivateConstructor()
+            {
+            }
+        }
+
+        private class InternalConstructor : List<Random>
+        {
+            // ReSharper disable once EmptyConstructor
+            internal InternalConstructor()
+            {
+            }
+        }
+
+        private class ProtectedConstructor : List<Random>
+        {
+            protected ProtectedConstructor()
+            {
+            }
+        }
+
+        private class NoParameterlessConstructor : List<Random>
+        {
+            public NoParameterlessConstructor(bool _)
+            {
+            }
+        }
+
+        private abstract class Abstract : List<Random>
+        {
+        }
+    }
+}

--- a/test/EntityFramework.Core.Tests/Metadata/Internal/InternalRelationshipBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/Internal/InternalRelationshipBuilderTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Internal
             var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
             var relationshipBuilder = dependentEntityBuilder.Relationship(
-                principalEntityBuilder, ConfigurationSource.Convention)
+                principalEntityBuilder, Order.CustomerProperty.Name, ConfigurationSource.Convention)
                 .PrincipalEntityType(principalEntityBuilder, ConfigurationSource.Explicit)
                 .HasForeignKey(new[]
                 {
@@ -57,12 +57,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Internal
             var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
             var relationshipBuilder = orderEntityBuilder
-                .Relationship(customerEntityBuilder, ConfigurationSource.Convention)
+                .Relationship(customerEntityBuilder, null, ConfigurationSource.Convention)
                 .HasForeignKey(new[] { Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name }, ConfigurationSource.DataAnnotation);
 
             Assert.NotNull(relationshipBuilder);
             Assert.Same(relationshipBuilder, orderEntityBuilder
-                .Relationship(customerEntityBuilder, ConfigurationSource.Convention)
+                .Relationship(customerEntityBuilder, null, ConfigurationSource.Convention)
                 .HasForeignKey(new[] { Order.CustomerIdProperty, Order.CustomerUniqueProperty }, ConfigurationSource.DataAnnotation));
         }
 
@@ -73,7 +73,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Internal
             var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
             var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
-            var relationshipBuilder = orderEntityBuilder.Relationship(customerEntityBuilder, ConfigurationSource.Convention);
+            var relationshipBuilder = orderEntityBuilder.Relationship(customerEntityBuilder, null, ConfigurationSource.Convention);
             relationshipBuilder = relationshipBuilder.IsRequired(false, ConfigurationSource.DataAnnotation);
 
             var nullableId = orderEntityBuilder.Property("NullableId", typeof(int?), ConfigurationSource.Explicit);
@@ -100,7 +100,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Internal
             var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
             var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
-            var relationshipBuilder = orderEntityBuilder.Relationship(customerEntityBuilder, ConfigurationSource.Convention);
+            var relationshipBuilder = orderEntityBuilder.Relationship(customerEntityBuilder, null, ConfigurationSource.Convention);
             relationshipBuilder = relationshipBuilder.HasPrincipalKey(new[] { Customer.IdProperty }, ConfigurationSource.DataAnnotation);
 
             relationshipBuilder = relationshipBuilder.HasForeignKey(new[] { Order.CustomerIdProperty }, ConfigurationSource.Convention);
@@ -129,11 +129,11 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Internal
             var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
             var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
-            var relationshipBuilder = customerEntityBuilder.Relationship(orderEntityBuilder, ConfigurationSource.DataAnnotation)
+            var relationshipBuilder = customerEntityBuilder.Relationship(orderEntityBuilder, null, ConfigurationSource.DataAnnotation)
                 .HasPrincipalKey(new[] { Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name }, ConfigurationSource.DataAnnotation);
 
             Assert.NotNull(relationshipBuilder);
-            Assert.NotSame(relationshipBuilder, customerEntityBuilder.Relationship(orderEntityBuilder, ConfigurationSource.DataAnnotation)
+            Assert.NotSame(relationshipBuilder, customerEntityBuilder.Relationship(orderEntityBuilder, null, ConfigurationSource.DataAnnotation)
                 .HasPrincipalKey(new[] { Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name }, ConfigurationSource.DataAnnotation));
 
             Assert.Equal(2, customerEntityBuilder.Metadata.GetForeignKeys().Count());
@@ -147,7 +147,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Internal
             customerEntityBuilder.PrimaryKey(new[] { Customer.IdProperty }, ConfigurationSource.Explicit);
             var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
-            var relationshipBuilder = orderEntityBuilder.Relationship(customerEntityBuilder, ConfigurationSource.Convention)
+            var relationshipBuilder = orderEntityBuilder.Relationship(customerEntityBuilder, null, ConfigurationSource.Convention)
                 .HasForeignKey(new[] { Order.CustomerIdProperty, Order.CustomerUniqueProperty }, ConfigurationSource.DataAnnotation)
                 .HasPrincipalKey(new[] { Customer.IdProperty, Customer.UniqueProperty }, ConfigurationSource.Convention);
             Assert.Equal(new[] { Customer.IdProperty.Name, Customer.UniqueProperty.Name },
@@ -175,7 +175,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Internal
             var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
             var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
-            var relationshipBuilder = orderEntityBuilder.Relationship(customerEntityBuilder, ConfigurationSource.Convention);
+            var relationshipBuilder = orderEntityBuilder.Relationship(customerEntityBuilder, null, ConfigurationSource.Convention);
             Assert.Null(relationshipBuilder.Metadata.IsUnique);
             Assert.False(((IForeignKey)relationshipBuilder.Metadata).IsUnique);
 
@@ -258,7 +258,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Internal
             var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
             var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
-            var relationshipBuilder = orderEntityBuilder.Relationship(customerEntityBuilder, ConfigurationSource.Convention);
+            var relationshipBuilder = orderEntityBuilder.Relationship(customerEntityBuilder, null, ConfigurationSource.Convention);
             Assert.Null(relationshipBuilder.Metadata.IsRequired);
             Assert.False(((IForeignKey)relationshipBuilder.Metadata).IsRequired);
 
@@ -316,7 +316,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Internal
             var customerEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
             var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
-            var relationshipBuilder = orderEntityBuilder.Relationship(customerEntityBuilder, ConfigurationSource.Convention);
+            var relationshipBuilder = orderEntityBuilder.Relationship(customerEntityBuilder, null, ConfigurationSource.Convention);
             relationshipBuilder = relationshipBuilder.HasForeignKey(new[] { Order.CustomerIdProperty }, ConfigurationSource.DataAnnotation);
             Assert.Null(relationshipBuilder.Metadata.IsRequired);
             Assert.True(((IForeignKey)relationshipBuilder.Metadata).IsRequired);
@@ -347,7 +347,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Internal
             var orderEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
             var relationshipBuilder = orderEntityBuilder
-                .Relationship(customerEntityBuilder, ConfigurationSource.Convention);
+                .Relationship(customerEntityBuilder, null, ConfigurationSource.Convention);
 
             Assert.Same(orderEntityBuilder.Metadata, relationshipBuilder.Metadata.DeclaringEntityType);
 

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/ConventionDispatcherTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/ConventionDispatcherTest.cs
@@ -258,7 +258,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
 
             var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Convention);
             entityBuilder.PrimaryKey(new[] { "OrderId" }, ConfigurationSource.Convention);
-            Assert.Null(entityBuilder.Relationship(entityBuilder, ConfigurationSource.Convention));
+            Assert.Null(entityBuilder.Relationship(entityBuilder, null, ConfigurationSource.Convention));
 
             Assert.NotNull(relationshipBuilder);
         }

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/ForeignKeyPropertyDiscoveryConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/ForeignKeyPropertyDiscoveryConventionTest.cs
@@ -334,7 +334,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
         {
             DependentType.PrimaryKey(new[] { DependentEntity.PrincipalEntityPeEKaYProperty }, ConfigurationSource.Explicit);
 
-            var relationshipBuilder = DependentType.Relationship(PrincipalType, ConfigurationSource.Convention)
+            var relationshipBuilder = DependentType.Relationship(PrincipalType, null,ConfigurationSource.Convention)
                 .IsUnique(false, ConfigurationSource.Convention);
 
             Assert.Same(relationshipBuilder, new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder));
@@ -350,7 +350,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
         {
             var fkProperty = DependentType.Metadata.FindPrimaryKey().Properties.Single();
 
-            var relationshipBuilder = DependentType.Relationship(PrincipalType, ConfigurationSource.Convention)
+            var relationshipBuilder = DependentType.Relationship(PrincipalType, null, ConfigurationSource.Convention)
                 .PrincipalEntityType(PrincipalType, ConfigurationSource.DataAnnotation)
                 .IsUnique(true, ConfigurationSource.DataAnnotation)
                 .IsRequired(false, ConfigurationSource.DataAnnotation);
@@ -368,7 +368,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
         [Fact]
         public void Does_not_match_dependent_PK_for_self_ref()
         {
-            var relationshipBuilder = PrincipalType.Relationship(PrincipalType, ConfigurationSource.Convention)
+            var relationshipBuilder = PrincipalType.Relationship(PrincipalType, null, ConfigurationSource.Convention)
                 .IsUnique(true, ConfigurationSource.DataAnnotation);
 
             Assert.Same(relationshipBuilder, new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder));
@@ -438,7 +438,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             DependentTypeWithCompositeKey.PrimaryKey(new[] { fkProperty1.Name }, ConfigurationSource.Explicit);
 
             var relationshipBuilder = DependentTypeWithCompositeKey.Relationship(
-                PrincipalTypeWithCompositeKey, ConfigurationSource.Convention)
+                PrincipalTypeWithCompositeKey, null, ConfigurationSource.Convention)
                 .HasPrincipalKey(PrincipalTypeWithCompositeKey.Metadata.FindPrimaryKey().Properties, ConfigurationSource.DataAnnotation)
                 .IsUnique(true, ConfigurationSource.DataAnnotation);
 
@@ -531,7 +531,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
         {
             var fkProperty = DependentType.Property(DependentEntity.PeEKaYProperty, ConfigurationSource.Convention).Metadata;
 
-            var relationshipBuilder = DependentType.Relationship(PrincipalType, ConfigurationSource.Convention)
+            var relationshipBuilder = DependentType.Relationship(PrincipalType, null, ConfigurationSource.Convention)
                 .IsUnique(true, ConfigurationSource.Convention);
 
             var newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder);
@@ -553,7 +553,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
         {
             var fkProperty = DependentType.Property(DependentEntity.PeEKaYProperty, ConfigurationSource.Convention).Metadata;
 
-            var relationshipBuilder = DependentType.Relationship(PrincipalType, ConfigurationSource.Convention)
+            var relationshipBuilder = DependentType.Relationship(PrincipalType, null, ConfigurationSource.Convention)
                 .IsUnique(true, ConfigurationSource.Convention);
 
             var newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder);
@@ -577,7 +577,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             PrincipalType.Property(PrincipalEntity.DependentEntityKayPeeProperty, ConfigurationSource.Convention);
 
             var relationshipBuilder = DependentType.Relationship(
-                PrincipalType, ConfigurationSource.Convention)
+                PrincipalType, null, ConfigurationSource.Convention)
                 .IsUnique(true, ConfigurationSource.Convention);
 
             var newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder);
@@ -599,7 +599,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             var fkProperty = PrincipalType.Property(PrincipalEntity.DependentEntityKayPeeProperty, ConfigurationSource.Convention).Metadata;
 
             var relationshipBuilder = DependentType.Relationship(
-                PrincipalType, ConfigurationSource.Convention)
+                PrincipalType, null, ConfigurationSource.Convention)
                 .IsUnique(true, ConfigurationSource.Convention)
                 .IsRequired(false, ConfigurationSource.DataAnnotation);
 
@@ -684,10 +684,10 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
         [Fact]
         public void Inverts_if_dependent_entity_type_is_referenced()
         {
-            DependentType.Relationship(PrincipalType, ConfigurationSource.Convention);
+            DependentType.Relationship(PrincipalType, null, ConfigurationSource.Convention);
 
             var relationshipBuilder = PrincipalType.Relationship(
-                DependentType, ConfigurationSource.Convention)
+                DependentType, null, ConfigurationSource.Convention)
                 .IsUnique(true, ConfigurationSource.Convention);
 
             var newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder);
@@ -706,10 +706,11 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
         [Fact]
         public void Does_not_invert_if_both_are_referenced()
         {
-            DependentType.Relationship(PrincipalType, ConfigurationSource.Convention);
-            PrincipalType.Relationship(DependentType, ConfigurationSource.Convention);
+            DependentType.Relationship(PrincipalType, null, ConfigurationSource.Convention);
+            PrincipalType.Relationship(DependentType, null, ConfigurationSource.Convention);
 
-            var relationshipBuilder = PrincipalType.Relationship(DependentType, ConfigurationSource.Convention)
+            var relationshipBuilder = PrincipalType.Relationship(
+                DependentType, null, ConfigurationSource.Convention)
                 .IsUnique(true, ConfigurationSource.Convention);
 
             var newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder);

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/OneToManyTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/OneToManyTestBase.cs
@@ -1672,6 +1672,18 @@ namespace Microsoft.Data.Entity.Tests
                 var newForeignKey = model.FindEntityType(typeof(DependentEntity)).GetForeignKeys().Single();
                 Assert.Equal("PrincipalEntityId", newForeignKey.Properties.Single().Name);
             }
+
+            [Fact]
+            public virtual void Creates_shadow_foreign_key_properties_based_on_their_respective_navigation_to_principal_names()
+            {
+                var model = new Model();
+                var modelBuilder = CreateModelBuilder(model);
+                modelBuilder.Entity<EntityA>();
+
+                var entityType = model.FindEntityType(typeof(EntityA));
+                Assert.Equal("NavigationId", entityType.FindNavigation("Navigation").ForeignKey.Properties.First().Name);
+                Assert.Equal("AnotherNavigationId", entityType.FindNavigation("AnotherNavigation").ForeignKey.Properties.First().Name);
+            }
         }
     }
 }

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/TestModel.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/TestModel.cs
@@ -323,5 +323,17 @@ namespace Microsoft.Data.Entity.Tests
             public PrincipalEntity Nav { get; set; }
         }
 
+
+        protected class EntityA
+        {
+            public int Id { get; set; }
+            public EntityB Navigation { get; set; }
+            public EntityB AnotherNavigation { get; set; }
+        }
+
+        protected class EntityB
+        {
+            public int Id { get; set; }
+        }
     }
 }


### PR DESCRIPTION
resolves #3503 
Issue here was when we were creating the relationship we create the foreign key first and then add navigation. Therefore the `NavigationToPrincipalName` was always null while creating foreign key, hence navigation name was never used while creating shadow properties for FK.
Solution - Pass the Navigation to Principal Name as argument even when creating FK (even though navigation is not set) so that the shadow properties have appropriate names.
@AndriySvyryd - Is this correct way to fix this? Anymore tests needed?