### PR TITLE
Use generic snapshots for shadow values

### DIFF
--- a/src/EntityFramework.Core/ChangeTracking/Internal/EmptyShadowValuesFactoryFactory.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/EmptyShadowValuesFactoryFactory.cs
@@ -1,17 +1,23 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Linq.Expressions;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Metadata.Internal;
 
 namespace Microsoft.Data.Entity.ChangeTracking.Internal
 {
-    public class RelationshipSnapshotFactoryFactory : SnapshotFactoryFactory<InternalEntityEntry>
+    public class EmptyShadowValuesFactoryFactory : SnapshotFactoryFactory
     {
         protected override int GetPropertyIndex(IPropertyBase propertyBase)
-            => propertyBase.GetRelationshipIndex();
+            => (propertyBase as IProperty)?.GetShadowIndex() ?? -1;
 
         protected override int GetPropertyCount(IEntityType entityType)
-            => entityType.RelationshipPropertyCount();
+            => entityType.ShadowPropertyCount();
+
+        protected override bool UseEntityVariable => false;
+
+        protected override Expression CreateReadShadowValueExpression(ParameterExpression parameter, IProperty property)
+            => Expression.Default(property.ClrType);
     }
 }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/InternalMixedEntityEntry.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/InternalMixedEntityEntry.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Metadata.Internal;
@@ -11,7 +10,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 {
     public class InternalMixedEntityEntry : InternalEntityEntry
     {
-        private readonly object[] _shadowValues;
+        private readonly ISnapshot _shadowValues;
 
         public InternalMixedEntityEntry(
             [NotNull] IStateManager stateManager,
@@ -20,7 +19,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
             : base(stateManager, entityType)
         {
             Entity = entity;
-            _shadowValues = new object[entityType.ShadowPropertyCount()];
+            _shadowValues = entityType.GetEmptyShadowValuesFactory()();
         }
 
         public InternalMixedEntityEntry(
@@ -31,7 +30,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
             : base(stateManager, entityType)
         {
             Entity = entity;
-            _shadowValues = ExtractShadowValues(valueBuffer);
+            _shadowValues = entityType.GetShadowValuesFactory()(valueBuffer);
         }
 
         public override object Entity { get; }
@@ -61,18 +60,6 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
             {
                 _shadowValues[property.GetShadowIndex()] = value;
             }
-        }
-
-        private object[] ExtractShadowValues(ValueBuffer valueBuffer)
-        {
-            var shadowValues = new object[EntityType.ShadowPropertyCount()];
-
-            foreach (var property in EntityType.GetProperties().Where(property => property.IsShadowProperty))
-            {
-                shadowValues[property.GetShadowIndex()] = valueBuffer[property.GetIndex()];
-            }
-
-            return shadowValues;
         }
     }
 }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/InternalShadowEntityEntry.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/InternalShadowEntityEntry.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 {
     public class InternalShadowEntityEntry : InternalEntityEntry
     {
-        private readonly object[] _propertyValues;
+        private readonly ISnapshot _propertyValues;
 
         public override object Entity => null;
 
@@ -20,7 +20,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
             [NotNull] IEntityType entityType)
             : base(stateManager, entityType)
         {
-            _propertyValues = new object[entityType.ShadowPropertyCount()];
+            _propertyValues = entityType.GetEmptyShadowValuesFactory()();
         }
 
         public InternalShadowEntityEntry(
@@ -29,13 +29,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
             ValueBuffer valueBuffer)
             : base(stateManager, entityType)
         {
-            _propertyValues = new object[valueBuffer.Count];
-
-            var index = 0;
-            foreach (var property in entityType.GetProperties())
-            {
-                _propertyValues[index++] = valueBuffer[property.GetIndex()];
-            }
+            _propertyValues = entityType.GetShadowValuesFactory()(valueBuffer);
         }
 
         public override object ReadShadowValue(int shadowIndex)

--- a/src/EntityFramework.Core/ChangeTracking/Internal/OriginalValuesFactoryFactory.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/OriginalValuesFactoryFactory.cs
@@ -6,7 +6,7 @@ using Microsoft.Data.Entity.Metadata.Internal;
 
 namespace Microsoft.Data.Entity.ChangeTracking.Internal
 {
-    public class OriginalValuesFactoryFactory : SnapshotFactoryFactory
+    public class OriginalValuesFactoryFactory : SnapshotFactoryFactory<InternalEntityEntry>
     {
         protected override int GetPropertyIndex(IPropertyBase propertyBase)
             => (propertyBase as IProperty)?.GetOriginalValueIndex() ?? -1;

--- a/src/EntityFramework.Core/ChangeTracking/Internal/ShadowValuesFactoryFactory.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/ShadowValuesFactoryFactory.cs
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq.Expressions;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Metadata.Internal;
+using Microsoft.Data.Entity.Storage;
+
+namespace Microsoft.Data.Entity.ChangeTracking.Internal
+{
+    public class ShadowValuesFactoryFactory : SnapshotFactoryFactory<ValueBuffer>
+    {
+        protected override int GetPropertyIndex(IPropertyBase propertyBase)
+            => (propertyBase as IProperty)?.GetShadowIndex() ?? -1;
+
+        protected override int GetPropertyCount(IEntityType entityType)
+            => entityType.ShadowPropertyCount();
+
+        protected override bool UseEntityVariable => false;
+
+        protected override Expression CreateReadShadowValueExpression(ParameterExpression parameter, IProperty property)
+            => Expression.Convert(
+                Expression.Call(
+                    parameter,
+                    ValueBuffer.GetValueMethod,
+                    Expression.Constant(property.GetIndex())),
+                property.ClrType);
+    }
+}

--- a/src/EntityFramework.Core/ChangeTracking/Internal/SnapshotFactoryFactory`.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/SnapshotFactoryFactory`.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+
+namespace Microsoft.Data.Entity.ChangeTracking.Internal
+{
+    public abstract class SnapshotFactoryFactory<TInput> : SnapshotFactoryFactory
+    {
+        public virtual Func<TInput, ISnapshot> Create([NotNull] IEntityType entityType)
+        {
+            if (GetPropertyCount(entityType) == 0)
+            {
+                return e => Snapshot.Empty;
+            }
+
+            var parameter = Expression.Parameter(typeof(TInput), "source");
+
+            return Expression.Lambda<Func<TInput, ISnapshot>>(
+                CreateConstructorExpression(entityType, parameter),
+                parameter)
+                .Compile();
+        }
+    }
+}

--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -60,6 +60,7 @@
     </Compile>
     <Compile Include="ChangeTracking\EntityEntryGraphNode.cs" />
     <Compile Include="ChangeTracking\Internal\ChangeTrackerFactory.cs" />
+    <Compile Include="ChangeTracking\Internal\EmptyShadowValuesFactoryFactory.cs" />
     <Compile Include="ChangeTracking\Internal\EntityGraphAttacher.cs" />
     <Compile Include="ChangeTracking\Internal\ISnapshot.cs" />
     <Compile Include="ChangeTracking\Internal\KeyValue.cs" />
@@ -69,9 +70,11 @@
     <Compile Include="ChangeTracking\Internal\OriginalValues.cs" />
     <Compile Include="ChangeTracking\Internal\OriginalValuesFactoryFactory.cs" />
     <Compile Include="ChangeTracking\Internal\RelationshipSnapshotFactoryFactory.cs" />
+    <Compile Include="ChangeTracking\Internal\ShadowValuesFactoryFactory.cs" />
     <Compile Include="ChangeTracking\Internal\SimpleKeyValueFactory.cs" />
     <Compile Include="ChangeTracking\Internal\Snapshot.cs" />
     <Compile Include="ChangeTracking\Internal\SnapshotFactoryFactory.cs" />
+    <Compile Include="ChangeTracking\Internal\SnapshotFactoryFactory`.cs" />
     <Compile Include="DbUpdateConcurrencyException.cs" />
     <Compile Include="DbUpdateException.cs" />
     <Compile Include="Extensions\Internal\CoreLoggerExtensions.cs" />

--- a/src/EntityFramework.Core/Metadata/Internal/EntityTypeExtensions.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/EntityTypeExtensions.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Internal;
+using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Metadata.Internal
@@ -146,6 +147,24 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             return source != null
                 ? source.OriginalValuesFactory
                 : new OriginalValuesFactoryFactory().Create(entityType);
+        }
+
+        public static Func<ValueBuffer, ISnapshot> GetShadowValuesFactory([NotNull] this IEntityType entityType)
+        {
+            var source = entityType as ISnapshotFactorySource;
+
+            return source != null
+                ? source.ShadowValuesFactory
+                : new ShadowValuesFactoryFactory().Create(entityType);
+        }
+
+        public static Func<ISnapshot> GetEmptyShadowValuesFactory([NotNull] this IEntityType entityType)
+        {
+            var source = entityType as ISnapshotFactorySource;
+
+            return source != null
+                ? source.EmptyShadowValuesFactory
+                : new EmptyShadowValuesFactoryFactory().CreateEmpty(entityType);
         }
 
         public static bool HasPropertyChangingNotifications([NotNull] this IEntityType entityType)

--- a/src/EntityFramework.Core/Metadata/Internal/ISnapshotFactorySource.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/ISnapshotFactorySource.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
+using Microsoft.Data.Entity.Storage;
 
 namespace Microsoft.Data.Entity.Metadata.Internal
 {
@@ -10,5 +11,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
     {
         Func<InternalEntityEntry, ISnapshot> OriginalValuesFactory { get; }
         Func<InternalEntityEntry, ISnapshot> RelationshipSnapshotFactory { get; }
+        Func<ValueBuffer, ISnapshot> ShadowValuesFactory { get; }
+        Func<ISnapshot> EmptyShadowValuesFactory { get; }
     }
 }

--- a/src/EntityFramework.Core/Storage/ValueBuffer.cs
+++ b/src/EntityFramework.Core/Storage/ValueBuffer.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
 using JetBrains.Annotations;
 
 namespace Microsoft.Data.Entity.Storage
@@ -61,6 +63,9 @@ namespace Microsoft.Data.Entity.Storage
             get { return _values[_offset + index]; }
             [param: CanBeNull] set { _values[_offset + index] = value; }
         }
+
+        internal static readonly MethodInfo GetValueMethod
+            = typeof(ValueBuffer).GetTypeInfo().GetProperties().Single(p => p.GetIndexParameters().Any()).GetMethod;
 
         /// <summary>
         ///     Gets the number of values in this buffer.

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntityEntryTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntityEntryTestBase.cs
@@ -359,16 +359,9 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var entry = CreateInternalEntry(configuration, entityType, new SomeEntity());
 
-            if (keyProperty.IsShadowProperty)
-            {
-                Assert.Null(entry[keyProperty]);
-            }
-            else
-            {
-                Assert.Equal(0, entry[keyProperty]);
-            }
+            Assert.Equal(0, entry[keyProperty]);
 
-            Assert.Null(entry[nonKeyProperty]);
+            Assert.Equal(0, entry[nonKeyProperty]);
 
             entry.SetEntityState(EntityState.Added);
 
@@ -458,14 +451,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             entry[keyProperties[1]] = "ReadySalted";
             entry[fkProperty] = 0;
 
-            if (property.IsShadowProperty)
-            {
-                Assert.Null(entry[property]);
-            }
-            else
-            {
-                Assert.Equal(0, entry[property]);
-            }
+            Assert.Equal(0, entry[property]);
 
             entry.SetEntityState(EntityState.Added);
 

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalMixedEntityEntryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalMixedEntityEntryTest.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             var entity = new SomeEntity { Id = 77, Name = "Magic Tree House" };
             var entry = CreateInternalEntry(configuration, entityType, entity);
 
-            Assert.Null(entry[keyProperty]); // In shadow
+            Assert.Equal(0, entry[keyProperty]); // In shadow
             Assert.Equal("Magic Tree House", entry[nonKeyProperty]);
 
             entry[keyProperty] = 78;


### PR DESCRIPTION
Improves the perf of creating shadow value storage and storage uses less memory.