### PR TITLE
Fix to #3758 - Including Many-To-Many Relation in Select

### DIFF
--- a/src/EntityFramework.Core/Metadata/Internal/IClrCollectionAccessor.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/IClrCollectionAccessor.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 
@@ -12,5 +13,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
         void AddRange([NotNull] object instance, [NotNull] IEnumerable<object> values);
         bool Contains([NotNull] object instance, [NotNull] object value);
         void Remove([NotNull] object instance, [NotNull] object value);
+        object Create([NotNull] IEnumerable<object> values);
+        Type CollectionType { get; }
     }
 }

--- a/test/EntityFramework.Core.FunctionalTests/QueryNavigationsTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/QueryNavigationsTestBase.cs
@@ -296,6 +296,38 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
+        public virtual void Select_collection_navigation_simple()
+        {
+            using (var context = CreateContext())
+            {
+                var query = from c in context.Customers
+                            where c.CustomerID.StartsWith("A")
+                            select new { Orders = c.Orders };
+
+                var results = query.ToList();
+
+                Assert.Equal(4, results.Count);
+                Assert.True(results.All(r => r.Orders.Count > 0));
+            }
+        }
+
+        [Fact]
+        public virtual void Select_collection_navigation_multi_part()
+        {
+            using (var context = CreateContext())
+            {
+                var query = from o in context.Orders
+                            where o.CustomerID == "ALFKI"
+                            select new { Orders = o.Customer.Orders };
+
+                var results = query.ToList();
+
+                Assert.Equal(6, results.Count);
+                Assert.True(results.All(r => r.Orders.Count > 0));
+            }
+        }
+
+        [Fact]
         public virtual void Collection_select_nav_prop_any()
         {
             using (var context = CreateContext())

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
@@ -214,6 +214,59 @@ WHERE [e].[ReportsTo] IS NULL",
                 Sql);
         }
 
+        public override void Select_collection_navigation_simple()
+        {
+            base.Select_collection_navigation_simple();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE 'A' + '%'
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]",
+                Sql);
+        }
+
+        public override void Select_collection_navigation_multi_part()
+        {
+            base.Select_collection_navigation_multi_part();
+
+            Assert.Equal(
+                @"SELECT [o.Customer].[CustomerID]
+FROM [Orders] AS [o]
+INNER JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
+WHERE [o].[CustomerID] = 'ALFKI'
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]",
+                Sql);
+        }
+
         public override void Collection_select_nav_prop_any()
         {
             base.Collection_select_nav_prop_any();


### PR DESCRIPTION
Problem was that we were making some incorrect assumptions when materializing collections directly - we always assumed there will be a subquery present in those cases, and also we were not materializing correct collection types.
Fix is to inject subquery to navigation access, if the subquery was not present before. Also added a client-side method that materializes a correct collection, based on the information in the INavigation.