### PR TITLE
[SMALL] Move *AnnotationNames => .Internal

### DIFF
--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -213,7 +213,7 @@
     <Compile Include="Metadata\Conventions\Internal\PropertyDiscoveryConvention.cs" />
     <Compile Include="Metadata\Conventions\Internal\RelationshipDiscoveryConvention.cs" />
     <Compile Include="Metadata\Conventions\Internal\RequiredPropertyAttributeConvention.cs" />
-    <Compile Include="Metadata\CoreAnnotationNames.cs" />
+    <Compile Include="Metadata\Internal\CoreAnnotationNames.cs" />
     <Compile Include="Metadata\DeleteBehavior.cs" />
     <Compile Include="Metadata\IMutableAnnotatable.cs" />
     <Compile Include="Metadata\IMutableEntityType.cs" />

--- a/src/EntityFramework.Core/Extensions/MutablePropertyExtensions.cs
+++ b/src/EntityFramework.Core/Extensions/MutablePropertyExtensions.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity

--- a/src/EntityFramework.Core/Metadata/Internal/CoreAnnotationNames.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/CoreAnnotationNames.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-namespace Microsoft.Data.Entity.Metadata
+namespace Microsoft.Data.Entity.Metadata.Internal
 {
     public static class CoreAnnotationNames
     {

--- a/src/EntityFramework.Relational.Design/EntityFramework.Relational.Design.csproj
+++ b/src/EntityFramework.Relational.Design/EntityFramework.Relational.Design.csproj
@@ -101,7 +101,7 @@
     <Compile Include="Internal\ReverseEngineeringConfiguration.cs" />
     <Compile Include="Internal\ReverseEngineeringGenerator.cs" />
     <Compile Include="RelationalScaffoldingModelFactory.cs" />
-    <Compile Include="Metadata\ScaffoldingAnnotationNames.cs" />
+    <Compile Include="Metadata\Internal\ScaffoldingAnnotationNames.cs" />
     <Compile Include="Internal\CSharpUtilities.cs" />
     <Compile Include="Internal\ModelUtilities.cs" />
     <EmbeddedResource Include="Properties\RelationalDesignStrings.resx">

--- a/src/EntityFramework.Relational.Design/Metadata/Internal/ScaffoldingAnnotationNames.cs
+++ b/src/EntityFramework.Relational.Design/Metadata/Internal/ScaffoldingAnnotationNames.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-namespace Microsoft.Data.Entity.Scaffolding.Metadata
+namespace Microsoft.Data.Entity.Scaffolding.Metadata.Internal
 {
     public class ScaffoldingAnnotationNames
     {

--- a/src/EntityFramework.Relational.Design/Metadata/ScaffoldingForeignKeyAnnotations.cs
+++ b/src/EntityFramework.Relational.Design/Metadata/ScaffoldingForeignKeyAnnotations.cs
@@ -3,6 +3,7 @@
 
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Scaffolding.Metadata.Internal;
 using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Scaffolding.Metadata

--- a/src/EntityFramework.Relational.Design/Metadata/ScaffoldingMetadataExtensions.cs
+++ b/src/EntityFramework.Relational.Design/Metadata/ScaffoldingMetadataExtensions.cs
@@ -3,6 +3,7 @@
 
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Scaffolding.Metadata;
+using Microsoft.Data.Entity.Scaffolding.Metadata.Internal;
 using Microsoft.Data.Entity.Utilities;
 
 // ReSharper disable once CheckNamespace

--- a/src/EntityFramework.Relational.Design/Metadata/ScaffoldingModelAnnotations.cs
+++ b/src/EntityFramework.Relational.Design/Metadata/ScaffoldingModelAnnotations.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Scaffolding.Metadata.Internal;
 using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Scaffolding.Metadata

--- a/src/EntityFramework.Relational/EntityFramework.Relational.csproj
+++ b/src/EntityFramework.Relational/EntityFramework.Relational.csproj
@@ -168,7 +168,7 @@
     <Compile Include="Metadata\IRelationalModelAnnotations.cs" />
     <Compile Include="Metadata\IRelationalPropertyAnnotations.cs" />
     <Compile Include="Metadata\ISequence.cs" />
-    <Compile Include="Metadata\RelationalAnnotationNames.cs" />
+    <Compile Include="Metadata\Internal\RelationalAnnotationNames.cs" />
     <Compile Include="RelationalEntityTypeBuilderExtensions.cs" />
     <Compile Include="Metadata\RelationalEntityTypeAnnotations.cs" />
     <Compile Include="Metadata\RelationalForeignKeyAnnotations.cs" />

--- a/src/EntityFramework.Relational/Metadata/Internal/RelationalAnnotationNames.cs
+++ b/src/EntityFramework.Relational/Metadata/Internal/RelationalAnnotationNames.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-namespace Microsoft.Data.Entity.Metadata
+namespace Microsoft.Data.Entity.Metadata.Internal
 {
     public static class RelationalAnnotationNames
     {

--- a/src/EntityFramework.Relational/Metadata/RelationalAnnotations.cs
+++ b/src/EntityFramework.Relational/Metadata/RelationalAnnotations.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Metadata

--- a/src/EntityFramework.Relational/Metadata/RelationalPropertyAnnotations.cs
+++ b/src/EntityFramework.Relational/Metadata/RelationalPropertyAnnotations.cs
@@ -3,6 +3,7 @@
 
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Metadata


### PR DESCRIPTION
The public surface on these are the extension methods we expose. The
only place we are directly using the names (outside of the assembly they
belong) are in the Tests and a couple of places in our design code. The
raw names are not something that provider writers or app developers
should really need to use.