### PR TITLE
Small API changes discussed with others while writing doc comments

### DIFF
--- a/src/EntityFramework.Commands/Design/Internal/DesignTimeServicesBuilder.cs
+++ b/src/EntityFramework.Commands/Design/Internal/DesignTimeServicesBuilder.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Data.Entity.Design.Internal
             ConfigureServices(services);
             ConfigureDnxServices(services);
 
-            var contextServices = ((IAccessor<IServiceProvider>)context).Service;
+            var contextServices = ((IInfrastructure<IServiceProvider>)context).Instance;
             ConfigureContextServices(contextServices, services);
 
             var databaseProviderServices = contextServices.GetRequiredService<IDatabaseProviderServices>();

--- a/src/EntityFramework.Core/ChangeTracking/ChangeTracker.cs
+++ b/src/EntityFramework.Core/ChangeTracking/ChangeTracker.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
     ///     Instances of this class are typically obtained from <see cref="DbContext.ChangeTracker" /> and it is not designed
     ///     to be directly constructed in your application code.
     /// </summary>
-    public class ChangeTracker : IAccessor<IStateManager>
+    public class ChangeTracker : IInfrastructure<IStateManager>
     {
         private readonly IStateManager _stateManager;
         private readonly IChangeDetector _changeDetector;
@@ -129,7 +129,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
         ///         application code.
         ///     </para>
         /// </summary>
-        IStateManager IAccessor<IStateManager>.Service => _stateManager;
+        IStateManager IInfrastructure<IStateManager>.Instance => _stateManager;
 
         /// <summary>
         ///     Gets the context this change tracker belongs to.

--- a/src/EntityFramework.Core/ChangeTracking/EntityEntry.cs
+++ b/src/EntityFramework.Core/ChangeTracking/EntityEntry.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
     ///     </para>
     /// </summary>
     [DebuggerDisplay("{_internalEntityEntry,nq}")]
-    public class EntityEntry : IAccessor<InternalEntityEntry>
+    public class EntityEntry : IInfrastructure<InternalEntityEntry>
     {
         private readonly InternalEntityEntry _internalEntityEntry;
 
@@ -76,7 +76,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
         ///         application code.
         ///     </para>
         /// </summary>
-        InternalEntityEntry IAccessor<InternalEntityEntry>.Service => _internalEntityEntry;
+        InternalEntityEntry IInfrastructure<InternalEntityEntry>.Instance => _internalEntityEntry;
 
         /// <summary>
         ///     Gets the context that is tracking the entity.

--- a/src/EntityFramework.Core/ChangeTracking/EntityEntry`.cs
+++ b/src/EntityFramework.Core/ChangeTracking/EntityEntry`.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
 
             var propertyInfo = propertyExpression.GetPropertyAccess();
 
-            return new PropertyEntry<TEntity, TProperty>(this.GetService(), propertyInfo.Name);
+            return new PropertyEntry<TEntity, TProperty>(this.GetInfrastructure(), propertyInfo.Name);
         }
 
         /// <summary>
@@ -73,7 +73,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
         {
             Check.NotNull(propertyName, nameof(propertyName));
 
-            var property = this.GetService().EntityType.FindProperty(propertyName);
+            var property = this.GetInfrastructure().EntityType.FindProperty(propertyName);
 
             if (property != null
                 && property.ClrType != typeof(TProperty))
@@ -81,7 +81,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
                 throw new ArgumentException(CoreStrings.WrongGenericPropertyType(propertyName, property.DeclaringEntityType.Name, property.ClrType.Name, typeof(TProperty).Name));
             }
 
-            return new PropertyEntry<TEntity, TProperty>(this.GetService(), propertyName);
+            return new PropertyEntry<TEntity, TProperty>(this.GetInfrastructure(), propertyName);
         }
     }
 }

--- a/src/EntityFramework.Core/DbContext.cs
+++ b/src/EntityFramework.Core/DbContext.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Data.Entity
     ///         is discovered by convention, you can override the <see cref="OnModelCreating(ModelBuilder)" /> method.
     ///     </para>
     /// </remarks>
-    public class DbContext : IDisposable, IAccessor<IServiceProvider>
+    public class DbContext : IDisposable, IInfrastructure<IServiceProvider>
     {
         private static readonly ConcurrentDictionary<Type, Type> _optionsTypes = new ConcurrentDictionary<Type, Type>();
 
@@ -237,7 +237,7 @@ namespace Microsoft.Data.Entity
         ///         not directly exposed in the public API surface.
         ///     </para>
         /// </summary>
-        IServiceProvider IAccessor<IServiceProvider>.Service => ServiceProvider;
+        IServiceProvider IInfrastructure<IServiceProvider>.Instance => ServiceProvider;
 
         /// <summary>
         ///     <para>
@@ -574,7 +574,7 @@ namespace Microsoft.Data.Entity
         {
             var entry = EntryWithoutDetectChanges(entity);
 
-            SetEntityState(entry.GetService(), entityState, behavior);
+            SetEntityState(entry.GetInfrastructure(), entityState, behavior);
 
             return entry;
         }
@@ -671,7 +671,7 @@ namespace Microsoft.Data.Entity
         {
             var entry = EntryWithoutDetectChanges(entity);
 
-            SetEntityState(entry.GetService(), entityState, behavior);
+            SetEntityState(entry.GetInfrastructure(), entityState, behavior);
 
             return entry;
         }

--- a/src/EntityFramework.Core/DbContextOptionsBuilder.cs
+++ b/src/EntityFramework.Core/DbContextOptionsBuilder.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Utilities;
 

--- a/src/EntityFramework.Core/DbSet`.cs
+++ b/src/EntityFramework.Core/DbSet`.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Data.Entity
     /// </summary>
     /// <typeparam name="TEntity"> The type of entity being operated on by this set. </typeparam>
     public abstract partial class DbSet<TEntity>
-        : IOrderedQueryable<TEntity>, IAsyncEnumerableAccessor<TEntity>, IAccessor<IServiceProvider>
+        : IOrderedQueryable<TEntity>, IAsyncEnumerableAccessor<TEntity>, IInfrastructure<IServiceProvider>
         where TEntity : class
     {
         /// <summary>
@@ -311,7 +311,7 @@ namespace Microsoft.Data.Entity
         ///         not directly exposed in the public API surface.
         ///     </para>
         /// </summary>
-        IServiceProvider IAccessor<IServiceProvider>.Service
+        IServiceProvider IInfrastructure<IServiceProvider>.Instance
         {
             get { throw new NotImplementedException(); }
         }

--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -67,7 +67,6 @@
     <Compile Include="ChangeTracking\Internal\SimpleKeyValueFactory.cs" />
     <Compile Include="ChangeTracking\Internal\ValueBufferOriginalValues.cs" />
     <Compile Include="ChangeTracking\Internal\ValueBufferSidecar.cs" />
-    <Compile Include="ChangeTracking\QueryTrackingBehavior.cs" />
     <Compile Include="DbUpdateConcurrencyException.cs" />
     <Compile Include="DbUpdateException.cs" />
     <Compile Include="Extensions\Internal\CoreLoggerExtensions.cs" />
@@ -81,6 +80,7 @@
     <Compile Include="Infrastructure\IKeyValue.cs" />
     <Compile Include="Infrastructure\ModelSource.cs" />
     <Compile Include="Infrastructure\CoreLoggingEventId.cs" />
+    <Compile Include="Internal\CoreOptionsExtension.cs" />
     <Compile Include="Internal\DatabaseProviderSelector.cs" />
     <Compile Include="Internal\EnumerableExtensions.cs" />
     <Compile Include="Internal\Graph.cs" />
@@ -220,7 +220,6 @@
     <Compile Include="Metadata\Internal\InternalMetadataBuilder`.cs" />
     <Compile Include="Metadata\Internal\MetadataHelper.cs" />
     <Compile Include="Metadata\ValueGenerated.cs" />
-    <Compile Include="Infrastructure\CoreOptionsExtension.cs" />
     <Compile Include="Infrastructure\DbContextOptions.cs" />
     <Compile Include="Infrastructure\DbContextOptions`.cs" />
     <Compile Include="Infrastructure\IDbContextOptions.cs" />
@@ -248,6 +247,7 @@
     <Compile Include="Metadata\Internal\IFieldMatcher.cs" />
     <Compile Include="Metadata\Internal\IMemberMapper.cs" />
     <Compile Include="ModelBuilder.cs" />
+    <Compile Include="QueryTrackingBehavior.cs" />
     <Compile Include="Query\Annotations\QueryAnnotation.cs" />
     <Compile Include="Query\Annotations\IncludeQueryAnnotation.cs" />
     <Compile Include="EF.cs" />

--- a/src/EntityFramework.Core/Infrastructure/AccessorExtensions.cs
+++ b/src/EntityFramework.Core/Infrastructure/AccessorExtensions.cs
@@ -10,14 +10,14 @@ namespace Microsoft.Data.Entity.Infrastructure
 {
     /// <summary>
     ///     <para>
-    ///         Extension methods for <see cref="IAccessor{TService}"/>. 
+    ///         Extension methods for <see cref="IInfrastructure{T}"/>. 
     ///     </para>
     ///     <para>
     ///         These methods are typically used by database providers (and other extensions). They are generally
     ///         not used in application code.
     ///     </para>
     ///     <para>
-    ///         <see cref="IAccessor{TService}"/> is used to hide properties that are not intended to be used in 
+    ///         <see cref="IInfrastructure{T}"/> is used to hide properties that are not intended to be used in 
     ///         application code but can be used in extension methods written by database providers etc.
     ///     </para>
     /// </summary>
@@ -26,40 +26,40 @@ namespace Microsoft.Data.Entity.Infrastructure
         /// <summary>
         ///     <para>
         ///         Resolves a service from the <see cref="IServiceProvider"/> exposed from a type that implements 
-        ///         <see cref="IAccessor{IServiceProvider}"/>. 
+        ///         <see cref="IInfrastructure{IServiceProvider}"/>. 
         ///     </para>
         ///     <para>
         ///         This method is typically used by database providers (and other extensions). It is generally
         ///         not used in application code.
         ///     </para>
         ///     <para>
-        ///         <see cref="IAccessor{TService}"/> is used to hide properties that are not intended to be used in 
+        ///         <see cref="IInfrastructure{T}"/> is used to hide properties that are not intended to be used in 
         ///         application code but can be used in extension methods written by database providers etc.
         ///     </para>
         /// </summary>
         /// <typeparam name="TService"> The type of service to be resolved. </typeparam>
         /// <param name="accessor"> The object exposing the service provider. </param>
         /// <returns> The requested service. </returns>
-        public static TService GetService<TService>([NotNull] this IAccessor<IServiceProvider> accessor)
-            => Check.NotNull(accessor, nameof(accessor)).Service.GetRequiredService<TService>();
+        public static TService GetService<TService>([NotNull] this IInfrastructure<IServiceProvider> accessor)
+            => Check.NotNull(accessor, nameof(accessor)).Instance.GetRequiredService<TService>();
 
         /// <summary>
         ///     <para>
-        ///         Gets the value from a property that is being hidden using <see cref="IAccessor{TService}"/>.
+        ///         Gets the value from a property that is being hidden using <see cref="IInfrastructure{T}"/>.
         ///     </para>
         ///     <para>
         ///         This method is typically used by database providers (and other extensions). It is generally
         ///         not used in application code.
         ///     </para>
         ///     <para>
-        ///         <see cref="IAccessor{TService}"/> is used to hide properties that are not intended to be used in 
+        ///         <see cref="IInfrastructure{T}"/> is used to hide properties that are not intended to be used in 
         ///         application code but can be used in extension methods written by database providers etc.
         ///     </para>
         /// </summary>
-        /// <typeparam name="TService"> The type of the property being hidden by <see cref="IAccessor{TService}"/>. </typeparam>
+        /// <typeparam name="T"> The type of the property being hidden by <see cref="IInfrastructure{T}"/>. </typeparam>
         /// <param name="accessor"> The object that exposes the property. </param>
         /// <returns> The object assigned to the property. </returns>
-        public static TService GetService<TService>([NotNull] this IAccessor<TService> accessor)
-            => Check.NotNull(accessor, nameof(accessor)).Service;
+        public static T GetInfrastructure<T>([NotNull] this IInfrastructure<T> accessor)
+            => Check.NotNull(accessor, nameof(accessor)).Instance;
     }
 }

--- a/src/EntityFramework.Core/Infrastructure/DatabaseFacade.cs
+++ b/src/EntityFramework.Core/Infrastructure/DatabaseFacade.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Data.Entity.Infrastructure
     ///     Instances of this class are typically obtained from <see cref="DbContext.Database" /> and it is not designed
     ///     to be directly constructed in your application code.
     /// </summary>
-    public class DatabaseFacade : IAccessor<IServiceProvider>
+    public class DatabaseFacade : IInfrastructure<IServiceProvider>
     {
         private readonly DbContext _context;
 
@@ -83,6 +83,6 @@ namespace Microsoft.Data.Entity.Infrastructure
         ///         not directly exposed in the public API surface.
         ///     </para>
         /// </summary>
-        IServiceProvider IAccessor<IServiceProvider>.Service => ((IAccessor<IServiceProvider>)_context).Service;
+        IServiceProvider IInfrastructure<IServiceProvider>.Instance => ((IInfrastructure<IServiceProvider>)_context).Instance;
     }
 }

--- a/src/EntityFramework.Core/Infrastructure/EntityFrameworkServicesBuilder.cs
+++ b/src/EntityFramework.Core/Infrastructure/EntityFrameworkServicesBuilder.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Data.Entity.Infrastructure
     ///     <see cref="EntityFrameworkServiceCollectionExtensions.AddEntityFramework(IServiceCollection)" />
     ///     and then chaining API calls on the returned <see cref="EntityFrameworkServicesBuilder" />.
     /// </summary>
-    public class EntityFrameworkServicesBuilder : IAccessor<IServiceCollection>
+    public class EntityFrameworkServicesBuilder : IInfrastructure<IServiceCollection>
     {
         private readonly IServiceCollection _serviceCollection;
 
@@ -111,6 +111,6 @@ namespace Microsoft.Data.Entity.Infrastructure
         ///         not directly exposed in the public API surface.
         ///     </para>
         /// </summary>
-        IServiceCollection IAccessor<IServiceCollection>.Service => _serviceCollection;
+        IServiceCollection IInfrastructure<IServiceCollection>.Instance => _serviceCollection;
     }
 }

--- a/src/EntityFramework.Core/Infrastructure/IAccessor.cs
+++ b/src/EntityFramework.Core/Infrastructure/IAccessor.cs
@@ -13,12 +13,12 @@ namespace Microsoft.Data.Entity.Infrastructure
     ///         not used in application code.
     ///     </para>
     /// </summary>
-    /// <typeparam name="TService"> The type of the property being hidden. </typeparam>
-    public interface IAccessor<out TService>
+    /// <typeparam name="T"> The type of the property being hidden. </typeparam>
+    public interface IInfrastructure<out T>
     {
         /// <summary>
         ///     Gets the value of the property being hidden.
         /// </summary>
-        TService Service { get; }
+        T Instance { get; }
     }
 }

--- a/src/EntityFramework.Core/Internal/CoreOptionsExtension.cs
+++ b/src/EntityFramework.Core/Internal/CoreOptionsExtension.cs
@@ -2,10 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using System;
 
-namespace Microsoft.Data.Entity.Infrastructure
+namespace Microsoft.Data.Entity.Internal
 {
     /// <summary>
     ///     Used to store the options specified via <see cref="DbContextOptionsBuilder"/> that are applicable to all databases.

--- a/src/EntityFramework.Core/Internal/InternalDbSet.cs
+++ b/src/EntityFramework.Core/Internal/InternalDbSet.cs
@@ -16,7 +16,7 @@ using Microsoft.Data.Entity.Utilities;
 namespace Microsoft.Data.Entity.Internal
 {
     public class InternalDbSet<TEntity>
-        : DbSet<TEntity>, IOrderedQueryable<TEntity>, IAsyncEnumerableAccessor<TEntity>, IAccessor<IServiceProvider>
+        : DbSet<TEntity>, IOrderedQueryable<TEntity>, IAsyncEnumerableAccessor<TEntity>, IInfrastructure<IServiceProvider>
         where TEntity : class
     {
         private readonly DbContext _context;
@@ -92,6 +92,6 @@ namespace Microsoft.Data.Entity.Internal
 
         IQueryProvider IQueryable.Provider => _entityQueryable.Value.Provider;
 
-        IServiceProvider IAccessor<IServiceProvider>.Service => ((IAccessor<IServiceProvider>)_context).Service;
+        IServiceProvider IInfrastructure<IServiceProvider>.Instance => ((IInfrastructure<IServiceProvider>)_context).Instance;
     }
 }

--- a/src/EntityFramework.Core/Metadata/Builders/CollectionNavigationBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Builders/CollectionNavigationBuilder.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
     ///         and it is not designed to be directly constructed in your application code.
     ///     </para>
     /// </summary>
-    public class CollectionNavigationBuilder : IAccessor<InternalRelationshipBuilder>
+    public class CollectionNavigationBuilder : IInfrastructure<InternalRelationshipBuilder>
     {
         /// <summary>
         ///     <para>
@@ -42,7 +42,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         /// <summary>
         ///     Gets the internal builder being used to configure the relationship.
         /// </summary>
-        InternalRelationshipBuilder IAccessor<InternalRelationshipBuilder>.Service => Builder;
+        InternalRelationshipBuilder IInfrastructure<InternalRelationshipBuilder>.Instance => Builder;
 
         /// <summary>
         ///     Configures this as a one-to-many relationship.

--- a/src/EntityFramework.Core/Metadata/Builders/EntityTypeBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Builders/EntityTypeBuilder.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
     ///         and it is not designed to be directly constructed in your application code.
     ///     </para>
     /// </summary>
-    public class EntityTypeBuilder : IAccessor<IMutableModel>, IAccessor<InternalEntityTypeBuilder>
+    public class EntityTypeBuilder : IInfrastructure<IMutableModel>, IInfrastructure<InternalEntityTypeBuilder>
     {
         /// <summary>
         ///     <para>
@@ -48,7 +48,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         /// <summary>
         ///     The internal builder being used to configure the entity type.
         /// </summary>
-        InternalEntityTypeBuilder IAccessor<InternalEntityTypeBuilder>.Service => Builder;
+        InternalEntityTypeBuilder IInfrastructure<InternalEntityTypeBuilder>.Instance => Builder;
 
         /// <summary>
         ///     The entity type being configured.
@@ -58,7 +58,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         /// <summary>
         ///     The model that the entity type belongs to.
         /// </summary>
-        IMutableModel IAccessor<IMutableModel>.Service => Builder.ModelBuilder.Metadata;
+        IMutableModel IInfrastructure<IMutableModel>.Instance => Builder.ModelBuilder.Metadata;
 
         /// <summary>
         ///     Adds or updates an annotation on the entity type. If an annotation with the key specified in

--- a/src/EntityFramework.Core/Metadata/Builders/EntityTypeBuilder`.cs
+++ b/src/EntityFramework.Core/Metadata/Builders/EntityTypeBuilder`.cs
@@ -241,6 +241,6 @@ namespace Microsoft.Data.Entity.Metadata.Builders
                 CollectionBuilder(relatedEntityType, navigationName));
         }
 
-        private InternalEntityTypeBuilder Builder => this.GetService<InternalEntityTypeBuilder>();
+        private InternalEntityTypeBuilder Builder => this.GetInfrastructure<InternalEntityTypeBuilder>();
     }
 }

--- a/src/EntityFramework.Core/Metadata/Builders/IndexBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Builders/IndexBuilder.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
     ///         and it is not designed to be directly constructed in your application code.
     ///     </para>
     /// </summary>
-    public class IndexBuilder : IAccessor<IMutableModel>, IAccessor<InternalIndexBuilder>
+    public class IndexBuilder : IInfrastructure<IMutableModel>, IInfrastructure<InternalIndexBuilder>
     {
         private readonly InternalIndexBuilder _builder;
 
@@ -41,7 +41,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         /// <summary>
         ///     The internal builder being used to configure the index.
         /// </summary>
-        InternalIndexBuilder IAccessor<InternalIndexBuilder>.Service => _builder;
+        InternalIndexBuilder IInfrastructure<InternalIndexBuilder>.Instance => _builder;
 
         /// <summary>
         ///     The index being configured.
@@ -51,7 +51,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         /// <summary>
         ///     The model that the index belongs to.
         /// </summary>
-        IMutableModel IAccessor<IMutableModel>.Service => Builder.ModelBuilder.Metadata;
+        IMutableModel IInfrastructure<IMutableModel>.Instance => Builder.ModelBuilder.Metadata;
 
         /// <summary>
         ///     Adds or updates an annotation on the index. If an annotation with the key specified in
@@ -83,6 +83,6 @@ namespace Microsoft.Data.Entity.Metadata.Builders
             return this;
         }
 
-        private InternalIndexBuilder Builder => this.GetService<InternalIndexBuilder>();
+        private InternalIndexBuilder Builder => this.GetInfrastructure<InternalIndexBuilder>();
     }
 }

--- a/src/EntityFramework.Core/Metadata/Builders/KeyBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Builders/KeyBuilder.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
     ///         and it is not designed to be directly constructed in your application code.
     ///     </para>
     /// </summary>
-    public class KeyBuilder : IAccessor<IMutableModel>, IAccessor<InternalKeyBuilder>
+    public class KeyBuilder : IInfrastructure<IMutableModel>, IInfrastructure<InternalKeyBuilder>
     {
         private readonly InternalKeyBuilder _builder;
 
@@ -41,7 +41,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         /// <summary>
         ///     The internal builder being used to configure the key.
         /// </summary>
-        InternalKeyBuilder IAccessor<InternalKeyBuilder>.Service => _builder;
+        InternalKeyBuilder IInfrastructure<InternalKeyBuilder>.Instance => _builder;
 
         /// <summary>
         ///     The key being configured.
@@ -51,7 +51,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         /// <summary>
         ///     The model that the key belongs to.
         /// </summary>
-        IMutableModel IAccessor<IMutableModel>.Service => Builder.ModelBuilder.Metadata;
+        IMutableModel IInfrastructure<IMutableModel>.Instance => Builder.ModelBuilder.Metadata;
 
         /// <summary>
         ///     Adds or updates an annotation on the key. If an annotation with the key specified in
@@ -71,6 +71,6 @@ namespace Microsoft.Data.Entity.Metadata.Builders
             return this;
         }
 
-        private InternalKeyBuilder Builder => this.GetService<InternalKeyBuilder>();
+        private InternalKeyBuilder Builder => this.GetInfrastructure<InternalKeyBuilder>();
     }
 }

--- a/src/EntityFramework.Core/Metadata/Builders/PropertyBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Builders/PropertyBuilder.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
     ///         and it is not designed to be directly constructed in your application code.
     ///     </para>
     /// </summary>
-    public class PropertyBuilder : IAccessor<IMutableModel>, IAccessor<InternalPropertyBuilder>
+    public class PropertyBuilder : IInfrastructure<IMutableModel>, IInfrastructure<InternalPropertyBuilder>
     {
         /// <summary>
         ///     <para>
@@ -40,7 +40,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         /// <summary>
         ///     The internal builder being used to configure the property.
         /// </summary>
-        InternalPropertyBuilder IAccessor<InternalPropertyBuilder>.Service => Builder;
+        InternalPropertyBuilder IInfrastructure<InternalPropertyBuilder>.Instance => Builder;
 
         /// <summary>
         ///     The property being configured.
@@ -50,7 +50,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         /// <summary>
         ///     The model that the property belongs to.
         /// </summary>
-        IMutableModel IAccessor<IMutableModel>.Service => Builder.ModelBuilder.Metadata;
+        IMutableModel IInfrastructure<IMutableModel>.Instance => Builder.ModelBuilder.Metadata;
 
         /// <summary>
         ///     Adds or updates an annotation on the property. If an annotation with the key specified in

--- a/src/EntityFramework.Core/Metadata/Builders/ReferenceCollectionBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Builders/ReferenceCollectionBuilder.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
     ///         and it is not designed to be directly constructed in your application code.
     ///     </para>
     /// </summary>
-    public class ReferenceCollectionBuilder : IAccessor<IMutableModel>, IAccessor<InternalRelationshipBuilder>
+    public class ReferenceCollectionBuilder : IInfrastructure<IMutableModel>, IInfrastructure<InternalRelationshipBuilder>
     {
         private readonly IReadOnlyList<Property> _foreignKeyProperties;
         private readonly IReadOnlyList<Property> _principalKeyProperties;
@@ -86,12 +86,12 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         /// <summary>
         ///     The model that this relationship belongs to.
         /// </summary>
-        IMutableModel IAccessor<IMutableModel>.Service => Builder.ModelBuilder.Metadata;
+        IMutableModel IInfrastructure<IMutableModel>.Instance => Builder.ModelBuilder.Metadata;
 
         /// <summary>
         ///     Gets the internal builder being used to configure this relationship.
         /// </summary>
-        InternalRelationshipBuilder IAccessor<InternalRelationshipBuilder>.Service => Builder;
+        InternalRelationshipBuilder IInfrastructure<InternalRelationshipBuilder>.Instance => Builder;
 
         /// <summary>
         ///     Adds or updates an annotation on the relationship. If an annotation with the key specified in

--- a/src/EntityFramework.Core/Metadata/Builders/ReferenceNavigationBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Builders/ReferenceNavigationBuilder.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
     ///         and it is not designed to be directly constructed in your application code.
     ///     </para>
     /// </summary>
-    public class ReferenceNavigationBuilder : IAccessor<InternalRelationshipBuilder>
+    public class ReferenceNavigationBuilder : IInfrastructure<InternalRelationshipBuilder>
     {
         /// <summary>
         ///     <para>
@@ -66,7 +66,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         /// <summary>
         ///     Gets the internal builder being used to configure the relationship.
         /// </summary>
-        InternalRelationshipBuilder IAccessor<InternalRelationshipBuilder>.Service => Builder;
+        InternalRelationshipBuilder IInfrastructure<InternalRelationshipBuilder>.Instance => Builder;
 
         /// <summary>
         ///     Configures this as a one-to-many relationship.

--- a/src/EntityFramework.Core/Metadata/Builders/ReferenceReferenceBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Builders/ReferenceReferenceBuilder.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
     ///         entity type.
     ///     </para>
     /// </summary>
-    public class ReferenceReferenceBuilder : IAccessor<IMutableModel>, IAccessor<InternalRelationshipBuilder>
+    public class ReferenceReferenceBuilder : IInfrastructure<IMutableModel>, IInfrastructure<InternalRelationshipBuilder>
     {
         private readonly IReadOnlyList<Property> _foreignKeyProperties;
         private readonly IReadOnlyList<Property> _principalKeyProperties;
@@ -102,7 +102,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         /// <summary>
         ///     Gets the internal builder being used to configure this relationship.
         /// </summary>
-        InternalRelationshipBuilder IAccessor<InternalRelationshipBuilder>.Service => Builder;
+        InternalRelationshipBuilder IInfrastructure<InternalRelationshipBuilder>.Instance => Builder;
 
         /// <summary>
         ///     The foreign key that represents this relationship.
@@ -112,7 +112,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         /// <summary>
         ///     The model that this relationship belongs to.
         /// </summary>
-        IMutableModel IAccessor<IMutableModel>.Service => Builder.ModelBuilder.Metadata;
+        IMutableModel IInfrastructure<IMutableModel>.Instance => Builder.ModelBuilder.Metadata;
 
         /// <summary>
         ///     Adds or updates an annotation on the relationship. If an annotation with the key specified in

--- a/src/EntityFramework.Core/ModelBuilder.cs
+++ b/src/EntityFramework.Core/ModelBuilder.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Data.Entity
     ///         model externally and set it on a <see cref="DbContextOptions" /> instance that is passed to the context constructor.
     ///     </para>
     /// </summary>
-    public class ModelBuilder : IAccessor<InternalModelBuilder>
+    public class ModelBuilder : IInfrastructure<InternalModelBuilder>
     {
         private readonly InternalModelBuilder _builder;
 
@@ -91,7 +91,7 @@ namespace Microsoft.Data.Entity
         ///         application code.
         ///     </para>
         /// </summary>
-        InternalModelBuilder IAccessor<InternalModelBuilder>.Service => _builder;
+        InternalModelBuilder IInfrastructure<InternalModelBuilder>.Instance => _builder;
 
         /// <summary>
         ///     Returns an object that can be used to configure a given entity type in the model.
@@ -229,6 +229,6 @@ namespace Microsoft.Data.Entity
             return this;
         }
 
-        private InternalModelBuilder Builder => this.GetService();
+        private InternalModelBuilder Builder => this.GetInfrastructure();
     }
 }

--- a/src/EntityFramework.Core/QueryTrackingBehavior.cs
+++ b/src/EntityFramework.Core/QueryTrackingBehavior.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-namespace Microsoft.Data.Entity.ChangeTracking
+using Microsoft.Data.Entity.ChangeTracking;
+
+namespace Microsoft.Data.Entity
 {
     /// <summary>
     ///     Indicates how the results of a query are tracked by the <see cref="ChangeTracker"/>.

--- a/src/EntityFramework.InMemory/Extensions/InMemoryEntityFrameworkServicesBuilderExtensions.cs
+++ b/src/EntityFramework.InMemory/Extensions/InMemoryEntityFrameworkServicesBuilderExtensions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             Check.NotNull(builder, nameof(builder));
 
-            var service = builder.GetService();
+            var service = builder.GetInfrastructure();
 
             service.TryAddEnumerable(ServiceDescriptor
                 .Singleton<IDatabaseProvider, DatabaseProvider<InMemoryDatabaseProviderServices, InMemoryOptionsExtension>>());

--- a/src/EntityFramework.MicrosoftSqlServer/Extensions/SqlServerEntityFrameworkServicesBuilderExtensions.cs
+++ b/src/EntityFramework.MicrosoftSqlServer/Extensions/SqlServerEntityFrameworkServicesBuilderExtensions.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             Check.NotNull(builder, nameof(builder));
 
-            var service = builder.AddRelational().GetService();
+            var service = builder.AddRelational().GetInfrastructure();
 
             service.TryAddEnumerable(ServiceDescriptor
                 .Singleton<IDatabaseProvider, DatabaseProvider<SqlServerDatabaseProviderServices, SqlServerOptionsExtension>>());

--- a/src/EntityFramework.MicrosoftSqlServer/Extensions/SqlServerEntityTypeBuilderExtensions.cs
+++ b/src/EntityFramework.MicrosoftSqlServer/Extensions/SqlServerEntityTypeBuilderExtensions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Data.Entity
             Check.NotNull(entityTypeBuilder, nameof(entityTypeBuilder));
             Check.NullButNotEmpty(name, nameof(name));
 
-            var relationalEntityTypeBuilder = ((IAccessor<InternalEntityTypeBuilder>)entityTypeBuilder).GetService()
+            var relationalEntityTypeBuilder = ((IInfrastructure<InternalEntityTypeBuilder>)entityTypeBuilder).GetInfrastructure()
                 .SqlServer(ConfigurationSource.Explicit);
             relationalEntityTypeBuilder.TableName = name;
 
@@ -42,7 +42,7 @@ namespace Microsoft.Data.Entity
             Check.NullButNotEmpty(name, nameof(name));
             Check.NullButNotEmpty(schema, nameof(schema));
 
-            var relationalEntityTypeBuilder = ((IAccessor<InternalEntityTypeBuilder>)entityTypeBuilder).GetService()
+            var relationalEntityTypeBuilder = ((IInfrastructure<InternalEntityTypeBuilder>)entityTypeBuilder).GetInfrastructure()
                 .SqlServer(ConfigurationSource.Explicit);
             relationalEntityTypeBuilder.TableName = name;
             relationalEntityTypeBuilder.Schema = schema;

--- a/src/EntityFramework.Relational/Infrastructure/RelationalEntityFrameworkServicesBuilderExtensions.cs
+++ b/src/EntityFramework.Relational/Infrastructure/RelationalEntityFrameworkServicesBuilderExtensions.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Data.Entity.Infrastructure
         {
             Check.NotNull(builder, nameof(builder));
 
-            builder.GetService()
+            builder.GetInfrastructure()
                 .TryAdd(new ServiceCollection()
                 .AddSingleton(s => new DiagnosticListener("Microsoft.Data.Entity"))
                 .AddSingleton<DiagnosticSource>(s => s.GetService<DiagnosticListener>())

--- a/src/EntityFramework.Relational/Migrations/MigrationBuilder.cs
+++ b/src/EntityFramework.Relational/Migrations/MigrationBuilder.cs
@@ -334,7 +334,7 @@ namespace Microsoft.Data.Entity.Migrations
             var columnMap = new Dictionary<PropertyInfo, AddColumnOperation>();
             foreach (var property in typeof(TColumns).GetTypeInfo().DeclaredProperties)
             {
-                var addColumnOperation = ((IAccessor<AddColumnOperation>)property.GetMethod.Invoke(columnsObject, null)).Service;
+                var addColumnOperation = ((IInfrastructure<AddColumnOperation>)property.GetMethod.Invoke(columnsObject, null)).Instance;
                 if (addColumnOperation.Name == null)
                 {
                     addColumnOperation.Name = property.Name;

--- a/src/EntityFramework.Relational/Migrations/Operations/Builders/OperationBuilder.cs
+++ b/src/EntityFramework.Relational/Migrations/Operations/Builders/OperationBuilder.cs
@@ -7,7 +7,7 @@ using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Migrations.Operations.Builders
 {
-    public class OperationBuilder<TOperation> : IAccessor<TOperation>
+    public class OperationBuilder<TOperation> : IInfrastructure<TOperation>
         where TOperation : MigrationOperation
     {
         public OperationBuilder([NotNull] TOperation operation)
@@ -19,7 +19,7 @@ namespace Microsoft.Data.Entity.Migrations.Operations.Builders
 
         protected virtual TOperation Operation { get; }
 
-        TOperation IAccessor<TOperation>.Service => Operation;
+        TOperation IInfrastructure<TOperation>.Instance => Operation;
 
         public virtual OperationBuilder<TOperation> Annotation(
             [NotNull] string name,

--- a/src/EntityFramework.Relational/RelationalEntityTypeBuilderExtensions.cs
+++ b/src/EntityFramework.Relational/RelationalEntityTypeBuilderExtensions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Data.Entity
             Check.NotNull(entityTypeBuilder, nameof(entityTypeBuilder));
             Check.NullButNotEmpty(name, nameof(name));
 
-            ((IAccessor<InternalEntityTypeBuilder>)entityTypeBuilder).GetService()
+            ((IInfrastructure<InternalEntityTypeBuilder>)entityTypeBuilder).GetInfrastructure()
                 .Relational(ConfigurationSource.Explicit)
                 .ToTable(name);
 
@@ -44,7 +44,7 @@ namespace Microsoft.Data.Entity
             Check.NullButNotEmpty(name, nameof(name));
             Check.NullButNotEmpty(schema, nameof(schema));
 
-            ((IAccessor<InternalEntityTypeBuilder>)entityTypeBuilder).GetService()
+            ((IInfrastructure<InternalEntityTypeBuilder>)entityTypeBuilder).GetInfrastructure()
                 .Relational(ConfigurationSource.Explicit)
                 .ToTable(name, schema);
 
@@ -62,7 +62,7 @@ namespace Microsoft.Data.Entity
         {
             Check.NotNull(entityTypeBuilder, nameof(entityTypeBuilder));
 
-            return ((IAccessor<InternalEntityTypeBuilder>)entityTypeBuilder).GetService()
+            return ((IInfrastructure<InternalEntityTypeBuilder>)entityTypeBuilder).GetInfrastructure()
                 .Relational(ConfigurationSource.Explicit).HasDiscriminator();
         }
 
@@ -75,7 +75,7 @@ namespace Microsoft.Data.Entity
             Check.NotEmpty(name, nameof(name));
             Check.NotNull(discriminatorType, nameof(discriminatorType));
 
-            return ((IAccessor<InternalEntityTypeBuilder>)entityTypeBuilder).GetService()
+            return ((IInfrastructure<InternalEntityTypeBuilder>)entityTypeBuilder).GetInfrastructure()
                 .Relational(ConfigurationSource.Explicit).HasDiscriminator(name, discriminatorType);
         }
 
@@ -86,7 +86,7 @@ namespace Microsoft.Data.Entity
             Check.NotNull(entityTypeBuilder, nameof(entityTypeBuilder));
             Check.NotEmpty(name, nameof(name));
 
-            return new DiscriminatorBuilder<TDiscriminator>(((IAccessor<InternalEntityTypeBuilder>)entityTypeBuilder).GetService()
+            return new DiscriminatorBuilder<TDiscriminator>(((IInfrastructure<InternalEntityTypeBuilder>)entityTypeBuilder).GetInfrastructure()
                 .Relational(ConfigurationSource.Explicit).HasDiscriminator(name, typeof(TDiscriminator)));
         }
 
@@ -98,7 +98,7 @@ namespace Microsoft.Data.Entity
             Check.NotNull(entityTypeBuilder, nameof(entityTypeBuilder));
             Check.NotNull(propertyExpression, nameof(propertyExpression));
 
-            return new DiscriminatorBuilder<TDiscriminator>(((IAccessor<InternalEntityTypeBuilder>)entityTypeBuilder).GetService()
+            return new DiscriminatorBuilder<TDiscriminator>(((IInfrastructure<InternalEntityTypeBuilder>)entityTypeBuilder).GetInfrastructure()
                 .Relational(ConfigurationSource.Explicit).HasDiscriminator(propertyExpression.GetPropertyAccess()));
         }
     }

--- a/src/EntityFramework.Relational/Storage/IRelationalTransaction.cs
+++ b/src/EntityFramework.Relational/Storage/IRelationalTransaction.cs
@@ -7,7 +7,7 @@ using Microsoft.Data.Entity.Infrastructure;
 
 namespace Microsoft.Data.Entity.Storage
 {
-    public interface IRelationalTransaction : IDisposable, IAccessor<DbTransaction>
+    public interface IRelationalTransaction : IDisposable, IInfrastructure<DbTransaction>
     {
         IRelationalConnection Connection { get; }
         void Commit();

--- a/src/EntityFramework.Relational/Storage/Internal/RelationalCommand.cs
+++ b/src/EntityFramework.Relational/Storage/Internal/RelationalCommand.cs
@@ -329,7 +329,7 @@ namespace Microsoft.Data.Entity.Storage.Internal
 
             if (connection.Transaction != null)
             {
-                command.Transaction = connection.Transaction.GetService();
+                command.Transaction = connection.Transaction.GetInfrastructure();
             }
 
             if (connection.CommandTimeout != null)

--- a/src/EntityFramework.Relational/Storage/RelationalConnection.cs
+++ b/src/EntityFramework.Relational/Storage/RelationalConnection.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Data.Entity.Storage
             }
         }
 
-        public virtual DbTransaction DbTransaction => Transaction?.GetService();
+        public virtual DbTransaction DbTransaction => Transaction?.GetInfrastructure();
 
         [NotNull]
         public virtual IRelationalTransaction BeginTransaction() => BeginTransaction(IsolationLevel.Unspecified);

--- a/src/EntityFramework.Relational/Storage/RelationalTransaction.cs
+++ b/src/EntityFramework.Relational/Storage/RelationalTransaction.cs
@@ -88,6 +88,6 @@ namespace Microsoft.Data.Entity.Storage
             Connection.UseTransaction(null);
         }
 
-        DbTransaction IAccessor<DbTransaction>.Service => _transaction;
+        DbTransaction IInfrastructure<DbTransaction>.Instance => _transaction;
     }
 }

--- a/src/EntityFramework.Sqlite/Infrastructure/SqliteEntityFrameworkServicesBuilderExtensions.cs
+++ b/src/EntityFramework.Sqlite/Infrastructure/SqliteEntityFrameworkServicesBuilderExtensions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             Check.NotNull(builder, nameof(builder));
 
-            var service = builder.AddRelational().GetService();
+            var service = builder.AddRelational().GetInfrastructure();
 
             service.TryAddEnumerable(ServiceDescriptor
                 .Singleton<IDatabaseProvider, DatabaseProvider<SqliteDatabaseProviderServices, SqliteOptionsExtension>>());

--- a/test/EntityFramework.Core.FunctionalTests/DatabaseErrorLogStateTest.cs
+++ b/test/EntityFramework.Core.FunctionalTests/DatabaseErrorLogStateTest.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             var serviceProvider = new ServiceCollection()
                 .AddEntityFramework()
                 .AddInMemoryDatabase()
-                .GetService()
+                .GetInfrastructure()
                 .AddInstance<ILoggerFactory>(loggerFactory)
                 .BuildServiceProvider();
 
@@ -133,8 +133,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
             {
                 context.Blogs.Add(new BloggingContext.Blog(false) { Url = "http://sample.com" });
                 context.SaveChanges();
-                var entry = context.ChangeTracker.Entries().Single().GetService();
-                context.ChangeTracker.GetService().StopTracking(entry);
+                var entry = context.ChangeTracker.Entries().Single().GetInfrastructure();
+                context.ChangeTracker.GetInfrastructure().StopTracking(entry);
 
                 var ex = Assert.ThrowsAny<Exception>(() => test(context));
                 while (ex.InnerException != null)

--- a/test/EntityFramework.Core.FunctionalTests/FixupTest.cs
+++ b/test/EntityFramework.Core.FunctionalTests/FixupTest.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 var productType = context.Model.FindEntityType(typeof(Product));
                 var offerType = context.Model.FindEntityType(typeof(SpecialOffer));
 
-                var stateManager = context.ChangeTracker.GetService();
+                var stateManager = context.ChangeTracker.GetInfrastructure();
 
                 stateManager.StartTracking(categoryType, new SimpleKeyValue<int>(categoryType.FindPrimaryKey(), 11), new Category { Id = 11 }, new ValueBuffer(new object[] { 11 }));
                 stateManager.StartTracking(categoryType, new SimpleKeyValue<int>(categoryType.FindPrimaryKey(), 12), new Category { Id = 12 }, new ValueBuffer(new object[] { 12 }));

--- a/test/EntityFramework.Core.FunctionalTests/GraphUpdatesTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/GraphUpdatesTestBase.cs
@@ -293,8 +293,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
                         root.RequiredChildren.Remove(removed1);
                         break;
                     case ChangeMechanism.FK:
-                        context.Entry(removed2).GetService()[context.Entry(removed2).Property(e => e.ParentId).Metadata] = null;
-                        context.Entry(removed1).GetService()[context.Entry(removed1).Property(e => e.ParentId).Metadata] = null;
+                        context.Entry(removed2).GetInfrastructure()[context.Entry(removed2).Property(e => e.ParentId).Metadata] = null;
+                        context.Entry(removed1).GetInfrastructure()[context.Entry(removed1).Property(e => e.ParentId).Metadata] = null;
                         break;
                     default:
                         throw new ArgumentOutOfRangeException(nameof(changeMechanism));
@@ -3501,7 +3501,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             public class KeyValueEntityTracker
             {
                 public virtual void TrackEntity(EntityEntry entry)
-                    => entry.GetService()
+                    => entry.GetInfrastructure()
                         .SetEntityState(DetermineState(entry), acceptChanges: true);
 
                 public virtual EntityState DetermineState(EntityEntry entry)

--- a/test/EntityFramework.Core.FunctionalTests/MonsterFixupTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/MonsterFixupTestBase.cs
@@ -188,7 +188,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 context.Database.EnsureCreated();
                 context.SeedUsingFKs(saveChanges: false);
 
-                var stateManager = context.ChangeTracker.GetService();
+                var stateManager = context.ChangeTracker.GetInfrastructure();
 
                 var beforeSnapshot = stateManager.Entries.SelectMany(e => e.EntityType.GetProperties().Select(p => e[p])).ToList();
 

--- a/test/EntityFramework.Core.FunctionalTests/OptimisticConcurrencyTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/OptimisticConcurrencyTestBase.cs
@@ -36,10 +36,10 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         public static void SetValues(this EntityEntry entry, Dictionary<IProperty, object> values)
-            => entry.GetService().SetValues(values);
+            => entry.GetInfrastructure().SetValues(values);
 
         public static void SetOriginalValues(this EntityEntry entry, Dictionary<IProperty, object> values)
-            => entry.GetService().SetOriginalValues(values);
+            => entry.GetInfrastructure().SetOriginalValues(values);
 
         public static void Reload(this InternalEntityEntry internalEntry, DbContext context)
         {
@@ -67,7 +67,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         public static void Reload(this EntityEntry entityEntry, DbContext context)
-            => entityEntry.GetService().Reload(context);
+            => entityEntry.GetInfrastructure().Reload(context);
 
         public static Dictionary<IProperty, object> GetDatabaseValues(this InternalEntityEntry internalEntry, DbContext context)
         {
@@ -93,7 +93,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         public static Dictionary<IProperty, object> GetDatabaseValues(this EntityEntry entry, DbContext context)
-            => entry.GetService().GetDatabaseValues(context);
+            => entry.GetInfrastructure().GetDatabaseValues(context);
 
         private static Dictionary<IProperty, object> GetValues(this Driver driver, IEntityType entityType)
         {

--- a/test/EntityFramework.Core.FunctionalTests/StoreGeneratedTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/StoreGeneratedTestBase.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             using (var context = CreateContext())
             {
                 var entry = context.Add(new Gumball { Identity = "Masami" });
-                entry.GetService().MarkAsTemporary(entry.Property(e => e.Identity).Metadata);
+                entry.GetInfrastructure().MarkAsTemporary(entry.Property(e => e.Identity).Metadata);
 
                 context.SaveChanges();
                 id = entry.Entity.Id;
@@ -214,7 +214,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             using (var context = CreateContext())
             {
                 var entry = context.Add(new Gumball { AlwaysIdentity = "Masami" });
-                entry.GetService().MarkAsTemporary(entry.Property(e => e.AlwaysIdentity).Metadata);
+                entry.GetInfrastructure().MarkAsTemporary(entry.Property(e => e.AlwaysIdentity).Metadata);
 
                 context.SaveChanges();
                 id = entry.Entity.Id;
@@ -388,7 +388,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             using (var context = CreateContext())
             {
                 var entry = context.Add(new Gumball { Computed = "Masami" });
-                entry.GetService().MarkAsTemporary(entry.Property(e => e.Computed).Metadata);
+                entry.GetInfrastructure().MarkAsTemporary(entry.Property(e => e.Computed).Metadata);
 
                 context.SaveChanges();
                 id = entry.Entity.Id;
@@ -562,7 +562,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             using (var context = CreateContext())
             {
                 var entry = context.Add(new Gumball { AlwaysComputed = "Masami" });
-                entry.GetService().MarkAsTemporary(entry.Property(e => e.AlwaysComputed).Metadata);
+                entry.GetInfrastructure().MarkAsTemporary(entry.Property(e => e.AlwaysComputed).Metadata);
 
                 context.SaveChanges();
                 id = entry.Entity.Id;

--- a/test/EntityFramework.Core.FunctionalTests/TestHelpers.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestHelpers.cs
@@ -88,30 +88,30 @@ namespace Microsoft.Data.Entity.Tests
             => new DbContext(CreateServiceProvider(customServices), CreateOptions());
 
         public IServiceProvider CreateContextServices(IServiceProvider serviceProvider, IModel model)
-            => ((IAccessor<IServiceProvider>)CreateContext(serviceProvider, model)).Service;
+            => ((IInfrastructure<IServiceProvider>)CreateContext(serviceProvider, model)).Instance;
 
         public IServiceProvider CreateContextServices(IServiceProvider serviceProvider, DbContextOptions options)
-            => ((IAccessor<IServiceProvider>)CreateContext(serviceProvider, options)).Service;
+            => ((IInfrastructure<IServiceProvider>)CreateContext(serviceProvider, options)).Instance;
 
-        public IServiceProvider CreateContextServices(IServiceProvider serviceProvider) => ((IAccessor<IServiceProvider>)CreateContext(serviceProvider)).Service;
+        public IServiceProvider CreateContextServices(IServiceProvider serviceProvider) => ((IInfrastructure<IServiceProvider>)CreateContext(serviceProvider)).Instance;
 
         public IServiceProvider CreateContextServices(IModel model)
-            => ((IAccessor<IServiceProvider>)CreateContext(model)).Service;
+            => ((IInfrastructure<IServiceProvider>)CreateContext(model)).Instance;
 
         public IServiceProvider CreateContextServices(DbContextOptions options)
-            => ((IAccessor<IServiceProvider>)CreateContext(options)).Service;
+            => ((IInfrastructure<IServiceProvider>)CreateContext(options)).Instance;
 
         public IServiceProvider CreateContextServices()
-            => ((IAccessor<IServiceProvider>)CreateContext()).Service;
+            => ((IInfrastructure<IServiceProvider>)CreateContext()).Instance;
 
         public IServiceProvider CreateContextServices(IServiceCollection customServices, IModel model)
-            => ((IAccessor<IServiceProvider>)CreateContext(customServices, model)).Service;
+            => ((IInfrastructure<IServiceProvider>)CreateContext(customServices, model)).Instance;
 
         public IServiceProvider CreateContextServices(IServiceCollection customServices, DbContextOptions options)
-            => ((IAccessor<IServiceProvider>)CreateContext(customServices, options)).Service;
+            => ((IInfrastructure<IServiceProvider>)CreateContext(customServices, options)).Instance;
 
         public IServiceProvider CreateContextServices(IServiceCollection customServices)
-            => ((IAccessor<IServiceProvider>)CreateContext(customServices)).Service;
+            => ((IInfrastructure<IServiceProvider>)CreateContext(customServices)).Instance;
 
         public IMutableModel BuildModelFor<TEntity>() where TEntity : class
         {

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/Northwind/NorthwindData.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/Northwind/NorthwindData.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.Northwind
             foreach (var employee in CreateEmployees())
             {
                 context.Set<Employee>().Add(employee);
-                context.Entry(employee).GetService()[titleProperty] = employee.Title;
+                context.Entry(employee).GetInfrastructure()[titleProperty] = employee.Title;
             }
 
             context.Set<Order>().AddRange(CreateOrders());

--- a/test/EntityFramework.Core.FunctionalTests/TestUtilities/Extensions.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestUtilities/Extensions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
     public static class Extensions
     {
         public static IServiceCollection ServiceCollection(this EntityFrameworkServicesBuilder builder)
-            => builder.GetService();
+            => builder.GetInfrastructure();
 
         public static IEnumerable<T> NullChecked<T>(this IEnumerable<T> enumerable)
             => enumerable ?? Enumerable.Empty<T>();

--- a/test/EntityFramework.Core.Tests/ChangeTracking/ChangeTrackerTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/ChangeTrackerTest.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             {
                 var stateManger = context.GetService<IStateManager>();
 
-                Assert.Same(stateManger, context.ChangeTracker.GetService());
+                Assert.Same(stateManger, context.ChangeTracker.GetInfrastructure());
             }
         }
 
@@ -409,7 +409,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             {
                 if (!entry.IsKeySet)
                 {
-                    entry.GetService()[entry.Metadata.FindPrimaryKey().Properties.Single()] = 777;
+                    entry.GetInfrastructure()[entry.Metadata.FindPrimaryKey().Properties.Single()] = 777;
                     return EntityState.Added;
                 }
 
@@ -1074,7 +1074,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             }
 
             public virtual void TrackEntity(EntityEntryGraphNode node)
-                => node.Entry.GetService().SetEntityState(DetermineState(node.Entry), acceptChanges: true);
+                => node.Entry.GetInfrastructure().SetEntityState(DetermineState(node.Entry), acceptChanges: true);
 
             public virtual EntityState DetermineState(EntityEntry entry)
                 => entry.IsKeySet

--- a/test/EntityFramework.Core.Tests/ChangeTracking/EntityEntryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/EntityEntryTest.cs
@@ -43,10 +43,10 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             using (var context = new FreezerContext())
             {
                 var entity = context.Add(new Chunky()).Entity;
-                var entry = context.ChangeTracker.GetService().GetOrCreateEntry(entity);
+                var entry = context.ChangeTracker.GetInfrastructure().GetOrCreateEntry(entity);
 
-                Assert.Same(entry, context.Entry(entity).GetService());
-                Assert.Same(entry, context.Entry((object)entity).GetService());
+                Assert.Same(entry, context.Entry(entity).GetInfrastructure());
+                Assert.Same(entry, context.Entry((object)entity).GetInfrastructure());
             }
         }
 
@@ -69,7 +69,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             using (var context = new FreezerContext())
             {
                 var entity = new Chunky();
-                var entry = context.Add(entity).GetService();
+                var entry = context.Add(entity).GetInfrastructure();
 
                 context.Entry(entity).State = EntityState.Modified;
                 Assert.Equal(EntityState.Modified, entry.EntityState);

--- a/test/EntityFramework.Core.Tests/DatabaseFacadeTest.cs
+++ b/test/EntityFramework.Core.Tests/DatabaseFacadeTest.cs
@@ -57,8 +57,8 @@ namespace Microsoft.Data.Entity.Tests
             using (var context = TestHelpers.Instance.CreateContext())
             {
                 Assert.Same(
-                    ((IAccessor<IServiceProvider>)context).Service,
-                    ((IAccessor<IServiceProvider>)context.Database).Service);
+                    ((IInfrastructure<IServiceProvider>)context).Instance,
+                    ((IInfrastructure<IServiceProvider>)context.Database).Instance);
             }
         }
 

--- a/test/EntityFramework.Core.Tests/DbContextOptionsTest.cs
+++ b/test/EntityFramework.Core.Tests/DbContextOptionsTest.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
 using Xunit;
 

--- a/test/EntityFramework.Core.Tests/DbContextTest.cs
+++ b/test/EntityFramework.Core.Tests/DbContextTest.cs
@@ -34,13 +34,13 @@ namespace Microsoft.Data.Entity.Tests
             IServiceProvider contextServices;
             using (var context = new EarlyLearningCenter(serviceProvider))
             {
-                contextServices = ((IAccessor<IServiceProvider>)context).Service;
-                Assert.Same(contextServices, ((IAccessor<IServiceProvider>)context).Service);
+                contextServices = ((IInfrastructure<IServiceProvider>)context).Instance;
+                Assert.Same(contextServices, ((IInfrastructure<IServiceProvider>)context).Instance);
             }
 
             using (var context = new EarlyLearningCenter(serviceProvider))
             {
-                Assert.NotSame(contextServices, ((IAccessor<IServiceProvider>)context).Service);
+                Assert.NotSame(contextServices, ((IInfrastructure<IServiceProvider>)context).Instance);
             }
         }
 
@@ -50,13 +50,13 @@ namespace Microsoft.Data.Entity.Tests
             IServiceProvider contextServices;
             using (var context = new Mock<DbContext> { CallBase = true }.Object)
             {
-                contextServices = ((IAccessor<IServiceProvider>)context).Service;
-                Assert.Same(contextServices, ((IAccessor<IServiceProvider>)context).Service);
+                contextServices = ((IInfrastructure<IServiceProvider>)context).Instance;
+                Assert.Same(contextServices, ((IInfrastructure<IServiceProvider>)context).Instance);
             }
 
             using (var context = new Mock<DbContext> { CallBase = true }.Object)
             {
-                Assert.NotSame(contextServices, ((IAccessor<IServiceProvider>)context).Service);
+                Assert.NotSame(contextServices, ((IInfrastructure<IServiceProvider>)context).Instance);
             }
         }
 
@@ -70,13 +70,13 @@ namespace Microsoft.Data.Entity.Tests
             IServiceProvider contextServices;
             using (var context = new DbContext(serviceProvider, options))
             {
-                contextServices = ((IAccessor<IServiceProvider>)context).Service;
-                Assert.Same(contextServices, ((IAccessor<IServiceProvider>)context).Service);
+                contextServices = ((IInfrastructure<IServiceProvider>)context).Instance;
+                Assert.Same(contextServices, ((IInfrastructure<IServiceProvider>)context).Instance);
             }
 
             using (var context = new DbContext(serviceProvider, options))
             {
-                Assert.NotSame(contextServices, ((IAccessor<IServiceProvider>)context).Service);
+                Assert.NotSame(contextServices, ((IInfrastructure<IServiceProvider>)context).Instance);
             }
         }
 
@@ -88,13 +88,13 @@ namespace Microsoft.Data.Entity.Tests
             IServiceProvider contextServices;
             using (var context = new DbContext(options))
             {
-                contextServices = ((IAccessor<IServiceProvider>)context).Service;
-                Assert.Same(contextServices, ((IAccessor<IServiceProvider>)context).Service);
+                contextServices = ((IInfrastructure<IServiceProvider>)context).Instance;
+                Assert.Same(contextServices, ((IInfrastructure<IServiceProvider>)context).Instance);
             }
 
             using (var context = new DbContext(options))
             {
-                Assert.NotSame(contextServices, ((IAccessor<IServiceProvider>)context).Service);
+                Assert.NotSame(contextServices, ((IInfrastructure<IServiceProvider>)context).Instance);
             }
         }
 
@@ -207,8 +207,8 @@ namespace Microsoft.Data.Entity.Tests
 
             using (var context = new EarlyLearningCenter(serviceProvider))
             {
-                Assert.Same(entry, context.Entry(entity).GetService());
-                Assert.Same(entry, context.Entry((object)entity).GetService());
+                Assert.Same(entry, context.Entry(entity).GetInfrastructure());
+                Assert.Same(entry, context.Entry((object)entity).GetInfrastructure());
             }
         }
 
@@ -403,10 +403,10 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Same(product2, productEntry2.Entity);
                 Assert.Equal(expectedState, productEntry2.State);
 
-                Assert.Same(categoryEntry1.GetService(), context.Entry(category1).GetService());
-                Assert.Same(categoryEntry2.GetService(), context.Entry(category2).GetService());
-                Assert.Same(productEntry1.GetService(), context.Entry(product1).GetService());
-                Assert.Same(productEntry2.GetService(), context.Entry(product2).GetService());
+                Assert.Same(categoryEntry1.GetInfrastructure(), context.Entry(category1).GetInfrastructure());
+                Assert.Same(categoryEntry2.GetInfrastructure(), context.Entry(category2).GetInfrastructure());
+                Assert.Same(productEntry1.GetInfrastructure(), context.Entry(product1).GetInfrastructure());
+                Assert.Same(productEntry2.GetInfrastructure(), context.Entry(product2).GetInfrastructure());
             }
         }
 
@@ -572,10 +572,10 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Same(product2, productEntry2.Entity);
                 Assert.Equal(expectedState, productEntry2.State);
 
-                Assert.Same(categoryEntry1.GetService(), context.Entry(category1).GetService());
-                Assert.Same(categoryEntry2.GetService(), context.Entry(category2).GetService());
-                Assert.Same(productEntry1.GetService(), context.Entry(product1).GetService());
-                Assert.Same(productEntry2.GetService(), context.Entry(product2).GetService());
+                Assert.Same(categoryEntry1.GetInfrastructure(), context.Entry(category1).GetInfrastructure());
+                Assert.Same(categoryEntry2.GetInfrastructure(), context.Entry(category2).GetInfrastructure());
+                Assert.Same(productEntry1.GetInfrastructure(), context.Entry(product1).GetInfrastructure());
+                Assert.Same(productEntry2.GetInfrastructure(), context.Entry(product2).GetInfrastructure());
             }
         }
 
@@ -1895,7 +1895,7 @@ namespace Microsoft.Data.Entity.Tests
             var services = new ServiceCollection();
             services
                 .AddEntityFramework()
-                .GetService()
+                .GetInfrastructure()
                 .AddSingleton<IModelSource, FakeModelSource>()
                 .AddScoped<IStateManager, FakeStateManager>();
 
@@ -1931,7 +1931,7 @@ namespace Microsoft.Data.Entity.Tests
         {
             var provider = new ServiceCollection()
                 .AddEntityFramework()
-                .GetService()
+                .GetInfrastructure()
                 .AddSingleton<IEntityMaterializerSource, FakeEntityMaterializerSource>()
                 .BuildServiceProvider();
 
@@ -2045,7 +2045,7 @@ namespace Microsoft.Data.Entity.Tests
 
             using (var context = serviceProvider.GetRequiredService<ContextWithDefaults>())
             {
-                var contextServices = ((IAccessor<IServiceProvider>)context).Service;
+                var contextServices = ((IInfrastructure<IServiceProvider>)context).Instance;
 
                 Assert.NotNull(serviceProvider.GetRequiredService<FakeService>());
                 Assert.NotSame(serviceProvider, contextServices);
@@ -2203,7 +2203,7 @@ namespace Microsoft.Data.Entity.Tests
                 .AddEntityFramework()
                 .AddInMemoryDatabase()
                 .AddDbContext<UseModelInOnModelCreatingContext>()
-                .GetService()
+                .GetInfrastructure()
                 .BuildServiceProvider();
 
             using (var context = serviceProvider.GetRequiredService<UseModelInOnModelCreatingContext>())
@@ -2239,7 +2239,7 @@ namespace Microsoft.Data.Entity.Tests
                 .AddEntityFramework()
                 .AddInMemoryDatabase()
                 .AddDbContext<UseInOnModelCreatingContext>()
-                .GetService()
+                .GetInfrastructure()
                 .BuildServiceProvider();
 
             using (var context = serviceProvider.GetRequiredService<UseInOnModelCreatingContext>())
@@ -2273,7 +2273,7 @@ namespace Microsoft.Data.Entity.Tests
                 .AddEntityFramework()
                 .AddInMemoryDatabase()
                 .AddDbContext<UseInOnConfiguringContext>()
-                .GetService()
+                .GetInfrastructure()
                 .BuildServiceProvider();
 
             using (var context = serviceProvider.GetRequiredService<UseInOnConfiguringContext>())
@@ -2560,7 +2560,7 @@ namespace Microsoft.Data.Entity.Tests
                 userMessage: "Unexpected properties on DbContext. " + 
                     "Update test to ensure all getters throw ObjectDisposedException after dispose.");
 
-            Assert.Throws<ObjectDisposedException>(() => ((IAccessor<IServiceProvider>)context).Service);
+            Assert.Throws<ObjectDisposedException>(() => ((IInfrastructure<IServiceProvider>)context).Instance);
         }
 
         [Fact]
@@ -2588,7 +2588,7 @@ namespace Microsoft.Data.Entity.Tests
 
             Assert.True(scopeService.Disposed);
 
-            Assert.Throws<ObjectDisposedException>(() => ((IAccessor<IServiceProvider>)context).Service);
+            Assert.Throws<ObjectDisposedException>(() => ((IInfrastructure<IServiceProvider>)context).Instance);
         }
 
         public class FakeServiceProvider : IServiceProvider, IDisposable
@@ -2597,8 +2597,8 @@ namespace Microsoft.Data.Entity.Tests
 
             public FakeServiceProvider()
             {
-                _realProvider = ((IAccessor<IServiceCollection>)new ServiceCollection().AddEntityFramework())
-                    .Service.BuildServiceProvider();
+                _realProvider = ((IInfrastructure<IServiceCollection>)new ServiceCollection().AddEntityFramework())
+                    .Instance.BuildServiceProvider();
             }
             public bool Disposed { get; set; }
 

--- a/test/EntityFramework.Core.Tests/DbSetTest.cs
+++ b/test/EntityFramework.Core.Tests/DbSetTest.cs
@@ -86,10 +86,10 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Same(product2, productEntry2.Entity);
                 Assert.Equal(expectedState, productEntry2.State);
 
-                Assert.Same(categoryEntry1.GetService(), context.Entry(category1).GetService());
-                Assert.Same(categoryEntry2.GetService(), context.Entry(category2).GetService());
-                Assert.Same(productEntry1.GetService(), context.Entry(product1).GetService());
-                Assert.Same(productEntry2.GetService(), context.Entry(product2).GetService());
+                Assert.Same(categoryEntry1.GetInfrastructure(), context.Entry(category1).GetInfrastructure());
+                Assert.Same(categoryEntry2.GetInfrastructure(), context.Entry(category2).GetInfrastructure());
+                Assert.Same(productEntry1.GetInfrastructure(), context.Entry(product1).GetInfrastructure());
+                Assert.Same(productEntry2.GetInfrastructure(), context.Entry(product2).GetInfrastructure());
             }
         }
 
@@ -399,8 +399,8 @@ namespace Microsoft.Data.Entity.Tests
             using (var context = new EarlyLearningCenter())
             {
                 Assert.Same(
-                    ((IAccessor<IServiceProvider>)context).Service,
-                    ((IAccessor<IServiceProvider>)context.Products).Service);
+                    ((IInfrastructure<IServiceProvider>)context).Instance,
+                    ((IInfrastructure<IServiceProvider>)context.Products).Instance);
             }
         }
 

--- a/test/EntityFramework.Core.Tests/EntityFrameworkServiceCollectionExtensionsTest.cs
+++ b/test/EntityFramework.Core.Tests/EntityFrameworkServiceCollectionExtensionsTest.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Data.Entity.Tests
 
         private IServiceCollection AddServices(IServiceCollection serviceCollection)
         {
-            return _testHelpers.AddProviderServices(serviceCollection.AddEntityFramework()).GetService();
+            return _testHelpers.AddProviderServices(serviceCollection.AddEntityFramework()).GetInfrastructure();
         }
 
         public void Dispose()
@@ -155,7 +155,7 @@ namespace Microsoft.Data.Entity.Tests
             bool isRequired)
             where TService : class
         {
-            var provider = ((IAccessor<IServiceProvider>)_firstContext).Service;
+            var provider = ((IInfrastructure<IServiceProvider>)_firstContext).Instance;
             var service = provider.GetService<TService>();
             if (isRequired)
             {
@@ -164,13 +164,13 @@ namespace Microsoft.Data.Entity.Tests
 
             Assert.Same(service, provider.GetService<TService>());
 
-            var otherScopeService = ((IAccessor<IServiceProvider>)_secondContext).Service.GetService<TService>();
+            var otherScopeService = ((IInfrastructure<IServiceProvider>)_secondContext).Instance.GetService<TService>();
 
             if (isSingleton)
             {
                 Assert.Same(service, otherScopeService);
             }
-            Assert.Equal(1, ((IAccessor<IServiceProvider>)_firstContext).Service.GetServices<TService>().Count());
+            Assert.Equal(1, ((IInfrastructure<IServiceProvider>)_firstContext).Instance.GetServices<TService>().Count());
 
             if (typeof(TService) != typeof(IDbContextServices))
             {
@@ -178,7 +178,7 @@ namespace Microsoft.Data.Entity.Tests
 
                 using (var customContext = _testHelpers.CreateContext(customServiceCollection.BuildServiceProvider()))
                 {
-                    var serviceProviderWithCustomService = ((IAccessor<IServiceProvider>)customContext).Service;
+                    var serviceProviderWithCustomService = ((IInfrastructure<IServiceProvider>)customContext).Instance;
                     if (isExistingReplaced)
                     {
                         Assert.NotSame(service, serviceProviderWithCustomService.GetService<TService>());

--- a/test/EntityFramework.Core.Tests/Metadata/MetadataBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/MetadataBuilderTest.cs
@@ -474,7 +474,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             builder.HasAnnotation("Annotation", value + ".Annotation");
             builder.Metadata["Metadata"] = value + ".Metadata";
-            builder.GetService<IMutableModel>()["Model"] = value + ".Model";
+            builder.GetInfrastructure<IMutableModel>()["Model"] = value + ".Model";
 
             return builder;
         }
@@ -484,7 +484,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             builder.HasAnnotation("Annotation", value + ".Annotation");
             builder.Metadata["Metadata"] = value + ".Metadata";
-            builder.GetService<IMutableModel>()["Model"] = value + ".Model";
+            builder.GetInfrastructure<IMutableModel>()["Model"] = value + ".Model";
 
             return builder;
         }
@@ -493,7 +493,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             builder.HasAnnotation("Annotation", value + ".Annotation");
             builder.Metadata["Metadata"] = value + ".Metadata";
-            builder.GetService<IMutableModel>()["Model"] = value + ".Model";
+            builder.GetInfrastructure<IMutableModel>()["Model"] = value + ".Model";
 
             return builder;
         }
@@ -502,7 +502,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             builder.HasAnnotation("Annotation", value + ".Annotation");
             builder.Metadata["Metadata"] = value + ".Metadata";
-            builder.GetService<IMutableModel>()["Model"] = value + ".Model";
+            builder.GetInfrastructure<IMutableModel>()["Model"] = value + ".Model";
 
             return builder;
         }
@@ -511,7 +511,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             builder.HasAnnotation("Annotation", value + ".Annotation");
             builder.Metadata["Metadata"] = value + ".Metadata";
-            builder.GetService<IMutableModel>()["Model"] = value + ".Model";
+            builder.GetInfrastructure<IMutableModel>()["Model"] = value + ".Model";
 
             return builder;
         }
@@ -520,7 +520,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             builder.HasAnnotation("Annotation", value + ".Annotation");
             builder.Metadata["Metadata"] = value + ".Metadata";
-            builder.GetService<IMutableModel>()["Model"] = value + ".Model";
+            builder.GetInfrastructure<IMutableModel>()["Model"] = value + ".Model";
 
             return builder;
         }
@@ -529,7 +529,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             builder.HasAnnotation("Annotation", value + ".Annotation");
             builder.Metadata["Metadata"] = value + ".Metadata";
-            builder.GetService<IMutableModel>()["Model"] = value + ".Model";
+            builder.GetInfrastructure<IMutableModel>()["Model"] = value + ".Model";
 
             return builder;
         }
@@ -538,7 +538,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             builder.HasAnnotation("Annotation", value + ".Annotation");
             builder.Metadata["Metadata"] = value + ".Metadata";
-            builder.GetService<IMutableModel>()["Model"] = value + ".Model";
+            builder.GetInfrastructure<IMutableModel>()["Model"] = value + ".Model";
 
             return builder;
         }
@@ -556,7 +556,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             builder.HasAnnotation("Annotation", value + ".Annotation");
             builder.Metadata["Metadata"] = value + ".Metadata";
-            builder.GetService<IMutableModel>()["Model"] = value + ".Model";
+            builder.GetInfrastructure<IMutableModel>()["Model"] = value + ".Model";
 
             return builder;
         }
@@ -566,7 +566,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             builder.HasAnnotation("Annotation", value + ".Annotation");
             builder.Metadata["Metadata"] = value + ".Metadata";
-            builder.GetService<IMutableModel>()["Model"] = value + ".Model";
+            builder.GetInfrastructure<IMutableModel>()["Model"] = value + ".Model";
 
             return builder;
         }
@@ -575,7 +575,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             builder.HasAnnotation("Annotation", value + ".Annotation");
             builder.Metadata["Metadata"] = value + ".Metadata";
-            builder.GetService<IMutableModel>()["Model"] = value + ".Model";
+            builder.GetInfrastructure<IMutableModel>()["Model"] = value + ".Model";
 
             return builder;
         }
@@ -584,7 +584,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             builder.HasAnnotation("Annotation", value + ".Annotation");
             builder.Metadata["Metadata"] = value + ".Metadata";
-            builder.GetService<IMutableModel>()["Model"] = value + ".Model";
+            builder.GetInfrastructure<IMutableModel>()["Model"] = value + ".Model";
 
             return builder;
         }
@@ -593,7 +593,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             builder.HasAnnotation("Annotation", value + ".Annotation");
             builder.Metadata["Metadata"] = value + ".Metadata";
-            builder.GetService<IMutableModel>()["Model"] = value + ".Model";
+            builder.GetInfrastructure<IMutableModel>()["Model"] = value + ".Model";
 
             return builder;
         }
@@ -602,7 +602,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             builder.HasAnnotation("Annotation", value + ".Annotation");
             builder.Metadata["Metadata"] = value + ".Metadata";
-            builder.GetService<IMutableModel>()["Model"] = value + ".Model";
+            builder.GetInfrastructure<IMutableModel>()["Model"] = value + ".Model";
 
             return builder;
         }
@@ -611,7 +611,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             builder.HasAnnotation("Annotation", value + ".Annotation");
             builder.Metadata["Metadata"] = value + ".Metadata";
-            builder.GetService<IMutableModel>()["Model"] = value + ".Model";
+            builder.GetInfrastructure<IMutableModel>()["Model"] = value + ".Model";
 
             return builder;
         }

--- a/test/EntityFramework.CrossStore.FunctionalTests/EndToEndTest.cs
+++ b/test/EntityFramework.CrossStore.FunctionalTests/EndToEndTest.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 // TODO: Replace with
                 // context.ChangeTracker.Entry(entity).Property(SimpleEntity.ShadowPropertyName).CurrentValue = "shadow";
                 var property = context.Model.FindEntityType(typeof(SimpleEntity)).FindProperty(SimpleEntity.ShadowPropertyName);
-                context.Entry(second).GetService()[property] = "shadow";
+                context.Entry(second).GetInfrastructure()[property] = "shadow";
                 SetPartitionId(second, context);
 
                 Assert.Equal(1, context.SaveChanges());
@@ -70,7 +70,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         private void SetPartitionId(SimpleEntity entity, CrossStoreContext context)
         {
             var property = context.Model.FindEntityType(entity.GetType()).FindProperty(SimpleEntity.ShadowPartitionIdName);
-            context.Entry(entity).GetService()[property] = "Partition";
+            context.Entry(entity).GetInfrastructure()[property] = "Partition";
         }
 
         protected EndToEndTest(TFixture fixture)

--- a/test/EntityFramework.InMemory.FunctionalTests/CompositeKeyEndToEndTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/CompositeKeyEndToEndTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
             var serviceProvider = new ServiceCollection()
                 .AddEntityFramework()
                 .AddInMemoryDatabase()
-                .GetService()
+                .GetInfrastructure()
                 .BuildServiceProvider();
 
             var ticks = DateTime.UtcNow.Ticks;

--- a/test/EntityFramework.InMemory.FunctionalTests/EndToEndTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/EndToEndTest.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
             T entity;
             using (var context = new DbContext(_fixture.ServiceProvider, optionsBuilder.Options))
             {
-                var entry = context.ChangeTracker.GetService().CreateNewEntry(entityType);
+                var entry = context.ChangeTracker.GetInfrastructure().CreateNewEntry(entityType);
                 entity = (T)entry.Entity;
 
                 entry[idProperty] = 42;
@@ -64,7 +64,7 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
                 Assert.Equal(42, entityEntry.Property(idProperty.Name).CurrentValue);
                 Assert.Equal("The", entityEntry.Property(nameProperty.Name).CurrentValue);
 
-                entityEntry.GetService()[nameProperty] = "A";
+                entityEntry.GetInfrastructure()[nameProperty] = "A";
 
                 context.Update(entityFromStore);
 

--- a/test/EntityFramework.InMemory.FunctionalTests/ShadowStateUpdateTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/ShadowStateUpdateTest.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
             using (var context = new DbContext(_fixture.ServiceProvider, optionsBuilder.Options))
             {
                 // TODO: Better API for shadow state access
-                var customerEntry = context.ChangeTracker.GetService().CreateNewEntry(customerType);
+                var customerEntry = context.ChangeTracker.GetInfrastructure().CreateNewEntry(customerType);
                 customerEntry[customerType.FindProperty("Id")] = 42;
                 customerEntry[customerType.FindProperty("Name")] = "Daenerys";
 
@@ -47,7 +47,7 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
 
             using (var context = new DbContext(_fixture.ServiceProvider, optionsBuilder.Options))
             {
-                var customerEntry = context.ChangeTracker.GetService().CreateNewEntry(customerType);
+                var customerEntry = context.ChangeTracker.GetInfrastructure().CreateNewEntry(customerType);
                 customerEntry[customerType.FindProperty("Id")] = 42;
                 customerEntry[customerType.FindProperty("Name")] = "Daenerys Targaryen";
 
@@ -63,7 +63,7 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
 
             using (var context = new DbContext(_fixture.ServiceProvider, optionsBuilder.Options))
             {
-                var customerEntry = context.ChangeTracker.GetService().CreateNewEntry(customerType);
+                var customerEntry = context.ChangeTracker.GetInfrastructure().CreateNewEntry(customerType);
                 customerEntry[customerType.FindProperty("Id")] = 42;
 
                 customerEntry.SetEntityState(EntityState.Deleted);
@@ -96,7 +96,7 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
                 context.Add(customer);
 
                 // TODO: Better API for shadow state access
-                var customerEntry = context.Entry(customer).GetService();
+                var customerEntry = context.Entry(customer).GetInfrastructure();
                 customerEntry[customerType.FindProperty("Name")] = "Daenerys";
 
                 await context.SaveChangesAsync();
@@ -116,7 +116,7 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
 
             using (var context = new DbContext(_fixture.ServiceProvider, optionsBuilder.Options))
             {
-                var customerEntry = context.Entry(customer).GetService();
+                var customerEntry = context.Entry(customer).GetInfrastructure();
                 customerEntry[customerType.FindProperty("Name")] = "Daenerys Targaryen";
 
                 context.Update(customer);

--- a/test/EntityFramework.Microbenchmarks/Models/Orders/OrdersFixture.cs
+++ b/test/EntityFramework.Microbenchmarks/Models/Orders/OrdersFixture.cs
@@ -42,7 +42,7 @@ namespace EntityFramework.Microbenchmarks.Models.Orders
         {
             using (var context = new OrdersContext(_connectionString))
             {
-                var database = ((IAccessor<IServiceProvider>)context).GetService<IRelationalDatabaseCreator>();
+                var database = ((IInfrastructure<IServiceProvider>)context).GetService<IRelationalDatabaseCreator>();
                 if (!database.Exists())
                 {
                     context.Database.EnsureCreated();

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/CompiledQueryCacheKeyGeneratorTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/CompiledQueryCacheKeyGeneratorTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             Expression query;
             using (var context1 = new QueryKeyCacheContext(rowNumberPaging: true))
             {
-                var services = ((IAccessor<IServiceProvider>)context1).Service.GetService<IDbContextServices>().DatabaseProviderServices;
+                var services = ((IInfrastructure<IServiceProvider>)context1).Instance.GetService<IDbContextServices>().DatabaseProviderServices;
                 query = context1.Set<Poco1>().Skip(4).Take(10).Expression;
                 var generator = services.CompiledQueryCacheKeyGenerator;
                 key1 = generator.GenerateCacheKey(query, false);
@@ -28,7 +28,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
             using (var context2 = new QueryKeyCacheContext(rowNumberPaging: false))
             {
-                var services = ((IAccessor<IServiceProvider>)context2).Service.GetService<IDbContextServices>().DatabaseProviderServices;
+                var services = ((IInfrastructure<IServiceProvider>)context2).Instance.GetService<IDbContextServices>().DatabaseProviderServices;
                 var generator = services.CompiledQueryCacheKeyGenerator;
                 key2 = generator.GenerateCacheKey(query, false);
             }

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/SqlServerDatabaseCreatorTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/SqlServerDatabaseCreatorTest.cs
@@ -377,10 +377,10 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             var optionsBuilder = new DbContextOptionsBuilder();
             optionsBuilder.UseSqlServer(testStore.Connection.ConnectionString);
 
-            return ((IAccessor<IServiceProvider>)new BloggingContext(
+            return ((IInfrastructure<IServiceProvider>)new BloggingContext(
                 serviceCollection.BuildServiceProvider(),
                 optionsBuilder.Options))
-                .Service;
+                .Instance;
         }
 
         private static IRelationalDatabaseCreator GetDatabaseCreator(SqlServerTestStore testStore)

--- a/test/EntityFramework.Relational.FunctionalTests/MigrationsTestBase.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/MigrationsTestBase.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
                 db.Database.Migrate();
 
-                var history = db.GetService().GetRequiredService<IHistoryRepository>();
+                var history = db.GetInfrastructure().GetRequiredService<IHistoryRepository>();
                 Assert.Collection(
                     history.GetAppliedMigrations(),
                     x => Assert.Equal("00000000000001_Migration1", x.MigrationId),
@@ -53,10 +53,10 @@ namespace Microsoft.Data.Entity.FunctionalTests
             {
                 db.Database.EnsureDeleted();
 
-                var migrator = db.GetService().GetRequiredService<IMigrator>();
+                var migrator = db.GetInfrastructure().GetRequiredService<IMigrator>();
                 migrator.Migrate("Migration1");
 
-                var history = db.GetService().GetRequiredService<IHistoryRepository>();
+                var history = db.GetInfrastructure().GetRequiredService<IHistoryRepository>();
                 Assert.Collection(
                     history.GetAppliedMigrations(),
                     x => Assert.Equal("00000000000001_Migration1", x.MigrationId));
@@ -71,10 +71,10 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 db.Database.EnsureDeleted();
                 db.Database.Migrate();
 
-                var migrator = db.GetService().GetRequiredService<IMigrator>();
+                var migrator = db.GetInfrastructure().GetRequiredService<IMigrator>();
                 migrator.Migrate(Migration.InitialDatabase);
 
-                var history = db.GetService().GetRequiredService<IHistoryRepository>();
+                var history = db.GetInfrastructure().GetRequiredService<IHistoryRepository>();
                 Assert.Empty(history.GetAppliedMigrations());
             }
         }
@@ -87,10 +87,10 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 db.Database.EnsureDeleted();
                 db.Database.Migrate();
 
-                var migrator = db.GetService().GetRequiredService<IMigrator>();
+                var migrator = db.GetInfrastructure().GetRequiredService<IMigrator>();
                 migrator.Migrate("Migration1");
 
-                var history = db.GetService().GetRequiredService<IHistoryRepository>();
+                var history = db.GetInfrastructure().GetRequiredService<IHistoryRepository>();
                 Assert.Collection(
                     history.GetAppliedMigrations(),
                     x => Assert.Equal("00000000000001_Migration1", x.MigrationId));
@@ -106,7 +106,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
                 await db.Database.MigrateAsync();
 
-                var history = db.GetService().GetRequiredService<IHistoryRepository>();
+                var history = db.GetInfrastructure().GetRequiredService<IHistoryRepository>();
                 Assert.Collection(
                     await history.GetAppliedMigrationsAsync(),
                     x => Assert.Equal("00000000000001_Migration1", x.MigrationId),
@@ -119,7 +119,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             using (var db = _fixture.CreateContext())
             {
-                var migrator = db.GetService().GetRequiredService<IMigrator>();
+                var migrator = db.GetInfrastructure().GetRequiredService<IMigrator>();
 
                 SetSql(migrator.GenerateScript());
             }
@@ -130,7 +130,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             using (var db = _fixture.CreateContext())
             {
-                var migrator = db.GetService().GetRequiredService<IMigrator>();
+                var migrator = db.GetInfrastructure().GetRequiredService<IMigrator>();
 
                 SetSql(migrator.GenerateScript(idempotent: true));
             }
@@ -141,7 +141,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             using (var db = _fixture.CreateContext())
             {
-                var migrator = db.GetService().GetRequiredService<IMigrator>();
+                var migrator = db.GetInfrastructure().GetRequiredService<IMigrator>();
 
                 SetSql(
                     migrator.GenerateScript(
@@ -155,7 +155,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             using (var db = _fixture.CreateContext())
             {
-                var migrator = db.GetService().GetRequiredService<IMigrator>();
+                var migrator = db.GetInfrastructure().GetRequiredService<IMigrator>();
 
                 SetSql(
                     migrator.GenerateScript(
@@ -170,7 +170,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             using (var db = _fixture.CreateContext())
             {
-                var migrator = db.GetService().GetRequiredService<IMigrator>();
+                var migrator = db.GetInfrastructure().GetRequiredService<IMigrator>();
                 MigrationsFixtureBase.ActiveProvider = null;
 
                 migrator.GenerateScript(toMigration: "Migration1");
@@ -192,7 +192,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 await db.Database.EnsureDeletedAsync();
                 await db.Database.EnsureCreatedAsync();
 
-                var services = db.GetService();
+                var services = db.GetInfrastructure();
                 var connection = db.Database.GetDbConnection();
 
                 await db.Database.OpenConnectionAsync();

--- a/test/EntityFramework.Relational.FunctionalTests/TransactionTestBase.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/TransactionTestBase.cs
@@ -157,7 +157,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
                     Assert.Equal(EntityState.Deleted, firstEntry.State);
                     Assert.Equal(EntityState.Added, lastEntry.State);
-                    Assert.NotNull(transaction.GetService().Connection);
+                    Assert.NotNull(transaction.GetInfrastructure().Connection);
                 }
             }
         }
@@ -184,7 +184,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
                     Assert.Equal(EntityState.Deleted, firstEntry.State);
                     Assert.Equal(EntityState.Added, lastEntry.State);
-                    Assert.NotNull(transaction.GetService().Connection);
+                    Assert.NotNull(transaction.GetInfrastructure().Connection);
                 }
             }
         }
@@ -290,7 +290,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
                     using (var innerContext = CreateContext(context.Database.GetDbConnection()))
                     {
-                        innerContext.Database.UseTransaction(transaction.GetService());
+                        innerContext.Database.UseTransaction(transaction.GetInfrastructure());
                         Assert.Equal(Fixture.Customers.Count - 1, innerContext.Set<TransactionCustomer>().Count());
                     }
                 }
@@ -328,7 +328,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
                     using (var innerContext = CreateContext(context.Database.GetDbConnection()))
                     {
-                        innerContext.Database.UseTransaction(transaction.GetService());
+                        innerContext.Database.UseTransaction(transaction.GetInfrastructure());
                         Assert.Equal(Fixture.Customers.Count - 1, await innerContext.Set<TransactionCustomer>().CountAsync());
                     }
                 }

--- a/test/EntityFramework.Relational.Tests/Storage/RelationalCommandTest.cs
+++ b/test/EntityFramework.Relational.Tests/Storage/RelationalCommandTest.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Data.Entity.Storage
 
             var command = fakeConnection.DbConnections[0].DbCommands[0];
 
-            Assert.Same(relationalTransaction.GetService(), command.Transaction);
+            Assert.Same(relationalTransaction.GetInfrastructure(), command.Transaction);
         }
 
         [Fact]

--- a/test/EntityFramework.Relational.Tests/Update/CommandBatchPreparerTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/CommandBatchPreparerTest.cs
@@ -265,7 +265,7 @@ namespace Microsoft.Data.Entity.Tests.Update
                 .UseModel(model);
             optionsBuilder.UseInMemoryDatabase();
 
-            return new DbContext(optionsBuilder.Options).GetService();
+            return new DbContext(optionsBuilder.Options).GetInfrastructure();
         }
 
         private static ICommandBatchPreparer CreateCommandBatchPreparer(IModificationCommandBatchFactory modificationCommandBatchFactory = null)

--- a/test/EntityFramework.Relational.Tests/Update/ModificationCommandComparerTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/ModificationCommandComparerTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Data.Entity.Tests.Update
                 .UseModel(model);
             optionsBuilder.UseInMemoryDatabase();
 
-            var contextServices = new DbContext(optionsBuilder.Options).GetService();
+            var contextServices = new DbContext(optionsBuilder.Options).GetInfrastructure();
             var stateManager = contextServices.GetRequiredService<IStateManager>();
 
             var key = entityType.AddProperty("Id", typeof(int));


### PR DESCRIPTION
Moving CoreOptionsExtension to Internal
Moving QueryTracking behavior to root namespace (because it is set on a top level DbContext.ChangeTracker API)
Renaming IAccessor