### PR TITLE
[SMALL] Fix to #3616 - Projection with multiple aggregates only running last one

### DIFF
--- a/src/EntityFramework.Core/Query/Internal/ExpressionPrinter.cs
+++ b/src/EntityFramework.Core/Query/Internal/ExpressionPrinter.cs
@@ -27,7 +27,8 @@ namespace Microsoft.Data.Entity.Query.Internal
             { ExpressionType.LessThan, " < " },
             { ExpressionType.LessThanOrEqual, " <= " },
             { ExpressionType.OrElse, " || " },
-            { ExpressionType.AndAlso, " && " }
+            { ExpressionType.AndAlso, " && " },
+            { ExpressionType.Coalesce, " ?? " },
         };
 
         protected static Action<IndentedStringBuilder, string> Append
@@ -81,6 +82,7 @@ namespace Microsoft.Data.Entity.Query.Internal
                 case ExpressionType.LessThanOrEqual:
                 case ExpressionType.NotEqual:
                 case ExpressionType.OrElse:
+                case ExpressionType.Coalesce:
                     VisitBinary((BinaryExpression)node);
                     break;
 
@@ -135,6 +137,10 @@ namespace Microsoft.Data.Entity.Query.Internal
                 case ExpressionType.Convert:
                 case ExpressionType.Throw:
                     VisitUnary((UnaryExpression)node);
+                    break;
+
+                case ExpressionType.Default:
+                    VisitDefault((DefaultExpression)node);
                     break;
 
                 default:
@@ -472,6 +478,13 @@ namespace Microsoft.Data.Entity.Query.Internal
             }
 
             _stringBuilder.AppendLine(CoreStrings.UnhandledNodeType(node.NodeType));
+
+            return node;
+        }
+
+        protected override Expression VisitDefault(DefaultExpression node)
+        {
+            _stringBuilder.Append("default(" + node.Type + ")");
 
             return node;
         }

--- a/src/EntityFramework.Relational/Query/ExpressionVisitors/RelationalProjectionExpressionVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionVisitors/RelationalProjectionExpressionVisitor.cs
@@ -178,6 +178,10 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
 
                                 return Expression.Convert(readValueExpression, node.Type);
                             }
+                            else
+                            {
+                                return node;
+                            }
                         }
                     }
                 }

--- a/src/EntityFramework.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/EntityFramework.Relational/Query/Expressions/SelectExpression.cs
@@ -325,7 +325,7 @@ namespace Microsoft.Data.Entity.Query.Expressions
 
             if (expression is SelectExpression)
             {
-                ClearProjection();
+                ClearColumnProjections();
             }
 
             _projection.Add(expression);
@@ -470,6 +470,23 @@ namespace Microsoft.Data.Entity.Query.Expressions
         {
             _projection.Clear();
             IsProjectStar = true;
+        }
+
+        public virtual void ClearColumnProjections()
+        {
+            for (int i = _projection.Count - 1; i >= 0; i--)
+            {
+                var aliasExpression = _projection[i] as AliasExpression;
+                if (aliasExpression != null && aliasExpression.Expression is ColumnExpression)
+                {
+                    _projection.RemoveAt(i);
+                }
+            }
+
+            if (_projection.Count == 0)
+            {
+                IsProjectStar = true;
+            }
         }
 
         public virtual void RemoveRangeFromProjection(int index)

--- a/test/EntityFramework.Core.FunctionalTests/QueryNavigationsTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/QueryNavigationsTestBase.cs
@@ -494,6 +494,29 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
+        public virtual void Select_multiple_complex_projections()
+        {
+            using (var context = CreateContext())
+            {
+                var customers
+                    = (from o in context.Orders
+                       where o.CustomerID.StartsWith("A")
+                       select new
+                       {
+                           collection1 = o.OrderDetails.Count(),
+                           scalar1 = o.OrderDate,
+                           any = o.OrderDetails.Select(od => od.UnitPrice).Any(up => up > 10),
+                           conditional = o.CustomerID == "ALFKI" ? "50" : "10",
+                           scalar2 = (int?)o.OrderID,
+                           all = o.OrderDetails.All(od => od.OrderID == 42),
+                           collection2 = o.OrderDetails.LongCount(),
+                       }).ToList();
+
+                Assert.Equal(30, customers.Count);
+            }
+        }
+
+        [Fact]
         public virtual void Collection_select_nav_prop_sum()
         {
             using (var context = CreateContext())

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/QueryLoggingSqlServerTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/QueryLoggingSqlServerTest.cs
@@ -86,8 +86,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         shaper: BufferedEntityShaper`1
     )
     , 
-    entityAccessor: Unhandled expression type: Default
-    , 
+    entityAccessor: default(System.Func`2[FunctionalTests.TestModels.Northwind.Customer,System.Object]), 
     navigationPath: INavigation[] { Customer.Orders, }, 
     includeRelatedValuesStrategyFactories: new Func<IIncludeRelatedValuesStrategy>[]{ () => IIncludeRelatedValuesStrategy _CreateCollectionIncludeStrategy(
             relatedValueBuffers: IEnumerable<ValueBuffer> _Query(

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
@@ -459,6 +459,44 @@ FROM [Customers] AS [c]",
                 Sql);
         }
 
+        public override void Select_multiple_complex_projections()
+        {
+            base.Select_multiple_complex_projections();
+
+            Assert.Equal(
+                @"SELECT (
+    SELECT COUNT(*)
+    FROM [Order Details] AS [o]
+    WHERE [o].[OrderID] = [o].[OrderID]
+), (
+    SELECT CASE
+        WHEN EXISTS (
+            SELECT 1
+            FROM [Order Details] AS [od]
+            WHERE ([od].[UnitPrice] > 10) AND ([o].[OrderID] = [od].[OrderID]))
+        THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+    END
+), CASE
+    WHEN [o].[CustomerID] = 'ALFKI'
+    THEN '50' ELSE '10'
+END, [o].[OrderID], (
+    SELECT CASE
+        WHEN NOT (EXISTS (
+            SELECT 1
+            FROM [Order Details] AS [od]
+            WHERE ([o].[OrderID] = [od].[OrderID]) AND ([od].[OrderID] <> 42)))
+        THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+    END
+), (
+    SELECT COUNT_BIG(*)
+    FROM [Order Details] AS [o]
+    WHERE [o].[OrderID] = [o].[OrderID]
+), [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] LIKE 'A' + '%'",
+                Sql);
+        }
+
         public override void Collection_select_nav_prop_sum()
         {
             base.Collection_select_nav_prop_sum();


### PR DESCRIPTION
Problem was that when we were adding a subquery to the projection we were clearing everything that was in the projection list before. This is not a problem for scalars, because they are all re-added when we bind the query, but complex expressions are not added and are ignored. Fix is to only remove column projection elements instead.