### PR TITLE
[SMALL] Align Infrastructure/Internal types

### DIFF
--- a/src/EntityFramework.MicrosoftSqlServer/EntityFramework.MicrosoftSqlServer.csproj
+++ b/src/EntityFramework.MicrosoftSqlServer/EntityFramework.MicrosoftSqlServer.csproj
@@ -47,9 +47,9 @@
       <DependentUpon>Resources.tt</DependentUpon>
     </Compile>
     <Compile Include="Infrastructure\SqlServerDbContextOptionsBuilder.cs" />
-    <Compile Include="Internal\SqlServerModelSource.cs" />
+    <Compile Include="Infrastructure\Internal\SqlServerModelSource.cs" />
     <Compile Include="Internal\SqlServerModelValidator.cs" />
-    <Compile Include="Internal\SqlServerOptionsExtension.cs" />
+    <Compile Include="Infrastructure\Internal\SqlServerOptionsExtension.cs" />
     <Compile Include="Metadata\Conventions\Internal\SqlServerConventionSetBuilder.cs" />
     <Compile Include="Metadata\Conventions\Internal\SqlServerValueGenerationStrategyConvention.cs" />
     <Compile Include="Metadata\Internal\SqlServerAnnotationNames.cs" />

--- a/src/EntityFramework.MicrosoftSqlServer/Extensions/SqlServerDbContextOptionsExtensions.cs
+++ b/src/EntityFramework.MicrosoftSqlServer/Extensions/SqlServerDbContextOptionsExtensions.cs
@@ -4,7 +4,7 @@
 using System.Data.Common;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
-using Microsoft.Data.Entity.Internal;
+using Microsoft.Data.Entity.Infrastructure.Internal;
 using Microsoft.Data.Entity.Utilities;
 
 // ReSharper disable once CheckNamespace

--- a/src/EntityFramework.MicrosoftSqlServer/Extensions/SqlServerEntityFrameworkServicesBuilderExtensions.cs
+++ b/src/EntityFramework.MicrosoftSqlServer/Extensions/SqlServerEntityFrameworkServicesBuilderExtensions.cs
@@ -3,6 +3,7 @@
 
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Infrastructure.Internal;
 using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Metadata.Conventions.Internal;

--- a/src/EntityFramework.MicrosoftSqlServer/Infrastructure/Internal/SqlServerModelSource.cs
+++ b/src/EntityFramework.MicrosoftSqlServer/Infrastructure/Internal/SqlServerModelSource.cs
@@ -2,10 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
-using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata.Conventions.Internal;
 
-namespace Microsoft.Data.Entity.Internal
+namespace Microsoft.Data.Entity.Infrastructure.Internal
 {
     public class SqlServerModelSource : ModelSource
     {

--- a/src/EntityFramework.MicrosoftSqlServer/Infrastructure/Internal/SqlServerOptionsExtension.cs
+++ b/src/EntityFramework.MicrosoftSqlServer/Infrastructure/Internal/SqlServerOptionsExtension.cs
@@ -6,7 +6,7 @@ using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Microsoft.Data.Entity.Internal
+namespace Microsoft.Data.Entity.Infrastructure.Internal
 {
     public class SqlServerOptionsExtension : RelationalOptionsExtension
     {

--- a/src/EntityFramework.MicrosoftSqlServer/Infrastructure/SqlServerDbContextOptionsBuilder.cs
+++ b/src/EntityFramework.MicrosoftSqlServer/Infrastructure/SqlServerDbContextOptionsBuilder.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure.Internal;
 using Microsoft.Data.Entity.Internal;
 
 namespace Microsoft.Data.Entity.Infrastructure

--- a/src/EntityFramework.MicrosoftSqlServer/Query/Internal/SqlServerCompiledQueryCacheKeyGenerator.cs
+++ b/src/EntityFramework.MicrosoftSqlServer/Query/Internal/SqlServerCompiledQueryCacheKeyGenerator.cs
@@ -4,7 +4,7 @@
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
-using Microsoft.Data.Entity.Internal;
+using Microsoft.Data.Entity.Infrastructure.Internal;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Utilities;
 

--- a/src/EntityFramework.MicrosoftSqlServer/Query/Internal/SqlServerQueryModelVisitor.cs
+++ b/src/EntityFramework.MicrosoftSqlServer/Query/Internal/SqlServerQueryModelVisitor.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
-using Microsoft.Data.Entity.Internal;
+using Microsoft.Data.Entity.Infrastructure.Internal;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Query.Expressions;

--- a/src/EntityFramework.MicrosoftSqlServer/Storage/Internal/SqlServerDatabaseProviderServices.cs
+++ b/src/EntityFramework.MicrosoftSqlServer/Storage/Internal/SqlServerDatabaseProviderServices.cs
@@ -5,6 +5,7 @@ using System;
 using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Infrastructure.Internal;
 using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Metadata.Conventions.Internal;

--- a/src/EntityFramework.MicrosoftSqlServer/Update/Internal/SqlServerModificationCommandBatchFactory.cs
+++ b/src/EntityFramework.MicrosoftSqlServer/Update/Internal/SqlServerModificationCommandBatchFactory.cs
@@ -4,7 +4,7 @@
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
-using Microsoft.Data.Entity.Internal;
+using Microsoft.Data.Entity.Infrastructure.Internal;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Utilities;
 

--- a/src/EntityFramework.Sqlite/EntityFramework.Sqlite.csproj
+++ b/src/EntityFramework.Sqlite/EntityFramework.Sqlite.csproj
@@ -63,7 +63,7 @@
       <Link>Extensions\SharedTypeExtensions.cs</Link>
     </Compile>
     <Compile Include="Infrastructure\Internal\SqliteModelSource.cs" />
-    <Compile Include="Infrastructure\Internal\SqliteModelValidator.cs" />
+    <Compile Include="Internal\SqliteModelValidator.cs" />
     <Compile Include="Infrastructure\Internal\SqliteOptionsExtension.cs" />
     <Compile Include="Metadata\Builders\SqliteEntityTypeBuilderExtensions.cs" />
     <Compile Include="Metadata\Builders\SqliteReferenceCollectionBuilderExtensions.cs" />

--- a/src/EntityFramework.Sqlite/Infrastructure/SqliteEntityFrameworkServicesBuilderExtensions.cs
+++ b/src/EntityFramework.Sqlite/Infrastructure/SqliteEntityFrameworkServicesBuilderExtensions.cs
@@ -4,6 +4,7 @@
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Infrastructure.Internal;
+using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata.Conventions.Internal;
 using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Migrations;

--- a/src/EntityFramework.Sqlite/Internal/SqliteModelValidator.cs
+++ b/src/EntityFramework.Sqlite/Internal/SqliteModelValidator.cs
@@ -2,11 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
-using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Extensions.Logging;
 
-namespace Microsoft.Data.Entity.Infrastructure.Internal
+namespace Microsoft.Data.Entity.Internal
 {
     public class SqliteModelValidator : RelationalModelValidator
     {

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/Utilities/TestSqlServerModelSource.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/Utilities/TestSqlServerModelSource.cs
@@ -4,6 +4,7 @@
 using System;
 using Microsoft.Data.Entity.FunctionalTests;
 using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Infrastructure.Internal;
 using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Metadata.Conventions.Internal;

--- a/test/EntityFramework.MicrosoftSqlServer.Tests/Migrations/SqlServerHistoryRepositoryTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.Tests/Migrations/SqlServerHistoryRepositoryTest.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.Data.Entity.Infrastructure;
-using Microsoft.Data.Entity.Internal;
+using Microsoft.Data.Entity.Infrastructure.Internal;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Migrations.Internal;
 using Microsoft.Data.Entity.Storage;

--- a/test/EntityFramework.MicrosoftSqlServer.Tests/SqlServerDatabaseSourceTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.Tests/SqlServerDatabaseSourceTest.cs
@@ -3,7 +3,7 @@
 
 using System.Reflection;
 using Microsoft.Data.Entity.Infrastructure;
-using Microsoft.Data.Entity.Internal;
+using Microsoft.Data.Entity.Infrastructure.Internal;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Storage.Internal;
 using Microsoft.Data.Entity.Tests;

--- a/test/EntityFramework.MicrosoftSqlServer.Tests/SqlServerDbContextOptionsExtensionsTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.Tests/SqlServerDbContextOptionsExtensionsTest.cs
@@ -4,7 +4,7 @@
 using System.Data.SqlClient;
 using System.Linq;
 using Microsoft.Data.Entity.Infrastructure;
-using Microsoft.Data.Entity.Internal;
+using Microsoft.Data.Entity.Infrastructure.Internal;
 using Xunit;
 
 namespace Microsoft.Data.Entity.SqlServer.Tests

--- a/test/EntityFramework.MicrosoftSqlServer.Tests/SqlServerEntityFrameworkServicesBuilderExtensionsTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.Tests/SqlServerEntityFrameworkServicesBuilderExtensionsTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.Data.Entity.Infrastructure.Internal;
 using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Metadata.Conventions.Internal;

--- a/test/EntityFramework.MicrosoftSqlServer.Tests/SqlServerOptionsExtensionTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.Tests/SqlServerOptionsExtensionTest.cs
@@ -3,7 +3,7 @@
 
 using System.Linq;
 using Microsoft.Data.Entity.Infrastructure;
-using Microsoft.Data.Entity.Internal;
+using Microsoft.Data.Entity.Infrastructure.Internal;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;

--- a/test/EntityFramework.Sqlite.Tests/Infrastructure/SqliteEntityFrameworkServicesBuilderExtensionsTest.cs
+++ b/test/EntityFramework.Sqlite.Tests/Infrastructure/SqliteEntityFrameworkServicesBuilderExtensionsTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Data.Entity.Infrastructure.Internal;
+using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata.Conventions.Internal;
 using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Migrations;


### PR DESCRIPTION
Equivalent types for SQLite and SQL Server were in different namespaces.
Applying our rule that types should follow the namespace of the type
they inherit (plus a `.Internal` if they are "internal").
Fixes #3374