### PR TITLE
RevEng: Support Type Aliases

### DIFF
--- a/src/EntityFramework.MicrosoftSqlServer/Storage/Internal/SqlServerTypeMapper.cs
+++ b/src/EntityFramework.MicrosoftSqlServer/Storage/Internal/SqlServerTypeMapper.cs
@@ -35,9 +35,6 @@ namespace Microsoft.Data.Entity.Storage.Internal
         private readonly RelationalTypeMapping _decimal = new RelationalTypeMapping("decimal(18, 2)", typeof(decimal));
         private readonly RelationalTypeMapping _time = new RelationalTypeMapping("time", typeof(TimeSpan));
 
-        private readonly Dictionary<string, RelationalTypeMapping> _simpleNameMappings;
-        private readonly Dictionary<Type, RelationalTypeMapping> _simpleMappings;
-
         public SqlServerTypeMapper()
         {
             _simpleNameMappings
@@ -109,12 +106,6 @@ namespace Microsoft.Data.Entity.Storage.Internal
         }
 
         protected override string GetColumnType(IProperty property) => property.SqlServer().ColumnType;
-
-        protected override IReadOnlyDictionary<Type, RelationalTypeMapping> GetSimpleMappings()
-            => _simpleMappings;
-
-        protected override IReadOnlyDictionary<string, RelationalTypeMapping> GetSimpleNameMappings()
-            => _simpleNameMappings;
 
         public override RelationalTypeMapping FindMapping(Type clrType)
         {

--- a/src/EntityFramework.Relational.Design/EntityFramework.Relational.Design.csproj
+++ b/src/EntityFramework.Relational.Design/EntityFramework.Relational.Design.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Metadata\IndexModel.cs" />
     <Compile Include="Metadata\ScaffoldingModelAnnotations.cs" />
     <Compile Include="Metadata\TableModel.cs" />
+    <Compile Include="Metadata\TypeAliasModel.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\InternalsVisibleTo.cs" />
     <Compile Include="..\Shared\Check.cs">

--- a/src/EntityFramework.Relational.Design/Metadata/DatabaseModel.cs
+++ b/src/EntityFramework.Relational.Design/Metadata/DatabaseModel.cs
@@ -15,5 +15,7 @@ namespace Microsoft.Data.Entity.Scaffolding.Metadata
         public virtual string DefaultSchemaName { get; [param: CanBeNull] set; }
 
         public virtual IList<TableModel> Tables { get; } = new List<TableModel>();
+
+        public virtual IList<TypeAliasModel> TypeAliases { get; } = new List<TypeAliasModel>();
     }
 }

--- a/src/EntityFramework.Relational.Design/Metadata/TypeAliasModel.cs
+++ b/src/EntityFramework.Relational.Design/Metadata/TypeAliasModel.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+
+namespace Microsoft.Data.Entity.Scaffolding.Metadata
+{
+    public class TypeAliasModel
+    {
+        public virtual string Alias { get; [param: NotNull] set; }
+        public virtual string SystemType { get; [param: NotNull] set; }
+    }
+}

--- a/src/EntityFramework.Relational.Design/Properties/RelationalDesignStrings.Designer.cs
+++ b/src/EntityFramework.Relational.Design/Properties/RelationalDesignStrings.Designer.cs
@@ -116,6 +116,14 @@ namespace Microsoft.Data.Entity.Internal
             return string.Format(CultureInfo.CurrentCulture, GetString("ExistingFiles", "outputDirectoryName", "existingFiles"), outputDirectoryName, existingFiles);
         }
 
+        /// <summary>
+        /// Unable to add type alias '{alias}' with underlying system type '{storeSystemType}' into type mappings.
+        /// </summary>
+        public static string UnableToAddTypeAlias([CanBeNull] object alias, [CanBeNull] object storeSystemType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("UnableToAddTypeAlias", "alias", "storeSystemType"), alias, storeSystemType);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EntityFramework.Relational.Design/Properties/RelationalDesignStrings.resx
+++ b/src/EntityFramework.Relational.Design/Properties/RelationalDesignStrings.resx
@@ -156,4 +156,7 @@
   <data name="ExistingFiles" xml:space="preserve">
     <value>The following file(s) already exist in directory {outputDirectoryName}: {existingFiles}. Use the Force flag to overwrite these files.</value>
   </data>
+  <data name="UnableToAddTypeAlias" xml:space="preserve">
+    <value>Unable to add type alias '{alias}' with underlying system type '{storeSystemType}' into type mappings.</value>
+  </data>
 </root>

--- a/src/EntityFramework.Relational.Design/RelationalScaffoldingModelFactory.cs
+++ b/src/EntityFramework.Relational.Design/RelationalScaffoldingModelFactory.cs
@@ -52,8 +52,23 @@ namespace Microsoft.Data.Entity.Scaffolding
             Check.NotEmpty(connectionString, nameof(connectionString));
 
             var schemaInfo = _databaseModelFactory.Create(connectionString, tableSelectionSet ?? TableSelectionSet.All);
+            AddTypeAliasesToTypeMapper(schemaInfo.TypeAliases);
 
             return CreateFromDatabaseModel(schemaInfo);
+        }
+
+        protected virtual void AddTypeAliasesToTypeMapper([NotNull] IEnumerable<TypeAliasModel> typeAliases)
+        {
+            Check.NotNull(typeAliases, nameof(typeAliases));
+
+            foreach (var typeAlias in typeAliases)
+            {
+                if (!_typeMapper.AddTypeAlias(typeAlias.Alias, typeAlias.SystemType))
+                {
+                    Logger.LogWarning(RelationalDesignStrings
+                        .UnableToAddTypeAlias(typeAlias.Alias, typeAlias.SystemType));
+                }
+            }
         }
 
         protected virtual IModel CreateFromDatabaseModel([NotNull] DatabaseModel databaseModel)

--- a/src/EntityFramework.Relational/Storage/IRelationalTypeMapper.cs
+++ b/src/EntityFramework.Relational/Storage/IRelationalTypeMapper.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Data.Entity.Storage
 {
     public interface IRelationalTypeMapper
     {
+        bool AddTypeAlias([NotNull] string typeAlias, [NotNull] string systemDataType);
         RelationalTypeMapping FindMapping([NotNull] IProperty property);
         RelationalTypeMapping FindMapping([NotNull] Type clrType);
         RelationalTypeMapping FindMapping([NotNull] string typeName);

--- a/src/EntityFramework.Relational/Storage/RelationalTypeMapper.cs
+++ b/src/EntityFramework.Relational/Storage/RelationalTypeMapper.cs
@@ -21,12 +21,34 @@ namespace Microsoft.Data.Entity.Storage
         private readonly ConcurrentDictionary<int, RelationalTypeMapping> _boundedBinaryMappings
             = new ConcurrentDictionary<int, RelationalTypeMapping>();
 
-        protected abstract IReadOnlyDictionary<Type, RelationalTypeMapping> GetSimpleMappings();
+        protected virtual IReadOnlyDictionary<Type, RelationalTypeMapping> GetSimpleMappings()
+            => _simpleMappings;
 
-        protected abstract IReadOnlyDictionary<string, RelationalTypeMapping> GetSimpleNameMappings();
+        protected virtual IReadOnlyDictionary<string, RelationalTypeMapping> GetSimpleNameMappings()
+            => _simpleNameMappings;
+
+        protected Dictionary<string, RelationalTypeMapping> _simpleNameMappings;
+        protected Dictionary<Type, RelationalTypeMapping> _simpleMappings;
 
         // Not using IRelationalAnnotationProvider here because type mappers are Singletons
         protected abstract string GetColumnType([NotNull] IProperty property);
+
+        public virtual bool AddTypeAlias(
+            [NotNull] string typeAlias, [NotNull] string systemDataType)
+        {
+            Check.NotEmpty(typeAlias, nameof(typeAlias));
+            Check.NotEmpty(systemDataType, nameof(systemDataType));
+
+            RelationalTypeMapping mapping;
+            if (_simpleNameMappings.ContainsKey(typeAlias)
+                || !_simpleNameMappings.TryGetValue(systemDataType, out mapping))
+            {
+                return false;
+            }
+
+            _simpleNameMappings.Add(typeAlias, mapping);
+            return true;
+        }
 
         public virtual RelationalTypeMapping FindMapping([NotNull] IProperty property)
         {

--- a/src/EntityFramework.Sqlite/Storage/Internal/SqliteTypeMapper.cs
+++ b/src/EntityFramework.Sqlite/Storage/Internal/SqliteTypeMapper.cs
@@ -17,10 +17,6 @@ namespace Microsoft.Data.Entity.Storage.Internal
         private static readonly RelationalTypeMapping _text = new RelationalTypeMapping("TEXT", typeof(string));
         private static readonly RelationalTypeMapping _default = _text;
 
-        private readonly Dictionary<string, RelationalTypeMapping> _simpleNameMappings;
-
-        private readonly Dictionary<Type, RelationalTypeMapping> _simpleMappings;
-
         public SqliteTypeMapper()
         {
             _simpleNameMappings
@@ -95,11 +91,5 @@ namespace Microsoft.Data.Entity.Storage.Internal
 
         private static bool Contains(string haystack, string needle)
             => haystack.IndexOf(needle, StringComparison.OrdinalIgnoreCase) >= 0;
-
-        protected override IReadOnlyDictionary<Type, RelationalTypeMapping> GetSimpleMappings()
-            => _simpleMappings;
-
-        protected override IReadOnlyDictionary<string, RelationalTypeMapping> GetSimpleNameMappings()
-            => _simpleNameMappings;
     }
 }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/E2E.sql
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/E2E.sql
@@ -38,6 +38,10 @@ if exists (select * from sysobjects where id = object_id('dbo.AllDataTypes') and
 	DROP TABLE "dbo"."AllDataTypes"
 GO
 
+if exists (select * from systypes where name = 'TestTypeAlias')
+	drop TYPE "dbo"."TestTypeAlias"
+GO
+
 if exists (select * from sysobjects where id = object_id('dbo.PropertyConfiguration') and sysstat & 0xf = 3)
 	DROP TABLE "dbo"."PropertyConfiguration"
 GO
@@ -94,6 +98,9 @@ if exists (select * from sysobjects where id = object_id('dbo.FilteredOut') and 
 	drop table "dbo"."FilteredOut"
 GO
 
+CREATE TYPE TestTypeAlias FROM nvarchar(max)
+GO
+
 CREATE TABLE "dbo"."AllDataTypes" (
 	"AllDataTypesID" "int" IDENTITY(1, 1) PRIMARY KEY,
 	"bigintColumn" "bigint" NOT NULL,
@@ -132,6 +139,7 @@ CREATE TABLE "dbo"."AllDataTypes" (
 	"xmlColumn" "xml" NULL,
 	"geographyColumn" "geography" NULL,
 	"geometryColumn" "geometry" NULL,
+	"typeAliasColumn" "TestTypeAlias" NULL,
 )
 
 GO

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/AllDataTypes.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/AllDataTypes.expected
@@ -34,6 +34,7 @@ namespace E2ETest.Namespace
         public TimeSpan? timeColumn { get; set; }
         public byte[] timestampColumn { get; set; }
         public byte tinyintColumn { get; set; }
+        public string typeAliasColumn { get; set; }
         public Guid? uniqueidentifierColumn { get; set; }
         public byte[] varbinaryColumn { get; set; }
         public string varcharColumn { get; set; }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/SqlServerReverseEngineerTestE2EContext.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/SqlServerReverseEngineerTestE2EContext.expected
@@ -58,6 +58,8 @@ namespace E2ETest.Namespace
                     .HasColumnType("timestamp")
                     .ValueGeneratedOnAddOrUpdate();
 
+                entity.Property(e => e.typeAliasColumn).HasColumnType("TestTypeAlias");
+
                 entity.Property(e => e.varbinaryColumn)
                     .HasMaxLength(1)
                     .HasColumnType("varbinary");

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/AllDataTypes.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/AllDataTypes.expected
@@ -40,6 +40,7 @@ namespace E2ETest.Namespace
         public TimeSpan? timeColumn { get; set; }
         public byte[] timestampColumn { get; set; }
         public byte tinyintColumn { get; set; }
+        public string typeAliasColumn { get; set; }
         public Guid? uniqueidentifierColumn { get; set; }
         [MaxLength(1)]
         public byte[] varbinaryColumn { get; set; }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/AttributesContext.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/AttributesContext.expected
@@ -50,6 +50,8 @@ namespace E2ETest.Namespace
                     .HasColumnType("timestamp")
                     .ValueGeneratedOnAddOrUpdate();
 
+                entity.Property(e => e.typeAliasColumn).HasColumnType("TestTypeAlias");
+
                 entity.Property(e => e.varbinaryColumn).HasColumnType("varbinary");
 
                 entity.Property(e => e.varcharColumn).HasColumnType("varchar");

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/SqlServerDatabaseModelFactoryTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/SqlServerDatabaseModelFactoryTest.cs
@@ -17,6 +17,31 @@ namespace Microsoft.Data.Entity.SqlServer.Design.FunctionalTests
     public class SqlServerDatabaseModelFactoryTest : IClassFixture<SqlServerDatabaseModelFixture>
     {
         [Fact]
+        public void It_reads_type_aliases()
+        {
+            var sql = @"
+CREATE TYPE [dbo].[nvarcharMaxTestTypeAlias] FROM nvarchar(max);
+CREATE TYPE [dbo].[floatTestTypeAlias] FROM float";
+
+            var dbInfo = CreateModel(sql);
+
+            // There are some pre-existing type aliases already defined in the DB
+            // hence the Where() clause.
+            Assert.Collection(dbInfo.TypeAliases
+                .Where(ta => ta.Alias.Contains("TestTypeAlias")).OrderBy(ta => ta.Alias),
+                ta0 =>
+                {
+                    Assert.Equal("floatTestTypeAlias", ta0.Alias);
+                    Assert.Equal("float", ta0.SystemType);
+                },
+                ta1 =>
+                {
+                    Assert.Equal("nvarcharMaxTestTypeAlias", ta1.Alias);
+                    Assert.Equal("nvarchar", ta1.SystemType);
+                });
+        }
+
+        [Fact]
         public void It_reads_tables()
         {
             var sql = @"

--- a/test/EntityFramework.Relational.Design.Tests/RelationalDatabaseModelFactoryTest.cs
+++ b/test/EntityFramework.Relational.Design.Tests/RelationalDatabaseModelFactoryTest.cs
@@ -615,26 +615,23 @@ namespace Microsoft.Data.Entity.Relational.Design
         private static readonly RelationalTypeMapping _string = new RelationalTypeMapping("string", typeof(string));
         private static readonly RelationalTypeMapping _long = new RelationalTypeMapping("long", typeof(long));
 
-        private readonly IReadOnlyDictionary<Type, RelationalTypeMapping> _simpleMappings
-            = new Dictionary<Type, RelationalTypeMapping>
-                {
-                    { typeof(string), _string },
-                    { typeof(long), _long }
-                };
+        public TestTypeMapper()
+        {
+            _simpleMappings
+                = new Dictionary<Type, RelationalTypeMapping>
+                    {
+                        { typeof(string), _string },
+                        { typeof(long), _long }
+                    };
 
-        private readonly IReadOnlyDictionary<string, RelationalTypeMapping> _simpleNameMappings
-            = new Dictionary<string, RelationalTypeMapping>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "string", _string },
-                    { "alias for string", _string },
-                    { "long", _long }
-                };
-
-        protected override IReadOnlyDictionary<Type, RelationalTypeMapping> GetSimpleMappings()
-            => _simpleMappings;
-
-        protected override IReadOnlyDictionary<string, RelationalTypeMapping> GetSimpleNameMappings()
-            => _simpleNameMappings;
+            _simpleNameMappings
+                = new Dictionary<string, RelationalTypeMapping>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        { "string", _string },
+                        { "alias for string", _string },
+                        { "long", _long }
+                    };
+        }
 
         protected override string GetColumnType(IProperty property) => ((Property)property).Relational().ColumnType;
     }

--- a/test/EntityFramework.Relational.Tests/Migrations/Internal/MigrationsModelDifferTestBase.cs
+++ b/test/EntityFramework.Relational.Tests/Migrations/Internal/MigrationsModelDifferTestBase.cs
@@ -40,6 +40,23 @@ namespace Microsoft.Data.Entity.Migrations.Internal
 
         private class ConcreteTypeMapper : RelationalTypeMapper
         {
+            public ConcreteTypeMapper()
+            {
+                _simpleMappings
+                    = new Dictionary<Type, RelationalTypeMapping>
+                        {
+                            { typeof(int), new RelationalTypeMapping("int", typeof(int)) },
+                            { typeof(bool), new RelationalTypeMapping("boolean", typeof(bool)) }
+                        };
+
+                _simpleNameMappings
+                    = new Dictionary<string, RelationalTypeMapping>
+                        {
+                            { "varchar", new RelationalTypeMapping("varchar", typeof(string)) },
+                            { "bigint", new RelationalTypeMapping("bigint", typeof(long)) }
+                        };
+            }
+
             protected override string GetColumnType(IProperty property) => property.TestProvider().ColumnType;
 
             public override RelationalTypeMapping FindMapping([NotNull] Type clrType)
@@ -51,27 +68,6 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                 => property.ClrType == typeof(string) && property.GetMaxLength().HasValue
                     ? new RelationalTypeMapping("varchar(" + property.GetMaxLength() + ")", typeof(string))
                     : base.FindCustomMapping(property);
-
-
-            private readonly IReadOnlyDictionary<Type, RelationalTypeMapping> _simpleMappings
-                = new Dictionary<Type, RelationalTypeMapping>
-                    {
-                        { typeof(int), new RelationalTypeMapping("int", typeof(int)) },
-                        { typeof(bool), new RelationalTypeMapping("boolean", typeof(bool)) }
-                    };
-
-            private readonly IReadOnlyDictionary<string, RelationalTypeMapping> _simpleNameMappings
-                = new Dictionary<string, RelationalTypeMapping>
-                    {
-                        { "varchar", new RelationalTypeMapping("varchar", typeof(string)) },
-                        { "bigint", new RelationalTypeMapping("bigint", typeof(long)) }
-                    };
-
-            protected override IReadOnlyDictionary<Type, RelationalTypeMapping> GetSimpleMappings()
-                => _simpleMappings;
-
-            protected override IReadOnlyDictionary<string, RelationalTypeMapping> GetSimpleNameMappings()
-                => _simpleNameMappings;
         }
     }
 }

--- a/test/EntityFramework.Relational.Tests/Migrations/MigrationSqlGeneratorTest.cs
+++ b/test/EntityFramework.Relational.Tests/Migrations/MigrationSqlGeneratorTest.cs
@@ -303,23 +303,21 @@ namespace Microsoft.Data.Entity.Migrations
 
         private class ConcreteRelationalTypeMapper : RelationalTypeMapper
         {
-            private readonly IReadOnlyDictionary<Type, RelationalTypeMapping> _simpleMappings
-                = new Dictionary<Type, RelationalTypeMapping>
-                {
-                    { typeof(int), new RelationalTypeMapping("int", typeof(int)) }
-                };
+            public ConcreteRelationalTypeMapper()
+            {
+                _simpleMappings
+                    = new Dictionary<Type, RelationalTypeMapping>
+                    {
+                        { typeof(int), new RelationalTypeMapping("int", typeof(int)) }
+                    };
 
-            private readonly IReadOnlyDictionary<string, RelationalTypeMapping> _simpleNameMappings
-                = new Dictionary<string, RelationalTypeMapping>
-                {
-                    { "nvarchar", new RelationalTypeMapping("nvarchar", typeof(string)) }
-                };
+                _simpleNameMappings
+                    = new Dictionary<string, RelationalTypeMapping>
+                    {
+                        { "nvarchar", new RelationalTypeMapping("nvarchar", typeof(string)) }
+                    };
+            }
 
-            protected override IReadOnlyDictionary<Type, RelationalTypeMapping> GetSimpleMappings()
-                => _simpleMappings;
-
-            protected override IReadOnlyDictionary<string, RelationalTypeMapping> GetSimpleNameMappings()
-                => _simpleNameMappings;
 
             protected override string GetColumnType(IProperty property) => property.TestProvider().ColumnType;
 

--- a/test/EntityFramework.Relational.Tests/SqlBatchBuilderTest.cs
+++ b/test/EntityFramework.Relational.Tests/SqlBatchBuilderTest.cs
@@ -100,20 +100,17 @@ Statement3
 
         private class TestRelationalTypeMapper : RelationalTypeMapper
         {
-            private readonly IReadOnlyDictionary<Type, RelationalTypeMapping> _simpleMappings
-                = new Dictionary<Type, RelationalTypeMapping>
-                    {
-                        { typeof(int), new RelationalTypeMapping("int", typeof(int), DbType.String) }
-                    };
+            public TestRelationalTypeMapper()
+            {
+                _simpleMappings
+                    = new Dictionary<Type, RelationalTypeMapping>
+                        {
+                            { typeof(int), new RelationalTypeMapping("int", typeof(int), DbType.String) }
+                        };
 
-            private readonly IReadOnlyDictionary<string, RelationalTypeMapping> _simpleNameMappings
-                = new Dictionary<string, RelationalTypeMapping>();
-
-            protected override IReadOnlyDictionary<Type, RelationalTypeMapping> GetSimpleMappings()
-                => _simpleMappings;
-
-            protected override IReadOnlyDictionary<string, RelationalTypeMapping> GetSimpleNameMappings()
-                => _simpleNameMappings;
+                _simpleNameMappings
+                    = new Dictionary<string, RelationalTypeMapping>();
+            }
 
             protected override string GetColumnType(IProperty property) => property.TestProvider().ColumnType;
         }

--- a/test/EntityFramework.Relational.Tests/TestRelationalTypeMapper.cs
+++ b/test/EntityFramework.Relational.Tests/TestRelationalTypeMapper.cs
@@ -21,28 +21,25 @@ namespace Microsoft.Data.Entity.Tests
         private static readonly RelationalTypeMapping _defaultIntMapping = new RelationalTypeMapping("default_int_mapping", typeof(int));
         private static readonly RelationalTypeMapping _someIntMapping = new RelationalTypeMapping("some_int_mapping", typeof(int));
 
+        public TestRelationalTypeMapper()
+        {
+            _simpleMappings
+                = new Dictionary<Type, RelationalTypeMapping>
+                    {
+                        { typeof(int), _defaultIntMapping },
+                        { typeof(string), _string }
+                    };
+
+            _simpleNameMappings
+                = new Dictionary<string, RelationalTypeMapping>
+                    {
+                        { "some_int_mapping", _someIntMapping },
+                        { "some_string(max)", _string },
+                        { "some_binary(max)", _binary }
+                    };
+        }
+
         protected override string GetColumnType(IProperty property) => property.TestProvider().ColumnType;
-
-        private readonly IReadOnlyDictionary<Type, RelationalTypeMapping> _simpleMappings
-        = new Dictionary<Type, RelationalTypeMapping>
-            {
-                { typeof(int), _defaultIntMapping },
-                { typeof(string), _string }
-            };
-
-        private readonly IReadOnlyDictionary<string, RelationalTypeMapping> _simpleNameMappings
-        = new Dictionary<string, RelationalTypeMapping>
-            {
-                { "some_int_mapping", _someIntMapping },
-                { "some_string(max)", _string },
-                { "some_binary(max)", _binary }
-            };
-
-        protected override IReadOnlyDictionary<Type, RelationalTypeMapping> GetSimpleMappings()
-            => _simpleMappings;
-
-        protected override IReadOnlyDictionary<string, RelationalTypeMapping> GetSimpleNameMappings()
-            => _simpleNameMappings;
 
         protected override RelationalTypeMapping FindCustomMapping(IProperty property)
         {

--- a/test/EntityFramework.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalTypeMapper.cs
+++ b/test/EntityFramework.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalTypeMapper.cs
@@ -16,28 +16,25 @@ namespace Microsoft.Data.Entity.TestUtilities.FakeProvider
         private static readonly RelationalTypeMapping _long = new RelationalTypeMapping("DefaultLong", typeof(long), DbType.Int64);
         private static readonly RelationalTypeMapping _string = new RelationalTypeMapping("DefaultString", typeof(string), DbType.String);
 
-        protected override string GetColumnType(IProperty property) => property.TestProvider().ColumnType;
+        public FakeRelationalTypeMapper()
+        {
+            _simpleMappings
+                = new Dictionary<Type, RelationalTypeMapping>
+                    {
+                        { typeof(int), _int },
+                        { typeof(long), _long },
+                        { typeof(string), _string }
+                    };
 
-        private readonly IReadOnlyDictionary<Type, RelationalTypeMapping> _simpleMappings
-            = new Dictionary<Type, RelationalTypeMapping>
-                {
-                    { typeof(int), _int },
-                    { typeof(long), _long },
-                    { typeof(string), _string }
-                };
+            _simpleNameMappings
+                = new Dictionary<string, RelationalTypeMapping>
+                    {
+                        { "DefaultInt", _int },
+                        { "DefaultLong", _long },
+                        { "DefaultString", _string}
+                    };
+        }
 
-        private readonly IReadOnlyDictionary<string, RelationalTypeMapping> _simpleNameMappings
-            = new Dictionary<string, RelationalTypeMapping>
-                {
-                    { "DefaultInt", _int },
-                    { "DefaultLong", _long },
-                    { "DefaultString", _string}
-                };
-
-        protected override IReadOnlyDictionary<Type, RelationalTypeMapping> GetSimpleMappings()
-            => _simpleMappings;
-
-        protected override IReadOnlyDictionary<string, RelationalTypeMapping> GetSimpleNameMappings()
-            => _simpleNameMappings;
+    protected override string GetColumnType(IProperty property) => property.TestProvider().ColumnType;
     }
 }


### PR DESCRIPTION
Fix for #3843 - allow columns to use user-defined data types as the column type.

Note: I'm open to reducing this down to only the `SqlServerTypeMapper`, `SqlServerDatabaseModelFactory` etc. But I wanted to put this wider approach out there so that other providers could re-use the same architecture i.e. they would only have to provide their own implementation of `XyzDatabaseModelFactory.GetUserDefinedDataTypes()` and after that it would "just work". The price is `GetUserDefinedDataTypes()` has to run before the first call to `Create()` and so it has to manage its own connection.