### PR TITLE
Stop taking key from query

### DIFF
--- a/src/EntityFramework.Core/ChangeTracking/Internal/IStateManager.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/IStateManager.cs
@@ -16,11 +16,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
     {
         InternalEntityEntry GetOrCreateEntry([NotNull] object entity);
 
-        InternalEntityEntry StartTracking(
-            [NotNull] IEntityType entityType,
-            [NotNull] IKeyValue keyValue,
-            [NotNull] object entity,
-            ValueBuffer valueBuffer);
+        InternalEntityEntry StartTracking([NotNull] IEntityType entityType, [NotNull] object entity, ValueBuffer valueBuffer);
 
         void BeginTrackingQuery();
 

--- a/src/EntityFramework.Core/Query/Internal/EntityTrackingInfo.cs
+++ b/src/EntityFramework.Core/Query/Internal/EntityTrackingInfo.cs
@@ -78,7 +78,6 @@ namespace Microsoft.Data.Entity.Query.Internal
 
             stateManager.StartTracking(
                 _entityType,
-                _keyValueFactory.Create(valueBuffer),
                 entity,
                 valueBuffer);
         }
@@ -125,7 +124,6 @@ namespace Microsoft.Data.Entity.Query.Internal
 
                 stateManager.StartTracking(
                     IncludedEntityTrackingInfo.EntityType,
-                    IncludedEntityTrackingInfo.CreateKeyValue(valueBuffer),
                     Entity,
                     valueBuffer);
             }

--- a/test/EntityFramework.Core.FunctionalTests/FixupTest.cs
+++ b/test/EntityFramework.Core.FunctionalTests/FixupTest.cs
@@ -60,30 +60,30 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
                 var stateManager = context.ChangeTracker.GetInfrastructure();
 
-                stateManager.StartTracking(categoryType, new KeyValue<int>(categoryType.FindPrimaryKey(), 11), new Category { Id = 11 }, new ValueBuffer(new object[] { 11 }));
-                stateManager.StartTracking(categoryType, new KeyValue<int>(categoryType.FindPrimaryKey(), 12), new Category { Id = 12 }, new ValueBuffer(new object[] { 12 }));
-                stateManager.StartTracking(categoryType, new KeyValue<int>(categoryType.FindPrimaryKey(), 13), new Category { Id = 13 }, new ValueBuffer(new object[] { 13 }));
+                stateManager.StartTracking(categoryType, new Category { Id = 11 }, new ValueBuffer(new object[] { 11 }));
+                stateManager.StartTracking(categoryType, new Category { Id = 12 }, new ValueBuffer(new object[] { 12 }));
+                stateManager.StartTracking(categoryType, new Category { Id = 13 }, new ValueBuffer(new object[] { 13 }));
 
-                stateManager.StartTracking(productType, new KeyValue<int>(productType.FindPrimaryKey(), 21), new Product { Id = 21, CategoryId = 11 }, new ValueBuffer(new object[] { 21, 11 }));
+                stateManager.StartTracking(productType, new Product { Id = 21, CategoryId = 11 }, new ValueBuffer(new object[] { 21, 11 }));
                 AssertAllFixedUp(context);
-                stateManager.StartTracking(productType, new KeyValue<int>(productType.FindPrimaryKey(), 22), new Product { Id = 22, CategoryId = 11 }, new ValueBuffer(new object[] { 22, 11 }));
+                stateManager.StartTracking(productType, new Product { Id = 22, CategoryId = 11 }, new ValueBuffer(new object[] { 22, 11 }));
                 AssertAllFixedUp(context);
-                stateManager.StartTracking(productType, new KeyValue<int>(productType.FindPrimaryKey(), 23), new Product { Id = 23, CategoryId = 11 }, new ValueBuffer(new object[] { 23, 11 }));
+                stateManager.StartTracking(productType, new Product { Id = 23, CategoryId = 11 }, new ValueBuffer(new object[] { 23, 11 }));
                 AssertAllFixedUp(context);
-                stateManager.StartTracking(productType, new KeyValue<int>(productType.FindPrimaryKey(), 24), new Product { Id = 24, CategoryId = 12 }, new ValueBuffer(new object[] { 24, 12 }));
+                stateManager.StartTracking(productType, new Product { Id = 24, CategoryId = 12 }, new ValueBuffer(new object[] { 24, 12 }));
                 AssertAllFixedUp(context);
-                stateManager.StartTracking(productType, new KeyValue<int>(productType.FindPrimaryKey(), 25), new Product { Id = 25, CategoryId = 12 }, new ValueBuffer(new object[] { 25, 12 }));
+                stateManager.StartTracking(productType, new Product { Id = 25, CategoryId = 12 }, new ValueBuffer(new object[] { 25, 12 }));
                 AssertAllFixedUp(context);
 
-                stateManager.StartTracking(offerType, new KeyValue<int>(offerType.FindPrimaryKey(), 31), new SpecialOffer { Id = 31, ProductId = 22 }, new ValueBuffer(new object[] { 31, 22 }));
+                stateManager.StartTracking(offerType, new SpecialOffer { Id = 31, ProductId = 22 }, new ValueBuffer(new object[] { 31, 22 }));
                 AssertAllFixedUp(context);
-                stateManager.StartTracking(offerType, new KeyValue<int>(offerType.FindPrimaryKey(), 32), new SpecialOffer { Id = 32, ProductId = 22 }, new ValueBuffer(new object[] { 32, 22 }));
+                stateManager.StartTracking(offerType, new SpecialOffer { Id = 32, ProductId = 22 }, new ValueBuffer(new object[] { 32, 22 }));
                 AssertAllFixedUp(context);
-                stateManager.StartTracking(offerType, new KeyValue<int>(offerType.FindPrimaryKey(), 33), new SpecialOffer { Id = 33, ProductId = 24 }, new ValueBuffer(new object[] { 33, 24 }));
+                stateManager.StartTracking(offerType, new SpecialOffer { Id = 33, ProductId = 24 }, new ValueBuffer(new object[] { 33, 24 }));
                 AssertAllFixedUp(context);
-                stateManager.StartTracking(offerType, new KeyValue<int>(offerType.FindPrimaryKey(), 34), new SpecialOffer { Id = 34, ProductId = 24 }, new ValueBuffer(new object[] { 34, 24 }));
+                stateManager.StartTracking(offerType, new SpecialOffer { Id = 34, ProductId = 24 }, new ValueBuffer(new object[] { 34, 24 }));
                 AssertAllFixedUp(context);
-                stateManager.StartTracking(offerType, new KeyValue<int>(offerType.FindPrimaryKey(), 35), new SpecialOffer { Id = 35, ProductId = 24 }, new ValueBuffer(new object[] { 35, 24 }));
+                stateManager.StartTracking(offerType, new SpecialOffer { Id = 35, ProductId = 24 }, new ValueBuffer(new object[] { 35, 24 }));
 
                 AssertAllFixedUp(context);
 

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/StateManagerTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/StateManagerTest.cs
@@ -40,17 +40,15 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var categoryType = model.FindEntityType(typeof(Category));
             var stateManager = CreateStateManager(model);
 
-            var entityKey = new KeyValue<int>(categoryType.FindPrimaryKey(), 77);
             var valueBuffer = new ValueBuffer(new object[] { 77, "Bjork", null });
 
-            stateManager.StartTracking(categoryType, entityKey, new Category { Id = 77 }, valueBuffer);
+            stateManager.StartTracking(categoryType, new Category { Id = 77 }, valueBuffer);
 
             Assert.Equal(
                 CoreStrings.IdentityConflict("Category"),
                 Assert.Throws<InvalidOperationException>(
                     () => stateManager.StartTracking(
                         categoryType,
-                        entityKey,
                         new Category { Id = 77 },
                         valueBuffer)).Message);
         }
@@ -63,27 +61,26 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var stateManager = CreateStateManager(model);
 
             var category = new Category { Id = 77 };
-            var entityKey = new KeyValue<int>(categoryType.FindPrimaryKey(), 77);
             var valueBuffer = new ValueBuffer(new object[] { 77, "Bjork", null });
 
-            var entry = stateManager.StartTracking(categoryType, entityKey, category, valueBuffer);
+            var entry = stateManager.StartTracking(categoryType, category, valueBuffer);
 
-            Assert.Same(entry, stateManager.StartTracking(categoryType, entityKey, category, valueBuffer));
+            Assert.Same(entry, stateManager.StartTracking(categoryType, category, valueBuffer));
         }
 
         [Fact]
         public void StartTracking_throws_for_invalid_entity_key()
         {
             var model = BuildModel();
-            var categoryType = model.FindEntityType(typeof(Category));
+            var categoryType = model.FindEntityType(typeof(Dogegory));
             var stateManager = CreateStateManager(model);
 
-            var valueBuffer = new ValueBuffer(new object[] { 0, "Bjork", null });
+            var valueBuffer = new ValueBuffer(new object[] { null });
 
             Assert.Equal(
-                CoreStrings.InvalidPrimaryKey("Category"),
+                CoreStrings.InvalidPrimaryKey("Dogegory"),
                 Assert.Throws<InvalidOperationException>(
-                    () => stateManager.StartTracking(categoryType, new KeyValue<int>(null, 0), new Category { Id = 0 }, valueBuffer)).Message);
+                    () => stateManager.StartTracking(categoryType, new Dogegory { Id = null }, valueBuffer)).Message);
         }
 
         [Fact]
@@ -101,7 +98,6 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             stateManager.StartTracking(
                 categoryType,
-                new KeyValue<int>(categoryType.FindPrimaryKey(), 77),
                 new Category { Id = 77 },
                 new ValueBuffer(new object[] { 77, "Bjork", null }));
 
@@ -109,7 +105,6 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             stateManager.StartTracking(
                 categoryType,
-                new KeyValue<int>(categoryType.FindPrimaryKey(), 78),
                 new Category { Id = 78 },
                 new ValueBuffer(new object[] { 78, "Beck", null }));
 
@@ -121,7 +116,6 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             stateManager.StartTracking(
                 categoryType,
-                new KeyValue<int>(categoryType.FindPrimaryKey(), 79),
                 new Category { Id = 79 },
                 new ValueBuffer(new object[] { 79, "Bush", null }));
 
@@ -143,7 +137,6 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             stateManager.StartTracking(
                 categoryType,
-                new KeyValue<int>(categoryType.FindPrimaryKey(), 77),
                 new Category { Id = 77 },
                 new ValueBuffer(new object[] { 77, "Bjork", null }));
 
@@ -151,7 +144,6 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             var entry = stateManager.StartTracking(
                 categoryType,
-                new KeyValue<int>(categoryType.FindPrimaryKey(), 78),
                 new Category { Id = 78 },
                 new ValueBuffer(new object[] { 78, "Beck", null }));
 
@@ -177,7 +169,6 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             stateManager.StartTracking(
                 categoryType,
-                new KeyValue<int>(categoryType.FindPrimaryKey(), 77),
                 new Category { Id = 77 },
                 new ValueBuffer(new object[] { 77, "Bjork", null }));
 
@@ -185,7 +176,6 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             var entry = stateManager.StartTracking(
                 categoryType,
-                new KeyValue<int>(categoryType.FindPrimaryKey(), 78),
                 new Category { Id = 78 },
                 new ValueBuffer(new object[] { 78, "Beck", null }));
 
@@ -211,7 +201,6 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             var entry = stateManager.StartTracking(
                 categoryType,
-                new KeyValue<int>(categoryType.FindPrimaryKey(), 77),
                 new Category { Id = 77 },
                 new ValueBuffer(new object[] { 77, "Bjork", null }));
 
@@ -219,7 +208,6 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             stateManager.StartTracking(
                 categoryType,
-                new KeyValue<int>(categoryType.FindPrimaryKey(), 78),
                 new Category { Id = 78 },
                 new ValueBuffer(new object[] { 78, "Beck", null }));
 

--- a/test/EntityFramework.Core.Tests/DbContextTest.cs
+++ b/test/EntityFramework.Core.Tests/DbContextTest.cs
@@ -263,7 +263,6 @@ namespace Microsoft.Data.Entity.Tests
 
             public InternalEntityEntry StartTracking(
                 IEntityType entityType,
-                IKeyValue keyValue,
                 object entity,
                 ValueBuffer valueBuffer)
             {


### PR DESCRIPTION
State manager doesn't need to take key from query since it can be obtained from the entity