### PR TITLE
Make scaffolding database model annotatable

### DIFF
--- a/src/EntityFramework.MicrosoftSqlServer.Design/EntityFramework.MicrosoftSqlServer.Design.csproj
+++ b/src/EntityFramework.MicrosoftSqlServer.Design/EntityFramework.MicrosoftSqlServer.Design.csproj
@@ -43,6 +43,10 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.tt</DependentUpon>
     </Compile>
+    <Compile Include="Internal\SqlServerColumnModelAnnotations.cs" />
+    <Compile Include="Internal\SqlServerDatabaseModelAnnotationNames.cs" />
+    <Compile Include="Internal\SqlServerDatabaseModelExtensions.cs" />
+    <Compile Include="Internal\SqlServerIndexModelAnnotations.cs" />
     <Compile Include="SqlServerTableSelectionSetExtensions.cs" />
     <Compile Include="SqlServerDesignTimeServices.cs" />
     <Compile Include="SqlServerScaffoldingModelFactory.cs" />

--- a/src/EntityFramework.MicrosoftSqlServer.Design/Internal/SqlServerColumnModelAnnotations.cs
+++ b/src/EntityFramework.MicrosoftSqlServer.Design/Internal/SqlServerColumnModelAnnotations.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Scaffolding.Metadata;
+
+namespace Microsoft.Data.Entity.Scaffolding.Internal
+{
+    public class SqlServerColumnModelAnnotations
+    {
+        private readonly ColumnModel _columnModel;
+
+        public SqlServerColumnModelAnnotations([NotNull] ColumnModel columnModel)
+        {
+            _columnModel = columnModel;
+        }
+
+        public virtual bool IsIdentity
+        {
+            get { return (bool)_columnModel[SqlServerDatabaseModelAnnotationNames.ColumnIsIdentity]; }
+             set { _columnModel[SqlServerDatabaseModelAnnotationNames.ColumnIsIdentity] = value; }
+        }
+
+        public virtual int? DateTimePrecision
+        {
+            get { return _columnModel[SqlServerDatabaseModelAnnotationNames.ColumnDateTimePrecision] as int?; }
+            [param: CanBeNull] set { _columnModel[SqlServerDatabaseModelAnnotationNames.ColumnDateTimePrecision] = value; }
+        }
+    }
+}

--- a/src/EntityFramework.MicrosoftSqlServer.Design/Internal/SqlServerDatabaseModelAnnotationNames.cs
+++ b/src/EntityFramework.MicrosoftSqlServer.Design/Internal/SqlServerDatabaseModelAnnotationNames.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Data.Entity.Scaffolding.Internal
+{
+    internal class SqlServerDatabaseModelAnnotationNames
+    {
+        public const string Prefix = "SqlServerDatabaseModel";
+        public const string ColumnIsIdentity = Prefix + "ColumnIsIdentity";
+        public const string ColumnDateTimePrecision = Prefix + "ColumnDateTimePrecision";
+        public const string IndexIsClustered = Prefix + "IndexIsClustered";
+    }
+}

--- a/src/EntityFramework.MicrosoftSqlServer.Design/Internal/SqlServerDatabaseModelExtensions.cs
+++ b/src/EntityFramework.MicrosoftSqlServer.Design/Internal/SqlServerDatabaseModelExtensions.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Scaffolding.Metadata;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Scaffolding.Internal
+{
+    public static class SqlServerDatabaseModelExtensions
+    {
+        public static SqlServerColumnModelAnnotations SqlServer([NotNull] this ColumnModel columnModel)
+            => new SqlServerColumnModelAnnotations(Check.NotNull(columnModel, nameof(columnModel)));
+
+        public static SqlServerIndexModelAnnotations SqlServer([NotNull] this IndexModel indexModel)
+            => new SqlServerIndexModelAnnotations(Check.NotNull(indexModel, nameof(indexModel)));
+    }
+}

--- a/src/EntityFramework.MicrosoftSqlServer.Design/Internal/SqlServerIndexModelAnnotations.cs
+++ b/src/EntityFramework.MicrosoftSqlServer.Design/Internal/SqlServerIndexModelAnnotations.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Scaffolding.Metadata;
+
+namespace Microsoft.Data.Entity.Scaffolding.Internal
+{
+    public class SqlServerIndexModelAnnotations
+    {
+        private readonly IndexModel _indexModel;
+
+        public SqlServerIndexModelAnnotations([NotNull] IndexModel indexModel)
+        {
+            _indexModel = indexModel;
+        }
+
+        public virtual bool IsClustered
+        {
+            get { return (bool)_indexModel[SqlServerDatabaseModelAnnotationNames.IndexIsClustered]; }
+            set { _indexModel[SqlServerDatabaseModelAnnotationNames.IndexIsClustered] = value; }
+        }
+    }
+}

--- a/src/EntityFramework.Relational.Design/Metadata/ColumnModel.cs
+++ b/src/EntityFramework.Relational.Design/Metadata/ColumnModel.cs
@@ -1,13 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 
 namespace Microsoft.Data.Entity.Scaffolding.Metadata
 {
-    public class ColumnModel
+    public class ColumnModel : Annotatable
     {
         public virtual TableModel Table { get; [param: NotNull] set; }
         public virtual string Name { get; [param: NotNull] set; }
@@ -25,8 +25,6 @@ namespace Microsoft.Data.Entity.Scaffolding.Metadata
         public virtual int? Precision { get; [param: CanBeNull] set; }
         public virtual int? Scale { get; [param: CanBeNull] set; }
         public virtual ValueGenerated? ValueGenerated { get; set; }
-        // SQL Server
-        public virtual bool? IsIdentity { get; [param: CanBeNull] set; }
 
         public virtual string DisplayName
         {

--- a/src/EntityFramework.Relational.Design/Metadata/DatabaseModel.cs
+++ b/src/EntityFramework.Relational.Design/Metadata/DatabaseModel.cs
@@ -3,10 +3,11 @@
 
 using System.Collections.Generic;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
 
 namespace Microsoft.Data.Entity.Scaffolding.Metadata
 {
-    public class DatabaseModel
+    public class DatabaseModel : Annotatable
     {
         [CanBeNull]
         public virtual string DatabaseName { get; [param: CanBeNull] set; }

--- a/src/EntityFramework.Relational.Design/Metadata/ForeignKeyModel.cs
+++ b/src/EntityFramework.Relational.Design/Metadata/ForeignKeyModel.cs
@@ -4,11 +4,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Migrations;
 
 namespace Microsoft.Data.Entity.Scaffolding.Metadata
 {
-    public class ForeignKeyModel
+    public class ForeignKeyModel : Annotatable
     {
         [CanBeNull]
         public virtual TableModel Table { get; [param: CanBeNull] set; }
@@ -18,9 +19,6 @@ namespace Microsoft.Data.Entity.Scaffolding.Metadata
 
         public virtual IList<ColumnModel> Columns { get; } = new List<ColumnModel>();
         public virtual IList<ColumnModel> PrincipalColumns { get; } = new List<ColumnModel>();
-
-        [NotNull]
-        public virtual string Name { get; [param: CanBeNull] set; }
 
         public virtual ReferentialAction? OnDelete { get; [param: NotNull] set; }
 

--- a/src/EntityFramework.Relational.Design/Metadata/IndexModel.cs
+++ b/src/EntityFramework.Relational.Design/Metadata/IndexModel.cs
@@ -3,10 +3,11 @@
 
 using System.Collections.Generic;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
 
 namespace Microsoft.Data.Entity.Scaffolding.Metadata
 {
-    public class IndexModel
+    public class IndexModel : Annotatable
     {
         [CanBeNull]
         public virtual TableModel Table { get; [param: CanBeNull] set; }
@@ -14,6 +15,5 @@ namespace Microsoft.Data.Entity.Scaffolding.Metadata
         public virtual string Name { get; [param: NotNull] set; }
         public virtual IList<ColumnModel> Columns { get; [param: NotNull] set; } = new List<ColumnModel>();
         public virtual bool IsUnique { get; [param: NotNull] set; }
-        public virtual bool? IsClustered { get; [param: CanBeNull] set; }
     }
 }

--- a/src/EntityFramework.Relational.Design/Metadata/TableModel.cs
+++ b/src/EntityFramework.Relational.Design/Metadata/TableModel.cs
@@ -3,10 +3,11 @@
 
 using System.Collections.Generic;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
 
 namespace Microsoft.Data.Entity.Scaffolding.Metadata
 {
-    public class TableModel
+    public class TableModel : Annotatable
     {
         public virtual string Name { get; [param: NotNull] set; }
 


### PR DESCRIPTION
Reverting a design decision we made for RC1. 

Move SQL Server concepts into strong-type annotations instead of making the database model a grab-bag of features from multiple providers. Fix https://github.com/aspnet/EntityFramework/issues/3766.

This pattern made it easier to resolve a quirk scaffolding "DateTimePrecision" on SqlServer. (see https://github.com/aspnet/EntityFramework/issues/3454).

Alternative to #3783 