### PR TITLE
Use OUTPUT INTO for generated values in SqlServer to support tables with triggers

### DIFF
--- a/src/EntityFramework.Core/Metadata/Builders/EntityTypeBuilder`.cs
+++ b/src/EntityFramework.Core/Metadata/Builders/EntityTypeBuilder`.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         /// </summary>
         /// <param name="name"> The name of the base type. </param>
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
-        public new virtual EntityTypeBuilder<TEntity> HasBaseType([NotNull] string name)
+        public new virtual EntityTypeBuilder<TEntity> HasBaseType([CanBeNull] string name)
             => (EntityTypeBuilder<TEntity>)base.HasBaseType(name);
 
         /// <summary>
@@ -73,7 +73,7 @@ namespace Microsoft.Data.Entity.Metadata.Builders
         /// </summary>
         /// <param name="entityType"> The base type. </param>
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
-        public new virtual EntityTypeBuilder<TEntity> HasBaseType([NotNull] Type entityType)
+        public new virtual EntityTypeBuilder<TEntity> HasBaseType([CanBeNull] Type entityType)
             => (EntityTypeBuilder<TEntity>)base.HasBaseType(entityType);
 
         /// <summary>

--- a/src/EntityFramework.MicrosoftSqlServer/EntityFramework.MicrosoftSqlServer.csproj
+++ b/src/EntityFramework.MicrosoftSqlServer/EntityFramework.MicrosoftSqlServer.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Storage\Internal\SqlServerSqlGenerator.cs" />
     <Compile Include="Storage\Internal\SqlServerTypeMapper.cs" />
     <Compile Include="Update\Internal\ISqlServerUpdateSqlGenerator.cs" />
+    <Compile Include="Update\Internal\ResultsGrouping.cs" />
     <Compile Include="Update\Internal\SqlServerModificationCommandBatch.cs" />
     <Compile Include="Update\Internal\SqlServerModificationCommandBatchFactory.cs" />
     <Compile Include="Update\Internal\SqlServerUpdateSqlGenerator.cs" />

--- a/src/EntityFramework.MicrosoftSqlServer/Storage/Internal/SqlServerSqlGenerator.cs
+++ b/src/EntityFramework.MicrosoftSqlServer/Storage/Internal/SqlServerSqlGenerator.cs
@@ -1,10 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Globalization;
 using System.Text;
-using JetBrains.Annotations;
 using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Storage.Internal
@@ -13,13 +12,13 @@ namespace Microsoft.Data.Entity.Storage.Internal
     {
         public override string BatchSeparator => "GO" + Environment.NewLine + Environment.NewLine;
 
-        public override string EscapeIdentifier([NotNull] string identifier)
+        public override string EscapeIdentifier(string identifier)
             => Check.NotEmpty(identifier, nameof(identifier)).Replace("]", "]]");
 
-        public override string DelimitIdentifier([NotNull] string identifier)
+        public override string DelimitIdentifier(string identifier)
             => $"[{EscapeIdentifier(Check.NotEmpty(identifier, nameof(identifier)))}]";
 
-        protected override string GenerateLiteralValue([NotNull] byte[] value)
+        protected override string GenerateLiteralValue(byte[] value)
         {
             Check.NotNull(value, nameof(value));
 

--- a/src/EntityFramework.MicrosoftSqlServer/Update/Internal/ISqlServerUpdateSqlGenerator.cs
+++ b/src/EntityFramework.MicrosoftSqlServer/Update/Internal/ISqlServerUpdateSqlGenerator.cs
@@ -9,8 +9,9 @@ namespace Microsoft.Data.Entity.Update.Internal
 {
     public interface ISqlServerUpdateSqlGenerator : IUpdateSqlGenerator
     {
-        SqlServerUpdateSqlGenerator.ResultsGrouping AppendBulkInsertOperation(
+        ResultsGrouping AppendBulkInsertOperation(
             [NotNull] StringBuilder commandStringBuilder,
-            [NotNull] IReadOnlyList<ModificationCommand> modificationCommands);
+            [NotNull] IReadOnlyList<ModificationCommand> modificationCommands,
+            int commandPosition);
     }
 }

--- a/src/EntityFramework.MicrosoftSqlServer/Update/Internal/ResultsGrouping.cs
+++ b/src/EntityFramework.MicrosoftSqlServer/Update/Internal/ResultsGrouping.cs
@@ -1,0 +1,11 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Data.Entity.Update.Internal
+{
+    public enum ResultsGrouping
+    {
+        OneResultSet,
+        OneCommandPerResultSet
+    }
+}

--- a/src/EntityFramework.MicrosoftSqlServer/Update/Internal/SqlServerModificationCommandBatch.cs
+++ b/src/EntityFramework.MicrosoftSqlServer/Update/Internal/SqlServerModificationCommandBatch.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Data.Entity.Update.Internal
         public SqlServerModificationCommandBatch(
             [NotNull] IRelationalCommandBuilderFactory commandBuilderFactory,
             [NotNull] ISqlGenerator sqlGenerator,
+            // ReSharper disable once SuggestBaseTypeForParameter
             [NotNull] ISqlServerUpdateSqlGenerator updateSqlGenerator,
             [NotNull] IRelationalValueBufferFactoryFactory valueBufferFactoryFactory,
             [CanBeNull] int? maxBatchSize)
@@ -42,6 +43,8 @@ namespace Microsoft.Data.Entity.Update.Internal
 
             _maxBatchSize = Math.Min(maxBatchSize ?? int.MaxValue, MaxRowCount);
         }
+
+        protected new virtual ISqlServerUpdateSqlGenerator UpdateSqlGenerator => (ISqlServerUpdateSqlGenerator)base.UpdateSqlGenerator;
 
         protected override bool CanAddCommand(ModificationCommand modificationCommand)
         {
@@ -115,10 +118,10 @@ namespace Microsoft.Data.Entity.Update.Internal
             }
 
             var stringBuilder = new StringBuilder();
-            var grouping = ((ISqlServerUpdateSqlGenerator)UpdateSqlGenerator).AppendBulkInsertOperation(stringBuilder, _bulkInsertCommands);
+            var grouping = UpdateSqlGenerator.AppendBulkInsertOperation(stringBuilder, _bulkInsertCommands, lastIndex);
             for (var i = lastIndex - _bulkInsertCommands.Count; i < lastIndex; i++)
             {
-                ResultSetEnds[i] = grouping == SqlServerUpdateSqlGenerator.ResultsGrouping.OneCommandPerResultSet;
+                ResultSetEnds[i] = grouping == ResultsGrouping.OneCommandPerResultSet;
             }
 
             ResultSetEnds[lastIndex - 1] = true;

--- a/src/EntityFramework.Relational/Update/IUpdateSqlGenerator.cs
+++ b/src/EntityFramework.Relational/Update/IUpdateSqlGenerator.cs
@@ -10,8 +10,14 @@ namespace Microsoft.Data.Entity.Update
     {
         string GenerateNextSequenceValueOperation([NotNull] string name, [CanBeNull] string schema);
         void AppendBatchHeader([NotNull] StringBuilder commandStringBuilder);
-        void AppendDeleteOperation([NotNull] StringBuilder commandStringBuilder, [NotNull] ModificationCommand command);
-        void AppendInsertOperation([NotNull] StringBuilder commandStringBuilder, [NotNull] ModificationCommand command);
-        void AppendUpdateOperation([NotNull] StringBuilder commandStringBuilder, [NotNull] ModificationCommand command);
+
+        void AppendDeleteOperation(
+            [NotNull] StringBuilder commandStringBuilder, [NotNull] ModificationCommand command, int commandPosition);
+
+        void AppendInsertOperation(
+            [NotNull] StringBuilder commandStringBuilder, [NotNull] ModificationCommand command, int commandPosition);
+
+        void AppendUpdateOperation(
+            [NotNull] StringBuilder commandStringBuilder, [NotNull] ModificationCommand command, int commandPosition);
     }
 }

--- a/src/EntityFramework.Relational/Update/ReaderModificationCommandBatch.cs
+++ b/src/EntityFramework.Relational/Update/ReaderModificationCommandBatch.cs
@@ -105,13 +105,13 @@ namespace Microsoft.Data.Entity.Update
             switch (newModificationCommand.EntityState)
             {
                 case EntityState.Added:
-                    UpdateSqlGenerator.AppendInsertOperation(CachedCommandText, newModificationCommand);
+                    UpdateSqlGenerator.AppendInsertOperation(CachedCommandText, newModificationCommand, commandPosition);
                     break;
                 case EntityState.Modified:
-                    UpdateSqlGenerator.AppendUpdateOperation(CachedCommandText, newModificationCommand);
+                    UpdateSqlGenerator.AppendUpdateOperation(CachedCommandText, newModificationCommand, commandPosition);
                     break;
                 case EntityState.Deleted:
-                    UpdateSqlGenerator.AppendDeleteOperation(CachedCommandText, newModificationCommand);
+                    UpdateSqlGenerator.AppendDeleteOperation(CachedCommandText, newModificationCommand, commandPosition);
                     break;
             }
 

--- a/src/EntityFramework.Relational/Update/UpdateSqlGenerator.cs
+++ b/src/EntityFramework.Relational/Update/UpdateSqlGenerator.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Data.Entity.Update
 
         protected virtual ISqlGenerator SqlGenerator { get; }
 
-        public virtual void AppendInsertOperation(StringBuilder commandStringBuilder, ModificationCommand command)
+        public virtual void AppendInsertOperation(StringBuilder commandStringBuilder, ModificationCommand command, int commandPosition)
         {
             Check.NotNull(commandStringBuilder, nameof(commandStringBuilder));
             Check.NotNull(command, nameof(command));
@@ -39,15 +39,15 @@ namespace Microsoft.Data.Entity.Update
             {
                 var keyOperations = operations.Where(o => o.IsKey).ToArray();
 
-                AppendSelectAffectedCommand(commandStringBuilder, name, schema, readOperations, keyOperations);
+                AppendSelectAffectedCommand(commandStringBuilder, name, schema, readOperations, keyOperations, commandPosition);
             }
             else
             {
-                AppendSelectAffectedCountCommand(commandStringBuilder, name, schema);
+                AppendSelectAffectedCountCommand(commandStringBuilder, name, schema, commandPosition);
             }
         }
 
-        public virtual void AppendUpdateOperation(StringBuilder commandStringBuilder, ModificationCommand command)
+        public virtual void AppendUpdateOperation(StringBuilder commandStringBuilder, ModificationCommand command, int commandPosition)
         {
             Check.NotNull(commandStringBuilder, nameof(commandStringBuilder));
             Check.NotNull(command, nameof(command));
@@ -66,15 +66,15 @@ namespace Microsoft.Data.Entity.Update
             {
                 var keyOperations = operations.Where(o => o.IsKey).ToArray();
 
-                AppendSelectAffectedCommand(commandStringBuilder, name, schema, readOperations, keyOperations);
+                AppendSelectAffectedCommand(commandStringBuilder, name, schema, readOperations, keyOperations, commandPosition);
             }
             else
             {
-                AppendSelectAffectedCountCommand(commandStringBuilder, name, schema);
+                AppendSelectAffectedCountCommand(commandStringBuilder, name, schema, commandPosition);
             }
         }
 
-        public virtual void AppendDeleteOperation(StringBuilder commandStringBuilder, ModificationCommand command)
+        public virtual void AppendDeleteOperation(StringBuilder commandStringBuilder, ModificationCommand command, int commandPosition)
         {
             Check.NotNull(commandStringBuilder, nameof(commandStringBuilder));
             Check.NotNull(command, nameof(command));
@@ -85,7 +85,7 @@ namespace Microsoft.Data.Entity.Update
 
             AppendDeleteCommand(commandStringBuilder, name, schema, conditionOperations);
 
-            AppendSelectAffectedCountCommand(commandStringBuilder, name, schema);
+            AppendSelectAffectedCountCommand(commandStringBuilder, name, schema, commandPosition);
         }
 
         protected virtual void AppendInsertCommand(
@@ -139,7 +139,8 @@ namespace Microsoft.Data.Entity.Update
         protected virtual void AppendSelectAffectedCountCommand(
             [NotNull] StringBuilder commandStringBuilder,
             [NotNull] string name,
-            [CanBeNull] string schema)
+            [CanBeNull] string schema,
+            int commandPosition)
         {
         }
 
@@ -148,7 +149,8 @@ namespace Microsoft.Data.Entity.Update
             [NotNull] string name,
             [CanBeNull] string schema,
             [NotNull] IReadOnlyList<ColumnModification> readOperations,
-            [NotNull] IReadOnlyList<ColumnModification> conditionOperations)
+            [NotNull] IReadOnlyList<ColumnModification> conditionOperations,
+            int commandPosition)
         {
             Check.NotNull(commandStringBuilder, nameof(commandStringBuilder));
             Check.NotEmpty(name, nameof(name));

--- a/src/EntityFramework.Sqlite/Update/Internal/SqliteUpdateSqlGenerator.cs
+++ b/src/EntityFramework.Sqlite/Update/Internal/SqliteUpdateSqlGenerator.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Data.Entity.Update.Internal
                 .Append("last_insert_rowid()");
         }
 
-        protected override void AppendSelectAffectedCountCommand(StringBuilder commandStringBuilder, string name, string schema)
+        protected override void AppendSelectAffectedCountCommand(StringBuilder commandStringBuilder, string name, string schema, int commandPosition)
         {
             Check.NotNull(commandStringBuilder, nameof(commandStringBuilder));
             Check.NotEmpty(name, nameof(name));

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/BatchingTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/BatchingTest.cs
@@ -5,7 +5,6 @@ using System;
 using System.Linq;
 using Microsoft.Data.Entity.FunctionalTests;
 using Microsoft.Data.Entity.Infrastructure;
-using Microsoft.Data.Entity.Metadata;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
@@ -56,9 +56,12 @@ SELECT @@ROWCOUNT;",
 @p2: 00000000-0000-0000-0000-000000000003
 
 SET NOCOUNT OFF;
+DECLARE @generated1 TABLE ([UniqueNo] int);
 INSERT INTO [Sample] ([MaxLengthProperty], [Name], [RowVersion])
 OUTPUT INSERTED.[UniqueNo]
-VALUES (@p0, @p1, @p2);",
+INTO @generated1
+VALUES (@p0, @p1, @p2);
+SELECT [UniqueNo] FROM @generated1;",
                 Sql);
         }
 
@@ -71,18 +74,24 @@ VALUES (@p0, @p1, @p2);",
 @p2: 00000000-0000-0000-0000-000000000001
 
 SET NOCOUNT OFF;
+DECLARE @generated1 TABLE ([UniqueNo] int);
 INSERT INTO [Sample] ([MaxLengthProperty], [Name], [RowVersion])
 OUTPUT INSERTED.[UniqueNo]
+INTO @generated1
 VALUES (@p0, @p1, @p2);
+SELECT [UniqueNo] FROM @generated1;
 
 @p0: VeryVeryVeryVeryVeryVeryLongString
 @p1: ValidString
 @p2: 00000000-0000-0000-0000-000000000002
 
 SET NOCOUNT OFF;
+DECLARE @generated1 TABLE ([UniqueNo] int);
 INSERT INTO [Sample] ([MaxLengthProperty], [Name], [RowVersion])
 OUTPUT INSERTED.[UniqueNo]
-VALUES (@p0, @p1, @p2);",
+INTO @generated1
+VALUES (@p0, @p1, @p2);
+SELECT [UniqueNo] FROM @generated1;",
                 Sql);
         }
 
@@ -117,18 +126,24 @@ SELECT @@ROWCOUNT;",
 @p2: 00000000-0000-0000-0000-000000000001
 
 SET NOCOUNT OFF;
+DECLARE @generated1 TABLE ([UniqueNo] int);
 INSERT INTO [Sample] ([MaxLengthProperty], [Name], [RowVersion])
 OUTPUT INSERTED.[UniqueNo]
+INTO @generated1
 VALUES (@p0, @p1, @p2);
+SELECT [UniqueNo] FROM @generated1;
 
 @p0: 
 @p1: 
 @p2: 00000000-0000-0000-0000-000000000002
 
 SET NOCOUNT OFF;
+DECLARE @generated1 TABLE ([UniqueNo] int);
 INSERT INTO [Sample] ([MaxLengthProperty], [Name], [RowVersion])
 OUTPUT INSERTED.[UniqueNo]
-VALUES (@p0, @p1, @p2);",
+INTO @generated1
+VALUES (@p0, @p1, @p2);
+SELECT [UniqueNo] FROM @generated1;",
                 Sql);
         }
 
@@ -139,16 +154,22 @@ VALUES (@p0, @p1, @p2);",
             Assert.Equal(@"@p0: ValidString
 
 SET NOCOUNT OFF;
+DECLARE @generated1 TABLE ([Id] int, [Timestamp] varbinary(8));
 INSERT INTO [Two] ([Data])
 OUTPUT INSERTED.[Id], INSERTED.[Timestamp]
+INTO @generated1
 VALUES (@p0);
+SELECT [Id], [Timestamp] FROM @generated1;
 
 @p0: ValidButLongString
 
 SET NOCOUNT OFF;
+DECLARE @generated1 TABLE ([Id] int, [Timestamp] varbinary(8));
 INSERT INTO [Two] ([Data])
 OUTPUT INSERTED.[Id], INSERTED.[Timestamp]
-VALUES (@p0);",
+INTO @generated1
+VALUES (@p0);
+SELECT [Id], [Timestamp] FROM @generated1;",
                 Sql);
         }
 
@@ -169,18 +190,24 @@ WHERE [r].[Id] = 1
 @p2: System.Byte[]
 
 SET NOCOUNT OFF;
+DECLARE @generated0 TABLE ([Timestamp] varbinary(8));
 UPDATE [Two] SET [Data] = @p1
 OUTPUT INSERTED.[Timestamp]
+INTO @generated0
 WHERE [Id] = @p0 AND [Timestamp] = @p2;
+SELECT [Timestamp] FROM @generated0;
 
 @p0: 1
 @p1: ChangedData
 @p2: System.Byte[]
 
 SET NOCOUNT OFF;
+DECLARE @generated0 TABLE ([Timestamp] varbinary(8));
 UPDATE [Two] SET [Data] = @p1
 OUTPUT INSERTED.[Timestamp]
-WHERE [Id] = @p0 AND [Timestamp] = @p2;",
+INTO @generated0
+WHERE [Id] = @p0 AND [Timestamp] = @p2;
+SELECT [Timestamp] FROM @generated0;",
                 Sql);
         }
 

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/EntityFramework.MicrosoftSqlServer.FunctionalTests.csproj
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/EntityFramework.MicrosoftSqlServer.FunctionalTests.csproj
@@ -96,6 +96,7 @@
     <Compile Include="OptimisticConcurrencySqlServerTest.cs" />
     <Compile Include="SequenceEndToEndTest.cs" />
     <Compile Include="SequentialGuidEndToEndTest.cs" />
+    <Compile Include="SqlServerTriggersTest.cs" />
     <Compile Include="Utilities\DbContextOptionsBuilderExtensions.cs" />
     <Compile Include="Utilities\SqlFileLogger.cs" />
     <Compile Include="SqlServerConfigPatternsTest.cs" />

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/SqlServerTriggersTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/SqlServerTriggersTest.cs
@@ -1,0 +1,213 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
+{
+    public class SqlServerTriggersTest : IClassFixture<SqlServerTriggersTest.SqlServerTriggersFixture>, IDisposable
+    {
+        [Fact]
+        public void Triggers_run_on_insert_update_and_delete()
+        {
+            using (var context = CreateContext())
+            {
+                var product = new Product { Name = "blah" };
+                context.Products.Add(product);
+                context.SaveChanges();
+
+                var firstVersion = product.Version;
+                var productBackup = context.ProductBackups.AsNoTracking().Single();
+                Assert.Equal(product.Id, productBackup.Id);
+                Assert.Equal(product.Name, productBackup.Name);
+                Assert.Equal(product.Version, productBackup.Version);
+
+                product.Name = "fooh";
+                context.SaveChanges();
+
+                Assert.NotEqual(firstVersion, product.Version);
+                productBackup = context.ProductBackups.AsNoTracking().Single();
+                Assert.Equal(product.Id, productBackup.Id);
+                Assert.Equal(product.Name, productBackup.Name);
+                Assert.Equal(product.Version, productBackup.Version);
+
+                context.Products.Remove(product);
+                context.SaveChanges();
+
+                Assert.Empty(context.Products);
+                Assert.Empty(context.ProductBackups);
+            }
+        }
+
+        [Fact]
+        public void Triggers_work_with_batch_operations()
+        {
+            using (var context = CreateContext())
+            {
+                var productToBeUpdated1 = new Product { Name = "u1" };
+                var productToBeUpdated2 = new Product { Name = "u2" };
+                context.Products.Add(productToBeUpdated1);
+                context.Products.Add(productToBeUpdated2);
+
+                var productToBeDeleted1 = new Product { Name = "d1" };
+                var productToBeDeleted2 = new Product { Name = "d2" };
+                context.Products.Add(productToBeDeleted1);
+                context.Products.Add(productToBeDeleted2);
+
+                context.SaveChanges();
+
+                var productToBeAdded1 = new Product { Name = "a1" };
+                var productToBeAdded2 = new Product { Name = "a2" };
+                context.Products.Add(productToBeAdded1);
+                context.Products.Add(productToBeAdded2);
+
+                productToBeUpdated1.Name = "n1";
+                productToBeUpdated2.Name = "n2";
+
+                context.Products.Remove(productToBeDeleted1);
+                context.Products.Remove(productToBeDeleted2);
+
+                context.SaveChanges();
+
+                var productBackups = context.ProductBackups.ToList();
+
+                Assert.Equal(4, productBackups.Count);
+                Assert.True(productBackups.Any(p => p.Name == "a1"));
+                Assert.True(productBackups.Any(p => p.Name == "a2"));
+                Assert.True(productBackups.Any(p => p.Name == "n1"));
+                Assert.True(productBackups.Any(p => p.Name == "n2"));
+            }
+        }
+
+        private readonly SqlServerTriggersFixture _fixture;
+        private readonly SqlServerTestStore _testStore;
+
+        public SqlServerTriggersTest(SqlServerTriggersFixture fixture)
+        {
+            _fixture = fixture;
+            _testStore = _fixture.GetTestStore();
+        }
+
+        private TriggersContext CreateContext() => _fixture.CreateContext(_testStore);
+
+        public void Dispose() => _testStore.Dispose();
+
+        public class SqlServerTriggersFixture
+        {
+            private readonly IServiceProvider _serviceProvider;
+
+            public SqlServerTriggersFixture()
+            {
+                _serviceProvider
+                    = new ServiceCollection()
+                        .AddEntityFramework()
+                        .AddSqlServer()
+                        .ServiceCollection()
+                        .AddSingleton(TestSqlServerModelSource.GetFactory(OnModelCreating))
+                        .AddSingleton<ILoggerFactory>(new TestSqlLoggerFactory())
+                        .BuildServiceProvider();
+            }
+
+            public virtual SqlServerTestStore GetTestStore()
+            {
+                var testStore = SqlServerTestStore.CreateScratch();
+
+                using (var context = CreateContext(testStore))
+                {
+                    context.Database.EnsureCreated();
+
+                    testStore.ExecuteNonQuery(@"
+CREATE TRIGGER TRG_InsertProduct
+ON Product
+AFTER INSERT AS
+BEGIN
+	if @@ROWCOUNT = 0
+		return
+	set nocount on;
+
+    INSERT INTO ProductBackup
+    SELECT * FROM INSERTED;
+END");
+
+                    testStore.ExecuteNonQuery(@"
+CREATE TRIGGER TRG_UpdateProduct
+ON Product
+AFTER UPDATE AS
+BEGIN
+	if @@ROWCOUNT = 0
+		return
+	set nocount on;
+
+    DELETE FROM ProductBackup
+    WHERE Id IN(SELECT DELETED.Id FROM DELETED);
+
+    INSERT INTO ProductBackup
+    SELECT * FROM INSERTED;
+END");
+
+                    testStore.ExecuteNonQuery(@"
+CREATE TRIGGER TRG_DeleteProduct
+ON Product
+AFTER DELETE AS
+BEGIN
+	if @@ROWCOUNT = 0
+		return
+	set nocount on;
+
+    DELETE FROM ProductBackup
+    WHERE Id IN(SELECT DELETED.Id FROM DELETED);
+END");
+                }
+
+                return testStore;
+            }
+
+            public void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<Product>().Property(e => e.Version)
+                    .ValueGeneratedOnAddOrUpdate()
+                    .IsConcurrencyToken();
+                modelBuilder.Entity<ProductBackup>().HasBaseType((Type)null)
+                    .Property(e => e.Id).ValueGeneratedNever();
+            }
+
+            public TriggersContext CreateContext(SqlServerTestStore testStore)
+            {
+                var optionsBuilder = new DbContextOptionsBuilder();
+                optionsBuilder
+                    .EnableSensitiveDataLogging()
+                    .UseSqlServer(testStore.Connection);
+                
+                return new TriggersContext(_serviceProvider, optionsBuilder.Options);
+            }
+        }
+
+        public class TriggersContext : DbContext
+        {
+            public TriggersContext(IServiceProvider serviceProvider, DbContextOptions options)
+                : base(serviceProvider, options)
+            {
+            }
+
+            public virtual DbSet<Product> Products { get; set; }
+            public virtual DbSet<ProductBackup> ProductBackups { get; set; }
+        }
+
+        public class Product
+        {
+            public virtual int Id { get; set; }
+            public virtual byte[] Version { get; set; }
+            public virtual string Name { get; set; }
+        }
+
+        public class ProductBackup : Product
+        {
+        }
+    }
+}

--- a/test/EntityFramework.MicrosoftSqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
 
             var generator = new SqlServerSequenceHiLoValueGenerator<TValue>(
                 new FakeSqlCommandBuilder(blockSize),
-                new SqlServerUpdateSqlGenerator(new SqlServerSqlGenerator()),
+                new SqlServerUpdateSqlGenerator(new SqlServerSqlGenerator(), new SqlServerTypeMapper()),
                 state,
                 CreateConnection());
 
@@ -104,7 +104,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                 });
 
             var executor = new FakeSqlCommandBuilder(blockSize);
-            var sqlGenerator = new SqlServerUpdateSqlGenerator(new SqlServerSqlGenerator());
+            var sqlGenerator = new SqlServerUpdateSqlGenerator(new SqlServerSqlGenerator(), new SqlServerTypeMapper());
 
             var tests = new Action[threadCount];
             var generatedValues = new List<long>[threadCount];
@@ -141,7 +141,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
 
             var generator = new SqlServerSequenceHiLoValueGenerator<int>(
                 new FakeSqlCommandBuilder(4),
-                new SqlServerUpdateSqlGenerator(new SqlServerSqlGenerator()),
+                new SqlServerUpdateSqlGenerator(new SqlServerSqlGenerator(), new SqlServerTypeMapper()),
                 state,
                 CreateConnection());
 

--- a/test/EntityFramework.MicrosoftSqlServer.Tests/Update/SqlServerModificationCommandBatchFactoryTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.Tests/Update/SqlServerModificationCommandBatchFactoryTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Update
                     new DiagnosticListener("Fake"),
                     new SqlServerTypeMapper()),
                 new SqlServerSqlGenerator(),
-                new SqlServerUpdateSqlGenerator(new SqlServerSqlGenerator()),
+                new SqlServerUpdateSqlGenerator(new SqlServerSqlGenerator(), new SqlServerTypeMapper()),
                 new UntypedRelationalValueBufferFactoryFactory(),
                 optionsBuilder.Options);
 
@@ -47,7 +47,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Update
                     new DiagnosticListener("Fake"),
                     new SqlServerTypeMapper()),
                 new SqlServerSqlGenerator(),
-                new SqlServerUpdateSqlGenerator(new SqlServerSqlGenerator()),
+                new SqlServerUpdateSqlGenerator(new SqlServerSqlGenerator(), new SqlServerTypeMapper()),
                 new UntypedRelationalValueBufferFactoryFactory(),
                 optionsBuilder.Options);
 

--- a/test/EntityFramework.MicrosoftSqlServer.Tests/Update/SqlServerModificationCommandBatchTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.Tests/Update/SqlServerModificationCommandBatchTest.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Update
                     new DiagnosticListener("Fake"),
                     new SqlServerTypeMapper()),
                 new SqlServerSqlGenerator(),
-                new SqlServerUpdateSqlGenerator(new SqlServerSqlGenerator()),
+                new SqlServerUpdateSqlGenerator(new SqlServerSqlGenerator(), new SqlServerTypeMapper()),
                 new UntypedRelationalValueBufferFactoryFactory(),
                 1);
 

--- a/test/EntityFramework.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Data.Entity.Tests.Update
             batch.UpdateCachedCommandTextBase(0);
 
             sqlGeneratorMock.Verify(g => g.AppendBatchHeader(It.IsAny<StringBuilder>()));
-            sqlGeneratorMock.Verify(g => g.AppendInsertOperation(It.IsAny<StringBuilder>(), command));
+            sqlGeneratorMock.Verify(g => g.AppendInsertOperation(It.IsAny<StringBuilder>(), command, 0));
         }
 
         [Fact]
@@ -105,7 +105,7 @@ namespace Microsoft.Data.Entity.Tests.Update
             batch.UpdateCachedCommandTextBase(0);
 
             sqlGeneratorMock.Verify(g => g.AppendBatchHeader(It.IsAny<StringBuilder>()));
-            sqlGeneratorMock.Verify(g => g.AppendUpdateOperation(It.IsAny<StringBuilder>(), command));
+            sqlGeneratorMock.Verify(g => g.AppendUpdateOperation(It.IsAny<StringBuilder>(), command, 0));
         }
 
         [Fact]
@@ -123,7 +123,7 @@ namespace Microsoft.Data.Entity.Tests.Update
             batch.UpdateCachedCommandTextBase(0);
 
             sqlGeneratorMock.Verify(g => g.AppendBatchHeader(It.IsAny<StringBuilder>()));
-            sqlGeneratorMock.Verify(g => g.AppendDeleteOperation(It.IsAny<StringBuilder>(), command));
+            sqlGeneratorMock.Verify(g => g.AppendDeleteOperation(It.IsAny<StringBuilder>(), command, 0));
         }
 
         [Fact]
@@ -151,7 +151,7 @@ namespace Microsoft.Data.Entity.Tests.Update
             {
             }
 
-            public override void AppendInsertOperation(StringBuilder commandStringBuilder, ModificationCommand command)
+            public override void AppendInsertOperation(StringBuilder commandStringBuilder, ModificationCommand command, int commandPosition)
             {
                 if (!string.IsNullOrEmpty(command.Schema))
                 {
@@ -168,7 +168,7 @@ namespace Microsoft.Data.Entity.Tests.Update
                 base.AppendBatchHeader(commandStringBuilder);
             }
 
-            protected override void AppendSelectAffectedCountCommand(StringBuilder commandStringBuilder, string name, string schema)
+            protected override void AppendSelectAffectedCountCommand(StringBuilder commandStringBuilder, string name, string schema, int commandPosition)
             {
             }
 

--- a/test/EntityFramework.Relational.Tests/Update/UpdateSqlGeneratorTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/UpdateSqlGeneratorTest.cs
@@ -10,25 +10,16 @@ namespace Microsoft.Data.Entity.Tests
 {
     public class UpdateSqlGeneratorTest : UpdateSqlGeneratorTestBase
     {
-        protected override IUpdateSqlGenerator CreateSqlGenerator()
-        {
-            return new ConcreteSqlGenerator();
-        }
+        protected override IUpdateSqlGenerator CreateSqlGenerator() => new ConcreteSqlGenerator();
 
-        protected override string RowsAffected
-        {
-            get { return "provider_specific_rowcount()"; }
-        }
+        protected override string RowsAffected => "provider_specific_rowcount()";
 
-        protected override string Identity
-        {
-            get { return "provider_specific_identity()"; }
-        }
+        protected override string Identity => "provider_specific_identity()";
 
         private class ConcreteSqlGenerator : UpdateSqlGenerator
         {
             public ConcreteSqlGenerator()
-                :base(new RelationalSqlGenerator())
+                : base(new RelationalSqlGenerator())
             {
             }
 
@@ -40,7 +31,7 @@ namespace Microsoft.Data.Entity.Tests
                     .Append("provider_specific_identity()");
             }
 
-            protected override void AppendSelectAffectedCountCommand(StringBuilder commandStringBuilder, string name, string schema)
+            protected override void AppendSelectAffectedCountCommand(StringBuilder commandStringBuilder, string name, string schema, int commandPosition)
             {
                 commandStringBuilder
                     .Append("SELECT provider_specific_rowcount();" + Environment.NewLine);

--- a/test/EntityFramework.Relational.Tests/Update/UpdateSqlGeneratorTestBase.cs
+++ b/test/EntityFramework.Relational.Tests/Update/UpdateSqlGeneratorTestBase.cs
@@ -16,14 +16,13 @@ namespace Microsoft.Data.Entity.Tests
 {
     public abstract class UpdateSqlGeneratorTestBase
     {
-
         [Fact]
         public void AppendDeleteOperation_creates_full_delete_command_text()
         {
             var stringBuilder = new StringBuilder();
             var command = CreateDeleteCommand(false);
 
-            CreateSqlGenerator().AppendDeleteOperation(stringBuilder, command);
+            CreateSqlGenerator().AppendDeleteOperation(stringBuilder, command, 0);
 
             Assert.Equal(
                 "DELETE FROM " + SchemaPrefix + OpenDelimeter + "Ducks" + CloseDelimeter + "" + Environment.NewLine +
@@ -38,7 +37,7 @@ namespace Microsoft.Data.Entity.Tests
             var stringBuilder = new StringBuilder();
             var command = CreateDeleteCommand(concurrencyToken: true);
 
-            CreateSqlGenerator().AppendDeleteOperation(stringBuilder, command);
+            CreateSqlGenerator().AppendDeleteOperation(stringBuilder, command, 0);
 
             Assert.Equal(
                 "DELETE FROM " + SchemaPrefix + OpenDelimeter + "Ducks" + CloseDelimeter + "" + Environment.NewLine +
@@ -53,7 +52,7 @@ namespace Microsoft.Data.Entity.Tests
             var stringBuilder = new StringBuilder();
             var command = CreateInsertCommand(identityKey: true, isComputed: true);
 
-            CreateSqlGenerator().AppendInsertOperation(stringBuilder, command);
+            CreateSqlGenerator().AppendInsertOperation(stringBuilder, command, 0);
 
             AppendInsertOperation_appends_insert_and_select_and_where_if_store_generated_columns_exist_verification(stringBuilder);
         }
@@ -75,7 +74,7 @@ namespace Microsoft.Data.Entity.Tests
             var stringBuilder = new StringBuilder();
             var command = CreateInsertCommand(false, false);
 
-            CreateSqlGenerator().AppendInsertOperation(stringBuilder, command);
+            CreateSqlGenerator().AppendInsertOperation(stringBuilder, command, 0);
 
             Assert.Equal(
                 "INSERT INTO " + SchemaPrefix + OpenDelimeter + "Ducks" + CloseDelimeter + " (" +
@@ -92,7 +91,7 @@ namespace Microsoft.Data.Entity.Tests
             var stringBuilder = new StringBuilder();
             var command = CreateInsertCommand(false, isComputed: true);
 
-            CreateSqlGenerator().AppendInsertOperation(stringBuilder, command);
+            CreateSqlGenerator().AppendInsertOperation(stringBuilder, command, 0);
 
             AppendInsertOperation_appends_insert_and_select_store_generated_columns_but_no_identity_verification(stringBuilder);
         }
@@ -116,7 +115,7 @@ namespace Microsoft.Data.Entity.Tests
             var stringBuilder = new StringBuilder();
             var command = CreateInsertCommand(true, false);
 
-            CreateSqlGenerator().AppendInsertOperation(stringBuilder, command);
+            CreateSqlGenerator().AppendInsertOperation(stringBuilder, command, 0);
 
             AppendInsertOperation_appends_insert_and_select_for_only_identity_verification(stringBuilder);
         }
@@ -139,7 +138,7 @@ namespace Microsoft.Data.Entity.Tests
             var stringBuilder = new StringBuilder();
             var command = CreateInsertCommand(true, true, true);
 
-            CreateSqlGenerator().AppendInsertOperation(stringBuilder, command);
+            CreateSqlGenerator().AppendInsertOperation(stringBuilder, command, 0);
 
             AppendInsertOperation_appends_insert_and_select_for_all_store_generated_columns_verification(stringBuilder);
         }
@@ -161,7 +160,7 @@ namespace Microsoft.Data.Entity.Tests
             var stringBuilder = new StringBuilder();
             var command = CreateInsertCommand(true, false, true);
 
-            CreateSqlGenerator().AppendInsertOperation(stringBuilder, command);
+            CreateSqlGenerator().AppendInsertOperation(stringBuilder, command, 0);
 
             AppendInsertOperation_appends_insert_and_select_for_only_single_identity_columns_verification(stringBuilder);
         }
@@ -183,7 +182,7 @@ namespace Microsoft.Data.Entity.Tests
             var stringBuilder = new StringBuilder();
             var command = CreateUpdateCommand(isComputed: true, concurrencyToken: true);
 
-            CreateSqlGenerator().AppendUpdateOperation(stringBuilder, command);
+            CreateSqlGenerator().AppendUpdateOperation(stringBuilder, command, 0);
 
             AppendUpdateOperation_appends_update_and_select_if_store_generated_columns_exist_verification(stringBuilder);
         }
@@ -206,7 +205,7 @@ namespace Microsoft.Data.Entity.Tests
             var stringBuilder = new StringBuilder();
             var command = CreateUpdateCommand(false, false);
 
-            CreateSqlGenerator().AppendUpdateOperation(stringBuilder, command);
+            CreateSqlGenerator().AppendUpdateOperation(stringBuilder, command, 0);
 
             Assert.Equal(
                 "UPDATE " + SchemaPrefix + OpenDelimeter + "Ducks" + CloseDelimeter + " SET " +
@@ -223,7 +222,7 @@ namespace Microsoft.Data.Entity.Tests
             var stringBuilder = new StringBuilder();
             var command = CreateUpdateCommand(false, concurrencyToken: true);
 
-            CreateSqlGenerator().AppendUpdateOperation(stringBuilder, command);
+            CreateSqlGenerator().AppendUpdateOperation(stringBuilder, command, 0);
 
             Assert.Equal(
                 "UPDATE " + SchemaPrefix + OpenDelimeter + "Ducks" + CloseDelimeter + " SET " +
@@ -240,7 +239,7 @@ namespace Microsoft.Data.Entity.Tests
             var stringBuilder = new StringBuilder();
             var command = CreateUpdateCommand(true, false);
 
-            CreateSqlGenerator().AppendUpdateOperation(stringBuilder, command);
+            CreateSqlGenerator().AppendUpdateOperation(stringBuilder, command, 0);
 
             AppendUpdateOperation_appends_select_for_computed_property_verification(stringBuilder);
         }
@@ -284,10 +283,11 @@ namespace Microsoft.Data.Entity.Tests
 
         protected abstract string Identity { get; }
 
-        protected IProperty CreateMockProperty(string name)
+        protected IProperty CreateMockProperty(string name, Type type)
         {
             var propertyMock = new Mock<IProperty>();
             propertyMock.Setup(m => m.Name).Returns(name);
+            propertyMock.Setup(m => m.ClrType).Returns(type);
             return propertyMock.Object;
         }
 
@@ -304,27 +304,28 @@ namespace Microsoft.Data.Entity.Tests
 
         protected ModificationCommand CreateInsertCommand(bool identityKey = true, bool isComputed = true, bool defaultsOnly = false)
         {
-            var entry = CreateInternalEntryMock().Object;
+            var duck = GetDuckType();
+            var entry = CreateInternalEntryMock(duck).Object;
             var generator = new ParameterNameGenerator();
 
-            var idProperty = CreateMockProperty("Id");
-            var nameProperty = CreateMockProperty("Name");
-            var quacksProperty = CreateMockProperty("Quacks");
-            var computedProperty = CreateMockProperty("Computed");
-            var concurrencyProperty = CreateMockProperty("ConcurrencyToken");
+            var idProperty = duck.FindProperty(nameof(Duck.Id));
+            var nameProperty = duck.FindProperty(nameof(Duck.Name));
+            var quacksProperty = duck.FindProperty(nameof(Duck.Quacks));
+            var computedProperty = duck.FindProperty(nameof(Duck.Computed));
+            var concurrencyProperty = duck.FindProperty(nameof(Duck.ConcurrencyToken));
             var columnModifications = new[]
-                {
-                    new ColumnModification(
-                        entry, idProperty, idProperty.TestProvider(), generator, identityKey, !identityKey, true, false),
-                    new ColumnModification(
-                        entry, nameProperty, nameProperty.TestProvider(), generator, false, true, false, false),
-                    new ColumnModification(
-                        entry, quacksProperty, quacksProperty.TestProvider(), generator, false, true, false, false),
-                    new ColumnModification(
-                        entry, computedProperty, computedProperty.TestProvider(), generator, isComputed, false, false, false),
-                    new ColumnModification(
-                        entry, concurrencyProperty, concurrencyProperty.TestProvider(), generator, false, true, false, false)
-                };
+            {
+                new ColumnModification(
+                    entry, idProperty, idProperty.TestProvider(), generator, identityKey, !identityKey, true, false),
+                new ColumnModification(
+                    entry, nameProperty, nameProperty.TestProvider(), generator, false, true, false, false),
+                new ColumnModification(
+                    entry, quacksProperty, quacksProperty.TestProvider(), generator, false, true, false, false),
+                new ColumnModification(
+                    entry, computedProperty, computedProperty.TestProvider(), generator, isComputed, false, false, false),
+                new ColumnModification(
+                    entry, concurrencyProperty, concurrencyProperty.TestProvider(), generator, false, true, false, false)
+            };
 
             if (defaultsOnly)
             {
@@ -340,27 +341,28 @@ namespace Microsoft.Data.Entity.Tests
 
         protected ModificationCommand CreateUpdateCommand(bool isComputed = true, bool concurrencyToken = true)
         {
-            var entry = CreateInternalEntryMock().Object;
+            var duck = GetDuckType();
+            var entry = CreateInternalEntryMock(duck).Object;
             var generator = new ParameterNameGenerator();
 
-            var idProperty = CreateMockProperty("Id");
-            var nameProperty = CreateMockProperty("Name");
-            var quacksProperty = CreateMockProperty("Quacks");
-            var computedProperty = CreateMockProperty("Computed");
-            var concurrencyProperty = CreateMockProperty("ConcurrencyToken");
+            var idProperty = duck.FindProperty(nameof(Duck.Id));
+            var nameProperty = duck.FindProperty(nameof(Duck.Name));
+            var quacksProperty = duck.FindProperty(nameof(Duck.Quacks));
+            var computedProperty = duck.FindProperty(nameof(Duck.Computed));
+            var concurrencyProperty = duck.FindProperty(nameof(Duck.ConcurrencyToken));
             var columnModifications = new[]
-                {
-                    new ColumnModification(
-                        entry, idProperty, idProperty.TestProvider(), generator, false, false, true, true),
-                    new ColumnModification(
-                        entry, nameProperty, nameProperty.TestProvider(), generator, false, true, false, false),
-                    new ColumnModification(
-                        entry, quacksProperty, quacksProperty.TestProvider(), generator, false, true, false, false),
-                    new ColumnModification(
-                        entry, computedProperty, computedProperty.TestProvider(), generator, isComputed, false, false, false),
-                    new ColumnModification(
-                        entry, concurrencyProperty, concurrencyProperty.TestProvider(), generator, false, true, false, concurrencyToken)
-                };
+            {
+                new ColumnModification(
+                    entry, idProperty, idProperty.TestProvider(), generator, false, false, true, true),
+                new ColumnModification(
+                    entry, nameProperty, nameProperty.TestProvider(), generator, false, true, false, false),
+                new ColumnModification(
+                    entry, quacksProperty, quacksProperty.TestProvider(), generator, false, true, false, false),
+                new ColumnModification(
+                    entry, computedProperty, computedProperty.TestProvider(), generator, isComputed, false, false, false),
+                new ColumnModification(
+                    entry, concurrencyProperty, concurrencyProperty.TestProvider(), generator, false, true, false, concurrencyToken)
+            };
 
             Func<IProperty, IRelationalPropertyAnnotations> func = p => p.TestProvider();
             var commandMock = new Mock<ModificationCommand>("Ducks", Schema, new ParameterNameGenerator(), func) { CallBase = true };
@@ -371,18 +373,19 @@ namespace Microsoft.Data.Entity.Tests
 
         protected ModificationCommand CreateDeleteCommand(bool concurrencyToken = true)
         {
-            var entry = CreateInternalEntryMock().Object;
+            var duck = GetDuckType();
+            var entry = CreateInternalEntryMock(duck).Object;
             var generator = new ParameterNameGenerator();
 
-            var idProperty = CreateMockProperty("Id");
-            var concurrencyProperty = CreateMockProperty("ConcurrencyToken");
+            var idProperty = duck.FindProperty(nameof(Duck.Id));
+            var concurrencyProperty = duck.FindProperty(nameof(Duck.ConcurrencyToken));
             var columnModifications = new[]
-                {
-                    new ColumnModification(
-                        entry, idProperty, idProperty.TestProvider(), generator, false, false, true, true),
-                    new ColumnModification(
-                        entry, concurrencyProperty, concurrencyProperty.TestProvider(), generator, false, false, false, concurrencyToken)
-                };
+            {
+                new ColumnModification(
+                    entry, idProperty, idProperty.TestProvider(), generator, false, false, true, true),
+                new ColumnModification(
+                    entry, concurrencyProperty, concurrencyProperty.TestProvider(), generator, false, false, false, concurrencyToken)
+            };
 
             Func<IProperty, IRelationalPropertyAnnotations> func = p => p.TestProvider();
             var commandMock = new Mock<ModificationCommand>("Ducks", Schema, new ParameterNameGenerator(), func) { CallBase = true };
@@ -391,16 +394,28 @@ namespace Microsoft.Data.Entity.Tests
             return commandMock.Object;
         }
 
-        private static Mock<InternalEntityEntry> CreateInternalEntryMock()
+        private static Mock<InternalEntityEntry> CreateInternalEntryMock(EntityType entityType)
+            => new Mock<InternalEntityEntry>(Mock.Of<IStateManager>(), entityType);
+
+        private EntityType GetDuckType()
         {
-            var entityTypeMock = new Mock<IEntityType>();
-            entityTypeMock.Setup(e => e.GetProperties()).Returns(new IProperty[0]);
+            var entityType = new Entity.Metadata.Internal.Model().AddEntityType(typeof(Duck));
+            var id = entityType.AddProperty(typeof(Duck).GetProperty(nameof(Duck.Id)));
+            entityType.AddProperty(typeof(Duck).GetProperty(nameof(Duck.Name)));
+            entityType.AddProperty(typeof(Duck).GetProperty(nameof(Duck.Quacks)));
+            entityType.AddProperty(typeof(Duck).GetProperty(nameof(Duck.Computed)));
+            entityType.AddProperty(typeof(Duck).GetProperty(nameof(Duck.ConcurrencyToken)));
+            entityType.SetPrimaryKey(id);
+            return entityType;
+        }
 
-            entityTypeMock.As<IPropertyCountsAccessor>().Setup(e => e.Counts).Returns(new PropertyCounts(0, 0, 0, 0, 0, 0));
-
-            var internalEntryMock = new Mock<InternalEntityEntry>(
-                Mock.Of<IStateManager>(), entityTypeMock.Object);
-            return internalEntryMock;
+        protected class Duck
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public int Quacks { get; set; }
+            public Guid Computed { get; set; }
+            public byte[] ConcurrencyToken { get; set; }
         }
     }
 }


### PR DESCRIPTION
Add commandPosition argument to methods on IUpdateSqlGenerator to provide a unique id for a modification command in a batch

Fixes #1441