### PR TITLE
Migrations: Fix some scaffolding bugs

### DIFF
--- a/src/EntityFramework.Commands/Migrations/Design/CSharpHelper.cs
+++ b/src/EntityFramework.Commands/Migrations/Design/CSharpHelper.cs
@@ -40,101 +40,60 @@ namespace Microsoft.Data.Entity.Migrations.Design
             "__reftype",
             "__refvalue",
             "abstract",
-            "add",
-            "alias",
             "as",
-            "ascending",
-            "assembly",
-            "async",
-            "await",
             "base",
             "bool",
             "break",
-            "by",
             "byte",
             "case",
             "catch",
             "char",
             "checked",
-            "checksum",
             "class",
             "const",
             "continue",
             "decimal",
             "default",
-            "define",
             "delegate",
-            "descending",
-            "disable",
             "do",
             "double",
-            "elif",
             "else",
-            "endif",
-            "endregion",
             "enum",
-            "equals",
-            "error",
             "event",
             "explicit",
             "extern",
             "false",
-            "field",
             "finally",
             "fixed",
             "float",
             "for",
             "foreach",
-            "from",
-            "get",
-            "global",
             "goto",
-            "group",
-            "hidden",
             "if",
             "implicit",
             "in",
             "int",
             "interface",
             "internal",
-            "into",
             "is",
-            "join",
-            "let",
-            "line",
             "lock",
             "long",
-            "method",
-            "module",
-            "nameof",
             "namespace",
             "new",
             "null",
             "object",
-            "on",
             "operator",
-            "orderby",
             "out",
             "override",
-            "param",
             "params",
-            "partial",
-            "pragma",
             "private",
-            "property",
             "protected",
             "public",
-            "r",
             "readonly",
             "ref",
-            "region",
-            "remove",
-            "restore",
             "return",
             "sbyte",
             "sealed",
-            "select",
-            "set",
             "short",
             "sizeof",
             "stackalloc",
@@ -146,24 +105,17 @@ namespace Microsoft.Data.Entity.Migrations.Design
             "throw",
             "true",
             "try",
-            "type",
             "typeof",
-            "typevar",
             "uint",
             "ulong",
             "unchecked",
-            "undef",
             "unsafe",
             "ushort",
             "using",
             "virtual",
             "void",
             "volatile",
-            "warning",
-            "when",
-            "where",
-            "while",
-            "yield"
+            "while"
         };
 
         private static readonly IReadOnlyDictionary<Type, Func<CSharpHelper, object, string>> _literalFuncs =
@@ -223,27 +175,47 @@ namespace Microsoft.Data.Entity.Migrations.Design
         {
             Check.NotNull(type, nameof(type));
 
-            if (type.IsConstructedGenericType
-                && type.GetGenericTypeDefinition() == typeof(Nullable<>))
-            {
-                return Reference(type.UnwrapNullableType()) + "?";
-            }
-            if (type.IsArray)
-            {
-                return Reference(type.GetElementType()) + "[]";
-            }
-            if (type.IsNested)
-            {
-                return Reference(type.DeclaringType) + "." + type.Name;
-            }
-
             string builtInType;
             if (_builtInTypes.TryGetValue(type, out builtInType))
             {
                 return builtInType;
             }
 
-            return type.Name;
+            if (type.IsConstructedGenericType
+                && type.GetGenericTypeDefinition() == typeof(Nullable<>))
+            {
+                return Reference(type.UnwrapNullableType()) + "?";
+            }
+
+            var builder = new StringBuilder();
+
+            if (type.IsArray)
+            {
+                builder
+                    .Append(Reference(type.GetElementType()))
+                    .Append("[");
+
+                var rank = type.GetArrayRank();
+                for (int i = 1; i < rank; i++)
+                {
+                    builder.Append(",");
+                }
+
+                builder.Append("]");
+
+                return builder.ToString();
+            }
+
+            if (type.IsNested)
+            {
+                builder
+                    .Append(Reference(type.DeclaringType))
+                    .Append(".");
+            }
+
+            builder.Append(type.DisplayName(fullName: false));
+
+            return builder.ToString();
         }
 
         public virtual string Identifier([NotNull] string name, [CanBeNull] ICollection<string> scope = null)

--- a/src/EntityFramework.Commands/Migrations/Design/MigrationsScaffolder.cs
+++ b/src/EntityFramework.Commands/Migrations/Design/MigrationsScaffolder.cs
@@ -91,6 +91,13 @@ namespace Microsoft.Data.Entity.Migrations.Design
                 migrationNamespace = GetNamespace(lastMigration.Value?.AsType(), migrationNamespace);
             }
 
+            var sanitizedContextName = _contextType.Name;
+            var genericMarkIndex = sanitizedContextName.IndexOf('`');
+            if (genericMarkIndex != -1)
+            {
+                sanitizedContextName = sanitizedContextName.Substring(0, genericMarkIndex);
+            }
+
             if (ContainsForeignMigrations(migrationNamespace))
             {
                 if (subNamespaceDefaulted)
@@ -99,14 +106,14 @@ namespace Microsoft.Data.Entity.Migrations.Design
                         .Append(rootNamespace)
                         .Append(".Migrations.");
 
-                    if (_contextType.Name.EndsWith("Context"))
+                    if (sanitizedContextName.EndsWith("Context"))
                     {
-                        builder.Append(_contextType.Name.Substring(0, _contextType.Name.Length - 7));
+                        builder.Append(sanitizedContextName.Substring(0, sanitizedContextName.Length - 7));
                     }
                     else
                     {
                         builder
-                            .Append(_contextType.Name)
+                            .Append(sanitizedContextName)
                             .Append("Migrations");
                     }
 
@@ -127,7 +134,7 @@ namespace Microsoft.Data.Entity.Migrations.Design
             var migrationId = _idGenerator.GenerateId(migrationName);
             var modelSnapshotNamespace = GetNamespace(modelSnapshot?.GetType(), migrationNamespace);
 
-            var modelSnapshotName = _contextType.Name + "ModelSnapshot";
+            var modelSnapshotName = sanitizedContextName + "ModelSnapshot";
             if (modelSnapshot != null)
             {
                 var lastModelSnapshotName = modelSnapshot.GetType().Name;

--- a/test/EntityFramework.Commands.Tests/Migrations/Design/CSharpHelperTest.cs
+++ b/test/EntityFramework.Commands.Tests/Migrations/Design/CSharpHelperTest.cs
@@ -195,27 +195,30 @@ namespace Microsoft.Data.Entity.Migrations.Design
             Assert.Equal(CommandsStrings.UnknownLiteral(typeof(object)), ex.Message);
         }
 
-        [Fact]
-        public void Reference_works_when_nested()
-        {
-            Assert.Equal(
-                "CSharpHelperTest.Nested",
-                new CSharpHelper().Reference(typeof(Nested)));
-        }
-
-        [Fact]
-        public void Reference_works_when_nested_more()
-        {
-            Assert.Equal(
-                "CSharpHelperTest.Nested.DoubleNested",
-                new CSharpHelper().Reference(typeof(Nested.DoubleNested)));
-        }
+        [Theory]
+        [InlineData(typeof(int), "int")]
+        [InlineData(typeof(int?), "int?")]
+        [InlineData(typeof(int[]), "int[]")]
+        [InlineData(typeof(int[,]), "int[,]")]
+        [InlineData(typeof(int[][]), "int[][]")]
+        [InlineData(typeof(Generic<int>), "Generic<int>")]
+        [InlineData(typeof(Nested), "CSharpHelperTest.Nested")]
+        [InlineData(typeof(Generic<Generic<int>>), "Generic<Generic<int>>")]
+        [InlineData(typeof(MultiGeneric<int, int>), "MultiGeneric<int, int>")]
+        [InlineData(typeof(NestedGeneric<int>), "CSharpHelperTest.NestedGeneric<int>")]
+        [InlineData(typeof(Nested.DoubleNested), "CSharpHelperTest.Nested.DoubleNested")]
+        public void Reference_works(Type type, string expected)
+            => Assert.Equal(expected, new CSharpHelper().Reference(type));
 
         private class Nested
         {
             public class DoubleNested
             {
             }
+        }
+
+        internal class NestedGeneric<T>
+        {
         }
 
         private enum SomeEnum
@@ -227,7 +230,7 @@ namespace Microsoft.Data.Entity.Migrations.Design
         [InlineData("dash-er", "dasher")]
         [InlineData("params", "@params")]
         [InlineData("true", "@true")]
-        [InlineData("yield", "@yield")]
+        [InlineData("yield", "yield")]
         [InlineData("spac ed", "spaced")]
         [InlineData("1nders", "_1nders")]
         [InlineData("name.space", "@namespace")]
@@ -249,5 +252,13 @@ namespace Microsoft.Data.Entity.Migrations.Design
         {
             Assert.Equal(excepted, new CSharpHelper().Namespace(input));
         }
+    }
+
+    internal class Generic<T>
+    {
+    }
+
+    internal class MultiGeneric<T1, T2>
+    {
     }
 }

--- a/test/EntityFramework.Commands.Tests/Migrations/Design/MigrationScaffolderTest.cs
+++ b/test/EntityFramework.Commands.Tests/Migrations/Design/MigrationScaffolderTest.cs
@@ -6,7 +6,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Internal;
-using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Metadata.Conventions.Internal;
 using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Migrations.Internal;
@@ -34,6 +33,16 @@ namespace Microsoft.Data.Entity.Migrations.Design
             Assert.Equal(typeof(ContextWithSnapshotModelSnapshot).Namespace, migration.SnapshotSubnamespace);
         }
 
+        [Fact]
+        public void ScaffoldMigration_handles_generic_contexts()
+        {
+            var scaffolder = CreateMigrationScaffolder<GenericContext<int>>();
+
+            var migration = scaffolder.ScaffoldMigration("EmptyMigration", "WebApplication1");
+
+            Assert.Equal("GenericContextModelSnapshot", migration.SnapshotName);
+        }
+
         private MigrationsScaffolder CreateMigrationScaffolder<TContext>()
             where TContext : DbContext, new()
         {
@@ -57,6 +66,10 @@ namespace Microsoft.Data.Entity.Migrations.Design
                 new MockHistoryRepository(),
                 new LoggerFactory(),
                 new MockProviderServices());
+        }
+
+        private class GenericContext<T> : DbContext
+        {
         }
 
         private class ContextWithSnapshot : DbContext


### PR DESCRIPTION
Highlights:
* Stops escaping contextual C# keywords out of context
* Handle generic types (fixes #3388)