### PR TITLE
Create explicit index object for Keys & ForeignKeys

### DIFF
--- a/src/EntityFramework.Commands/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EntityFramework.Commands/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Data.Entity.Migrations.Design
 
                     GenerateKeys(entityType.GetDeclaredKeys(), entityType.FindDeclaredPrimaryKey(), stringBuilder);
 
-                    GenerateIndexes(entityType.GetDeclaredIndexes(), stringBuilder);
+                    GenerateIndexes(entityType.GetDeclaredIndexes().Except(entityType.GetKeys().Select(key => key.Index)), stringBuilder);
 
                     GenerateEntityTypeAnnotations(entityType, stringBuilder);
                 }

--- a/src/EntityFramework.Core/Metadata/IForeignKey.cs
+++ b/src/EntityFramework.Core/Metadata/IForeignKey.cs
@@ -47,6 +47,11 @@ namespace Microsoft.Data.Entity.Metadata
         INavigation PrincipalToDependent { get; }
 
         /// <summary>
+        ///     Gets the index object defined on the foreign key properties.
+        /// </summary>
+        IIndex Index { get; }
+
+        /// <summary>
         ///     Gets a value indicating whether the values assigned to the foreign key properties are unique.
         /// </summary>
         bool IsUnique { get; }

--- a/src/EntityFramework.Core/Metadata/IKey.cs
+++ b/src/EntityFramework.Core/Metadata/IKey.cs
@@ -22,5 +22,10 @@ namespace Microsoft.Data.Entity.Metadata
         ///     may be defined on a base type).
         /// </summary>
         IEntityType DeclaringEntityType { get; }
+
+        /// <summary>
+        ///     Gets the index object defined on the key properties.
+        /// </summary>
+        IIndex Index { get; }
     }
 }

--- a/src/EntityFramework.Core/Metadata/IMutableForeignKey.cs
+++ b/src/EntityFramework.Core/Metadata/IMutableForeignKey.cs
@@ -73,9 +73,14 @@ namespace Microsoft.Data.Entity.Metadata
         IMutableNavigation HasPrincipalToDependent([CanBeNull] string name);
 
         /// <summary>
-        ///     Gets or sets a value indicating whether the values assigned to the foreign key properties are unique.
+        ///     Gets the index object defined on the foreign key properties.
         /// </summary>
-        new bool? IsUnique { get; set; }
+        new IMutableIndex Index { get; }
+
+        /// <summary>
+        ///     Gets a value indicating whether the values assigned to the foreign key properties are unique.
+        /// </summary>
+        new bool? IsUnique { get; }
 
         /// <summary>
         ///     Gets or sets a value indicating if this relationship is required. If true, the dependent entity must always be

--- a/src/EntityFramework.Core/Metadata/IMutableKey.cs
+++ b/src/EntityFramework.Core/Metadata/IMutableKey.cs
@@ -27,5 +27,10 @@ namespace Microsoft.Data.Entity.Metadata
         ///     may be defined on a base type).
         /// </summary>
         new IMutableEntityType DeclaringEntityType { get; }
+
+        /// <summary>
+        ///     Gets the index object defined on the key properties.
+        /// </summary>
+        new IMutableIndex Index { get; }
     }
 }

--- a/src/EntityFramework.Core/Metadata/Internal/ForeignKey.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/ForeignKey.cs
@@ -96,7 +96,8 @@ namespace Microsoft.Data.Entity.Metadata.Internal
         public virtual EntityType DeclaringEntityType { get; }
         public virtual EntityType PrincipalEntityType { get; }
 
-        public virtual bool? IsUnique { get; set; }
+        public virtual Index Index => DeclaringEntityType.FindIndex(Properties);
+        public virtual bool? IsUnique => Index?.IsUnique;
         protected virtual bool DefaultIsUnique => false;
 
         public virtual bool? IsRequired
@@ -190,6 +191,8 @@ namespace Microsoft.Data.Entity.Metadata.Internal
         IMutableNavigation IMutableForeignKey.PrincipalToDependent => PrincipalToDependent;
         IMutableNavigation IMutableForeignKey.HasPrincipalToDependent(string name) => HasPrincipalToDependent(name);
 
+        IIndex IForeignKey.Index => Index;
+        IMutableIndex IMutableForeignKey.Index => Index;
         bool IForeignKey.IsUnique => IsUnique ?? DefaultIsUnique;
         bool IForeignKey.IsRequired => IsRequired ?? DefaultIsRequired;
         DeleteBehavior IForeignKey.DeleteBehavior => DeleteBehavior ?? DefaultDeleteBehavior;

--- a/src/EntityFramework.Core/Metadata/Internal/Index.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/Index.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Utilities;
 
@@ -49,5 +50,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
         [UsedImplicitly]
         private string DebuggerDisplay => Property.Format(Properties);
+
+        public virtual bool IsInUse() => (DeclaringEntityType.FindKey(Properties) != null) || DeclaringEntityType.FindForeignKeys(Properties).Any();
     }
 }

--- a/src/EntityFramework.Core/Metadata/Internal/Key.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/Key.cs
@@ -38,10 +38,13 @@ namespace Microsoft.Data.Entity.Metadata.Internal
         public virtual IEnumerable<ForeignKey> FindReferencingForeignKeys()
             => ((IKey)this).FindReferencingForeignKeys().Cast<ForeignKey>();
 
+        public virtual Index Index => DeclaringEntityType.FindIndex(Properties);
         IReadOnlyList<IProperty> IKey.Properties => Properties;
         IReadOnlyList<IMutableProperty> IMutableKey.Properties => Properties;
         IEntityType IKey.DeclaringEntityType => DeclaringEntityType;
         IMutableEntityType IMutableKey.DeclaringEntityType => DeclaringEntityType;
+        IIndex IKey.Index => Index;
+        IMutableIndex IMutableKey.Index => Index;
 
         [UsedImplicitly]
         private string DebuggerDisplay => Property.Format(Properties);

--- a/src/EntityFramework.MicrosoftSqlServer/Metadata/Internal/SqlServerKeyBuilderAnnotations.cs
+++ b/src/EntityFramework.MicrosoftSqlServer/Metadata/Internal/SqlServerKeyBuilderAnnotations.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Linq;
 using JetBrains.Annotations;
 
 namespace Microsoft.Data.Entity.Metadata.Internal
@@ -16,6 +17,13 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
         public new virtual bool Name([CanBeNull] string value) => SetName(value);
 
-        public virtual bool Clustered(bool value) => SetIsClustered(value);
+        public virtual bool Clustered(bool value)
+        {
+            var annotationsBuilder = (RelationalAnnotationsBuilder)Annotations;
+            var internalBuilder = (InternalKeyBuilder)annotationsBuilder.EntityTypeBuilder;
+            var indexBuilder = internalBuilder.Metadata.DeclaringEntityType.Builder
+                .HasIndex(internalBuilder.Metadata.Properties.Select(p => p.Name).ToList(), ConfigurationSource.Convention);
+            return new SqlServerIndexBuilderAnnotations(indexBuilder, annotationsBuilder.ConfigurationSource).Clustered(value);
+        }
     }
 }

--- a/src/EntityFramework.MicrosoftSqlServer/Metadata/SqlServerKeyAnnotations.cs
+++ b/src/EntityFramework.MicrosoftSqlServer/Metadata/SqlServerKeyAnnotations.cs
@@ -20,10 +20,8 @@ namespace Microsoft.Data.Entity.Metadata
 
         public virtual bool? IsClustered
         {
-            get { return (bool?)Annotations.GetAnnotation(SqlServerAnnotationNames.Clustered); }
-            [param: CanBeNull] set { SetIsClustered(value); }
+            get { return Key.Index.SqlServer().IsClustered; }
+            [param: CanBeNull] set { ((SqlServerIndexAnnotations)(Key.Index.SqlServer())).IsClustered = value; }
         }
-
-        protected virtual bool SetIsClustered(bool? value) => Annotations.SetAnnotation(SqlServerAnnotationNames.Clustered, value);
     }
 }

--- a/src/EntityFramework.MicrosoftSqlServer/Migrations/Internal/SqlServerMigrationsAnnotationProvider.cs
+++ b/src/EntityFramework.MicrosoftSqlServer/Migrations/Internal/SqlServerMigrationsAnnotationProvider.cs
@@ -10,16 +10,6 @@ namespace Microsoft.Data.Entity.Migrations.Internal
 {
     public class SqlServerMigrationsAnnotationProvider : MigrationsAnnotationProvider
     {
-        public override IEnumerable<IAnnotation> For(IKey key)
-        {
-            if (key.SqlServer().IsClustered.HasValue)
-            {
-                yield return new Annotation(
-                     SqlServerAnnotationNames.Prefix + SqlServerAnnotationNames.Clustered,
-                     key.SqlServer().IsClustered.Value);
-            }
-        }
-
         public override IEnumerable<IAnnotation> For(IIndex index)
         {
             if (index.SqlServer().IsClustered.HasValue)

--- a/src/EntityFramework.Relational.Design/RelationalScaffoldingModelFactory.cs
+++ b/src/EntityFramework.Relational.Design/RelationalScaffoldingModelFactory.cs
@@ -391,8 +391,6 @@ namespace Microsoft.Data.Entity.Scaffolding
 
             var key = dependentEntityType.GetOrAddForeignKey(depProps, principalKey, principalEntityType);
 
-            key.IsUnique = dependentEntityType.FindKey(depProps) != null;
-
             AssignOnDeleteAction(foreignKey, key);
 
             return key;

--- a/src/EntityFramework.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EntityFramework.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -328,7 +328,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
 
             var operations = Diff(source.GetPropertiesInHierarchy(), target.GetPropertiesInHierarchy(), diffContext)
                 .Concat(Diff(source.GetKeys(), target.GetKeys(), diffContext))
-                .Concat(Diff(source.GetIndexesInHierarchy(), target.GetIndexesInHierarchy(), diffContext));
+                .Concat(Diff(source.GetIndexesInHierarchy().Except(source.GetKeys().Select(key => key.Index)), target.GetIndexesInHierarchy().Except(target.GetKeys().Select(key => key.Index)), diffContext));
             foreach (var operation in operations)
             {
                 yield return operation;
@@ -356,7 +356,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
 
             yield return createTableOperation;
 
-            foreach (var operation in target.GetIndexesInHierarchy().SelectMany(Add))
+            foreach (var operation in target.GetIndexesInHierarchy().Except(target.GetKeys().Select(key => key.Index)).SelectMany(Add))
             {
                 yield return operation;
             }
@@ -513,7 +513,10 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                           && s.IsPrimaryKey() == t.IsPrimaryKey());
 
         protected virtual IEnumerable<MigrationOperation> Diff([NotNull] IKey source, [NotNull] IKey target)
-            => HasDifferences(MigrationsAnnotations.For(source), MigrationsAnnotations.For(target))
+            => (HasDifferences(MigrationsAnnotations.For(source), MigrationsAnnotations.For(target))
+                || HasDifferences(
+                    source.Index != null ? MigrationsAnnotations.For(source.Index) : Enumerable.Empty<IAnnotation>(),
+                    target.Index != null ? MigrationsAnnotations.For(target.Index) : Enumerable.Empty<IAnnotation>()))
                 ? Remove(source).Concat(Add(target))
                 : Enumerable.Empty<MigrationOperation>();
 
@@ -543,6 +546,13 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     Columns = GetColumns(target.Properties)
                 };
             }
+
+            // For implicit index associated with key
+            if (target.Index != null)
+            {
+                CopyAnnotations(MigrationsAnnotations.For(target.Index), operation);
+            }
+
             CopyAnnotations(MigrationsAnnotations.For(target), operation);
 
             yield return operation;

--- a/src/EntityFramework.Sqlite.Design/Internal/SqliteDmlParser.cs
+++ b/src/EntityFramework.Sqlite.Design/Internal/SqliteDmlParser.cs
@@ -75,7 +75,8 @@ namespace Microsoft.Data.Entity.Scaffolding.Internal
                 return;
             }
 
-            if (statement.IndexOf(" UNIQUE", StringComparison.OrdinalIgnoreCase) > 0)
+            if (statement.IndexOf(" UNIQUE", StringComparison.OrdinalIgnoreCase) > 0
+                || statement.IndexOf(" PRIMARY KEY", StringComparison.OrdinalIgnoreCase) > 0)
             {
                 var indexInfo = table.Indexes.FirstOrDefault(i =>
                     i.Columns.SingleOrDefault()?.Name.Equals(column.Name, StringComparison.OrdinalIgnoreCase) == true);
@@ -90,7 +91,8 @@ namespace Microsoft.Data.Entity.Scaffolding.Internal
         public static void ParseConstraints(TableModel table, string statement)
         {
             var constraint = statement.Split(' ', '(')[0];
-            if (constraint.Equals("UNIQUE", StringComparison.OrdinalIgnoreCase))
+            if (constraint.Equals("UNIQUE", StringComparison.OrdinalIgnoreCase)
+                || statement.Equals(" PRIMARY KEY", StringComparison.OrdinalIgnoreCase))
             {
                 ParseInlineUniqueConstraint(table, statement);
             }

--- a/test/EntityFramework.Commands.FunctionalTests/Migrations/ModelSnapshotTest.cs
+++ b/test/EntityFramework.Commands.FunctionalTests/Migrations/ModelSnapshotTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Data.Entity.Commands.TestUtilities;
@@ -280,8 +281,7 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 ",
                 o =>
                     {
-                        Assert.Equal(1, o.GetEntityTypes().First().GetIndexes().Count());
-                        Assert.Equal("AlternateId", o.GetEntityTypes().First().GetIndexes().First().Properties[0].Name);
+                        Assert.Contains("AlternateId", o.GetEntityTypes().First().GetIndexes().Select(index => index.Properties.First().Name));
                     });
         }
 
@@ -305,11 +305,9 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 ",
                 o =>
                     {
-                        Assert.Equal(1, o.GetEntityTypes().First().GetIndexes().Count());
-                        Assert.Collection(
-                            o.GetEntityTypes().First().GetIndexes().First().Properties,
-                            t => Assert.Equal("Id", t.Name),
-                            t => Assert.Equal("AlternateId", t.Name));
+                        Assert.Contains(
+                            new List<string> { "Id", "AlternateId" },
+                            o.GetEntityTypes().First().GetIndexes().Select(index => index.Properties).Select(t => t.Select(p => p.Name).ToList()));
                     });
         }
 
@@ -335,6 +333,9 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
         b.Property<int>(""AlternateId"");
 
         b.HasKey(""Id"");
+
+        b.HasIndex(""AlternateId"")
+            .IsUnique();
     });
 
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", b =>
@@ -597,6 +598,9 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
         b.Property<int>(""AlternateId"");
 
         b.HasKey(""Id"");
+
+        b.HasIndex(""AlternateId"")
+            .IsUnique();
     });
 
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", b =>
@@ -639,6 +643,9 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
             .IsRequired();
 
         b.HasKey(""Id"");
+
+        b.HasIndex(""Name"")
+            .IsUnique();
     });
 
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithStringProperty"", b =>
@@ -678,6 +685,8 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
         b.Property<string>(""Name"");
 
         b.HasKey(""Id"");
+
+        b.HasIndex(""Name"");
     });
 
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithStringProperty"", b =>

--- a/test/EntityFramework.Core.FunctionalTests/TestUtilities/Extensions.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestUtilities/Extensions.cs
@@ -130,7 +130,6 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     foreignKey.Properties.Select(p => targetEntityType.FindProperty(p.Name)).ToList(),
                     targetPrincipalEntityType.FindKey(foreignKey.PrincipalKey.Properties.Select(p => targetPrincipalEntityType.FindProperty(p.Name)).ToList()),
                     targetPrincipalEntityType);
-                clonedForeignKey.IsUnique = foreignKey.IsUnique;
                 clonedForeignKey.IsRequired = foreignKey.IsRequired;
                 foreignKey.GetAnnotations().ForEach(annotation => clonedForeignKey[annotation.Name] = annotation.Value);
             }

--- a/test/EntityFramework.Core.Tests/Infrastructure/ModelValidatorTest.cs
+++ b/test/EntityFramework.Core.Tests/Infrastructure/ModelValidatorTest.cs
@@ -174,7 +174,8 @@ namespace Microsoft.Data.Entity.Tests.Infrastructure
         protected ForeignKey CreateForeignKey(EntityType dependEntityType, IReadOnlyList<Property> dependentProperties, Key principalKey)
         {
             var foreignKey = dependEntityType.AddForeignKey(dependentProperties, principalKey, principalKey.DeclaringEntityType);
-            foreignKey.IsUnique = true;
+            var index = dependEntityType.AddIndex(dependentProperties);
+            index.IsUnique = true;
             foreignKey.IsRequired = false;
             foreach (var property in dependentProperties)
             {

--- a/test/EntityFramework.Core.Tests/Metadata/EntityTypeExtensionsTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/EntityTypeExtensionsTest.cs
@@ -18,7 +18,8 @@ namespace Microsoft.Data.Entity.Metadata.Tests
             var fkProp = entityType.AddProperty(SelfRef.SelfRefIdProperty);
 
             var fk = entityType.AddForeignKey(new[] { fkProp }, pk, entityType);
-            fk.IsUnique = true;
+            var index = entityType.AddIndex(fkProp);
+            index.IsUnique = true;
             var dependentToPrincipal = fk.HasDependentToPrincipal(nameof(SelfRef.SelfRefPrincipal));
             var principalToDependent = fk.HasPrincipalToDependent(nameof(SelfRef.SelfRefDependent));
 

--- a/test/EntityFramework.Core.Tests/Metadata/Internal/EntityTypeTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/Internal/EntityTypeTest.cs
@@ -2087,7 +2087,8 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var principalKeyProperty = entityType.AddProperty(SelfRef.IdProperty);
             var referencedKey = entityType.SetPrimaryKey(principalKeyProperty);
             var fk = entityType.AddForeignKey(fkProperty, referencedKey, entityType);
-            fk.IsUnique = true;
+            var index = entityType.AddIndex(fkProperty);
+            index.IsUnique = true;
 
             var navigationToDependent = fk.HasPrincipalToDependent("SelfRef1");
             var navigationToPrincipal = fk.HasDependentToPrincipal("SelfRef2");
@@ -2105,7 +2106,8 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var principalKeyProperty = entityType.AddProperty(SelfRef.IdProperty);
             var referencedKey = entityType.SetPrimaryKey(principalKeyProperty);
             var fk = entityType.AddForeignKey(fkProperty, referencedKey, entityType);
-            fk.IsUnique = true;
+            var index = entityType.AddIndex(fkProperty);
+            index.IsUnique = true;
 
             fk.HasPrincipalToDependent("SelfRef1");
             Assert.Equal(CoreStrings.DuplicateNavigation("SelfRef1", typeof(SelfRef).Name, typeof(SelfRef).Name),

--- a/test/EntityFramework.Core.Tests/Metadata/Internal/ForeignKeyTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/Internal/ForeignKeyTest.cs
@@ -21,7 +21,8 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             entityType.GetOrSetPrimaryKey(principalProp);
 
             var foreignKey = entityType.AddForeignKey(new[] { dependentProp }, entityType.FindPrimaryKey(), entityType, ConfigurationSource.Convention);
-            foreignKey.IsUnique = true;
+            var index = entityType.AddIndex(new[] { dependentProp });
+            index.IsUnique = true;
 
             Assert.Same(entityType, foreignKey.PrincipalEntityType);
             Assert.Same(principalProp, foreignKey.PrincipalKey.Properties.Single());
@@ -99,7 +100,8 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var principalKey = entityType.AddKey(principalProp);
 
             var foreignKey = entityType.AddForeignKey(new[] { dependentProp }, principalKey, entityType);
-            foreignKey.IsUnique = false;
+            var index = entityType.AddIndex(new[] { dependentProp });
+            index.IsUnique = false;
 
             Assert.Same(entityType, foreignKey.PrincipalEntityType);
             Assert.Same(principalProp, foreignKey.PrincipalKey.Properties.Single());
@@ -397,7 +399,8 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 : pk;
 
             var fk = entityType.AddForeignKey(new[] { fkProp }, principalKey, entityType);
-            fk.IsUnique = true;
+            var index = entityType.AddIndex(fkProp);
+            index.IsUnique = true;
             fk.HasDependentToPrincipal("SelfRefPrincipal");
             fk.HasPrincipalToDependent("SelfRefDependent");
             return fk;

--- a/test/EntityFramework.Core.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
@@ -1230,6 +1230,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
             Assert.False(dependentEntityBuilder.CanAddNavigation(Order.CustomerProperty.Name, ConfigurationSource.Explicit));
             Assert.True(dependentEntityBuilder.CanAddOrReplaceNavigation(Order.CustomerProperty.Name, ConfigurationSource.Explicit));
+
             Assert.True(principalEntityBuilder.CanAddNavigation(Customer.OrdersProperty.Name, ConfigurationSource.Convention));
 
             foreignKeyBuilder = foreignKeyBuilder.PrincipalToDependent(Customer.OrdersProperty.Name, ConfigurationSource.DataAnnotation);
@@ -1240,6 +1241,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var newForeignKeyBuilder = dependentEntityBuilder.Relationship(principalEntityBuilder, ConfigurationSource.Convention)
                 .PrincipalToDependent(Customer.OrdersProperty.Name, ConfigurationSource.Convention);
             Assert.Same(foreignKeyBuilder, newForeignKeyBuilder);
+
             newForeignKeyBuilder = principalEntityBuilder.Relationship(dependentEntityBuilder, ConfigurationSource.Convention)
                 .PrincipalToDependent(Order.CustomerProperty.Name, ConfigurationSource.Convention);
             Assert.Same(foreignKeyBuilder, newForeignKeyBuilder);
@@ -1264,8 +1266,9 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             conflictingForeignKeyBuilder = conflictingForeignKeyBuilder.PrincipalToDependent(Customer.OrdersProperty.Name, ConfigurationSource.DataAnnotation);
 
             var foreignKeyBuilder = dependentEntityBuilder.HasForeignKey(typeof(Customer).FullName, new[] { Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name }, ConfigurationSource.Convention);
-
             Assert.Same(conflictingForeignKeyBuilder, foreignKeyBuilder.DependentToPrincipal(Order.CustomerProperty.Name, ConfigurationSource.Convention));
+
+            foreignKeyBuilder = dependentEntityBuilder.HasForeignKey(typeof(Customer).FullName, new[] { Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name }, ConfigurationSource.Convention);
             Assert.Same(conflictingForeignKeyBuilder, foreignKeyBuilder.PrincipalToDependent(Customer.OrdersProperty.Name, ConfigurationSource.Convention));
 
             Assert.Same(conflictingForeignKeyBuilder.Metadata, dependentEntityBuilder.Metadata.FindNavigation(Order.CustomerProperty.Name).ForeignKey);

--- a/test/EntityFramework.Core.Tests/Metadata/NavigationExtensionsTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/NavigationExtensionsTest.cs
@@ -106,7 +106,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var categoryFk = productType.GetOrAddForeignKey(productType.FindProperty("CategoryId"), categoryType.FindPrimaryKey(), categoryType);
             var featuredProductFk = categoryType.GetOrAddForeignKey(categoryType.FindProperty("FeaturedProductId"), productType.FindPrimaryKey(), productType);
-            featuredProductFk.IsUnique = true;
+            var featuredProductIndex = categoryType.GetOrAddIndex(categoryType.FindProperty("FeaturedProductId"));
+            featuredProductIndex.IsUnique = true;
 
             if (createProducts)
             {

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/ManyToOneTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/ManyToOneTestBase.cs
@@ -337,7 +337,8 @@ namespace Microsoft.Data.Entity.Tests
 
                 var property = dependentType.GetOrAddProperty(Ingredient.BurgerIdProperty);
                 var fk = dependentType.AddForeignKey(property, principalKey, principalType);
-                fk.IsUnique = false;
+                var index = dependentType.AddIndex(property);
+                index.IsUnique = false;
 
                 modelBuilder
                     .Entity<Pickle>().HasOne(e => e.BigMak).WithMany(e => e.Pickles)

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/ModelBuilderTestBase.cs
@@ -191,8 +191,8 @@ namespace Microsoft.Data.Entity.Tests
             public virtual TestIndexBuilder HasAnnotation(string annotation, object value)
                 => new TestIndexBuilder(IndexBuilder.HasAnnotation(annotation, value));
 
-            public virtual TestIndexBuilder IsUnique(bool isUnique = true)
-                => new TestIndexBuilder(IndexBuilder.IsUnique(isUnique));
+            public virtual TestIndexBuilder IsUnique(bool unique = true)
+                => new TestIndexBuilder(IndexBuilder.IsUnique(unique));
         }
 
         public abstract class TestPropertyBuilder<TProperty>

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/NonRelationshipTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/NonRelationshipTestBase.cs
@@ -630,8 +630,7 @@ namespace Microsoft.Data.Entity.Tests
 
                 var entityType = model.FindEntityType(typeof(Customer));
 
-                var index = entityType.GetIndexes().Single();
-                Assert.Equal(Customer.NameProperty.Name, index.Properties.Single().Name);
+                Assert.Contains(Customer.NameProperty.Name, entityType.GetIndexes().Select(index => index.Properties.Single().Name));
             }
 
             [Fact]
@@ -649,8 +648,7 @@ namespace Microsoft.Data.Entity.Tests
 
                 var entityType = model.FindEntityType(typeof(Customer));
 
-                var index = entityType.GetIndexes().Single();
-                Assert.Equal("Index", index.Properties.Single().Name);
+                Assert.Contains("Index", entityType.GetIndexes().Select(index => index.Properties.Single().Name));
             }
 
             [Fact]

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/OneToOneTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/OneToOneTestBase.cs
@@ -387,7 +387,6 @@ namespace Microsoft.Data.Entity.Tests
                 var dependentType = model.FindEntityType(typeof(Bun));
                 var principalType = model.FindEntityType(typeof(BigMak));
                 var fk = dependentType.GetForeignKeys().Single(foreignKey => foreignKey.Properties.All(p => p.Name == "BurgerId"));
-                fk.IsUnique = true;
 
                 var principalKey = principalType.GetKeys().Single();
                 var dependentKey = dependentType.GetKeys().Single();

--- a/test/EntityFramework.MicrosoftSqlServer.Tests/Metadata/InternalSqlServerMetadataBuilderExtensionsTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.Tests/Metadata/InternalSqlServerMetadataBuilderExtensionsTest.cs
@@ -78,6 +78,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             var entityTypeBuilder = modelBuilder.Entity(typeof(Splot), ConfigurationSource.Convention);
             var idProperty = entityTypeBuilder.Property("Id", ConfigurationSource.Convention).Metadata;
             var keyBuilder = entityTypeBuilder.HasKey(new[] { idProperty.Name }, ConfigurationSource.Convention);
+            var indexBuilder = entityTypeBuilder.HasIndex(new[] { idProperty.Name }, ConfigurationSource.Convention);
 
             Assert.True(keyBuilder.SqlServer(ConfigurationSource.Convention).Clustered(true));
             Assert.True(keyBuilder.Metadata.SqlServer().IsClustered);
@@ -88,7 +89,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
             Assert.False(keyBuilder.SqlServer(ConfigurationSource.Convention).Clustered(true));
             Assert.False(keyBuilder.Metadata.SqlServer().IsClustered);
 
-            Assert.Equal(1, keyBuilder.Metadata.GetAnnotations().Count(
+            Assert.Equal(1, indexBuilder.Metadata.GetAnnotations().Count(
                 a => a.Name.StartsWith(SqlServerAnnotationNames.Prefix, StringComparison.Ordinal)));
         }
 

--- a/test/EntityFramework.MicrosoftSqlServer.Tests/Migrations/SqlServerModelDifferTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.Tests/Migrations/SqlServerModelDifferTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Linq;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Migrations.Operations;
 using Microsoft.Data.Entity.Storage.Internal;
@@ -455,12 +456,17 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         }),
                 operations =>
                     {
-                        Assert.Equal(1, operations.Count);
+                        Assert.Equal(2, operations.Count);
 
-                        var operation = Assert.IsType<AddForeignKeyOperation>(operations[0]);
-                        Assert.Equal("dbo", operation.Schema);
-                        Assert.Equal("Amoeba", operation.Table);
-                        Assert.Equal("FK_Amoeba_Parent", operation.Name);
+                        var createIndexOperation = Assert.IsType<CreateIndexOperation>(operations[0]);
+                        Assert.Equal("dbo", createIndexOperation.Schema);
+                        Assert.Equal("Amoeba", createIndexOperation.Table);
+                        Assert.Equal("IX_Amoeba_ParentId", createIndexOperation.Name);
+
+                        var addFkOperation = Assert.IsType<AddForeignKeyOperation>(operations[1]);
+                        Assert.Equal("dbo", addFkOperation.Schema);
+                        Assert.Equal("Amoeba", addFkOperation.Table);
+                        Assert.Equal("FK_Amoeba_Parent", addFkOperation.Name);
                     });
         }
 
@@ -489,12 +495,17 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         }),
                 operations =>
                     {
-                        Assert.Equal(1, operations.Count);
+                        Assert.Equal(2, operations.Count);
 
-                        var operation = Assert.IsType<DropForeignKeyOperation>(operations[0]);
-                        Assert.Equal("dbo", operation.Schema);
-                        Assert.Equal("Anemone", operation.Table);
-                        Assert.Equal("FK_Anemone_Parent", operation.Name);
+                        var dropFkOperation = Assert.IsType<DropForeignKeyOperation>(operations[0]);
+                        Assert.Equal("dbo", dropFkOperation.Schema);
+                        Assert.Equal("Anemone", dropFkOperation.Table);
+                        Assert.Equal("FK_Anemone_Parent", dropFkOperation.Name);
+
+                        var dropIndexOperation = Assert.IsType<DropIndexOperation>(operations[1]);
+                        Assert.Equal("dbo", dropIndexOperation.Schema);
+                        Assert.Equal("Anemone", dropIndexOperation.Table);
+                        Assert.Equal("IX_Anemone_ParentId", dropIndexOperation.Name);
                     });
         }
 

--- a/test/EntityFramework.Relational.Design.Tests/RelationalDatabaseModelFactoryTest.cs
+++ b/test/EntityFramework.Relational.Design.Tests/RelationalDatabaseModelFactoryTest.cs
@@ -313,7 +313,7 @@ namespace Microsoft.Data.Entity.Relational.Design
 
             Assert.NotEmpty(parent.GetReferencingForeignKeys());
             var fk = Assert.Single(children.GetForeignKeys());
-            Assert.False(fk.IsUnique);
+            Assert.Null(fk.IsUnique);
             Assert.Equal(DeleteBehavior.Cascade, fk.DeleteBehavior);
 
             var principalKey = fk.PrincipalKey;
@@ -335,6 +335,11 @@ namespace Microsoft.Data.Entity.Relational.Design
                 PrincipalTable = parentTable,
                 PrincipalColumns = { parentTable.Columns[0] },
                 OnDelete = Migrations.ReferentialAction.NoAction
+            });
+            childrenTable.Indexes.Add(new IndexModel
+            {
+                Columns = { childrenTable.Columns[0] },
+                IsUnique = true
             });
 
             var model = _factory.Create(new DatabaseModel { Tables = { parentTable, childrenTable } });
@@ -387,7 +392,7 @@ namespace Microsoft.Data.Entity.Relational.Design
             Assert.NotEmpty(parent.GetReferencingForeignKeys());
 
             var fk = Assert.Single(children.GetForeignKeys());
-            Assert.False(fk.IsUnique);
+            Assert.Null(fk.IsUnique);
             Assert.Equal(DeleteBehavior.SetNull, fk.DeleteBehavior);
 
             var principalKey = fk.PrincipalKey;

--- a/test/EntityFramework.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
+++ b/test/EntityFramework.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
@@ -42,19 +42,23 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                 },
                 result =>
                 {
-                    Assert.Equal(3, result.Count);
+                    Assert.Equal(5, result.Count);
 
                     var firstOperation = result[0] as CreateTableOperation;
                     var secondOperation = result[1] as CreateTableOperation;
-                    var thirdOperation = result[2] as AddForeignKeyOperation;
+                    var thirdOperation = result[2] as CreateIndexOperation;
+                    var fourthOperation = result[3] as CreateIndexOperation;
+                    var fifthOperation = result[4] as AddForeignKeyOperation;
 
                     Assert.NotNull(firstOperation);
                     Assert.NotNull(secondOperation);
                     Assert.NotNull(thirdOperation);
+                    Assert.NotNull(fourthOperation);
+                    Assert.NotNull(fifthOperation);
 
                     Assert.Equal(0, firstOperation.ForeignKeys.Count);
                     Assert.Equal(1, secondOperation.ForeignKeys.Count);
-                    Assert.Equal(firstOperation.Name, thirdOperation.Table);
+                    Assert.Equal(firstOperation.Name, fifthOperation.Table);
                 });
         }
 
@@ -958,18 +962,23 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     }),
                 operations =>
                 {
-                    Assert.Equal(1, operations.Count);
+                    Assert.Equal(2, operations.Count);
 
-                    var operation = Assert.IsType<AddForeignKeyOperation>(operations[0]);
-                    Assert.Equal("dbo", operation.Schema);
-                    Assert.Equal("Amoeba", operation.Table);
-                    Assert.Equal("FK_Amoeba_Amoeba_ParentId", operation.Name);
-                    Assert.Equal(new[] { "ParentId" }, operation.Columns);
-                    Assert.Equal("dbo", operation.PrincipalSchema);
-                    Assert.Equal("Amoeba", operation.PrincipalTable);
-                    Assert.Equal(new[] { "Id" }, operation.PrincipalColumns);
-                    Assert.Equal(ReferentialAction.Cascade, operation.OnDelete);
-                    Assert.Equal(ReferentialAction.NoAction, operation.OnUpdate);
+                    var createIndexOperation = Assert.IsType<CreateIndexOperation>(operations[0]);
+                    Assert.Equal("dbo", createIndexOperation.Schema);
+                    Assert.Equal("Amoeba", createIndexOperation.Table);
+                    Assert.Equal("IX_Amoeba_ParentId", createIndexOperation.Name);
+
+                    var addFkOperation = Assert.IsType<AddForeignKeyOperation>(operations[1]);
+                    Assert.Equal("dbo", addFkOperation.Schema);
+                    Assert.Equal("Amoeba", addFkOperation.Table);
+                    Assert.Equal("FK_Amoeba_Amoeba_ParentId", addFkOperation.Name);
+                    Assert.Equal(new[] { "ParentId" }, addFkOperation.Columns);
+                    Assert.Equal("dbo", addFkOperation.PrincipalSchema);
+                    Assert.Equal("Amoeba", addFkOperation.PrincipalTable);
+                    Assert.Equal(new[] { "Id" }, addFkOperation.PrincipalColumns);
+                    Assert.Equal(ReferentialAction.Cascade, addFkOperation.OnDelete);
+                    Assert.Equal(ReferentialAction.NoAction, addFkOperation.OnUpdate);
                 });
         }
 
@@ -998,18 +1007,23 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     }),
                 operations =>
                 {
-                    Assert.Equal(1, operations.Count);
+                    Assert.Equal(2, operations.Count);
 
-                    var operation = Assert.IsType<AddForeignKeyOperation>(operations[0]);
-                    Assert.Equal("dbo", operation.Schema);
-                    Assert.Equal("Amoeba", operation.Table);
-                    Assert.Equal("FK_Amoeba_Amoeba_ParentId", operation.Name);
-                    Assert.Equal(new[] { "ParentId" }, operation.Columns);
-                    Assert.Equal("dbo", operation.PrincipalSchema);
-                    Assert.Equal("Amoeba", operation.PrincipalTable);
-                    Assert.Equal(new[] { "Id" }, operation.PrincipalColumns);
-                    Assert.Equal(ReferentialAction.Restrict, operation.OnDelete);
-                    Assert.Equal(ReferentialAction.NoAction, operation.OnUpdate);
+                    var createIndexOperation = Assert.IsType<CreateIndexOperation>(operations[0]);
+                    Assert.Equal("dbo", createIndexOperation.Schema);
+                    Assert.Equal("Amoeba", createIndexOperation.Table);
+                    Assert.Equal("IX_Amoeba_ParentId", createIndexOperation.Name);
+
+                    var addFkOperation = Assert.IsType<AddForeignKeyOperation>(operations[1]);
+                    Assert.Equal("dbo", addFkOperation.Schema);
+                    Assert.Equal("Amoeba", addFkOperation.Table);
+                    Assert.Equal("FK_Amoeba_Amoeba_ParentId", addFkOperation.Name);
+                    Assert.Equal(new[] { "ParentId" }, addFkOperation.Columns);
+                    Assert.Equal("dbo", addFkOperation.PrincipalSchema);
+                    Assert.Equal("Amoeba", addFkOperation.PrincipalTable);
+                    Assert.Equal(new[] { "Id" }, addFkOperation.PrincipalColumns);
+                    Assert.Equal(ReferentialAction.Restrict, addFkOperation.OnDelete);
+                    Assert.Equal(ReferentialAction.NoAction, addFkOperation.OnUpdate);
                 });
         }
 
@@ -1038,9 +1052,13 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     }),
                 operations =>
                 {
-                    Assert.Equal(1, operations.Count);
+                    Assert.Equal(2, operations.Count);
 
-                    var operation = Assert.IsType<AddForeignKeyOperation>(operations[0]);
+                    var createIndexOperation = Assert.IsType<CreateIndexOperation>(operations[0]);
+                    Assert.Equal("Amoeba", createIndexOperation.Table);
+                    Assert.Equal("IX_Amoeba_ParentId", createIndexOperation.Name);
+
+                    var operation = Assert.IsType<AddForeignKeyOperation>(operations[1]);
                     Assert.Equal("dbo", operation.Schema);
                     Assert.Equal("Amoeba", operation.Table);
                     Assert.Equal("FK_Amoeba_Amoeba_ParentId", operation.Name);
@@ -1078,23 +1096,28 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     }),
                 operations =>
                 {
-                    Assert.Equal(1, operations.Count);
+                    Assert.Equal(2, operations.Count);
 
-                    var operation = Assert.IsType<AddForeignKeyOperation>(operations[0]);
-                    Assert.Equal("dbo", operation.Schema);
-                    Assert.Equal("Amoeba", operation.Table);
-                    Assert.Equal("FK_Amoeba_Amoeba_ParentId", operation.Name);
-                    Assert.Equal(new[] { "ParentId" }, operation.Columns);
-                    Assert.Equal("dbo", operation.PrincipalSchema);
-                    Assert.Equal("Amoeba", operation.PrincipalTable);
-                    Assert.Equal(new[] { "Id" }, operation.PrincipalColumns);
-                    Assert.Equal(ReferentialAction.Restrict, operation.OnDelete);
-                    Assert.Equal(ReferentialAction.NoAction, operation.OnUpdate);
+                    var createIndexOperation = Assert.IsType<CreateIndexOperation>(operations[0]);
+                    Assert.Equal("dbo", createIndexOperation.Schema);
+                    Assert.Equal("Amoeba", createIndexOperation.Table);
+                    Assert.Equal("IX_Amoeba_ParentId", createIndexOperation.Name);
+
+                    var addFkOperation = Assert.IsType<AddForeignKeyOperation>(operations[1]);
+                    Assert.Equal("dbo", addFkOperation.Schema);
+                    Assert.Equal("Amoeba", addFkOperation.Table);
+                    Assert.Equal("FK_Amoeba_Amoeba_ParentId", addFkOperation.Name);
+                    Assert.Equal(new[] { "ParentId" }, addFkOperation.Columns);
+                    Assert.Equal("dbo", addFkOperation.PrincipalSchema);
+                    Assert.Equal("Amoeba", addFkOperation.PrincipalTable);
+                    Assert.Equal(new[] { "Id" }, addFkOperation.PrincipalColumns);
+                    Assert.Equal(ReferentialAction.Restrict, addFkOperation.OnDelete);
+                    Assert.Equal(ReferentialAction.NoAction, addFkOperation.OnUpdate);
                 });
         }
 
         [Fact]
-        public void Add_optional_foreign_key_wit_set_null()
+        public void Add_optional_foreign_key_with_set_null()
         {
             Execute(
                 source => source.Entity(
@@ -1118,18 +1141,23 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     }),
                 operations =>
                 {
-                    Assert.Equal(1, operations.Count);
+                    Assert.Equal(2, operations.Count);
 
-                    var operation = Assert.IsType<AddForeignKeyOperation>(operations[0]);
-                    Assert.Equal("dbo", operation.Schema);
-                    Assert.Equal("Amoeba", operation.Table);
-                    Assert.Equal("FK_Amoeba_Amoeba_ParentId", operation.Name);
-                    Assert.Equal(new[] { "ParentId" }, operation.Columns);
-                    Assert.Equal("dbo", operation.PrincipalSchema);
-                    Assert.Equal("Amoeba", operation.PrincipalTable);
-                    Assert.Equal(new[] { "Id" }, operation.PrincipalColumns);
-                    Assert.Equal(ReferentialAction.SetNull, operation.OnDelete);
-                    Assert.Equal(ReferentialAction.NoAction, operation.OnUpdate);
+                    var createIndexOperation = Assert.IsType<CreateIndexOperation>(operations[0]);
+                    Assert.Equal("dbo", createIndexOperation.Schema);
+                    Assert.Equal("Amoeba", createIndexOperation.Table);
+                    Assert.Equal("IX_Amoeba_ParentId", createIndexOperation.Name);
+
+                    var addFkOperation = Assert.IsType<AddForeignKeyOperation>(operations[1]);
+                    Assert.Equal("dbo", addFkOperation.Schema);
+                    Assert.Equal("Amoeba", addFkOperation.Table);
+                    Assert.Equal("FK_Amoeba_Amoeba_ParentId", addFkOperation.Name);
+                    Assert.Equal(new[] { "ParentId" }, addFkOperation.Columns);
+                    Assert.Equal("dbo", addFkOperation.PrincipalSchema);
+                    Assert.Equal("Amoeba", addFkOperation.PrincipalTable);
+                    Assert.Equal(new[] { "Id" }, addFkOperation.PrincipalColumns);
+                    Assert.Equal(ReferentialAction.SetNull, addFkOperation.OnDelete);
+                    Assert.Equal(ReferentialAction.NoAction, addFkOperation.OnUpdate);
                 });
         }
 
@@ -1158,12 +1186,17 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     }),
                 operations =>
                 {
-                    Assert.Equal(1, operations.Count);
+                    Assert.Equal(2, operations.Count);
 
-                    var operation = Assert.IsType<DropForeignKeyOperation>(operations[0]);
-                    Assert.Equal("dbo", operation.Schema);
-                    Assert.Equal("Anemone", operation.Table);
-                    Assert.Equal("FK_Anemone_Anemone_ParentId", operation.Name);
+                    var dropFkOperation = Assert.IsType<DropForeignKeyOperation>(operations[0]);
+                    Assert.Equal("dbo", dropFkOperation.Schema);
+                    Assert.Equal("Anemone", dropFkOperation.Table);
+                    Assert.Equal("FK_Anemone_Anemone_ParentId", dropFkOperation.Name);
+
+                    var dropIndexOperation = Assert.IsType<DropIndexOperation>(operations[1]);
+                    Assert.Equal("dbo", dropIndexOperation.Schema);
+                    Assert.Equal("Anemone", dropIndexOperation.Table);
+                    Assert.Equal("IX_Anemone_ParentId", dropIndexOperation.Name);
                 });
         }
 
@@ -1239,21 +1272,31 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     }),
                 operations =>
                 {
-                    Assert.Equal(2, operations.Count);
+                    Assert.Equal(4, operations.Count);
 
-                    var dropOperation = Assert.IsType<DropForeignKeyOperation>(operations[0]);
-                    Assert.Equal("dbo", dropOperation.Schema);
-                    Assert.Equal("Mushroom", dropOperation.Table);
-                    Assert.Equal("FK_Mushroom_Mushroom_ParentId1", dropOperation.Name);
+                    var dropFkOperation = Assert.IsType<DropForeignKeyOperation>(operations[0]);
+                    Assert.Equal("dbo", dropFkOperation.Schema);
+                    Assert.Equal("Mushroom", dropFkOperation.Table);
+                    Assert.Equal("FK_Mushroom_Mushroom_ParentId1", dropFkOperation.Name);
 
-                    var addOperation = Assert.IsType<AddForeignKeyOperation>(operations[1]);
-                    Assert.Equal("dbo", addOperation.Schema);
-                    Assert.Equal("Mushroom", addOperation.Table);
-                    Assert.Equal("FK_Mushroom_Mushroom_ParentId1", addOperation.Name);
-                    Assert.Equal(new[] { "ParentId2" }, addOperation.Columns);
-                    Assert.Equal("dbo", addOperation.PrincipalSchema);
-                    Assert.Equal("Mushroom", addOperation.PrincipalTable);
-                    Assert.Equal(new[] { "Id" }, addOperation.PrincipalColumns);
+                    var dropIndexOperation = Assert.IsType<DropIndexOperation>(operations[1]);
+                    Assert.Equal("dbo", dropIndexOperation.Schema);
+                    Assert.Equal("Mushroom", dropIndexOperation.Table);
+                    Assert.Equal("IX_Mushroom_ParentId1", dropIndexOperation.Name);
+
+                    var createIndexOperation = Assert.IsType<CreateIndexOperation>(operations[2]);
+                    Assert.Equal("dbo", createIndexOperation.Schema);
+                    Assert.Equal("Mushroom", createIndexOperation.Table);
+                    Assert.Equal("IX_Mushroom_ParentId2", createIndexOperation.Name);
+
+                    var addFkOperation = Assert.IsType<AddForeignKeyOperation>(operations[3]);
+                    Assert.Equal("dbo", addFkOperation.Schema);
+                    Assert.Equal("Mushroom", addFkOperation.Table);
+                    Assert.Equal("FK_Mushroom_Mushroom_ParentId1", addFkOperation.Name);
+                    Assert.Equal(new[] { "ParentId2" }, addFkOperation.Columns);
+                    Assert.Equal("dbo", addFkOperation.PrincipalSchema);
+                    Assert.Equal("Mushroom", addFkOperation.PrincipalTable);
+                    Assert.Equal(new[] { "Id" }, addFkOperation.PrincipalColumns);
                 });
         }
 
@@ -2080,6 +2123,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                 operations => Assert.Collection(
                     operations,
                     o => Assert.IsType<AddColumnOperation>(o),
+                    o => Assert.IsType<CreateIndexOperation>(o),
                     o => Assert.IsType<AddForeignKeyOperation>(o)));
         }
 
@@ -2106,6 +2150,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                 operations => Assert.Collection(
                     operations,
                     o => Assert.IsType<DropForeignKeyOperation>(o),
+                    o => Assert.IsType<DropIndexOperation>(o),
                     o => Assert.IsType<DropColumnOperation>(o)));
         }
 
@@ -2143,6 +2188,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                 operations => Assert.Collection(
                     operations,
                     o => Assert.IsType<CreateTableOperation>(o),
+                    o => Assert.IsType<CreateIndexOperation>(o),
                     o => Assert.IsType<AddForeignKeyOperation>(o)));
         }
 
@@ -2180,6 +2226,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                 operations => Assert.Collection(
                     operations,
                     o => Assert.IsType<DropForeignKeyOperation>(o),
+                    o => Assert.IsType<DropIndexOperation>(o),
                     o => Assert.IsType<DropTableOperation>(o)));
         }
 
@@ -2229,6 +2276,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     operations,
                     o => Assert.IsType<AddColumnOperation>(o),
                     o => Assert.IsType<AddUniqueConstraintOperation>(o),
+                    o => Assert.IsType<CreateIndexOperation>(o),
                     o => Assert.IsType<AddForeignKeyOperation>(o)));
         }
 
@@ -2277,6 +2325,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                 operations => Assert.Collection(
                     operations,
                     o => Assert.IsType<DropForeignKeyOperation>(o),
+                    o => Assert.IsType<DropIndexOperation>(o),
                     o => Assert.IsType<DropUniqueConstraintOperation>(o),
                     o => Assert.IsType<DropColumnOperation>(o)));
         }
@@ -2307,7 +2356,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                 },
                 operations =>
                 {
-                    Assert.Equal(2, operations.Count);
+                    Assert.Equal(3, operations.Count);
 
                     var operation1 = Assert.IsType<CreateTableOperation>(operations[0]);
                     Assert.Equal("Maker", operation1.Name);
@@ -3285,7 +3334,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                 },
                 operations =>
                 {
-                    Assert.Equal(2, operations.Count);
+                    Assert.Equal(3, operations.Count);
                     Assert.IsType<CreateTableOperation>(operations[0]);
 
                     var createTableOperation = Assert.IsType<CreateTableOperation>(operations[1]);
@@ -3297,6 +3346,10 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     Assert.Equal(new[] { "HandlerId" }, addForeignKeyOperation.Columns);
                     Assert.Equal("Person", addForeignKeyOperation.PrincipalTable);
                     Assert.Equal(new[] { "Id" }, addForeignKeyOperation.PrincipalColumns);
+
+                    var createIndexOperation = Assert.IsType<CreateIndexOperation>(operations[2]);
+                    Assert.Equal("Animal", createIndexOperation.Table);
+                    Assert.Equal("IX_Animal_HandlerId", createIndexOperation.Name);
                 });
         }
 
@@ -3339,7 +3392,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                 },
                 operations =>
                 {
-                    Assert.Equal(2, operations.Count);
+                    Assert.Equal(3, operations.Count);
 
                     Assert.IsType<CreateTableOperation>(operations[0]);
 
@@ -3352,6 +3405,10 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     Assert.Equal(new[] { "HandlerId" }, addForeignKeyOperation.Columns);
                     Assert.Equal("Person", addForeignKeyOperation.PrincipalTable);
                     Assert.Equal(new[] { "Id" }, addForeignKeyOperation.PrincipalColumns);
+
+                    var createIndexOperation = Assert.IsType<CreateIndexOperation>(operations[2]);
+                    Assert.Equal("Animal", createIndexOperation.Table);
+                    Assert.Equal("IX_Stag_HandlerId", createIndexOperation.Name);
                 });
         }
 
@@ -3394,7 +3451,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                 },
                 operations =>
                 {
-                    Assert.Equal(2, operations.Count);
+                    Assert.Equal(3, operations.Count);
 
                     Assert.IsType<CreateTableOperation>(operations[0]);
 
@@ -3407,6 +3464,10 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     Assert.Equal(new[] { "PetId" }, addForeignKeyOperation.Columns);
                     Assert.Equal("Animal", addForeignKeyOperation.PrincipalTable);
                     Assert.Equal(new[] { "Id" }, addForeignKeyOperation.PrincipalColumns);
+
+                    var createIndexOperation = Assert.IsType<CreateIndexOperation>(operations[2]);
+                    Assert.Equal("Person", createIndexOperation.Table);
+                    Assert.Equal("IX_Person_PetId", createIndexOperation.Name);
                 });
         }
 
@@ -3442,16 +3503,21 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                 },
                 operations =>
                 {
-                    Assert.Equal(1, operations.Count);
+                    Assert.Equal(2, operations.Count);
 
                     var createTableOperation = Assert.IsType<CreateTableOperation>(operations[0]);
                     Assert.Equal(1, createTableOperation.ForeignKeys.Count);
+                    Assert.Equal("Animal", createTableOperation.Name);
 
                     var addForeignKeyOperation = createTableOperation.ForeignKeys[0];
                     Assert.Equal("FK_Predator_Animal_PreyId", addForeignKeyOperation.Name);
                     Assert.Equal(new[] { "PreyId" }, addForeignKeyOperation.Columns);
                     Assert.Equal("Animal", addForeignKeyOperation.PrincipalTable);
                     Assert.Equal(new[] { "Id" }, addForeignKeyOperation.PrincipalColumns);
+
+                    var createIndexOperation = Assert.IsType<CreateIndexOperation>(operations[1]);
+                    Assert.Equal("Animal", createIndexOperation.Table);
+                    Assert.Equal("IX_Predator_PreyId",  createIndexOperation.Name);
                 });
         }
 
@@ -3500,14 +3566,18 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                 },
                 operations =>
                 {
-                    Assert.Equal(1, operations.Count);
+                    Assert.Equal(2, operations.Count);
 
-                    var operation = Assert.IsType<AddForeignKeyOperation>(operations[0]);
-                    Assert.Equal("Animal", operation.Table);
-                    Assert.Equal("FK_Animal_Person_HandlerId", operation.Name);
-                    Assert.Equal(new[] { "HandlerId" }, operation.Columns);
-                    Assert.Equal("Person", operation.PrincipalTable);
-                    Assert.Equal(new[] { "Id" }, operation.PrincipalColumns);
+                    var createIndexOperation = Assert.IsType<CreateIndexOperation>(operations[0]);
+                    Assert.Equal("Animal", createIndexOperation.Table);
+                    Assert.Equal("IX_Animal_HandlerId", createIndexOperation.Name);
+
+                    var addFkOperation = Assert.IsType<AddForeignKeyOperation>(operations[1]);
+                    Assert.Equal("Animal", addFkOperation.Table);
+                    Assert.Equal("FK_Animal_Person_HandlerId", addFkOperation.Name);
+                    Assert.Equal(new[] { "HandlerId" }, addFkOperation.Columns);
+                    Assert.Equal("Person", addFkOperation.PrincipalTable);
+                    Assert.Equal(new[] { "Id" }, addFkOperation.PrincipalColumns);
                 });
         }
 
@@ -3580,14 +3650,18 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                 },
                 operations =>
                 {
-                    Assert.Equal(1, operations.Count);
+                    Assert.Equal(2, operations.Count);
 
-                    var operation = Assert.IsType<AddForeignKeyOperation>(operations[0]);
-                    Assert.Equal("Animal", operation.Table);
-                    Assert.Equal("FK_GameAnimal_Person_HunterId", operation.Name);
-                    Assert.Equal(new[] { "HunterId" }, operation.Columns);
-                    Assert.Equal("Person", operation.PrincipalTable);
-                    Assert.Equal(new[] { "Id" }, operation.PrincipalColumns);
+                    var createIndexOperation = Assert.IsType<CreateIndexOperation>(operations[0]);
+                    Assert.Equal("Animal", createIndexOperation.Table);
+                    Assert.Equal("IX_GameAnimal_HunterId", createIndexOperation.Name);
+
+                    var addFkOperation = Assert.IsType<AddForeignKeyOperation>(operations[1]);
+                    Assert.Equal("Animal", addFkOperation.Table);
+                    Assert.Equal("FK_GameAnimal_Person_HunterId", addFkOperation.Name);
+                    Assert.Equal(new[] { "HunterId" }, addFkOperation.Columns);
+                    Assert.Equal("Person", addFkOperation.PrincipalTable);
+                    Assert.Equal(new[] { "Id" }, addFkOperation.PrincipalColumns);
                 });
         }
 
@@ -3660,14 +3734,18 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                 },
                 operations =>
                 {
-                    Assert.Equal(1, operations.Count);
+                    Assert.Equal(2, operations.Count);
 
-                    var operation = Assert.IsType<AddForeignKeyOperation>(operations[0]);
-                    Assert.Equal("Person", operation.Table);
-                    Assert.Equal("FK_Person_TrophyAnimal_TrophyId", operation.Name);
-                    Assert.Equal(new[] { "TrophyId" }, operation.Columns);
-                    Assert.Equal("Animal", operation.PrincipalTable);
-                    Assert.Equal(new[] { "Id" }, operation.PrincipalColumns);
+                    var createIndexOperation = Assert.IsType<CreateIndexOperation>(operations[0]);
+                    Assert.Equal("Person", createIndexOperation.Table);
+                    Assert.Equal("IX_Person_TrophyId", createIndexOperation.Name);
+
+                    var addFkOperation = Assert.IsType<AddForeignKeyOperation>(operations[1]);
+                    Assert.Equal("Person", addFkOperation.Table);
+                    Assert.Equal("FK_Person_TrophyAnimal_TrophyId", addFkOperation.Name);
+                    Assert.Equal(new[] { "TrophyId" }, addFkOperation.Columns);
+                    Assert.Equal("Animal", addFkOperation.PrincipalTable);
+                    Assert.Equal(new[] { "Id" }, addFkOperation.PrincipalColumns);
                 });
         }
 
@@ -3740,11 +3818,16 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                 },
                 operations =>
                 {
-                    Assert.Equal(1, operations.Count);
+                    Assert.Equal(2, operations.Count);
 
-                    var operation = Assert.IsType<DropForeignKeyOperation>(operations[0]);
-                    Assert.Equal("Animal", operation.Table);
-                    Assert.Equal("FK_MountAnimal_Person_RiderId", operation.Name);
+                    var dropFkOperation = Assert.IsType<DropForeignKeyOperation>(operations[0]);
+                    Assert.Equal("Animal", dropFkOperation.Table);
+                    Assert.Equal("FK_MountAnimal_Person_RiderId", dropFkOperation.Name);
+
+                    var dropIndexOperation = Assert.IsType<DropIndexOperation>(operations[1]);
+                    Assert.Equal("Animal", dropIndexOperation.Table);
+                    Assert.Equal("IX_MountAnimal_RiderId", dropIndexOperation.Name);
+
                 });
         }
 


### PR DESCRIPTION
Resolves #700 
`Key` & `ForeignKey` has Index object associated. `IsUnique` and `IsClustered` from key/foreignkey moved to index object.
Need review from @bricelam for Migrations & @AndriySvyryd for metadata.