### PR TITLE
Remove dependent map from state manager

### DIFF
--- a/src/EntityFramework.Core/ChangeTracking/Internal/ChangeDetector.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/ChangeDetector.cs
@@ -151,14 +151,6 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
                     if (foreignKeys.Count > 0)
                     {
                         stateManager.Notify.ForeignKeyPropertyChanged(entry, property, snapshotValue, currentValue);
-
-                        foreach (var foreignKey in foreignKeys)
-                        {
-                            stateManager.UpdateDependentMap(
-                                entry,
-                                entry.GetDependentKeyValue(foreignKey, ValueSource.RelationshipSnapshot),
-                                foreignKey);
-                        }
                     }
 
                     if (keys.Count > 0)

--- a/src/EntityFramework.Core/ChangeTracking/Internal/IStateManager.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/IStateManager.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
         void UpdateIdentityMap([NotNull] InternalEntityEntry entry, [NotNull] IKeyValue oldKeyValue, [NotNull] IKey principalKey);
 
-        void UpdateDependentMap([NotNull] InternalEntityEntry entry, [NotNull] IKeyValue oldKeyValue, [NotNull] IForeignKey foreignKey);
+        IEnumerable<InternalEntityEntry> GetDependentsFromNavigation([NotNull] InternalEntityEntry principalEntry, [NotNull] IForeignKey foreignKey);
 
         IEnumerable<InternalEntityEntry> GetDependents([NotNull] InternalEntityEntry principalEntry, [NotNull] IForeignKey foreignKey);
 

--- a/src/EntityFramework.Core/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -11,7 +11,6 @@ using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Metadata.Internal;
-using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Update;
 
 namespace Microsoft.Data.Entity.ChangeTracking.Internal
@@ -490,7 +489,8 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         {
             foreach (var fk in EntityType.GetReferencingForeignKeys())
             {
-                foreach (var dependent in StateManager.GetDependents(this, fk).ToList())
+                foreach (var dependent in (StateManager.GetDependentsFromNavigation(this, fk)
+                                           ?? StateManager.GetDependents(this, fk)).ToList())
                 {
                     if ((dependent.EntityState != EntityState.Deleted)
                         && (dependent.EntityState != EntityState.Detached))

--- a/test/EntityFramework.Core.Tests/DbContextTest.cs
+++ b/test/EntityFramework.Core.Tests/DbContextTest.cs
@@ -230,12 +230,12 @@ namespace Microsoft.Data.Entity.Tests
                 throw new NotImplementedException();
             }
 
-            public void UpdateDependentMap(InternalEntityEntry entry, IKeyValue oldKeyValue, IForeignKey foreignKey)
+            public IEnumerable<InternalEntityEntry> GetDependents(InternalEntityEntry principalEntry, IForeignKey foreignKey)
             {
                 throw new NotImplementedException();
             }
 
-            public IEnumerable<InternalEntityEntry> GetDependents(InternalEntityEntry principalEntry, IForeignKey foreignKey)
+            public IEnumerable<InternalEntityEntry> GetDependentsFromNavigation(InternalEntityEntry principalEntry, IForeignKey foreignKey)
             {
                 throw new NotImplementedException();
             }


### PR DESCRIPTION
We were previously keeping track of all dependent entries referenced from a principal such that lookups for these were fast. However, we are currently only using these in three cases. In two of these, if the principal has a navigation property to the dependent(s), then we use that instead. Otherwise we fall back to a linear scan of all entries, which seems to be okay for when we need it. This allows the dependent map to be removed which has a big impact on initial query perf and reduces the amount of storage needed to track entities.