### PR TITLE
RevEng: Updating FluentApiConfigurations to allow multiple lines …

### DIFF
--- a/src/EntityFramework.Commands/Scaffolding/Internal/Configuration/FluentApiConfiguration.cs
+++ b/src/EntityFramework.Commands/Scaffolding/Internal/Configuration/FluentApiConfiguration.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Utilities;
 
@@ -22,8 +23,6 @@ namespace Microsoft.Data.Entity.Scaffolding.Internal.Configuration
 
         public virtual bool HasAttributeEquivalent { get; set; }
 
-        public virtual string For { get; }
-
         public virtual string MethodBody
         {
             get
@@ -34,13 +33,11 @@ namespace Microsoft.Data.Entity.Scaffolding.Internal.Configuration
             }
         }
 
-        public virtual string FluentApi
+        public virtual ICollection<string> FluentApiLines
         {
             get
             {
-                return For == null
-                    ? MethodBody
-                    : For + "()." + MethodBody;
+                return new List<string>() { MethodBody };
             }
         }
     }

--- a/src/EntityFramework.Commands/Scaffolding/Internal/Configuration/IFluentApiConfiguration.cs
+++ b/src/EntityFramework.Commands/Scaffolding/Internal/Configuration/IFluentApiConfiguration.cs
@@ -1,12 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+
 namespace Microsoft.Data.Entity.Scaffolding.Internal.Configuration
 {
     public interface IFluentApiConfiguration
     {
-        string For { get; }
         bool HasAttributeEquivalent { get; }
-        string FluentApi { get; }
+        ICollection<string> FluentApiLines { get; }
     }
 }

--- a/src/EntityFramework.Commands/Scaffolding/Internal/Configuration/IndexConfiguration.cs
+++ b/src/EntityFramework.Commands/Scaffolding/Internal/Configuration/IndexConfiguration.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Text;
+using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Metadata.Builders;
 using Microsoft.Data.Entity.Metadata.Internal;
@@ -26,32 +26,27 @@ namespace Microsoft.Data.Entity.Scaffolding.Internal.Configuration
         public virtual Index Index { get; }
 
         public virtual bool HasAttributeEquivalent { get; }
-        public virtual string For { get; }
 
-        public virtual string FluentApi
+        public virtual ICollection<string> FluentApiLines
         {
             get
             {
-                var sb = new StringBuilder();
-                sb.Append(nameof(EntityTypeBuilder<EntityType>.HasIndex) + "(");
-                sb.Append(LambdaIdentifier);
-                sb.Append(" => ");
-                sb.Append(new ScaffoldingUtilities().GenerateLambdaToKey(Index.Properties, LambdaIdentifier));
-                sb.Append(")");
+                var lines = new List<string>();
+                lines.Add(nameof(EntityTypeBuilder<EntityType>.HasIndex) + "(" + LambdaIdentifier + " => "
+                    + new ScaffoldingUtilities().GenerateLambdaToKey(Index.Properties, LambdaIdentifier) + ")");
 
                 if (!string.IsNullOrEmpty(Index.Relational().Name))
                 {
-                    sb.Append("." + nameof(RelationalIndexBuilderExtensions.HasName) + "(");
-                    sb.Append(CSharpUtilities.Instance.DelimitString(Index.Relational().Name));
-                    sb.Append(")");
+                    lines.Add("." + nameof(RelationalIndexBuilderExtensions.HasName) + "("
+                        + CSharpUtilities.Instance.DelimitString(Index.Relational().Name) + ")");
                 }
 
                 if (Index.IsUnique)
                 {
-                    sb.Append("." + nameof(IndexBuilder.IsUnique) + "()");
+                    lines.Add("." + nameof(IndexBuilder.IsUnique) + "()");
                 }
 
-                return sb.ToString();
+                return lines;
             }
         }
     }

--- a/src/EntityFramework.Commands/Scaffolding/Internal/Configuration/KeyFluentApiConfiguration.cs
+++ b/src/EntityFramework.Commands/Scaffolding/Internal/Configuration/KeyFluentApiConfiguration.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Globalization;
 using JetBrains.Annotations;
-using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Metadata.Builders;
 using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Utilities;
@@ -28,13 +27,14 @@ namespace Microsoft.Data.Entity.Scaffolding.Internal.Configuration
         public virtual IReadOnlyList<Property> Properties { get; }
 
         public virtual bool HasAttributeEquivalent { get; set; }
-        public virtual string For { get; }
 
-        public virtual string FluentApi => string.Format(
+        public virtual ICollection<string> FluentApiLines =>
+            new List<string> { string.Format(
                 CultureInfo.InvariantCulture,
                 "{0}({1} => {2})",
                 nameof(EntityTypeBuilder.HasKey),
                 LambdaIdentifier,
-                new ScaffoldingUtilities().GenerateLambdaToKey(Properties, LambdaIdentifier));
+                new ScaffoldingUtilities().GenerateLambdaToKey(Properties, LambdaIdentifier))
+            };
     }
 }

--- a/src/EntityFramework.Commands/Scaffolding/Internal/Configuration/ModelConfiguration.cs
+++ b/src/EntityFramework.Commands/Scaffolding/Internal/Configuration/ModelConfiguration.cs
@@ -125,10 +125,12 @@ namespace Microsoft.Data.Entity.Scaffolding.Internal.Configuration
 
             _onConfiguringConfigurations.Add(
                 _configurationFactory.CreateOptionsBuilderConfiguration(
-                    methodName
-                    + "("
-                    + CSharpUtilities.GenerateVerbatimStringLiteral(CustomConfiguration.ConnectionString)
-                    + ")"));
+                    new List<string>() {
+                        methodName
+                        + "("
+                        + CSharpUtilities.GenerateVerbatimStringLiteral(CustomConfiguration.ConnectionString)
+                        + ")"
+                    }));
         }
 
         public virtual void AddEntityPropertiesConfiguration([NotNull] EntityConfiguration entityConfiguration)

--- a/src/EntityFramework.Commands/Scaffolding/Internal/Configuration/OptionsBuilderConfiguration.cs
+++ b/src/EntityFramework.Commands/Scaffolding/Internal/Configuration/OptionsBuilderConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Utilities;
 
@@ -8,17 +9,15 @@ namespace Microsoft.Data.Entity.Scaffolding.Internal.Configuration
 {
     public class OptionsBuilderConfiguration : IFluentApiConfiguration
     {
-        public OptionsBuilderConfiguration([NotNull] string methodBody)
+        public OptionsBuilderConfiguration([NotNull] ICollection<string> methodBodyLines)
         {
-            Check.NotEmpty(methodBody, nameof(methodBody));
+            Check.NotNull(methodBodyLines, nameof(methodBodyLines));
 
-            FluentApi = methodBody;
+            FluentApiLines = methodBodyLines;
         }
 
         public virtual bool HasAttributeEquivalent { get; } = false;
-        public virtual string For { get; }
 
-        public virtual string FluentApi { get;[param: NotNull] set; }
-
+        public virtual ICollection<string> FluentApiLines { get;[param: NotNull] set; }
     }
 }

--- a/src/EntityFramework.Commands/Scaffolding/Internal/Configuration/PropertyConfiguration.cs
+++ b/src/EntityFramework.Commands/Scaffolding/Internal/Configuration/PropertyConfiguration.cs
@@ -26,25 +26,11 @@ namespace Microsoft.Data.Entity.Scaffolding.Internal.Configuration
         public virtual List<IAttributeConfiguration> AttributeConfigurations { get; } = new List<IAttributeConfiguration>();
         public virtual List<FluentApiConfiguration> FluentApiConfigurations { get; } = new List<FluentApiConfiguration>();
 
-        public virtual Dictionary<string, List<FluentApiConfiguration>>
-            GetFluentApiConfigurations(bool useFluentApiOnly)
+        public virtual List<FluentApiConfiguration> GetFluentApiConfigurations(bool useFluentApiOnly)
         {
-            var fluentApiConfigsDictionary = new Dictionary<string, List<FluentApiConfiguration>>();
-            var fluentApiConfigs = useFluentApiOnly
+            return useFluentApiOnly
                 ? FluentApiConfigurations
-                : FluentApiConfigurations.Where(fc => !fc.HasAttributeEquivalent);
-            foreach (var fluentApiConfiguration in fluentApiConfigs)
-            {
-                var @for = fluentApiConfiguration.For ?? string.Empty;
-                List<FluentApiConfiguration> listOfFluentApiMethodBodies;
-                if (!fluentApiConfigsDictionary.TryGetValue(@for, out listOfFluentApiMethodBodies))
-                {
-                    listOfFluentApiMethodBodies = new List<FluentApiConfiguration>();
-                    fluentApiConfigsDictionary.Add(@for, listOfFluentApiMethodBodies);
-                }
-                listOfFluentApiMethodBodies.Add(fluentApiConfiguration);
-            }
-            return fluentApiConfigsDictionary;
+                : FluentApiConfigurations.Where(fc => !fc.HasAttributeEquivalent).ToList();
         }
     }
 }

--- a/src/EntityFramework.Commands/Scaffolding/Internal/ConfigurationFactory.cs
+++ b/src/EntityFramework.Commands/Scaffolding/Internal/ConfigurationFactory.cs
@@ -43,11 +43,11 @@ namespace Microsoft.Data.Entity.Scaffolding.Internal
         }
 
         public virtual OptionsBuilderConfiguration CreateOptionsBuilderConfiguration(
-            [NotNull] string methodBody)
+            [NotNull] ICollection<string> methodBodyLines)
         {
-            Check.NotEmpty(methodBody, nameof(methodBody));
+            Check.NotNull(methodBodyLines, nameof(methodBodyLines));
 
-            return new OptionsBuilderConfiguration(methodBody);
+            return new OptionsBuilderConfiguration(methodBodyLines);
         }
 
         public virtual EntityConfiguration CreateEntityConfiguration(

--- a/src/EntityFramework.Commands/Scaffolding/Internal/ScaffoldingUtilities.cs
+++ b/src/EntityFramework.Commands/Scaffolding/Internal/ScaffoldingUtilities.cs
@@ -38,55 +38,6 @@ namespace Microsoft.Data.Entity.Scaffolding.Internal
             return sb.ToString();
         }
 
-        public virtual List<string> LayoutPropertyConfigurationLines(
-            [NotNull] PropertyConfiguration pc,
-            [NotNull] string propertyLambdaIdentifier,
-            [NotNull] string indent,
-            bool useFluentApi)
-        {
-            Check.NotNull(pc, nameof(pc));
-            Check.NotEmpty(propertyLambdaIdentifier, nameof(propertyLambdaIdentifier));
-            Check.NotNull(indent, nameof(indent));
-
-            var lines = new List<string>();
-            foreach (var keyValuePair in pc.GetFluentApiConfigurations(useFluentApi))
-            {
-                var forMethod = keyValuePair.Key;
-                var fluentApiConfigurationList = keyValuePair.Value;
-                if (fluentApiConfigurationList.Count == 0)
-                {
-                    continue;
-                }
-
-                if (string.IsNullOrEmpty(forMethod))
-                {
-                    foreach (var fluentApiConfiguration in fluentApiConfigurationList)
-                    {
-                        lines.Add("." + fluentApiConfiguration.MethodBody);
-                    }
-                }
-                else
-                {
-                    if (fluentApiConfigurationList.Count == 1)
-                    {
-                        lines.Add("." + forMethod + "()." + fluentApiConfigurationList.First().MethodBody);
-                    }
-                    else
-                    {
-                        lines.Add("." + forMethod + "(" + propertyLambdaIdentifier + " =>");
-                        lines.Add("{");
-                        foreach (var fluentApiConfiguration in fluentApiConfigurationList)
-                        {
-                            lines.Add(indent + propertyLambdaIdentifier + "." + fluentApiConfiguration.MethodBody + ";");
-                        }
-                        lines.Add("})");
-                    }
-                }
-            }
-
-            return lines;
-        }
-
         public virtual void LayoutRelationshipConfigurationLines(
             [NotNull] IndentedStringBuilder sb,
             [NotNull] string entityLambdaIdentifier,

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/SqlServerReverseEngineerTestE2EContext.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/SqlServerReverseEngineerTestE2EContext.expected
@@ -107,7 +107,9 @@ namespace E2ETest.Namespace
             {
                 entity.HasKey(e => new { e.OneToOneFKToUniqueKeyDependentID1, e.OneToOneFKToUniqueKeyDependentID2 });
 
-                entity.HasIndex(e => new { e.OneToOneFKToUniqueKeyDependentFK1, e.OneToOneFKToUniqueKeyDependentFK2 }).HasName("UK_OneToOneFKToUniqueKeyDependent").IsUnique();
+                entity.HasIndex(e => new { e.OneToOneFKToUniqueKeyDependentFK1, e.OneToOneFKToUniqueKeyDependentFK2 })
+                    .HasName("UK_OneToOneFKToUniqueKeyDependent")
+                    .IsUnique();
 
                 entity.Property(e => e.SomeColumn)
                     .IsRequired()
@@ -123,7 +125,9 @@ namespace E2ETest.Namespace
             {
                 entity.HasKey(e => new { e.OneToOneFKToUniqueKeyPrincipalID1, e.OneToOneFKToUniqueKeyPrincipalID2 });
 
-                entity.HasIndex(e => new { e.OneToOneFKToUniqueKeyPrincipalUniqueKey1, e.OneToOneFKToUniqueKeyPrincipalUniqueKey2 }).HasName("UK_OneToOneFKToUniqueKeyPrincipal").IsUnique();
+                entity.HasIndex(e => new { e.OneToOneFKToUniqueKeyPrincipalUniqueKey1, e.OneToOneFKToUniqueKeyPrincipalUniqueKey2 })
+                    .HasName("UK_OneToOneFKToUniqueKeyPrincipal")
+                    .IsUnique();
 
                 entity.Property(e => e.SomePrincipalColumn)
                     .IsRequired()
@@ -143,7 +147,9 @@ namespace E2ETest.Namespace
             {
                 entity.HasKey(e => new { e.OneToOneSeparateFKDependentID1, e.OneToOneSeparateFKDependentID2 });
 
-                entity.HasIndex(e => new { e.OneToOneSeparateFKDependentFK1, e.OneToOneSeparateFKDependentFK2 }).HasName("UK_OneToOneSeparateFKDependent").IsUnique();
+                entity.HasIndex(e => new { e.OneToOneSeparateFKDependentFK1, e.OneToOneSeparateFKDependentFK2 })
+                    .HasName("UK_OneToOneSeparateFKDependent")
+                    .IsUnique();
 
                 entity.Property(e => e.SomeDependentEndColumn)
                     .IsRequired()
@@ -165,7 +171,8 @@ namespace E2ETest.Namespace
 
             modelBuilder.Entity<PropertyConfiguration>(entity =>
             {
-                entity.HasIndex(e => new { e.A, e.B }).HasName("Test_PropertyConfiguration_Index");
+                entity.HasIndex(e => new { e.A, e.B })
+                    .HasName("Test_PropertyConfiguration_Index");
 
                 entity.Property(e => e.PropertyConfiguration1).HasColumnName("PropertyConfiguration");
 

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/AttributesContext.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/AttributesContext.expected
@@ -74,7 +74,9 @@ namespace E2ETest.Namespace
             {
                 entity.HasKey(e => new { e.OneToOneFKToUniqueKeyDependentID1, e.OneToOneFKToUniqueKeyDependentID2 });
 
-                entity.HasIndex(e => new { e.OneToOneFKToUniqueKeyDependentFK1, e.OneToOneFKToUniqueKeyDependentFK2 }).HasName("UK_OneToOneFKToUniqueKeyDependent").IsUnique();
+                entity.HasIndex(e => new { e.OneToOneFKToUniqueKeyDependentFK1, e.OneToOneFKToUniqueKeyDependentFK2 })
+                    .HasName("UK_OneToOneFKToUniqueKeyDependent")
+                    .IsUnique();
 
                 entity.HasOne(d => d.OneToOneFKToUniqueKeyDependentFK)
                     .WithOne(p => p.OneToOneFKToUniqueKeyDependent)
@@ -86,7 +88,9 @@ namespace E2ETest.Namespace
             {
                 entity.HasKey(e => new { e.OneToOneFKToUniqueKeyPrincipalID1, e.OneToOneFKToUniqueKeyPrincipalID2 });
 
-                entity.HasIndex(e => new { e.OneToOneFKToUniqueKeyPrincipalUniqueKey1, e.OneToOneFKToUniqueKeyPrincipalUniqueKey2 }).HasName("UK_OneToOneFKToUniqueKeyPrincipal").IsUnique();
+                entity.HasIndex(e => new { e.OneToOneFKToUniqueKeyPrincipalUniqueKey1, e.OneToOneFKToUniqueKeyPrincipalUniqueKey2 })
+                    .HasName("UK_OneToOneFKToUniqueKeyPrincipal")
+                    .IsUnique();
             });
 
             modelBuilder.Entity<OneToOnePrincipal>(entity =>
@@ -98,7 +102,9 @@ namespace E2ETest.Namespace
             {
                 entity.HasKey(e => new { e.OneToOneSeparateFKDependentID1, e.OneToOneSeparateFKDependentID2 });
 
-                entity.HasIndex(e => new { e.OneToOneSeparateFKDependentFK1, e.OneToOneSeparateFKDependentFK2 }).HasName("UK_OneToOneSeparateFKDependent").IsUnique();
+                entity.HasIndex(e => new { e.OneToOneSeparateFKDependentFK1, e.OneToOneSeparateFKDependentFK2 })
+                    .HasName("UK_OneToOneSeparateFKDependent")
+                    .IsUnique();
             });
 
             modelBuilder.Entity<OneToOneSeparateFKPrincipal>(entity =>
@@ -108,7 +114,8 @@ namespace E2ETest.Namespace
 
             modelBuilder.Entity<PropertyConfiguration>(entity =>
             {
-                entity.HasIndex(e => new { e.A, e.B }).HasName("Test_PropertyConfiguration_Index");
+                entity.HasIndex(e => new { e.A, e.B })
+                    .HasName("Test_PropertyConfiguration_Index");
 
                 entity.Property(e => e.RowversionColumn)
                     .HasColumnType("timestamp")

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/FkToAltKey/FkToAltKeyContext.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/FkToAltKey/FkToAltKeyContext.expected
@@ -23,7 +23,9 @@ namespace E2E.Sqlite
 
             modelBuilder.Entity<User>(entity =>
             {
-                entity.HasIndex(e => e.AltId).HasName("sqlite_autoindex_User_1").IsUnique();
+                entity.HasIndex(e => e.AltId)
+                    .HasName("sqlite_autoindex_User_1")
+                    .IsUnique();
             });
         }
 

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/ManyToMany/ManyToManyFluentApiContext.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/ManyToMany/ManyToManyFluentApiContext.expected
@@ -14,7 +14,9 @@ namespace E2E.Sqlite
         {
             modelBuilder.Entity<Users_Groups>(entity =>
             {
-                entity.HasIndex(e => new { e.UserId, e.GroupId }).HasName("sqlite_autoindex_Users_Groups_2").IsUnique();
+                entity.HasIndex(e => new { e.UserId, e.GroupId })
+                    .HasName("sqlite_autoindex_Users_Groups_2")
+                    .IsUnique();
 
                 entity.HasOne(d => d.Group)
                     .WithMany(p => p.Users_Groups)

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/OneToOne/OneToOneFluentApiContext.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/OneToOne/OneToOneFluentApiContext.expected
@@ -14,7 +14,9 @@ namespace E2E.Sqlite
         {
             modelBuilder.Entity<Dependent>(entity =>
             {
-                entity.HasIndex(e => e.PrincipalId).HasName("sqlite_autoindex_Dependent_1").IsUnique();
+                entity.HasIndex(e => e.PrincipalId)
+                    .HasName("sqlite_autoindex_Dependent_1")
+                    .IsUnique();
 
                 entity.Property(e => e.Id).HasColumnType("INT");
 

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/FkToAltKey/FkToAltKeyContext.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/FkToAltKey/FkToAltKeyContext.expected
@@ -23,7 +23,9 @@ namespace E2E.Sqlite
 
             modelBuilder.Entity<User>(entity =>
             {
-                entity.HasIndex(e => e.AltId).HasName("sqlite_autoindex_User_1").IsUnique();
+                entity.HasIndex(e => e.AltId)
+                    .HasName("sqlite_autoindex_User_1")
+                    .IsUnique();
             });
         }
 

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/ManyToMany/ManyToManyAttributesContext.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/ManyToMany/ManyToManyAttributesContext.expected
@@ -14,7 +14,9 @@ namespace E2E.Sqlite
         {
             modelBuilder.Entity<Users_Groups>(entity =>
             {
-                entity.HasIndex(e => new { e.UserId, e.GroupId }).HasName("sqlite_autoindex_Users_Groups_2").IsUnique();
+                entity.HasIndex(e => new { e.UserId, e.GroupId })
+                    .HasName("sqlite_autoindex_Users_Groups_2")
+                    .IsUnique();
             });
         }
 

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/OneToOne/OneToOneAttributesContext.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/OneToOne/OneToOneAttributesContext.expected
@@ -14,7 +14,9 @@ namespace E2E.Sqlite
         {
             modelBuilder.Entity<Dependent>(entity =>
             {
-                entity.HasIndex(e => e.PrincipalId).HasName("sqlite_autoindex_Dependent_1").IsUnique();
+                entity.HasIndex(e => e.PrincipalId)
+                    .HasName("sqlite_autoindex_Dependent_1")
+                    .IsUnique();
 
                 entity.Property(e => e.Id).HasColumnType("INT");
 


### PR DESCRIPTION
…and removing the ability for them to be prefixed by the ForXXX() concept which we no longer use.

This fixes the last part of #3394 - allowing the HasIndex() fluent API line to be split.