### PR TITLE
Use cached compiled delegates to create relationship snapshots

### DIFF
--- a/src/EntityFramework.Core/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Internal;
@@ -221,6 +222,11 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
             _stateData.FlagProperty(property.GetIndex(), PropertyFlag.TemporaryOrModified, isTemporary);
         }
+
+        internal static readonly MethodInfo ReadShadowValueMethod
+            = typeof(InternalEntityEntry).GetTypeInfo().GetDeclaredMethod(nameof(ReadShadowValue));
+
+        public virtual object ReadShadowValue(int shadowIndex) => null;
 
         protected virtual object ReadPropertyValue([NotNull] IPropertyBase propertyBase)
         {

--- a/src/EntityFramework.Core/ChangeTracking/Internal/InternalMixedEntityEntry.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/InternalMixedEntityEntry.cs
@@ -36,6 +36,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
         public override object Entity { get; }
 
+        public override object ReadShadowValue(int shadowIndex)
+            => _shadowValues[shadowIndex];
+
         protected override object ReadPropertyValue(IPropertyBase propertyBase)
         {
             var property = propertyBase as IProperty;

--- a/src/EntityFramework.Core/ChangeTracking/Internal/InternalShadowEntityEntry.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/InternalShadowEntityEntry.cs
@@ -38,6 +38,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
             }
         }
 
+        public override object ReadShadowValue(int shadowIndex)
+            => _propertyValues[shadowIndex];
+
         protected override object ReadPropertyValue(IPropertyBase propertyBase)
         {
             var property = propertyBase as IProperty;

--- a/src/EntityFramework.Core/ChangeTracking/Internal/RelationshipSnapshotFactoryFactory.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/RelationshipSnapshotFactoryFactory.cs
@@ -1,0 +1,114 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Internal;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Metadata.Internal;
+
+namespace Microsoft.Data.Entity.ChangeTracking.Internal
+{
+    public class RelationshipSnapshotFactoryFactory
+    {
+        public virtual Func<InternalEntityEntry, object[]> Create([NotNull] IEntityType entityType)
+        {
+            var entryParameter = Expression.Parameter(typeof(InternalEntityEntry), "entry");
+            var valuesVariable = Expression.Variable(typeof(object[]), "values");
+            var entityVariable = entityType.ClrType == null ? null : Expression.Variable(entityType.ClrType, "entity");
+
+            var variables = new List<ParameterExpression>
+            {
+                valuesVariable
+            };
+
+            var blockExpressions = new List<Expression>
+            {
+                Expression.Assign(
+                    valuesVariable,
+                    Expression.NewArrayBounds(
+                        typeof(object),
+                        Expression.Constant(entityType.RelationshipPropertyCount())))
+            };
+
+            if (entityVariable != null)
+            {
+                variables.Add(entityVariable);
+
+                blockExpressions.Add(
+                    Expression.Assign(
+                        entityVariable,
+                        Expression.Convert(
+                            Expression.Property(entryParameter, "Entity"),
+                            entityType.ClrType)));
+            }
+
+            foreach (var propertyBase in entityType.GetPropertiesAndNavigations())
+            {
+                var index = propertyBase.GetRelationshipIndex();
+
+                if (index >= 0)
+                {
+                    var navigation = propertyBase as INavigation;
+                    var property = propertyBase as IProperty;
+
+                    blockExpressions.Add(
+                        Expression.Assign(
+                            Expression.ArrayAccess(
+                                valuesVariable,
+                                Expression.Constant(index)),
+                            navigation != null
+                            && navigation.IsCollection()
+                                ? Expression.Call(
+                                    null,
+                                    _snapshotCollectionMethod,
+                                    Expression.Property(
+                                        entityVariable,
+                                        propertyBase.DeclaringEntityType.ClrType.GetAnyProperty(propertyBase.Name)))
+                                : property != null
+                                  && property.IsShadowProperty
+                                    ? Expression.Call(
+                                        entryParameter,
+                                        InternalEntityEntry.ReadShadowValueMethod,
+                                        Expression.Constant(property.GetShadowIndex()))
+                                    : (Expression)Expression.Convert(
+                                        Expression.Property(
+                                            entityVariable,
+                                            propertyBase.DeclaringEntityType.ClrType.GetAnyProperty(propertyBase.Name)),
+                                        typeof(object))));
+                }
+            }
+
+            blockExpressions.Add(valuesVariable);
+
+            return Expression.Lambda<Func<InternalEntityEntry, object[]>>(
+                Expression.Block(variables, blockExpressions),
+                entryParameter)
+                .Compile();
+        }
+
+        private static readonly MethodInfo _snapshotCollectionMethod
+            = typeof(RelationshipSnapshotFactoryFactory).GetTypeInfo().GetDeclaredMethod(nameof(SnapshotCollection));
+
+        [UsedImplicitly]
+        private static HashSet<object> SnapshotCollection(IEnumerable collection)
+        {
+            if (collection == null)
+            {
+                return null;
+            }
+
+            var snapshot = new HashSet<object>(ReferenceEqualityComparer.Instance);
+            foreach (var product in collection)
+            {
+                snapshot.Add(product);
+            }
+
+            return snapshot;
+        }
+    }
+}

--- a/src/EntityFramework.Core/ChangeTracking/Internal/RelationshipsSnapshot.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/RelationshipsSnapshot.cs
@@ -18,40 +18,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
             public RelationshipsSnapshot(InternalEntityEntry entry)
             {
-                var entityType = entry.EntityType;
-                _values = new object[entityType.RelationshipPropertyCount()];
-
-                foreach (var propertyBase in entityType.GetPropertiesAndNavigations())
-                {
-                    var index = propertyBase.GetRelationshipIndex();
-
-                    if (index >= 0)
-                    {
-                        var value = entry[propertyBase];
-
-                        if (value != null)
-                        {
-                            var navigation = propertyBase as INavigation;
-
-                            if ((navigation == null)
-                                || !navigation.IsCollection())
-                            {
-                                _values[index] = value;
-                            }
-                            else
-                            {
-                                var snapshot = new HashSet<object>(ReferenceEqualityComparer.Instance);
-
-                                foreach (var entity in (IEnumerable)value)
-                                {
-                                    snapshot.Add(entity);
-                                }
-
-                                _values[index] = snapshot;
-                            }
-                        }
-                    }
-                }
+                _values = entry.EntityType.GetRelationshipSnapshotFactory()(entry);
             }
 
             public object GetValue(InternalEntityEntry entry, IPropertyBase propertyBase)

--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -65,6 +65,7 @@
     <Compile Include="ChangeTracking\Internal\IChangeTrackerFactory.cs" />
     <Compile Include="ChangeTracking\Internal\IEntityGraphAttacher.cs" />
     <Compile Include="ChangeTracking\Internal\OriginalValues.cs" />
+    <Compile Include="ChangeTracking\Internal\RelationshipSnapshotFactoryFactory.cs" />
     <Compile Include="ChangeTracking\Internal\SimpleKeyValueFactory.cs" />
     <Compile Include="DbUpdateConcurrencyException.cs" />
     <Compile Include="DbUpdateException.cs" />
@@ -93,6 +94,7 @@
     <Compile Include="Metadata\Internal\IPropertyBaseAccessors.cs" />
     <Compile Include="Metadata\Internal\IPropertyCountsAccessor.cs" />
     <Compile Include="Metadata\Internal\IPropertyIndexesAccessor.cs" />
+    <Compile Include="Metadata\Internal\IRelationshipSnapshotFactorySource.cs" />
     <Compile Include="Metadata\Internal\KeyExtensions.cs" />
     <Compile Include="Metadata\Internal\ModelExtensions.cs" />
     <Compile Include="Metadata\Internal\MutableEntityTypeExtensions.cs" />

--- a/src/EntityFramework.Core/Metadata/Internal/EntityTypeExtensions.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/EntityTypeExtensions.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Utilities;
 
@@ -126,6 +128,15 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                     baseCounts.ShadowCount + shadowCount,
                     baseCounts.RelationshipCount + relationshipCount,
                     baseCounts.StoreGeneratedCount + storeGeneratedCount);
+        }
+
+        public static Func<InternalEntityEntry, object[]> GetRelationshipSnapshotFactory([NotNull] this IEntityType entityType)
+        {
+            var source = entityType as IRelationshipSnapshotFactorySource;
+
+            return source != null
+                ? source.RelationshipSnapshotFactory
+                : new RelationshipSnapshotFactoryFactory().Create(entityType);
         }
 
         public static bool HasPropertyChangingNotifications([NotNull] this IEntityType entityType)

--- a/src/EntityFramework.Core/Metadata/Internal/IRelationshipSnapshotFactorySource.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/IRelationshipSnapshotFactorySource.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Data.Entity.ChangeTracking.Internal;
+
+namespace Microsoft.Data.Entity.Metadata.Internal
+{
+    public interface IRelationshipSnapshotFactorySource
+    {
+        Func<InternalEntityEntry, object[]> RelationshipSnapshotFactory { get; }
+    }
+}


### PR DESCRIPTION
Builds on previous refactoring to pre-compile relationship snapshot factories such that decision making and metadata look-ups are reduced.