### PR TITLE
[rc1] Temporarily add reference System.Net.Security 

### DIFF
--- a/src/EntityFramework.MicrosoftSqlServer/project.json
+++ b/src/EntityFramework.MicrosoftSqlServer/project.json
@@ -22,6 +22,7 @@
     "dotnet5.4": {
       "dependencies": {
         "System.Data.SqlClient": "4.0.0-*",
+        "System.Net.Security": "4.0.0-*",
         "System.Text.Encoding.CodePages": "4.0.1-beta-*",
         "System.Threading.Thread": "4.0.0-*",
         "System.Threading.ThreadPool": "4.0.10-*"


### PR DESCRIPTION
Workaround for unresolved issues in dnu restore on linux. (See https://github.com/dotnet/corefx/issues/4230).

As long as users don't use MARS, SqlClient on Linux/OSX appears to be *mostly ok.