### PR TITLE
Reveng: Only get NONCLUSTERED and CLUSTERED indexes from sys.indexes

### DIFF
--- a/src/EntityFramework.MicrosoftSqlServer.Design/SqlServerDatabaseModelFactory.cs
+++ b/src/EntityFramework.MicrosoftSqlServer.Design/SqlServerDatabaseModelFactory.cs
@@ -214,6 +214,7 @@ FROM sys.indexes i
     INNER JOIN sys.columns c ON ic.object_id = c.object_id AND c.column_id = ic.column_id
 WHERE object_schema_name(i.object_id) <> 'sys'
     AND i.is_primary_key <> 1
+    AND i.type IN (1,2)
     AND object_name(i.object_id) <> '" + HistoryRepository.DefaultTableName + @"'
 ORDER BY object_schema_name(i.object_id), object_name(i.object_id), i.name, ic.key_ordinal";
 


### PR DESCRIPTION
to avoid name being NULL and also ignore other irrelevant index types
https://msdn.microsoft.com/da-dk/library/ms173760.aspx
Fixes some of the issues reported in #3861