### PR TITLE
Reveng: Guarding against duplicate or bad metadata and adding warning messages

### DIFF
--- a/src/EntityFramework.MicrosoftSqlServer.Design/EntityFramework.MicrosoftSqlServer.Design.csproj
+++ b/src/EntityFramework.MicrosoftSqlServer.Design/EntityFramework.MicrosoftSqlServer.Design.csproj
@@ -43,6 +43,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.tt</DependentUpon>
     </Compile>
+    <Compile Include="Internal\SqlDataReaderExtensions.cs" />
     <Compile Include="SqlServerTableSelectionSetExtensions.cs" />
     <Compile Include="SqlServerDesignTimeServices.cs" />
     <Compile Include="SqlServerScaffoldingModelFactory.cs" />

--- a/src/EntityFramework.MicrosoftSqlServer.Design/Internal/SqlDataReaderExtensions.cs
+++ b/src/EntityFramework.MicrosoftSqlServer.Design/Internal/SqlDataReaderExtensions.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Data.SqlClient;
+using JetBrains.Annotations;
+
+namespace Microsoft.Data.Entity.Scaffolding.Internal
+{
+    public static class SqlDataReaderExtensions
+    {
+        public static string GetStringOrNull([NotNull] this SqlDataReader reader, int ordinal)
+        {
+            return reader.IsDBNull(ordinal) ? null : reader.GetString(ordinal);
+        }
+    }
+}

--- a/src/EntityFramework.MicrosoftSqlServer.Design/Properties/SqlServerDesignStrings.Designer.cs
+++ b/src/EntityFramework.MicrosoftSqlServer.Design/Properties/SqlServerDesignStrings.Designer.cs
@@ -13,11 +13,43 @@ namespace Microsoft.Data.Entity.Internal
             = new ResourceManager("EntityFramework.MicrosoftSqlServer.Design.SqlServerDesignStrings", typeof(SqlServerDesignStrings).GetTypeInfo().Assembly);
 
         /// <summary>
+        /// For index {indexName}. Unable to find the table [{schemaName}].[{tableName}] to which this index belongs.
+        /// </summary>
+        public static string CannotFindTableForIndex([CanBeNull] object indexName, [CanBeNull] object schemaName, [CanBeNull] object tableName)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("CannotFindTableForIndex", "indexName", "schemaName", "tableName"), indexName, schemaName, tableName);
+        }
+
+        /// <summary>
         /// Unable to interpret the string {sqlServerStringLiteral} as a SQLServer string literal.
         /// </summary>
         public static string CannotInterpretSqlServerStringLiteral([CanBeNull] object sqlServerStringLiteral)
         {
             return string.Format(CultureInfo.CurrentCulture, GetString("CannotInterpretSqlServerStringLiteral", "sqlServerStringLiteral"), sqlServerStringLiteral);
+        }
+
+        /// <summary>
+        /// Found a column on table [{schemaName}].[{tableName}] with an empty or null name. Skipping column.
+        /// </summary>
+        public static string ColumnNameEmpty([CanBeNull] object schemaName, [CanBeNull] object tableName)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("ColumnNameEmpty", "schemaName", "tableName"), schemaName, tableName);
+        }
+
+        /// <summary>
+        /// Found a column on foreign key [{schemaName}].[{tableName}].[{fkName}] with an empty or null name. Not including column in foreign key
+        /// </summary>
+        public static string ColumnNameEmptyOnForeignKey([CanBeNull] object schemaName, [CanBeNull] object tableName, [CanBeNull] object fkName)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("ColumnNameEmptyOnForeignKey", "schemaName", "tableName", "fkName"), schemaName, tableName, fkName);
+        }
+
+        /// <summary>
+        /// Found a column on index [{schemaName}].[{tableName}].[{indexName}] with an empty or null name. Not including column in index.
+        /// </summary>
+        public static string ColumnNameEmptyOnIndex([CanBeNull] object schemaName, [CanBeNull] object tableName, [CanBeNull] object indexName)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("ColumnNameEmptyOnIndex", "schemaName", "tableName", "indexName"), schemaName, tableName, indexName);
         }
 
         /// <summary>
@@ -29,11 +61,51 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
+        /// Found an index on table [{schemaName}].[{tableName}] with an empty or null name. Skipping index.
+        /// </summary>
+        public static string IndexNameEmpty([CanBeNull] object schemaName, [CanBeNull] object tableName)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("IndexNameEmpty", "schemaName", "tableName"), schemaName, tableName);
+        }
+
+        /// <summary>
         /// For column {columnId} unable to convert default value {defaultValue} into type {propertyType}. Will not generate code setting a default value for the property {propertyName} on entity type {entityTypeName}.
         /// </summary>
         public static string UnableToConvertDefaultValue([CanBeNull] object columnId, [CanBeNull] object defaultValue, [CanBeNull] object propertyType, [CanBeNull] object propertyName, [CanBeNull] object entityTypeName)
         {
             return string.Format(CultureInfo.CurrentCulture, GetString("UnableToConvertDefaultValue", "columnId", "defaultValue", "propertyType", "propertyName", "entityTypeName"), columnId, defaultValue, propertyType, propertyName, entityTypeName);
+        }
+
+        /// <summary>
+        /// For foreign Key {fkName}. The column named {columnName} cannot be found on table [{schemaName}].[{tableName}]. Not including column in foreign key definition.
+        /// </summary>
+        public static string UnableToFindColumnForForeignKey([CanBeNull] object fkName, [CanBeNull] object columnName, [CanBeNull] object schemaName, [CanBeNull] object tableName)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("UnableToFindColumnForForeignKey", "fkName", "columnName", "schemaName", "tableName"), fkName, columnName, schemaName, tableName);
+        }
+
+        /// <summary>
+        /// Index {indexName} contains a column named {columnName} which we cannot find on table [{schemaName}].[{tableName}]. Not including column in foreign key definition.
+        /// </summary>
+        public static string UnableToFindColumnForIndex([CanBeNull] object indexName, [CanBeNull] object columnName, [CanBeNull] object schemaName, [CanBeNull] object tableName)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("UnableToFindColumnForIndex", "indexName", "columnName", "schemaName", "tableName"), indexName, columnName, schemaName, tableName);
+        }
+
+        /// <summary>
+        /// For index {indexName}. Unable to find table [{schemaName}].[{tablename}]. Skipping column.
+        /// </summary>
+        public static string UnableToFindIndexForColumn([CanBeNull] object indexName, [CanBeNull] object schemaName, [CanBeNull] object tablename)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("UnableToFindIndexForColumn", "indexName", "schemaName", "tablename"), indexName, schemaName, tablename);
+        }
+
+        /// <summary>
+        /// For column {columnName}. Unable to find table [{schemaName}].[{tablename}]. Skipping column.
+        /// </summary>
+        public static string UnableToFindTableForColumn([CanBeNull] object columnName, [CanBeNull] object schemaName, [CanBeNull] object tablename)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("UnableToFindTableForColumn", "columnName", "schemaName", "tablename"), columnName, schemaName, tablename);
         }
 
         private static string GetString(string name, params string[] formatterNames)

--- a/src/EntityFramework.MicrosoftSqlServer.Design/Properties/SqlServerDesignStrings.resx
+++ b/src/EntityFramework.MicrosoftSqlServer.Design/Properties/SqlServerDesignStrings.resx
@@ -117,13 +117,40 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="CannotFindTableForIndex" xml:space="preserve">
+    <value>For index {indexName}. Unable to find the table [{schemaName}].[{tableName}] to which this index belongs.</value>
+  </data>
   <data name="CannotInterpretSqlServerStringLiteral" xml:space="preserve">
     <value>Unable to interpret the string {sqlServerStringLiteral} as a SQLServer string literal.</value>
+  </data>
+  <data name="ColumnNameEmpty" xml:space="preserve">
+    <value>Found a column on table [{schemaName}].[{tableName}] with an empty or null name. Skipping column.</value>
+  </data>
+  <data name="ColumnNameEmptyOnForeignKey" xml:space="preserve">
+    <value>Found a column on foreign key [{schemaName}].[{tableName}].[{fkName}] with an empty or null name. Not including column in foreign key</value>
+  </data>
+  <data name="ColumnNameEmptyOnIndex" xml:space="preserve">
+    <value>Found a column on index [{schemaName}].[{tableName}].[{indexName}] with an empty or null name. Not including column in index.</value>
   </data>
   <data name="DataTypeDoesNotAllowSqlServerIdentityStrategy" xml:space="preserve">
     <value>For column {columnId}. This column is set up as an Identity column, but the SQL Server data type is {sqlServerDataType}. This will be mapped to CLR type byte which does not allow the SqlServerValueGenerationStrategy.IdentityColumn setting. Generating a matching Property but ignoring the Identity setting.</value>
   </data>
+  <data name="IndexNameEmpty" xml:space="preserve">
+    <value>Found an index on table [{schemaName}].[{tableName}] with an empty or null name. Skipping index.</value>
+  </data>
   <data name="UnableToConvertDefaultValue" xml:space="preserve">
     <value>For column {columnId} unable to convert default value {defaultValue} into type {propertyType}. Will not generate code setting a default value for the property {propertyName} on entity type {entityTypeName}.</value>
+  </data>
+  <data name="UnableToFindColumnForForeignKey" xml:space="preserve">
+    <value>For foreign Key {fkName}. The column named {columnName} cannot be found on table [{schemaName}].[{tableName}]. Not including column in foreign key definition.</value>
+  </data>
+  <data name="UnableToFindColumnForIndex" xml:space="preserve">
+    <value>Index {indexName} contains a column named {columnName} which we cannot find on table [{schemaName}].[{tableName}]. Not including column in foreign key definition.</value>
+  </data>
+  <data name="UnableToFindIndexForColumn" xml:space="preserve">
+    <value>For index {indexName}. Unable to find table [{schemaName}].[{tablename}]. Skipping column.</value>
+  </data>
+  <data name="UnableToFindTableForColumn" xml:space="preserve">
+    <value>For column {columnName}. Unable to find table [{schemaName}].[{tablename}]. Skipping column.</value>
   </data>
 </root>

--- a/src/EntityFramework.MicrosoftSqlServer.Design/SqlServerDatabaseModelFactory.cs
+++ b/src/EntityFramework.MicrosoftSqlServer.Design/SqlServerDatabaseModelFactory.cs
@@ -4,10 +4,14 @@
 using System;
 using System.Collections.Generic;
 using System.Data.SqlClient;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Migrations;
+using Microsoft.Data.Entity.Scaffolding.Internal;
 using Microsoft.Data.Entity.Scaffolding.Metadata;
 using Microsoft.Data.Entity.Utilities;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Data.Entity.Scaffolding
 {
@@ -22,6 +26,15 @@ namespace Microsoft.Data.Entity.Scaffolding
         private static string TableKey(TableModel table) => TableKey(table.Name, table.SchemaName);
         private static string TableKey(string name, string schema = null) => "[" + (schema ?? "") + "].[" + name + "]";
         private static string ColumnKey(TableModel table, string columnName) => TableKey(table) + ".[" + columnName + "]";
+
+        public SqlServerDatabaseModelFactory([NotNull] ILoggerFactory loggerFactory)
+        {
+            Check.NotNull(loggerFactory, nameof(loggerFactory));
+
+            Logger = loggerFactory.CreateCommandsLogger();
+        }
+
+        public virtual ILogger Logger { get; }
 
         private void ResetState()
         {
@@ -59,8 +72,9 @@ namespace Microsoft.Data.Entity.Scaffolding
         private void GetTables()
         {
             var command = _connection.CreateCommand();
-            command.CommandText = "SELECT schema_name(t.schema_id) AS [schema], t.name FROM sys.tables AS t " +
-                                  $"WHERE t.name <> '{HistoryRepository.DefaultTableName}'";
+            command.CommandText =
+                "SELECT schema_name(t.schema_id) AS [schema], t.name FROM sys.tables AS t " +
+                $"WHERE t.name <> '{HistoryRepository.DefaultTableName}'";
             using (var reader = command.ExecuteReader())
             {
                 while (reader.Read())
@@ -83,34 +97,34 @@ namespace Microsoft.Data.Entity.Scaffolding
         private void GetColumns()
         {
             var command = _connection.CreateCommand();
-            command.CommandText = @"SELECT DISTINCT 
-    schema_name(t.schema_id) AS [schema], 
+            command.CommandText = @"SELECT DISTINCT
+    schema_name(t.schema_id) AS [schema],
     t.name AS [table], 
     type_name(c.user_type_id) AS [typename],
-    c.name AS [column_name], 
+    c.name AS [column_name],
     c.column_id AS [ordinal],
     c.is_nullable AS [nullable],
     CAST(ic.key_ordinal AS int) AS [primary_key_ordinal],
-	object_definition(c.default_object_id) AS [default_sql],
+    object_definition(c.default_object_id) AS [default_sql],
     CAST(CASE WHEN c.precision <> tp.precision
-			THEN c.precision
-			ELSE null
-		END AS int) AS [precision],
-	CAST(CASE WHEN c.scale <> tp.scale
-			THEN c.scale
-			ELSE null
-		END AS int) AS [scale],
+            THEN c.precision
+            ELSE null
+        END AS int) AS [precision],
+    CAST(CASE WHEN c.scale <> tp.scale
+            THEN c.scale
+            ELSE null
+        END AS int) AS [scale],
     CAST(CASE WHEN c.max_length <> tp.max_length
-			THEN c.max_length
-			ELSE null
-		END AS int) AS [max_length],
+            THEN c.max_length
+            ELSE null
+        END AS int) AS [max_length],
     c.is_identity,
     c.is_computed
 FROM sys.index_columns ic
-	RIGHT JOIN (SELECT * FROM sys.indexes WHERE is_primary_key = 1) AS i ON i.object_id = ic.object_id AND i.index_id = ic.index_id
-	RIGHT JOIN sys.columns c ON ic.object_id = c.object_id AND c.column_id = ic.column_id
-	RIGHT JOIN sys.types tp ON tp.user_type_id = c.user_type_id
-JOIN sys.tables AS t ON t.object_id = c.object_id
+    RIGHT JOIN (SELECT * FROM sys.indexes WHERE is_primary_key = 1) AS i ON i.object_id = ic.object_id AND i.index_id = ic.index_id
+    RIGHT JOIN sys.columns c ON ic.object_id = c.object_id AND c.column_id = ic.column_id
+    RIGHT JOIN sys.types tp ON tp.user_type_id = c.user_type_id
+    JOIN sys.tables AS t ON t.object_id = c.object_id
 WHERE t.name <> '" + HistoryRepository.DefaultTableName + "'";
 
             using (var reader = command.ExecuteReader())
@@ -119,13 +133,28 @@ WHERE t.name <> '" + HistoryRepository.DefaultTableName + "'";
                 {
                     var schemaName = reader.GetString(0);
                     var tableName = reader.GetString(1);
+                    var columnName = reader.GetStringOrNull(3);
                     if (!_tableSelectionSet.Allows(schemaName, tableName))
                     {
                         continue;
                     }
 
+                    if (string.IsNullOrEmpty(columnName))
+                    {
+                        Logger.LogWarning(SqlServerDesignStrings.ColumnNameEmpty(schemaName, tableName));
+                        continue;
+                    }
+
+                    TableModel table;
+                    if (!_tables.TryGetValue(TableKey(tableName, schemaName), out table))
+                    {
+                        Logger.LogWarning(
+                            SqlServerDesignStrings.UnableToFindTableForColumn(columnName, schemaName, tableName));
+                        continue;
+                    }
+
                     var dataTypeName = reader.GetString(2);
-                    var nullable = reader.GetBoolean(5);
+                    var nullable = reader.IsDBNull(5) ? false : reader.GetBoolean(5);
 
                     var maxLength = reader.IsDBNull(10) ? default(int?) : reader.GetInt32(10);
 
@@ -145,12 +174,11 @@ WHERE t.name <> '" + HistoryRepository.DefaultTableName + "'";
                     var isIdentity = !reader.IsDBNull(11) && reader.GetBoolean(11);
                     var isComputed = reader.GetBoolean(12) || dataTypeName == "timestamp";
 
-                    var table = _tables[TableKey(tableName, schemaName)];
                     var column = new ColumnModel
                     {
                         Table = table,
                         DataType = dataTypeName,
-                        Name = reader.GetString(3),
+                        Name = columnName,
                         Ordinal = reader.GetInt32(4) - 1,
                         IsNullable = nullable,
                         PrimaryKeyOrdinal = reader.IsDBNull(6) ? default(int?) : reader.GetInt32(6),
@@ -174,41 +202,50 @@ WHERE t.name <> '" + HistoryRepository.DefaultTableName + "'";
         private void GetIndexes()
         {
             var command = _connection.CreateCommand();
-            command.CommandText = @"SELECT 
-    i.name AS [index_name],
+            command.CommandText = @"SELECT
     object_schema_name(i.object_id) AS [schema_name],
     object_name(i.object_id) AS [table_name],
-	i.is_unique,
+    i.name AS [index_name],
+    i.is_unique,
     c.name AS [column_name],
     i.type_desc
 FROM sys.indexes i
-    inner join sys.index_columns ic  ON i.object_id = ic.object_id AND i.index_id = ic.index_id
-    inner join sys.columns c ON ic.object_id = c.object_id AND c.column_id = ic.column_id
-WHERE   object_schema_name(i.object_id) <> 'sys' 
+    INNER JOIN sys.index_columns ic  ON i.object_id = ic.object_id AND i.index_id = ic.index_id
+    INNER JOIN sys.columns c ON ic.object_id = c.object_id AND c.column_id = ic.column_id
+WHERE object_schema_name(i.object_id) <> 'sys'
     AND i.is_primary_key <> 1
     AND object_name(i.object_id) <> '" + HistoryRepository.DefaultTableName + @"'
-ORDER BY i.name, ic.key_ordinal";
+ORDER BY object_schema_name(i.object_id), object_name(i.object_id), i.name, ic.key_ordinal";
 
             using (var reader = command.ExecuteReader())
             {
                 IndexModel index = null;
                 while (reader.Read())
                 {
-                    var indexName = reader.GetString(0);
-                    var schemaName = reader.GetString(1);
-                    var tableName = reader.GetString(2);
-
+                    var schemaName = reader.GetString(0);
+                    var tableName = reader.GetString(1);
+                    var indexName = reader.GetStringOrNull(2);
                     if (!_tableSelectionSet.Allows(schemaName, tableName))
                     {
                         continue;
                     }
 
+                    if (string.IsNullOrEmpty(indexName))
+                    {
+                        Logger.LogWarning(SqlServerDesignStrings.IndexNameEmpty(schemaName, tableName));
+                        continue;
+                    }
+
                     if (index == null
-                        || index.Name != indexName)
+                        || index.Name != indexName
+                        || index.Table.Name != tableName
+                        || index.Table.SchemaName != schemaName)
                     {
                         TableModel table;
                         if(!_tables.TryGetValue(TableKey(tableName, schemaName), out table))
                         {
+                            Logger.LogWarning(
+                                SqlServerDesignStrings.UnableToFindTableForColumn(indexName, schemaName, tableName));
                             continue;
                         }
 
@@ -216,14 +253,33 @@ ORDER BY i.name, ic.key_ordinal";
                         {
                             Table = table,
                             Name = indexName,
-                            IsUnique = reader.GetBoolean(3),
-                            IsClustered = (reader.GetString(5) == "CLUSTERED") ? true : default(bool?)
+                            IsUnique = reader.IsDBNull(3) ? false : reader.GetBoolean(3),
+                            IsClustered =
+                                (!reader.IsDBNull(5) && reader.GetString(5) == "CLUSTERED")
+                                ? true
+                                : default(bool?)
                         };
                         table.Indexes.Add(index);
                     }
-                    var columnName = reader.GetString(4);
-                    var column = _tableColumns[ColumnKey(index.Table, columnName)];
-                    index.Columns.Add(column);
+
+                    var columnName = reader.GetStringOrNull(4);
+                    ColumnModel column = null;
+                    if (string.IsNullOrEmpty(columnName))
+                    {
+                        Logger.LogWarning(
+                            SqlServerDesignStrings.ColumnNameEmptyOnIndex(
+                                schemaName, tableName, indexName));
+                    }
+                    else if (!_tableColumns.TryGetValue(ColumnKey(index.Table, columnName), out column))
+                    {
+                        Logger.LogWarning(
+                            SqlServerDesignStrings.UnableToFindColumnForIndex(
+                                indexName, columnName, schemaName, tableName));
+                    }
+                    else
+                    {
+                        index.Columns.Add(column);
+                    }
                 }
             }
         }
@@ -232,9 +288,9 @@ ORDER BY i.name, ic.key_ordinal";
         {
             var command = _connection.CreateCommand();
             command.CommandText = @"SELECT 
-    f.name AS foreign_key_name,
     schema_name(f.schema_id) AS [schema_name],
     object_name(f.parent_object_id) AS table_name,
+    f.name AS foreign_key_name,
     object_schema_name(f.referenced_object_id) AS principal_table_schema_name,
     object_name(f.referenced_object_id) AS principal_table_name,
     col_name(fc.parent_object_id, fc.parent_column_id) AS constraint_column_name,
@@ -243,32 +299,46 @@ ORDER BY i.name, ic.key_ordinal";
     delete_referential_action_desc,
     update_referential_action_desc
 FROM sys.foreign_keys AS f
-INNER JOIN sys.foreign_key_columns AS fc 
-   ON f.object_id = fc.constraint_object_id
-ORDER BY f.name, fc.constraint_column_id";
+    INNER JOIN sys.foreign_key_columns AS fc ON f.object_id = fc.constraint_object_id
+ORDER BY schema_name(f.schema_id), object_name(f.parent_object_id), f.name, fc.constraint_column_id";
             using (var reader = command.ExecuteReader())
             {
-                var lastFkName = "";
+                var lastFkName = string.Empty;
+                var lastFkSchemaName = string.Empty;
+                var lastFkTableName = string.Empty;
                 ForeignKeyModel fkInfo = null;
                 while (reader.Read())
                 {
-                    var fkName = reader.GetString(0);
-                    var schemaName = reader.GetString(1);
-                    var tableName = reader.GetString(2);
+                    var schemaName = reader.GetString(0);
+                    var tableName = reader.GetString(1);
+                    var fkName = reader.GetStringOrNull(2);
+                    if (string.IsNullOrEmpty(fkName))
+                    {
+                        continue;
+                    }
 
                     if (!_tableSelectionSet.Allows(schemaName, tableName))
                     {
                         continue;
                     }
                     if (fkInfo == null
+                        || lastFkSchemaName != schemaName
+                        || lastFkTableName != tableName
                         || lastFkName != fkName)
                     {
                         lastFkName = fkName;
-                        var principalSchemaTableName = reader.GetString(3);
-                        var principalTableName = reader.GetString(4);
+                        lastFkSchemaName = schemaName;
+                        lastFkTableName = tableName;
                         var table = _tables[TableKey(tableName, schemaName)];
-                        TableModel principalTable;
-                        _tables.TryGetValue(TableKey(principalTableName, principalSchemaTableName), out principalTable);
+
+                        var principalSchemaTableName = reader.GetStringOrNull(3);
+                        var principalTableName = reader.GetStringOrNull(4);
+                        TableModel principalTable = null;
+                        if (!string.IsNullOrEmpty(principalSchemaTableName)
+                            && !string.IsNullOrEmpty(principalTableName))
+                        {
+                            _tables.TryGetValue(TableKey(principalTableName, principalSchemaTableName), out principalTable);
+                        }
 
                         fkInfo = new ForeignKeyModel
                         {
@@ -278,19 +348,51 @@ ORDER BY f.name, fc.constraint_column_id";
 
                         table.ForeignKeys.Add(fkInfo);
                     }
-                    var fromColumnName = reader.GetString(5);
-                    var fromColumn = _tableColumns[ColumnKey(fkInfo.Table, fromColumnName)];
-                    fkInfo.Columns.Add(fromColumn);
+
+                    var fromColumnName = reader.GetStringOrNull(5);
+                    ColumnModel fromColumn;
+                    if ((fromColumn = FindColumnForForeignKey(fromColumnName, fkInfo.Table, fkName)) != null)
+                    {
+                        fkInfo.Columns.Add(fromColumn);
+                    }
 
                     if (fkInfo.PrincipalTable != null)
                     {
                         var toColumnName = reader.GetString(6);
-                        var toColumn = _tableColumns[ColumnKey(fkInfo.PrincipalTable, toColumnName)];
-                        fkInfo.PrincipalColumns.Add(toColumn);
+                        ColumnModel toColumn;
+                        if ((toColumn = FindColumnForForeignKey(toColumnName, fkInfo.PrincipalTable, fkName)) != null)
+                        {
+                            fkInfo.PrincipalColumns.Add(toColumn);
+                        }
                     }
 
-                    fkInfo.OnDelete = ConvertToReferentialAction(reader.GetString(8));
+                    fkInfo.OnDelete = ConvertToReferentialAction(reader.GetStringOrNull(8));
                 }
+            }
+        }
+
+        private ColumnModel FindColumnForForeignKey(
+            string columnName, TableModel table, string fkName)
+        {
+            ColumnModel column = null;
+            if (string.IsNullOrEmpty(columnName))
+            {
+                Logger.LogWarning(
+                    SqlServerDesignStrings.ColumnNameEmptyOnForeignKey(
+                        table.SchemaName, table.Name, fkName));
+                return null;
+            }
+            else if (!_tableColumns.TryGetValue(
+                ColumnKey(table, columnName), out column))
+            {
+                Logger.LogWarning(
+                    SqlServerDesignStrings.UnableToFindColumnForForeignKey(
+                        fkName, columnName, table.SchemaName, table.Name));
+                return null;
+            }
+            else
+            {
+                return column;
             }
         }
 

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/SqlServerDatabaseModelFactoryTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/SqlServerDatabaseModelFactoryTest.cs
@@ -9,6 +9,7 @@ using Microsoft.Data.Entity.Migrations;
 using Microsoft.Data.Entity.Scaffolding;
 using Microsoft.Data.Entity.Scaffolding.Metadata;
 using Microsoft.Data.Entity.SqlServer.FunctionalTests;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Microsoft.Data.Entity.SqlServer.Design.FunctionalTests
@@ -257,7 +258,7 @@ CREATE TABLE [dbo].[Kilimanjaro] ( Id int,B varchar, UNIQUE (B ), FOREIGN KEY (B
         {
             _testStore.ExecuteNonQuery(createSql);
 
-            var reader = new SqlServerDatabaseModelFactory();
+            var reader = new SqlServerDatabaseModelFactory(new LoggerFactory());
 
             return reader.Create(_testStore.Connection.ConnectionString, selection ?? TableSelectionSet.All);
         }


### PR DESCRIPTION
Fix for #3861. We had problems with Foreign Keys or Indexes with same name on different tables. We also experienced some problems where we were receiving NULLs in metadata we expected to be non-null or we were unable to find tables for column metadata or columns for indexes/FKs etc. I've fixed the duplicate issue and now we guard against bad metadata and issue warning messages.

