### PR TITLE
[SMALL] RelationalCommand: Less closures and awaits.

### DIFF
--- a/src/EntityFramework.Relational/EntityFramework.Relational.csproj
+++ b/src/EntityFramework.Relational/EntityFramework.Relational.csproj
@@ -53,6 +53,7 @@
       <Link>Extensions\AsyncEnumerableExtensions.cs</Link>
     </Compile>
     <Compile Include="Extensions\DbCommandLogData.cs" />
+    <Compile Include="Extensions\TaskExtensions.cs" />
     <Compile Include="Internal\RelationalDiagnostics.cs" />
     <Compile Include="..\Shared\LoggingExtensions.cs">
       <Link>Extensions\LoggingExtensions.cs</Link>

--- a/src/EntityFramework.Relational/Extensions/TaskExtensions.cs
+++ b/src/EntityFramework.Relational/Extensions/TaskExtensions.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// ReSharper disable once CheckNamespace
+
+namespace System.Threading.Tasks
+{
+    internal static class TaskExtensions
+    {
+        public static Task<TDerived> Cast<T, TDerived>(this Task<T> task)
+            where TDerived : T
+        {
+            var taskCompletionSource = new TaskCompletionSource<TDerived>();
+
+            task.ContinueWith(t =>
+                {
+                    if (t.IsFaulted)
+                    {
+                        // ReSharper disable once PossibleNullReferenceException
+                        taskCompletionSource.TrySetException(t.Exception.InnerExceptions);
+                    }
+                    else if (t.IsCanceled)
+                    {
+                        taskCompletionSource.TrySetCanceled();
+                    }
+                    else
+                    {
+                        taskCompletionSource.TrySetResult((TDerived)t.Result);
+                    }
+                },
+                TaskContinuationOptions.ExecuteSynchronously);
+
+            return taskCompletionSource.Task;
+        }
+    }
+}

--- a/src/EntityFramework.Relational/Internal/RelationalDiagnostics.cs
+++ b/src/EntityFramework.Relational/Internal/RelationalDiagnostics.cs
@@ -15,13 +15,6 @@ namespace Microsoft.Data.Entity.Internal
         public const string AfterExecuteCommand = NamePrefix + nameof(AfterExecuteCommand);
         public const string CommandExecutionError = NamePrefix + nameof(CommandExecutionError);
 
-        public static class ExecuteMethod
-        {
-            public const string ExecuteReader = nameof(ExecuteReader);
-            public const string ExecuteScalar = nameof(ExecuteScalar);
-            public const string ExecuteNonQuery = nameof(ExecuteNonQuery);
-        }
-
         public static void WriteCommand(
             this DiagnosticSource diagnosticSource,
             string diagnosticName,

--- a/test/EntityFramework.Relational.Tests/Storage/RelationalCommandTest.cs
+++ b/test/EntityFramework.Relational.Tests/Storage/RelationalCommandTest.cs
@@ -434,32 +434,32 @@ namespace Microsoft.Data.Entity.Storage
                 {
                     {
                         new Action<RelationalCommand, bool, IRelationalConnection>( (command, manage, connection) => command.ExecuteNonQuery(connection, manageConnection: manage)),
-                        RelationalDiagnostics.ExecuteMethod.ExecuteNonQuery,
+                        "ExecuteNonQuery",
                         false
                     },
                     {
                         new Action<RelationalCommand, bool, IRelationalConnection>( (command, manage, connection) => command.ExecuteScalar(connection, manageConnection: manage)),
-                        RelationalDiagnostics.ExecuteMethod.ExecuteScalar,
+                        "ExecuteScalar",
                         false
                     },
                     {
                         new Action<RelationalCommand, bool, IRelationalConnection>( (command, manage, connection) => command.ExecuteReader(connection, manageConnection: manage)),
-                        RelationalDiagnostics.ExecuteMethod.ExecuteReader,
+                        "ExecuteReader",
                         false
                     },
                     {
                         new Func<RelationalCommand, bool, IRelationalConnection, Task>( (command, manage, connection) => command.ExecuteNonQueryAsync(connection, manageConnection: manage)),
-                        RelationalDiagnostics.ExecuteMethod.ExecuteNonQuery,
+                        "ExecuteNonQuery",
                         true
                     },
                     {
                         new Func<RelationalCommand, bool, IRelationalConnection, Task>( (command, manage, connection) => command.ExecuteScalarAsync(connection, manageConnection: manage)),
-                        RelationalDiagnostics.ExecuteMethod.ExecuteScalar,
+                        "ExecuteScalar",
                         true
                     },
                     {
                         new Func<RelationalCommand, bool, IRelationalConnection, Task>( (command, manage, connection) => command.ExecuteReaderAsync(connection, manageConnection: manage)),
-                        RelationalDiagnostics.ExecuteMethod.ExecuteReader,
+                        "ExecuteReader",
                         true
                     }
                 };


### PR DESCRIPTION
- Decompiled code size goes from 887 loc to 544.