### PR TITLE
RevEng: Canonicalizing output paths

### DIFF
--- a/src/EntityFramework.Commands/Scaffolding/Internal/ReverseEngineeringGenerator.cs
+++ b/src/EntityFramework.Commands/Scaffolding/Internal/ReverseEngineeringGenerator.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Data.Entity.Scaffolding.Internal
         ///  an <see cref="NamespaceAndOutputPaths"> object containing the canonicalized paths
         ///  and the namespace
         /// </returns>
-        public static NamespaceAndOutputPaths ConstructNamespaceAndCanonicalizedPaths(
+        internal static NamespaceAndOutputPaths ConstructNamespaceAndCanonicalizedPaths(
             [NotNull] string rootNamespace,
             [NotNull] string projectPath,
             [CanBeNull] string outputPath)
@@ -150,7 +150,10 @@ namespace Microsoft.Data.Entity.Scaffolding.Internal
             Check.NotEmpty(rootNamespace, nameof(rootNamespace));
             Check.NotEmpty(projectPath, nameof(projectPath));
 
-            // strip off any directory separator chars at end of project path
+            // Strip off any directory separator chars at end of project path
+            // to ensure that when we strip off the canonicalized project path
+            // later to form the canonicalized relative path we strip off the
+            // correct number of characters.
             for (var projectPathLastChar = projectPath.Last();
                 directorySeparatorChars.Contains(projectPathLastChar);
                 projectPathLastChar = projectPath.Last())
@@ -186,9 +189,9 @@ namespace Microsoft.Data.Entity.Scaffolding.Internal
                 canonicalizedFullOutputPath, canonicalizedRelativeOutputPath);
         }
 
-        public class NamespaceAndOutputPaths
+        internal class NamespaceAndOutputPaths
         {
-            public NamespaceAndOutputPaths(
+            internal NamespaceAndOutputPaths(
                 [NotNull] string @namespace,
                 [NotNull] string canonicalizedFullOutputPath,
                 [CanBeNull] string canonicalizedRelativeOutputPath)
@@ -201,9 +204,9 @@ namespace Microsoft.Data.Entity.Scaffolding.Internal
                 CanonicalizedRelativeOutputPath = canonicalizedRelativeOutputPath;
             }
 
-            public virtual string Namespace { get; }
-            public virtual string CanonicalizedFullOutputPath { get; }
-            public virtual string CanonicalizedRelativeOutputPath { get; }
+            internal string Namespace { get; }
+            internal string CanonicalizedFullOutputPath { get; }
+            internal string CanonicalizedRelativeOutputPath { get; }
         }
     }
 }

--- a/src/EntityFramework.Commands/Scaffolding/Internal/ReverseEngineeringGenerator.cs
+++ b/src/EntityFramework.Commands/Scaffolding/Internal/ReverseEngineeringGenerator.cs
@@ -147,6 +147,7 @@ namespace Microsoft.Data.Entity.Scaffolding.Internal
             [NotNull] string projectPath,
             [CanBeNull] string outputPath)
         {
+            Check.NotEmpty(rootNamespace, nameof(rootNamespace));
             Check.NotEmpty(projectPath, nameof(projectPath));
 
             // strip off any directory separator chars at end of project path

--- a/src/EntityFramework.Commands/Scaffolding/Internal/StringBuilderCodeWriter.cs
+++ b/src/EntityFramework.Commands/Scaffolding/Internal/StringBuilderCodeWriter.cs
@@ -10,10 +10,10 @@ using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Scaffolding.Internal
 {  
-    public class StringBuilderCodeWriter : CodeWriter  
+    public class StringBuilderCodeWriter : CodeWriter
     {  
-        public virtual DbContextWriter DbContextWriter { get; }  
-        public virtual EntityTypeWriter EntityTypeWriter { get; }  
+        public virtual DbContextWriter DbContextWriter { get; }
+        public virtual EntityTypeWriter EntityTypeWriter { get; }
   
         public StringBuilderCodeWriter(  
             [NotNull] IFileService fileService,
@@ -21,43 +21,43 @@ namespace Microsoft.Data.Entity.Scaffolding.Internal
             [NotNull] EntityTypeWriter entityTypeWriter)
             : base(fileService)  
         {  
-            Check.NotNull(dbContextWriter, nameof(dbContextWriter));  
-            Check.NotNull(entityTypeWriter, nameof(entityTypeWriter));  
+            Check.NotNull(dbContextWriter, nameof(dbContextWriter));
+            Check.NotNull(entityTypeWriter, nameof(entityTypeWriter));
   
             DbContextWriter = dbContextWriter;
             EntityTypeWriter = entityTypeWriter;
         }  
   
-        public override Task<ReverseEngineerFiles> WriteCodeAsync(  
+        public override Task<ReverseEngineerFiles> WriteCodeAsync(
             [NotNull] ModelConfiguration modelConfiguration,
             [NotNull] string outputPath,
             [NotNull] string dbContextClassName,
             CancellationToken cancellationToken = default(CancellationToken))
         {  
-            Check.NotNull(modelConfiguration, nameof(modelConfiguration));  
-            Check.NotEmpty(outputPath, nameof(outputPath));  
-            Check.NotEmpty(dbContextClassName, nameof(dbContextClassName));  
+            Check.NotNull(modelConfiguration, nameof(modelConfiguration));
+            Check.NotEmpty(outputPath, nameof(outputPath));
+            Check.NotEmpty(dbContextClassName, nameof(dbContextClassName));
   
-            cancellationToken.ThrowIfCancellationRequested();  
+            cancellationToken.ThrowIfCancellationRequested();
   
-            var resultingFiles = new ReverseEngineerFiles();  
+            var resultingFiles = new ReverseEngineerFiles();
   
-            var generatedCode = DbContextWriter.WriteCode(modelConfiguration);  
+            var generatedCode = DbContextWriter.WriteCode(modelConfiguration);
   
-            // output DbContext .cs file  
-            var dbContextFileName = dbContextClassName + FileExtension;  
+            // output DbContext .cs file
+            var dbContextFileName = dbContextClassName + FileExtension;
             var dbContextFileFullPath = FileService.OutputFile(
-                outputPath, dbContextFileName, generatedCode);  
-            resultingFiles.ContextFile = dbContextFileFullPath;  
+                outputPath, dbContextFileName, generatedCode);
+            resultingFiles.ContextFile = dbContextFileFullPath;
   
-            foreach (var entityConfig in modelConfiguration.EntityConfigurations)  
+            foreach (var entityConfig in modelConfiguration.EntityConfigurations)
             {  
-                generatedCode = EntityTypeWriter.WriteCode(entityConfig);  
+                generatedCode = EntityTypeWriter.WriteCode(entityConfig);
   
-                // output EntityType poco .cs file  
-                var entityTypeFileName = entityConfig.EntityType.DisplayName() + FileExtension;  
+                // output EntityType poco .cs file
+                var entityTypeFileName = entityConfig.EntityType.DisplayName() + FileExtension;
                 var entityTypeFileFullPath = FileService.OutputFile(
-                    outputPath, entityTypeFileName, generatedCode);  
+                    outputPath, entityTypeFileName, generatedCode);
                 resultingFiles.EntityTypeFiles.Add(entityTypeFileFullPath);
             }
             

--- a/test/EntityFramework.Commands.Tests/EntityFramework.Commands.Tests.csproj
+++ b/test/EntityFramework.Commands.Tests/EntityFramework.Commands.Tests.csproj
@@ -46,6 +46,8 @@
     <Compile Include="Migrations\Design\CSharpMigrationOperationGeneratorTest.cs" />
     <Compile Include="Migrations\Design\MigrationScaffolderTest.cs" />
     <Compile Include="Migrations\Design\CSharpHelperTest.cs" />
+    <Compile Include="Scaffolding\Internal\ReverseEngineeringConfigurationTests.cs" />
+    <Compile Include="Scaffolding\Internal\ReverseEngineeringGeneratorTests.cs" />
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
@@ -74,6 +76,7 @@
       <Name>EntityFramework.Relational.Tests</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/test/EntityFramework.Commands.Tests/Scaffolding/Internal/ReverseEngineeringConfigurationTests.cs
+++ b/test/EntityFramework.Commands.Tests/Scaffolding/Internal/ReverseEngineeringConfigurationTests.cs
@@ -3,10 +3,9 @@
 
 using System;
 using Microsoft.Data.Entity.Internal;
-using Microsoft.Data.Entity.Scaffolding.Internal;
 using Xunit;
 
-namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering
+namespace Microsoft.Data.Entity.Scaffolding.Internal
 {
     public class ReverseEngineeringConfigurationTests
     {

--- a/test/EntityFramework.Commands.Tests/Scaffolding/Internal/ReverseEngineeringGeneratorTests.cs
+++ b/test/EntityFramework.Commands.Tests/Scaffolding/Internal/ReverseEngineeringGeneratorTests.cs
@@ -1,12 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.IO;
-using Microsoft.Data.Entity.Scaffolding.Internal;
 using Xunit;
 
-namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering
+namespace Microsoft.Data.Entity.Scaffolding.Internal
 {
     public class ReverseEngineeringGeneratorTests
     {

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/SqlServerE2ETests.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/SqlServerE2ETests.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Data.Entity.SqlServer.Design.FunctionalTests.ReverseEngineer
 
             var filePaths = Generator.GenerateAsync(configuration).GetAwaiter().GetResult();
 
-            var actualFileSet = new FileSet(InMemoryFiles, Path.Combine(TestProjectDir, TestSubDir))
+            var actualFileSet = new FileSet(InMemoryFiles, Path.GetFullPath(Path.Combine(TestProjectDir, TestSubDir)))
             {
                 Files = Enumerable.Repeat(filePaths.ContextFile, 1).Concat(filePaths.EntityTypeFiles).Select(Path.GetFileName).ToList()
             };
@@ -169,7 +169,7 @@ namespace Microsoft.Data.Entity.SqlServer.Design.FunctionalTests.ReverseEngineer
 
             var filePaths = Generator.GenerateAsync(configuration).GetAwaiter().GetResult();
 
-            var actualFileSet = new FileSet(InMemoryFiles, TestProjectDir)
+            var actualFileSet = new FileSet(InMemoryFiles, Path.GetFullPath(TestProjectDir))
             {
                 Files = Enumerable.Repeat(filePaths.ContextFile, 1).Concat(filePaths.EntityTypeFiles).Select(Path.GetFileName).ToList()
             };

--- a/test/EntityFramework.Relational.Design.Tests/EntityFramework.Relational.Design.Tests.csproj
+++ b/test/EntityFramework.Relational.Design.Tests/EntityFramework.Relational.Design.Tests.csproj
@@ -36,9 +36,7 @@
     <Compile Include="CSharpUniqueNamerTest.cs" />
     <Compile Include="NullLogger.cs" />
     <Compile Include="RelationalDatabaseModelFactoryTest.cs" />
-    <Compile Include="ReverseEngineering\ReverseEngineeringConfigurationTests.cs" />
     <Compile Include="ScaffoldingMetadataExtenstionsTest.cs" />
-    <Compile Include="ReverseEngineering\ReverseEngineeringGeneratorTests.cs" />
     <Compile Include="TestLogger.cs" />
     <None Include="project.json" />
   </ItemGroup>

--- a/test/EntityFramework.Relational.Design.Tests/ReverseEngineering/ReverseEngineeringGeneratorTests.cs
+++ b/test/EntityFramework.Relational.Design.Tests/ReverseEngineering/ReverseEngineeringGeneratorTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 using Microsoft.Data.Entity.Scaffolding.Internal;
 using Xunit;
@@ -14,8 +15,20 @@ namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering
         public void Constructs_correct_namespace(
             string rootNamespace, string projectPath, string outputPath, string resultingNamespace)
         {
+            var outputPaths = ReverseEngineeringGenerator.ConstructCanonicalizedPaths(projectPath, outputPath);
             Assert.Equal(resultingNamespace,
-                ReverseEngineeringGenerator.ConstructNamespace(rootNamespace, projectPath, outputPath));
+                ReverseEngineeringGenerator.ConstructNamespace(rootNamespace, outputPaths.CanonicalizedRelativeOutputPath));
+        }
+
+        [Theory]
+        [MemberData(nameof(PathOptions))]
+        public void Constructs_correct_canonical_paths(
+            string projectPath, string outputPath,
+            string canonicalizedFullOutputPath, string canonicalizedRelativeOutputPath)
+        {
+            var outputPaths = ReverseEngineeringGenerator.ConstructCanonicalizedPaths(projectPath, outputPath);
+            Assert.Equal(canonicalizedFullOutputPath, outputPaths.CanonicalizedFullOutputPath);
+            Assert.Equal(canonicalizedRelativeOutputPath, outputPaths.CanonicalizedRelativeOutputPath);
         }
 
         public static TheoryData NamespaceOptions
@@ -40,6 +53,38 @@ namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering
                     data.Add("Root.Namespace", @"project\Path", @"..\..\Path\Outside\Project", "Root.Namespace");
                     data.Add("Root.Namespace", @"project\Path", @"Path\Inside\Project", "Root.Namespace.Path.Inside.Project");
                     data.Add("Root.Namespace", @"project\Path", @"Keyword\volatile\123\Bad!$&Chars", "Root.Namespace.Keyword._volatile._123.Bad___Chars");
+                }
+
+                return data;
+            }
+        }
+
+        public static TheoryData PathOptions
+        {
+            get
+            {
+                var data = new TheoryData<string, string, string, string>();
+
+                if (Path.DirectorySeparatorChar == '\\'
+                    || Path.AltDirectorySeparatorChar == '\\')
+                {
+                    data.Add(@"X:\project\Path", null, @"X:\project\Path", string.Empty);
+                    data.Add(@"X:\project\Path", string.Empty, @"X:\project\Path", string.Empty);
+                    data.Add(@"X:\project\Path", @"X:\Absolute\Output\Path", @"X:\Absolute\Output\Path", null);
+                    data.Add(@"X:\project\Path", @"..\..\Path\Outside\Project", @"X:\Path\Outside\Project", null);
+                    data.Add(@"X:\project\Path", @"Path\Inside\Project", @"X:\project\Path\Path\Inside\Project", @"Path\Inside\Project");
+                    data.Add(@"X:\project\Path", @"Path\.\Inside\Project", @"X:\project\Path\Path\Inside\Project", @"Path\Inside\Project");
+                    data.Add(@"X:\project\Path", @"FirstDir\IgnoreThisDir\..\AnotherDir", @"X:\project\Path\FirstDir\AnotherDir", @"FirstDir\AnotherDir");
+                }
+                else
+                {
+                    data.Add("/project/Path", null, "/project/Path", string.Empty);
+                    data.Add("/project/Path", string.Empty, "project/Path", string.Empty);
+                    data.Add("/project/Path", "/Absolute/Output/Path", "/Absolute/Output/Path", null);
+                    data.Add("/project/Path", "../../Path/Outside/Project", "/Path/Outside/Project", null);
+                    data.Add("/project/Path", "Path/Inside/Project", "/project/Path/Path/Inside/Project", "Path/Inside/Project");
+                    data.Add("/project/Path", "Path/./Inside/Project", "/project/Path/Path/Inside/Project", "Path/Inside/Project");
+                    data.Add("/project/Path", "FirstDir/IgnoreThisDir/../AnotherDir", "/project/Path/FirstDir/AnotherDir", "FirstDir/AnotherDir");
                 }
 
                 return data;

--- a/test/EntityFramework.Relational.Design.Tests/ReverseEngineering/ReverseEngineeringGeneratorTests.cs
+++ b/test/EntityFramework.Relational.Design.Tests/ReverseEngineering/ReverseEngineeringGeneratorTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Data.Entity.Relational.Design.ReverseEngineering
                 else
                 {
                     data.Add("Root.Namespace", "/project/Path", null, "Root.Namespace", "/project/Path", string.Empty);
-                    data.Add("Root.Namespace", "/project/Path", string.Empty, "Root.Namespace", "project/Path", string.Empty);
+                    data.Add("Root.Namespace", "/project/Path", string.Empty, "Root.Namespace", "/project/Path", string.Empty);
                     data.Add("Root.Namespace", "/project/Path", "/Absolute/Output/Path", "Root.Namespace", "/Absolute/Output/Path", null);
                     data.Add("Root.Namespace", "/project/Path", "../../Path/Outside/Project", "Root.Namespace", "/Path/Outside/Project", null);
                     data.Add("Root.Namespace", "/project/Path", "Path/Inside/Project", "Root.Namespace.Path.Inside.Project", "/project/Path/Path/Inside/Project", "Path/Inside/Project");

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/SqliteE2ETestBase.cs
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/SqliteE2ETestBase.cs
@@ -18,6 +18,9 @@ namespace Microsoft.Data.Entity.Sqlite.Design.FunctionalTests.ReverseEngineering
 {
     public abstract class SqliteE2ETestBase : E2ETestBase
     {
+        public const string TestProjectPath = "testout";
+        public static readonly string TestProjectFullPath = Path.GetFullPath(TestProjectPath);
+
         public SqliteE2ETestBase(ITestOutputHelper output)
             : base(output)
         {
@@ -44,7 +47,7 @@ CREATE TABLE IF NOT EXISTS Dependent (
                 var results = await Generator.GenerateAsync(new ReverseEngineeringConfiguration
                 {
                     ConnectionString = testStore.Connection.ConnectionString,
-                    ProjectPath = "testout",
+                    ProjectPath = TestProjectPath,
                     ProjectRootNamespace = "E2E.Sqlite",
                     UseFluentApiOnly = UseFluentApiOnly,
                     TableSelectionSet = TableSelectionSet.All
@@ -61,7 +64,7 @@ CREATE TABLE IF NOT EXISTS Dependent (
                         "Principal.expected"
                     }
                 };
-                var actualFileSet = new FileSet(InMemoryFiles, "testout")
+                var actualFileSet = new FileSet(InMemoryFiles, TestProjectFullPath)
                 {
                     Files = Enumerable.Repeat(results.ContextFile, 1).Concat(results.EntityTypeFiles).Select(Path.GetFileName).ToList()
                 };
@@ -98,7 +101,7 @@ CREATE TABLE IF NOT EXISTS OneToManyDependent (
                 var results = await Generator.GenerateAsync(new ReverseEngineeringConfiguration
                 {
                     ConnectionString = testStore.Connection.ConnectionString,
-                    ProjectPath = "testout",
+                    ProjectPath = TestProjectPath,
                     ProjectRootNamespace = "E2E.Sqlite",
                     UseFluentApiOnly = UseFluentApiOnly,
                     TableSelectionSet = TableSelectionSet.All
@@ -115,7 +118,7 @@ CREATE TABLE IF NOT EXISTS OneToManyDependent (
                         "OneToManyPrincipal.expected"
                     }
                 };
-                var actualFileSet = new FileSet(InMemoryFiles, "testout")
+                var actualFileSet = new FileSet(InMemoryFiles, TestProjectFullPath)
                 {
                     Files = Enumerable.Repeat(results.ContextFile, 1).Concat(results.EntityTypeFiles).Select(Path.GetFileName).ToList()
                 };
@@ -146,7 +149,7 @@ CREATE TABLE Users_Groups (
                 var results = await Generator.GenerateAsync(new ReverseEngineeringConfiguration
                 {
                     ConnectionString = testStore.Connection.ConnectionString,
-                    ProjectPath = "testout",
+                    ProjectPath = TestProjectPath,
                     ProjectRootNamespace = "E2E.Sqlite",
                     UseFluentApiOnly = UseFluentApiOnly,
                     TableSelectionSet = TableSelectionSet.All
@@ -164,7 +167,7 @@ CREATE TABLE Users_Groups (
                         "Users_Groups.expected"
                     }
                 };
-                var actualFileSet = new FileSet(InMemoryFiles, "testout")
+                var actualFileSet = new FileSet(InMemoryFiles, TestProjectFullPath)
                 {
                     Files = Enumerable.Repeat(results.ContextFile, 1).Concat(results.EntityTypeFiles).Select(Path.GetFileName).ToList()
                 };
@@ -188,7 +191,7 @@ CREATE TABLE Users_Groups (
                 var results = await Generator.GenerateAsync(new ReverseEngineeringConfiguration
                 {
                     ConnectionString = testStore.Connection.ConnectionString,
-                    ProjectPath = "testout",
+                    ProjectPath = TestProjectPath,
                     ProjectRootNamespace = "E2E.Sqlite",
                     UseFluentApiOnly = UseFluentApiOnly,
                     TableSelectionSet = TableSelectionSet.All
@@ -204,7 +207,7 @@ CREATE TABLE Users_Groups (
                         "SelfRef.expected"
                     }
                 };
-                var actualFileSet = new FileSet(InMemoryFiles, "testout")
+                var actualFileSet = new FileSet(InMemoryFiles, TestProjectFullPath)
                 {
                     Files = Enumerable.Repeat(results.ContextFile, 1).Concat(results.EntityTypeFiles).Select(Path.GetFileName).ToList()
                 };
@@ -223,7 +226,7 @@ CREATE TABLE Users_Groups (
                 var results = await Generator.GenerateAsync(new ReverseEngineeringConfiguration
                 {
                     ConnectionString = testStore.Connection.ConnectionString,
-                    ProjectPath = "testout",
+                    ProjectPath = TestProjectPath,
                     ProjectRootNamespace = "E2E.Sqlite",
                     UseFluentApiOnly = UseFluentApiOnly,
                     TableSelectionSet = TableSelectionSet.All
@@ -238,7 +241,7 @@ CREATE TABLE Users_Groups (
                     }
                 };
                 AssertLog(expectedLog);
-                Assert.Contains(errorMessage, InMemoryFiles.RetrieveFileContents("testout", Path.GetFileName(results.ContextFile)));
+                Assert.Contains(errorMessage, InMemoryFiles.RetrieveFileContents(TestProjectFullPath, Path.GetFileName(results.ContextFile)));
             }
         }
 
@@ -258,7 +261,7 @@ CREATE TABLE Principal ( Id INT);");
                 var results = await Generator.GenerateAsync(new ReverseEngineeringConfiguration
                 {
                     ConnectionString = testStore.Connection.ConnectionString,
-                    ProjectPath = "testout",
+                    ProjectPath = TestProjectPath,
                     ProjectRootNamespace = "E2E.Sqlite",
                     UseFluentApiOnly = UseFluentApiOnly,
                     TableSelectionSet = TableSelectionSet.All
@@ -283,7 +286,7 @@ CREATE TABLE Principal ( Id INT);");
                         "Dependent.expected",
                     }
                 };
-                var actualFileSet = new FileSet(InMemoryFiles, "testout")
+                var actualFileSet = new FileSet(InMemoryFiles, TestProjectFullPath)
                 {
                     Files = Enumerable.Repeat(results.ContextFile, 1).Concat(results.EntityTypeFiles).Select(Path.GetFileName).ToList()
                 };
@@ -325,7 +328,7 @@ CREATE TABLE String (
                 var results = await Generator.GenerateAsync(new ReverseEngineeringConfiguration
                 {
                     ConnectionString = testStore.Connection.ConnectionString,
-                    ProjectPath = "testout",
+                    ProjectPath = TestProjectPath,
                     ProjectRootNamespace = "E2E.Sqlite",
                     UseFluentApiOnly = UseFluentApiOnly,
                     TableSelectionSet = TableSelectionSet.All
@@ -333,7 +336,7 @@ CREATE TABLE String (
 
                 AssertLog(new LoggerMessages());
 
-                var files = new FileSet(InMemoryFiles, "testout")
+                var files = new FileSet(InMemoryFiles, TestProjectFullPath)
                 {
                     Files = Enumerable.Repeat(results.ContextFile, 1).Concat(results.EntityTypeFiles).Select(Path.GetFileName).ToList()
                 };
@@ -363,7 +366,7 @@ CREATE TABLE Comment (
                 {
                     ConnectionString = testStore.Connection.ConnectionString,
                     ContextClassName = "FkToAltKeyContext",
-                    ProjectPath = "testout",
+                    ProjectPath = TestProjectPath,
                     ProjectRootNamespace = "E2E.Sqlite",
                     UseFluentApiOnly = UseFluentApiOnly,
                     TableSelectionSet = TableSelectionSet.All
@@ -380,7 +383,7 @@ CREATE TABLE Comment (
                         "User.expected"
                     }
                 };
-                var actualFileSet = new FileSet(InMemoryFiles, "testout")
+                var actualFileSet = new FileSet(InMemoryFiles, TestProjectFullPath)
                 {
                     Files = Enumerable.Repeat(results.ContextFile, 1).Concat(results.EntityTypeFiles).Select(Path.GetFileName).ToList()
                 };


### PR DESCRIPTION
Fix for #3830. For Scaffold-DbContext we send back a list of the paths to the generated files to powershell so that it can update the VS project to include them in the project. When the output directory looked like ".\Models" we were sending back filenames like "X:\Project\Path\\.\Models\MyEntity.cs". The extra "." was being interpreted by the VS AddFromFile() API as a real part of the name of the file. This fixes that by canonicalizing the name of the path before it get sent back so that the above now becomes "X:\Project\Path\Models\MyEntity.cs".