### PR TITLE
[SMALL] Fix to #3633 - Query :: QuerySourceTracingExpressionVisitor doesn't prune EF.Property calls when looking for query sources

### DIFF
--- a/src/EntityFramework.Core/Query/ExpressionVisitors/Internal/QuerySourceTracingExpressionVisitor.cs
+++ b/src/EntityFramework.Core/Query/ExpressionVisitors/Internal/QuerySourceTracingExpressionVisitor.cs
@@ -94,5 +94,13 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors.Internal
         protected override Expression VisitLambda<T>(Expression<T> expression) => expression;
 
         protected override Expression VisitInvocation(InvocationExpression expression) => expression;
+
+        protected override Expression VisitMethodCall(MethodCallExpression expression)
+        {
+            var isPropertyMethod = expression.Method.IsGenericMethod
+                && expression.Method.GetGenericMethodDefinition() == EntityQueryModelVisitor.PropertyMethodInfo;
+
+            return isPropertyMethod ? expression : base.VisitMethodCall(expression);
+        }
     }
 }

--- a/test/EntityFramework.Core.FunctionalTests/IncludeTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/IncludeTestBase.cs
@@ -207,8 +207,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
             {
                 var customers
                     = (from c1 in context.Set<Customer>().OrderBy(c => c.CustomerID).Take(5)
-                        from c2 in context.Set<Customer>().Include(c => c.Orders)
-                        select c2)
+                       from c2 in context.Set<Customer>().Include(c => c.Orders)
+                       select c2)
                         .ToList();
 
                 Assert.Equal(455, customers.Count);
@@ -225,10 +225,10 @@ namespace Microsoft.Data.Entity.FunctionalTests
             {
                 var customers
                     = (from c1 in context.Set<Customer>()
-                        from c2 in context.Set<Customer>()
-                            .Include(c => c.Orders)
-                            .Where(c => c.CustomerID == "ALFKI")
-                        select c2)
+                       from c2 in context.Set<Customer>()
+                           .Include(c => c.Orders)
+                           .Where(c => c.CustomerID == "ALFKI")
+                       select c2)
                         .ToList();
 
                 Assert.Equal(91, customers.Count);
@@ -245,8 +245,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
             {
                 var customers
                     = (from c1 in context.Set<Customer>().OrderBy(c => c.CustomerID).Take(5)
-                        from c2 in context.Set<Customer>().Include(c => c.Orders)
-                        select c1)
+                       from c2 in context.Set<Customer>().Include(c => c.Orders)
+                       select c1)
                         .ToList();
 
                 Assert.Equal(455, customers.Count);
@@ -262,9 +262,9 @@ namespace Microsoft.Data.Entity.FunctionalTests
             {
                 var customers
                     = (from c in context.Set<Customer>().Include(c => c.Orders)
-                        join o in context.Set<Order>() on c.CustomerID equals o.CustomerID
-                        where c.CustomerID == "ALFKI"
-                        select c)
+                       join o in context.Set<Order>() on c.CustomerID equals o.CustomerID
+                       where c.CustomerID == "ALFKI"
+                       select c)
                         .ToList();
 
                 Assert.Equal(6, customers.Count);
@@ -281,10 +281,10 @@ namespace Microsoft.Data.Entity.FunctionalTests
             {
                 var customers
                     = (from c in context.Set<Customer>().Include(c => c.Orders)
-                        join o in context.Set<Order>() on c.CustomerID equals o.CustomerID
-                        where c.CustomerID == "ALFKI"
-                        orderby c.City
-                        select c)
+                       join o in context.Set<Order>() on c.CustomerID equals o.CustomerID
+                       where c.CustomerID == "ALFKI"
+                       orderby c.City
+                       select c)
                         .ToList();
 
                 Assert.Equal(6, customers.Count);
@@ -454,12 +454,12 @@ namespace Microsoft.Data.Entity.FunctionalTests
                         .Include(c => c.Orders)
                         .OrderBy(c => c.CustomerID)
                         .Take(2)
-                        from c2 in context.Set<Customer>()
-                            .Include(c => c.Orders)
-                            .OrderBy(c => c.CustomerID)
-                            .Skip(2)
-                            .Take(2)
-                        select new { c1, c2 })
+                       from c2 in context.Set<Customer>()
+                           .Include(c => c.Orders)
+                           .OrderBy(c => c.CustomerID)
+                           .Skip(2)
+                           .Take(2)
+                       select new { c1, c2 })
                         .ToList();
 
                 Assert.Equal(4, customers.Count);
@@ -481,12 +481,12 @@ namespace Microsoft.Data.Entity.FunctionalTests
                         .Include(c => c.Orders)
                         .OrderBy(c => c.CustomerID)
                         .Take(2)
-                        from c2 in context.Set<Customer>()
-                            .Include(c => c.Orders)
-                            .OrderBy(c => c.CustomerID)
-                            .Skip(2)
-                            .Take(2)
-                        select new { c1, c2 })
+                       from c2 in context.Set<Customer>()
+                           .Include(c => c.Orders)
+                           .OrderBy(c => c.CustomerID)
+                           .Skip(2)
+                           .Take(2)
+                       select new { c1, c2 })
                         .Take(1)
                         .ToList();
 
@@ -509,11 +509,11 @@ namespace Microsoft.Data.Entity.FunctionalTests
                         .Include(c => c.Orders)
                         .OrderBy(c => c.CustomerID)
                         .Take(2)
-                        from c2 in context.Set<Customer>()
-                            .OrderBy(c => c.CustomerID)
-                            .Skip(2)
-                            .Take(2)
-                        select new { c1, c2 })
+                       from c2 in context.Set<Customer>()
+                           .OrderBy(c => c.CustomerID)
+                           .Skip(2)
+                           .Take(2)
+                       select new { c1, c2 })
                         .Take(1)
                         .ToList();
 
@@ -535,12 +535,12 @@ namespace Microsoft.Data.Entity.FunctionalTests
                         .Include(o => o.Customer)
                         .OrderBy(o => o.CustomerID)
                         .Take(2)
-                        from o2 in context.Set<Order>()
-                            .Include(o => o.Customer)
-                            .OrderBy(o => o.CustomerID)
-                            .Skip(2)
-                            .Take(2)
-                        select new { o1, o2 })
+                       from o2 in context.Set<Order>()
+                           .Include(o => o.Customer)
+                           .OrderBy(o => o.CustomerID)
+                           .Skip(2)
+                           .Take(2)
+                       select new { o1, o2 })
                         .ToList();
 
                 Assert.Equal(4, orders.Count);
@@ -562,11 +562,11 @@ namespace Microsoft.Data.Entity.FunctionalTests
                         .Include(o => o.Customer)
                         .OrderBy(o => o.OrderID)
                         .Take(2)
-                        from o2 in context.Set<Order>()
-                            .OrderBy(o => o.OrderID)
-                            .Skip(2)
-                            .Take(2)
-                        select new { o1, o2 })
+                       from o2 in context.Set<Order>()
+                           .OrderBy(o => o.OrderID)
+                           .Skip(2)
+                           .Take(2)
+                       select new { o1, o2 })
                         .ToList();
 
                 Assert.Equal(4, orders.Count);
@@ -586,12 +586,12 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     = (from o1 in context.Set<Order>()
                         .OrderBy(o => o.OrderID)
                         .Take(2)
-                        from o2 in context.Set<Order>()
-                            .OrderBy(o => o.OrderID)
-                            .Include(o => o.Customer)
-                            .Skip(2)
-                            .Take(2)
-                        select new { o1, o2 })
+                       from o2 in context.Set<Order>()
+                           .OrderBy(o => o.OrderID)
+                           .Include(o => o.Customer)
+                           .Skip(2)
+                           .Take(2)
+                       select new { o1, o2 })
                         .ToList();
 
                 Assert.Equal(4, orders.Count);
@@ -770,8 +770,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
             {
                 var result
                     = (from o in context.Set<Order>().Include(o => o.OrderDetails)
-                        where o.CustomerID == "ALFKI"
-                        select o)
+                       where o.CustomerID == "ALFKI"
+                       select o)
                         .ToList();
 
                 Assert.Equal(6, result.Count());
@@ -1045,7 +1045,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 Assert.True(orderDetails.All(od => od.Order.Customer.Orders != null));
             }
         }
-   
+
         [Fact]
         public virtual void Include_multiple_references_then_include_multi_level()
         {
@@ -1111,7 +1111,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-         [Fact]
+        [Fact]
         public virtual void Include_references_then_include_multi_level()
         {
             using (var context = CreateContext())
@@ -1123,6 +1123,24 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
                 Assert.True(orderDetails.Count > 0);
                 Assert.True(orderDetails.All(od => od.Order.Customer != null));
+            }
+        }
+
+        [Fact]
+        public virtual void Include_with_complex_projection()
+        {
+            using (var context = CreateContext())
+            {
+                var query = from o in context.Orders.Include(o => o.Customer)
+                            select new
+                            {
+                                CustomerId = new
+                                {
+                                    Id = o.Customer.CustomerID
+                                }
+                            };
+
+                var result = query.ToList();
             }
         }
     }

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/IncludeSqlServerTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/IncludeSqlServerTest.cs
@@ -899,6 +899,16 @@ ORDER BY [c].[CustomerID]",
                 Sql);
         }
 
+        public override void Include_with_complex_projection()
+        {
+            base.Include_with_complex_projection();
+
+            Assert.Equal(
+                @"SELECT [o].[CustomerID]
+FROM [Orders] AS [o]",
+                Sql);
+        }
+
         private static string Sql => TestSqlLoggerFactory.Sql;
     }
 }


### PR DESCRIPTION
QuerySourceTracingExpressionVisitor is looking for query sources that are being materialized, so that we know which includes need to be applied to the query. The logic filters out references that are not being projected (e.g. property access), however we were not pruning property access done via EF.Property method.

Fix is to add the missing overload.