### PR TITLE
Improve perf of relationship snapshot

### DIFF
--- a/src/EntityFramework.Commands/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EntityFramework.Commands/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -450,7 +450,7 @@ namespace Microsoft.Data.Entity.Migrations.Design
             Check.NotNull(annotations, nameof(annotations));
             Check.NotNull(stringBuilder, nameof(stringBuilder));
 
-            foreach (var annotation in annotations.Where(annotation => !MigrationsCodeGenerator.IgnoredAnnotations.Contains(annotation.Name)))
+            foreach (var annotation in annotations)
             {
                 stringBuilder.AppendLine();
                 GenerateAnnotation(annotation, stringBuilder);

--- a/src/EntityFramework.Commands/Migrations/Design/MigrationsCodeGenerator.cs
+++ b/src/EntityFramework.Commands/Migrations/Design/MigrationsCodeGenerator.cs
@@ -14,13 +14,6 @@ namespace Microsoft.Data.Entity.Migrations.Design
 {
     public abstract class MigrationsCodeGenerator
     {
-        public static IReadOnlyList<string> IgnoredAnnotations { get; } = new List<string>
-        {
-            CoreAnnotationNames.OriginalValueIndexAnnotation,
-            CoreAnnotationNames.ShadowIndexAnnotation,
-            CoreAnnotationNames.IndexAnnotation
-        };
-
         public abstract string FileExtension { get; }
 
         public abstract string GenerateMigration(
@@ -110,7 +103,7 @@ namespace Microsoft.Data.Entity.Migrations.Design
         private IEnumerable<string> GetAnnotationNamespaces(IEnumerable<IAnnotatable> items)
             => from i in items
                from a in i.GetAnnotations()
-               where a.Value != null && !IgnoredAnnotations.Contains(a.Name)
+               where a.Value != null
                select a.Value.GetType().Namespace;
     }
 }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
             StateManager = stateManager;
             MetadataServices = metadataServices;
             EntityType = entityType;
-            _stateData = new StateData(entityType.GetProperties().Count());
+            _stateData = new StateData(entityType.PropertyCount());
         }
 
         public abstract object Entity { get; }
@@ -114,7 +114,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
             if (EntityState == EntityState.Modified)
             {
-                _stateData.FlagAllProperties(EntityType.GetProperties().Count(), PropertyFlag.TemporaryOrModified, flagged: false);
+                _stateData.FlagAllProperties(EntityType.PropertyCount(), PropertyFlag.TemporaryOrModified, flagged: false);
             }
 
             // Temporarily change the internal state to unknown so that key generation, including setting key values
@@ -162,7 +162,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
             if (newState == EntityState.Unchanged)
             {
-                _stateData.FlagAllProperties(EntityType.GetProperties().Count(), PropertyFlag.TemporaryOrModified, flagged: false);
+                _stateData.FlagAllProperties(EntityType.PropertyCount(), PropertyFlag.TemporaryOrModified, flagged: false);
             }
 
             StateManager.Notify.StateChanging(this, newState);
@@ -195,7 +195,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
                         this[property] = property.ClrType.GetDefaultValue();
                     }
                 }
-                var propertyCount = EntityType.GetProperties().Count();
+                var propertyCount = EntityType.PropertyCount();
 
                 _stateData.FlagAllProperties(propertyCount, PropertyFlag.TemporaryOrModified, flagged: false);
                 _stateData.FlagAllProperties(propertyCount, PropertyFlag.Null, flagged: false);

--- a/src/EntityFramework.Core/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/NavigationFixer.cs
@@ -385,7 +385,11 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
             foreach (var navigation in navigations)
             {
                 Unfixup(navigation, oldPrincipalEntry, dependentEntry);
-                oldPrincipalEntry.RelationshipsSnapshot.TakeSnapshot(navigation);
+
+                if (!navigation.IsDependentToPrincipal())
+                {
+                    oldPrincipalEntry.RelationshipsSnapshot.TakeSnapshot(navigation);
+                }
             }
         }
 

--- a/src/EntityFramework.Core/ChangeTracking/Internal/RelationshipsSnapshot.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/RelationshipsSnapshot.cs
@@ -1,33 +1,28 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
-using Microsoft.Data.Entity.Utilities;
+using Microsoft.Data.Entity.Metadata.Internal;
 
 namespace Microsoft.Data.Entity.ChangeTracking.Internal
 {
-    // TODO: Consider using ArraySidecar with pre-defined indexes
-    // Issue #741
-    public class RelationshipsSnapshot : DictionarySidecar
+    public class RelationshipsSnapshot : ArraySidecar
     {
         public RelationshipsSnapshot([NotNull] InternalEntityEntry entry)
-            : base(entry, GetProperties(Check.NotNull(entry, nameof(entry))))
+            : base(entry, entry.EntityType.RelationshipPropertyCount())
         {
         }
 
-        private static IEnumerable<IPropertyBase> GetProperties(InternalEntityEntry entry)
-        {
-            var entityType = entry.EntityType;
+        protected override int Index(IPropertyBase property) => property.GetRelationshipIndex();
 
-            return entityType.GetKeys().SelectMany(k => k.Properties)
-                .Concat(entityType.GetForeignKeys().SelectMany(fk => fk.Properties))
-                .Distinct()
-                .Concat<IPropertyBase>(entityType.GetNavigations());
+        protected override void ThrowInvalidIndexException(IPropertyBase property)
+        {
+            throw new InvalidOperationException();
         }
 
         protected override object CopyValueFromEntry(IPropertyBase property)

--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -92,11 +92,14 @@
     <Compile Include="Metadata\Internal\ICanGetNavigations.cs" />
     <Compile Include="Metadata\Internal\INavigationAccessors.cs" />
     <Compile Include="Metadata\Internal\IPropertyBaseAccessors.cs" />
+    <Compile Include="Metadata\Internal\IPropertyCountsAccessor.cs" />
+    <Compile Include="Metadata\Internal\IPropertyIndexesAccessor.cs" />
     <Compile Include="Metadata\Internal\KeyExtensions.cs" />
     <Compile Include="Metadata\Internal\ModelExtensions.cs" />
     <Compile Include="Metadata\Internal\MutableEntityTypeExtensions.cs" />
     <Compile Include="Metadata\Internal\NavigationExtensions.cs" />
     <Compile Include="Metadata\Internal\PropertyBaseExtensions.cs" />
+    <Compile Include="Metadata\Internal\PropertyCounts.cs" />
     <Compile Include="Metadata\Internal\PropertyExtensions.cs" />
     <Compile Include="Extensions\MutableAnnotatableExtensions.cs" />
     <Compile Include="Metadata\Internal\EntityTypeExtensions.cs" />
@@ -234,6 +237,7 @@
     <Compile Include="Extensions\MutableModelExtensions.cs" />
     <Compile Include="Extensions\MutableNavigationExtensions.cs" />
     <Compile Include="Extensions\MutablePropertyExtensions.cs" />
+    <Compile Include="Metadata\Internal\PropertyIndexes.cs" />
     <Compile Include="Metadata\SimpleModelFactory.cs" />
     <Compile Include="Metadata\ValueGenerated.cs" />
     <Compile Include="Infrastructure\DbContextOptions.cs" />

--- a/src/EntityFramework.Core/Metadata/Internal/CoreAnnotationNames.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/CoreAnnotationNames.cs
@@ -6,9 +6,6 @@ namespace Microsoft.Data.Entity.Metadata.Internal
     public static class CoreAnnotationNames
     {
         public const string MaxLengthAnnotation = "MaxLength";
-        public const string OriginalValueIndexAnnotation = "OriginalValueIndex";
         public const string ProductVersionAnnotation = "ProductVersion";
-        public const string ShadowIndexAnnotation = "ShadowIndex";
-        public const string IndexAnnotation = "Index";
     }
 }

--- a/src/EntityFramework.Core/Metadata/Internal/IPropertyCountsAccessor.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/IPropertyCountsAccessor.cs
@@ -1,0 +1,10 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Data.Entity.Metadata.Internal
+{
+    public interface IPropertyCountsAccessor
+    {
+        PropertyCounts Counts { get; }
+    }
+}

--- a/src/EntityFramework.Core/Metadata/Internal/IPropertyIndexesAccessor.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/IPropertyIndexesAccessor.cs
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+
+namespace Microsoft.Data.Entity.Metadata.Internal
+{
+    public interface IPropertyIndexesAccessor
+    {
+        PropertyIndexes Indexes { get; [param: CanBeNull] set; }
+    }
+}

--- a/src/EntityFramework.Core/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -540,7 +540,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 var indexesToDetach = propertyToDetach.FindContainingIndexes().ToList();
                 if (indexesToDetach.Count > 0)
                 {
-                    detachedIndexes.Add(DetachIndexes(indexesToDetach));
+                    detachedIndexes.Add(DetachIndexes(indexesToDetach.OfType<Index>()));
                 }
             }
 

--- a/src/EntityFramework.Core/Metadata/Internal/PropertyCounts.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/PropertyCounts.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Data.Entity.Metadata.Internal
+{
+    public class PropertyCounts
+    {
+        public PropertyCounts(int propertyCount, int navigationCount, int originalValueCount, int shadowCount, int relationshipCount)
+        {
+            PropertyCount = propertyCount;
+            NavigationCount = navigationCount;
+            OriginalValueCount = originalValueCount;
+            ShadowCount = shadowCount;
+            RelationshipCount = relationshipCount;
+        }
+
+        public virtual int PropertyCount { get; }
+        public virtual int NavigationCount { get; }
+        public virtual int OriginalValueCount { get; }
+        public virtual int ShadowCount { get; }
+        public virtual int RelationshipCount { get; }
+    }
+}

--- a/src/EntityFramework.Core/Metadata/Internal/PropertyIndexes.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/PropertyIndexes.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Data.Entity.Metadata.Internal
+{
+    public class PropertyIndexes
+    {
+        public PropertyIndexes(int index, int originalValueIndex, int shadowIndex, int relationshipIndex)
+        {
+            Index = index;
+            OriginalValueIndex = originalValueIndex;
+            ShadowIndex = shadowIndex;
+            RelationshipIndex = relationshipIndex;
+        }
+
+        public virtual int Index { get; }
+        public virtual int OriginalValueIndex { get; }
+        public virtual int ShadowIndex { get; }
+        public virtual int RelationshipIndex { get; }
+    }
+}

--- a/src/EntityFramework.Relational.Design/RelationalScaffoldingModelFactory.cs
+++ b/src/EntityFramework.Relational.Design/RelationalScaffoldingModelFactory.cs
@@ -25,12 +25,6 @@ namespace Microsoft.Data.Entity.Scaffolding
         internal const string NavigationNameUniquifyingPattern = "{0}Navigation";
         internal const string SelfReferencingPrincipalEndNavigationNamePattern = "Inverse{0}";
 
-        internal static IReadOnlyList<string> IgnoredAnnotations { get; } = new List<string>
-        {
-            CoreAnnotationNames.OriginalValueIndexAnnotation,
-            CoreAnnotationNames.ShadowIndexAnnotation
-        };
-
         protected virtual ILogger Logger { get; }
 
         private Dictionary<TableModel, CSharpUniqueNamer<ColumnModel>> _columnNamers;

--- a/src/EntityFramework.Relational/Query/ExpressionVisitors/Internal/MaterializerFactory.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionVisitors/Internal/MaterializerFactory.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors.Internal
             var concreteEntityTypes
                 = entityType.GetConcreteTypesInHierarchy().ToArray();
 
-            var indexMap = new int[concreteEntityTypes[0].GetProperties().Count()];
+            var indexMap = new int[concreteEntityTypes[0].PropertyCount()];
             var propertyIndex = 0;
 
             foreach (var property in concreteEntityTypes[0].GetProperties())
@@ -119,7 +119,7 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors.Internal
 
             foreach (var concreteEntityType in concreteEntityTypes.Skip(1))
             {
-                indexMap = new int[concreteEntityType.GetProperties().Count()];
+                indexMap = new int[concreteEntityType.PropertyCount()];
                 propertyIndex = 0;
 
                 foreach (var property in concreteEntityType.GetProperties())

--- a/test/EntityFramework.Core.Tests/DbContextTest.cs
+++ b/test/EntityFramework.Core.Tests/DbContextTest.cs
@@ -2521,6 +2521,8 @@ namespace Microsoft.Data.Entity.Tests
             var entityTypeMock = new Mock<IEntityType>();
             entityTypeMock.Setup(e => e.GetProperties()).Returns(new IProperty[0]);
 
+            entityTypeMock.As<IPropertyCountsAccessor>().Setup(e => e.Counts).Returns(new PropertyCounts(0, 0, 0, 0, 0));
+
             var internalEntryMock = new Mock<InternalEntityEntry>(
                 Mock.Of<IStateManager>(), entityTypeMock.Object, Mock.Of<IEntityEntryMetadataServices>());
             return internalEntryMock;

--- a/test/EntityFramework.Core.Tests/Infrastructure/ModelValidatorTest.cs
+++ b/test/EntityFramework.Core.Tests/Infrastructure/ModelValidatorTest.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Data.Entity.Tests.Infrastructure
         {
             if (startingPropertyIndex == -1)
             {
-                startingPropertyIndex = entityType.PropertyCount - 1;
+                startingPropertyIndex = entityType.PropertyCount() - 1;
             }
             var keyProperties = new Property[propertyCount];
             for (var i = 0; i < propertyCount; i++)

--- a/test/EntityFramework.Core.Tests/Metadata/Internal/PropertyTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/Internal/PropertyTest.cs
@@ -342,59 +342,6 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             Assert.True(property.IsReadOnlyAfterSave.Value);
         }
 
-        [Fact]
-        public void Can_get_and_set_property_index_for_normal_property()
-        {
-            var entityType = new Model().AddEntityType(typeof(Entity));
-            var property = entityType.AddProperty("Name", typeof(string));
-            property.IsShadowProperty = false;
-
-            Assert.Equal(0, property.GetIndex());
-            Assert.Equal(-1, property.GetShadowIndex());
-
-            property.SetIndex(1);
-
-            Assert.Equal(1, property.GetIndex());
-            Assert.Equal(-1, property.GetShadowIndex());
-            
-            Assert.Equal(
-                "value",
-                Assert.Throws<ArgumentOutOfRangeException>(() => property.SetIndex(-1)).ParamName);
-
-            Assert.Equal(
-                "index",
-                Assert.Throws<ArgumentOutOfRangeException>(() => property.SetShadowIndex(-1)).ParamName);
-
-            Assert.Equal(
-                "index",
-                Assert.Throws<ArgumentOutOfRangeException>(() => property.SetShadowIndex(1)).ParamName);
-        }
-
-        [Fact]
-        public void Can_get_and_set_property_and_shadow_index_for_shadow_property()
-        {
-            var entityType = new Model().AddEntityType(typeof(object));
-            var property = entityType.AddProperty("Kake", typeof(int));
-            property.IsShadowProperty = true;
-
-            Assert.Equal(0, property.GetIndex());
-            Assert.Equal(0, property.GetShadowIndex());
-
-            property.SetIndex(1);
-            property.SetShadowIndex(2);
-
-            Assert.Equal(1, property.GetIndex());
-            Assert.Equal(2, property.GetShadowIndex());
-            
-            Assert.Equal(
-                "value",
-                Assert.Throws<ArgumentOutOfRangeException>(() => property.SetIndex(-1)).ParamName);
-
-            Assert.Equal(
-                "index",
-                Assert.Throws<ArgumentOutOfRangeException>(() => property.SetShadowIndex(-1)).ParamName);
-        }
-
         private class Entity
         {
             public string Name { get; set; }

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/OneToOneTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/OneToOneTestBase.cs
@@ -1037,8 +1037,8 @@ namespace Microsoft.Data.Entity.Tests
                 var fkProperty = dependentType.FindProperty("OrderId");
                 var principalProperty = principalType.FindProperty("OrderId");
 
-                var principalPropertyCount = principalType.PropertyCount;
-                var dependentPropertyCount = dependentType.PropertyCount;
+                var principalPropertyCount = principalType.PropertyCount();
+                var dependentPropertyCount = dependentType.PropertyCount();
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
 
@@ -1055,8 +1055,8 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Equal("Details", principalType.GetNavigations().Single().Name);
                 Assert.Same(fk, dependentType.GetNavigations().Single().ForeignKey);
                 Assert.Same(fk, principalType.GetNavigations().Single().ForeignKey);
-                Assert.Equal(principalPropertyCount, principalType.PropertyCount);
-                Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
+                Assert.Equal(principalPropertyCount, principalType.PropertyCount());
+                Assert.Equal(dependentPropertyCount, dependentType.PropertyCount());
                 Assert.Empty(principalType.GetForeignKeys());
                 Assert.Same(principalKey, principalType.GetKeys().Single());
                 Assert.Same(dependentKey, dependentType.GetKeys().Single());
@@ -1079,8 +1079,8 @@ namespace Microsoft.Data.Entity.Tests
                 var fkProperty = dependentType.FindProperty("OrderId");
                 var principalProperty = principalType.FindProperty("OrderId");
 
-                var principalPropertyCount = principalType.PropertyCount;
-                var dependentPropertyCount = dependentType.PropertyCount;
+                var principalPropertyCount = principalType.PropertyCount();
+                var dependentPropertyCount = dependentType.PropertyCount();
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();
 
@@ -1097,8 +1097,8 @@ namespace Microsoft.Data.Entity.Tests
                 Assert.Equal("Details", principalType.GetNavigations().Single().Name);
                 Assert.Same(fk, dependentType.GetNavigations().Single().ForeignKey);
                 Assert.Same(fk, principalType.GetNavigations().Single().ForeignKey);
-                Assert.Equal(principalPropertyCount, principalType.PropertyCount);
-                Assert.Equal(dependentPropertyCount, dependentType.PropertyCount);
+                Assert.Equal(principalPropertyCount, principalType.PropertyCount());
+                Assert.Equal(dependentPropertyCount, dependentType.PropertyCount());
                 Assert.Empty(principalType.GetForeignKeys());
                 Assert.Same(principalKey, principalType.GetKeys().Single());
                 Assert.Same(dependentKey, dependentType.GetKeys().Single());

--- a/test/EntityFramework.Relational.Tests/Update/ColumnModificationTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/ColumnModificationTest.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Update;
 using Moq;
@@ -79,6 +80,8 @@ namespace Microsoft.Data.Entity.Tests.Update
         {
             var entityTypeMock = new Mock<IEntityType>();
             entityTypeMock.Setup(e => e.GetProperties()).Returns(new[] { property });
+
+            entityTypeMock.As<IPropertyCountsAccessor>().Setup(e => e.Counts).Returns(new PropertyCounts(0, 0, 0, 0, 0));
 
             var internalEntryMock = new Mock<InternalEntityEntry>(
                 Mock.Of<IStateManager>(), entityTypeMock.Object, Mock.Of<IEntityEntryMetadataServices>());

--- a/test/EntityFramework.Relational.Tests/Update/UpdateSqlGeneratorTestBase.cs
+++ b/test/EntityFramework.Relational.Tests/Update/UpdateSqlGeneratorTestBase.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Update;
 using Moq;
@@ -394,6 +395,8 @@ namespace Microsoft.Data.Entity.Tests
         {
             var entityTypeMock = new Mock<IEntityType>();
             entityTypeMock.Setup(e => e.GetProperties()).Returns(new IProperty[0]);
+
+            entityTypeMock.As<IPropertyCountsAccessor>().Setup(e => e.Counts).Returns(new PropertyCounts(0, 0, 0, 0, 0));
 
             var internalEntryMock = new Mock<InternalEntityEntry>(
                 Mock.Of<IStateManager>(), entityTypeMock.Object, Mock.Of<IEntityEntryMetadataServices>());


### PR DESCRIPTION
This is done by calculating indexes for the properties that need to be snapshotted and using an array sidecar to store the snapshot.

Perf improvement is about 15%, with also about 10% improvement in memory usage.