### PR TITLE
Move SQL Server concepts into provider-specific scaffolding model

### DIFF
--- a/src/EntityFramework.MicrosoftSqlServer.Design/EntityFramework.MicrosoftSqlServer.Design.csproj
+++ b/src/EntityFramework.MicrosoftSqlServer.Design/EntityFramework.MicrosoftSqlServer.Design.csproj
@@ -43,6 +43,8 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.tt</DependentUpon>
     </Compile>
+    <Compile Include="Metadata\SqlServerColumnModel.cs" />
+    <Compile Include="Metadata\SqlServerIndexModel.cs" />
     <Compile Include="Internal\SqlDataReaderExtensions.cs" />
     <Compile Include="SqlServerTableSelectionSetExtensions.cs" />
     <Compile Include="SqlServerDesignTimeServices.cs" />

--- a/src/EntityFramework.MicrosoftSqlServer.Design/Metadata/SqlServerColumnModel.cs
+++ b/src/EntityFramework.MicrosoftSqlServer.Design/Metadata/SqlServerColumnModel.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+
+namespace Microsoft.Data.Entity.Scaffolding.Metadata
+{
+    public class SqlServerColumnModel : ColumnModel
+    {
+        public virtual bool IsIdentity { get; [param: CanBeNull] set; }
+
+        public virtual int? DateTimePrecision { get; [param: CanBeNull] set; }
+    }
+}

--- a/src/EntityFramework.MicrosoftSqlServer.Design/Metadata/SqlServerIndexModel.cs
+++ b/src/EntityFramework.MicrosoftSqlServer.Design/Metadata/SqlServerIndexModel.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+
+namespace Microsoft.Data.Entity.Scaffolding.Metadata
+{
+    public class SqlServerIndexModel : IndexModel
+    {
+        public virtual bool IsClustered { get; [param: CanBeNull] set; }
+    }
+}

--- a/src/EntityFramework.Relational.Design/Metadata/ColumnModel.cs
+++ b/src/EntityFramework.Relational.Design/Metadata/ColumnModel.cs
@@ -25,8 +25,6 @@ namespace Microsoft.Data.Entity.Scaffolding.Metadata
         public virtual int? Precision { get; [param: CanBeNull] set; }
         public virtual int? Scale { get; [param: CanBeNull] set; }
         public virtual ValueGenerated? ValueGenerated { get; set; }
-        // SQL Server
-        public virtual bool? IsIdentity { get; [param: CanBeNull] set; }
 
         public virtual string DisplayName
         {

--- a/src/EntityFramework.Relational.Design/Metadata/IndexModel.cs
+++ b/src/EntityFramework.Relational.Design/Metadata/IndexModel.cs
@@ -14,6 +14,5 @@ namespace Microsoft.Data.Entity.Scaffolding.Metadata
         public virtual string Name { get; [param: NotNull] set; }
         public virtual IList<ColumnModel> Columns { get; [param: NotNull] set; } = new List<ColumnModel>();
         public virtual bool IsUnique { get; [param: NotNull] set; }
-        public virtual bool? IsClustered { get; [param: CanBeNull] set; }
     }
 }


### PR DESCRIPTION
Reverting a design decision we made for RC1. 

Use inheritance instead of making the database model a grab-bag of features from multiple providers. Fix https://github.com/aspnet/EntityFramework/issues/3766.

This pattern made it easier to resolve a quirk scaffolding "DateTimePrecision" on SqlServer. (see https://github.com/aspnet/EntityFramework/issues/3454).