### PR TITLE
Conditionally skip SQL Server tests on Linux w/o external server

### DIFF
--- a/test/EntityFramework.Core.FunctionalTests/EntityFramework.Core.FunctionalTests.csproj
+++ b/test/EntityFramework.Core.FunctionalTests/EntityFramework.Core.FunctionalTests.csproj
@@ -163,7 +163,9 @@
     <Compile Include="TestUtilities\PropertyComparer.cs" />
     <Compile Include="TestUtilities\Extensions.cs" />
     <Compile Include="TestUtilities\TestPlatformHelper.cs" />
+    <Compile Include="TestUtilities\Xunit\ConditionalTestFramework.cs" />
     <Compile Include="TestUtilities\Xunit\ConditionalFactDiscoverer.cs" />
+    <Compile Include="TestUtilities\Xunit\ConditionalTestFrameworkExecutor.cs" />
     <Compile Include="TestUtilities\Xunit\ConditionalTheoryDiscoverer.cs" />
     <Compile Include="TestUtilities\Xunit\ConditionalFactAttribute.cs" />
     <Compile Include="TestUtilities\Xunit\ConditionalTheoryAttribute.cs" />

--- a/test/EntityFramework.Core.FunctionalTests/TestUtilities/Xunit/ConditionalTestFramework.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestUtilities/Xunit/ConditionalTestFramework.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+using Microsoft.Data.Entity.FunctionalTests.TestUtilities.Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+// ReSharper disable once CheckNamespace
+public class ConditionalTestFramework : XunitTestFramework
+{
+    public ConditionalTestFramework(IMessageSink messageSink)
+        : base(messageSink)
+    {
+        messageSink.OnMessage(new DiagnosticMessage
+        {
+            Message = "Using " + nameof(ConditionalTestFramework)
+        });
+    }
+
+    protected override ITestFrameworkExecutor CreateExecutor(AssemblyName assemblyName)
+        => new ConditionalTestFrameworkExecutor(assemblyName, SourceInformationProvider, DiagnosticMessageSink);
+}

--- a/test/EntityFramework.Core.FunctionalTests/TestUtilities/Xunit/ConditionalTestFrameworkExecutor.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestUtilities/Xunit/ConditionalTestFrameworkExecutor.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.Data.Entity.FunctionalTests.TestUtilities.Xunit
+{
+    public class ConditionalTestFrameworkExecutor : XunitTestFrameworkExecutor
+    {
+        public ConditionalTestFrameworkExecutor(AssemblyName assemblyName, ISourceInformationProvider sourceInformationProvider, IMessageSink diagnosticMessageSink)
+            : base(assemblyName, sourceInformationProvider, diagnosticMessageSink)
+        {
+        }
+
+        protected override void RunTestCases(IEnumerable<IXunitTestCase> testCases, IMessageSink executionMessageSink, ITestFrameworkExecutionOptions executionOptions)
+        {
+            var skipReason = EvaluateSkipConditions(AssemblyInfo);
+            if (string.IsNullOrEmpty(skipReason))
+            {
+                base.RunTestCases(testCases, executionMessageSink, executionOptions);
+            }
+            else
+            {
+                skipReason = "Unmet assembly test condition(s): " + skipReason;
+                var testCaseCount = testCases.Count();
+                using (var messageBus = CreateMessageBus(executionMessageSink, executionOptions))
+                {
+                    foreach (var test in testCases.Select(testCase => new XunitTest(testCase, testCase.DisplayName)))
+                    {
+                        messageBus.QueueMessage(new TestStarting(test));
+                        messageBus.QueueMessage(new TestSkipped(test, skipReason));
+                        messageBus.QueueMessage(new TestFinished(test, 0, null));
+                    }
+
+                    messageBus.QueueMessage(new TestAssemblyFinished(testCases, TestAssembly, 0, testCaseCount, 0, testCaseCount));
+                }
+            }
+        }
+
+        private IMessageBus CreateMessageBus(IMessageSink messageSink, ITestFrameworkExecutionOptions executionOptions)
+        {
+            if (executionOptions.SynchronousMessageReportingOrDefault())
+            {
+                return new SynchronousMessageBus(messageSink);
+            }
+
+            return new MessageBus(messageSink);
+        }
+
+        private string EvaluateSkipConditions(IAssemblyInfo assembly)
+        {
+            var reasons = assembly
+                .GetCustomAttributes(typeof(ITestCondition))
+                .OfType<ReflectionAttributeInfo>()
+                .Select(attributeInfo => (ITestCondition)attributeInfo.Attribute)
+                .Where(condition => !condition.IsMet)
+                .Select(condition => condition.SkipReason)
+                .ToList();
+
+            return reasons.Count > 0 ? string.Join(Environment.NewLine, reasons) : null;
+        }
+    }
+}

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests.csproj
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests.csproj
@@ -168,6 +168,7 @@
     <Compile Include="ReverseEngineering\SqlServerE2EFixture.cs" />
     <Compile Include="ReverseEngineering\SqlServerE2ETests.cs" />
     <Compile Include="SqlServerDatabaseModelFactoryTest.cs" />
+    <Compile Include="Properties\TestAssemblyConditions.cs" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/Properties/TestAssemblyConditions.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/Properties/TestAssemblyConditions.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.SqlServer.FunctionalTests;
+using Xunit;
+
+[assembly: TestFramework("ConditionalTestFramework", "EntityFramework.Core.FunctionalTests")]
+
+// Skip the entire assembly if not on Windows and no external SQL Server is configured
+
+[assembly: SqlServerConfiguredCondition]

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/EntityFramework.MicrosoftSqlServer.FunctionalTests.csproj
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/EntityFramework.MicrosoftSqlServer.FunctionalTests.csproj
@@ -97,6 +97,7 @@
     <Compile Include="SequenceEndToEndTest.cs" />
     <Compile Include="SequentialGuidEndToEndTest.cs" />
     <Compile Include="SqlServerTriggersTest.cs" />
+    <Compile Include="Properties\TestAssemblyConditions.cs" />
     <Compile Include="Utilities\DbContextOptionsBuilderExtensions.cs" />
     <Compile Include="Utilities\SqlFileLogger.cs" />
     <Compile Include="SqlServerConfigPatternsTest.cs" />

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/Properties/TestAssemblyConditions.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/Properties/TestAssemblyConditions.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.SqlServer.FunctionalTests;
+using Xunit;
+
+[assembly: TestFramework("ConditionalTestFramework", "EntityFramework.Core.FunctionalTests")]
+
+// Skip the entire assembly if not on Windows and no external SQL Server is configured
+
+[assembly: SqlServerConfiguredCondition]

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/Utilities/SqlServerConfiguredConditionAttribute.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/Utilities/SqlServerConfiguredConditionAttribute.cs
@@ -2,16 +2,22 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
+using System.Data.SqlClient;
+using Microsoft.Data.Entity.FunctionalTests.TestUtilities;
 using Microsoft.Data.Entity.FunctionalTests.TestUtilities.Xunit;
 
 namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 {
-    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly)]
     public class SqlServerConfiguredConditionAttribute : Attribute, ITestCondition
     {
-        public bool IsMet => SqlServerTestStore.IsConfigured;
+        private static readonly string _dataSource = new SqlConnectionStringBuilder(SqlServerTestStore.CreateConnectionString("sample")).DataSource;
+        private readonly bool _isLocalDb = _dataSource.StartsWith("(localdb)", StringComparison.OrdinalIgnoreCase);
 
-        public string SkipReason => "No test SQL Server has been configured.";
+        public bool IsMet => TestPlatformHelper.IsWindows || !_isLocalDb;
+
+        public string SkipReason => _isLocalDb
+            ? "LocalDb is not accessible on this platform. An external SQL Server must be configured."
+            : "No test SQL Server has been configured.";
     }
 }

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/Utilities/SqlServerTestStore.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/Utilities/SqlServerTestStore.cs
@@ -11,7 +11,6 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.Entity.FunctionalTests;
-using Microsoft.Data.Entity.FunctionalTests.TestUtilities;
 
 namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 {
@@ -489,8 +488,5 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             };
             return connStrBuilder.ApplyConfiguration().ConnectionString;
         }
-
-        public static bool IsConfigured
-            => TestPlatformHelper.IsWindows || !string.IsNullOrEmpty(TestEnvironment.Config["DataSource"]);
     }
 }

--- a/tools/coreclr-build.sh
+++ b/tools/coreclr-build.sh
@@ -21,16 +21,12 @@ SKIPPED=()
 
 for t in `grep -l "xunit.runner" test/*/project.json`; do
     TEST_DIR=$(dirname $t)
-    if [[ $TEST_DIR == *"MicrosoftSqlServer"* && $TEST_DIR == *"Functional"* && "${Test__SqlServer__DataSource}" == "" ]]; then
-        printf "${YELLOW}Skipping ${TEST_DIR}. Project requires SQL Server${NC}\n"
-        SKIPPED+=("${TEST_DIR} skipped")
-        continue
-    fi
 
     _=$(grep "dnxcore50" $t)
     rc=$?
     if [[ $rc != 0 ]]; then
         printf "${YELLOW}Skipping tests on project ${TEST_DIR}. Project does not support CoreCLR${NC}\n"
+        SKIPPED+=("${TEST_DIR} skipped")
         continue
     fi
     


### PR DESCRIPTION
Use Xunit to skip assemblies rather than test runner. 

Future proofing against pending build system changes.