### PR TITLE
Query: Async GroupBy improvements:

### DIFF
--- a/src/EntityFramework.Core/Query/Internal/ILinqOperatorProvider.cs
+++ b/src/EntityFramework.Core/Query/Internal/ILinqOperatorProvider.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
 
@@ -47,7 +46,6 @@ namespace Microsoft.Data.Entity.Query.Internal
         MethodInfo TrackGroupedEntities { get; }
 
         MethodInfo GetAggregateMethod([NotNull] string methodName, [NotNull] Type elementType);
-        Expression AdjustSequenceType([NotNull] Expression expression);
 
         Type MakeSequenceType([NotNull] Type elementType);
     }

--- a/src/EntityFramework.Core/Query/Internal/LinqOperatorProvider.cs
+++ b/src/EntityFramework.Core/Query/Internal/LinqOperatorProvider.cs
@@ -412,8 +412,6 @@ namespace Microsoft.Data.Entity.Query.Internal
                     .MakeGenericMethod(elementType);
         }
 
-        public virtual Expression AdjustSequenceType(Expression expression) => expression;
-
         public virtual Type MakeSequenceType(Type elementType)
             => typeof(IEnumerable<>)
                 .MakeGenericType(Check.NotNull(elementType, nameof(elementType)));

--- a/src/EntityFramework.Relational/Query/Internal/RelationalResultOperatorHandler.cs
+++ b/src/EntityFramework.Relational/Query/Internal/RelationalResultOperatorHandler.cs
@@ -396,7 +396,7 @@ namespace Microsoft.Data.Entity.Query.Internal
             }
 
             return Expression.Call(
-                handlerContext.QueryModelVisitor.QueryCompilationContext.LinqOperatorProvider.Cast
+                handlerContext.QueryModelVisitor.LinqOperatorProvider.Cast
                     .MakeGenericMethod(ofTypeResultOperator.SearchedItemType),
                 handlerContext.QueryModelVisitor.Expression);
         }

--- a/src/EntityFramework.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EntityFramework.Relational/Query/RelationalQueryModelVisitor.cs
@@ -333,7 +333,7 @@ namespace Microsoft.Data.Entity.Query
                                 .Create(
                                     fromClause,
                                     QueryCompilationContext,
-                                    QueryCompilationContext.LinqOperatorProvider.SelectMany,
+                                    LinqOperatorProvider.SelectMany,
                                     readerOffset)
                                 .Flatten((MethodCallExpression)Expression);
 
@@ -369,7 +369,7 @@ namespace Microsoft.Data.Entity.Query
                 queryModel,
                 index,
                 () => base.VisitJoinClause(joinClause, queryModel, index),
-                QueryCompilationContext.LinqOperatorProvider.Join);
+                LinqOperatorProvider.Join);
         }
 
         protected override Expression CompileJoinClauseInnerSequenceExpression(
@@ -394,7 +394,7 @@ namespace Microsoft.Data.Entity.Query
                 queryModel,
                 index,
                 () => base.VisitGroupJoinClause(groupJoinClause, queryModel, index),
-                QueryCompilationContext.LinqOperatorProvider.GroupJoin,
+                LinqOperatorProvider.GroupJoin,
                 outerJoin: true);
         }
 
@@ -586,7 +586,10 @@ namespace Microsoft.Data.Entity.Query
 
                     var liftSubQuery
                         = new QuerySourceUpdater(
-                            querySource, QueryCompilationContext, subSelectExpression)
+                            querySource,
+                            QueryCompilationContext,
+                            LinqOperatorProvider,
+                            subSelectExpression)
                             .Visit(subQueryModelVisitor.Expression);
 
                     return
@@ -601,15 +604,18 @@ namespace Microsoft.Data.Entity.Query
         {
             private readonly IQuerySource _querySource;
             private readonly RelationalQueryCompilationContext _relationalQueryCompilationContext;
+            private readonly ILinqOperatorProvider _linqOperatorProvider;
             private readonly SelectExpression _selectExpression;
 
             public QuerySourceUpdater(
                 IQuerySource querySource,
                 RelationalQueryCompilationContext relationalQueryCompilationContext,
+                ILinqOperatorProvider linqOperatorProvider,
                 SelectExpression selectExpression)
             {
                 _querySource = querySource;
                 _relationalQueryCompilationContext = relationalQueryCompilationContext;
+                _linqOperatorProvider = linqOperatorProvider;
                 _selectExpression = selectExpression;
             }
 
@@ -656,7 +662,7 @@ namespace Microsoft.Data.Entity.Query
                     }
 
                     if (methodCallExpression.Method.MethodIsClosedFormOf(
-                        _relationalQueryCompilationContext.LinqOperatorProvider.Cast)
+                        _linqOperatorProvider.Cast)
                         && (arguments[0].Type.GetSequenceType() == typeof(ValueBuffer)))
                     {
                         return arguments[0];

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/AsyncQuerySqlServerTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/AsyncQuerySqlServerTest.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.Data.Entity.FunctionalTests;
 using Microsoft.Data.Entity.FunctionalTests.TestModels.Northwind;
 using Xunit;
+using Xunit.Abstractions;
 
 #pragma warning disable 1998
 
@@ -59,9 +60,10 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 await Single_Predicate_Cancellation(Fixture.CancelQuery()));
         }
 
-        public AsyncQuerySqlServerTest(NorthwindQuerySqlServerFixture fixture)
+        public AsyncQuerySqlServerTest(NorthwindQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
+           // TestSqlLoggerFactory.CaptureOutput(testOutputHelper);
         }
     }
 }


### PR DESCRIPTION
- Created EF impl. of async GroupBy using await.
- Use IGrouping when client-eval'ing GroupBy because groups are always buffered.
- Fixes sporadic async GroupBy test failure.