### PR TITLE
Avoid checking fixup in state manager when query is known to have done it

### DIFF
--- a/src/EntityFramework.Core/ChangeTracking/Internal/EntityTrackingSource.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/EntityTrackingSource.cs
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Data.Entity.ChangeTracking.Internal
+{
+    public enum EntityTrackingSource
+    {
+        NewQuery,
+        ContinuingQuery,
+        NonQuery
+    }
+}

--- a/src/EntityFramework.Core/ChangeTracking/Internal/IEntityStateListener.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/IEntityStateListener.cs
@@ -10,6 +10,6 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
     public interface IEntityStateListener
     {
         void StateChanging([NotNull] InternalEntityEntry entry, EntityState newState);
-        void StateChanged([NotNull] InternalEntityEntry entry, EntityState oldState);
+        void StateChanged([NotNull] InternalEntityEntry entry, EntityState oldState, bool skipInitialFixup);
     }
 }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/IInternalEntityEntryNotifier.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/IInternalEntityEntryNotifier.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
     {
         void StateChanging([NotNull] InternalEntityEntry entry, EntityState newState);
 
-        void StateChanged([NotNull] InternalEntityEntry entry, EntityState oldState);
+        void StateChanged([NotNull] InternalEntityEntry entry, EntityState oldState, bool skipInitialFixup);
 
         void ForeignKeyPropertyChanged(
             [NotNull] InternalEntityEntry entry,

--- a/src/EntityFramework.Core/ChangeTracking/Internal/IStateManager.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/IStateManager.cs
@@ -13,15 +13,14 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 {
     public interface IStateManager
     {
-        InternalEntityEntry CreateNewEntry([NotNull] IEntityType entityType);
-
         InternalEntityEntry GetOrCreateEntry([NotNull] object entity);
 
         InternalEntityEntry StartTracking(
             [NotNull] IEntityType entityType,
             [NotNull] IKeyValue keyValue,
             [NotNull] object entity,
-            ValueBuffer valueBuffer);
+            ValueBuffer valueBuffer,
+            EntityTrackingSource entityTrackingSource);
 
         InternalEntityEntry TryGetEntry([NotNull] IKeyValue keyValueValue);
 
@@ -52,5 +51,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         void AcceptAllChanges();
 
         DbContext Context { get; }
+
+        bool? SingleQueryMode { get; set; }
     }
 }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -121,6 +121,8 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
             // can happen without constraints on changing read-only values kicking in
             _stateData.EntityState = EntityState.Detached;
 
+            StateManager.SingleQueryMode = false;
+
             return true;
         }
 
@@ -149,6 +151,8 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
                 {
                     _stateData.FlagProperty(property.GetIndex(), PropertyFlag.TemporaryOrModified, isFlagged: true);
                 }
+
+                StateManager.SingleQueryMode = false;
             }
 
             if (oldState == newState)
@@ -199,7 +203,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
                 StateManager.StopTracking(this);
             }
 
-            StateManager.Notify.StateChanged(this, oldState);
+            StateManager.Notify.StateChanged(this,  oldState, StateManager.SingleQueryMode == true);
         }
 
         public virtual EntityState EntityState => _stateData.EntityState;
@@ -240,14 +244,15 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
             {
                 StateManager.Notify.StateChanging(this, EntityState.Modified);
                 _stateData.EntityState = EntityState.Modified;
-                StateManager.Notify.StateChanged(this, currentState);
+                StateManager.SingleQueryMode = false;
+                StateManager.Notify.StateChanged(this, currentState, skipInitialFixup: false);
             }
             else if (!isModified
                      && !_stateData.AnyPropertiesFlagged(PropertyFlag.TemporaryOrModified))
             {
                 StateManager.Notify.StateChanging(this, EntityState.Unchanged);
                 _stateData.EntityState = EntityState.Unchanged;
-                StateManager.Notify.StateChanged(this, currentState);
+                StateManager.Notify.StateChanged(this, currentState, skipInitialFixup: false);
             }
         }
 

--- a/src/EntityFramework.Core/ChangeTracking/Internal/InternalEntityEntryNotifier.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/InternalEntityEntryNotifier.cs
@@ -58,8 +58,8 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         public virtual void StateChanging(InternalEntityEntry entry, EntityState newState)
             => Dispatch(l => l.StateChanging(entry, newState));
 
-        public virtual void StateChanged(InternalEntityEntry entry, EntityState oldState)
-            => Dispatch(l => l.StateChanged(entry, oldState));
+        public virtual void StateChanged(InternalEntityEntry entry, EntityState oldState, bool skipInitialFixup)
+            => Dispatch(l => l.StateChanged(entry, oldState, skipInitialFixup));
 
         public virtual void ForeignKeyPropertyChanged(InternalEntityEntry entry, IProperty property, object oldValue, object newValue)
             => Dispatch(l => l.ForeignKeyPropertyChanged(entry, property, oldValue, newValue));

--- a/src/EntityFramework.Core/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/NavigationFixer.cs
@@ -166,9 +166,10 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         {
         }
 
-        public virtual void StateChanged(InternalEntityEntry entry, EntityState oldState)
+        public virtual void StateChanged(InternalEntityEntry entry, EntityState oldState, bool skipInitialFixup)
         {
-            if (oldState == EntityState.Detached)
+            if (oldState == EntityState.Detached
+                && !skipInitialFixup)
             {
                 PerformFixup(() => InitialFixup(entry));
             }

--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -61,6 +61,7 @@
     <Compile Include="ChangeTracking\EntityEntryGraphNode.cs" />
     <Compile Include="ChangeTracking\Internal\ChangeTrackerFactory.cs" />
     <Compile Include="ChangeTracking\Internal\EntityGraphAttacher.cs" />
+    <Compile Include="ChangeTracking\Internal\EntityTrackingSource.cs" />
     <Compile Include="ChangeTracking\Internal\IChangeTrackerFactory.cs" />
     <Compile Include="ChangeTracking\Internal\IEntityGraphAttacher.cs" />
     <Compile Include="ChangeTracking\Internal\SimpleKeyValueFactory.cs" />

--- a/src/EntityFramework.Core/Query/Internal/EntityTrackingInfo.cs
+++ b/src/EntityFramework.Core/Query/Internal/EntityTrackingInfo.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Data.Entity.Query.Internal
         public virtual IQuerySource QuerySource => QuerySourceReferenceExpression.ReferencedQuerySource;
 
         public virtual void StartTracking(
-            [NotNull] IStateManager stateManager, [NotNull] object entity, ValueBuffer valueBuffer)
+            [NotNull] IStateManager stateManager, [NotNull] object entity, ValueBuffer valueBuffer, EntityTrackingSource entityTrackingSource)
         {
             Check.NotNull(stateManager, nameof(stateManager));
             Check.NotNull(entity, nameof(entity));
@@ -80,7 +80,8 @@ namespace Microsoft.Data.Entity.Query.Internal
                 _entityType,
                 _keyValueFactory.Create(valueBuffer),
                 entity,
-                valueBuffer);
+                valueBuffer,
+                entityTrackingSource);
         }
 
         public class IncludedEntityTrackingInfo
@@ -119,7 +120,7 @@ namespace Microsoft.Data.Entity.Query.Internal
 
             private IncludedEntityTrackingInfo IncludedEntityTrackingInfo { get; }
 
-            public void StartTracking([NotNull] IStateManager stateManager, ValueBuffer valueBuffer)
+            public void StartTracking([NotNull] IStateManager stateManager, ValueBuffer valueBuffer, EntityTrackingSource entityTrackingSource)
             {
                 Check.NotNull(stateManager, nameof(stateManager));
 
@@ -127,7 +128,8 @@ namespace Microsoft.Data.Entity.Query.Internal
                     IncludedEntityTrackingInfo.EntityType,
                     IncludedEntityTrackingInfo.CreateKeyValue(valueBuffer),
                     Entity,
-                    valueBuffer);
+                    valueBuffer,
+                    entityTrackingSource);
             }
         }
 

--- a/src/EntityFramework.Core/Query/Internal/QueryBuffer.cs
+++ b/src/EntityFramework.Core/Query/Internal/QueryBuffer.cs
@@ -32,6 +32,8 @@ namespace Microsoft.Data.Entity.Query.Internal
 
         private int _identityMapGarbageCollectionIterations;
 
+        private EntityTrackingSource _entityTrackingSource = EntityTrackingSource.NewQuery;
+
         public QueryBuffer(
             [NotNull] IStateManager stateManager,
             [NotNull] IKeyValueFactorySource keyValueFactorySource)
@@ -130,7 +132,9 @@ namespace Microsoft.Data.Entity.Query.Internal
             if (_valueBuffers.TryGetValue(entity, out boxedValueBuffer))
             {
                 entityTrackingInfo
-                    .StartTracking(_stateManager, entity, (ValueBuffer)boxedValueBuffer);
+                    .StartTracking(_stateManager, entity, (ValueBuffer)boxedValueBuffer, _entityTrackingSource);
+
+                _entityTrackingSource = EntityTrackingSource.ContinuingQuery;
             }
 
             foreach (var includedEntity 
@@ -138,7 +142,9 @@ namespace Microsoft.Data.Entity.Query.Internal
                     .Where(includedEntity
                         => _valueBuffers.TryGetValue(includedEntity.Entity, out boxedValueBuffer)))
             {
-                includedEntity.StartTracking(_stateManager, (ValueBuffer)boxedValueBuffer);
+                includedEntity.StartTracking(_stateManager, (ValueBuffer)boxedValueBuffer, _entityTrackingSource);
+
+                _entityTrackingSource = EntityTrackingSource.ContinuingQuery;
             }
         }
 

--- a/test/EntityFramework.Core.FunctionalTests/FixupTest.cs
+++ b/test/EntityFramework.Core.FunctionalTests/FixupTest.cs
@@ -1,12 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Infrastructure;
-using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
 using Xunit;
 
@@ -62,30 +60,114 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
                 var stateManager = context.ChangeTracker.GetInfrastructure();
 
-                stateManager.StartTracking(categoryType, new SimpleKeyValue<int>(categoryType.FindPrimaryKey(), 11), new Category { Id = 11 }, new ValueBuffer(new object[] { 11 }));
-                stateManager.StartTracking(categoryType, new SimpleKeyValue<int>(categoryType.FindPrimaryKey(), 12), new Category { Id = 12 }, new ValueBuffer(new object[] { 12 }));
-                stateManager.StartTracking(categoryType, new SimpleKeyValue<int>(categoryType.FindPrimaryKey(), 13), new Category { Id = 13 }, new ValueBuffer(new object[] { 13 }));
+                stateManager.StartTracking(
+                    categoryType,
+                    new SimpleKeyValue<int>(categoryType.FindPrimaryKey(), 11),
+                    new Category { Id = 11 },
+                    new ValueBuffer(new object[] { 11 }),
+                    EntityTrackingSource.NewQuery);
 
-                stateManager.StartTracking(productType, new SimpleKeyValue<int>(productType.FindPrimaryKey(), 21), new Product { Id = 21, CategoryId = 11 }, new ValueBuffer(new object[] { 21, 11 }));
-                AssertAllFixedUp(context);
-                stateManager.StartTracking(productType, new SimpleKeyValue<int>(productType.FindPrimaryKey(), 22), new Product { Id = 22, CategoryId = 11 }, new ValueBuffer(new object[] { 22, 11 }));
-                AssertAllFixedUp(context);
-                stateManager.StartTracking(productType, new SimpleKeyValue<int>(productType.FindPrimaryKey(), 23), new Product { Id = 23, CategoryId = 11 }, new ValueBuffer(new object[] { 23, 11 }));
-                AssertAllFixedUp(context);
-                stateManager.StartTracking(productType, new SimpleKeyValue<int>(productType.FindPrimaryKey(), 24), new Product { Id = 24, CategoryId = 12 }, new ValueBuffer(new object[] { 24, 12 }));
-                AssertAllFixedUp(context);
-                stateManager.StartTracking(productType, new SimpleKeyValue<int>(productType.FindPrimaryKey(), 25), new Product { Id = 25, CategoryId = 12 }, new ValueBuffer(new object[] { 25, 12 }));
+                stateManager.StartTracking(
+                    categoryType,
+                    new SimpleKeyValue<int>(categoryType.FindPrimaryKey(), 12),
+                    new Category { Id = 12 },
+                    new ValueBuffer(new object[] { 12 }),
+                    EntityTrackingSource.NewQuery);
+
+                stateManager.StartTracking(
+                    categoryType,
+                    new SimpleKeyValue<int>(categoryType.FindPrimaryKey(), 13),
+                    new Category { Id = 13 },
+                    new ValueBuffer(new object[] { 13 }),
+                    EntityTrackingSource.NewQuery);
+
+                stateManager.StartTracking(
+                    productType,
+                    new SimpleKeyValue<int>(productType.FindPrimaryKey(), 21),
+                    new Product { Id = 21, CategoryId = 11 },
+                    new ValueBuffer(new object[] { 21, 11 }),
+                    EntityTrackingSource.NewQuery);
+
                 AssertAllFixedUp(context);
 
-                stateManager.StartTracking(offerType, new SimpleKeyValue<int>(offerType.FindPrimaryKey(), 31), new SpecialOffer { Id = 31, ProductId = 22 }, new ValueBuffer(new object[] { 31, 22 }));
+                stateManager.StartTracking(
+                    productType,
+                    new SimpleKeyValue<int>(productType.FindPrimaryKey(), 22),
+                    new Product { Id = 22, CategoryId = 11 },
+                    new ValueBuffer(new object[] { 22, 11 }),
+                    EntityTrackingSource.NewQuery);
+
                 AssertAllFixedUp(context);
-                stateManager.StartTracking(offerType, new SimpleKeyValue<int>(offerType.FindPrimaryKey(), 32), new SpecialOffer { Id = 32, ProductId = 22 }, new ValueBuffer(new object[] { 32, 22 }));
+
+                stateManager.StartTracking(
+                    productType,
+                    new SimpleKeyValue<int>(productType.FindPrimaryKey(), 23),
+                    new Product { Id = 23, CategoryId = 11 },
+                    new ValueBuffer(new object[] { 23, 11 }),
+                    EntityTrackingSource.NewQuery);
+
                 AssertAllFixedUp(context);
-                stateManager.StartTracking(offerType, new SimpleKeyValue<int>(offerType.FindPrimaryKey(), 33), new SpecialOffer { Id = 33, ProductId = 24 }, new ValueBuffer(new object[] { 33, 24 }));
+
+                stateManager.StartTracking(
+                    productType,
+                    new SimpleKeyValue<int>(productType.FindPrimaryKey(), 24),
+                    new Product { Id = 24, CategoryId = 12 },
+                    new ValueBuffer(new object[] { 24, 12 }),
+                    EntityTrackingSource.NewQuery);
+
                 AssertAllFixedUp(context);
-                stateManager.StartTracking(offerType, new SimpleKeyValue<int>(offerType.FindPrimaryKey(), 34), new SpecialOffer { Id = 34, ProductId = 24 }, new ValueBuffer(new object[] { 34, 24 }));
+
+                stateManager.StartTracking(
+                    productType,
+                    new SimpleKeyValue<int>(productType.FindPrimaryKey(), 25),
+                    new Product { Id = 25, CategoryId = 12 },
+                    new ValueBuffer(new object[] { 25, 12 }),
+                    EntityTrackingSource.NewQuery);
+
                 AssertAllFixedUp(context);
-                stateManager.StartTracking(offerType, new SimpleKeyValue<int>(offerType.FindPrimaryKey(), 35), new SpecialOffer { Id = 35, ProductId = 24 }, new ValueBuffer(new object[] { 35, 24 }));
+
+                stateManager.StartTracking(
+                    offerType,
+                    new SimpleKeyValue<int>(offerType.FindPrimaryKey(), 31),
+                    new SpecialOffer { Id = 31, ProductId = 22 },
+                    new ValueBuffer(new object[] { 31, 22 }),
+                    EntityTrackingSource.NewQuery);
+
+                AssertAllFixedUp(context);
+
+                stateManager.StartTracking(
+                    offerType,
+                    new SimpleKeyValue<int>(offerType.FindPrimaryKey(), 32),
+                    new SpecialOffer { Id = 32, ProductId = 22 },
+                    new ValueBuffer(new object[] { 32, 22 }),
+                    EntityTrackingSource.NewQuery);
+
+                AssertAllFixedUp(context);
+
+                stateManager.StartTracking(
+                    offerType,
+                    new SimpleKeyValue<int>(offerType.FindPrimaryKey(), 33),
+                    new SpecialOffer { Id = 33, ProductId = 24 },
+                    new ValueBuffer(new object[] { 33, 24 }),
+                    EntityTrackingSource.NewQuery);
+
+                AssertAllFixedUp(context);
+
+                stateManager.StartTracking(
+                    offerType,
+                    new SimpleKeyValue<int>(offerType.FindPrimaryKey(), 34),
+                    new SpecialOffer { Id = 34, ProductId = 24 },
+                    new ValueBuffer(new object[] { 34, 24 }),
+                    EntityTrackingSource.NewQuery);
+
+                AssertAllFixedUp(context);
+
+                stateManager.StartTracking(
+                    offerType,
+                    new SimpleKeyValue<int>(offerType.FindPrimaryKey(), 35),
+                    new SpecialOffer { Id = 35, ProductId = 24 },
+                    new ValueBuffer(new object[] { 35, 24 }),
+                    EntityTrackingSource.NewQuery);
 
                 AssertAllFixedUp(context);
 
@@ -246,15 +328,9 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             protected override void OnModelCreating(ModelBuilder modelBuilder)
             {
-                modelBuilder.Entity<Product>(b =>
-                    {
-                        b.HasMany(e => e.SpecialOffers).WithOne(e => e.Product);
-                    });
+                modelBuilder.Entity<Product>(b => { b.HasMany(e => e.SpecialOffers).WithOne(e => e.Product); });
 
-                modelBuilder.Entity<Category>(b =>
-                    {
-                        b.HasMany(e => e.Products).WithOne(e => e.Category);
-                    });
+                modelBuilder.Entity<Category>(b => { b.HasMany(e => e.Products).WithOne(e => e.Category); });
             }
 
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)

--- a/test/EntityFramework.Core.FunctionalTests/GraphUpdatesTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/GraphUpdatesTestBase.cs
@@ -2383,7 +2383,6 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-
         [ConditionalFact]
         public virtual void Required_many_to_one_dependents_with_alternate_key_are_cascade_deleted_in_store()
         {
@@ -2725,11 +2724,16 @@ namespace Microsoft.Data.Entity.FunctionalTests
         protected static Root LoadFullGraph(GraphUpdatesContext context, Expression<Func<Root, bool>> predicate = null)
         {
             var query = context.Roots
-                .Include(e => e.RequiredChildren)
-                .Include(e => e.OptionalChildren)
-                .Include(e => e.RequiredSingle)
-                .Include(e => e.RequiredNonPkSingle)
-                .Include(e => e.OptionalSingle);
+                .Include(e => e.RequiredChildren).ThenInclude(e => e.Children)
+                .Include(e => e.OptionalChildren).ThenInclude(e => e.Children)
+                .Include(e => e.RequiredSingle).ThenInclude(e => e.Single)
+                .Include(e => e.RequiredNonPkSingle).ThenInclude(e => e.Single)
+                .Include(e => e.OptionalSingle).ThenInclude(e => e.Single)
+                .Include(e => e.RequiredChildrenAk).ThenInclude(e => e.Children)
+                .Include(e => e.OptionalChildrenAk).ThenInclude(e => e.Children)
+                .Include(e => e.RequiredSingleAk).ThenInclude(e => e.Single)
+                .Include(e => e.RequiredNonPkSingleAk).ThenInclude(e => e.Single)
+                .Include(e => e.OptionalSingleAk).ThenInclude(e => e.Single);
 
             var loadedGraph = predicate == null
                 ? query.Single()

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/NavigationFixerTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/NavigationFixerTest.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var principalEntry = manager.StartTracking(manager.GetOrCreateEntry(principal));
 
             var fixer = CreateNavigationFixer(contextServices);
-            fixer.StateChanged(principalEntry, EntityState.Detached);
+            fixer.StateChanged(principalEntry, EntityState.Detached, skipInitialFixup: false);
 
             Assert.Same(dependent1.Category, principal);
             Assert.Null(dependent2.Category);

--- a/test/EntityFramework.Core.Tests/DbContextTest.cs
+++ b/test/EntityFramework.Core.Tests/DbContextTest.cs
@@ -217,6 +217,7 @@ namespace Microsoft.Data.Entity.Tests
             public IEnumerable<InternalEntityEntry> InternalEntries { get; set; }
             public bool SaveChangesCalled { get; set; }
             public bool SaveChangesAsyncCalled { get; set; }
+            public virtual bool? SingleQueryMode { get; set; }
 
             public void UpdateIdentityMap(InternalEntityEntry entry, IKeyValue oldKeyValue, IKey principalKey)
             {
@@ -250,17 +251,17 @@ namespace Microsoft.Data.Entity.Tests
                 throw new NotImplementedException();
             }
 
-            public InternalEntityEntry CreateNewEntry(IEntityType entityType)
-            {
-                throw new NotImplementedException();
-            }
-
             public InternalEntityEntry GetOrCreateEntry(object entity)
             {
                 throw new NotImplementedException();
             }
 
-            public InternalEntityEntry StartTracking(IEntityType entityType, IKeyValue keyValue, object entity, ValueBuffer valueBuffer)
+            public InternalEntityEntry StartTracking(
+                IEntityType entityType, 
+                IKeyValue keyValue, 
+                object entity, 
+                ValueBuffer valueBuffer,
+                EntityTrackingSource entityTrackingSource)
             {
                 throw new NotImplementedException();
             }

--- a/test/EntityFramework.InMemory.FunctionalTests/EndToEndTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/EndToEndTest.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
         }
 
         private void Can_add_update_delete_end_to_end<T>()
-            where T : class
+            where T : class, new()
         {
             var type = typeof(T);
             var model = new Model();
@@ -45,7 +45,7 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
             T entity;
             using (var context = new DbContext(_fixture.ServiceProvider, optionsBuilder.Options))
             {
-                var entry = context.ChangeTracker.GetInfrastructure().CreateNewEntry(entityType);
+                var entry = context.ChangeTracker.GetInfrastructure().GetOrCreateEntry(new T());
                 entity = (T)entry.Entity;
 
                 entry[idProperty] = 42;

--- a/test/EntityFramework.InMemory.FunctionalTests/ShadowStateUpdateTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/ShadowStateUpdateTest.cs
@@ -1,12 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Infrastructure;
-using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Metadata.Internal;
 using Xunit;
 
@@ -14,68 +11,6 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
 {
     public class ShadowStateUpdateTest : IClassFixture<InMemoryFixture>
     {
-        [Fact]
-        public async Task Can_add_update_delete_end_to_end_using_only_shadow_state()
-        {
-            var model = new Model();
-
-            var customerType = model.AddEntityType("Customer");
-            customerType.GetOrSetPrimaryKey(customerType.AddProperty("Id", typeof(int)));
-            customerType.AddProperty("Name", typeof(string));
-
-            var optionsBuilder = new DbContextOptionsBuilder()
-                .UseModel(model);
-            optionsBuilder.UseInMemoryDatabase();
-
-            using (var context = new DbContext(_fixture.ServiceProvider, optionsBuilder.Options))
-            {
-                // TODO: Better API for shadow state access
-                var customerEntry = context.ChangeTracker.GetInfrastructure().CreateNewEntry(customerType);
-                customerEntry[customerType.FindProperty("Id")] = 42;
-                customerEntry[customerType.FindProperty("Name")] = "Daenerys";
-
-                customerEntry.SetEntityState(EntityState.Added);
-
-                await context.SaveChangesAsync();
-
-                customerEntry[customerType.FindProperty("Name")] = "Changed!";
-            }
-
-            // TODO: Fix this when we can query shadow entities
-            // var customerFromStore = await inMemoryDatabase.Read(customerType).SingleAsync();
-            //
-            // Assert.Equal(new object[] { 42, "Daenerys" }, customerFromStore);
-
-            using (var context = new DbContext(_fixture.ServiceProvider, optionsBuilder.Options))
-            {
-                var customerEntry = context.ChangeTracker.GetInfrastructure().CreateNewEntry(customerType);
-                customerEntry[customerType.FindProperty("Id")] = 42;
-                customerEntry[customerType.FindProperty("Name")] = "Daenerys Targaryen";
-
-                customerEntry.SetEntityState(EntityState.Modified);
-
-                await context.SaveChangesAsync();
-            }
-
-            // TODO: Fix this when we can query shadow entities
-            // customerFromStore = await inMemoryDatabase.Read(customerType).SingleAsync();
-            // 
-            // Assert.Equal(new object[] { 42, "Daenerys Targaryen" }, customerFromStore);
-
-            using (var context = new DbContext(_fixture.ServiceProvider, optionsBuilder.Options))
-            {
-                var customerEntry = context.ChangeTracker.GetInfrastructure().CreateNewEntry(customerType);
-                customerEntry[customerType.FindProperty("Id")] = 42;
-
-                customerEntry.SetEntityState(EntityState.Deleted);
-
-                await context.SaveChangesAsync();
-            }
-
-            // TODO: Fix this when we can query shadow entities
-            // Assert.Equal(0, await inMemoryDatabase.Read(customerType).CountAsync());
-        }
-
         [Fact]
         public async Task Can_add_update_delete_end_to_end_using_partial_shadow_state()
         {


### PR DESCRIPTION
Query always fixes up navigations between entities returned by a given query, regardless of whether the query is going to be tracked or not. If the state manager ends up tracking only these entities, then it does not need to do any fixup work. Not doing this work can improve query tracking performance by about 22% for this common case.

The state manager switches out of this mode when:
- A second query starts
- An entity is attached or added
- An entity changes to the Modified or Added state, since this could be an FK change