### PR TITLE
Minor changes to enable Linux testing

### DIFF
--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -4077,6 +4077,9 @@ ORDER BY COALESCE([c].[Region], 'ZZ')",
                 Sql);
         }
 
-        private static string Sql => TestSqlLoggerFactory.Sql;
+        private static string FileLineEnding = @"
+";
+
+        private static string Sql => TestSqlLoggerFactory.Sql.Replace(Environment.NewLine, FileLineEnding);
     }
 }

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/RowNumberPagingTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/RowNumberPagingTest.cs
@@ -172,6 +172,10 @@ WHERE [t1].[__RowNumber__] > 5", Sql);
             // base.String_Contains_Literal()
         }
 
-        private static string Sql => TestSqlLoggerFactory.Sql;
+
+        private static string FileLineEnding = @"
+";
+
+        private static string Sql => TestSqlLoggerFactory.Sql.Replace(Environment.NewLine, FileLineEnding);
     }
 }

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/Utilities/SqlConnectionStringBuilderExtensions.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/Utilities/SqlConnectionStringBuilderExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Data.SqlClient;
 
 namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
@@ -41,6 +42,11 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             if (!string.IsNullOrEmpty(config["Password"]))
             {
                 builder.Password = config["Password"];
+
+                if (Type.GetType("Mono.Runtime") == null)
+                {
+                    builder.PersistSecurityInfo = true;
+                }
             }
 
             return builder;

--- a/test/EntityFramework.Relational.FunctionalTests/TestSqlLoggerFactory.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/TestSqlLoggerFactory.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
     public class TestSqlLoggerFactory : ILoggerFactory
     {
         private static SqlLogger _logger;
+        private static string EOL = Environment.NewLine;
 
         public LogLevel MinimumLevel { get; set; }
 
@@ -52,7 +53,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         public static string Log => Logger.SqlLoggerData._log.ToString();
 
         public static string Sql
-            => string.Join("\r\n\r\n", Logger.SqlLoggerData._sqlStatements);
+            => string.Join(EOL + EOL, Logger.SqlLoggerData._sqlStatements);
 
         public static List<string> SqlStatements => Logger.SqlLoggerData._sqlStatements;
 
@@ -129,11 +130,11 @@ namespace Microsoft.Data.Entity.FunctionalTests
                         {
                             parameters
                                 = string.Join(
-                                    "\r\n",
+                                    EOL,
                                     commandLogData.Parameters
                                         .Select(kv => kv.Key + ": "
                                                       + Convert.ToString(kv.Value, CultureInfo.InvariantCulture)))
-                                  + "\r\n\r\n";
+                                  + EOL + EOL;
                         }
 
                         sqlLoggerData._sqlStatements.Add(parameters + commandLogData.CommandText);

--- a/test/EntityFramework.Sqlite.FunctionalTests/QuerySqliteTest.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/QuerySqliteTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using Microsoft.Data.Entity.FunctionalTests;
 using Microsoft.Data.Entity.FunctionalTests.TestModels.Northwind;
@@ -44,6 +45,10 @@ LIMIT -1 OFFSET 5",
         {
         }
 
-        private static string Sql => TestSqlLoggerFactory.Sql;
+
+        private static string FileLineEnding = @"
+";
+
+        private static string Sql => TestSqlLoggerFactory.Sql.Replace(Environment.NewLine, FileLineEnding);
     }
 }


### PR DESCRIPTION
Handle line endings in query tests.

Fix #3658