### PR TITLE
Convert IEntityType.GetNavigations() and related methods to extention methods

### DIFF
--- a/src/EntityFramework.Core/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -466,7 +466,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
         public virtual void CascadeDelete()
         {
-            foreach (var fk in EntityType.FindReferencingForeignKeys())
+            foreach (var fk in EntityType.GetReferencingForeignKeys())
             {
                 foreach (var dependent in StateManager.GetDependents(this, fk).ToList())
                 {

--- a/src/EntityFramework.Core/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/NavigationFixer.cs
@@ -308,7 +308,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
                 }
             }
 
-            foreach (var foreignKey in entityType.FindReferencingForeignKeys())
+            foreach (var foreignKey in entityType.GetReferencingForeignKeys())
             {
                 var dependents = entry.StateManager.GetDependents(entry, foreignKey).ToArray();
                 if (dependents.Length > 0)

--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Internal\IDatabaseProviderSelector.cs" />
     <Compile Include="Internal\IndentedStringBuilder.cs" />
     <Compile Include="Internal\LazyRef.cs" />
+    <Compile Include="Metadata\Internal\ICanGetNavigations.cs" />
     <Compile Include="Metadata\Internal\INavigationAccessors.cs" />
     <Compile Include="Metadata\Internal\IPropertyBaseAccessors.cs" />
     <Compile Include="Metadata\Internal\KeyExtensions.cs" />

--- a/src/EntityFramework.Core/Extensions/EntityTypeExtensions.cs
+++ b/src/EntityFramework.Core/Extensions/EntityTypeExtensions.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Data.Entity
             return entityType.FindForeignKey(new[] { property }, principalKey, principalEntityType);
         }
 
-        public static IEnumerable<IForeignKey> FindReferencingForeignKeys([NotNull] this IEntityType entityType)
+        public static IEnumerable<IForeignKey> GetReferencingForeignKeys([NotNull] this IEntityType entityType)
         {
             Check.NotNull(entityType, nameof(entityType));
 
@@ -100,6 +100,28 @@ namespace Microsoft.Data.Entity
             Check.NotNull(propertyInfo, nameof(propertyInfo));
 
             return entityType.FindNavigation(propertyInfo.Name);
+        }
+
+        public static INavigation FindNavigation([NotNull] this IEntityType entityType, [NotNull] string name)
+        {
+            Check.NotNull(entityType, nameof(entityType));
+            Check.NotNull(name, nameof(name));
+
+            return entityType.GetNavigations().FirstOrDefault(n => n.Name.Equals(name));
+        }
+
+        public static IEnumerable<INavigation> GetNavigations([NotNull] this IEntityType entityType)
+        {
+            Check.NotNull(entityType, nameof(entityType));
+
+            var fastEntityType = entityType as ICanGetNavigations;
+            if (fastEntityType != null)
+            {
+                return fastEntityType.GetNavigations();
+            }
+
+            return entityType.BaseType?.GetNavigations().Concat(entityType.GetDeclaredNavigations())
+                   ?? entityType.GetDeclaredNavigations();
         }
 
         public static IProperty FindProperty([NotNull] this IEntityType entityType, [NotNull] PropertyInfo propertyInfo)

--- a/src/EntityFramework.Core/Extensions/MutableEntityTypeExtensions.cs
+++ b/src/EntityFramework.Core/Extensions/MutableEntityTypeExtensions.cs
@@ -87,8 +87,8 @@ namespace Microsoft.Data.Entity
             return entityType.FindForeignKey(new[] { property }, principalKey, principalEntityType);
         }
 
-        public static IEnumerable<IMutableForeignKey> FindReferencingForeignKeys([NotNull] this IMutableEntityType entityType)
-            => ((IEntityType)entityType).FindReferencingForeignKeys().Cast<IMutableForeignKey>();
+        public static IEnumerable<IMutableForeignKey> GetReferencingForeignKeys([NotNull] this IMutableEntityType entityType)
+            => ((IEntityType)entityType).GetReferencingForeignKeys().Cast<IMutableForeignKey>();
 
         public static IMutableForeignKey AddForeignKey(
             [NotNull] this IMutableEntityType entityType,
@@ -129,17 +129,11 @@ namespace Microsoft.Data.Entity
             return entityType.FindNavigation(propertyInfo.Name);
         }
 
-        public static IMutableNavigation GetOrAddNavigation(
-            [NotNull] this IMutableEntityType entityType,
-            [NotNull] string name,
-            [NotNull] IMutableForeignKey foreignKey,
-            bool pointsToPrincipal)
-        {
-            Check.NotNull(entityType, nameof(entityType));
+        public static IMutableNavigation FindNavigation([NotNull] this IMutableEntityType entityType, [NotNull] string name)
+            => (IMutableNavigation)((IEntityType)entityType).FindNavigation(name);
 
-            return entityType.FindNavigation(name)
-                   ?? entityType.AddNavigation(name, foreignKey, pointsToPrincipal);
-        }
+        public static IEnumerable<IMutableNavigation> GetNavigations([NotNull] this IMutableEntityType entityType)
+            => ((IEntityType)entityType).GetNavigations().Cast<IMutableNavigation>();
 
         public static IMutableProperty FindProperty([NotNull] this IMutableEntityType entityType, [NotNull] PropertyInfo propertyInfo)
         {

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/ForeignKeyPropertyDiscoveryConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/ForeignKeyPropertyDiscoveryConvention.cs
@@ -267,7 +267,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
                     var relationshipBuilder = entityTypeBuilder.Relationship(foreignKey, ConfigurationSource.Convention);
                     Apply(relationshipBuilder);
                 }
-                foreach (var foreignKey in entityType.FindReferencingForeignKeys().ToList())
+                foreach (var foreignKey in entityType.GetReferencingForeignKeys().ToList())
                 {
                     var relationshipBuilder = propertyBuilder.ModelBuilder
                         .Entity(foreignKey.DeclaringEntityType.Name, ConfigurationSource.Convention)

--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/RelationshipDiscoveryConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/RelationshipDiscoveryConvention.cs
@@ -316,7 +316,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
 
         private void ApplyOnRelatedEntityTypes(InternalModelBuilder modelBuilder, EntityType entityType)
         {
-            var relatedEntityTypes = entityType.FindReferencingForeignKeys().Select(fk => fk.DeclaringEntityType)
+            var relatedEntityTypes = entityType.GetReferencingForeignKeys().Select(fk => fk.DeclaringEntityType)
                 .Concat(entityType.GetForeignKeys().Select(fk => fk.PrincipalEntityType))
                 .Distinct()
                 .ToList();

--- a/src/EntityFramework.Core/Metadata/IEntityType.cs
+++ b/src/EntityFramework.Core/Metadata/IEntityType.cs
@@ -24,8 +24,6 @@ namespace Microsoft.Data.Entity.Metadata
             [NotNull] IEntityType principalEntityType);
 
         IEnumerable<IForeignKey> GetForeignKeys();
-        INavigation FindNavigation([NotNull] string name);
-        IEnumerable<INavigation> GetNavigations();
         IIndex FindIndex([NotNull] IReadOnlyList<IProperty> properties);
         IEnumerable<IIndex> GetIndexes();
         IProperty FindProperty([NotNull] string name);

--- a/src/EntityFramework.Core/Metadata/IMutableEntityType.cs
+++ b/src/EntityFramework.Core/Metadata/IMutableEntityType.cs
@@ -29,12 +29,7 @@ namespace Microsoft.Data.Entity.Metadata
 
         new IEnumerable<IMutableForeignKey> GetForeignKeys();
         IMutableForeignKey RemoveForeignKey([NotNull] IReadOnlyList<IProperty> properties, [NotNull] IKey principalKey, [NotNull] IEntityType principalEntityType);
-
-        IMutableNavigation AddNavigation([NotNull] string name, [NotNull] IMutableForeignKey foreignKey, bool pointsToPrincipal);
-        new IMutableNavigation FindNavigation([NotNull] string name);
-        new IEnumerable<IMutableNavigation> GetNavigations();
-        IMutableNavigation RemoveNavigation([NotNull] string name);
-
+        
         IMutableIndex AddIndex([NotNull] IReadOnlyList<IMutableProperty> properties);
         new IMutableIndex FindIndex([NotNull] IReadOnlyList<IProperty> properties);
         new IEnumerable<IMutableIndex> GetIndexes();

--- a/src/EntityFramework.Core/Metadata/IMutableForeignKey.cs
+++ b/src/EntityFramework.Core/Metadata/IMutableForeignKey.cs
@@ -9,8 +9,10 @@ namespace Microsoft.Data.Entity.Metadata
         new IMutableKey PrincipalKey { get; }
         new IMutableEntityType DeclaringEntityType { get; }
         new IMutableEntityType PrincipalEntityType { get; }
-        new IMutableNavigation DependentToPrincipal { get; [param: CanBeNull] set; }
-        new IMutableNavigation PrincipalToDependent { get; [param: CanBeNull] set; }
+        new IMutableNavigation DependentToPrincipal { get; }
+        new IMutableNavigation PrincipalToDependent { get; }
+        IMutableNavigation HasDependentToPrincipal([CanBeNull] string name);
+        IMutableNavigation HasPrincipalToDependent([CanBeNull] string name);
         new bool? IsUnique { get; set; }
         new bool? IsRequired { get; set; }
         new DeleteBehavior? DeleteBehavior { get; set; }

--- a/src/EntityFramework.Core/Metadata/Internal/ICanGetNavigations.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/ICanGetNavigations.cs
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Data.Entity.Metadata.Internal
+{
+    interface ICanGetNavigations
+    {
+        IEnumerable<INavigation> GetNavigations();
+    }
+}

--- a/src/EntityFramework.Core/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -635,7 +635,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                         foreignKey.DependentToPrincipal,
                         foreignKey.PrincipalToDependent,
                         isDependent: true))
-                .Concat(entityType.FindReferencingForeignKeys().Where(foreignKey => !foreignKey.IsSelfReferencing())
+                .Concat(entityType.GetReferencingForeignKeys().Where(foreignKey => !foreignKey.IsSelfReferencing())
                     .Select(foreignKey =>
                         new RelationshipSnapshot(foreignKey,
                             foreignKey.PrincipalToDependent,
@@ -716,12 +716,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             }
 
             var navigationToDependent = foreignKey.PrincipalToDependent;
-            var removedNavigation = navigationToDependent?.DeclaringEntityType.RemoveNavigation(navigationToDependent.Name);
-            Debug.Assert(removedNavigation == navigationToDependent);
-
             var navigationToPrincipal = foreignKey.DependentToPrincipal;
-            removedNavigation = navigationToPrincipal?.DeclaringEntityType.RemoveNavigation(navigationToPrincipal.Name);
-            Debug.Assert(removedNavigation == navigationToPrincipal);
 
             var removedForeignKey = Metadata.RemoveForeignKey(foreignKey);
             Debug.Assert(removedForeignKey == foreignKey);

--- a/src/EntityFramework.Core/Metadata/Internal/InternalModelBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/InternalModelBuilder.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 Debug.Assert(removed.HasValue);
             }
 
-            foreach (var foreignKey in entityType.FindDeclaredReferencingForeignKeys().ToList())
+            foreach (var foreignKey in entityType.GetDeclaredReferencingForeignKeys().ToList())
             {
                 var removed = entityTypeBuilder.RemoveForeignKey(foreignKey, configurationSource);
                 Debug.Assert(removed.HasValue);

--- a/src/EntityFramework.Core/Metadata/Internal/InternalRelationshipBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/InternalRelationshipBuilder.cs
@@ -224,16 +224,18 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                     strictPrincipal: strictPrincipal);
             }
 
-            if (oldNavigation != null)
-            {
-                var removedNavigation = entityType.RemoveNavigation(oldNavigation.Name);
-                Debug.Assert(removedNavigation == oldNavigation);
-            }
-
             if (navigationName != null)
             {
                 entityTypeBuilder.Unignore(navigationName);
-                entityType.AddNavigation(navigationName, builder.Metadata, pointsToPrincipal);
+            }
+
+            if (pointsToPrincipal)
+            {
+                builder.Metadata.HasDependentToPrincipal(navigationName);
+            }
+            else
+            {
+                builder.Metadata.HasPrincipalToDependent(navigationName);
             }
 
             if (pointsToPrincipal)

--- a/src/EntityFramework.Core/Metadata/Internal/Model.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/Model.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
         {
             Check.NotNull(entityType, nameof(entityType));
 
-            var referencingForeignKey = entityType.FindDeclaredReferencingForeignKeys().FirstOrDefault();
+            var referencingForeignKey = entityType.GetDeclaredReferencingForeignKeys().FirstOrDefault();
             if (referencingForeignKey != null)
             {
                 throw new InvalidOperationException(

--- a/src/EntityFramework.Core/Metadata/Internal/ModelNavigationsGraphAdapter.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/ModelNavigationsGraphAdapter.cs
@@ -21,10 +21,10 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
         public override IEnumerable<EntityType> GetOutgoingNeighbours(EntityType from)
             => @from.GetForeignKeys().Where(fk => fk.DependentToPrincipal != null).Select(fk => fk.PrincipalEntityType)
-                .Union(@from.FindReferencingForeignKeys().Where(fk => fk.PrincipalToDependent != null).Select(fk => fk.DeclaringEntityType));
+                .Union(@from.GetReferencingForeignKeys().Where(fk => fk.PrincipalToDependent != null).Select(fk => fk.DeclaringEntityType));
 
         public override IEnumerable<EntityType> GetIncomingNeighbours(EntityType to)
             => to.GetForeignKeys().Where(fk => fk.PrincipalToDependent != null).Select(fk => fk.PrincipalEntityType)
-                .Union(to.FindReferencingForeignKeys().Where(fk => fk.DependentToPrincipal != null).Select(fk => fk.DeclaringEntityType));
+                .Union(to.GetReferencingForeignKeys().Where(fk => fk.DependentToPrincipal != null).Select(fk => fk.DeclaringEntityType));
     }
 }

--- a/src/EntityFramework.Core/Metadata/Internal/Navigation.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/Navigation.cs
@@ -60,7 +60,8 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             {
                 if (shouldThrow)
                 {
-                    throw new InvalidOperationException(CoreStrings.NavigationOnShadowEntity(navigationPropertyName, sourceType.Name));
+                    throw new InvalidOperationException(
+                        CoreStrings.NavigationOnShadowEntity(navigationPropertyName, sourceType.DisplayName()));
                 }
                 return false;
             }
@@ -70,7 +71,8 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             {
                 if (shouldThrow)
                 {
-                    throw new InvalidOperationException(CoreStrings.NavigationToShadowEntity(navigationPropertyName, sourceType.Name, targetType.Name));
+                    throw new InvalidOperationException(
+                        CoreStrings.NavigationToShadowEntity(navigationPropertyName, sourceType.DisplayName(), targetType.DisplayName()));
                 }
                 return false;
             }
@@ -80,7 +82,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             {
                 if (shouldThrow)
                 {
-                    throw new InvalidOperationException(CoreStrings.NoClrNavigation(navigationPropertyName, sourceType.Name));
+                    throw new InvalidOperationException(CoreStrings.NoClrNavigation(navigationPropertyName, sourceType.DisplayName()));
                 }
                 return false;
             }
@@ -94,8 +96,12 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 {
                     if (shouldThrow)
                     {
-                        throw new InvalidOperationException(CoreStrings.NavigationCollectionWrongClrType(
-                            navigationProperty.Name, sourceClrType.FullName, navigationProperty.PropertyType.FullName, targetClrType.FullName));
+                        throw new InvalidOperationException(
+                            CoreStrings.NavigationCollectionWrongClrType(
+                            navigationProperty.Name,
+                            sourceClrType.Name,
+                            navigationProperty.PropertyType.FullName,
+                            targetClrType.FullName));
                     }
                     return false;
                 }
@@ -105,7 +111,10 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                     if (shouldThrow)
                     {
                         throw new InvalidOperationException(CoreStrings.NavigationSingleWrongClrType(
-                            navigationProperty.Name, sourceClrType.FullName, navigationProperty.PropertyType.FullName, targetClrType.FullName));
+                            navigationProperty.Name,
+                            sourceClrType.Name,
+                            navigationProperty.PropertyType.FullName,
+                            targetClrType.FullName));
                     }
                     return false;
                 }

--- a/src/EntityFramework.Core/Properties/CoreStrings.Designer.cs
+++ b/src/EntityFramework.Core/Properties/CoreStrings.Designer.cs
@@ -389,22 +389,6 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
-        /// Cannot remove foreign key {foreignKey} from entity type '{entityType}' because it is referenced by navigation property '{navigation}' in entity type '{dependentType}'. All navigations must be removed or redefined before the referenced foreign key can be removed.
-        /// </summary>
-        public static string ForeignKeyInUse([CanBeNull] object foreignKey, [CanBeNull] object entityType, [CanBeNull] object navigation, [CanBeNull] object dependentType)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("ForeignKeyInUse", "foreignKey", "entityType", "navigation", "dependentType"), foreignKey, entityType, navigation, dependentType);
-        }
-
-        /// <summary>
-        /// The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because according to the specified foreign key it should belong to entity type '{existingEntityType}'.
-        /// </summary>
-        public static string NavigationOnWrongEntityType([CanBeNull] object navigation, [CanBeNull] object entityType, [CanBeNull] object existingEntityType)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("NavigationOnWrongEntityType", "navigation", "entityType", "existingEntityType"), navigation, entityType, existingEntityType);
-        }
-
-        /// <summary>
         /// The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because a navigation property with the same name already exists on entity type '{duplicateEntityType}'.
         /// </summary>
         public static string DuplicateNavigation([CanBeNull] object navigation, [CanBeNull] object entityType, [CanBeNull] object duplicateEntityType)
@@ -413,7 +397,7 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
-        /// The navigation property '{navigation}' cannot be added to entity type '{entityType}' because the entity type is defined in shadow state and navigations properties cannot be added to shadow state.
+        /// The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because the entity type is defined in shadow state and navigations properties cannot be added to shadow state.
         /// </summary>
         public static string NavigationOnShadowEntity([CanBeNull] object navigation, [CanBeNull] object entityType)
         {
@@ -421,7 +405,7 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
-        /// The navigation property '{navigation}' cannot be added to entity type '{entityType}' because there is no corresponding CLR property on the underlying type and navigations properties cannot be added to shadow state.
+        /// The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because there is no corresponding CLR property on the underlying type and navigations properties cannot be added to shadow state.
         /// </summary>
         public static string NoClrNavigation([CanBeNull] object navigation, [CanBeNull] object entityType)
         {
@@ -429,7 +413,7 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
-        /// The navigation property '{navigation}' cannot be added to entity type '{entityType}' because its CLR type '{clrType}' does not match the expected CLR type '{targetType}'.
+        /// The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because its CLR type '{clrType}' does not match the expected CLR type '{targetType}'.
         /// </summary>
         public static string NavigationSingleWrongClrType([CanBeNull] object navigation, [CanBeNull] object entityType, [CanBeNull] object clrType, [CanBeNull] object targetType)
         {
@@ -437,27 +421,11 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
-        /// The collection navigation property '{navigation}' cannot be added to entity type '{entityType}' because its CLR type '{clrType}' does not implement 'IEnumerable&lt;{targetType}&gt;'. Collection navigation properties must implement IEnumerable&lt;&gt; of the related entity.
+        /// The collection navigation property '{navigation}' cannot be added to the entity type '{entityType}' because its CLR type '{clrType}' does not implement 'IEnumerable&lt;{targetType}&gt;'. Collection navigation properties must implement IEnumerable&lt;&gt; of the related entity.
         /// </summary>
         public static string NavigationCollectionWrongClrType([CanBeNull] object navigation, [CanBeNull] object entityType, [CanBeNull] object clrType, [CanBeNull] object targetType)
         {
             return string.Format(CultureInfo.CurrentCulture, GetString("NavigationCollectionWrongClrType", "navigation", "entityType", "clrType", "targetType"), navigation, entityType, clrType, targetType);
-        }
-
-        /// <summary>
-        /// The navigation property '{navigation}' on entity type '{entityType}' could not be found. Ensure that the navigation property exists and has been included in the model.
-        /// </summary>
-        public static string NavigationNotFound([CanBeNull] object navigation, [CanBeNull] object entityType)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("NavigationNotFound", "navigation", "entityType"), navigation, entityType);
-        }
-
-        /// <summary>
-        /// The navigation properties '{navigation1}' and '{navigation2}' on entity type '{entityType}' are both backed by the same foreign key and point in the same direction. Each foreign key can have at most one navigation property and one inverse navigation property.
-        /// </summary>
-        public static string MultipleNavigations([CanBeNull] object navigation1, [CanBeNull] object navigation2, [CanBeNull] object entityType)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("MultipleNavigations", "navigation1", "navigation2", "entityType"), navigation1, navigation2, entityType);
         }
 
         /// <summary>
@@ -477,7 +445,7 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
-        /// The type of navigation property '{navigation}' on entity type '{entityType}' is '{foundType}' which does not implement ICollection&lt;{targetType}&gt;. Collection navigation properties must implement ICollection&lt;&gt; of the target type.
+        /// The type of navigation property '{navigation}' on the entity type '{entityType}' is '{foundType}' which does not implement ICollection&lt;{targetType}&gt;. Collection navigation properties must implement ICollection&lt;&gt; of the target type.
         /// </summary>
         public static string NavigationBadType([CanBeNull] object navigation, [CanBeNull] object entityType, [CanBeNull] object foundType, [CanBeNull] object targetType)
         {
@@ -485,7 +453,7 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
-        /// The type of navigation property '{navigation}' on entity type '{entityType}' is '{foundType}' which is an array type.. Collection navigation properties cannot be arrays.
+        /// The type of navigation property '{navigation}' on the entity type '{entityType}' is '{foundType}' which is an array type.. Collection navigation properties cannot be arrays.
         /// </summary>
         public static string NavigationArray([CanBeNull] object navigation, [CanBeNull] object entityType, [CanBeNull] object foundType)
         {
@@ -493,7 +461,7 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
-        /// The navigation property '{navigation}' on entity type '{entityType}' does not have a getter.
+        /// The navigation property '{navigation}' on the entity type '{entityType}' does not have a getter.
         /// </summary>
         public static string NavigationNoGetter([CanBeNull] object navigation, [CanBeNull] object entityType)
         {
@@ -501,7 +469,7 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
-        /// The navigation property '{navigation}' on entity type '{entityType}' does not have a setter. Read-only collection navigation properties must be initialized before use.
+        /// The navigation property '{navigation}' on the entity type '{entityType}' does not have a setter. Read-only collection navigation properties must be initialized before use.
         /// </summary>
         public static string NavigationNoSetter([CanBeNull] object navigation, [CanBeNull] object entityType)
         {
@@ -509,7 +477,7 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
-        /// The type of navigation property '{navigation}' on entity type '{entityType}' is '{foundType}' for which it was not possible to create a concrete instance. Either initialize the property before use, add a public parameterless constructor to the type, or use a type which can be assigned a HashSet&lt;&gt; or List&lt;&gt;.
+        /// The type of navigation property '{navigation}' on the entity type '{entityType}' is '{foundType}' for which it was not possible to create a concrete instance. Either initialize the property before use, add a public parameterless constructor to the type, or use a type which can be assigned a HashSet&lt;&gt; or List&lt;&gt;.
         /// </summary>
         public static string NavigationCannotCreateType([CanBeNull] object navigation, [CanBeNull] object entityType, [CanBeNull] object foundType)
         {
@@ -589,7 +557,7 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
-        /// The navigation property '{navigation}' cannot be added to entity type '{entityType}' because the target entity type '{targetType}' is defined in shadow state and navigations properties cannot point to shadow state entities.
+        /// The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because the target entity type '{targetType}' is defined in shadow state and navigations properties cannot point to shadow state entities.
         /// </summary>
         public static string NavigationToShadowEntity([CanBeNull] object navigation, [CanBeNull] object entityType, [CanBeNull] object targetType)
         {
@@ -861,14 +829,6 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
-        /// The navigation for property '{navigation}' on entity type '{entityType}' cannot be associated with foreign key {targetFk} because it was created for foreign key {actualFk}.
-        /// </summary>
-        public static string NavigationForWrongForeignKey([CanBeNull] object navigation, [CanBeNull] object entityType, [CanBeNull] object targetFk, [CanBeNull] object actualFk)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("NavigationForWrongForeignKey", "navigation", "entityType", "targetFk", "actualFk"), navigation, entityType, targetFk, actualFk);
-        }
-
-        /// <summary>
         /// Property '{property}' on entity type '{entityType}' is of type '{actualType}' but the generic type provided is of type '{genericType}'.
         /// </summary>
         public static string WrongGenericPropertyType([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object actualType, [CanBeNull] object genericType)
@@ -930,22 +890,6 @@ namespace Microsoft.Data.Entity.Internal
         public static string CompositePKWithDataAnnotation([CanBeNull] object entityType)
         {
             return string.Format(CultureInfo.CurrentCulture, GetString("CompositePKWithDataAnnotation", "entityType"), entityType);
-        }
-
-        /// <summary>
-        /// The navigation property '{navigation}' cannot be removed because it is still referenced from entity type '{entityType}'.
-        /// </summary>
-        public static string NavigationStillOnEntityType([CanBeNull] object navigation, [CanBeNull] object entityType)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("NavigationStillOnEntityType", "navigation", "entityType"), navigation, entityType);
-        }
-
-        /// <summary>
-        /// The navigation property corresponding to '{entityType}' cannot be determined because the principal entity type for foreign key {foreignKey} is '{principalEntityType}' and it is in the same hierarchy as the dependent entity type '{dependentEntityType}'.
-        /// </summary>
-        public static string IntraHierarchicalAmbiguousNavigation([CanBeNull] object entityType, [CanBeNull] object foreignKey, [CanBeNull] object principalEntityType, [CanBeNull] object dependentEntityType)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("IntraHierarchicalAmbiguousNavigation", "entityType", "foreignKey", "principalEntityType", "dependentEntityType"), entityType, foreignKey, principalEntityType, dependentEntityType);
         }
 
         /// <summary>
@@ -1117,14 +1061,6 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
-        /// The navigation property corresponding to '{entityType}' cannot be determined because the principal entity type for foreign key {foreignKey} is the same as the dependent entity type.
-        /// </summary>
-        public static string SelfReferencingAmbiguousNavigation([CanBeNull] object entityType, [CanBeNull] object foreignKey)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("SelfReferencingAmbiguousNavigation", "entityType", "foreignKey"), entityType, foreignKey);
-        }
-
-        /// <summary>
         /// The entity type '{entityType}' cannot be removed because '{derivedEntityType}' is derived from it. All derived entity types must be removed or redefined before the entity type can be removed.
         /// </summary>
         public static string EntityTypeInUseByDerived([CanBeNull] object entityType, [CanBeNull] object derivedEntityType)
@@ -1154,6 +1090,14 @@ namespace Microsoft.Data.Entity.Internal
         public static string PropertyNotMapped([CanBeNull] object property, [CanBeNull] object entityType)
         {
             return string.Format(CultureInfo.CurrentCulture, GetString("PropertyNotMapped", "property", "entityType"), property, entityType);
+        }
+
+        /// <summary>
+        /// The navigation property '{navigation}' on entity type '{entityType}' cannot be associated with foreign key {targetFk} because it was created for foreign key {actualFk}.
+        /// </summary>
+        public static string NavigationForWrongForeignKey([CanBeNull] object navigation, [CanBeNull] object entityType, [CanBeNull] object targetFk, [CanBeNull] object actualFk)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("NavigationForWrongForeignKey", "navigation", "entityType", "targetFk", "actualFk"), navigation, entityType, targetFk, actualFk);
         }
 
         private static string GetString(string name, params string[] formatterNames)

--- a/src/EntityFramework.Core/Properties/CoreStrings.resx
+++ b/src/EntityFramework.Core/Properties/CoreStrings.resx
@@ -258,32 +258,20 @@
   <data name="KeyInUse" xml:space="preserve">
     <value>Cannot remove key {key} from entity type '{entityType}' because it is referenced by a foreign key in entity type '{dependentType}'. All foreign keys must be removed or redefined before the referenced key can be removed.</value>
   </data>
-  <data name="ForeignKeyInUse" xml:space="preserve">
-    <value>Cannot remove foreign key {foreignKey} from entity type '{entityType}' because it is referenced by navigation property '{navigation}' in entity type '{dependentType}'. All navigations must be removed or redefined before the referenced foreign key can be removed.</value>
-  </data>
-  <data name="NavigationOnWrongEntityType" xml:space="preserve">
-    <value>The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because according to the specified foreign key it should belong to entity type '{existingEntityType}'.</value>
-  </data>
   <data name="DuplicateNavigation" xml:space="preserve">
     <value>The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because a navigation property with the same name already exists on entity type '{duplicateEntityType}'.</value>
   </data>
   <data name="NavigationOnShadowEntity" xml:space="preserve">
-    <value>The navigation property '{navigation}' cannot be added to entity type '{entityType}' because the entity type is defined in shadow state and navigations properties cannot be added to shadow state.</value>
+    <value>The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because the entity type is defined in shadow state and navigations properties cannot be added to shadow state.</value>
   </data>
   <data name="NoClrNavigation" xml:space="preserve">
-    <value>The navigation property '{navigation}' cannot be added to entity type '{entityType}' because there is no corresponding CLR property on the underlying type and navigations properties cannot be added to shadow state.</value>
+    <value>The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because there is no corresponding CLR property on the underlying type and navigations properties cannot be added to shadow state.</value>
   </data>
   <data name="NavigationSingleWrongClrType" xml:space="preserve">
-    <value>The navigation property '{navigation}' cannot be added to entity type '{entityType}' because its CLR type '{clrType}' does not match the expected CLR type '{targetType}'.</value>
+    <value>The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because its CLR type '{clrType}' does not match the expected CLR type '{targetType}'.</value>
   </data>
   <data name="NavigationCollectionWrongClrType" xml:space="preserve">
-    <value>The collection navigation property '{navigation}' cannot be added to entity type '{entityType}' because its CLR type '{clrType}' does not implement 'IEnumerable&lt;{targetType}&gt;'. Collection navigation properties must implement IEnumerable&lt;&gt; of the related entity.</value>
-  </data>
-  <data name="NavigationNotFound" xml:space="preserve">
-    <value>The navigation property '{navigation}' on entity type '{entityType}' could not be found. Ensure that the navigation property exists and has been included in the model.</value>
-  </data>
-  <data name="MultipleNavigations" xml:space="preserve">
-    <value>The navigation properties '{navigation1}' and '{navigation2}' on entity type '{entityType}' are both backed by the same foreign key and point in the same direction. Each foreign key can have at most one navigation property and one inverse navigation property.</value>
+    <value>The collection navigation property '{navigation}' cannot be added to the entity type '{entityType}' because its CLR type '{clrType}' does not implement 'IEnumerable&lt;{targetType}&gt;'. Collection navigation properties must implement IEnumerable&lt;&gt; of the related entity.</value>
   </data>
   <data name="ForeignKeyCountMismatch" xml:space="preserve">
     <value>The number of properties specified for the foreign key {foreignKey} on entity type '{dependentType}' does not match the number of properties in the principal key {principalKey} on entity type '{principalType}'.</value>
@@ -292,19 +280,19 @@
     <value>The types of the properties specified for the foreign key {foreignKey} on entity type '{dependentType}' do not match the types of the properties in the principal key {principalKey} on entity type '{principalType}'.</value>
   </data>
   <data name="NavigationBadType" xml:space="preserve">
-    <value>The type of navigation property '{navigation}' on entity type '{entityType}' is '{foundType}' which does not implement ICollection&lt;{targetType}&gt;. Collection navigation properties must implement ICollection&lt;&gt; of the target type.</value>
+    <value>The type of navigation property '{navigation}' on the entity type '{entityType}' is '{foundType}' which does not implement ICollection&lt;{targetType}&gt;. Collection navigation properties must implement ICollection&lt;&gt; of the target type.</value>
   </data>
   <data name="NavigationArray" xml:space="preserve">
-    <value>The type of navigation property '{navigation}' on entity type '{entityType}' is '{foundType}' which is an array type.. Collection navigation properties cannot be arrays.</value>
+    <value>The type of navigation property '{navigation}' on the entity type '{entityType}' is '{foundType}' which is an array type.. Collection navigation properties cannot be arrays.</value>
   </data>
   <data name="NavigationNoGetter" xml:space="preserve">
-    <value>The navigation property '{navigation}' on entity type '{entityType}' does not have a getter.</value>
+    <value>The navigation property '{navigation}' on the entity type '{entityType}' does not have a getter.</value>
   </data>
   <data name="NavigationNoSetter" xml:space="preserve">
-    <value>The navigation property '{navigation}' on entity type '{entityType}' does not have a setter. Read-only collection navigation properties must be initialized before use.</value>
+    <value>The navigation property '{navigation}' on the entity type '{entityType}' does not have a setter. Read-only collection navigation properties must be initialized before use.</value>
   </data>
   <data name="NavigationCannotCreateType" xml:space="preserve">
-    <value>The type of navigation property '{navigation}' on entity type '{entityType}' is '{foundType}' for which it was not possible to create a concrete instance. Either initialize the property before use, add a public parameterless constructor to the type, or use a type which can be assigned a HashSet&lt;&gt; or List&lt;&gt;.</value>
+    <value>The type of navigation property '{navigation}' on the entity type '{entityType}' is '{foundType}' for which it was not possible to create a concrete instance. Either initialize the property before use, add a public parameterless constructor to the type, or use a type which can be assigned a HashSet&lt;&gt; or List&lt;&gt;.</value>
   </data>
   <data name="KeyReadOnly" xml:space="preserve">
     <value>The property '{property}' on entity type '{entityType}' is part of a key and so cannot be modified or marked as modified.</value>
@@ -334,7 +322,7 @@
     <value>The key {key} cannot be added to the entity type '{entityType}' because a key on the same properties already exists on entity type '{duplicateEntityType}'.</value>
   </data>
   <data name="NavigationToShadowEntity" xml:space="preserve">
-    <value>The navigation property '{navigation}' cannot be added to entity type '{entityType}' because the target entity type '{targetType}' is defined in shadow state and navigations properties cannot point to shadow state entities.</value>
+    <value>The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because the target entity type '{targetType}' is defined in shadow state and navigations properties cannot point to shadow state entities.</value>
   </data>
   <data name="CollectionArgumentContainsNulls" xml:space="preserve">
     <value>The collection argument '{argumentName}' must not contain any null references.</value>
@@ -435,9 +423,6 @@
   <data name="ForeignKeyReferencedEntityKeyMismatch" xml:space="preserve">
     <value>The provided principal entity key '{principalKey}' is not a key on the entity type '{principalEntityType}'.</value>
   </data>
-  <data name="NavigationForWrongForeignKey" xml:space="preserve">
-    <value>The navigation for property '{navigation}' on entity type '{entityType}' cannot be associated with foreign key {targetFk} because it was created for foreign key {actualFk}.</value>
-  </data>
   <data name="WrongGenericPropertyType" xml:space="preserve">
     <value>Property '{property}' on entity type '{entityType}' is of type '{actualType}' but the generic type provided is of type '{genericType}'.</value>
   </data>
@@ -461,12 +446,6 @@
   </data>
   <data name="CompositePKWithDataAnnotation" xml:space="preserve">
     <value>Entity type '{entityType}' has composite primary key defined with data annotations. To set composite primary key, use fluent API.</value>
-  </data>
-  <data name="NavigationStillOnEntityType" xml:space="preserve">
-    <value>The navigation property '{navigation}' cannot be removed because it is still referenced from entity type '{entityType}'.</value>
-  </data>
-  <data name="IntraHierarchicalAmbiguousNavigation" xml:space="preserve">
-    <value>The navigation property corresponding to '{entityType}' cannot be determined because the principal entity type for foreign key {foreignKey} is '{principalEntityType}' and it is in the same hierarchy as the dependent entity type '{dependentEntityType}'.</value>
   </data>
   <data name="DuplicateNavigationsOnBase" xml:space="preserve">
     <value>The type '{entityType}' cannot have base type '{baseType}' because both types include the navigations: {navigations}.</value>
@@ -531,9 +510,6 @@
   <data name="EntityTypeNotInRelationshipStrict" xml:space="preserve">
     <value>The specified entity type '{entityType}' is invalid. It should be either the dependent entity type '{dependentType}' or the principal entity type '{principalType}'.</value>
   </data>
-  <data name="SelfReferencingAmbiguousNavigation" xml:space="preserve">
-    <value>The navigation property corresponding to '{entityType}' cannot be determined because the principal entity type for foreign key {foreignKey} is the same as the dependent entity type.</value>
-  </data>
   <data name="EntityTypeInUseByDerived" xml:space="preserve">
     <value>The entity type '{entityType}' cannot be removed because '{derivedEntityType}' is derived from it. All derived entity types must be removed or redefined before the entity type can be removed.</value>
   </data>
@@ -545,5 +521,8 @@
   </data>
   <data name="PropertyNotMapped" xml:space="preserve">
     <value>The property '{property}' on entity type '{entityType}' has CLR type which is not supported by current provider and it has not been configured to use any supported column type.</value>
+  </data>
+  <data name="NavigationForWrongForeignKey" xml:space="preserve">
+    <value>The navigation property '{navigation}' on entity type '{entityType}' cannot be associated with foreign key {targetFk} because it was created for foreign key {actualFk}.</value>
   </data>
 </root>

--- a/src/EntityFramework.Relational/Update/Internal/CommandBatchPreparer.cs
+++ b/src/EntityFramework.Relational/Update/Internal/CommandBatchPreparer.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Data.Entity.Update.Internal
                     foreach (var entry in command.Entries)
                     {
                         // TODO: Perf: Consider only adding foreign keys defined on entity types involved in a modification
-                        foreach (var foreignKey in entry.EntityType.FindReferencingForeignKeys())
+                        foreach (var foreignKey in entry.EntityType.GetReferencingForeignKeys())
                         {
                             var candidateKeyValueColumnModifications =
                                 command.ColumnModifications.Where(cm =>
@@ -211,7 +211,7 @@ namespace Microsoft.Data.Entity.Update.Internal
                 {
                     foreach (var entry in command.Entries)
                     {
-                        foreach (var foreignKey in entry.EntityType.FindReferencingForeignKeys())
+                        foreach (var foreignKey in entry.EntityType.GetReferencingForeignKeys())
                         {
                             var principalKeyValue = CreatePrincipalKeyValue(entry, foreignKey, ValueType.Original);
 

--- a/test/EntityFramework.Core.FunctionalTests/TestUtilities/Extensions.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestUtilities/Extensions.cs
@@ -147,7 +147,9 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     targetPrincipalEntityType.FindKey(navigation.ForeignKey.PrincipalKey.Properties.Select(
                         p => targetPrincipalEntityType.FindProperty(p.Name)).ToList()),
                     targetPrincipalEntityType);
-                var clonedNavigation = targetEntityType.AddNavigation(navigation.Name, targetForeignKey, pointsToPrincipal: navigation.IsDependentToPrincipal());
+                var clonedNavigation = navigation.IsDependentToPrincipal()
+                    ? targetForeignKey.HasDependentToPrincipal(navigation.Name)
+                    : targetForeignKey.HasPrincipalToDependent(navigation.Name);
                 navigation.Annotations.ForEach(annotation => clonedNavigation[annotation.Name] = annotation.Value);
             }
         }

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/RelationshipsSnapshotTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/RelationshipsSnapshotTest.cs
@@ -308,8 +308,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             entityType.AddProperty("Name", typeof(string)).IsShadowProperty = false;
 
-            entityType.AddNavigation("LesserBananas", fk, pointsToPrincipal: false);
-            entityType.AddNavigation("TopBanana", fk, pointsToPrincipal: true);
+            fk.HasPrincipalToDependent("LesserBananas");
+            fk.HasDependentToPrincipal("TopBanana");
 
             return model;
         }

--- a/test/EntityFramework.Core.Tests/Metadata/Internal/ClrCollectionAccessorFactoryTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/Internal/ClrCollectionAccessorFactoryTest.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 entityType.GetOrSetPrimaryKey(entityType.AddProperty("Id", typeof(int))),
                 entityType);
 
-            return entityType.AddNavigation(navigationName, foreignKey, pointsToPrincipal: false);
+            return foreignKey.HasPrincipalToDependent(navigationName);
         }
 
         private class MyEntity

--- a/test/EntityFramework.Core.Tests/Metadata/Internal/ForeignKeyTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/Internal/ForeignKeyTest.cs
@@ -22,9 +22,9 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
             var foreignKey
                 = new ForeignKey(new[] { dependentProp }, entityType.FindPrimaryKey(), entityType, entityType)
-                    {
-                        IsUnique = true
-                    };
+                {
+                    IsUnique = true
+                };
 
             Assert.Same(entityType, foreignKey.PrincipalEntityType);
             Assert.Same(principalProp, foreignKey.PrincipalKey.Properties.Single());
@@ -79,10 +79,10 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var property2 = principalType.AddProperty("Id1", typeof(int));
             var property3 = principalType.AddProperty("Id2", typeof(int));
             principalType.GetOrSetPrimaryKey(new[]
-                {
-                    property2,
-                    property3
-                });
+            {
+                property2,
+                property3
+            });
 
             Assert.Equal(
                 CoreStrings.ForeignKeyTypeMismatch("{'P1', 'P2'}", "D", "{'Id1', 'Id2'}", "P"),
@@ -102,9 +102,9 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
             var foreignKey
                 = new ForeignKey(new[] { dependentProp }, principalKey, entityType, entityType)
-                    {
-                        IsUnique = false
-                    };
+                {
+                    IsUnique = false
+                };
 
             Assert.Same(entityType, foreignKey.PrincipalEntityType);
             Assert.Same(principalProp, foreignKey.PrincipalKey.Properties.Single());
@@ -182,10 +182,10 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var property = entityType.AddProperty("Id1", typeof(int));
             var property1 = entityType.AddProperty("Id2", typeof(string));
             entityType.GetOrSetPrimaryKey(new[]
-                {
-                    property,
-                    property1
-                });
+            {
+                property,
+                property1
+            });
 
             var dependentProp1 = entityType.AddProperty("P1", typeof(int));
             var dependentProp2 = entityType.AddProperty("P2", typeof(string));
@@ -203,10 +203,10 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var property = entityType.AddProperty("Id1", typeof(int));
             var property1 = entityType.AddProperty("Id2", typeof(string));
             entityType.GetOrSetPrimaryKey(new[]
-                {
-                    property,
-                    property1
-                });
+            {
+                property,
+                property1
+            });
 
             var dependentProp1 = entityType.AddProperty("P1", typeof(int));
             var dependentProp2 = entityType.AddProperty("P2", typeof(string));
@@ -231,16 +231,16 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var property3 = entityType.AddProperty("Id2", typeof(string));
             entityType.GetOrSetPrimaryKey(
                 new[]
-                    {
-                        property,
-                        property3
-                    });
+                {
+                    property,
+                    property3
+                });
 
             var dependentProp1 = entityType.AddProperty("P1", typeof(int));
             var dependentProp2 = entityType.AddProperty("P2", typeof(string));
 
             var foreignKey = new ForeignKey(new[] { dependentProp1, dependentProp2 }, entityType.FindPrimaryKey(), entityType, entityType)
-                { IsRequired = true };
+            { IsRequired = true };
 
             Assert.True(foreignKey.IsRequired.Value);
             Assert.False(dependentProp1.IsNullable.Value);
@@ -254,10 +254,10 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var property = entityType.AddProperty("Id1", typeof(int));
             var property1 = entityType.AddProperty("Id2", typeof(string));
             entityType.GetOrSetPrimaryKey(new[]
-                {
-                    property,
-                    property1
-                });
+            {
+                property,
+                property1
+            });
 
             var dependentProp1 = entityType.AddProperty("P1", typeof(int?));
             var dependentProp2 = entityType.AddProperty("P2", typeof(string));
@@ -268,7 +268,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             Assert.True(dependentProp1.IsNullable.Value);
             Assert.True(dependentProp2.IsNullable.Value);
         }
-        
+
         private ForeignKey CreateOneToManyFK()
         {
             var model = new Model();
@@ -279,9 +279,8 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var dependentEntityType = model.AddEntityType(typeof(OneToManyDependent));
             var fkProp = dependentEntityType.AddProperty(NavigationBase.IdProperty);
             var fk = dependentEntityType.AddForeignKey(new[] { fkProp }, pk, principalEntityType);
-
-            principalEntityType.AddNavigation("OneToManyDependents", fk, pointsToPrincipal: false);
-            dependentEntityType.AddNavigation("OneToManyPrincipal", fk, pointsToPrincipal: true);
+            fk.HasPrincipalToDependent("OneToManyDependents");
+            fk.HasDependentToPrincipal("OneToManyPrincipal");
             return fk;
         }
 
@@ -300,9 +299,8 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             dependentEntityType.BaseType = baseEntityType;
             var fkProp = dependentEntityType.AddProperty("Fk", typeof(int));
             var fk = dependentEntityType.AddForeignKey(new[] { fkProp }, pk, principalEntityType);
-
-            principalEntityType.AddNavigation("OneToManyDependents", fk, pointsToPrincipal: false);
-            dependentEntityType.AddNavigation("OneToManyPrincipal", fk, pointsToPrincipal: true);
+            fk.HasPrincipalToDependent("OneToManyDependents");
+            fk.HasDependentToPrincipal("OneToManyPrincipal");
             return fk;
         }
 
@@ -318,8 +316,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             dependentEntityType.BaseType = baseEntityType;
             var fkProp = dependentEntityType.AddProperty("Fk", typeof(int));
             var fk = dependentEntityType.AddForeignKey(new[] { fkProp }, pk, baseEntityType);
-
-            baseEntityType.AddNavigation("OneToManyDependents", fk, pointsToPrincipal: false);
+            fk.HasPrincipalToDependent("OneToManyDependents");
             return fk;
         }
 
@@ -354,70 +351,42 @@ namespace Microsoft.Data.Entity.Metadata.Internal
         public void Throws_when_setting_navigation_to_principal_on_wrong_FK()
         {
             var foreignKey1 = CreateOneToManyFK();
-            foreignKey1.DeclaringEntityType.RemoveNavigation(foreignKey1.DependentToPrincipal.Name);
-            var navigation = foreignKey1.DeclaringEntityType.AddNavigation("Deception", foreignKey1, pointsToPrincipal: true);
+            foreignKey1.HasDependentToPrincipal("Deception");
 
-            var foreignKey2 = CreateSelfRefFK();
+            var newFkProp = foreignKey1.DeclaringEntityType.AddProperty("FkProp", typeof(int));
+            var foreignKey2 = foreignKey1.DeclaringEntityType.AddForeignKey(
+                new[] { newFkProp },
+                foreignKey1.PrincipalEntityType.FindPrimaryKey(),
+                foreignKey1.PrincipalEntityType);
 
             Assert.Equal(
-                CoreStrings.NavigationForWrongForeignKey("Deception", "OneToManyDependent", Property.Format(foreignKey2.Properties), Property.Format(foreignKey1.Properties)),
-                Assert.Throws<InvalidOperationException>(() => foreignKey2.DependentToPrincipal = navigation).Message);
+                CoreStrings.NavigationForWrongForeignKey(
+                    "Deception",
+                    nameof(OneToManyDependent),
+                    Property.Format(foreignKey2.Properties),
+                    Property.Format(foreignKey1.Properties)),
+                Assert.Throws<InvalidOperationException>(() => foreignKey2.HasDependentToPrincipal("Deception")).Message);
         }
 
         [Fact]
         public void Throws_when_setting_navigation_to_dependent_on_wrong_FK()
         {
             var foreignKey1 = CreateOneToManyFK();
-            foreignKey1.PrincipalEntityType.RemoveNavigation(foreignKey1.PrincipalToDependent.Name);
-            var navigation = foreignKey1.PrincipalEntityType.AddNavigation("Deception", foreignKey1, pointsToPrincipal: false);
+            foreignKey1.HasPrincipalToDependent("Deception");
 
-            var foreignKey2 = CreateSelfRefFK();
-
-            Assert.Equal(
-                CoreStrings.NavigationForWrongForeignKey("Deception", "OneToManyPrincipal", Property.Format(foreignKey2.Properties), Property.Format(foreignKey1.Properties)),
-                Assert.Throws<InvalidOperationException>(() => foreignKey2.PrincipalToDependent = navigation).Message);
-        }
-
-        [Fact]
-        public void Throws_when_setting_navigation_to_principal_directly()
-        {
-            var foreignKey = CreateOneToManyFK();
-
-            var newNav = new Navigation("NewNav", foreignKey);
-            Assert.Equal(
-                CoreStrings.NavigationNotFound("NewNav", foreignKey.DeclaringEntityType.Name),
-                Assert.Throws<InvalidOperationException>(() => foreignKey.DependentToPrincipal = newNav).Message);
-        }
-
-        [Fact]
-        public void Throws_when_setting_navigation_to_dependent_directly()
-        {
-            var foreignKey = CreateOneToManyFK();
-
-            var newNav = new Navigation("NewNav", foreignKey);
-            Assert.Equal(
-                CoreStrings.NavigationNotFound("NewNav", foreignKey.PrincipalEntityType.Name),
-                Assert.Throws<InvalidOperationException>(() => foreignKey.PrincipalToDependent = newNav).Message);
-        }
-
-        [Fact]
-        public void Throws_when_setting_navigation_to_principal_to_null_directly()
-        {
-            var foreignKey = CreateOneToManyFK();
+            var newFkProp = foreignKey1.DeclaringEntityType.AddProperty("FkProp", typeof(int));
+            var foreignKey2 = foreignKey1.DeclaringEntityType.AddForeignKey(
+                new[] { newFkProp },
+                foreignKey1.PrincipalEntityType.FindPrimaryKey(),
+                foreignKey1.PrincipalEntityType);
 
             Assert.Equal(
-                CoreStrings.NavigationStillOnEntityType(foreignKey.DependentToPrincipal.Name, foreignKey.DeclaringEntityType),
-                Assert.Throws<InvalidOperationException>(() => foreignKey.DependentToPrincipal = null).Message);
-        }
-
-        [Fact]
-        public void Throws_when_setting_navigation_to_dependent_to_null_directly()
-        {
-            var foreignKey = CreateOneToManyFK();
-
-            Assert.Equal(
-                CoreStrings.NavigationStillOnEntityType(foreignKey.PrincipalToDependent.Name, foreignKey.PrincipalEntityType),
-                Assert.Throws<InvalidOperationException>(() => foreignKey.PrincipalToDependent = null).Message);
+                CoreStrings.NavigationForWrongForeignKey(
+                    "Deception",
+                    nameof(OneToManyPrincipal),
+                    Property.Format(foreignKey2.Properties),
+                    Property.Format(foreignKey1.Properties)),
+                Assert.Throws<InvalidOperationException>(() => foreignKey2.HasPrincipalToDependent("Deception")).Message);
         }
 
         private ForeignKey CreateSelfRefFK(bool useAltKey = false)
@@ -433,8 +402,8 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
             var fk = entityType.AddForeignKey(new[] { fkProp }, principalKey, entityType);
             fk.IsUnique = true;
-            entityType.AddNavigation("SelfRefPrincipal", fk, pointsToPrincipal: true);
-            entityType.AddNavigation("SelfRefDependent", fk, pointsToPrincipal: false);
+            fk.HasDependentToPrincipal("SelfRefPrincipal");
+            fk.HasPrincipalToDependent("SelfRefDependent");
             return fk;
         }
 
@@ -608,19 +577,19 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
             Assert.Same(fk.PrincipalEntityType, fk.ResolveOtherEntityType(fk.DeclaringEntityType));
             Assert.Same(fk.DeclaringEntityType, fk.ResolveOtherEntityType(fk.PrincipalEntityType));
-            Assert.Same(fk.PrincipalToDependent, fk.FindNavigationFrom(fk.PrincipalEntityType));
-            Assert.Same(fk.DependentToPrincipal, fk.FindNavigationFrom(fk.DeclaringEntityType));
-            Assert.Same(fk.DependentToPrincipal, fk.FindNavigationTo(fk.PrincipalEntityType));
-            Assert.Same(fk.PrincipalToDependent, fk.FindNavigationTo(fk.DeclaringEntityType));
+            Assert.Equal(new[] { fk.PrincipalToDependent }, fk.FindNavigationsFrom(fk.PrincipalEntityType));
+            Assert.Equal(new[] { fk.DependentToPrincipal }, fk.FindNavigationsFrom(fk.DeclaringEntityType));
+            Assert.Equal(new[] { fk.DependentToPrincipal }, fk.FindNavigationsTo(fk.PrincipalEntityType));
+            Assert.Equal(new[] { fk.PrincipalToDependent }, fk.FindNavigationsTo(fk.DeclaringEntityType));
 
             Assert.Same(fk.DeclaringEntityType, fk.ResolveEntityTypeInHierarchy(fk.DeclaringEntityType));
             Assert.Same(fk.PrincipalEntityType, fk.ResolveEntityTypeInHierarchy(fk.PrincipalEntityType));
             Assert.Same(fk.PrincipalEntityType, fk.ResolveOtherEntityTypeInHierarchy(fk.DeclaringEntityType));
             Assert.Same(fk.DeclaringEntityType, fk.ResolveOtherEntityTypeInHierarchy(fk.PrincipalEntityType));
-            Assert.Same(fk.PrincipalToDependent, fk.FindNavigationFromInHierarchy(fk.PrincipalEntityType));
-            Assert.Same(fk.DependentToPrincipal, fk.FindNavigationFromInHierarchy(fk.DeclaringEntityType));
-            Assert.Same(fk.DependentToPrincipal, fk.FindNavigationToInHierarchy(fk.PrincipalEntityType));
-            Assert.Same(fk.PrincipalToDependent, fk.FindNavigationToInHierarchy(fk.DeclaringEntityType));
+            Assert.Equal(new[] { fk.PrincipalToDependent }, fk.FindNavigationsFromInHierarchy(fk.PrincipalEntityType));
+            Assert.Equal(new[] { fk.DependentToPrincipal }, fk.FindNavigationsFromInHierarchy(fk.DeclaringEntityType));
+            Assert.Equal(new[] { fk.DependentToPrincipal }, fk.FindNavigationsToInHierarchy(fk.PrincipalEntityType));
+            Assert.Equal(new[] { fk.PrincipalToDependent }, fk.FindNavigationsToInHierarchy(fk.DeclaringEntityType));
         }
 
         [Fact]
@@ -637,19 +606,19 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
             Assert.Same(fk.PrincipalEntityType, fk.ResolveOtherEntityType(fk.DeclaringEntityType));
             Assert.Same(fk.DeclaringEntityType, fk.ResolveOtherEntityType(fk.PrincipalEntityType));
-            Assert.Same(fk.PrincipalToDependent, fk.FindNavigationFrom(fk.PrincipalEntityType));
-            Assert.Same(fk.DependentToPrincipal, fk.FindNavigationFrom(fk.DeclaringEntityType));
-            Assert.Same(fk.DependentToPrincipal, fk.FindNavigationTo(fk.PrincipalEntityType));
-            Assert.Same(fk.PrincipalToDependent, fk.FindNavigationTo(fk.DeclaringEntityType));
+            Assert.Same(fk.PrincipalToDependent, fk.FindNavigationsFrom(fk.PrincipalEntityType).SingleOrDefault());
+            Assert.Same(fk.DependentToPrincipal, fk.FindNavigationsFrom(fk.DeclaringEntityType).SingleOrDefault());
+            Assert.Same(fk.DependentToPrincipal, fk.FindNavigationsTo(fk.PrincipalEntityType).SingleOrDefault());
+            Assert.Same(fk.PrincipalToDependent, fk.FindNavigationsTo(fk.DeclaringEntityType).SingleOrDefault());
 
             Assert.Same(fk.DeclaringEntityType, fk.ResolveEntityTypeInHierarchy(fk.DeclaringEntityType));
             Assert.Same(fk.PrincipalEntityType, fk.ResolveEntityTypeInHierarchy(fk.PrincipalEntityType));
             Assert.Same(fk.PrincipalEntityType, fk.ResolveOtherEntityTypeInHierarchy(fk.DeclaringEntityType));
             Assert.Same(fk.DeclaringEntityType, fk.ResolveOtherEntityTypeInHierarchy(fk.PrincipalEntityType));
-            Assert.Same(fk.PrincipalToDependent, fk.FindNavigationFromInHierarchy(fk.PrincipalEntityType));
-            Assert.Same(fk.DependentToPrincipal, fk.FindNavigationFromInHierarchy(fk.DeclaringEntityType));
-            Assert.Same(fk.DependentToPrincipal, fk.FindNavigationToInHierarchy(fk.PrincipalEntityType));
-            Assert.Same(fk.PrincipalToDependent, fk.FindNavigationToInHierarchy(fk.DeclaringEntityType));
+            Assert.Same(fk.PrincipalToDependent, fk.FindNavigationsFromInHierarchy(fk.PrincipalEntityType).SingleOrDefault());
+            Assert.Same(fk.DependentToPrincipal, fk.FindNavigationsFromInHierarchy(fk.DeclaringEntityType).SingleOrDefault());
+            Assert.Same(fk.DependentToPrincipal, fk.FindNavigationsToInHierarchy(fk.PrincipalEntityType).SingleOrDefault());
+            Assert.Same(fk.PrincipalToDependent, fk.FindNavigationsToInHierarchy(fk.DeclaringEntityType).SingleOrDefault());
 
             Assert.Equal(
                 CoreStrings.EntityTypeNotInRelationshipStrict(derivedDependent.DisplayName(), fk.DeclaringEntityType.DisplayName(), fk.PrincipalEntityType.DisplayName()),
@@ -659,25 +628,25 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 Assert.Throws<ArgumentException>(() => fk.ResolveOtherEntityType(derivedPrincipal)).Message);
             Assert.Equal(
                 CoreStrings.EntityTypeNotInRelationshipStrict(derivedPrincipal.DisplayName(), fk.DeclaringEntityType.DisplayName(), fk.PrincipalEntityType.DisplayName()),
-                Assert.Throws<ArgumentException>(() => fk.FindNavigationFrom(derivedPrincipal)).Message);
+                Assert.Throws<ArgumentException>(() => fk.FindNavigationsFrom(derivedPrincipal)).Message);
             Assert.Equal(
                 CoreStrings.EntityTypeNotInRelationshipStrict(derivedDependent.DisplayName(), fk.DeclaringEntityType.DisplayName(), fk.PrincipalEntityType.DisplayName()),
-                Assert.Throws<ArgumentException>(() => fk.FindNavigationFrom(derivedDependent)).Message);
+                Assert.Throws<ArgumentException>(() => fk.FindNavigationsFrom(derivedDependent)).Message);
             Assert.Equal(
                 CoreStrings.EntityTypeNotInRelationshipStrict(derivedPrincipal.DisplayName(), fk.DeclaringEntityType.DisplayName(), fk.PrincipalEntityType.DisplayName()),
-                Assert.Throws<ArgumentException>(() => fk.FindNavigationTo(derivedPrincipal)).Message);
+                Assert.Throws<ArgumentException>(() => fk.FindNavigationsTo(derivedPrincipal)).Message);
             Assert.Equal(
                 CoreStrings.EntityTypeNotInRelationshipStrict(derivedDependent.DisplayName(), fk.DeclaringEntityType.DisplayName(), fk.PrincipalEntityType.DisplayName()),
-                Assert.Throws<ArgumentException>(() => fk.FindNavigationTo(derivedDependent)).Message);
-            
+                Assert.Throws<ArgumentException>(() => fk.FindNavigationsTo(derivedDependent)).Message);
+
             Assert.Same(fk.DeclaringEntityType, fk.ResolveEntityTypeInHierarchy(derivedDependent));
             Assert.Same(fk.PrincipalEntityType, fk.ResolveEntityTypeInHierarchy(derivedPrincipal));
             Assert.Same(fk.PrincipalEntityType, fk.ResolveOtherEntityTypeInHierarchy(derivedDependent));
             Assert.Same(fk.DeclaringEntityType, fk.ResolveOtherEntityTypeInHierarchy(derivedPrincipal));
-            Assert.Same(fk.PrincipalToDependent, fk.FindNavigationFromInHierarchy(derivedPrincipal));
-            Assert.Same(fk.DependentToPrincipal, fk.FindNavigationFromInHierarchy(derivedDependent));
-            Assert.Same(fk.DependentToPrincipal, fk.FindNavigationToInHierarchy(derivedPrincipal));
-            Assert.Same(fk.PrincipalToDependent, fk.FindNavigationToInHierarchy(derivedDependent));
+            Assert.Equal(new[] { fk.PrincipalToDependent }.Where(n => n != null), fk.FindNavigationsFromInHierarchy(derivedPrincipal));
+            Assert.Equal(new[] { fk.DependentToPrincipal }.Where(n => n != null), fk.FindNavigationsFromInHierarchy(derivedDependent));
+            Assert.Equal(new[] { fk.DependentToPrincipal }.Where(n => n != null), fk.FindNavigationsToInHierarchy(derivedPrincipal));
+            Assert.Equal(new[] { fk.PrincipalToDependent }.Where(n => n != null), fk.FindNavigationsToInHierarchy(derivedDependent));
         }
 
         [Fact]
@@ -687,68 +656,24 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
             Assert.Same(fk.PrincipalEntityType, fk.ResolveOtherEntityType(fk.DeclaringEntityType));
             Assert.Same(fk.DeclaringEntityType, fk.ResolveOtherEntityType(fk.PrincipalEntityType));
-            
-            Assert.Equal(
-                CoreStrings.SelfReferencingAmbiguousNavigation(
-                    fk.PrincipalEntityType.DisplayName(), Property.Format(fk.Properties)),
-                Assert.Throws<InvalidOperationException>(() => fk.FindNavigationFrom(fk.PrincipalEntityType)).Message);
-            Assert.Equal(
-                CoreStrings.SelfReferencingAmbiguousNavigation(
-                    fk.DeclaringEntityType.DisplayName(), Property.Format(fk.Properties)),
-                Assert.Throws<InvalidOperationException>(() => fk.FindNavigationFrom(fk.DeclaringEntityType)).Message);
 
-            Assert.Equal(
-                CoreStrings.SelfReferencingAmbiguousNavigation(
-                    fk.PrincipalEntityType.DisplayName(), Property.Format(fk.Properties)),
-                Assert.Throws<InvalidOperationException>(() => fk.FindNavigationTo(fk.PrincipalEntityType)).Message);
-            Assert.Equal(
-                CoreStrings.SelfReferencingAmbiguousNavigation(
-                    fk.DeclaringEntityType.DisplayName(), Property.Format(fk.Properties)),
-                Assert.Throws<InvalidOperationException>(() => fk.FindNavigationTo(fk.DeclaringEntityType)).Message);
+            Assert.Equal(new[] { fk.PrincipalToDependent, fk.DependentToPrincipal },
+                fk.FindNavigationsFrom(fk.PrincipalEntityType).ToArray());
+            Assert.Equal(new[] { fk.PrincipalToDependent, fk.DependentToPrincipal },
+                fk.FindNavigationsFrom(fk.DeclaringEntityType).ToArray());
+            Assert.Equal(new[] { fk.PrincipalToDependent, fk.DependentToPrincipal },
+                fk.FindNavigationsTo(fk.PrincipalEntityType).ToArray());
+            Assert.Equal(new[] { fk.PrincipalToDependent, fk.DependentToPrincipal },
+                fk.FindNavigationsTo(fk.DeclaringEntityType).ToArray());
 
-            Assert.Equal(
-                CoreStrings.IntraHierarchicalAmbiguousTargetEntityType(
-                    fk.DeclaringEntityType.DisplayName(), Property.Format(fk.Properties),
-                    fk.PrincipalEntityType.DisplayName(), fk.DeclaringEntityType.DisplayName()),
-                Assert.Throws<InvalidOperationException>(() => fk.ResolveEntityTypeInHierarchy(fk.DeclaringEntityType)).Message);
-            Assert.Equal(
-                CoreStrings.IntraHierarchicalAmbiguousTargetEntityType(
-                    fk.PrincipalEntityType.DisplayName(), Property.Format(fk.Properties),
-                    fk.PrincipalEntityType.DisplayName(), fk.DeclaringEntityType.DisplayName()),
-                Assert.Throws<InvalidOperationException>(() => fk.ResolveEntityTypeInHierarchy(fk.PrincipalEntityType)).Message);
-
-            Assert.Equal(
-                CoreStrings.IntraHierarchicalAmbiguousTargetEntityType(
-                    fk.DeclaringEntityType.DisplayName(), Property.Format(fk.Properties),
-                    fk.PrincipalEntityType.DisplayName(), fk.DeclaringEntityType.DisplayName()),
-                Assert.Throws<InvalidOperationException>(() => fk.ResolveOtherEntityTypeInHierarchy(fk.DeclaringEntityType)).Message);
-            Assert.Equal(
-                CoreStrings.IntraHierarchicalAmbiguousTargetEntityType(
-                    fk.PrincipalEntityType.DisplayName(), Property.Format(fk.Properties),
-                    fk.PrincipalEntityType.DisplayName(), fk.DeclaringEntityType.DisplayName()),
-                Assert.Throws<InvalidOperationException>(() => fk.ResolveOtherEntityTypeInHierarchy(fk.PrincipalEntityType)).Message);
-
-            Assert.Equal(
-                CoreStrings.IntraHierarchicalAmbiguousNavigation(
-                    fk.PrincipalEntityType.DisplayName(), Property.Format(fk.Properties),
-                    fk.PrincipalEntityType.DisplayName(), fk.DeclaringEntityType.DisplayName()),
-                Assert.Throws<InvalidOperationException>(() => fk.FindNavigationFromInHierarchy(fk.PrincipalEntityType)).Message);
-            Assert.Equal(
-                CoreStrings.IntraHierarchicalAmbiguousNavigation(
-                    fk.DeclaringEntityType.DisplayName(), Property.Format(fk.Properties),
-                    fk.PrincipalEntityType.DisplayName(), fk.DeclaringEntityType.DisplayName()),
-                Assert.Throws<InvalidOperationException>(() => fk.FindNavigationFromInHierarchy(fk.DeclaringEntityType)).Message);
-
-            Assert.Equal(
-                CoreStrings.IntraHierarchicalAmbiguousNavigation(
-                    fk.PrincipalEntityType.DisplayName(), Property.Format(fk.Properties),
-                    fk.PrincipalEntityType.DisplayName(), fk.DeclaringEntityType.DisplayName()),
-                Assert.Throws<InvalidOperationException>(() => fk.FindNavigationToInHierarchy(fk.PrincipalEntityType)).Message);
-            Assert.Equal(
-                CoreStrings.IntraHierarchicalAmbiguousNavigation(
-                    fk.DeclaringEntityType.DisplayName(), Property.Format(fk.Properties),
-                    fk.PrincipalEntityType.DisplayName(), fk.DeclaringEntityType.DisplayName()),
-                Assert.Throws<InvalidOperationException>(() => fk.FindNavigationToInHierarchy(fk.DeclaringEntityType)).Message);
+            Assert.Equal(new[] { fk.PrincipalToDependent, fk.DependentToPrincipal },
+                fk.FindNavigationsFromInHierarchy(fk.PrincipalEntityType).ToArray());
+            Assert.Equal(new[] { fk.PrincipalToDependent, fk.DependentToPrincipal },
+                fk.FindNavigationsFromInHierarchy(fk.DeclaringEntityType).ToArray());
+            Assert.Equal(new[] { fk.PrincipalToDependent, fk.DependentToPrincipal },
+                fk.FindNavigationsToInHierarchy(fk.PrincipalEntityType).ToArray());
+            Assert.Equal(new[] { fk.PrincipalToDependent, fk.DependentToPrincipal },
+                fk.FindNavigationsToInHierarchy(fk.DeclaringEntityType).ToArray());
         }
 
         [Fact]
@@ -758,11 +683,11 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
             Assert.Same(fk.PrincipalEntityType, fk.ResolveOtherEntityType(fk.DeclaringEntityType));
             Assert.Same(fk.DeclaringEntityType, fk.ResolveOtherEntityType(fk.PrincipalEntityType));
-            Assert.Same(fk.PrincipalToDependent, fk.FindNavigationFrom(fk.PrincipalEntityType));
-            Assert.Same(fk.DependentToPrincipal, fk.FindNavigationFrom(fk.DeclaringEntityType));
-            Assert.Same(fk.DependentToPrincipal, fk.FindNavigationTo(fk.PrincipalEntityType));
-            Assert.Same(fk.PrincipalToDependent, fk.FindNavigationTo(fk.DeclaringEntityType));
-            
+            Assert.Same(fk.PrincipalToDependent, fk.FindNavigationsFrom(fk.PrincipalEntityType).SingleOrDefault());
+            Assert.Same(fk.DependentToPrincipal, fk.FindNavigationsFrom(fk.DeclaringEntityType).SingleOrDefault());
+            Assert.Same(fk.DependentToPrincipal, fk.FindNavigationsTo(fk.PrincipalEntityType).SingleOrDefault());
+            Assert.Same(fk.PrincipalToDependent, fk.FindNavigationsTo(fk.DeclaringEntityType).SingleOrDefault());
+
             Assert.Equal(
                 CoreStrings.IntraHierarchicalAmbiguousTargetEntityType(fk.DeclaringEntityType.DisplayName(), Property.Format(fk.Properties), fk.PrincipalEntityType.DisplayName(), fk.DeclaringEntityType.DisplayName()),
                 Assert.Throws<InvalidOperationException>(() => fk.ResolveEntityTypeInHierarchy(fk.DeclaringEntityType)).Message);
@@ -777,23 +702,14 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 CoreStrings.IntraHierarchicalAmbiguousTargetEntityType(fk.PrincipalEntityType.DisplayName(), Property.Format(fk.Properties), fk.PrincipalEntityType.DisplayName(), fk.DeclaringEntityType.DisplayName()),
                 Assert.Throws<InvalidOperationException>(() => fk.ResolveOtherEntityTypeInHierarchy(fk.PrincipalEntityType)).Message);
 
-            Assert.Equal(
-                CoreStrings.IntraHierarchicalAmbiguousNavigation(fk.PrincipalEntityType.DisplayName(), Property.Format(fk.Properties),
-                    fk.PrincipalEntityType.DisplayName(), fk.DeclaringEntityType.DisplayName()),
-                Assert.Throws<InvalidOperationException>(() => fk.FindNavigationFromInHierarchy(fk.PrincipalEntityType)).Message);
-            Assert.Equal(
-                CoreStrings.IntraHierarchicalAmbiguousNavigation(fk.DeclaringEntityType.DisplayName(), Property.Format(fk.Properties),
-                    fk.PrincipalEntityType.DisplayName(), fk.DeclaringEntityType.DisplayName()),
-                Assert.Throws<InvalidOperationException>(() => fk.FindNavigationFromInHierarchy(fk.DeclaringEntityType)).Message);
-
-            Assert.Equal(
-                CoreStrings.IntraHierarchicalAmbiguousNavigation(fk.PrincipalEntityType.DisplayName(), Property.Format(fk.Properties),
-                    fk.PrincipalEntityType.DisplayName(), fk.DeclaringEntityType.DisplayName()),
-                Assert.Throws<InvalidOperationException>(() => fk.FindNavigationToInHierarchy(fk.PrincipalEntityType)).Message);
-            Assert.Equal(
-                CoreStrings.IntraHierarchicalAmbiguousNavigation(fk.DeclaringEntityType.DisplayName(), Property.Format(fk.Properties),
-                    fk.PrincipalEntityType.DisplayName(), fk.DeclaringEntityType.DisplayName()),
-                Assert.Throws<InvalidOperationException>(() => fk.FindNavigationToInHierarchy(fk.DeclaringEntityType)).Message);
+            Assert.Equal(new[] { fk.PrincipalToDependent, fk.DependentToPrincipal }.Where(n => n != null),
+                fk.FindNavigationsFromInHierarchy(fk.PrincipalEntityType));
+            Assert.Equal(new[] { fk.PrincipalToDependent, fk.DependentToPrincipal }.Where(n => n != null),
+                fk.FindNavigationsFromInHierarchy(fk.DeclaringEntityType));
+            Assert.Equal(new[] { fk.PrincipalToDependent, fk.DependentToPrincipal }.Where(n => n != null),
+                fk.FindNavigationsToInHierarchy(fk.PrincipalEntityType));
+            Assert.Equal(new[] { fk.PrincipalToDependent, fk.DependentToPrincipal }.Where(n => n != null),
+                fk.FindNavigationsToInHierarchy(fk.DeclaringEntityType));
         }
 
         [Fact]
@@ -811,17 +727,17 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
             Assert.Equal(
                 CoreStrings.EntityTypeNotInRelationshipStrict(unrelatedType.DisplayName(), fk.DeclaringEntityType.DisplayName(), fk.PrincipalEntityType.DisplayName()),
-                Assert.Throws<ArgumentException>(() => fk.FindNavigationFrom(unrelatedType)).Message);
+                Assert.Throws<ArgumentException>(() => fk.FindNavigationsFrom(unrelatedType)).Message);
             Assert.Equal(
                 CoreStrings.EntityTypeNotInRelationshipStrict(unrelatedType.DisplayName(), fk.DeclaringEntityType.DisplayName(), fk.PrincipalEntityType.DisplayName()),
-                Assert.Throws<ArgumentException>(() => fk.FindNavigationFrom(unrelatedType)).Message);
+                Assert.Throws<ArgumentException>(() => fk.FindNavigationsFrom(unrelatedType)).Message);
 
             Assert.Equal(
                 CoreStrings.EntityTypeNotInRelationshipStrict(unrelatedType.DisplayName(), fk.DeclaringEntityType.DisplayName(), fk.PrincipalEntityType.DisplayName()),
-                Assert.Throws<ArgumentException>(() => fk.FindNavigationTo(unrelatedType)).Message);
+                Assert.Throws<ArgumentException>(() => fk.FindNavigationsTo(unrelatedType)).Message);
             Assert.Equal(
                 CoreStrings.EntityTypeNotInRelationshipStrict(unrelatedType.DisplayName(), fk.DeclaringEntityType.DisplayName(), fk.PrincipalEntityType.DisplayName()),
-                Assert.Throws<ArgumentException>(() => fk.FindNavigationTo(unrelatedType)).Message);
+                Assert.Throws<ArgumentException>(() => fk.FindNavigationsTo(unrelatedType)).Message);
 
             Assert.Equal(
                 CoreStrings.EntityTypeNotInRelationship(unrelatedType.DisplayName(), fk.DeclaringEntityType.DisplayName(), fk.PrincipalEntityType.DisplayName()),
@@ -839,17 +755,17 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
             Assert.Equal(
                 CoreStrings.EntityTypeNotInRelationship(unrelatedType.DisplayName(), fk.DeclaringEntityType.DisplayName(), fk.PrincipalEntityType.DisplayName()),
-                Assert.Throws<ArgumentException>(() => fk.FindNavigationFromInHierarchy(unrelatedType)).Message);
+                Assert.Throws<ArgumentException>(() => fk.FindNavigationsFromInHierarchy(unrelatedType)).Message);
             Assert.Equal(
                 CoreStrings.EntityTypeNotInRelationship(unrelatedType.DisplayName(), fk.DeclaringEntityType.DisplayName(), fk.PrincipalEntityType.DisplayName()),
-                Assert.Throws<ArgumentException>(() => fk.FindNavigationFromInHierarchy(unrelatedType)).Message);
+                Assert.Throws<ArgumentException>(() => fk.FindNavigationsFromInHierarchy(unrelatedType)).Message);
 
             Assert.Equal(
                 CoreStrings.EntityTypeNotInRelationship(unrelatedType.DisplayName(), fk.DeclaringEntityType.DisplayName(), fk.PrincipalEntityType.DisplayName()),
-                Assert.Throws<ArgumentException>(() => fk.FindNavigationToInHierarchy(unrelatedType)).Message);
+                Assert.Throws<ArgumentException>(() => fk.FindNavigationsToInHierarchy(unrelatedType)).Message);
             Assert.Equal(
                 CoreStrings.EntityTypeNotInRelationship(unrelatedType.DisplayName(), fk.DeclaringEntityType.DisplayName(), fk.PrincipalEntityType.DisplayName()),
-                Assert.Throws<ArgumentException>(() => fk.FindNavigationToInHierarchy(unrelatedType)).Message);
+                Assert.Throws<ArgumentException>(() => fk.FindNavigationsToInHierarchy(unrelatedType)).Message);
         }
     }
 }

--- a/test/EntityFramework.Core.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
@@ -1295,8 +1295,9 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 },
                 principalEntityBuilder.Metadata.FindPrimaryKey(),
                 principalEntityBuilder.Metadata);
-            var navigationToPrincipal = dependentEntityBuilder.Metadata.AddNavigation(Order.CustomerProperty.Name, foreignKey, pointsToPrincipal: true);
-            var navigationToDependent = principalEntityBuilder.Metadata.AddNavigation(Customer.OrdersProperty.Name, foreignKey, pointsToPrincipal: false);
+
+            var navigationToPrincipal = foreignKey.HasDependentToPrincipal(Order.CustomerProperty.Name);
+            var navigationToDependent = foreignKey.HasPrincipalToDependent(Customer.OrdersProperty.Name);
 
             var relationship = dependentEntityBuilder.HasForeignKey(principalEntityBuilder, foreignKey.Properties, ConfigurationSource.Convention)
                 .DependentToPrincipal(navigationToPrincipal.Name, ConfigurationSource.Convention)
@@ -1363,10 +1364,8 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 },
                 principalEntityBuilder.Metadata.FindPrimaryKey(),
                 principalEntityBuilder.Metadata);
-            existingForeignKey.PrincipalEntityType
-                .AddNavigation(Customer.OrdersProperty.Name, existingForeignKey, pointsToPrincipal: false);
-            existingForeignKey.DeclaringEntityType
-                .AddNavigation(Order.CustomerProperty.Name, existingForeignKey, pointsToPrincipal: true);
+            existingForeignKey.HasPrincipalToDependent(Customer.OrdersProperty.Name);
+            existingForeignKey.HasDependentToPrincipal(Order.CustomerProperty.Name);
             var newForeignKeyBuilder = dependentEntityBuilder.HasForeignKey(typeof(Customer).FullName, new[] { Order.IdProperty.Name, Order.CustomerUniqueProperty.Name }, ConfigurationSource.Convention);
 
             newForeignKeyBuilder = newForeignKeyBuilder.DependentToPrincipal(Order.CustomerProperty.Name, ConfigurationSource.Convention);
@@ -1829,8 +1828,8 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             Assert.Equal(1, principalEntityBuilder.Metadata.GetDeclaredKeys().Count());
             Assert.Equal(0, derivedPrincipalEntityBuilder.Metadata.GetDeclaredKeys().Count());
             Assert.Equal(0, derivedPrincipalEntityBuilder.Metadata.GetForeignKeys().Count());
-            Assert.Equal(0, principalEntityBuilder.Metadata.FindReferencingForeignKeys().Count());
-            var fk = derivedPrincipalEntityBuilder.Metadata.FindReferencingForeignKeys().Single();
+            Assert.Equal(0, principalEntityBuilder.Metadata.GetReferencingForeignKeys().Count());
+            var fk = derivedPrincipalEntityBuilder.Metadata.GetReferencingForeignKeys().Single();
             Assert.Equal(Order.CustomerProperty.Name, fk.DependentToPrincipal.Name);
             Assert.Equal(Customer.OrdersProperty.Name, fk.PrincipalToDependent.Name);
         }

--- a/test/EntityFramework.Core.Tests/Metadata/Internal/ModelTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/Internal/ModelTest.cs
@@ -158,10 +158,10 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var fkProperty = entityType2.AddProperty("CustomerId", typeof(int?));
             var foreignKey = entityType2.GetOrAddForeignKey(fkProperty, entityType1.AddKey(keyProperty), entityType1);
 
-            var referencingForeignKeys = entityType1.FindReferencingForeignKeys();
+            var referencingForeignKeys = entityType1.GetReferencingForeignKeys();
 
             Assert.Same(foreignKey, referencingForeignKeys.Single());
-            Assert.Same(foreignKey, entityType1.FindReferencingForeignKeys().Single());
+            Assert.Same(foreignKey, entityType1.GetReferencingForeignKeys().Single());
         }
 
         private class Customer

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/RelationshipDiscoveryConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/RelationshipDiscoveryConventionTest.cs
@@ -355,8 +355,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
                 .Single(n => n.Name == nameof(NavigationsToBaseAndDerived.Base)).ForeignKey;
             var derivedFk = entityBuilder.Metadata.GetNavigations()
                 .Single(n => n.Name == nameof(NavigationsToBaseAndDerived.DerivedOne)).ForeignKey;
-            Assert.Null(baseFk.FindNavigationTo(entityBuilder.Metadata));
-            Assert.Null(derivedFk.FindNavigationTo(entityBuilder.Metadata));
+            Assert.Empty(baseFk.FindNavigationsTo(entityBuilder.Metadata));
+            Assert.Empty(derivedFk.FindNavigationsTo(entityBuilder.Metadata));
             Assert.Equal(2, entityBuilder.Metadata.GetNavigations().Count());
             Assert.Equal(3, entityBuilder.Metadata.Model.GetEntityTypes().Count);
         }
@@ -378,8 +378,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
                 .Single(n => n.Name == nameof(NavigationsToBaseAndDerived.Base)).ForeignKey;
             var derivedFk = entityBuilder.Metadata.GetNavigations()
                 .Single(n => n.Name == nameof(NavigationsToBaseAndDerived.DerivedOne)).ForeignKey;
-            Assert.Equal(nameof(Base.BaseNavigation), baseFk.FindNavigationTo(entityBuilder.Metadata).Name);
-            Assert.Null(derivedFk.FindNavigationTo(entityBuilder.Metadata));
+            Assert.Equal(nameof(Base.BaseNavigation), baseFk.FindNavigationsTo(entityBuilder.Metadata).Single().Name);
+            Assert.Empty(derivedFk.FindNavigationsTo(entityBuilder.Metadata));
             Assert.Equal(2, entityBuilder.Metadata.GetNavigations().Count());
             Assert.Equal(3, entityBuilder.Metadata.Model.GetEntityTypes().Count);
         }
@@ -401,8 +401,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
                 .Single(n => n.Name == nameof(NavigationsToBaseAndDerived.Base)).ForeignKey;
             var derivedFk = entityBuilder.Metadata.GetNavigations()
                 .Single(n => n.Name == nameof(NavigationsToBaseAndDerived.DerivedTwo)).ForeignKey;
-            Assert.Equal(nameof(Base.BaseNavigation), baseFk.FindNavigationTo(entityBuilder.Metadata).Name);
-            Assert.Null(derivedFk.FindNavigationTo(entityBuilder.Metadata));
+            Assert.Equal(nameof(Base.BaseNavigation), baseFk.FindNavigationsTo(entityBuilder.Metadata).Single().Name);
+            Assert.Empty(derivedFk.FindNavigationsTo(entityBuilder.Metadata));
             Assert.Equal(2, entityBuilder.Metadata.GetNavigations().Count());
             Assert.Equal(3, entityBuilder.Metadata.Model.GetEntityTypes().Count);
         }
@@ -424,8 +424,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
                 .Single(n => n.Name == nameof(NavigationsToBaseAndDerived.Base)).ForeignKey;
             var derivedFk = entityBuilder.Metadata.GetNavigations()
                 .Single(n => n.Name == nameof(NavigationsToBaseAndDerived.DerivedOne)).ForeignKey;
-            Assert.Null(baseFk.FindNavigationTo(entityBuilder.Metadata));
-            Assert.Equal(nameof(DerivedOne.DerivedNavigation), derivedFk.FindNavigationTo(entityBuilder.Metadata).Name);
+            Assert.Empty(baseFk.FindNavigationsTo(entityBuilder.Metadata));
+            Assert.Equal(nameof(DerivedOne.DerivedNavigation), derivedFk.FindNavigationsTo(entityBuilder.Metadata).Single().Name);
             Assert.Equal(2, entityBuilder.Metadata.GetNavigations().Count());
             Assert.Equal(3, entityBuilder.Metadata.Model.GetEntityTypes().Count);
         }
@@ -447,8 +447,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
                 .Single(n => n.Name == nameof(NavigationsToBaseAndDerived.Base)).ForeignKey;
             var derivedFk = entityBuilder.Metadata.GetNavigations()
                 .Single(n => n.Name == nameof(NavigationsToBaseAndDerived.DerivedOne)).ForeignKey;
-            Assert.Equal(nameof(Base.BaseNavigation), baseFk.FindNavigationTo(entityBuilder.Metadata).Name);
-            Assert.Equal(nameof(DerivedOne.DerivedNavigation), derivedFk.FindNavigationTo(entityBuilder.Metadata).Name);
+            Assert.Equal(nameof(Base.BaseNavigation), baseFk.FindNavigationsTo(entityBuilder.Metadata).Single().Name);
+            Assert.Equal(nameof(DerivedOne.DerivedNavigation), derivedFk.FindNavigationsTo(entityBuilder.Metadata).Single().Name);
             Assert.Equal(3, entityBuilder.Metadata.GetNavigations().Count());
             Assert.Equal(4, entityBuilder.Metadata.Model.GetEntityTypes().Count);
         }
@@ -609,7 +609,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
 
             var derivedFk = entityBuilder.Metadata.GetNavigations()
                 .Single(n => n.Name == nameof(NavigationsToBaseAndDerived.DerivedOne)).ForeignKey;
-            Assert.Equal(nameof(DerivedOne.DerivedNavigation), derivedFk.FindNavigationTo(entityBuilder.Metadata).Name);
+            Assert.Equal(nameof(DerivedOne.DerivedNavigation), derivedFk.FindNavigationsTo(entityBuilder.Metadata).Single().Name);
             Assert.Equal(1, entityBuilder.Metadata.GetNavigations().Count());
             Assert.Equal(3, entityBuilder.Metadata.Model.GetEntityTypes().Count);
         }
@@ -630,7 +630,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
 
             var derivedFk = entityBuilder.Metadata.GetNavigations()
                 .Single(n => n.Name == nameof(NavigationsToBaseAndDerived.DerivedOne)).ForeignKey;
-            Assert.Equal(nameof(Base.BaseNavigation), derivedFk.FindNavigationTo(entityBuilder.Metadata).Name);
+            Assert.Equal(nameof(Base.BaseNavigation), derivedFk.FindNavigationsTo(entityBuilder.Metadata).Single().Name);
             Assert.Equal(1, entityBuilder.Metadata.GetNavigations().Count());
             Assert.Equal(3, entityBuilder.Metadata.Model.GetEntityTypes().Count);
         }
@@ -666,7 +666,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
             Assert.Same(entityBuilder, new RelationshipDiscoveryConvention().Apply(entityBuilder));
 
             var derivedFk = entityBuilder.Metadata.FindNavigation(nameof(NavigationsToBaseAndDerived.DerivedOne)).ForeignKey;
-            Assert.Equal(nameof(DerivedOne.BaseNavigation), derivedFk.FindNavigationTo(entityBuilder.Metadata).Name);
+            Assert.Equal(nameof(DerivedOne.BaseNavigation), derivedFk.FindNavigationsTo(entityBuilder.Metadata).Single().Name);
             Assert.Equal(1, entityBuilder.Metadata.GetNavigations().Count());
             Assert.Equal(2, entityBuilder.Metadata.Model.GetEntityTypes().Count);
         }

--- a/test/EntityFramework.Core.Tests/Metadata/NavigationExtensionsTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/NavigationExtensionsTest.cs
@@ -111,20 +111,20 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             if (createProducts)
             {
-                categoryType.AddNavigation("Products", categoryFk, pointsToPrincipal: false);
+                categoryFk.HasPrincipalToDependent(nameof(Category.Products));
             }
             if (createCategory)
             {
-                productType.AddNavigation("Category", categoryFk, pointsToPrincipal: true);
+                categoryFk.HasDependentToPrincipal(nameof(Product.Category));
             }
 
             if (createFeaturedProductCategory)
             {
-                productType.AddNavigation("FeaturedProductCategory", featuredProductFk, pointsToPrincipal: false);
+                featuredProductFk.HasPrincipalToDependent(nameof(Product.FeaturedProductCategory));
             }
             if (createFeaturedProduct)
             {
-                categoryType.AddNavigation("FeaturedProduct", featuredProductFk, pointsToPrincipal: true);
+                featuredProductFk.HasDependentToPrincipal(nameof(Category.FeaturedProduct));
             }
 
             return model;

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/InheritanceTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/InheritanceTestBase.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Data.Entity.Tests
                 var initialKeys = pickleClone.GetKeys();
                 var initialIndexes = pickleClone.GetIndexes();
                 var initialForeignKeys = pickleClone.GetForeignKeys();
-                var initialReferencingForeignKeys = pickleClone.FindReferencingForeignKeys();
+                var initialReferencingForeignKeys = pickleClone.GetReferencingForeignKeys();
 
                 pickleBuilder.HasBaseType<Ingredient>();
                 var ingredientBuilder = modelBuilder.Entity<Ingredient>();
@@ -45,7 +45,7 @@ namespace Microsoft.Data.Entity.Tests
                 AssertEqual(initialKeys, pickle.GetKeys());
                 AssertEqual(initialIndexes, pickle.GetIndexes());
                 AssertEqual(initialForeignKeys, pickle.GetForeignKeys());
-                AssertEqual(initialReferencingForeignKeys, pickle.FindReferencingForeignKeys());
+                AssertEqual(initialReferencingForeignKeys, pickle.GetReferencingForeignKeys());
 
                 pickleBuilder.HasBaseType(null);
 
@@ -54,13 +54,13 @@ namespace Microsoft.Data.Entity.Tests
                 AssertEqual(initialKeys, pickle.GetKeys());
                 AssertEqual(initialIndexes, pickle.GetIndexes());
                 AssertEqual(initialForeignKeys, pickle.GetForeignKeys());
-                AssertEqual(initialReferencingForeignKeys, pickle.FindReferencingForeignKeys());
+                AssertEqual(initialReferencingForeignKeys, pickle.GetReferencingForeignKeys());
 
                 AssertEqual(initialProperties, ingredient.GetProperties(), new PropertyComparer(compareAnnotations: false));
                 AssertEqual(initialKeys, ingredient.GetKeys());
                 AssertEqual(initialIndexes, ingredient.GetIndexes());
                 Assert.Equal(initialForeignKeys.Count(), ingredient.GetForeignKeys().Count());
-                Assert.Equal(initialReferencingForeignKeys.Count(), ingredient.FindReferencingForeignKeys().Count());
+                Assert.Equal(initialReferencingForeignKeys.Count(), ingredient.GetReferencingForeignKeys().Count());
             }
             
             [Fact]

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/ManyToOneTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/ManyToOneTestBase.cs
@@ -32,8 +32,8 @@ namespace Microsoft.Data.Entity.Tests
                 var principalType = model.FindEntityType(typeof(Customer));
                 var fk = dependentType.GetForeignKeys().Single();
 
-                var navToPrincipal = dependentType.GetOrAddNavigation("Customer", fk, pointsToPrincipal: true);
-                var navToDependent = principalType.GetOrAddNavigation("Orders", fk, pointsToPrincipal: false);
+                var navToPrincipal = fk.HasDependentToPrincipal("Customer");
+                var navToDependent = fk.HasPrincipalToDependent("Orders");
 
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
@@ -1079,7 +1079,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentType = model.FindEntityType(typeof(Tomato));
                 var principalType = model.FindEntityType(typeof(Whoopper));
                 var fk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey.Properties.First().Name == "BurgerId1");
-                dependentType.RemoveNavigation(fk.DependentToPrincipal.Name);
+                fk.HasDependentToPrincipal(null);
 
                 var principalKey = principalType.FindPrimaryKey();
                 var dependentKey = dependentType.GetKeys().Single();

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/OneToManyTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/OneToManyTestBase.cs
@@ -337,7 +337,7 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentType = model.FindEntityType(typeof(Pickle));
                 var principalType = model.FindEntityType(typeof(BigMak));
                 var fk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey.Properties.Single().Name == "BurgerId");
-                dependentType.RemoveNavigation(fk.DependentToPrincipal.Name);
+                fk.HasDependentToPrincipal(null);
 
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();

--- a/test/EntityFramework.Relational.Design.Tests/RelationalDatabaseModelFactoryTest.cs
+++ b/test/EntityFramework.Relational.Design.Tests/RelationalDatabaseModelFactoryTest.cs
@@ -311,7 +311,7 @@ namespace Microsoft.Data.Entity.Relational.Design
 
             var children = (EntityType)model.FindEntityType("Children");
 
-            Assert.NotEmpty(parent.FindReferencingForeignKeys());
+            Assert.NotEmpty(parent.GetReferencingForeignKeys());
             var fk = Assert.Single(children.GetForeignKeys());
             Assert.False(fk.IsUnique);
             Assert.Equal(DeleteBehavior.Cascade, fk.DeleteBehavior);
@@ -384,7 +384,7 @@ namespace Microsoft.Data.Entity.Relational.Design
 
             var children = (EntityType)model.FindEntityType("Children");
 
-            Assert.NotEmpty(parent.FindReferencingForeignKeys());
+            Assert.NotEmpty(parent.GetReferencingForeignKeys());
 
             var fk = Assert.Single(children.GetForeignKeys());
             Assert.False(fk.IsUnique);
@@ -421,7 +421,7 @@ namespace Microsoft.Data.Entity.Relational.Design
             var model = _factory.Create(new DatabaseModel { Tables = { table } });
             var list = model.FindEntityType("ItemsList");
 
-            Assert.NotEmpty(list.FindReferencingForeignKeys());
+            Assert.NotEmpty(list.GetReferencingForeignKeys());
             Assert.NotEmpty(list.GetForeignKeys());
 
             var principalKey = list.FindForeignKeys(list.FindProperty("ParentId")).SingleOrDefault().PrincipalKey;

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/SqliteDatabaseModelFactoryTest.cs
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/SqliteDatabaseModelFactoryTest.cs
@@ -160,7 +160,7 @@ namespace EntityFramework.Sqlite.Design.FunctionalTests
             var parent = model.FindEntityType("Parent");
             var children = model.FindEntityType("Children");
 
-            Assert.NotEmpty(parent.FindReferencingForeignKeys());
+            Assert.NotEmpty(parent.GetReferencingForeignKeys());
             Assert.NotEmpty(children.GetForeignKeys());
 
             var principalKey = children.FindForeignKeys(children.FindProperty("ParentId")).SingleOrDefault().PrincipalKey;
@@ -183,7 +183,7 @@ namespace EntityFramework.Sqlite.Design.FunctionalTests
             var parent = model.FindEntityType("Parent");
             var children = model.FindEntityType("Children");
 
-            Assert.NotEmpty(parent.FindReferencingForeignKeys());
+            Assert.NotEmpty(parent.GetReferencingForeignKeys());
             Assert.NotEmpty(children.GetForeignKeys());
 
             var propList = new List<Property>
@@ -209,7 +209,7 @@ namespace EntityFramework.Sqlite.Design.FunctionalTests
             var model = GetModel(sql);
             var list = model.FindEntityType("ItemsList");
 
-            Assert.NotEmpty(list.FindReferencingForeignKeys());
+            Assert.NotEmpty(list.GetReferencingForeignKeys());
             Assert.NotEmpty(list.GetForeignKeys());
 
             var principalKey = list.FindForeignKeys(list.FindProperty("ParentId")).SingleOrDefault().PrincipalKey;


### PR DESCRIPTION
The same data can be accessed through IForeignKey
The implementation will still keep track of the navigations for perf reasons