### PR TITLE
:bug: object is not a valid navigation

### DIFF
--- a/src/EntityFramework.Core/Metadata/Internal/EntityType.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/EntityType.cs
@@ -289,7 +289,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
         {
             if (_baseType != null)
             {
-                throw new InvalidOperationException(CoreStrings.DerivedEntityTypeKey(Name));
+                throw new InvalidOperationException(CoreStrings.DerivedEntityTypeKey(DisplayName(), _baseType.DisplayName()));
             }
 
             if (_primaryKey != null)
@@ -379,7 +379,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
             if (_baseType != null)
             {
-                throw new InvalidOperationException(CoreStrings.DerivedEntityTypeKey(Name));
+                throw new InvalidOperationException(CoreStrings.DerivedEntityTypeKey(DisplayName(), _baseType.DisplayName()));
             }
 
             foreach (var property in properties)

--- a/src/EntityFramework.Core/Properties/CoreStrings.Designer.cs
+++ b/src/EntityFramework.Core/Properties/CoreStrings.Designer.cs
@@ -53,30 +53,6 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
-        /// Unhandled node type: {nodeType}
-        /// </summary>
-        public static string UnhandledNodeType([CanBeNull] object nodeType)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("UnhandledNodeType", "nodeType"), nodeType);
-        }
-
-        /// <summary>
-        /// Unhandled expression type: {expressionType}
-        /// </summary>
-        public static string UnhandledExpressionType([CanBeNull] object expressionType)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("UnhandledExpressionType", "expressionType"), expressionType);
-        }
-
-        /// <summary>
-        /// Unhandled operation: MemberInitExpression binding is not a MemberAssignment
-        /// </summary>
-        public static string InvalidMemberInitBinding
-        {
-            get { return GetString("InvalidMemberInitBinding"); }
-        }
-
-        /// <summary>
         /// The instance of entity type '{entityType}' cannot be tracked because another instance of this type with the same key is already being tracked. For new entities consider using an IIdentityGenerator to generate unique key values.
         /// </summary>
         public static string IdentityConflict([CanBeNull] object entityType)
@@ -685,11 +661,11 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
-        /// The derived type '{derivedType}' cannot have keys other than those declared on the root type.
+        /// The derived type '{derivedType}' cannot have keys other than those declared on the root type '{rootType}'.
         /// </summary>
-        public static string DerivedEntityTypeKey([CanBeNull] object derivedType)
+        public static string DerivedEntityTypeKey([CanBeNull] object derivedType, [CanBeNull] object rootType)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("DerivedEntityTypeKey", "derivedType"), derivedType);
+            return string.Format(CultureInfo.CurrentCulture, GetString("DerivedEntityTypeKey", "derivedType", "rootType"), derivedType, rootType);
         }
 
         /// <summary>
@@ -1026,6 +1002,30 @@ namespace Microsoft.Data.Entity.Internal
         public static string EntityTypeNotFound([CanBeNull] object entityType)
         {
             return string.Format(CultureInfo.CurrentCulture, GetString("EntityTypeNotFound", "entityType"), entityType);
+        }
+
+        /// <summary>
+        /// Unhandled operation: MemberInitExpression binding is not a MemberAssignment
+        /// </summary>
+        public static string InvalidMemberInitBinding
+        {
+            get { return GetString("InvalidMemberInitBinding"); }
+        }
+
+        /// <summary>
+        /// Unhandled expression type: {expressionType}
+        /// </summary>
+        public static string UnhandledExpressionType([CanBeNull] object expressionType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("UnhandledExpressionType", "expressionType"), expressionType);
+        }
+
+        /// <summary>
+        /// Unhandled node type: {nodeType}
+        /// </summary>
+        public static string UnhandledNodeType([CanBeNull] object nodeType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("UnhandledNodeType", "nodeType"), nodeType);
         }
 
         private static string GetString(string name, params string[] formatterNames)

--- a/src/EntityFramework.Core/Properties/CoreStrings.resx
+++ b/src/EntityFramework.Core/Properties/CoreStrings.resx
@@ -361,7 +361,7 @@
     <value>The '{factory}' cannot create a value generator for property '{property}' on entity type '{entityType}'. Only integer properties are supported.</value>
   </data>
   <data name="DerivedEntityTypeKey" xml:space="preserve">
-    <value>The derived type '{derivedType}' cannot have keys other than those declared on the root type.</value>
+    <value>The derived type '{derivedType}' cannot have keys other than those declared on the root type '{rootType}'.</value>
   </data>
   <data name="CircularInheritance" xml:space="preserve">
     <value>The entity type '{entityType}' cannot inherit from '{baseEntityType}' because '{baseEntityType}' is a descendent of '{entityType}'.</value>

--- a/src/Shared/PropertyInfoExtensions.cs
+++ b/src/Shared/PropertyInfoExtensions.cs
@@ -31,7 +31,8 @@ namespace System.Reflection
 
             if (isPrimitiveProperty(targetType)
                 || targetType.GetTypeInfo().IsInterface
-                || targetType.GetTypeInfo().IsValueType)
+                || targetType.GetTypeInfo().IsValueType
+                || targetType == typeof(object))
             {
                 return null;
             }

--- a/test/EntityFramework.Core.Tests/Metadata/Internal/EntityTypeTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/Internal/EntityTypeTest.cs
@@ -476,10 +476,10 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             b.HasBaseType(a);
 
             Assert.Equal(
-                CoreStrings.DerivedEntityTypeKey(typeof(B).FullName),
+                CoreStrings.DerivedEntityTypeKey(typeof(B).Name, typeof(A).Name),
                 Assert.Throws<InvalidOperationException>(() => b.SetPrimaryKey(b.AddProperty("G"))).Message);
             Assert.Equal(
-                CoreStrings.DerivedEntityTypeKey(typeof(B).FullName),
+                CoreStrings.DerivedEntityTypeKey(typeof(B).Name, typeof(A).Name),
                 Assert.Throws<InvalidOperationException>(() => b.AddKey(b.AddProperty("E"))).Message);
         }
 

--- a/test/EntityFramework.Core.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
@@ -555,7 +555,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var derivedEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
             derivedEntityBuilder.HasBaseType(entityBuilder.Metadata, ConfigurationSource.Convention);
 
-            Assert.Equal(CoreStrings.DerivedEntityTypeKey(typeof(SpecialOrder).FullName),
+            Assert.Equal(CoreStrings.DerivedEntityTypeKey(typeof(SpecialOrder).Name, typeof(Order).Name),
                 Assert.Throws<InvalidOperationException>(() =>
                     derivedEntityBuilder.HasKey(new[] { Order.IdProperty.Name, Order.CustomerIdProperty.Name }, ConfigurationSource.DataAnnotation)).Message);
         }
@@ -764,7 +764,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var derivedEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
             derivedEntityBuilder.HasBaseType(entityBuilder.Metadata, ConfigurationSource.Convention);
 
-            Assert.Equal(CoreStrings.DerivedEntityTypeKey(typeof(SpecialOrder).FullName),
+            Assert.Equal(CoreStrings.DerivedEntityTypeKey(typeof(SpecialOrder).Name, typeof(Order).Name),
                 Assert.Throws<InvalidOperationException>(() =>
                     derivedEntityBuilder.PrimaryKey(new[] { Order.IdProperty.Name, Order.CustomerIdProperty.Name }, ConfigurationSource.DataAnnotation)).Message);
         }

--- a/test/EntityFramework.Core.Tests/Metadata/ModelConventions/RelationshipDiscoveryConventionTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/ModelConventions/RelationshipDiscoveryConventionTest.cs
@@ -861,6 +861,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata.Conventions
         {
             public int Id { get; set; }
 
+            public object Object { get; set; }
+
             public static OneToManyDependent Static { get; set; }
 
             public OneToManyDependent WriteOnly


### PR DESCRIPTION
Fixes #3727 
Blocked `object` being discovered as entity type. Entity type with clr type `System.Object` is invalid entity type (due to absence of key) which is verified in model validator. Since System.Object is base type for any clr type, we set this entity type as base type for all other entities. Therefore we need to block it from being discovered in first place.
Also modified exception message in order to give information on what is the base type.