### PR TITLE
Allow generic, non-boxing access to state entry values

### DIFF
--- a/src/EntityFramework.Core/ChangeTracking/Internal/ISnapshot.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/ISnapshot.cs
@@ -8,5 +8,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
     public interface ISnapshot
     {
         object this[int index] { get; [param: CanBeNull] set; }
+
+        T GetValue<T>(int index);
     }
 }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -225,7 +225,41 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         internal static readonly MethodInfo ReadShadowValueMethod
             = typeof(InternalEntityEntry).GetTypeInfo().GetDeclaredMethod(nameof(ReadShadowValue));
 
-        public virtual object ReadShadowValue(int shadowIndex) => null;
+        [UsedImplicitly]
+        protected virtual T ReadShadowValue<T>(int shadowIndex) => default(T);
+
+        internal static readonly MethodInfo ReadOriginalValueMethod
+            = typeof(InternalEntityEntry).GetTypeInfo().GetDeclaredMethod(nameof(ReadOriginalValue));
+
+        [UsedImplicitly]
+        private T ReadOriginalValue<T>(IProperty property, int originalValueIndex) 
+            => _originalValues.GetValue<T>(this, property, originalValueIndex);
+
+        internal static readonly MethodInfo ReadRelationshipSnapshotValueMethod
+            = typeof(InternalEntityEntry).GetTypeInfo().GetDeclaredMethod(nameof(ReadRelationshipSnapshotValue));
+
+        [UsedImplicitly]
+        private T ReadRelationshipSnapshotValue<T>(IPropertyBase propertyBase, int relationshipSnapshotIndex)
+            => _relationshipsSnapshot.GetValue<T>(this, propertyBase, relationshipSnapshotIndex);
+
+        internal static readonly MethodInfo ReadStoreGeneratedValueMethod
+            = typeof(InternalEntityEntry).GetTypeInfo().GetDeclaredMethod(nameof(ReadStoreGeneratedValue));
+
+        [UsedImplicitly]
+        private T ReadStoreGeneratedValue<T>(T currentValue, int storeGeneratedIndex)
+            => _storeGeneratedValues.GetValue<T>(currentValue, storeGeneratedIndex);
+
+        internal static readonly MethodInfo GetCurrentValueMethod
+            = typeof(InternalEntityEntry).GetTypeInfo().GetDeclaredMethod(nameof(GetCurrentValue));
+
+        public virtual TProperty GetCurrentValue<TProperty>([NotNull] IPropertyBase propertyBase)
+            => ((Func<InternalEntityEntry, TProperty>)propertyBase.GetPropertyAccessors().CurrentValueGetter)(this);
+
+        public virtual TProperty GetOriginalValue<TProperty>([NotNull] IProperty property)
+            => ((Func<InternalEntityEntry, TProperty>)property.GetPropertyAccessors().OriginalValueGetter)(this);
+
+        public virtual TProperty GetRelationshipSnapshotValue<TProperty>([NotNull] IPropertyBase propertyBase)
+            => ((Func<InternalEntityEntry, TProperty>)propertyBase.GetPropertyAccessors().RelationshipSnapshotGetter)(this);
 
         protected virtual object ReadPropertyValue([NotNull] IPropertyBase propertyBase)
         {

--- a/src/EntityFramework.Core/ChangeTracking/Internal/InternalMixedEntityEntry.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/InternalMixedEntityEntry.cs
@@ -35,8 +35,8 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
         public override object Entity { get; }
 
-        public override object ReadShadowValue(int shadowIndex)
-            => _shadowValues[shadowIndex];
+        protected override T ReadShadowValue<T>(int shadowIndex)
+            => _shadowValues.GetValue<T>(shadowIndex);
 
         protected override object ReadPropertyValue(IPropertyBase propertyBase)
         {

--- a/src/EntityFramework.Core/ChangeTracking/Internal/InternalShadowEntityEntry.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/InternalShadowEntityEntry.cs
@@ -32,8 +32,8 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
             _propertyValues = entityType.GetShadowValuesFactory()(valueBuffer);
         }
 
-        public override object ReadShadowValue(int shadowIndex)
-            => _propertyValues[shadowIndex];
+        protected override T ReadShadowValue<T>(int shadowIndex)
+            => _propertyValues.GetValue<T>(shadowIndex);
 
         protected override object ReadPropertyValue(IPropertyBase propertyBase)
         {

--- a/src/EntityFramework.Core/ChangeTracking/Internal/MultiSnapshot.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/MultiSnapshot.cs
@@ -19,6 +19,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         internal static readonly ConstructorInfo Constructor 
             = typeof(MultiSnapshot).GetDeclaredConstructor(new[] { typeof(ISnapshot[]) });
 
+        public T GetValue<T>(int index) 
+            => _snapshots[index / Snapshot.MaxGenericTypes].GetValue<T>(index % Snapshot.MaxGenericTypes);
+
         public object this[int index]
         {
             get { return _snapshots[index / Snapshot.MaxGenericTypes][index % Snapshot.MaxGenericTypes]; }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/OriginalValues.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/OriginalValues.cs
@@ -30,6 +30,11 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
                 return index != -1 ? _values[index] : entry[property];
             }
 
+            public T GetValue<T>(InternalEntityEntry entry, IProperty property, int index) 
+                => IsEmpty 
+                ? entry.GetCurrentValue<T>(property) 
+                : _values.GetValue<T>(index);
+
             public void SetValue(IProperty property, object value)
             {
                 Debug.Assert(!IsEmpty);

--- a/src/EntityFramework.Core/ChangeTracking/Internal/RelationshipsSnapshot.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/RelationshipsSnapshot.cs
@@ -23,6 +23,11 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
             public object GetValue(InternalEntityEntry entry, IPropertyBase propertyBase)
                 => IsEmpty ? entry[propertyBase] : _values[propertyBase.GetRelationshipIndex()];
 
+            public T GetValue<T>(InternalEntityEntry entry, IPropertyBase propertyBase, int index)
+                => IsEmpty
+                ? entry.GetCurrentValue<T>(propertyBase)
+                : _values.GetValue<T>(index);
+
             public void SetValue(IPropertyBase propertyBase, object value)
             {
                 if (value == null)

--- a/src/EntityFramework.Core/ChangeTracking/Internal/Snapshot.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/Snapshot.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq.Expressions;
+using System.Reflection;
 using JetBrains.Annotations;
 
 namespace Microsoft.Data.Entity.ChangeTracking.Internal
@@ -20,6 +22,28 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         {
             get { throw new IndexOutOfRangeException(); }
             set { throw new IndexOutOfRangeException(); }
+        }
+
+        public T GetValue<T>(int index)
+        {
+            throw new IndexOutOfRangeException();
+        }
+
+        public static Delegate[] CreateReaders<TSnapshot>()
+        {
+            var genericArguments = typeof(TSnapshot).GetTypeInfo().GenericTypeArguments;
+            var delegates = new Delegate[genericArguments.Length];
+
+            for (var i = 0; i < genericArguments.Length; ++i)
+            {
+                var snapshotParameter = Expression.Parameter(typeof(TSnapshot), "snapshot");
+
+                delegates[i] = Expression.Lambda(typeof(Func<,>).MakeGenericType(typeof(TSnapshot), genericArguments[i]),
+                    Expression.Field(snapshotParameter, "_value" + i), snapshotParameter)
+                    .Compile();
+            }
+
+            return delegates;
         }
 
         public static Type CreateSnapshotType([NotNull] Type[] types)
@@ -92,9 +116,12 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         }
     }
 
-    public struct Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>
+    public sealed class Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>
         : ISnapshot
     {
+        private static readonly Delegate[] _valueReaders
+            = Snapshot.CreateReaders<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>>();
+
         public Snapshot(
             [CanBeNull] T0 value0,
             [CanBeNull] T1 value1,
@@ -189,6 +216,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         private T27 _value27;
         private T28 _value28;
         private T29 _value29;
+
+        public T GetValue<T>(int index)
+            => ((Func<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>, T>)_valueReaders[index])(this);
 
         public object this[int index]
         {
@@ -361,9 +391,12 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         }
     }
 
-    public struct Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>
+    public sealed class Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>
         : ISnapshot
     {
+        private static readonly Delegate[] _valueReaders
+            = Snapshot.CreateReaders<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>>();
+
         public Snapshot(
             [CanBeNull] T0 value0,
             [CanBeNull] T1 value1,
@@ -455,6 +488,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         private T26 _value26;
         private T27 _value27;
         private T28 _value28;
+
+        public T GetValue<T>(int index)
+            => ((Func<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>, T>)_valueReaders[index])(this);
 
         public object this[int index]
         {
@@ -622,9 +658,12 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         }
     }
 
-    public struct Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>
+    public sealed class Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>
         : ISnapshot
     {
+        private static readonly Delegate[] _valueReaders
+            = Snapshot.CreateReaders<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>>();
+
         public Snapshot(
             [CanBeNull] T0 value0,
             [CanBeNull] T1 value1,
@@ -713,6 +752,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         private T25 _value25;
         private T26 _value26;
         private T27 _value27;
+
+        public T GetValue<T>(int index)
+            => ((Func<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>, T>)_valueReaders[index])(this);
 
         public object this[int index]
         {
@@ -875,9 +917,12 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         }
     }
 
-    public struct Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>
+    public sealed class Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>
         : ISnapshot
     {
+        private static readonly Delegate[] _valueReaders
+            = Snapshot.CreateReaders<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>>();
+
         public Snapshot(
             [CanBeNull] T0 value0,
             [CanBeNull] T1 value1,
@@ -963,6 +1008,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         private T24 _value24;
         private T25 _value25;
         private T26 _value26;
+
+        public T GetValue<T>(int index)
+            => ((Func<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>, T>)_valueReaders[index])(this);
 
         public object this[int index]
         {
@@ -1120,9 +1168,12 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         }
     }
 
-    public struct Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>
+    public sealed class Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>
         : ISnapshot
     {
+        private static readonly Delegate[] _valueReaders
+            = Snapshot.CreateReaders<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>>();
+
         public Snapshot(
             [CanBeNull] T0 value0,
             [CanBeNull] T1 value1,
@@ -1205,6 +1256,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         private T23 _value23;
         private T24 _value24;
         private T25 _value25;
+
+        public T GetValue<T>(int index)
+            => ((Func<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>, T>)_valueReaders[index])(this);
 
         public object this[int index]
         {
@@ -1357,9 +1411,12 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         }
     }
 
-    public struct Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>
+    public sealed class Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>
         : ISnapshot
     {
+        private static readonly Delegate[] _valueReaders
+            = Snapshot.CreateReaders<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>>();
+
         public Snapshot(
             [CanBeNull] T0 value0,
             [CanBeNull] T1 value1,
@@ -1439,6 +1496,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         private T22 _value22;
         private T23 _value23;
         private T24 _value24;
+
+        public T GetValue<T>(int index)
+            => ((Func<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>, T>)_valueReaders[index])(this);
 
         public object this[int index]
         {
@@ -1586,9 +1646,12 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         }
     }
 
-    public struct Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>
+    public sealed class Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>
         : ISnapshot
     {
+        private static readonly Delegate[] _valueReaders
+            = Snapshot.CreateReaders<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>>();
+
         public Snapshot(
             [CanBeNull] T0 value0,
             [CanBeNull] T1 value1,
@@ -1665,6 +1728,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         private T21 _value21;
         private T22 _value22;
         private T23 _value23;
+
+        public T GetValue<T>(int index)
+            => ((Func<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>, T>)_valueReaders[index])(this);
 
         public object this[int index]
         {
@@ -1807,9 +1873,12 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         }
     }
 
-    public struct Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>
+    public sealed class Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>
         : ISnapshot
     {
+        private static readonly Delegate[] _valueReaders
+            = Snapshot.CreateReaders<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>>();
+
         public Snapshot(
             [CanBeNull] T0 value0,
             [CanBeNull] T1 value1,
@@ -1883,6 +1952,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         private T20 _value20;
         private T21 _value21;
         private T22 _value22;
+
+        public T GetValue<T>(int index)
+            => ((Func<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>, T>)_valueReaders[index])(this);
 
         public object this[int index]
         {
@@ -2020,9 +2092,12 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         }
     }
 
-    public struct Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>
+    public sealed class Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>
         : ISnapshot
     {
+        private static readonly Delegate[] _valueReaders
+            = Snapshot.CreateReaders<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>>();
+
         public Snapshot(
             [CanBeNull] T0 value0,
             [CanBeNull] T1 value1,
@@ -2093,6 +2168,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         private T19 _value19;
         private T20 _value20;
         private T21 _value21;
+
+        public T GetValue<T>(int index)
+            => ((Func<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>, T>)_valueReaders[index])(this);
 
         public object this[int index]
         {
@@ -2225,9 +2303,12 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         }
     }
 
-    public struct Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>
+    public sealed class Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>
         : ISnapshot
     {
+        private static readonly Delegate[] _valueReaders
+            = Snapshot.CreateReaders<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>>();
+
         public Snapshot(
             [CanBeNull] T0 value0,
             [CanBeNull] T1 value1,
@@ -2295,6 +2376,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         private T18 _value18;
         private T19 _value19;
         private T20 _value20;
+
+        public T GetValue<T>(int index)
+            => ((Func<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>, T>)_valueReaders[index])(this);
 
         public object this[int index]
         {
@@ -2422,9 +2506,12 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         }
     }
 
-    public struct Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>
+    public sealed class Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>
         : ISnapshot
     {
+        private static readonly Delegate[] _valueReaders
+            = Snapshot.CreateReaders<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>>();
+
         public Snapshot(
             [CanBeNull] T0 value0,
             [CanBeNull] T1 value1,
@@ -2489,6 +2576,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         private T17 _value17;
         private T18 _value18;
         private T19 _value19;
+
+        public T GetValue<T>(int index)
+            => ((Func<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>, T>)_valueReaders[index])(this);
 
         public object this[int index]
         {
@@ -2611,9 +2701,12 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         }
     }
 
-    public struct Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>
+    public sealed class Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>
         : ISnapshot
     {
+        private static readonly Delegate[] _valueReaders
+            = Snapshot.CreateReaders<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>>();
+
         public Snapshot(
             [CanBeNull] T0 value0,
             [CanBeNull] T1 value1,
@@ -2675,6 +2768,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         private T16 _value16;
         private T17 _value17;
         private T18 _value18;
+
+        public T GetValue<T>(int index)
+            => ((Func<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>, T>)_valueReaders[index])(this);
 
         public object this[int index]
         {
@@ -2792,9 +2888,12 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         }
     }
 
-    public struct Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>
+    public sealed class Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>
         : ISnapshot
     {
+        private static readonly Delegate[] _valueReaders
+            = Snapshot.CreateReaders<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>>();
+
         public Snapshot(
             [CanBeNull] T0 value0,
             [CanBeNull] T1 value1,
@@ -2853,6 +2952,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         private T15 _value15;
         private T16 _value16;
         private T17 _value17;
+
+        public T GetValue<T>(int index)
+            => ((Func<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>, T>)_valueReaders[index])(this);
 
         public object this[int index]
         {
@@ -2965,9 +3067,12 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         }
     }
 
-    public struct Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>
+    public sealed class Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>
         : ISnapshot
     {
+        private static readonly Delegate[] _valueReaders
+            = Snapshot.CreateReaders<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>>();
+
         public Snapshot(
             [CanBeNull] T0 value0,
             [CanBeNull] T1 value1,
@@ -3023,6 +3128,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         private T14 _value14;
         private T15 _value15;
         private T16 _value16;
+
+        public T GetValue<T>(int index)
+            => ((Func<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>, T>)_valueReaders[index])(this);
 
         public object this[int index]
         {
@@ -3130,9 +3238,12 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         }
     }
 
-    public struct Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>
+    public sealed class Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>
         : ISnapshot
     {
+        private static readonly Delegate[] _valueReaders
+            = Snapshot.CreateReaders<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>>();
+
         public Snapshot(
             [CanBeNull] T0 value0,
             [CanBeNull] T1 value1,
@@ -3185,6 +3296,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         private T13 _value13;
         private T14 _value14;
         private T15 _value15;
+
+        public T GetValue<T>(int index)
+            => ((Func<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>, T>)_valueReaders[index])(this);
 
         public object this[int index]
         {
@@ -3287,9 +3401,12 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         }
     }
 
-    public struct Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>
+    public sealed class Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>
         : ISnapshot
     {
+        private static readonly Delegate[] _valueReaders
+            = Snapshot.CreateReaders<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>>();
+
         public Snapshot(
             [CanBeNull] T0 value0,
             [CanBeNull] T1 value1,
@@ -3339,6 +3456,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         private T12 _value12;
         private T13 _value13;
         private T14 _value14;
+
+        public T GetValue<T>(int index)
+            => ((Func<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>, T>)_valueReaders[index])(this);
 
         public object this[int index]
         {
@@ -3436,9 +3556,12 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         }
     }
 
-    public struct Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>
+    public sealed class Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>
         : ISnapshot
     {
+        private static readonly Delegate[] _valueReaders
+            = Snapshot.CreateReaders<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>>();
+
         public Snapshot(
             [CanBeNull] T0 value0,
             [CanBeNull] T1 value1,
@@ -3485,6 +3608,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         private T11 _value11;
         private T12 _value12;
         private T13 _value13;
+
+        public T GetValue<T>(int index)
+            => ((Func<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>, T>)_valueReaders[index])(this);
 
         public object this[int index]
         {
@@ -3577,9 +3703,12 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         }
     }
 
-    public struct Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>
+    public sealed class Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>
         : ISnapshot
     {
+        private static readonly Delegate[] _valueReaders
+            = Snapshot.CreateReaders<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>>();
+
         public Snapshot(
             [CanBeNull] T0 value0,
             [CanBeNull] T1 value1,
@@ -3623,6 +3752,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         private T10 _value10;
         private T11 _value11;
         private T12 _value12;
+
+        public T GetValue<T>(int index)
+            => ((Func<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>, T>)_valueReaders[index])(this);
 
         public object this[int index]
         {
@@ -3710,9 +3842,12 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         }
     }
 
-    public struct Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>
+    public sealed class Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>
         : ISnapshot
     {
+        private static readonly Delegate[] _valueReaders
+            = Snapshot.CreateReaders<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>>();
+
         public Snapshot(
             [CanBeNull] T0 value0,
             [CanBeNull] T1 value1,
@@ -3753,6 +3888,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         private T9 _value9;
         private T10 _value10;
         private T11 _value11;
+
+        public T GetValue<T>(int index)
+            => ((Func<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>, T>)_valueReaders[index])(this);
 
         public object this[int index]
         {
@@ -3835,9 +3973,12 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         }
     }
 
-    public struct Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>
+    public sealed class Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>
         : ISnapshot
     {
+        private static readonly Delegate[] _valueReaders
+            = Snapshot.CreateReaders<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>>();
+
         public Snapshot(
             [CanBeNull] T0 value0,
             [CanBeNull] T1 value1,
@@ -3875,6 +4016,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         private T8 _value8;
         private T9 _value9;
         private T10 _value10;
+
+        public T GetValue<T>(int index)
+            => ((Func<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>, T>)_valueReaders[index])(this);
 
         public object this[int index]
         {
@@ -3952,9 +4096,12 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         }
     }
 
-    public struct Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>
+    public sealed class Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>
         : ISnapshot
     {
+        private static readonly Delegate[] _valueReaders
+            = Snapshot.CreateReaders<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>>();
+
         public Snapshot(
             [CanBeNull] T0 value0,
             [CanBeNull] T1 value1,
@@ -3989,6 +4136,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         private T7 _value7;
         private T8 _value8;
         private T9 _value9;
+
+        public T GetValue<T>(int index)
+            => ((Func<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>, T>)_valueReaders[index])(this);
 
         public object this[int index]
         {
@@ -4061,9 +4211,12 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         }
     }
 
-    public struct Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8>
+    public sealed class Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8>
         : ISnapshot
     {
+        private static readonly Delegate[] _valueReaders
+            = Snapshot.CreateReaders<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8>>();
+
         public Snapshot(
             [CanBeNull] T0 value0,
             [CanBeNull] T1 value1,
@@ -4095,6 +4248,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         private T6 _value6;
         private T7 _value7;
         private T8 _value8;
+
+        public T GetValue<T>(int index)
+            => ((Func<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7, T8>, T>)_valueReaders[index])(this);
 
         public object this[int index]
         {
@@ -4162,9 +4318,12 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         }
     }
 
-    public struct Snapshot<T0, T1, T2, T3, T4, T5, T6, T7>
+    public sealed class Snapshot<T0, T1, T2, T3, T4, T5, T6, T7>
         : ISnapshot
     {
+        private static readonly Delegate[] _valueReaders
+            = Snapshot.CreateReaders<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7>>();
+
         public Snapshot(
             [CanBeNull] T0 value0,
             [CanBeNull] T1 value1,
@@ -4193,6 +4352,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         private T5 _value5;
         private T6 _value6;
         private T7 _value7;
+
+        public T GetValue<T>(int index)
+            => ((Func<Snapshot<T0, T1, T2, T3, T4, T5, T6, T7>, T>)_valueReaders[index])(this);
 
         public object this[int index]
         {
@@ -4255,9 +4417,12 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         }
     }
 
-    public struct Snapshot<T0, T1, T2, T3, T4, T5, T6>
+    public sealed class Snapshot<T0, T1, T2, T3, T4, T5, T6>
         : ISnapshot
     {
+        private static readonly Delegate[] _valueReaders
+            = Snapshot.CreateReaders<Snapshot<T0, T1, T2, T3, T4, T5, T6>>();
+
         public Snapshot(
             [CanBeNull] T0 value0,
             [CanBeNull] T1 value1,
@@ -4283,6 +4448,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         private T4 _value4;
         private T5 _value5;
         private T6 _value6;
+
+        public T GetValue<T>(int index)
+            => ((Func<Snapshot<T0, T1, T2, T3, T4, T5, T6>, T>)_valueReaders[index])(this);
 
         public object this[int index]
         {
@@ -4340,9 +4508,12 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         }
     }
 
-    public struct Snapshot<T0, T1, T2, T3, T4, T5>
+    public sealed class Snapshot<T0, T1, T2, T3, T4, T5>
         : ISnapshot
     {
+        private static readonly Delegate[] _valueReaders
+            = Snapshot.CreateReaders<Snapshot<T0, T1, T2, T3, T4, T5>>();
+
         public Snapshot(
             [CanBeNull] T0 value0,
             [CanBeNull] T1 value1,
@@ -4365,6 +4536,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         private T3 _value3;
         private T4 _value4;
         private T5 _value5;
+
+        public T GetValue<T>(int index)
+            => ((Func<Snapshot<T0, T1, T2, T3, T4, T5>, T>)_valueReaders[index])(this);
 
         public object this[int index]
         {
@@ -4417,9 +4591,12 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         }
     }
 
-    public struct Snapshot<T0, T1, T2, T3, T4>
+    public sealed class Snapshot<T0, T1, T2, T3, T4>
         : ISnapshot
     {
+        private static readonly Delegate[] _valueReaders
+            = Snapshot.CreateReaders<Snapshot<T0, T1, T2, T3, T4>>();
+
         public Snapshot(
             [CanBeNull] T0 value0,
             [CanBeNull] T1 value1,
@@ -4439,6 +4616,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         private T2 _value2;
         private T3 _value3;
         private T4 _value4;
+
+        public T GetValue<T>(int index)
+            => ((Func<Snapshot<T0, T1, T2, T3, T4>, T>)_valueReaders[index])(this);
 
         public object this[int index]
         {
@@ -4486,9 +4666,12 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         }
     }
 
-    public struct Snapshot<T0, T1, T2, T3>
+    public sealed class Snapshot<T0, T1, T2, T3>
         : ISnapshot
     {
+        private static readonly Delegate[] _valueReaders
+            = Snapshot.CreateReaders<Snapshot<T0, T1, T2, T3>>();
+
         public Snapshot(
             [CanBeNull] T0 value0,
             [CanBeNull] T1 value1,
@@ -4505,6 +4688,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         private T1 _value1;
         private T2 _value2;
         private T3 _value3;
+
+        public T GetValue<T>(int index)
+            => ((Func<Snapshot<T0, T1, T2, T3>, T>)_valueReaders[index])(this);
 
         public object this[int index]
         {
@@ -4547,9 +4733,12 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         }
     }
 
-    public struct Snapshot<T0, T1, T2>
+    public sealed class Snapshot<T0, T1, T2>
         : ISnapshot
     {
+        private static readonly Delegate[] _valueReaders
+            = Snapshot.CreateReaders<Snapshot<T0, T1, T2>>();
+
         public Snapshot(
             [CanBeNull] T0 value0,
             [CanBeNull] T1 value1,
@@ -4563,6 +4752,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         private T0 _value0;
         private T1 _value1;
         private T2 _value2;
+
+        public T GetValue<T>(int index)
+            => ((Func<Snapshot<T0, T1, T2>, T>)_valueReaders[index])(this);
 
         public object this[int index]
         {
@@ -4600,9 +4792,12 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         }
     }
 
-    public struct Snapshot<T0, T1>
+    public sealed class Snapshot<T0, T1>
         : ISnapshot
     {
+        private static readonly Delegate[] _valueReaders
+            = Snapshot.CreateReaders<Snapshot<T0, T1>>();
+
         public Snapshot(
             [CanBeNull] T0 value0,
             [CanBeNull] T1 value1)
@@ -4613,6 +4808,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
         private T0 _value0;
         private T1 _value1;
+
+        public T GetValue<T>(int index)
+            => ((Func<Snapshot<T0, T1>, T>)_valueReaders[index])(this);
 
         public object this[int index]
         {
@@ -4645,9 +4843,12 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         }
     }
 
-    public struct Snapshot<T0>
+    public sealed class Snapshot<T0>
         : ISnapshot
     {
+        private static readonly Delegate[] _valueReaders
+            = Snapshot.CreateReaders<Snapshot<T0>>();
+
         public Snapshot(
             [CanBeNull] T0 value0)
         {
@@ -4655,6 +4856,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         }
 
         private T0 _value0;
+
+        public T GetValue<T>(int index)
+            => ((Func<Snapshot<T0>, T>)_valueReaders[index])(this);
 
         public object this[int index]
         {

--- a/src/EntityFramework.Core/ChangeTracking/Internal/SnapshotFactoryFactory.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/SnapshotFactoryFactory.cs
@@ -138,12 +138,10 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
         protected virtual Expression CreateReadShadowValueExpression(
             [CanBeNull] ParameterExpression parameter, [NotNull] IProperty property)
-            => Expression.Convert(
-                Expression.Call(
-                    parameter,
-                    InternalEntityEntry.ReadShadowValueMethod,
-                    Expression.Constant(property.GetShadowIndex())),
-                property.ClrType);
+            => Expression.Call(
+                parameter,
+                InternalEntityEntry.ReadShadowValueMethod.MakeGenericMethod(property.ClrType),
+                Expression.Constant(property.GetShadowIndex()));
 
         protected abstract int GetPropertyIndex([NotNull] IPropertyBase propertyBase);
 

--- a/src/EntityFramework.Core/ChangeTracking/Internal/StoreGeneratedValues.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/StoreGeneratedValues.cs
@@ -52,6 +52,22 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
                 return true;
             }
 
+            public T GetValue<T>(T currentValue, int index)
+            {
+                if (IsEmpty)
+                {
+                    return currentValue;
+                }
+
+                var value = _values[index];
+
+                return value == null
+                    ? currentValue
+                    : value == _nullSentinel
+                        ? default(T)
+                        : (T)value;
+            }
+
             public bool CanStoreValue(IPropertyBase propertyBase)
                 => (_values != null)
                    && (propertyBase.GetStoreGeneratedIndex() != -1);

--- a/src/EntityFramework.Core/ChangeTracking/PropertyEntry.cs
+++ b/src/EntityFramework.Core/ChangeTracking/PropertyEntry.cs
@@ -4,6 +4,7 @@
 using System;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Metadata.Internal;
@@ -21,7 +22,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
     ///         not designed to be directly constructed in your application code.
     ///     </para>
     /// </summary>
-    public class PropertyEntry
+    public class PropertyEntry : IInfrastructure<InternalEntityEntry>
     {
         private readonly InternalEntityEntry _internalEntry;
 
@@ -88,5 +89,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
             get { return _internalEntry.GetValue(Metadata, ValueSource.Original); }
             [param: CanBeNull] set { _internalEntry.SetValue(Metadata, value, ValueSource.Original); }
         }
+
+        InternalEntityEntry IInfrastructure<InternalEntityEntry>.Instance => _internalEntry;
     }
 }

--- a/src/EntityFramework.Core/ChangeTracking/PropertyEntry`.cs
+++ b/src/EntityFramework.Core/ChangeTracking/PropertyEntry`.cs
@@ -3,6 +3,7 @@
 
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
+using Microsoft.Data.Entity.Infrastructure;
 
 namespace Microsoft.Data.Entity.ChangeTracking
 {
@@ -43,7 +44,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
         /// </summary>
         public new virtual TProperty CurrentValue
         {
-            get { return (TProperty)base.CurrentValue; }
+            get { return this.GetInfrastructure().GetCurrentValue<TProperty>(Metadata); }
             [param: CanBeNull] set { base.CurrentValue = value; }
         }
 
@@ -55,7 +56,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
         /// </summary>
         public new virtual TProperty OriginalValue
         {
-            get { return (TProperty)base.OriginalValue; }
+            get { return this.GetInfrastructure().GetOriginalValue<TProperty>(Metadata); }
             [param: CanBeNull] set { base.OriginalValue = value; }
         }
     }

--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -110,6 +110,8 @@
     <Compile Include="Metadata\Internal\ModelExtensions.cs" />
     <Compile Include="Metadata\Internal\MutableEntityTypeExtensions.cs" />
     <Compile Include="Metadata\Internal\NavigationExtensions.cs" />
+    <Compile Include="Metadata\Internal\PropertyAccessors.cs" />
+    <Compile Include="Metadata\Internal\PropertyAccessorsFactory.cs" />
     <Compile Include="Metadata\Internal\PropertyBaseExtensions.cs" />
     <Compile Include="Metadata\Internal\PropertyCounts.cs" />
     <Compile Include="Metadata\Internal\PropertyExtensions.cs" />

--- a/src/EntityFramework.Core/Metadata/Internal/IPropertyBaseAccessors.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/IPropertyBaseAccessors.cs
@@ -7,5 +7,6 @@ namespace Microsoft.Data.Entity.Metadata.Internal
     {
         IClrPropertyGetter Getter { get; }
         IClrPropertySetter Setter { get; }
+        PropertyAccessors Accessors { get; }
     }
 }

--- a/src/EntityFramework.Core/Metadata/Internal/Navigation.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/Navigation.cs
@@ -15,16 +15,11 @@ namespace Microsoft.Data.Entity.Metadata.Internal
     [DebuggerDisplay("{DeclaringEntityType.Name,nq}.{Name,nq}")]
     public class Navigation : ConventionalAnnotatable, IMutableNavigation, INavigationAccessors, IPropertyIndexesAccessor
     {
-        // Warning: Never access this field directly as access needs to be thread-safe
+        // Warning: Never access these fieldd directly as access needs to be thread-safe
         private IClrPropertyGetter _getter;
-
-        // Warning: Never access this field directly as access needs to be thread-safe
         private IClrPropertySetter _setter;
-
-        // Warning: Never access this field directly as access needs to be thread-safe
         private IClrCollectionAccessor _collectionAccessor;
-
-        // Warning: Never access this field directly as access needs to be thread-safe
+        private PropertyAccessors _accessors;
         private PropertyIndexes _indexes;
 
         public Navigation([NotNull] string name, [NotNull] ForeignKey foreignKey)
@@ -164,6 +159,9 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
         public virtual IClrCollectionAccessor CollectionAccessor
             => LazyInitializer.EnsureInitialized(ref _collectionAccessor, () => new ClrCollectionAccessorFactory().Create(this));
+
+        public virtual PropertyAccessors Accessors
+            => LazyInitializer.EnsureInitialized(ref _accessors, () => new PropertyAccessorsFactory().Create(this));
 
         public virtual PropertyIndexes Indexes
         {

--- a/src/EntityFramework.Core/Metadata/Internal/Property.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/Property.cs
@@ -16,13 +16,10 @@ namespace Microsoft.Data.Entity.Metadata.Internal
     [DebuggerDisplay("{DeclaringEntityType.Name,nq}.{Name,nq} ({ClrType?.Name,nq})")]
     public class Property : ConventionalAnnotatable, IMutableProperty, IPropertyBaseAccessors, IPropertyIndexesAccessor
     {
-        // Warning: Never access this field directly as access needs to be thread-safe
+        // Warning: Never access these fields directly as access needs to be thread-safe
         private IClrPropertyGetter _getter;
-
-        // Warning: Never access this field directly as access needs to be thread-safe
         private IClrPropertySetter _setter;
-
-        // Warning: Never access this field directly as access needs to be thread-safe
+        private PropertyAccessors _accessors;
         private PropertyIndexes _indexes;
 
         private PropertyFlags _flags;
@@ -382,6 +379,9 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
         public virtual IClrPropertySetter Setter
             => LazyInitializer.EnsureInitialized(ref _setter, () => new ClrPropertySetterFactory().Create(this));
+
+        public virtual PropertyAccessors Accessors
+            => LazyInitializer.EnsureInitialized(ref _accessors, () => new PropertyAccessorsFactory().Create(this));
 
         public virtual PropertyIndexes Indexes
         {

--- a/src/EntityFramework.Core/Metadata/Internal/PropertyAccessors.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/PropertyAccessors.cs
@@ -1,0 +1,25 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+
+namespace Microsoft.Data.Entity.Metadata.Internal
+{
+    public sealed class PropertyAccessors
+    {
+        public PropertyAccessors(
+            [NotNull] Delegate currentValueGetter,
+            [NotNull] Delegate originalValueGetter,
+            [NotNull] Delegate relationshipSnapshotGetter)
+        {
+            CurrentValueGetter = currentValueGetter;
+            OriginalValueGetter = originalValueGetter;
+            RelationshipSnapshotGetter = relationshipSnapshotGetter;
+        }
+
+        public Delegate CurrentValueGetter { get; }
+        public Delegate OriginalValueGetter { get; }
+        public Delegate RelationshipSnapshotGetter { get; }
+    }
+}

--- a/src/EntityFramework.Core/Metadata/Internal/PropertyAccessorsFactory.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/PropertyAccessorsFactory.cs
@@ -1,0 +1,107 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.ChangeTracking.Internal;
+
+namespace Microsoft.Data.Entity.Metadata.Internal
+{
+    public class PropertyAccessorsFactory
+    {
+        public virtual PropertyAccessors Create([NotNull] IPropertyBase propertyBase)
+            => (PropertyAccessors)_genericCreate
+                .MakeGenericMethod((propertyBase as IProperty)?.ClrType
+                                   ?? (((INavigation)propertyBase).IsCollection()
+                                       ? typeof(HashSet<object>)
+                                       : typeof(object)))
+                .Invoke(null, new object[] { propertyBase });
+
+        private static readonly MethodInfo _genericCreate
+            = typeof(PropertyAccessorsFactory).GetTypeInfo().GetDeclaredMethods(nameof(CreateGeneric)).Single();
+
+        [UsedImplicitly]
+        private static PropertyAccessors CreateGeneric<TProperty>(IPropertyBase propertyBase)
+            => new PropertyAccessors(
+                CreateCurrentValueGetter<TProperty>(propertyBase),
+                CreateOriginalValueGetter<TProperty>(propertyBase),
+                CreateRelationshipSnapshotGetter<TProperty>(propertyBase));
+
+        private static Func<InternalEntityEntry, TProperty> CreateCurrentValueGetter<TProperty>(IPropertyBase propertyBase)
+        {
+            var entityClrType = propertyBase.DeclaringEntityType.ClrType;
+            var entryParameter = Expression.Parameter(typeof(InternalEntityEntry), "entry");
+
+            var shadowIndex = (propertyBase as IProperty)?.GetShadowIndex() ?? -1;
+            var currentValueExpression = shadowIndex >= 0
+                ? (Expression)Expression.Call(
+                    entryParameter,
+                    InternalEntityEntry.ReadShadowValueMethod.MakeGenericMethod(typeof(TProperty)),
+                    Expression.Constant(shadowIndex))
+                : Expression.Property(
+                    Expression.Convert(
+                        Expression.Property(entryParameter, "Entity"),
+                        entityClrType),
+                    entityClrType.GetAnyProperty(propertyBase.Name));
+
+            var storeGeneratedIndex = propertyBase.GetStoreGeneratedIndex();
+            if (storeGeneratedIndex >= 0)
+            {
+                currentValueExpression = Expression.Call(
+                    entryParameter,
+                    InternalEntityEntry.ReadStoreGeneratedValueMethod.MakeGenericMethod(typeof(TProperty)),
+                    currentValueExpression,
+                    Expression.Constant(storeGeneratedIndex));
+            }
+
+            return Expression.Lambda<Func<InternalEntityEntry, TProperty>>(
+                currentValueExpression,
+                entryParameter)
+                .Compile();
+        }
+
+        private static Func<InternalEntityEntry, TProperty> CreateOriginalValueGetter<TProperty>(IPropertyBase propertyBase)
+        {
+            var entryParameter = Expression.Parameter(typeof(InternalEntityEntry), "entry");
+            var originalValuesIndex = (propertyBase as IProperty)?.GetOriginalValueIndex() ?? -1;
+
+            return Expression.Lambda<Func<InternalEntityEntry, TProperty>>(
+                originalValuesIndex >= 0
+                    ? Expression.Call(
+                        entryParameter,
+                        InternalEntityEntry.ReadOriginalValueMethod.MakeGenericMethod(typeof(TProperty)),
+                        Expression.Constant((IProperty)propertyBase),
+                        Expression.Constant(originalValuesIndex))
+                    : Expression.Call(
+                        entryParameter,
+                        InternalEntityEntry.GetCurrentValueMethod.MakeGenericMethod(typeof(TProperty)),
+                        Expression.Constant(propertyBase)),
+                entryParameter)
+                .Compile();
+        }
+
+        private static Func<InternalEntityEntry, TProperty> CreateRelationshipSnapshotGetter<TProperty>(IPropertyBase propertyBase)
+        {
+            var entryParameter = Expression.Parameter(typeof(InternalEntityEntry), "entry");
+            var relationshipIndex = (propertyBase as IProperty)?.GetRelationshipIndex() ?? -1;
+
+            return Expression.Lambda<Func<InternalEntityEntry, TProperty>>(
+                relationshipIndex >= 0
+                    ? Expression.Call(
+                        entryParameter,
+                        InternalEntityEntry.ReadRelationshipSnapshotValueMethod.MakeGenericMethod(typeof(TProperty)),
+                        Expression.Constant(propertyBase),
+                        Expression.Constant(relationshipIndex))
+                    : Expression.Call(
+                        entryParameter,
+                        InternalEntityEntry.GetCurrentValueMethod.MakeGenericMethod(typeof(TProperty)),
+                        Expression.Constant(propertyBase)),
+                entryParameter)
+                .Compile();
+        }
+    }
+}

--- a/src/EntityFramework.Core/Metadata/Internal/PropertyBaseExtensions.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/PropertyBaseExtensions.cs
@@ -7,6 +7,15 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 {
     public static class PropertyBaseExtensions
     {
+        public static PropertyAccessors GetPropertyAccessors([NotNull] this IPropertyBase propertyBase)
+        {
+            var accessors = propertyBase as IPropertyBaseAccessors;
+
+            return accessors != null
+                ? accessors.Accessors
+                : new PropertyAccessorsFactory().Create(propertyBase);
+        }
+
         public static IClrPropertyGetter GetGetter([NotNull] this IPropertyBase propertyBase)
         {
             var accessors = propertyBase as IPropertyBaseAccessors;


### PR DESCRIPTION
Specifically, current values (including shadow), original values, and relationship snapshot values

This is a building block for some upcoming changes to the identity cache. The code is not used much yet.