### PR TITLE
[TINY] Fix to #3464 - StringCompareExpression throws 100% of the times

### DIFF
--- a/src/EntityFramework.Relational/Query/Expressions/StringCompareExpression.cs
+++ b/src/EntityFramework.Relational/Query/Expressions/StringCompareExpression.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Query.Sql;
@@ -18,6 +19,8 @@ namespace Microsoft.Data.Entity.Query.Expressions
         }
 
         public override ExpressionType NodeType => ExpressionType.Extension;
+
+        public override Type Type => typeof(bool);
 
         public virtual ExpressionType Operator { get; }
 

--- a/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
@@ -3521,6 +3521,18 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
+        [Fact]
+        public virtual void String_Compare_multi_predicate()
+        {
+            AssertQuery<Customer>(
+                cs => cs.Where(c => string.Compare(c.CustomerID, "ALFKI") > -1).Where(c => string.Compare(c.CustomerID, "CACTU") == -1),
+                entryCount: 11);
+
+            AssertQuery<Customer>(
+                cs => cs.Where(c => string.Compare(c.ContactTitle, "Owner") == 0).Where(c => string.Compare(c.Country, "USA") != 0),
+                entryCount: 15);
+        }
+
         protected static string LocalMethod1()
         {
             return "M";

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -3248,6 +3248,21 @@ WHERE [c].[CustomerID] < REPLACE('ALFKI', UPPER('ALF'), [c].[CustomerID])",
                 Sql);
         }
 
+        public override void String_Compare_multi_predicate()
+        {
+            base.String_Compare_multi_predicate();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] >= 'ALFKI' AND [c].[CustomerID] < 'CACTU'
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[ContactTitle] = 'Owner' AND [c].[Country] <> 'USA'",
+                Sql);
+        }
+
         public override void Where_math_abs1()
         {
             base.Where_math_abs1();


### PR DESCRIPTION
StringCompareExpression was missing Type property overload.