### PR TITLE
[SMALL] Fix to #3811 - .OrderBy on column 2 or more navigation properties away + .Include throws exception

### DIFF
--- a/src/EntityFramework.Core/Extensions/Internal/ExpressionExtensions.cs
+++ b/src/EntityFramework.Core/Extensions/Internal/ExpressionExtensions.cs
@@ -154,5 +154,17 @@ namespace System.Linq.Expressions
 
             return expression;
         }
+
+        public static TExpression GetRootExpression<TExpression>([NotNull] this Expression expression)
+            where TExpression : Expression
+        {
+            MemberExpression memberExpression;
+            while ((memberExpression = expression as MemberExpression) != null)
+            {
+                expression = memberExpression.Expression;
+            }
+
+            return expression as TExpression;
+        }
     }
 }

--- a/src/EntityFramework.Core/Query/EntityQueryModelVisitor.cs
+++ b/src/EntityFramework.Core/Query/EntityQueryModelVisitor.cs
@@ -1160,16 +1160,8 @@ namespace Microsoft.Data.Entity.Query
 
                 if (ReferenceEquals(methodInfo, PropertyMethodInfo))
                 {
-                    var targetExpression = methodCallExpression.Arguments[0];
-
-                    MemberExpression memberExpression;
-                    while ((memberExpression = targetExpression as MemberExpression) != null)
-                    {
-                        targetExpression = memberExpression.Expression;
-                    }
-
                     var querySourceReferenceExpression
-                        = targetExpression as QuerySourceReferenceExpression;
+                        = methodCallExpression.Arguments[0].GetRootExpression<QuerySourceReferenceExpression>();
 
                     if (querySourceReferenceExpression == null
                         || querySource == null

--- a/src/EntityFramework.Relational/Query/ExpressionVisitors/Internal/IncludeExpressionVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionVisitors/Internal/IncludeExpressionVisitor.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors.Internal
                             : Expression
                                 .Lambda(
                                     memberExpression,
-                                    (ParameterExpression)memberExpression.Expression);
+                                    memberExpression.GetRootExpression<ParameterExpression>());
 
                     return
                         Expression.Call(

--- a/test/EntityFramework.Core.FunctionalTests/GearsOfWarQueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/GearsOfWarQueryTestBase.cs
@@ -400,6 +400,29 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
+        public virtual void Include_with_nested_navigation_in_order_by()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Weapons
+                    .Include(w => w.Owner)
+                    .OrderBy(e => e.Owner.CityOfBirth.Name);
+
+                var result = query.ToList();
+                Assert.Equal(9, result.Count);
+                Assert.Equal("Ephyra", result[0].Owner.CityOrBirthName);
+                Assert.Equal("Ephyra", result[1].Owner.CityOrBirthName);
+                Assert.Equal("Hanover", result[2].Owner.CityOrBirthName);
+                Assert.Equal("Hanover", result[3].Owner.CityOrBirthName);
+                Assert.Equal("Jacinto", result[4].Owner.CityOrBirthName);
+                Assert.Equal("Jacinto", result[5].Owner.CityOrBirthName);
+                Assert.Equal("Unknown", result[6].Owner.CityOrBirthName);
+                Assert.Equal("Unknown", result[7].Owner.CityOrBirthName);
+                Assert.Equal("Unknown", result[8].Owner.CityOrBirthName);
+            }
+        }
+
+        [Fact]
         public virtual void Where_enum()
         {
             using (var context = CreateContext())

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -413,6 +413,24 @@ ORDER BY [c].[Name]",
                 Sql);
         }
 
+        public override void Include_with_nested_navigation_in_order_by()
+        {
+            base.Include_with_nested_navigation_in_order_by();
+
+            Assert.Equal(
+                @"SELECT [w].[Id], [w].[AmmunitionType], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+FROM [Weapon] AS [w]
+INNER JOIN [Gear] AS [w.Owner] ON [w].[OwnerFullName] = [w.Owner].[FullName]
+INNER JOIN [City] AS [w.Owner.CityOfBirth] ON [w.Owner].[CityOrBirthName] = [w.Owner.CityOfBirth].[Name]
+LEFT JOIN (
+    SELECT [g].*
+    FROM [Gear] AS [g]
+    WHERE ([g].[Discriminator] = 'Officer') OR ([g].[Discriminator] = 'Gear')
+) AS [g] ON [w].[OwnerFullName] = [g].[FullName]
+ORDER BY [w.Owner.CityOfBirth].[Name]",
+                Sql);
+        }
+
         public override void Where_enum()
         {
             base.Where_enum();


### PR DESCRIPTION
Problem was that in IncludeExpressionVisitor -> VisitMethodCall, when building entity accessor from a MemberExpression, we incorrectly assumed that member expression will always be one level.

Fix is to add a method that will go down the Expression chain to find a ParameterExpression which is the root of the given MemberExpression