### PR TITLE
Reverse engineer sequences for SQL Server

### DIFF
--- a/src/EntityFramework.Commands/EntityFramework.Commands.csproj
+++ b/src/EntityFramework.Commands/EntityFramework.Commands.csproj
@@ -89,6 +89,7 @@
     <Compile Include="Design\Internal\ForwardingProxy`.cs" />
     <Compile Include="Design\Internal\LoggerProvider.cs" />
     <Compile Include="Scaffolding\Internal\CodeWriter.cs" />
+    <Compile Include="Scaffolding\Internal\Configuration\SequenceConfiguration.cs" />
     <Compile Include="Scaffolding\Internal\ScaffoldingServiceCollectionExtensions.cs" />
     <Compile Include="Scaffolding\Internal\ScaffoldingUtilities.cs" />
     <Compile Include="Scaffolding\Internal\ConfigurationFactory.cs" />

--- a/src/EntityFramework.Commands/Scaffolding/Internal/Configuration/ModelConfiguration.cs
+++ b/src/EntityFramework.Commands/Scaffolding/Internal/Configuration/ModelConfiguration.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
@@ -26,6 +27,7 @@ namespace Microsoft.Data.Entity.Scaffolding.Internal.Configuration
         protected readonly ConfigurationFactory _configurationFactory;
         protected List<OptionsBuilderConfiguration> _onConfiguringConfigurations;
         protected SortedDictionary<EntityType, EntityConfiguration> _entityConfigurationMap;
+        private List<SequenceConfiguration> _sequenceConfigurations;
 
         public ModelConfiguration(
             [NotNull] ConfigurationFactory configurationFactory,
@@ -94,6 +96,84 @@ namespace Microsoft.Data.Entity.Scaffolding.Internal.Configuration
                 }
 
                 return _entityConfigurationMap.Values.ToList();
+            }
+        }
+
+        public virtual List<SequenceConfiguration> SequenceConfigurations
+        {
+            get
+            {
+                if (_sequenceConfigurations == null)
+                {
+                    AddSequenceConfigurations();
+                }
+                return _sequenceConfigurations;
+            }
+        }
+
+        public virtual void AddSequenceConfigurations()
+        {
+            _sequenceConfigurations = new List<SequenceConfiguration>();
+            foreach (var sequence in (Model as Model).Relational().Sequences)
+            {
+                var config = _configurationFactory.CreateSequenceConfiguration();
+
+                config.NameIdentifier = CSharpUtilities.DelimitString(sequence.Name);
+
+                if (sequence.ClrType != Sequence.DefaultClrType)
+                {
+                    config.TypeIdentifier = CSharpUtilities.GetTypeName(sequence.ClrType);
+                }
+
+                if (!string.IsNullOrEmpty(sequence.Schema) && (Model as Model).Relational().DefaultSchema != sequence.Schema)
+                {
+                    config.SchemaNameIdentifier = CSharpUtilities.DelimitString(sequence.Schema);
+                }
+
+                if (sequence.StartValue != Sequence.DefaultStartValue)
+                {
+                    config.FluentApiConfigurations.Add(
+                        _configurationFactory.CreateFluentApiConfiguration(
+                            false,
+                            nameof(RelationalSequenceBuilder.StartsAt),
+                            sequence.StartValue.ToString()));
+                }
+                if (sequence.IncrementBy != Sequence.DefaultIncrementBy)
+                {
+                    config.FluentApiConfigurations.Add(
+                        _configurationFactory.CreateFluentApiConfiguration(
+                            false,
+                            nameof(RelationalSequenceBuilder.IncrementsBy),
+                            sequence.IncrementBy.ToString()));
+                }
+
+                if (sequence.MinValue != Sequence.DefaultMinValue)
+                {
+                    config.FluentApiConfigurations.Add(
+                        _configurationFactory.CreateFluentApiConfiguration(
+                            false,
+                            nameof(RelationalSequenceBuilder.HasMin),
+                            sequence.MinValue.ToString()));
+                }
+
+                if (sequence.MaxValue != Sequence.DefaultMaxValue)
+                {
+                    config.FluentApiConfigurations.Add(
+                        _configurationFactory.CreateFluentApiConfiguration(
+                            false,
+                            nameof(RelationalSequenceBuilder.HasMax),
+                            sequence.MaxValue.ToString()));
+                }
+
+                if (sequence.IsCyclic != Sequence.DefaultIsCyclic)
+                {
+                    config.FluentApiConfigurations.Add(
+                        _configurationFactory.CreateFluentApiConfiguration(
+                            false,
+                            nameof(RelationalSequenceBuilder.IsCyclic)));
+                }
+
+                _sequenceConfigurations.Add(config);
             }
         }
 

--- a/src/EntityFramework.Commands/Scaffolding/Internal/Configuration/SequenceConfiguration.cs
+++ b/src/EntityFramework.Commands/Scaffolding/Internal/Configuration/SequenceConfiguration.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using JetBrains.Annotations;
+
+namespace Microsoft.Data.Entity.Scaffolding.Internal.Configuration
+{
+    public class SequenceConfiguration
+    {
+        public virtual string NameIdentifier { get; [param: NotNull] set; }
+
+        public virtual string SchemaNameIdentifier { get; [param: NotNull] set; }
+        public virtual string TypeIdentifier { get; [param: NotNull] set; }
+        public virtual List<FluentApiConfiguration> FluentApiConfigurations { get; } = new List<FluentApiConfiguration>();
+    }
+}

--- a/src/EntityFramework.Commands/Scaffolding/Internal/ConfigurationFactory.cs
+++ b/src/EntityFramework.Commands/Scaffolding/Internal/ConfigurationFactory.cs
@@ -151,5 +151,8 @@ namespace Microsoft.Data.Entity.Scaffolding.Internal
 
             return new IndexConfiguration(lambdaIdentifier, index);
         }
+
+        public virtual SequenceConfiguration CreateSequenceConfiguration()
+            => new SequenceConfiguration();
     }
 }

--- a/src/EntityFramework.MicrosoftSqlServer.Design/Properties/SqlServerDesignStrings.Designer.cs
+++ b/src/EntityFramework.MicrosoftSqlServer.Design/Properties/SqlServerDesignStrings.Designer.cs
@@ -61,6 +61,14 @@ namespace Microsoft.Data.Entity.Internal
         }
 
         /// <summary>
+        /// Found a sequence in schema [{schemaName}] with an empty or null name. Skipping sequence.
+        /// </summary>
+        public static string SequenceNameEmpty([CanBeNull] object schemaName)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("SequenceNameEmpty", "schemaName"), schemaName);
+        }
+
+        /// <summary>
         /// For column {columnId} unable to convert default value {defaultValue} into type {propertyType}. Will not generate code setting a default value for the property {propertyName} on entity type {entityTypeName}.
         /// </summary>
         public static string UnableToConvertDefaultValue([CanBeNull] object columnId, [CanBeNull] object defaultValue, [CanBeNull] object propertyType, [CanBeNull] object propertyName, [CanBeNull] object entityTypeName)

--- a/src/EntityFramework.MicrosoftSqlServer.Design/Properties/SqlServerDesignStrings.resx
+++ b/src/EntityFramework.MicrosoftSqlServer.Design/Properties/SqlServerDesignStrings.resx
@@ -135,6 +135,9 @@
   <data name="IndexNameEmpty" xml:space="preserve">
     <value>Found an index on table [{schemaName}].[{tableName}] with an empty or null name. Skipping index.</value>
   </data>
+  <data name="SequenceNameEmpty" xml:space="preserve">
+    <value>Found a sequence in schema [{schemaName}] with an empty or null name. Skipping sequence.</value>
+  </data>
   <data name="UnableToConvertDefaultValue" xml:space="preserve">
     <value>For column {columnId} unable to convert default value {defaultValue} into type {propertyType}. Will not generate code setting a default value for the property {propertyName} on entity type {entityTypeName}.</value>
   </data>

--- a/src/EntityFramework.Relational.Design/EntityFramework.Relational.Design.csproj
+++ b/src/EntityFramework.Relational.Design/EntityFramework.Relational.Design.csproj
@@ -57,6 +57,7 @@
     <Compile Include="Metadata\ForeignKeyModel.cs" />
     <Compile Include="Metadata\IndexModel.cs" />
     <Compile Include="Metadata\ScaffoldingModelAnnotations.cs" />
+    <Compile Include="Metadata\SequenceModel.cs" />
     <Compile Include="Metadata\TableModel.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\InternalsVisibleTo.cs" />

--- a/src/EntityFramework.Relational.Design/Metadata/DatabaseModel.cs
+++ b/src/EntityFramework.Relational.Design/Metadata/DatabaseModel.cs
@@ -15,5 +15,6 @@ namespace Microsoft.Data.Entity.Scaffolding.Metadata
         public virtual string DefaultSchemaName { get; [param: CanBeNull] set; }
 
         public virtual IList<TableModel> Tables { get; } = new List<TableModel>();
+        public virtual IList<SequenceModel> Sequences { get; } = new List<SequenceModel>();
     }
 }

--- a/src/EntityFramework.Relational.Design/Metadata/SequenceModel.cs
+++ b/src/EntityFramework.Relational.Design/Metadata/SequenceModel.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
+
+namespace Microsoft.Data.Entity.Scaffolding.Metadata
+{
+    public class SequenceModel : Annotatable
+    {
+        public virtual string Name { get; [param: NotNull] set; }
+        public virtual string SchemaName { get; [param: CanBeNull] set; }
+        public virtual string DataType { get; [param: CanBeNull] set; }
+        public virtual long? Start { get; [param: CanBeNull] set; }
+        public virtual int? IncrementBy { get; [param: CanBeNull] set; }
+        public virtual long? Min { get; [param: CanBeNull] set; }
+        public virtual long? Max { get; [param: CanBeNull] set; }
+        public virtual bool? IsCyclic { get; [param: CanBeNull] set; }
+    }
+}

--- a/src/EntityFramework.Relational.Design/Properties/RelationalDesignStrings.Designer.cs
+++ b/src/EntityFramework.Relational.Design/Properties/RelationalDesignStrings.Designer.cs
@@ -116,6 +116,22 @@ namespace Microsoft.Data.Entity.Internal
             return string.Format(CultureInfo.CurrentCulture, GetString("ExistingFiles", "outputDirectoryName", "existingFiles"), outputDirectoryName, existingFiles);
         }
 
+        /// <summary>
+        /// Sequence name cannot be null or empty. Entity Framework cannot model a sequence that does not have a name.
+        /// </summary>
+        public static string SequencesRequireName
+        {
+            get { return GetString("SequencesRequireName"); }
+        }
+
+        /// <summary>
+        /// For sequence '{sequenceName}'. Unable to scaffold because it uses an unsupported type: '{typeName}'.
+        /// </summary>
+        public static string BadSequenceType([CanBeNull] object sequenceName, [CanBeNull] object typeName)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("BadSequenceType", "sequenceName", "typeName"), sequenceName, typeName);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EntityFramework.Relational.Design/Properties/RelationalDesignStrings.resx
+++ b/src/EntityFramework.Relational.Design/Properties/RelationalDesignStrings.resx
@@ -156,4 +156,10 @@
   <data name="ExistingFiles" xml:space="preserve">
     <value>The following file(s) already exist in directory {outputDirectoryName}: {existingFiles}. Use the Force flag to overwrite these files.</value>
   </data>
+  <data name="SequencesRequireName" xml:space="preserve">
+    <value>Sequence name cannot be null or empty. Entity Framework cannot model a sequence that does not have a name.</value>
+  </data>
+  <data name="BadSequenceType" xml:space="preserve">
+    <value>For sequence '{sequenceName}'. Unable to scaffold because it uses an unsupported type: '{typeName}'.</value>
+  </data>
 </root>

--- a/src/EntityFramework.Relational/Metadata/Sequence.cs
+++ b/src/EntityFramework.Relational/Metadata/Sequence.cs
@@ -18,6 +18,14 @@ namespace Microsoft.Data.Entity.Metadata
         private readonly IModel _model;
         private readonly string _annotationName;
 
+        public static readonly Type DefaultClrType = typeof(long);
+        public const int DefaultIncrementBy = 1;
+        public const int DefaultStartValue = 1;
+
+        public static readonly long? DefaultMaxValue = default(long?);
+        public static readonly long? DefaultMinValue = default(long?);
+        public static readonly bool DefaultIsCyclic = default(bool);
+
         public Sequence(
             [NotNull] IMutableModel model,
             [NotNull] string annotationPrefix,
@@ -38,9 +46,9 @@ namespace Microsoft.Data.Entity.Metadata
                 {
                     Name = name,
                     Schema = schema,
-                    ClrType = typeof(long),
-                    IncrementBy = 1,
-                    StartValue = 1
+                    ClrType = DefaultClrType,
+                    IncrementBy = DefaultIncrementBy,
+                    StartValue = DefaultStartValue
                 });
             }
         }
@@ -131,16 +139,21 @@ namespace Microsoft.Data.Entity.Metadata
             }
         }
 
+        public static IReadOnlyCollection<Type> SupportedTypes { get; } = new[]
+        {
+            typeof(byte),
+            typeof(long),
+            typeof(int),
+            typeof(short)
+        };
+
         public virtual Type ClrType
         {
             get { return GetData().ClrType; }
             [param: NotNull]
             set
             {
-                if ((value != typeof(byte))
-                    && (value != typeof(long))
-                    && (value != typeof(int))
-                    && (value != typeof(short)))
+                if (!SupportedTypes.Contains(value))
                 {
                     throw new ArgumentException(RelationalStrings.BadSequenceType);
                 }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/App.config
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/App.config
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<!-- binding redirect so TD.NET gets the right assembly version -->
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="1.1.36.0" newVersion="1.1.37.0"/>
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests.csproj
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="..\..\tools\EntityFramework.props" />
@@ -76,6 +76,10 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="ReverseEngineering\E2E.sql" />
+    <None Include="App.config" />
+    <None Include="ReverseEngineering\ExpectedResults\SequenceContext.expected">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
@@ -170,7 +174,6 @@
     <Compile Include="SqlServerDatabaseModelFactoryTest.cs" />
     <Compile Include="Properties\TestAssemblyConditions.cs" />
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/SequenceContext.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/SequenceContext.expected
@@ -1,0 +1,31 @@
+﻿using Microsoft.Data.Entity;
+using Microsoft.Data.Entity.Metadata;
+
+namespace E2ETest.Namespace
+{
+    public partial class SequenceContext : DbContext
+    {
+        protected override void OnConfiguring(DbContextOptionsBuilder options)
+        {
+            options.UseSqlServer(@"{{connectionString}}");
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.HasSequence("CountByTwo").IncrementsBy(2);
+
+            modelBuilder.HasSequence("CyclicalCountByThree")
+                .StartsAt(6)
+                .IncrementsBy(3)
+                .HasMin(0)
+                .HasMax(27)
+                .IsCyclic();
+
+            modelBuilder.HasSequence<int>("IntSequence");
+
+            modelBuilder.HasSequence<short>("SmallIntSequence");
+
+            modelBuilder.HasSequence<byte>("TinyIntSequence");
+        }
+    }
+}

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/SqlServerDatabaseModelFactoryTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/SqlServerDatabaseModelFactoryTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Data.Entity.FunctionalTests.TestUtilities.Xunit;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Migrations;
 using Microsoft.Data.Entity.Scaffolding;
@@ -22,9 +23,9 @@ namespace Microsoft.Data.Entity.SqlServer.Design.FunctionalTests
             var sql = @"
 CREATE TABLE [dbo].[Everest] ( id int );
 CREATE TABLE [dbo].[Denali] ( id int );";
-            var dbInfo = CreateModel(sql, new TableSelectionSet(new List<string> { "Everest", "Denali" }));
+            var dbModel = CreateModel(sql, new TableSelectionSet(new List<string> { "Everest", "Denali" }));
 
-            Assert.Collection(dbInfo.Tables.OrderBy(t => t.Name),
+            Assert.Collection(dbModel.Tables.OrderBy(t => t.Name),
                 d =>
                     {
                         Assert.Equal("dbo", d.SchemaName);
@@ -43,9 +44,9 @@ CREATE TABLE [dbo].[Denali] ( id int );";
             _fixture.ExecuteNonQuery("CREATE SCHEMA db2");
             var sql = "CREATE TABLE dbo.Ranges ( Id INT IDENTITY (1,1) PRIMARY KEY);" +
                       "CREATE TABLE db2.Mountains ( RangeId INT NOT NULL, FOREIGN KEY (RangeId) REFERENCES Ranges(Id) ON DELETE CASCADE)";
-            var dbInfo = CreateModel(sql, new TableSelectionSet(new List<string> { "Ranges", "Mountains" }));
+            var dbModel = CreateModel(sql, new TableSelectionSet(new List<string> { "Ranges", "Mountains" }));
 
-            var fk = Assert.Single(dbInfo.Tables.Single(t => t.ForeignKeys.Count > 0).ForeignKeys);
+            var fk = Assert.Single(dbModel.Tables.Single(t => t.ForeignKeys.Count > 0).ForeignKeys);
 
             Assert.Equal("db2", fk.Table.SchemaName);
             Assert.Equal("Mountains", fk.Table.Name);
@@ -62,9 +63,9 @@ CREATE TABLE [dbo].[Denali] ( id int );";
             _fixture.ExecuteNonQuery("CREATE SCHEMA db3");
             var sql = "CREATE TABLE dbo.Ranges1 ( Id INT IDENTITY (1,1), AltId INT, PRIMARY KEY(Id, AltId));" +
                       "CREATE TABLE db3.Mountains1 ( RangeId INT NOT NULL, RangeAltId INT NOT NULL, FOREIGN KEY (RangeId, RangeAltId) REFERENCES Ranges1(Id, AltId) ON DELETE NO ACTION)";
-            var dbInfo = CreateModel(sql, new TableSelectionSet(new List<string> { "Ranges1", "Mountains1" }));
+            var dbModel = CreateModel(sql, new TableSelectionSet(new List<string> { "Ranges1", "Mountains1" }));
 
-            var fk = Assert.Single(dbInfo.Tables.Single(t => t.ForeignKeys.Count > 0).ForeignKeys);
+            var fk = Assert.Single(dbModel.Tables.Single(t => t.ForeignKeys.Count > 0).ForeignKeys);
 
             Assert.Equal("db3", fk.Table.SchemaName);
             Assert.Equal("Mountains1", fk.Table.Name);
@@ -81,9 +82,9 @@ CREATE TABLE [dbo].[Denali] ( id int );";
             var sql = "CREATE TABLE Place ( Id int PRIMARY KEY NONCLUSTERED, Name int UNIQUE, Location int );" +
                       "CREATE CLUSTERED INDEX IX_Location_Name ON Place (Location, Name);" +
                       "CREATE NONCLUSTERED INDEX IX_Location ON Place (Location);";
-            var dbInfo = CreateModel(sql, new TableSelectionSet(new List<string> { "Place" }));
+            var dbModel = CreateModel(sql, new TableSelectionSet(new List<string> { "Place" }));
 
-            var indexes = dbInfo.Tables.Single().Indexes;
+            var indexes = dbModel.Tables.Single().Indexes;
 
             Assert.All(indexes, c =>
                 {
@@ -126,9 +127,9 @@ CREATE TABLE [dbo].[MountainsColumns] (
     Modified rowversion,
     Primary Key (Name, Id)
 );";
-            var dbInfo = CreateModel(sql, new TableSelectionSet(new List<string> { "MountainsColumns" }));
+            var dbModel = CreateModel(sql, new TableSelectionSet(new List<string> { "MountainsColumns" }));
 
-            var columns = dbInfo.Tables.Single().Columns.OrderBy(c => c.Ordinal);
+            var columns = dbModel.Tables.Single().Columns.OrderBy(c => c.Ordinal);
 
             Assert.All(columns, c =>
                 {
@@ -214,13 +215,13 @@ CREATE TABLE [dbo].[MountainsColumns] (
         [InlineData(false)]
         public void It_reads_identity(bool isIdentity)
         {
-            var dbInfo = CreateModel(
+            var dbModel = CreateModel(
                 @"IF OBJECT_ID('dbo.Identities', 'U') IS NOT NULL 
     DROP TABLE [dbo].[Identities];
 CREATE TABLE [dbo].[Identities] ( Id INT " + (isIdentity ? "IDENTITY(1,1)" : "") + ")",
                 new TableSelectionSet(new List<string> { "Identities" }));
 
-            var column = Assert.IsType<SqlServerColumnModel>(Assert.Single(dbInfo.Tables.Single().Columns));
+            var column = Assert.IsType<SqlServerColumnModel>(Assert.Single(dbModel.Tables.Single().Columns));
             Assert.Equal(isIdentity, column.IsIdentity);
             Assert.Equal(isIdentity ? ValueGenerated.OnAdd : default(ValueGenerated?), column.ValueGenerated);
         }
@@ -231,14 +232,77 @@ CREATE TABLE [dbo].[Identities] ( Id INT " + (isIdentity ? "IDENTITY(1,1)" : "")
             var sql = @"CREATE TABLE [dbo].[K2] ( Id int, A varchar, UNIQUE (A ) );
 CREATE TABLE [dbo].[Kilimanjaro] ( Id int, B varchar, UNIQUE (B), FOREIGN KEY (B) REFERENCES K2 (A) );";
 
-            var selectionSet = new TableSelectionSet(new List<string>{ "K2" });
+            var selectionSet = new TableSelectionSet(new List<string> { "K2" });
 
-            var dbInfo = CreateModel(sql, selectionSet);
-            var table = Assert.Single(dbInfo.Tables);
+            var dbModel = CreateModel(sql, selectionSet);
+            var table = Assert.Single(dbModel.Tables);
             Assert.Equal("K2", table.Name);
             Assert.Equal(2, table.Columns.Count);
             Assert.Equal(1, table.Indexes.Count);
             Assert.Empty(table.ForeignKeys);
+        }
+
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.SupportsSequences)]
+        public void It_reads_sequences()
+        {
+            var sql = @"CREATE SEQUENCE DefaultValues_read;
+ 
+CREATE SEQUENCE CustomSequence_read
+    AS numeric
+    START WITH 1 
+    INCREMENT BY 2 
+    MAXVALUE 8 
+    MINVALUE -3 
+    CYCLE;";
+
+            var dbModel = CreateModel(sql);
+            Assert.Collection(dbModel.Sequences.Where(s => s.Name.EndsWith("_read")).OrderBy(s => s.Name),
+                c =>
+                    {
+                        Assert.Equal(c.Name, "CustomSequence_read");
+                        Assert.Equal(c.SchemaName, "dbo");
+                        Assert.Equal(c.DataType, "numeric");
+                        Assert.Equal(1, c.Start);
+                        Assert.Equal(2, c.IncrementBy);
+                        Assert.Equal(8, c.Max);
+                        Assert.Equal(-3, c.Min);
+                        Assert.True(c.IsCyclic);
+                    },
+                d =>
+                    {
+                        Assert.Equal(d.Name, "DefaultValues_read");
+                        Assert.Equal(d.SchemaName, "dbo");
+                        Assert.Equal(d.DataType, "bigint");
+                        Assert.Equal(1, d.IncrementBy);
+                        Assert.False(d.IsCyclic);
+                        Assert.Null(d.Max);
+                        Assert.Null(d.Min);
+                        Assert.Null(d.Start);
+                    });
+        }
+
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.SupportsSequences)]
+        public void SequenceModel_values_null_for_default_min_max_start()
+        {
+            var sql = @"CREATE SEQUENCE [TinyIntSequence_defaults]
+    AS tinyint;
+CREATE SEQUENCE [SmallIntSequence_defaults]
+    AS smallint;
+CREATE SEQUENCE [IntSequence_defaults]
+    AS int;
+CREATE SEQUENCE [DecimalSequence_defaults]
+    AS decimal;
+CREATE SEQUENCE [NumericSequence_defaults]
+    AS numeric;";
+            var dbModel = CreateModel(sql);
+            Assert.All(dbModel.Sequences.Where(s => s.Name.EndsWith("_defaults")), s =>
+                {
+                    Assert.Null(s.Start);
+                    Assert.Null(s.Min);
+                    Assert.Null(s.Max);
+                });
         }
 
         private readonly SqlServerDatabaseModelFixture _fixture;

--- a/test/EntityFramework.Relational.Design.FunctionalTests/App.config
+++ b/test/EntityFramework.Relational.Design.FunctionalTests/App.config
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<!-- binding redirect so TD.NET gets the right assembly version -->
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="1.1.36.0" newVersion="1.1.37.0"/>
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/test/EntityFramework.Relational.Design.FunctionalTests/EntityFramework.Relational.Design.FunctionalTests.csproj
+++ b/test/EntityFramework.Relational.Design.FunctionalTests/EntityFramework.Relational.Design.FunctionalTests.csproj
@@ -65,6 +65,7 @@
     <Compile Include="ReverseEngineering\InMemoryFileService.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="App.config" />
     <None Include="project.json" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/test/EntityFramework.Relational.Design.Tests/EntityFramework.Relational.Design.Tests.csproj
+++ b/test/EntityFramework.Relational.Design.Tests/EntityFramework.Relational.Design.Tests.csproj
@@ -65,7 +65,6 @@
   <ItemGroup>
     <Reference Include="System" />
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/test/EntityFramework.Relational.Design.Tests/RelationalDatabaseModelFactoryTest.cs
+++ b/test/EntityFramework.Relational.Design.Tests/RelationalDatabaseModelFactoryTest.cs
@@ -587,6 +587,31 @@ namespace Microsoft.Data.Entity.Relational.Design
                         Assert.Equal("Id", id.Relational().ColumnName);
                     });
         }
+
+        [Fact]
+        public void Sequences()
+        {
+            var info = new DatabaseModel
+            {
+                Sequences =
+                {
+                    new SequenceModel { Name = "CountByThree", IncrementBy = 3 },
+                }
+            };
+
+            var model = (Model)_factory.Create(info);
+
+            Assert.Collection(model.Relational().Sequences, first =>
+                {
+                    Assert.NotNull(first);
+                    Assert.Equal("CountByThree", first.Name);
+                    Assert.Equal(3, first.IncrementBy);
+                    Assert.Null(first.Schema);
+                    Assert.Null(first.MaxValue);
+                    Assert.Null(first.MinValue);
+                    Assert.False(first.IsCyclic);
+                });
+        }
     }
 
     public class FakeScaffoldingModelFactory : RelationalScaffoldingModelFactory

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/App.config
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/App.config
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<!-- binding redirect so TD.NET gets the right assembly version -->
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="1.1.36.0" newVersion="1.1.37.0"/>
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/EntityFramework.Sqlite.Design.FunctionalTests.csproj
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/EntityFramework.Sqlite.Design.FunctionalTests.csproj
@@ -34,6 +34,7 @@
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="App.config" />
     <None Include="project.json" />
     <None Include="ReverseEngineering\Expected\AllFluentApi\FkToAltKey\Comment.expected">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>


### PR DESCRIPTION
Fix #3510 

~~NB important change: `ISequence.IncrementBy` changed from `int` to `long` because `INCREMENT BY` can be greater than the range of an integer. The affected migrations and model building APIs.~~