### PR TITLE
Query: Perf: Improve performance of typed ValueBuffer factories by:

### DIFF
--- a/src/EntityFramework.Relational/Storage/TypedRelationalValueBufferFactoryFactory.cs
+++ b/src/EntityFramework.Relational/Storage/TypedRelationalValueBufferFactoryFactory.cs
@@ -16,10 +16,27 @@ namespace Microsoft.Data.Entity.Storage
     public class TypedRelationalValueBufferFactoryFactory : IRelationalValueBufferFactoryFactory
     {
         private static readonly MethodInfo _getFieldValueMethod
-            = typeof(DbDataReader).GetTypeInfo().GetDeclaredMethod("GetFieldValue");
+            = typeof(DbDataReader).GetTypeInfo().GetDeclaredMethod(nameof(DbDataReader.GetFieldValue));
 
         private static readonly MethodInfo _isDbNullMethod
-            = typeof(DbDataReader).GetTypeInfo().GetDeclaredMethod("IsDBNull");
+            = typeof(DbDataReader).GetTypeInfo().GetDeclaredMethod(nameof(DbDataReader.IsDBNull));
+
+        private static readonly IDictionary<Type, MethodInfo> _getXMethods
+            = new Dictionary<Type, MethodInfo>
+            {
+                { typeof(bool), typeof(DbDataReader).GetTypeInfo().GetDeclaredMethod(nameof(DbDataReader.GetBoolean)) },
+                { typeof(byte), typeof(DbDataReader).GetTypeInfo().GetDeclaredMethod(nameof(DbDataReader.GetByte)) },
+                { typeof(char), typeof(DbDataReader).GetTypeInfo().GetDeclaredMethod(nameof(DbDataReader.GetChar)) },
+                { typeof(DateTime), typeof(DbDataReader).GetTypeInfo().GetDeclaredMethod(nameof(DbDataReader.GetDateTime)) },
+                { typeof(decimal), typeof(DbDataReader).GetTypeInfo().GetDeclaredMethod(nameof(DbDataReader.GetDecimal)) },
+                { typeof(double), typeof(DbDataReader).GetTypeInfo().GetDeclaredMethod(nameof(DbDataReader.GetDouble)) },
+                { typeof(float), typeof(DbDataReader).GetTypeInfo().GetDeclaredMethod(nameof(DbDataReader.GetFloat)) },
+                { typeof(Guid), typeof(DbDataReader).GetTypeInfo().GetDeclaredMethod(nameof(DbDataReader.GetGuid)) },
+                { typeof(short), typeof(DbDataReader).GetTypeInfo().GetDeclaredMethod(nameof(DbDataReader.GetInt16)) },
+                { typeof(int), typeof(DbDataReader).GetTypeInfo().GetDeclaredMethod(nameof(DbDataReader.GetInt32)) },
+                { typeof(long), typeof(DbDataReader).GetTypeInfo().GetDeclaredMethod(nameof(DbDataReader.GetInt64)) },
+                { typeof(string), typeof(DbDataReader).GetTypeInfo().GetDeclaredMethod(nameof(DbDataReader.GetString)) }
+            };
 
         private struct CacheKey
         {
@@ -64,7 +81,7 @@ namespace Microsoft.Data.Entity.Storage
                 unchecked
                 {
                     return ValueTypes.Aggregate(0, (t, v) => (t * 397) ^ v.GetHashCode())
-                           ^ IndexMap?.Aggregate(0, (t, v) => (t * 397) ^ v.GetHashCode()) ?? 0;
+                           ^ (IndexMap?.Aggregate(0, (t, v) => (t * 397) ^ v.GetHashCode()) ?? 0);
                 }
             }
         }
@@ -85,7 +102,7 @@ namespace Microsoft.Data.Entity.Storage
 
         private static Func<DbDataReader, object[]> CreateArrayInitializer(CacheKey cacheKey)
         {
-            var dataReaderParam = Expression.Parameter(typeof(DbDataReader), "dataReader");
+            var dataReaderParameter = Expression.Parameter(typeof(DbDataReader), "dataReader");
 
             return Expression.Lambda<Func<DbDataReader, object[]>>(
                 Expression.NewArrayInit(
@@ -93,32 +110,47 @@ namespace Microsoft.Data.Entity.Storage
                     cacheKey.ValueTypes
                         .Select((type, i) =>
                             CreateGetValueExpression(
-                                dataReaderParam,
+                                dataReaderParameter,
                                 type,
                                 Expression.Constant(cacheKey.IndexMap?[i] ?? i)))),
-                dataReaderParam)
+                dataReaderParameter)
                 .Compile();
         }
 
         private static Expression CreateGetValueExpression(
             Expression dataReaderExpression, Type type, Expression indexExpression)
         {
-            var underlyingTargetMemberType = type.UnwrapNullableType().UnwrapEnumType();
+            var underlyingType = type.UnwrapNullableType().UnwrapEnumType();
 
-            Expression expression = Expression.Call(
-                dataReaderExpression,
-                _getFieldValueMethod.MakeGenericMethod(underlyingTargetMemberType),
-                indexExpression);
+            MethodInfo getMethod;
+            if (!_getXMethods.TryGetValue(underlyingType, out getMethod))
+            {
+                getMethod = _getFieldValueMethod.MakeGenericMethod(underlyingType);
+            }
 
-            if (underlyingTargetMemberType != type)
+            Expression expression
+                = Expression.Call(dataReaderExpression, getMethod, indexExpression);
+
+            if (expression.Type != type)
             {
                 expression = Expression.Convert(expression, type);
             }
 
-            return Expression.Condition(
-                Expression.Call(dataReaderExpression, _isDbNullMethod, indexExpression),
-                Expression.Constant(null, typeof(object)),
-                Expression.Convert(expression, typeof(object)));
+            if (expression.Type.GetTypeInfo().IsValueType)
+            {
+                expression = Expression.Convert(expression, typeof(object));
+            }
+
+            if (expression.Type.IsNullableType())
+            {
+                expression
+                    = Expression.Condition(
+                        Expression.Call(dataReaderExpression, _isDbNullMethod, indexExpression),
+                        Expression.Default(expression.Type),
+                        expression);
+            }
+
+            return expression;
         }
     }
 }

--- a/test/EntityFramework.Relational.Tests/TestUtilities/FakeProvider/FakeDbDataReader.cs
+++ b/test/EntityFramework.Relational.Tests/TestUtilities/FakeProvider/FakeDbDataReader.cs
@@ -17,15 +17,13 @@ namespace Microsoft.Data.Entity.TestUtilities.FakeProvider
         private readonly IList<object[]> _results;
 
         private object[] _currentRow;
-        private int _rowIndex = 0;
+        private int _rowIndex;
 
         public FakeDbDataReader(string[] columnNames = null, IList<object[]> results = null)
         {
             _columnNames = columnNames ?? new string[0];
             _results = results ?? new List<object[]>();
         }
-
-        public int ReadCount { get; private set; }
 
         public override bool Read()
         {
@@ -50,6 +48,7 @@ namespace Microsoft.Data.Entity.TestUtilities.FakeProvider
         }
 
         public int CloseCount { get; private set; }
+
         public override void Close()
         {
             CloseCount++;
@@ -63,7 +62,7 @@ namespace Microsoft.Data.Entity.TestUtilities.FakeProvider
             {
                 DisposeCount++;
 
-                base.Dispose(disposing);
+                base.Dispose(true);
             }
         }
 
@@ -81,78 +80,49 @@ namespace Microsoft.Data.Entity.TestUtilities.FakeProvider
         {
             GetInt32Count++;
 
-            return (Int32)_currentRow[ordinal];
+            return (int)_currentRow[ordinal];
         }
 
         public override object this[string name]
         {
-            get
-            {
-                throw new NotImplementedException();
-            }
+            get { throw new NotImplementedException(); }
         }
 
         public override object this[int ordinal]
         {
-            get
-            {
-                throw new NotImplementedException();
-            }
+            get { throw new NotImplementedException(); }
         }
 
         public override int Depth
         {
-            get
-            {
-                throw new NotImplementedException();
-            }
+            get { throw new NotImplementedException(); }
         }
-
-
 
         public override bool HasRows
         {
-            get
-            {
-                throw new NotImplementedException();
-            }
+            get { throw new NotImplementedException(); }
         }
 
         public override bool IsClosed
         {
-            get
-            {
-                throw new NotImplementedException();
-            }
+            get { throw new NotImplementedException(); }
         }
 
         public override int RecordsAffected
         {
-            get
-            {
-                throw new NotImplementedException();
-            }
+            get { throw new NotImplementedException(); }
         }
 
-        public override bool GetBoolean(int ordinal)
-        {
-            throw new NotImplementedException();
-        }
+        public override bool GetBoolean(int ordinal) => (bool)_currentRow[ordinal];
 
-        public override byte GetByte(int ordinal)
-        {
-            throw new NotImplementedException();
-        }
+        public override byte GetByte(int ordinal) => (byte)_currentRow[ordinal];
 
         public override long GetBytes(int ordinal, long dataOffset, byte[] buffer, int bufferOffset, int length)
         {
             throw new NotImplementedException();
         }
 
-        public override char GetChar(int ordinal)
-        {
-            throw new NotImplementedException();
-        }
+        public override char GetChar(int ordinal) => (char)_currentRow[ordinal];
 
         public override long GetChars(int ordinal, long dataOffset, char[] buffer, int bufferOffset, int length)
         {
@@ -164,20 +134,11 @@ namespace Microsoft.Data.Entity.TestUtilities.FakeProvider
             throw new NotImplementedException();
         }
 
-        public override DateTime GetDateTime(int ordinal)
-        {
-            throw new NotImplementedException();
-        }
+        public override DateTime GetDateTime(int ordinal) => (DateTime)_currentRow[ordinal];
 
-        public override decimal GetDecimal(int ordinal)
-        {
-            throw new NotImplementedException();
-        }
+        public override decimal GetDecimal(int ordinal) => (decimal)_currentRow[ordinal];
 
-        public override double GetDouble(int ordinal)
-        {
-            throw new NotImplementedException();
-        }
+        public override double GetDouble(int ordinal) => (double)_currentRow[ordinal];
 
         public override IEnumerator GetEnumerator()
         {
@@ -189,25 +150,13 @@ namespace Microsoft.Data.Entity.TestUtilities.FakeProvider
             throw new NotImplementedException();
         }
 
-        public override float GetFloat(int ordinal)
-        {
-            throw new NotImplementedException();
-        }
+        public override float GetFloat(int ordinal) => (float)_currentRow[ordinal];
 
-        public override Guid GetGuid(int ordinal)
-        {
-            throw new NotImplementedException();
-        }
+        public override Guid GetGuid(int ordinal) => (Guid)_currentRow[ordinal];
 
-        public override short GetInt16(int ordinal)
-        {
-            throw new NotImplementedException();
-        }
+        public override short GetInt16(int ordinal) => (short)_currentRow[ordinal];
 
-        public override long GetInt64(int ordinal)
-        {
-            throw new NotImplementedException();
-        }
+        public override long GetInt64(int ordinal) => (long)_currentRow[ordinal];
 
         public override int GetOrdinal(string name)
         {
@@ -219,10 +168,7 @@ namespace Microsoft.Data.Entity.TestUtilities.FakeProvider
             throw new NotImplementedException();
         }
 
-        public override string GetString(int ordinal)
-        {
-            throw new NotImplementedException();
-        }
+        public override string GetString(int ordinal) => (string)_currentRow[ordinal];
 
         public override int GetValues(object[] values)
         {


### PR DESCRIPTION
1) Use DbDataReader.GetX methods when available for target type.
2) Only box result when required.
3) Only perform IsDBNull check when target is nullable.

Yields ~25% speed up