### PR TITLE
Migrations: Preserve entity type table name in snapshot

### DIFF
--- a/src/EntityFramework.Commands/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EntityFramework.Commands/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -108,6 +108,8 @@ namespace Microsoft.Data.Entity.Migrations.Design
 
                     GenerateBaseType(entityType.BaseType, stringBuilder);
 
+                    GenerateTableName(entityType, stringBuilder);
+
                     GenerateProperties(entityType.GetDeclaredProperties(), stringBuilder);
 
                     GenerateKeys(entityType.GetDeclaredKeys(), entityType.FindDeclaredPrimaryKey(), stringBuilder);
@@ -163,6 +165,22 @@ namespace Microsoft.Data.Entity.Migrations.Design
                     .AppendLine()
                     .Append("b.HasBaseType(")
                     .Append(_code.Literal(baseType.Name))
+                    .AppendLine(");");
+            }
+        }
+
+        protected virtual void GenerateTableName([NotNull] IEntityType entityType, [NotNull] IndentedStringBuilder stringBuilder)
+        {
+            Check.NotNull(entityType, nameof(entityType));
+            Check.NotNull(stringBuilder, nameof(stringBuilder));
+
+            if (entityType.FindAnnotation(RelationalAnnotationNames.Prefix + RelationalAnnotationNames.TableName) == null
+                && entityType.HasClrType())
+            {
+                stringBuilder
+                    .AppendLine()
+                    .Append("b.ToTable(")
+                    .Append(_code.Literal(entityType.DisplayName()))
                     .AppendLine(");");
             }
         }

--- a/src/EntityFramework.Core/Metadata/Internal/EntityType.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/EntityType.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
             _properties = new SortedDictionary<string, Property>(new PropertyComparer(this));
 #if DEBUG
-            DebugName = DisplayName();
+            DebugName = this.DisplayName();
 #endif
         }
 
@@ -112,7 +112,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                         || GetDirectlyDerivedTypes().Any()
                         || GetProperties().Any())
                     {
-                        throw new InvalidOperationException(CoreStrings.EntityTypeInUse(DisplayName()));
+                        throw new InvalidOperationException(CoreStrings.EntityTypeInUse(this.DisplayName()));
                     }
 
                     _typeOrName = value;
@@ -261,23 +261,6 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             }
         }
 
-        public virtual string DisplayName()
-        {
-            if (ClrType != null)
-            {
-                return ClrType.DisplayName(false) ?? ParseSimpleName();
-            }
-            return ParseSimpleName();
-        }
-
-        private string ParseSimpleName()
-        {
-            var fullName = (string)_typeOrName;
-            var lastDot = fullName.LastIndexOfAny(_simpleNameChars);
-
-            return lastDot > 0 ? fullName.Substring(lastDot + 1) : fullName;
-        }
-
         public override string ToString() => Name;
 
         public virtual ConfigurationSource GetConfigurationSource() => _configurationSource;
@@ -314,7 +297,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
         {
             if (_baseType != null)
             {
-                throw new InvalidOperationException(CoreStrings.DerivedEntityTypeKey(DisplayName(), _baseType.DisplayName()));
+                throw new InvalidOperationException(CoreStrings.DerivedEntityTypeKey(this.DisplayName(), _baseType.DisplayName()));
             }
 
             var oldPrimaryKey = _primaryKey;
@@ -410,21 +393,21 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
             if (_baseType != null)
             {
-                throw new InvalidOperationException(CoreStrings.DerivedEntityTypeKey(DisplayName(), _baseType.DisplayName()));
+                throw new InvalidOperationException(CoreStrings.DerivedEntityTypeKey(this.DisplayName(), _baseType.DisplayName()));
             }
 
             foreach (var property in properties)
             {
                 if (FindProperty(property.Name) != property)
                 {
-                    throw new ArgumentException(CoreStrings.KeyPropertiesWrongEntity(Property.Format(properties), DisplayName()));
+                    throw new ArgumentException(CoreStrings.KeyPropertiesWrongEntity(Property.Format(properties), this.DisplayName()));
                 }
             }
 
             var key = FindKey(properties);
             if (key != null)
             {
-                throw new InvalidOperationException(CoreStrings.DuplicateKey(Property.Format(properties), DisplayName(), key.DeclaringEntityType.DisplayName()));
+                throw new InvalidOperationException(CoreStrings.DuplicateKey(Property.Format(properties), this.DisplayName(), key.DeclaringEntityType.DisplayName()));
             }
 
             key = new Key(properties, configurationSource);
@@ -539,7 +522,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             var duplicateForeignKey = FindForeignKeysInHierarchy(properties, principalKey, principalEntityType).FirstOrDefault();
             if (duplicateForeignKey != null)
             {
-                throw new InvalidOperationException(CoreStrings.DuplicateForeignKey(Property.Format(properties), DisplayName(), duplicateForeignKey.DeclaringEntityType.DisplayName()));
+                throw new InvalidOperationException(CoreStrings.DuplicateForeignKey(Property.Format(properties), this.DisplayName(), duplicateForeignKey.DeclaringEntityType.DisplayName()));
             }
 
             var foreignKey = new ForeignKey(properties, principalKey, this, principalEntityType, configurationSource ?? ConfigurationSource.Convention);
@@ -702,7 +685,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 return foreignKey;
             }
 
-            return  null;
+            return null;
         }
 
         public virtual IEnumerable<ForeignKey> GetReferencingForeignKeys()
@@ -740,13 +723,13 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 }
 
                 throw new InvalidOperationException(
-                    CoreStrings.DuplicateNavigation(name, DisplayName(), duplicateNavigation.DeclaringEntityType.DisplayName()));
+                    CoreStrings.DuplicateNavigation(name, this.DisplayName(), duplicateNavigation.DeclaringEntityType.DisplayName()));
             }
 
             var duplicateProperty = FindPropertiesInHierarchy(name).FirstOrDefault();
             if (duplicateProperty != null)
             {
-                throw new InvalidOperationException(CoreStrings.ConflictingProperty(name, DisplayName(),
+                throw new InvalidOperationException(CoreStrings.ConflictingProperty(name, this.DisplayName(),
                     duplicateProperty.DeclaringEntityType.DisplayName()));
             }
 
@@ -838,14 +821,14 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             {
                 if (FindProperty(property.Name) != property)
                 {
-                    throw new ArgumentException(CoreStrings.IndexPropertiesWrongEntity(Property.Format(properties), DisplayName()));
+                    throw new ArgumentException(CoreStrings.IndexPropertiesWrongEntity(Property.Format(properties), this.DisplayName()));
                 }
             }
 
             var duplicateIndex = FindIndexesInHierarchy(properties).FirstOrDefault();
             if (duplicateIndex != null)
             {
-                throw new InvalidOperationException(CoreStrings.DuplicateIndex(Property.Format(properties), DisplayName(), duplicateIndex.DeclaringEntityType.DisplayName()));
+                throw new InvalidOperationException(CoreStrings.DuplicateIndex(Property.Format(properties), this.DisplayName(), duplicateIndex.DeclaringEntityType.DisplayName()));
             }
 
             var index = new Index(properties, this, configurationSource);
@@ -929,13 +912,13 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             if (duplicateProperty != null)
             {
                 throw new InvalidOperationException(CoreStrings.DuplicateProperty(
-                    name, DisplayName(), duplicateProperty.DeclaringEntityType.DisplayName()));
+                    name, this.DisplayName(), duplicateProperty.DeclaringEntityType.DisplayName()));
             }
 
             var duplicateNavigation = FindNavigationsInHierarchy(name).FirstOrDefault();
             if (duplicateNavigation != null)
             {
-                throw new InvalidOperationException(CoreStrings.ConflictingNavigation(name, DisplayName(),
+                throw new InvalidOperationException(CoreStrings.ConflictingNavigation(name, this.DisplayName(),
                     duplicateNavigation.DeclaringEntityType.DisplayName()));
             }
 
@@ -1091,7 +1074,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             }
 
             _ignoredMembers[name] = configurationSource;
-            
+
             Model.ConventionDispatcher.OnEntityTypeMemberIgnored(Builder, name);
         }
 

--- a/src/EntityFramework.Core/Metadata/Internal/EntityTypeExtensions.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/EntityTypeExtensions.cs
@@ -17,18 +17,9 @@ namespace Microsoft.Data.Entity.Metadata.Internal
     public static class EntityTypeExtensions
     {
         public static string DisplayName([NotNull] this IEntityType entityType)
-        {
-            Check.NotNull(entityType, nameof(entityType));
-
-            if (entityType.ClrType != null)
-            {
-                return entityType.ClrType.DisplayName(false);
-            }
-
-            var lastDot = entityType.Name.LastIndexOfAny(new[] { '.', '+' });
-
-            return lastDot > 0 ? entityType.Name.Substring(lastDot + 1) : entityType.Name;
-        }
+            => entityType.ClrType != null
+                ? entityType.ClrType.DisplayName(fullName: false)
+                : entityType.Name;
 
         public static IEnumerable<IEntityType> GetAllBaseTypesInclusive([NotNull] this IEntityType entityType)
         {

--- a/src/EntityFramework.Relational/Metadata/RelationalForeignKeyAnnotations.cs
+++ b/src/EntityFramework.Relational/Metadata/RelationalForeignKeyAnnotations.cs
@@ -34,8 +34,15 @@ namespace Microsoft.Data.Entity.Metadata
             => Annotations.SetAnnotation(RelationalAnnotationNames.Name, Check.NullButNotEmpty(value, nameof(value)));
 
         protected virtual string GetDefaultName()
-            => "FK_" + ForeignKey.DeclaringEntityType.DisplayName() +
-               "_" + ForeignKey.PrincipalEntityType.DisplayName() +
-               "_" + string.Join("_", ForeignKey.Properties.Select(p => p.Name));
+        {
+            var entityType = new RelationalEntityTypeAnnotations(ForeignKey.DeclaringEntityType, Annotations.ProviderPrefix);
+            var principalEntityType = new RelationalEntityTypeAnnotations(
+                ForeignKey.PrincipalEntityType,
+                Annotations.ProviderPrefix);
+
+            return "FK_" + entityType.TableName +
+                "_" + principalEntityType.TableName +
+                "_" + string.Join("_", ForeignKey.Properties.Select(p => p.Name));
+        }
     }
 }

--- a/src/EntityFramework.Relational/Metadata/RelationalIndexAnnotations.cs
+++ b/src/EntityFramework.Relational/Metadata/RelationalIndexAnnotations.cs
@@ -34,9 +34,13 @@ namespace Microsoft.Data.Entity.Metadata
             => Annotations.SetAnnotation(RelationalAnnotationNames.Name, Check.NullButNotEmpty(value, nameof(value)));
 
         protected virtual string GetDefaultName()
-            => "IX_" +
-               Index.DeclaringEntityType.DisplayName() +
-               "_" +
-               string.Join("_", Index.Properties.Select(p => p.Name));
+        {
+            var entityType = new RelationalEntityTypeAnnotations(Index.DeclaringEntityType, Annotations.ProviderPrefix);
+
+            return "IX_" +
+                entityType.TableName +
+                "_" +
+                string.Join("_", Index.Properties.Select(p => p.Name));
+        }
     }
 }

--- a/src/EntityFramework.Relational/Metadata/RelationalKeyAnnotations.cs
+++ b/src/EntityFramework.Relational/Metadata/RelationalKeyAnnotations.cs
@@ -37,10 +37,11 @@ namespace Microsoft.Data.Entity.Metadata
         protected virtual string GetDefaultName()
         {
             var builder = new StringBuilder();
+            var entityType = new RelationalEntityTypeAnnotations(Key.DeclaringEntityType, Annotations.ProviderPrefix);
 
             builder
                 .Append(Key.IsPrimaryKey() ? "PK_" : "AK_")
-                .Append(Key.DeclaringEntityType.DisplayName());
+                .Append(entityType.TableName);
 
             if (!Key.IsPrimaryKey())
             {

--- a/test/EntityFramework.Commands.FunctionalTests/Migrations/ModelSnapshotTest.cs
+++ b/test/EntityFramework.Commands.FunctionalTests/Migrations/ModelSnapshotTest.cs
@@ -38,6 +38,17 @@ namespace Microsoft.Data.Entity.Commands.Migrations
             public string Id { get; set; }
         }
 
+        public class EntityWithGenericKey<TKey>
+        {
+            public Guid Id { get; set; }
+        }
+
+        public class EntityWithGenericProperty<TProperty>
+        {
+            public int Id { get; set; }
+            public TProperty Property { get; set; }
+        }
+
         public class BaseEntity
         {
             public int Id { get; set; }
@@ -82,6 +93,8 @@ namespace Microsoft.Data.Entity.Commands.Migrations
                 @"
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithOneProperty"", b =>
     {
+        b.ToTable(""EntityWithOneProperty"");
+
         b.Property<int>(""Id"")
             .ValueGeneratedOnAdd();
 
@@ -90,6 +103,8 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", b =>
     {
+        b.ToTable(""EntityWithTwoProperties"");
+
         b.Property<int>(""Id"")
             .ValueGeneratedOnAdd();
 
@@ -120,6 +135,8 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
                 @"
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithOneProperty"", b =>
     {
+        b.ToTable(""EntityWithOneProperty"");
+
         b.Property<int>(""Id"")
             .ValueGeneratedOnAdd();
 
@@ -130,7 +147,7 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 ",
                 o =>
                     {
-                        Assert.Equal(1, o.GetEntityTypes().First().GetAnnotations().Count());
+                        Assert.Equal(2, o.GetEntityTypes().First().GetAnnotations().Count());
                         Assert.Equal("AnnotationValue", o.GetEntityTypes().First()["AnnotationName"]);
                     });
         }
@@ -147,6 +164,8 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
                 @"
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+BaseEntity"", b =>
     {
+        b.ToTable(""BaseEntity"");
+
         b.Property<int>(""Id"")
             .ValueGeneratedOnAdd();
 
@@ -157,12 +176,16 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ano
     {
         b.HasBaseType(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+BaseEntity"");
 
+        b.ToTable(""AnotherDerivedEntity"");
+
         b.Property<string>(""Title"");
     });
 
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+DerivedEntity"", b =>
     {
         b.HasBaseType(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+BaseEntity"");
+
+        b.ToTable(""DerivedEntity"");
 
         b.Property<string>(""Name"");
     });
@@ -187,6 +210,8 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Der
                 @"
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", b =>
     {
+        b.ToTable(""EntityWithTwoProperties"");
+
         b.Property<int>(""Id"")
             .ValueGeneratedOnAdd();
 
@@ -214,6 +239,8 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
                 @"
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", b =>
     {
+        b.ToTable(""EntityWithTwoProperties"");
+
         b.Property<int>(""Id"");
 
         b.Property<int>(""AlternateId"");
@@ -240,6 +267,8 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
                 @"
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", b =>
     {
+        b.ToTable(""EntityWithTwoProperties"");
+
         b.Property<int>(""Id"")
             .ValueGeneratedOnAdd();
 
@@ -268,6 +297,8 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
                 @"
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", b =>
     {
+        b.ToTable(""EntityWithTwoProperties"");
+
         b.Property<int>(""Id"")
             .ValueGeneratedOnAdd();
 
@@ -293,6 +324,8 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
                 @"
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", b =>
     {
+        b.ToTable(""EntityWithTwoProperties"");
+
         b.Property<int>(""Id"")
             .ValueGeneratedOnAdd();
 
@@ -321,6 +354,8 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
                 @"
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithOneProperty"", b =>
     {
+        b.ToTable(""EntityWithOneProperty"");
+
         b.Property<int>(""Id"")
             .ValueGeneratedOnAdd();
 
@@ -329,6 +364,8 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", b =>
     {
+        b.ToTable(""EntityWithTwoProperties"");
+
         b.Property<int>(""Id"")
             .ValueGeneratedOnAdd();
 
@@ -366,6 +403,8 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
                 @"
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithOneProperty"", b =>
     {
+        b.ToTable(""EntityWithOneProperty"");
+
         b.Property<int>(""Id"");
 
         b.HasKey(""Id"");
@@ -375,6 +414,8 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", b =>
     {
+        b.ToTable(""EntityWithTwoProperties"");
+
         b.Property<int>(""Id"")
             .ValueGeneratedOnAdd();
 
@@ -398,6 +439,115 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
                     });
         }
 
+        [Fact]
+        public void TableName_preserved_when_generic()
+        {
+            IModel originalModel = null;
+
+            Test(
+                builder =>
+                {
+                    builder.Entity<EntityWithGenericKey<Guid>>();
+
+                    originalModel = builder.Model;
+                },
+                @"
+builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithGenericKey<System.Guid>"", b =>
+    {
+        b.ToTable(""EntityWithGenericKey<Guid>"");
+
+        b.Property<Guid>(""Id"")
+            .ValueGeneratedOnAdd();
+
+        b.HasKey(""Id"");
+    });
+",
+                model =>
+                {
+                    var originalEntity = originalModel.FindEntityType(typeof(EntityWithGenericKey<Guid>));
+                    var entity = model.FindEntityType(originalEntity.Name);
+
+                    Assert.NotNull(entity);
+                    Assert.Equal(originalEntity.SqlServer().TableName, entity.SqlServer().TableName);
+                });
+        }
+
+        [Fact]
+        public void PrimaryKey_name_preserved_when_generic()
+        {
+            IModel originalModel = null;
+
+            Test(
+                builder =>
+                {
+                    builder.Entity<EntityWithGenericKey<Guid>>();
+
+                    originalModel = builder.Model;
+                },
+                @"
+builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithGenericKey<System.Guid>"", b =>
+    {
+        b.ToTable(""EntityWithGenericKey<Guid>"");
+
+        b.Property<Guid>(""Id"")
+            .ValueGeneratedOnAdd();
+
+        b.HasKey(""Id"");
+    });
+",
+                model =>
+                {
+                    var originalEntity = originalModel.FindEntityType(typeof(EntityWithGenericKey<Guid>));
+                    var entity = model.FindEntityType(originalEntity.Name);
+                    Assert.NotNull(entity);
+
+                    var originalPrimaryKey = originalEntity.FindPrimaryKey();
+                    var primaryKey = entity.FindPrimaryKey();
+
+                    Assert.Equal(originalPrimaryKey.SqlServer().Name, primaryKey.SqlServer().Name);
+                });
+        }
+
+        [Fact]
+        public void AlternateKey_name_preserved_when_generic()
+        {
+            IModel originalModel = null;
+
+            Test(
+                builder =>
+                {
+                    builder.Entity<EntityWithGenericProperty<Guid>>().HasAlternateKey(e => e.Property);
+
+                    originalModel = builder.Model;
+                },
+                @"
+builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithGenericProperty<System.Guid>"", b =>
+    {
+        b.ToTable(""EntityWithGenericProperty<Guid>"");
+
+        b.Property<int>(""Id"")
+            .ValueGeneratedOnAdd();
+
+        b.Property<Guid>(""Property"");
+
+        b.HasKey(""Id"");
+
+        b.HasAlternateKey(""Property"");
+    });
+",
+                model =>
+                {
+                    var originalEntity = originalModel.FindEntityType(typeof(EntityWithGenericProperty<Guid>));
+                    var entity = model.FindEntityType(originalEntity.Name);
+                    Assert.NotNull(entity);
+
+                    var originalAlternateKey = originalEntity.FindKey(originalEntity.FindProperty("Property"));
+                    var alternateKey = entity.FindKey(entity.FindProperty("Property"));
+
+                    Assert.Equal(originalAlternateKey.SqlServer().Name, alternateKey.SqlServer().Name);
+                });
+        }
+
         #endregion
 
         #region Property
@@ -410,6 +560,8 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
                 @"
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithOneProperty"", b =>
     {
+        b.ToTable(""EntityWithOneProperty"");
+
         b.Property<int>(""Id"")
             .ValueGeneratedOnAdd()
             .HasAnnotation(""AnnotationName"", ""AnnotationValue"");
@@ -429,6 +581,8 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
                 @"
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithStringProperty"", b =>
     {
+        b.ToTable(""EntityWithStringProperty"");
+
         b.Property<int>(""Id"")
             .ValueGeneratedOnAdd();
 
@@ -449,6 +603,8 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
                 @"
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", b =>
     {
+        b.ToTable(""EntityWithTwoProperties"");
+
         b.Property<int>(""Id"")
             .ValueGeneratedOnAdd();
 
@@ -469,6 +625,8 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
                 @"
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithStringProperty"", b =>
     {
+        b.ToTable(""EntityWithStringProperty"");
+
         b.Property<int>(""Id"")
             .ValueGeneratedOnAdd();
 
@@ -489,6 +647,8 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
                 @"
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", b =>
     {
+        b.ToTable(""EntityWithTwoProperties"");
+
         b.Property<int>(""Id"")
             .ValueGeneratedOnAdd();
 
@@ -508,6 +668,8 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
                 @"
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", b =>
     {
+        b.ToTable(""EntityWithTwoProperties"");
+
         b.Property<int>(""Id"")
             .ValueGeneratedOnAdd();
 
@@ -532,6 +694,8 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
                 @"
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", b =>
     {
+        b.ToTable(""EntityWithTwoProperties"");
+
         b.Property<int>(""Id"")
             .ValueGeneratedOnAdd();
 
@@ -554,6 +718,8 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
                 @"
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", b =>
     {
+        b.ToTable(""EntityWithTwoProperties"");
+
         b.Property<int>(""Id"")
             .ValueGeneratedOnAdd();
 
@@ -587,6 +753,8 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
                 @"
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithOneProperty"", b =>
     {
+        b.ToTable(""EntityWithOneProperty"");
+
         b.Property<int>(""Id"")
             .ValueGeneratedOnAdd();
 
@@ -595,6 +763,8 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", b =>
     {
+        b.ToTable(""EntityWithTwoProperties"");
+
         b.Property<int>(""Id"")
             .ValueGeneratedOnAdd();
 
@@ -631,6 +801,8 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
                 @"
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithStringKey"", b =>
     {
+        b.ToTable(""EntityWithStringKey"");
+
         b.Property<string>(""Id"");
 
         b.HasKey(""Id"");
@@ -638,6 +810,8 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithStringProperty"", b =>
     {
+        b.ToTable(""EntityWithStringProperty"");
+
         b.Property<int>(""Id"")
             .ValueGeneratedOnAdd();
 
@@ -673,6 +847,8 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
                 @"
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithStringKey"", b =>
     {
+        b.ToTable(""EntityWithStringKey"");
+
         b.Property<string>(""Id"");
 
         b.HasKey(""Id"");
@@ -680,6 +856,8 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithStringProperty"", b =>
     {
+        b.ToTable(""EntityWithStringProperty"");
+
         b.Property<int>(""Id"")
             .ValueGeneratedOnAdd();
 
@@ -714,6 +892,8 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
                 @"
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithOneProperty"", b =>
     {
+        b.ToTable(""EntityWithOneProperty"");
+
         b.Property<int>(""Id"");
 
         b.HasKey(""Id"");
@@ -723,6 +903,8 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
 
 builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithTwoProperties"", b =>
     {
+        b.ToTable(""EntityWithTwoProperties"");
+
         b.Property<int>(""Id"")
             .ValueGeneratedOnAdd();
 
@@ -740,6 +922,80 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
     });
 ",
                 o => { Assert.Equal(DeleteBehavior.Cascade, o.FindEntityType(typeof(EntityWithOneProperty)).GetForeignKeys().First().DeleteBehavior); });
+        }
+
+        [Fact]
+        public void ForeignKey_name_preserved_when_generic()
+        {
+            IModel originalModel = null;
+
+            Test(
+                builder =>
+                {
+                    builder.Entity<EntityWithGenericKey<Guid>>().HasMany<EntityWithGenericProperty<Guid>>().WithOne()
+                        .HasForeignKey(e => e.Property);
+
+                    originalModel = builder.Model;
+                },
+                @"
+builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithGenericKey<System.Guid>"", b =>
+    {
+        b.ToTable(""EntityWithGenericKey<Guid>"");
+
+        b.Property<Guid>(""Id"")
+            .ValueGeneratedOnAdd();
+
+        b.HasKey(""Id"");
+    });
+
+builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithGenericProperty<System.Guid>"", b =>
+    {
+        b.ToTable(""EntityWithGenericProperty<Guid>"");
+
+        b.Property<int>(""Id"")
+            .ValueGeneratedOnAdd();
+
+        b.Property<Guid>(""Property"");
+
+        b.HasKey(""Id"");
+
+        b.HasIndex(""Property"");
+    });
+
+builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithGenericProperty<System.Guid>"", b =>
+    {
+        b.HasOne(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+EntityWithGenericKey<System.Guid>"")
+            .WithMany()
+            .HasForeignKey(""Property"")
+            .OnDelete(DeleteBehavior.Cascade);
+    });
+",
+                model =>
+                {
+                    var originalParent = originalModel.FindEntityType(typeof(EntityWithGenericKey<Guid>));
+                    var parent = model.FindEntityType(originalParent.Name);
+                    Assert.NotNull(parent);
+
+                    var originalChild = originalModel.FindEntityType(typeof(EntityWithGenericProperty<Guid>));
+                    var child = model.FindEntityType(originalChild.Name);
+                    Assert.NotNull(child);
+
+                    var originalForeignKey = originalChild.FindForeignKey(
+                        originalChild.FindProperty("Property"),
+                        originalParent.FindPrimaryKey(),
+                        originalParent);
+                    var foreignKey = child.FindForeignKey(
+                        child.FindProperty("Property"),
+                        parent.FindPrimaryKey(),
+                        parent);
+
+                    Assert.Equal(originalForeignKey.SqlServer().Name, foreignKey.SqlServer().Name);
+
+                    var originalIndex = originalChild.FindIndex(originalChild.FindProperty("Property"));
+                    var index = child.FindIndex(child.FindProperty("Property"));
+
+                    Assert.Equal(originalIndex.SqlServer().Name, index.SqlServer().Name);
+                });
         }
 
         #endregion
@@ -771,6 +1027,7 @@ builder.Entity(""Microsoft.Data.Entity.Commands.Migrations.ModelSnapshotTest+Ent
                     BuildReference.ByName("EntityFramework.Relational")
                 },
                 Sources = { @"
+                    using System;
                     using Microsoft.Data.Entity;
                     using Microsoft.Data.Entity.Metadata;
                     using Microsoft.Data.Entity.Metadata.Conventions;

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntityEntryTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntityEntryTestBase.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             entry[nonKeyProperty] = "Jillybean";
 
             Assert.Equal(
-                CoreStrings.PropertyReadOnlyBeforeSave("Name", typeof(SomeEntity).Name),
+                CoreStrings.PropertyReadOnlyBeforeSave("Name", entityType.DisplayName()),
                 Assert.Throws<InvalidOperationException>(() => entry.PrepareToSave()).Message);
 
             entry[nonKeyProperty] = null;
@@ -135,7 +135,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             entry[keyProperty] = 2;
 
             Assert.Equal(
-                CoreStrings.PropertyReadOnlyBeforeSave("Id", typeof(SomeEntity).Name),
+                CoreStrings.PropertyReadOnlyBeforeSave("Id", entityType.DisplayName()),
                 Assert.Throws<InvalidOperationException>(() => entry.PrepareToSave()).Message);
         }
 
@@ -166,7 +166,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             Assert.True(entry.IsModified(nonKeyProperty));
 
             Assert.Equal(
-                CoreStrings.PropertyReadOnlyAfterSave("Name", typeof(SomeEntity).Name),
+                CoreStrings.PropertyReadOnlyAfterSave("Name", entityType.DisplayName()),
                 Assert.Throws<InvalidOperationException>(() => entry.PrepareToSave()).Message);
 
             entry.SetPropertyModified(nonKeyProperty, isModified: false);
@@ -176,7 +176,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             Assert.True(entry.IsModified(nonKeyProperty));
 
             Assert.Equal(
-                CoreStrings.PropertyReadOnlyAfterSave("Name", typeof(SomeEntity).Name),
+                CoreStrings.PropertyReadOnlyAfterSave("Name", entityType.DisplayName()),
                 Assert.Throws<InvalidOperationException>(() => entry.PrepareToSave()).Message);
         }
 
@@ -201,14 +201,14 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             Assert.False(entry.IsModified(keyProperty));
 
             Assert.Equal(
-                CoreStrings.KeyReadOnly("Id", typeof(SomeEntity).Name),
+                CoreStrings.KeyReadOnly("Id", entityType.DisplayName()),
                 Assert.Throws<NotSupportedException>(() => entry.SetPropertyModified(keyProperty)).Message);
 
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
             Assert.False(entry.IsModified(keyProperty));
 
             Assert.Equal(
-                CoreStrings.KeyReadOnly("Id", typeof(SomeEntity).Name),
+                CoreStrings.KeyReadOnly("Id", entityType.DisplayName()),
                 Assert.Throws<NotSupportedException>(() => entry[keyProperty] = 2).Message);
 
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
@@ -296,7 +296,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             entry.MarkAsTemporary(keyProperty);
 
             Assert.Equal(
-                CoreStrings.TempValuePersists("Id", "SomeEntity", targetState.ToString()),
+                CoreStrings.TempValuePersists("Id", entityType.DisplayName(), targetState.ToString()),
                 Assert.Throws<InvalidOperationException>(() => entry.SetEntityState(targetState)).Message);
         }
 
@@ -1164,7 +1164,9 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             entry[fkProperty] = null;
 
             Assert.Equal(
-                CoreStrings.RelationshipConceptualNull("SomeEntity", "SomeDependentEntity"),
+                CoreStrings.RelationshipConceptualNull(
+                    model.FindEntityType(typeof(SomeEntity).FullName).DisplayName(),
+                    entityType.DisplayName()),
                 Assert.Throws<InvalidOperationException>(() => entry.HandleConceptualNulls()).Message);
         }
 
@@ -1186,7 +1188,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             entry[property] = null;
 
             Assert.Equal(
-                CoreStrings.PropertyConceptualNull("JustAProperty", "SomeDependentEntity"),
+                CoreStrings.PropertyConceptualNull("JustAProperty", entityType.DisplayName()),
                 Assert.Throws<InvalidOperationException>(() => entry.HandleConceptualNulls()).Message);
         }
 

--- a/test/EntityFramework.Core.Tests/Metadata/Internal/EntityTypeTest.cs
+++ b/test/EntityFramework.Core.Tests/Metadata/Internal/EntityTypeTest.cs
@@ -1183,13 +1183,10 @@ namespace Microsoft.Data.Entity.Metadata.Internal
         }
 
         [Fact]
-        public void Display_name_is_part_of_name_following_final_separator_when_no_CLR_type()
-        {
-            Assert.Equal("Everything", new Model().AddEntityType("Everything").DisplayName());
-            Assert.Equal("Is", new Model().AddEntityType("Everything.Is").DisplayName());
-            Assert.Equal("Awesome", new Model().AddEntityType("Everything.Is.Awesome").DisplayName());
-            Assert.Equal("WhenWe`reLivingOurDream", new Model().AddEntityType("Everything.Is.Awesome+WhenWe`reLivingOurDream").DisplayName());
-        }
+        public void Display_name_is_entity_type_name_when_no_CLR_type()
+            => Assert.Equal(
+                "Everything.Is+Awesome<When.We, re.Living<Our.Dream>>",
+                new Model().AddEntityType("Everything.Is+Awesome<When.We, re.Living<Our.Dream>>").DisplayName());
 
         [Fact]
         public void Name_is_prettified_CLR_full_name()

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/MigrationsSqlServerTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/MigrationsSqlServerTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
     CREATE TABLE [__EFMigrationsHistory] (
         [MigrationId] nvarchar(150) NOT NULL,
         [ProductVersion] nvarchar(32) NOT NULL,
-        CONSTRAINT [PK_HistoryRow] PRIMARY KEY ([MigrationId])
+        CONSTRAINT [PK___EFMigrationsHistory] PRIMARY KEY ([MigrationId])
     );
 
 GO
@@ -64,7 +64,7 @@ GO
     CREATE TABLE [__EFMigrationsHistory] (
         [MigrationId] nvarchar(150) NOT NULL,
         [ProductVersion] nvarchar(32) NOT NULL,
-        CONSTRAINT [PK_HistoryRow] PRIMARY KEY ([MigrationId])
+        CONSTRAINT [PK___EFMigrationsHistory] PRIMARY KEY ([MigrationId])
     );
 
 GO

--- a/test/EntityFramework.MicrosoftSqlServer.Tests/Migrations/SqlServerHistoryRepositoryTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.Tests/Migrations/SqlServerHistoryRepositoryTest.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Data.Entity.Migrations
                 "CREATE TABLE [__EFMigrationsHistory] (" + EOL +
                 "    [MigrationId] nvarchar(150) NOT NULL," + EOL +
                 "    [ProductVersion] nvarchar(32) NOT NULL," + EOL +
-                "    CONSTRAINT [PK_HistoryRow] PRIMARY KEY ([MigrationId])" + EOL +
+                "    CONSTRAINT [PK___EFMigrationsHistory] PRIMARY KEY ([MigrationId])" + EOL +
                 ");" + EOL,
                 sql);
         }
@@ -44,7 +44,7 @@ namespace Microsoft.Data.Entity.Migrations
                 "    CREATE TABLE [__EFMigrationsHistory] (" + EOL +
                 "        [MigrationId] nvarchar(150) NOT NULL," + EOL +
                 "        [ProductVersion] nvarchar(32) NOT NULL," + EOL +
-                "        CONSTRAINT [PK_HistoryRow] PRIMARY KEY ([MigrationId])" + EOL +
+                "        CONSTRAINT [PK___EFMigrationsHistory] PRIMARY KEY ([MigrationId])" + EOL +
                 "    );" + EOL,
                 sql);
         }

--- a/test/EntityFramework.MicrosoftSqlServer.Tests/Migrations/SqlServerModelDifferTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.Tests/Migrations/SqlServerModelDifferTest.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     x =>
                         {
                             x.Property<int>("Id");
-                            x.HasKey("Id");
+                            x.HasKey("Id").HasName("PK_Person");
                             x.ForSqlServerToTable("People", "dbo");
                         }),
                 operations =>

--- a/test/EntityFramework.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
+++ b/test/EntityFramework.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Cats", "dbo");
                         x.Property<int>("Id");
-                        x.HasKey("Id");
+                        x.HasKey("Id").HasName("PK_Cat");
                     }),
                 operations =>
                 {
@@ -2511,9 +2511,9 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Flies");
                         x.Property<int>("Id");
-                        x.HasKey("Id");
+                        x.HasKey("Id").HasName("PK_Fly");
                         x.Property<string>("Name");
-                        x.HasAlternateKey("Name");
+                        x.HasAlternateKey("Name").HasName("AK_Fly_Name");
                     }),
                 operations =>
                 {
@@ -2542,9 +2542,9 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     {
                         x.ToTable("Gnats");
                         x.Property<int>("Id");
-                        x.HasKey("Id");
+                        x.HasKey("Id").HasName("PK_Gnat");
                         x.Property<string>("Name");
-                        x.HasIndex("Name");
+                        x.HasIndex("Name").HasName("IX_Gnat_Name");
                     }),
                 operations =>
                 {
@@ -2710,9 +2710,10 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Zonkeys");
                             x.Property<int>("Id");
-                            x.HasKey("Id");
+                            x.HasKey("Id").HasName("PK_Zonkey");
                             x.Property<int>("ParentId");
-                            x.HasOne("Zebra").WithMany().HasForeignKey("ParentId");
+                            x.HasOne("Zebra").WithMany().HasForeignKey("ParentId").HasConstraintName("FK_Zonkey_Zebra_ParentId");
+                            x.HasIndex("ParentId").HasName("IX_Zonkey_ParentId");
                         });
                 },
                 operations =>
@@ -2753,7 +2754,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                         {
                             x.ToTable("Jaguars");
                             x.Property<int>("Id");
-                            x.HasKey("Id");
+                            x.HasKey("Id").HasName("PK_Jaguar");
                         });
                     target.Entity(
                         "Jaglion",
@@ -2762,7 +2763,8 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                             x.Property<int>("Id");
                             x.HasKey("Id");
                             x.Property<int>("ParentId");
-                            x.HasOne("Jaguar").WithMany().HasForeignKey("ParentId");
+                            x.HasOne("Jaguar").WithMany().HasForeignKey("ParentId")
+                                .HasConstraintName("FK_Jaglion_Jaguar_ParentId");
                         });
                 },
                 operations =>
@@ -3172,7 +3174,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     var operation = Assert.IsType<CreateIndexOperation>(operations[0]);
                     Assert.Equal("dbo", operation.Schema);
                     Assert.Equal("Animal", operation.Table);
-                    Assert.Equal("IX_Minnow_Name", operation.Name);
+                    Assert.Equal("IX_Animal_Name", operation.Name);
                     Assert.Equal(new[] { "Name" }, operation.Columns);
                 });
         }
@@ -3240,7 +3242,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     var operation = Assert.IsType<RenameIndexOperation>(operations[0]);
                     Assert.Equal("dbo", operation.Schema);
                     Assert.Equal("Animal", operation.Table);
-                    Assert.Equal("IX_Pike_Name", operation.Name);
+                    Assert.Equal("IX_Animal_Name", operation.Name);
                     Assert.Equal("IX_Animal_Pike_Name", operation.NewName);
                 });
         }
@@ -3307,7 +3309,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     var operation = Assert.IsType<DropIndexOperation>(operations[0]);
                     Assert.Equal("dbo", operation.Schema);
                     Assert.Equal("Animal", operation.Table);
-                    Assert.Equal("IX_Catfish_Name", operation.Name);
+                    Assert.Equal("IX_Animal_Name", operation.Name);
                 });
         }
 
@@ -3407,14 +3409,14 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     Assert.Equal(1, createTableOperation.ForeignKeys.Count);
 
                     var addForeignKeyOperation = createTableOperation.ForeignKeys[0];
-                    Assert.Equal("FK_Stag_Person_HandlerId", addForeignKeyOperation.Name);
+                    Assert.Equal("FK_Animal_Person_HandlerId", addForeignKeyOperation.Name);
                     Assert.Equal(new[] { "HandlerId" }, addForeignKeyOperation.Columns);
                     Assert.Equal("Person", addForeignKeyOperation.PrincipalTable);
                     Assert.Equal(new[] { "Id" }, addForeignKeyOperation.PrincipalColumns);
 
                     var createIndexOperation = Assert.IsType<CreateIndexOperation>(operations[2]);
                     Assert.Equal("Animal", createIndexOperation.Table);
-                    Assert.Equal("IX_Stag_HandlerId", createIndexOperation.Name);
+                    Assert.Equal("IX_Animal_HandlerId", createIndexOperation.Name);
                     Assert.Equal(new[] { "HandlerId" }, createIndexOperation.Columns);
                 });
         }
@@ -3467,7 +3469,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     Assert.Equal(1, createTableOperation.ForeignKeys.Count);
 
                     var addForeignKeyOperation = createTableOperation.ForeignKeys[0];
-                    Assert.Equal("FK_Person_DomesticAnimal_PetId", addForeignKeyOperation.Name);
+                    Assert.Equal("FK_Person_Animal_PetId", addForeignKeyOperation.Name);
                     Assert.Equal(new[] { "PetId" }, addForeignKeyOperation.Columns);
                     Assert.Equal("Animal", addForeignKeyOperation.PrincipalTable);
                     Assert.Equal(new[] { "Id" }, addForeignKeyOperation.PrincipalColumns);
@@ -3517,14 +3519,14 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                     Assert.Equal(1, createTableOperation.ForeignKeys.Count);
 
                     var addForeignKeyOperation = createTableOperation.ForeignKeys[0];
-                    Assert.Equal("FK_Predator_Animal_PreyId", addForeignKeyOperation.Name);
+                    Assert.Equal("FK_Animal_Animal_PreyId", addForeignKeyOperation.Name);
                     Assert.Equal(new[] { "PreyId" }, addForeignKeyOperation.Columns);
                     Assert.Equal("Animal", addForeignKeyOperation.PrincipalTable);
                     Assert.Equal(new[] { "Id" }, addForeignKeyOperation.PrincipalColumns);
 
                     var createIndexOperation = Assert.IsType<CreateIndexOperation>(operations[1]);
                     Assert.Equal("Animal", createIndexOperation.Table);
-                    Assert.Equal("IX_Predator_PreyId", createIndexOperation.Name);
+                    Assert.Equal("IX_Animal_PreyId", createIndexOperation.Name);
                     Assert.Equal(new[] { "PreyId" }, createIndexOperation.Columns);
                 });
         }
@@ -3663,12 +3665,12 @@ namespace Microsoft.Data.Entity.Migrations.Internal
 
                     var createIndexOperation = Assert.IsType<CreateIndexOperation>(operations[0]);
                     Assert.Equal("Animal", createIndexOperation.Table);
-                    Assert.Equal("IX_GameAnimal_HunterId", createIndexOperation.Name);
+                    Assert.Equal("IX_Animal_HunterId", createIndexOperation.Name);
                     Assert.Equal(new[] { "HunterId" }, createIndexOperation.Columns);
 
                     var addFkOperation = Assert.IsType<AddForeignKeyOperation>(operations[1]);
                     Assert.Equal("Animal", addFkOperation.Table);
-                    Assert.Equal("FK_GameAnimal_Person_HunterId", addFkOperation.Name);
+                    Assert.Equal("FK_Animal_Person_HunterId", addFkOperation.Name);
                     Assert.Equal(new[] { "HunterId" }, addFkOperation.Columns);
                     Assert.Equal("Person", addFkOperation.PrincipalTable);
                     Assert.Equal(new[] { "Id" }, addFkOperation.PrincipalColumns);
@@ -3753,7 +3755,7 @@ namespace Microsoft.Data.Entity.Migrations.Internal
 
                     var addFkOperation = Assert.IsType<AddForeignKeyOperation>(operations[1]);
                     Assert.Equal("Person", addFkOperation.Table);
-                    Assert.Equal("FK_Person_TrophyAnimal_TrophyId", addFkOperation.Name);
+                    Assert.Equal("FK_Person_Animal_TrophyId", addFkOperation.Name);
                     Assert.Equal(new[] { "TrophyId" }, addFkOperation.Columns);
                     Assert.Equal("Animal", addFkOperation.PrincipalTable);
                     Assert.Equal(new[] { "Id" }, addFkOperation.PrincipalColumns);
@@ -3833,11 +3835,11 @@ namespace Microsoft.Data.Entity.Migrations.Internal
 
                     var dropFkOperation = Assert.IsType<DropForeignKeyOperation>(operations[0]);
                     Assert.Equal("Animal", dropFkOperation.Table);
-                    Assert.Equal("FK_MountAnimal_Person_RiderId", dropFkOperation.Name);
+                    Assert.Equal("FK_Animal_Person_RiderId", dropFkOperation.Name);
 
                     var dropIndexOperation = Assert.IsType<DropIndexOperation>(operations[1]);
                     Assert.Equal("Animal", dropIndexOperation.Table);
-                    Assert.Equal("IX_MountAnimal_RiderId", dropIndexOperation.Name);
+                    Assert.Equal("IX_Animal_RiderId", dropIndexOperation.Name);
                 });
         }
 

--- a/test/EntityFramework.Relational.Tests/RelationalModelValidatorTest.cs
+++ b/test/EntityFramework.Relational.Tests/RelationalModelValidatorTest.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata.Conventions.Internal;
+using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Tests.Infrastructure;
 using Microsoft.Data.Entity.Tests.TestUtilities;
 using Microsoft.Extensions.Logging;
@@ -94,7 +95,7 @@ namespace Microsoft.Data.Entity.Tests
 
             CreateModelValidator().Validate(model);
         }
-        
+
         [Fact]
         public virtual void Does_not_detect_non_instantiable_types()
         {
@@ -106,7 +107,7 @@ namespace Microsoft.Data.Entity.Tests
 
             CreateModelValidator().Validate(model);
         }
-        
+
         [Fact]
         public virtual void Detects_missing_discriminator_property()
         {
@@ -131,7 +132,7 @@ namespace Microsoft.Data.Entity.Tests
             var discriminatorProperty = entityA.AddProperty("D", typeof(int));
             entityA.Relational().DiscriminatorProperty = discriminatorProperty;
             entityAbstract.Relational().DiscriminatorValue = 1;
-            
+
             VerifyError(RelationalStrings.NoDiscriminatorValue(entityA.DisplayName()), model);
         }
 
@@ -147,14 +148,14 @@ namespace Microsoft.Data.Entity.Tests
             var discriminatorProperty = entityAbstract.AddProperty("D", typeof(int));
             entityAbstract.Relational().DiscriminatorProperty = discriminatorProperty;
             entityAbstract.Relational().DiscriminatorValue = 0;
-            
+
             VerifyError(RelationalStrings.NoDiscriminatorValue(entityGeneric.DisplayName()), model);
         }
 
         protected class C : A
         {
         }
-        
+
         protected abstract class Abstract : A
         {
         }

--- a/test/EntityFramework.Sqlite.FunctionalTests/MigrationsSqliteTest.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/MigrationsSqliteTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
 
             Assert.Equal(
                 @"CREATE TABLE IF NOT EXISTS ""__EFMigrationsHistory"" (
-    ""MigrationId"" TEXT NOT NULL CONSTRAINT ""PK_HistoryRow"" PRIMARY KEY,
+    ""MigrationId"" TEXT NOT NULL CONSTRAINT ""PK___EFMigrationsHistory"" PRIMARY KEY,
     ""ProductVersion"" TEXT NOT NULL
 );
 

--- a/test/EntityFramework.Sqlite.Tests/Migrations/SqliteHistoryRepositoryTest.cs
+++ b/test/EntityFramework.Sqlite.Tests/Migrations/SqliteHistoryRepositoryTest.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Data.Entity.Migrations
 
             Assert.Equal(
                 "CREATE TABLE \"__EFMigrationsHistory\" (" + EOL +
-                "    \"MigrationId\" TEXT NOT NULL CONSTRAINT \"PK_HistoryRow\" PRIMARY KEY," + EOL +
+                "    \"MigrationId\" TEXT NOT NULL CONSTRAINT \"PK___EFMigrationsHistory\" PRIMARY KEY," + EOL +
                 "    \"ProductVersion\" TEXT NOT NULL" + EOL +
                 ");" + EOL,
                 sql);
@@ -41,7 +41,7 @@ namespace Microsoft.Data.Entity.Migrations
 
             Assert.Equal(
                 "CREATE TABLE IF NOT EXISTS \"__EFMigrationsHistory\" (" + EOL +
-                "    \"MigrationId\" TEXT NOT NULL CONSTRAINT \"PK_HistoryRow\" PRIMARY KEY," + EOL +
+                "    \"MigrationId\" TEXT NOT NULL CONSTRAINT \"PK___EFMigrationsHistory\" PRIMARY KEY," + EOL +
                 "    \"ProductVersion\" TEXT NOT NULL" + EOL +
                 ");" + EOL,
                 sql);


### PR DESCRIPTION
This also...
* Removes any semantics about a shadow entity's name
* Derives constraint names from table (not entity type) names

Fixes #3545