### PR TITLE
Skip tests on Mono that fail due to external bugs

### DIFF
--- a/test/EntityFramework.Core.FunctionalTests/AsNoTrackingTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/AsNoTrackingTestBase.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using Microsoft.Data.Entity.FunctionalTests.TestModels.Northwind;
+using Microsoft.Data.Entity.FunctionalTests.TestUtilities.Xunit;
 using Xunit;
 
 // ReSharper disable AccessToDisposedClosure
@@ -24,7 +25,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
+        [MonoVersionCondition(Min = "4.2.0", SkipReason = "Queries fail on Mono < 4.2.0 due to differences in the implementation of LINQ")]
         public virtual void Applied_to_body_clause()
         {
             using (var context = CreateContext())
@@ -59,7 +61,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
+        [MonoVersionCondition(Min = "4.2.0", SkipReason = "Queries fail on Mono < 4.2.0 due to differences in the implementation of LINQ")]
         public virtual void Applied_to_body_clause_with_projection()
         {
             using (var context = CreateContext())

--- a/test/EntityFramework.Core.FunctionalTests/AsTrackingTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/AsTrackingTestBase.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.FunctionalTests.TestModels.Northwind;
+using Microsoft.Data.Entity.FunctionalTests.TestUtilities.Xunit;
 using Xunit;
 
 namespace Microsoft.Data.Entity.FunctionalTests
@@ -23,7 +24,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
+        [MonoVersionCondition(Min = "4.2.0", SkipReason = "Queries fail on Mono < 4.2.0 due to differences in the implementation of LINQ")]
         public virtual void Applied_to_body_clause()
         {
             using (var context = CreateContext())
@@ -58,7 +60,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
+        [MonoVersionCondition(Min = "4.2.0", SkipReason = "Queries fail on Mono < 4.2.0 due to differences in the implementation of LINQ")]
         public virtual void Applied_to_body_clause_with_projection()
         {
             using (var context = CreateContext())
@@ -76,7 +79,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
+        [MonoVersionCondition(Min = "4.2.0", SkipReason = "Queries fail on Mono < 4.2.0 due to differences in the implementation of LINQ")]
         public virtual void Applied_to_projection()
         {
             using (var context = CreateContext())

--- a/test/EntityFramework.Core.FunctionalTests/AsyncQueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/AsyncQueryTestBase.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.Entity.FunctionalTests.TestModels.Northwind;
 using Microsoft.Data.Entity.Tests;
+using Microsoft.Data.Entity.FunctionalTests.TestUtilities.Xunit;
 using Xunit;
 // ReSharper disable AccessToDisposedClosure
 // ReSharper disable StringStartsWithIsCultureSpecific
@@ -16,6 +17,7 @@ using Xunit;
 
 namespace Microsoft.Data.Entity.FunctionalTests
 {
+    [MonoVersionCondition(Min = "4.2.0", SkipReason = "Async queries will not work on Mono < 4.2.0 due to differences in the IQueryable interface")]
     public abstract class AsyncQueryTestBase<TFixture> : IClassFixture<TFixture>
         where TFixture : NorthwindQueryFixtureBase, new()
     {
@@ -25,7 +27,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs => cs.SingleAsync(c => c.CustomerID == "ALFKI", cancellationToken));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Mixed_sync_async_in_query_cache()
         {
             using (var context = CreateContext())
@@ -35,7 +37,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Queryable_simple()
         {
             await AssertQuery<Customer>(
@@ -43,7 +45,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Queryable_simple_anonymous()
         {
             await AssertQuery<Customer>(
@@ -51,7 +53,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Queryable_nested_simple()
         {
             await AssertQuery<Customer>(
@@ -60,7 +62,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Take_simple()
         {
             await AssertQuery<Customer>(
@@ -69,7 +71,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 10);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Take_simple_projection()
         {
             await AssertQuery<Customer>(
@@ -77,7 +79,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 assertOrder: true);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Skip()
         {
             await AssertQuery<Customer>(
@@ -86,7 +88,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 86);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Take_Skip()
         {
             await AssertQuery<Customer>(
@@ -95,7 +97,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 5);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Distinct_Skip()
         {
             await AssertQuery<Customer>(
@@ -104,7 +106,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 86);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Skip_Take()
         {
             await AssertQuery<Customer>(
@@ -113,7 +115,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 10);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Distinct_Skip_Take()
         {
             await AssertQuery<Customer>(
@@ -122,7 +124,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 10);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Skip_Distinct()
         {
             await AssertQuery<Customer>(
@@ -130,7 +132,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 86);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Skip_Take_Distinct()
         {
             await AssertQuery<Customer>(
@@ -138,7 +140,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 10);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Take_Skip_Distinct()
         {
             await AssertQuery<Customer>(
@@ -146,7 +148,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 5);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Take_Distinct()
         {
             await AssertQuery<Order>(
@@ -154,7 +156,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 5);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Distinct_Take()
         {
             await AssertQuery<Order>(
@@ -163,56 +165,56 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 5);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Distinct_Take_Count()
         {
             await AssertQuery<Order>(
                 os => os.Distinct().Take(5).CountAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Take_Distinct_Count()
         {
             await AssertQuery<Order>(
                 os => os.Take(5).Distinct().CountAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Any_simple()
         {
             await AssertQuery<Customer>(
                 cs => cs.AnyAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task OrderBy_Take_Count()
         {
             await AssertQuery<Order>(
                 os => os.OrderBy(o => o.OrderID).Take(5).CountAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Take_OrderBy_Count()
         {
             await AssertQuery<Order>(
                 os => os.Take(5).OrderBy(o => o.OrderID).CountAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Any_predicate()
         {
             await AssertQuery<Customer>(
                 cs => cs.AnyAsync(c => c.ContactName.StartsWith("A")));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task All_top_level()
         {
             await AssertQuery<Customer>(
                 cs => cs.AllAsync(c => c.ContactName.StartsWith("A")));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task All_top_level_subquery()
         {
             // ReSharper disable once PossibleUnintendedReferenceComparison
@@ -220,7 +222,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs => cs.AllAsync(c1 => cs.Any(c2 => cs.Any(c3 => c1 == c3))));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Select_into()
         {
             await AssertQuery<Customer>(
@@ -232,7 +234,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     select id);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Projection_when_arithmetic_expressions()
         {
             await AssertQuery<Order>(
@@ -249,7 +251,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 830);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Projection_when_arithmetic_mixed()
         {
             await AssertQuery<Order, Employee>((os, es) =>
@@ -266,7 +268,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Projection_when_arithmetic_mixed_subqueries()
         {
             await AssertQuery<Order, Employee>((os, es) =>
@@ -283,21 +285,21 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Projection_when_null_value()
         {
             await AssertQuery<Customer>(
                 cs => cs.Select(c => c.Region));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Take_with_single()
         {
             await AssertQuery<Customer>(
                 cs => cs.OrderBy(c => c.CustomerID).Take(1).SingleAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Take_with_single_select_many()
         {
             await AssertQuery<Customer, Order>((cs, os) =>
@@ -310,13 +312,13 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     .SingleAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Cast_results_to_object()
         {
             await AssertQuery<Customer>(cs => from c in cs.Cast<object>() select c, entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_simple()
         {
             await AssertQuery<Customer>(
@@ -324,7 +326,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 6);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_simple_closure()
         {
             // ReSharper disable once ConvertToConstant.Local
@@ -335,7 +337,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 6);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_simple_closure_constant()
         {
             // ReSharper disable once ConvertToConstant.Local
@@ -346,7 +348,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_simple_closure_via_query_cache()
         {
             var city = "London";
@@ -389,7 +391,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_method_call_nullable_type_closure_via_query_cache()
         {
             var city = new City { Int = 2 };
@@ -405,7 +407,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 3);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_method_call_nullable_type_reverse_closure_via_query_cache()
         {
             var city = new City { NullableInt = 1 };
@@ -421,7 +423,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 4);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_method_call_closure_via_query_cache()
         {
             var city = new City { InstanceFieldValue = "London" };
@@ -437,7 +439,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_field_access_closure_via_query_cache()
         {
             var city = new City { InstanceFieldValue = "London" };
@@ -453,7 +455,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_property_access_closure_via_query_cache()
         {
             var city = new City { InstancePropertyValue = "London" };
@@ -469,7 +471,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_static_field_access_closure_via_query_cache()
         {
             City.StaticFieldValue = "London";
@@ -485,7 +487,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_static_property_access_closure_via_query_cache()
         {
             City.StaticPropertyValue = "London";
@@ -501,7 +503,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_nested_field_access_closure_via_query_cache()
         {
             var city = new City { Nested = new City { InstanceFieldValue = "London" } };
@@ -517,7 +519,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_nested_property_access_closure_via_query_cache()
         {
             var city = new City { Nested = new City { InstancePropertyValue = "London" } };
@@ -533,7 +535,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_nested_field_access_closure_via_query_cache_error_null()
         {
             var city = new City();
@@ -547,7 +549,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_nested_field_access_closure_via_query_cache_error_method_null()
         {
             var city = new City();
@@ -561,7 +563,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_new_instance_field_access_closure_via_query_cache()
         {
             await AssertQuery<Customer>(
@@ -573,7 +575,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_simple_closure_via_query_cache_nullable_type()
         {
             int? reportsTo = 2;
@@ -595,7 +597,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_simple_closure_via_query_cache_nullable_type_reverse()
         {
             int? reportsTo = null;
@@ -617,7 +619,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 5);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_simple_shadow()
         {
             await AssertQuery<Employee>(
@@ -625,7 +627,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 6);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_simple_shadow_projection()
         {
             await AssertQuery<Employee>(
@@ -641,7 +643,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 6);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_simple_shadow_subquery()
         {
             await AssertQuery<Employee>(
@@ -651,7 +653,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 3);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_shadow_subquery_first()
         {
             await AssertQuery<Employee>(es =>
@@ -662,7 +664,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_client()
         {
             await AssertQuery<Customer>(
@@ -670,14 +672,14 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 6);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task First_client_predicate()
         {
             await AssertQuery<Customer>(
                 cs => cs.OrderBy(c => c.CustomerID).FirstAsync(c => c.IsLondon));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_equals_method_string()
         {
             await AssertQuery<Customer>(
@@ -685,7 +687,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 6);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_equals_method_int()
         {
             await AssertQuery<Employee>(
@@ -693,7 +695,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_comparison_nullable_type_not_null()
         {
             await AssertQuery<Employee>(
@@ -701,7 +703,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 5);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_comparison_nullable_type_null()
         {
             await AssertQuery<Employee>(
@@ -709,7 +711,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_string_length()
         {
             await AssertQuery<Customer>(
@@ -717,7 +719,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 20);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_simple_reversed()
         {
             await AssertQuery<Customer>(
@@ -725,14 +727,14 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 6);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_is_null()
         {
             await AssertQuery<Customer>(
                 cs => cs.Where(c => c.City == null));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_null_is_null()
         {
             // ReSharper disable once EqualExpressionComparison
@@ -741,14 +743,14 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_constant_is_null()
         {
             await AssertQuery<Customer>(
                 cs => cs.Where(c => "foo" == null));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_is_not_null()
         {
             await AssertQuery<Customer>(
@@ -756,7 +758,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_null_is_not_null()
         {
             // ReSharper disable once EqualExpressionComparison
@@ -764,7 +766,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs => cs.Where(c => null != null));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_constant_is_not_null()
         {
             await AssertQuery<Customer>(
@@ -772,7 +774,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_identity_comparison()
         {
             // ReSharper disable once EqualExpressionComparison
@@ -781,7 +783,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_select_many_or()
         {
             await AssertQuery<Customer, Employee>((cs, es) =>
@@ -792,7 +794,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c, e });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_select_many_or2()
         {
             await AssertQuery<Customer, Employee>((cs, es) =>
@@ -803,7 +805,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c, e });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_select_many_or3()
         {
             await AssertQuery<Customer, Employee>((cs, es) =>
@@ -815,7 +817,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c, e });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_select_many_or4()
         {
             await AssertQuery<Customer, Employee>((cs, es) =>
@@ -828,7 +830,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c, e });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_select_many_or_with_parameter()
         {
             var london = "London";
@@ -844,7 +846,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c, e });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_in_optimization_multiple()
         {
             await AssertQuery<Customer, Employee>((cs, es) =>
@@ -857,7 +859,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c, e });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_not_in_optimization1()
         {
             await AssertQuery<Customer, Employee>((cs, es) =>
@@ -868,7 +870,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c, e });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_not_in_optimization2()
         {
             await AssertQuery<Customer, Employee>((cs, es) =>
@@ -879,7 +881,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c, e });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_not_in_optimization3()
         {
             await AssertQuery<Customer, Employee>((cs, es) =>
@@ -891,7 +893,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c, e });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_not_in_optimization4()
         {
             await AssertQuery<Customer, Employee>((cs, es) =>
@@ -904,7 +906,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c, e });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_select_many_and()
         {
             await AssertQuery<Customer, Employee>((cs, es) =>
@@ -915,14 +917,14 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c, e });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_primitive()
         {
             await AssertQuery<Employee>(
                 es => es.Select(e => e.EmployeeID).Take(9).Where(i => i == 5));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_primitive_tracked()
         {
             await AssertQuery<Employee>(
@@ -930,7 +932,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_primitive_tracked2()
         {
             await AssertQuery<Employee>(
@@ -938,7 +940,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_subquery_anon()
         {
             await AssertQuery<Employee, Order>((es, os) =>
@@ -948,114 +950,114 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { e, o });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_bool_member()
         {
             await AssertQuery<Product>(ps => ps.Where(p => p.Discontinued), entryCount: 8);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_bool_member_false()
         {
             await AssertQuery<Product>(ps => ps.Where(p => !p.Discontinued), entryCount: 69);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_bool_member_negated_twice()
         {
             // ReSharper disable once DoubleNegationOperator
             await AssertQuery<Product>(ps => ps.Where(p => !!p.Discontinued), entryCount: 8);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_bool_member_shadow()
         {
             await AssertQuery<Product>(ps => ps.Where(p => EF.Property<bool>(p, "Discontinued")), entryCount: 8);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_bool_member_false_shadow()
         {
             await AssertQuery<Product>(ps => ps.Where(p => !EF.Property<bool>(p, "Discontinued")), entryCount: 69);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_bool_member_equals_constant()
         {
             await AssertQuery<Product>(ps => ps.Where(p => p.Discontinued.Equals(true)), entryCount: 8);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_bool_member_in_complex_predicate()
         {
             // ReSharper disable once RedundantBoolCompare
             await AssertQuery<Product>(ps => ps.Where(p => p.ProductID > 100 && p.Discontinued || (p.Discontinued == true)), entryCount: 8);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_bool_member_compared_to_binary_expression()
         {
             await AssertQuery<Product>(ps => ps.Where(p => p.Discontinued == (p.ProductID > 50)), entryCount: 44);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_not_bool_member_compared_to_not_bool_member()
         {
             // ReSharper disable once EqualExpressionComparison
             await AssertQuery<Product>(ps => ps.Where(p => !p.Discontinued == !p.Discontinued), entryCount: 77);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_negated_boolean_expression_compared_to_another_negated_boolean_expression()
         {
             await AssertQuery<Product>(ps => ps.Where(p => !(p.ProductID > 50) == !(p.ProductID > 20)), entryCount: 47);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_not_bool_member_compared_to_binary_expression()
         {
             await AssertQuery<Product>(ps => ps.Where(p => !p.Discontinued == (p.ProductID > 50)), entryCount: 33);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_bool_parameter_compared_to_binary_expression()
         {
             var prm = true;
             await AssertQuery<Product>(ps => ps.Where(p => (p.ProductID > 50) != prm), entryCount: 50);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_bool_member_and_parameter_compared_to_binary_expression_nested()
         {
             var prm = true;
             await AssertQuery<Product>(ps => ps.Where(p => p.Discontinued == ((p.ProductID > 50) != prm)), entryCount: 33);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_de_morgan_or_optimizated()
         {
             await AssertQuery<Product>(ps => ps.Where(p => !(p.Discontinued || (p.ProductID < 20))), entryCount: 53);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_de_morgan_and_optimizated()
         {
             await AssertQuery<Product>(ps => ps.Where(p => !(p.Discontinued && (p.ProductID < 20))), entryCount: 74);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_complex_negated_expression_optimized()
         {
             await AssertQuery<Product>(ps => ps.Where(p => !(!(!p.Discontinued && (p.ProductID < 60)) || !(p.ProductID > 30))), entryCount: 27);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_short_member_comparison()
         {
             await AssertQuery<Product>(ps => ps.Where(p => p.UnitsInStock > 10), entryCount: 63);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_true()
         {
             await AssertQuery<Customer>(
@@ -1063,14 +1065,14 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_false()
         {
             await AssertQuery<Customer>(
                 cs => cs.Where(c => false));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_bool_closure()
         {
             var boolean = false;
@@ -1085,7 +1087,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Select_bool_closure()
         {
             var boolean = false;
@@ -1101,7 +1103,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
         // TODO: Re-write entity ref equality to identity equality.
         //
-        // [Fact]
+        // [ConditionalFact]
         // public virtual async Task Where_compare_entity_equal()
         // {
         //     var alfki = NorthwindData.Customers.SingleAsync(c => c.CustomerID == "ALFKI");
@@ -1111,7 +1113,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         //         AssertQuery<Customer>(cs => cs.Where(c => c == alfki)));
         // }
         //
-        // [Fact]
+        // [ConditionalFact]
         // public virtual async Task Where_compare_entity_not_equal()
         // {
         //     var alfki = new Customer { CustomerID = "ALFKI" };
@@ -1120,7 +1122,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         //         // ReSharper disable once PossibleUnintendedReferenceComparison
         //         AssertQuery<Customer>(cs => cs.Where(c => c != alfki)));
         //
-        // [Fact]
+        // [ConditionalFact]
         // public virtual async Task Project_compare_entity_equal()
         // {
         //     var alfki = NorthwindData.Customers.SingleAsync(c => c.CustomerID == "ALFKI");
@@ -1130,7 +1132,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         //         AssertQuery<Customer>(cs => cs.Select(c => c == alfki)));
         // }
         //
-        // [Fact]
+        // [ConditionalFact]
         // public virtual async Task Project_compare_entity_not_equal()
         // {
         //     var alfki = new Customer { CustomerID = "ALFKI" };
@@ -1140,21 +1142,21 @@ namespace Microsoft.Data.Entity.FunctionalTests
         //         AssertQuery<Customer>(cs => cs.Select(c => c != alfki)));
         // }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_compare_constructed_equal()
         {
             await AssertQuery<Customer>(
                 cs => cs.Where(c => new { x = c.City } == new { x = "London" }));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_compare_constructed_multi_value_equal()
         {
             await AssertQuery<Customer>(
                 cs => cs.Where(c => new { x = c.City, y = c.Country } == new { x = "London", y = "UK" }));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_compare_constructed_multi_value_not_equal()
         {
             await AssertQuery<Customer>(
@@ -1162,56 +1164,56 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_compare_constructed()
         {
             await AssertQuery<Customer>(
                 cs => cs.Where(c => new { x = c.City } == new { x = "London" }));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_compare_null()
         {
             await AssertQuery<Customer>(
                 cs => cs.Where(c => c.City == null && c.Country == "UK"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_projection()
         {
             await AssertQuery<Customer>(
                 cs => cs.Where(c => c.City == "London").Select(c => c.CompanyName));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Select_scalar()
         {
             await AssertQuery<Customer>(
                 cs => cs.Select(c => c.City));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Select_anonymous_one()
         {
             await AssertQuery<Customer>(
                 cs => cs.Select(c => new { c.City }));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Select_anonymous_two()
         {
             await AssertQuery<Customer>(
                 cs => cs.Select(c => new { c.City, c.Phone }));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Select_anonymous_three()
         {
             await AssertQuery<Customer>(
                 cs => cs.Select(c => new { c.City, c.Phone, c.Country }));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Select_customer_table()
         {
             await AssertQuery<Customer>(
@@ -1219,7 +1221,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Select_customer_identity()
         {
             await AssertQuery<Customer>(
@@ -1227,7 +1229,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Select_anonymous_with_object()
         {
             await AssertQuery<Customer>(
@@ -1235,39 +1237,39 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Select_anonymous_nested()
         {
             await AssertQuery<Customer>(
                 cs => cs.Select(c => new { c.City, Country = new { c.Country } }));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Select_anonymous_empty()
         {
             await AssertQuery<Customer>(
                 cs => cs.Select(c => new { }));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Select_anonymous_literal()
         {
             await AssertQuery<Customer>(cs => cs.Select(c => new { X = 10 }));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Select_constant_int()
         {
             await AssertQuery<Customer>(cs => cs.Select(c => 0));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Select_constant_null_string()
         {
             await AssertQuery<Customer>(cs => cs.Select(c => (string)null));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Select_local()
         {
             // ReSharper disable once ConvertToConstant.Local
@@ -1276,21 +1278,21 @@ namespace Microsoft.Data.Entity.FunctionalTests
             await AssertQuery<Customer>(cs => cs.Select(c => x));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Select_scalar_primitive()
         {
             await AssertQuery<Employee>(
                 es => es.Select(e => e.EmployeeID));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Select_scalar_primitive_after_take()
         {
             await AssertQuery<Employee>(
                 es => es.Take(9).Select(e => e.EmployeeID));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Select_project_filter()
         {
             await AssertQuery<Customer>(
@@ -1300,7 +1302,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     select c.CompanyName);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Select_project_filter2()
         {
             await AssertQuery<Customer>(
@@ -1310,7 +1312,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     select c.City);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Select_nested_collection()
         {
             await AssertQuery<Customer, Order>((cs, os) =>
@@ -1337,7 +1339,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Select_correlated_subquery_projection()
         {
             await AssertQuery<Customer, Order>((cs, os) =>
@@ -1361,7 +1363,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Select_correlated_subquery_ordered()
         {
             await AssertQuery<Customer, Order>((cs, os) =>
@@ -1386,7 +1388,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         // TODO: Re-linq parser
-        // [Fact]
+        // [ConditionalFact]
         // public virtual async Task Select_nested_ordered_enumerable_collection()
         // {
         //     AssertQuery<Customer>(cs =>
@@ -1394,7 +1396,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         //         assertOrder: true);
         // }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Select_nested_collection_in_anonymous_type()
         {
             await AssertQuery<Customer, Order>((cs, os) =>
@@ -1422,7 +1424,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Select_subquery_recursive_trivial()
         {
             await AssertQuery<Employee>(
@@ -1449,7 +1451,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     });
         }
 
-        // TODO: [Fact] See #153
+        // TODO: [ConditionalFact] See #153
         public virtual async Task Where_subquery_on_collection()
         {
             await AssertQuery<Product, OrderDetail>((pr, od) =>
@@ -1458,7 +1460,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select p);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_query_composition()
         {
             await AssertQuery<Employee>(
@@ -1469,7 +1471,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_subquery_recursive_trivial()
         {
             await AssertQuery<Employee>(
@@ -1486,7 +1488,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 9);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Select_nested_collection_deep()
         {
             await AssertQuery<Customer, Order>((cs, os) =>
@@ -1518,7 +1520,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task OrderBy_scalar_primitive()
         {
             await AssertQuery<Employee>(
@@ -1527,7 +1529,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 assertOrder: true);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task SelectMany_mixed()
         {
             await AssertQuery<Employee, Customer>(
@@ -1537,7 +1539,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                             select new { e1, s, c });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task SelectMany_simple1()
         {
             await AssertQuery<Employee, Customer>(
@@ -1546,7 +1548,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                             select new { c, e });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task SelectMany_simple2()
         {
             await AssertQuery<Employee, Customer>(
@@ -1556,7 +1558,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                             select new { e1, c, e2.FirstName });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task SelectMany_entity_deep()
         {
             await AssertQuery<Employee>(
@@ -1568,7 +1570,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 9);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task SelectMany_projection1()
         {
             await AssertQuery<Employee>(
@@ -1577,7 +1579,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                       select new { e1.City, e2.Country });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task SelectMany_projection2()
         {
             await AssertQuery<Employee>(
@@ -1587,7 +1589,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                       select new { e1.City, e2.Country, e3.FirstName });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task SelectMany_nested_simple()
         {
             await AssertQuery<Customer>(
@@ -1601,7 +1603,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task SelectMany_correlated_simple()
         {
             await AssertQuery<Customer, Employee>((cs, es) =>
@@ -1613,7 +1615,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 assertOrder: true);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task SelectMany_correlated_subquery_simple()
         {
             await AssertQuery<Customer, Employee>(
@@ -1625,7 +1627,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 assertOrder: true);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task SelectMany_correlated_subquery_hard()
         {
             await AssertQuery<Customer, Employee>(
@@ -1639,7 +1641,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     select new { c1, e1 });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task SelectMany_cartesian_product_with_ordering()
         {
             await AssertQuery<Customer, Employee>(
@@ -1652,7 +1654,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 assertOrder: true);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task SelectMany_primitive()
         {
             await AssertQuery<Employee>(
@@ -1662,7 +1664,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     select i);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task SelectMany_primitive_select_subquery()
         {
             await AssertQuery<Employee>(
@@ -1672,7 +1674,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     select es.Any());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Join_customers_orders_projection()
         {
             await AssertQuery<Customer, Order>((cs, os) =>
@@ -1681,7 +1683,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c.ContactName, o.OrderID });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Join_customers_orders_entities()
         {
             await AssertQuery<Customer, Order>((cs, os) =>
@@ -1690,7 +1692,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c, o });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Join_select_many()
         {
             await AssertQuery<Customer, Order, Employee>((cs, os, es) =>
@@ -1700,7 +1702,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c, o, e });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Join_customers_orders_select()
         {
             await AssertQuery<Customer, Order>((cs, os) =>
@@ -1711,7 +1713,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select p);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Join_customers_orders_with_subquery()
         {
             await AssertQuery<Customer, Order>((cs, os) =>
@@ -1722,7 +1724,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c.ContactName, o1.OrderID });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Join_customers_orders_with_subquery_anonymous_property_method()
         {
             await AssertQuery<Customer, Order>((cs, os) =>
@@ -1733,7 +1735,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { o1, o1.o2, Shadow = EF.Property<DateTime?>(o1.o2, "OrderDate") });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Join_customers_orders_with_subquery_predicate()
         {
             await AssertQuery<Customer, Order>((cs, os) =>
@@ -1744,7 +1746,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c.ContactName, o1.OrderID });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Join_composite_key()
         {
             await AssertQuery<Customer, Order>((cs, os) =>
@@ -1754,7 +1756,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c, o });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Join_client_new_expression()
         {
             await AssertQuery<Customer, Order>((cs, os) =>
@@ -1763,7 +1765,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c, o });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Join_Where_Count()
         {
             await AssertQuery<Customer, Order>((cs, os) =>
@@ -1773,7 +1775,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                  select c).CountAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Multiple_joins_Where_Order_Any()
         {
             await AssertQuery<Customer, Order, OrderDetail>((cs, os, ods) =>
@@ -1783,7 +1785,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     .AnyAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Join_OrderBy_Count()
         {
             await AssertQuery<Customer, Order>((cs, os) =>
@@ -1799,7 +1801,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             public string Bar { get; set; }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task GroupJoin_customers_orders()
         {
             await AssertQuery<Customer, Order>((cs, os) =>
@@ -1818,7 +1820,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task GroupJoin_customers_orders_count()
         {
             await AssertQuery<Customer, Order>((cs, os) =>
@@ -1827,7 +1829,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { cust = c, ords = orders.Count() });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Default_if_empty_top_level()
         {
             await AssertQuery<Employee>(cs =>
@@ -1835,7 +1837,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select c);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Default_if_empty_top_level_arg()
         {
             await AssertQuery<Employee>(cs =>
@@ -1844,7 +1846,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task GroupJoin_customers_employees_shadow()
         {
             await AssertQuery<Customer, Employee>((cs, es) =>
@@ -1860,7 +1862,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                         }));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task GroupJoin_customers_employees_subquery_shadow()
         {
             await AssertQuery<Customer, Employee>((cs, es) =>
@@ -1876,7 +1878,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                         }));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task SelectMany_customer_orders()
         {
             await AssertQuery<Customer, Order>((cs, os) =>
@@ -1886,7 +1888,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c.ContactName, o.OrderID });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task SelectMany_Count()
         {
             await AssertQuery<Customer, Order>((cs, os) =>
@@ -1895,7 +1897,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                  select c.CustomerID).CountAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task SelectMany_LongCount()
         {
             await AssertQuery<Customer, Order>((cs, os) =>
@@ -1904,7 +1906,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                  select c.CustomerID).LongCountAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task SelectMany_OrderBy_ThenBy_Any()
         {
             await AssertQuery<Customer, Order>((cs, os) =>
@@ -1916,7 +1918,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
         // TODO: Composite keys, slow..
 
-        //        [Fact]
+        //        [ConditionalFact]
         //        public virtual async Task Multiple_joins_with_join_conditions_in_where()
         //        {
         //            AssertQuery<Customer, Order, OrderDetail>((cs, os, ods) =>
@@ -1929,7 +1931,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         //                select od.ProductID,
         //                assertOrder: true);
         //        }
-        //        [Fact]
+        //        [ConditionalFact]
         //
         //        public virtual async Task TestMultipleJoinsWithMissingJoinCondition()
         //        {
@@ -1943,7 +1945,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         //                );
         //        }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task OrderBy()
         {
             await AssertQuery<Customer>(
@@ -1952,7 +1954,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task OrderBy_client_mixed()
         {
             await AssertQuery<Customer>(
@@ -1961,7 +1963,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task OrderBy_multiple_queries()
         {
             await AssertQuery<Customer, Order>((cs, os) =>
@@ -1971,7 +1973,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c, o });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task OrderBy_shadow()
         {
             await AssertQuery<Employee>(
@@ -1980,7 +1982,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 9);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task OrderBy_ThenBy_predicate()
         {
             await AssertQuery<Customer>(
@@ -1991,7 +1993,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 6);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task OrderBy_correlated_subquery_lol()
         {
             await AssertQuery<Customer>(
@@ -2001,7 +2003,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task OrderBy_Select()
         {
             await AssertQuery<Customer>(
@@ -2011,7 +2013,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 assertOrder: true);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task OrderBy_multiple()
         {
             await AssertQuery<Customer>(
@@ -2023,7 +2025,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 assertOrder: true);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task OrderBy_ThenBy()
         {
             await AssertQuery<Customer>(
@@ -2032,7 +2034,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 assertOrder: true);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task OrderByDescending()
         {
             await AssertQuery<Customer>(
@@ -2041,7 +2043,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 assertOrder: true);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task OrderByDescending_ThenBy()
         {
             await AssertQuery<Customer>(
@@ -2050,7 +2052,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 assertOrder: true);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task OrderByDescending_ThenByDescending()
         {
             await AssertQuery<Customer>(
@@ -2059,14 +2061,14 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 assertOrder: true);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task OrderBy_ThenBy_Any()
         {
             await AssertQuery<Customer>(
                 cs => cs.OrderBy(c => c.CustomerID).ThenBy(c => c.ContactName).AnyAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task OrderBy_Join()
         {
             await AssertQuery<Customer, Order>((cs, os) =>
@@ -2075,7 +2077,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c.CustomerID, o.OrderID });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task OrderBy_SelectMany()
         {
             await AssertQuery<Customer, Order>((cs, os) =>
@@ -2087,7 +2089,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         // TODO: Need to figure out how to do this 
-        //        [Fact]
+        //        [ConditionalFact]
         //        public virtual async Task GroupBy_anonymous()
         //        {
         //            AssertQuery<Customer>(cs =>
@@ -2096,7 +2098,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         //                assertOrder: true);
         //        }
         //
-        //        [Fact]
+        //        [ConditionalFact]
         //        public virtual async Task GroupBy_anonymous_subquery()
         //        {
         //            AssertQuery<Customer>(cs =>
@@ -2105,7 +2107,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         //                assertOrder: true);
         //        }
         //
-        //        [Fact]
+        //        [ConditionalFact]
         //        public virtual async Task GroupBy_nested_order_by_enumerable()
         //        {
         //            AssertQuery<Customer>(cs =>
@@ -2116,7 +2118,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         //                assertOrder: true);
         //        }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task GroupBy_SelectMany()
         {
             await AssertQuery<Customer>(
@@ -2124,7 +2126,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task GroupBy_simple()
         {
             await AssertQuery<Order>(
@@ -2143,7 +2145,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task GroupBy_simple2()
         {
             await AssertQuery<Order>(
@@ -2162,7 +2164,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task GroupBy_first()
         {
             await AssertQuery<Order>(
@@ -2178,28 +2180,28 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 6);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task GroupBy_Sum()
         {
             await AssertQuery<Order>(os =>
                 os.GroupBy(o => o.CustomerID).Select(g => g.Sum(o => o.OrderID)));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task GroupBy_Count()
         {
             await AssertQuery<Order>(os =>
                 os.GroupBy(o => o.CustomerID).Select(g => g.Count()));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task GroupBy_LongCount()
         {
             await AssertQuery<Order>(os =>
                 os.GroupBy(o => o.CustomerID).Select(g => g.LongCount()));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task GroupBy_Shadow()
         {
             await AssertQuery<Employee>(es =>
@@ -2209,7 +2211,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     .Select(g => EF.Property<string>(g.First(), "Title")));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task GroupBy_Shadow2()
         {
             await AssertQuery<Employee>(es =>
@@ -2219,7 +2221,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     .Select(g => g.First()));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task GroupBy_Shadow3()
         {
             await AssertQuery<Employee>(es =>
@@ -2228,7 +2230,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     .Select(g => EF.Property<string>(g.First(), "Title")));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task GroupBy_Sum_Min_Max_Avg()
         {
             await AssertQuery<Order>(os =>
@@ -2242,7 +2244,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     }));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task GroupBy_with_result_selector()
         {
             await AssertQuery<Order>(os =>
@@ -2256,14 +2258,14 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     }));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task GroupBy_with_element_selector_sum()
         {
             await AssertQuery<Order>(os =>
                 os.GroupBy(o => o.CustomerID, o => o.OrderID).Select(g => g.Sum()));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task GroupBy_with_element_selector()
         {
             await AssertQuery<Order>(os =>
@@ -2285,7 +2287,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task GroupBy_with_element_selector2()
         {
             await AssertQuery<Order>(os =>
@@ -2307,7 +2309,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task GroupBy_with_element_selector3()
         {
             await AssertQuery<Employee>(es =>
@@ -2317,7 +2319,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 assertOrder: true);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task GroupBy_with_element_selector_sum_max()
         {
             await AssertQuery<Order>(os =>
@@ -2325,7 +2327,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     .Select(g => new { Sum = g.Sum(), MaxAsync = g.Max() }));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task GroupBy_with_anonymous_element()
         {
             await AssertQuery<Order>(os =>
@@ -2333,7 +2335,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     .Select(g => g.Sum(x => x.OrderID)));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task GroupBy_with_two_part_key()
         {
             await AssertQuery<Order>(os =>
@@ -2341,7 +2343,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     .Select(g => g.Sum(o => o.OrderID)));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task OrderBy_GroupBy()
         {
             await AssertQuery<Order>(os =>
@@ -2350,7 +2352,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     .Select(g => g.Sum(o => o.OrderID)));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task OrderBy_GroupBy_SelectMany()
         {
             await AssertQuery<Order>(os =>
@@ -2360,7 +2362,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 830);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task OrderBy_GroupBy_SelectMany_shadow()
         {
             await AssertQuery<Employee>(es =>
@@ -2370,146 +2372,146 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     .Select(g => EF.Property<string>(g, "Title")));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Sum_with_no_arg()
         {
             await AssertQuery<Order>(os => os.Select(o => o.OrderID).SumAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Sum_with_binary_expression()
         {
             await AssertQuery<Order>(os => os.Select(o => o.OrderID * 2).SumAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Sum_with_no_arg_empty()
         {
             await AssertQuery<Order>(os => os.Where(o => o.OrderID == 42).Select(o => o.OrderID).SumAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Sum_with_arg()
         {
             await AssertQuery<Order>(os => os.SumAsync(o => o.OrderID));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Sum_with_arg_expression()
         {
             await AssertQuery<Order>(os => os.SumAsync(o => o.OrderID + o.OrderID));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Min_with_no_arg()
         {
             await AssertQuery<Order>(os => os.Select(o => o.OrderID).MinAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Min_with_arg()
         {
             await AssertQuery<Order>(os => os.MinAsync(o => o.OrderID));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Max_with_no_arg()
         {
             await AssertQuery<Order>(os => os.Select(o => o.OrderID).MaxAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Max_with_arg()
         {
             await AssertQuery<Order>(os => os.MaxAsync(o => o.OrderID));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Count_with_no_predicate()
         {
             await AssertQuery<Order>(os => os.CountAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Count_with_predicate()
         {
             await AssertQuery<Order>(os =>
                 os.CountAsync(o => o.CustomerID == "ALFKI"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Count_with_order_by()
         {
             await AssertQuery<Order>(os => os.OrderBy(o => o.CustomerID).CountAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_OrderBy_Count()
         {
             await AssertQuery<Order>(os => os.Where(o => o.CustomerID == "ALFKI").OrderBy(o => o.OrderID).CountAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task OrderBy_Where_Count()
         {
             await AssertQuery<Order>(os => os.OrderBy(o => o.OrderID).Where(o => o.CustomerID == "ALFKI").CountAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task OrderBy_Count_with_predicate()
         {
             await AssertQuery<Order>(os => os.OrderBy(o => o.OrderID).CountAsync(o => o.CustomerID == "ALFKI"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task OrderBy_Where_Count_with_predicate()
         {
             await AssertQuery<Order>(os => os.OrderBy(o => o.OrderID).Where(o => o.OrderID > 10).CountAsync(o => o.CustomerID != "ALFKI"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_OrderBy_Count_client_eval()
         {
             await AssertQuery<Order>(os => os.Where(o => ClientEvalPredicate(o)).OrderBy(o => ClientEvalSelectorStateless()).CountAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_OrderBy_Count_client_eval_mixed()
         {
             await AssertQuery<Order>(os => os.Where(o => o.OrderID > 10).OrderBy(o => ClientEvalPredicate(o)).CountAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task OrderBy_Where_Count_client_eval()
         {
             await AssertQuery<Order>(os => os.OrderBy(o => ClientEvalSelectorStateless()).Where(o => ClientEvalPredicate(o)).CountAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task OrderBy_Where_Count_client_eval_mixed()
         {
             await AssertQuery<Order>(os => os.OrderBy(o => o.OrderID).Where(o => ClientEvalPredicate(o)).CountAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task OrderBy_Count_with_predicate_client_eval()
         {
             await AssertQuery<Order>(os => os.OrderBy(o => ClientEvalSelectorStateless()).CountAsync(o => ClientEvalPredicate(o)));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task OrderBy_Count_with_predicate_client_eval_mixed()
         {
             await AssertQuery<Order>(os => os.OrderBy(o => o.OrderID).CountAsync(o => ClientEvalPredicateStateless()));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task OrderBy_Where_Count_with_predicate_client_eval()
         {
             await AssertQuery<Order>(os => os.OrderBy(o => ClientEvalSelectorStateless()).Where(o => ClientEvalPredicateStateless()).CountAsync(o => ClientEvalPredicate(o)));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task OrderBy_Where_Count_with_predicate_client_eval_mixed()
         {
             await AssertQuery<Order>(os => os.OrderBy(o => o.OrderID).Where(o => ClientEvalPredicate(o)).CountAsync(o => o.CustomerID != "ALFKI"));
@@ -2535,7 +2537,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             return order.EmployeeID.HasValue ? order.EmployeeID.Value % 10 : 0;
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Distinct()
         {
             await AssertQuery<Customer>(
@@ -2543,7 +2545,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Distinct_Scalar()
         {
             await AssertQuery<Customer>(
@@ -2551,7 +2553,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     cs.Select(c => c.City).Distinct());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task OrderBy_Distinct()
         {
             await AssertQuery<Customer>(
@@ -2559,7 +2561,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     cs.OrderBy(c => c.CustomerID).Select(c => c.City).Distinct());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Distinct_OrderBy()
         {
             await AssertQuery<Customer>(
@@ -2568,7 +2570,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 assertOrder: true);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Distinct_GroupBy()
         {
             await AssertQuery<Order>(os =>
@@ -2579,21 +2581,21 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 assertOrder: true);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task GroupBy_Distinct()
         {
             await AssertQuery<Order>(os =>
                 os.GroupBy(o => o.CustomerID).Distinct().Select(g => g.Key));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Distinct_Count()
         {
             await AssertQuery<Customer>(
                 cs => cs.Distinct().CountAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Select_Distinct_Count()
         {
             await AssertQuery<Customer>(
@@ -2601,7 +2603,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     cs.Select(c => c.City).Distinct().CountAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Select_Select_Distinct_Count()
         {
             await AssertQuery<Customer>(
@@ -2609,7 +2611,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     cs.Select(c => c.City).Select(c => c).Distinct().CountAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Single_Throws()
         {
             await Assert.ThrowsAsync<InvalidOperationException>(async () =>
@@ -2617,14 +2619,14 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     cs => cs.SingleAsync()));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Single_Predicate()
         {
             await AssertQuery<Customer>(
                 cs => cs.SingleAsync(c => c.CustomerID == "ALFKI"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_Single()
         {
             await AssertQuery<Customer>(
@@ -2632,7 +2634,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs => cs.Where(c => c.CustomerID == "ALFKI").SingleAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task SingleOrDefault_Throws()
         {
             await Assert.ThrowsAsync<InvalidOperationException>(async () =>
@@ -2640,14 +2642,14 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     cs => cs.SingleOrDefaultAsync()));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task SingleOrDefault_Predicate()
         {
             await AssertQuery<Customer>(
                 cs => cs.SingleOrDefaultAsync(c => c.CustomerID == "ALFKI"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_SingleOrDefault()
         {
             await AssertQuery<Customer>(
@@ -2655,21 +2657,21 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs => cs.Where(c => c.CustomerID == "ALFKI").SingleOrDefaultAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task FirstAsync()
         {
             await AssertQuery<Customer>(
                 cs => cs.OrderBy(c => c.ContactName).FirstAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task First_Predicate()
         {
             await AssertQuery<Customer>(
                 cs => cs.OrderBy(c => c.ContactName).FirstAsync(c => c.City == "London"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_First()
         {
             await AssertQuery<Customer>(
@@ -2677,21 +2679,21 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs => cs.OrderBy(c => c.ContactName).Where(c => c.City == "London").FirstAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task FirstOrDefault()
         {
             await AssertQuery<Customer>(
                 cs => cs.OrderBy(c => c.ContactName).FirstOrDefaultAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task FirstOrDefault_Predicate()
         {
             await AssertQuery<Customer>(
                 cs => cs.OrderBy(c => c.ContactName).FirstOrDefaultAsync(c => c.City == "London"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_FirstOrDefault()
         {
             await AssertQuery<Customer>(
@@ -2699,14 +2701,14 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs => cs.OrderBy(c => c.ContactName).Where(c => c.City == "London").FirstOrDefaultAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Last()
         {
             await AssertQuery<Customer>(
                 cs => cs.OrderBy(c => c.ContactName).LastAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Last_when_no_order_by()
         {
             await AssertQuery<Customer>(
@@ -2714,14 +2716,14 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs => cs.Where(c => c.CustomerID == "ALFKI").LastAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Last_Predicate()
         {
             await AssertQuery<Customer>(
                 cs => cs.OrderBy(c => c.ContactName).LastAsync(c => c.City == "London"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_Last()
         {
             await AssertQuery<Customer>(
@@ -2729,21 +2731,21 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs => cs.OrderBy(c => c.ContactName).Where(c => c.City == "London").LastAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task LastOrDefault()
         {
             await AssertQuery<Customer>(
                 cs => cs.OrderBy(c => c.ContactName).LastOrDefaultAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task LastOrDefault_Predicate()
         {
             await AssertQuery<Customer>(
                 cs => cs.OrderBy(c => c.ContactName).LastOrDefaultAsync(c => c.City == "London"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_LastOrDefault()
         {
             await AssertQuery<Customer>(
@@ -2751,7 +2753,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs => cs.OrderBy(c => c.ContactName).Where(c => c.City == "London").LastOrDefaultAsync());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task String_StartsWith_Literal()
         {
             await AssertQuery<Customer>(
@@ -2759,7 +2761,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 12);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task String_StartsWith_Identity()
         {
             await AssertQuery<Customer>(
@@ -2767,7 +2769,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task String_StartsWith_Column()
         {
             await AssertQuery<Customer>(
@@ -2775,7 +2777,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task String_StartsWith_MethodCall()
         {
             await AssertQuery<Customer>(
@@ -2783,7 +2785,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 12);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task String_EndsWith_Literal()
         {
             await AssertQuery<Customer>(
@@ -2791,7 +2793,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task String_EndsWith_Identity()
         {
             await AssertQuery<Customer>(
@@ -2799,7 +2801,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task String_EndsWith_Column()
         {
             await AssertQuery<Customer>(
@@ -2807,7 +2809,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task String_EndsWith_MethodCall()
         {
             await AssertQuery<Customer>(
@@ -2815,7 +2817,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task String_Contains_Literal()
         {
             await AssertQuery<Customer>(
@@ -2823,7 +2825,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 19);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task String_Contains_Identity()
         {
             await AssertQuery<Customer>(
@@ -2831,7 +2833,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task String_Contains_Column()
         {
             await AssertQuery<Customer>(
@@ -2839,7 +2841,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task String_Contains_MethodCall()
         {
             await AssertQuery<Customer>(
@@ -2857,7 +2859,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             return "m";
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task GroupJoin_simple()
         {
             await AssertQuery<Customer, Order>((cs, os) =>
@@ -2867,7 +2869,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select o);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task GroupJoin_projection()
         {
             await AssertQuery<Customer, Order>((cs, os) =>
@@ -2877,7 +2879,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c, o });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task GroupJoin_DefaultIfEmpty()
         {
             await AssertQuery<Customer, Order>((cs, os) =>
@@ -2887,7 +2889,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c, o });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task GroupJoin_DefaultIfEmpty2()
         {
             await AssertQuery<Employee, Order>((es, os) =>
@@ -2897,7 +2899,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { e, o });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task GroupJoin_DefaultIfEmpty3()
         {
             await AssertQuery<Customer, Order>((cs, os) =>
@@ -2907,7 +2909,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select o);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task SelectMany_Joined()
         {
             await AssertQuery<Customer, Order>((cs, os) =>
@@ -2916,7 +2918,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c.ContactName, o.OrderDate });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task SelectMany_Joined_DefaultIfEmpty()
         {
             await AssertQuery<Customer, Order>((cs, os) =>
@@ -2925,7 +2927,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c.ContactName, o });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task SelectMany_Joined_DefaultIfEmpty2()
         {
             await AssertQuery<Customer, Order>((cs, os) =>
@@ -2934,35 +2936,35 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select o);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Select_many_cross_join_same_collection()
         {
             await AssertQuery<Customer, Customer>((cs1, cs2) =>
                 cs1.SelectMany(c => cs2));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Join_same_collection_multiple()
         {
             await AssertQuery<Customer, Customer, Customer>((cs1, cs2, cs3) =>
                 cs1.Join(cs2, o => o.CustomerID, i => i.CustomerID, (c1, c2) => new { c1, c2 }).Join(cs3, o => o.c1.CustomerID, i => i.CustomerID, (c12, c3) => c3));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Join_same_collection_force_alias_uniquefication()
         {
             await AssertQuery<Order, Order>((os1, os2) =>
                 os1.Join(os2, o => o.CustomerID, i => i.CustomerID, (_, o) => new { _, o }));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Contains_with_subquery()
         {
             await AssertQuery<Customer, Order>((cs, os) =>
                 cs.Where(c => os.Select(o => o.CustomerID).Contains(c.CustomerID)));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Contains_with_local_array_closure()
         {
             string[] ids = { "ABCDE", "ALFKI" };
@@ -2970,14 +2972,14 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs.Where(c => ids.Contains(c.CustomerID)), entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Contains_with_local_array_inline()
         {
             await AssertQuery<Customer>(cs =>
                 cs.Where(c => new[] { "ABCDE", "ALFKI" }.Contains(c.CustomerID)), entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Contains_with_local_list_closure()
         {
             var ids = new List<string> { "ABCDE", "ALFKI" };
@@ -2985,14 +2987,14 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs.Where(c => ids.Contains(c.CustomerID)), entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Contains_with_local_list_inline()
         {
             await AssertQuery<Customer>(cs =>
                 cs.Where(c => new List<string> { "ABCDE", "ALFKI" }.Contains(c.CustomerID)), entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Contains_with_local_list_inline_closure_mix()
         {
             var alfki = "ALFKI";
@@ -3000,7 +3002,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs.Where(c => new List<string> { "ABCDE", alfki }.Contains(c.CustomerID)), entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Contains_with_local_collection_false()
         {
             string[] ids = { "ABCDE", "ALFKI" };
@@ -3008,7 +3010,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs.Where(c => !ids.Contains(c.CustomerID)), entryCount: 90);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Contains_with_local_collection_complex_predicate_and()
         {
             string[] ids = { "ABCDE", "ALFKI" };
@@ -3016,7 +3018,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs.Where(c => (c.CustomerID == "ALFKI" || c.CustomerID == "ABCDE") && ids.Contains(c.CustomerID)), entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Contains_with_local_collection_complex_predicate_or()
         {
             string[] ids = { "ABCDE", "ALFKI" };
@@ -3024,7 +3026,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs.Where(c => ids.Contains(c.CustomerID) || (c.CustomerID == "ALFKI" || c.CustomerID == "ABCDE")), entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Contains_with_local_collection_complex_predicate_not_matching_ins1()
         {
             string[] ids = { "ABCDE", "ALFKI" };
@@ -3032,7 +3034,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs.Where(c => (c.CustomerID == "ALFKI" || c.CustomerID == "ABCDE") || !ids.Contains(c.CustomerID)), entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Contains_with_local_collection_complex_predicate_not_matching_ins2()
         {
             string[] ids = { "ABCDE", "ALFKI" };
@@ -3040,7 +3042,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs.Where(c => ids.Contains(c.CustomerID) && (c.CustomerID != "ALFKI" && c.CustomerID != "ABCDE")));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Contains_with_local_collection_sql_injection()
         {
             string[] ids = { "ALFKI", "ABC')); GO; DROP TABLE Orders; GO; --" };
@@ -3048,7 +3050,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs.Where(c => ids.Contains(c.CustomerID) || (c.CustomerID == "ALFKI" || c.CustomerID == "ABCDE")), entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Contains_with_local_collection_empty_closure()
         {
             var ids = new string[0];
@@ -3057,21 +3059,21 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs.Where(c => ids.Contains(c.CustomerID)));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Contains_with_local_collection_empty_inline()
         {
             await AssertQuery<Customer>(cs =>
                 cs.Where(c => !(new List<string>().Contains(c.CustomerID))), entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Contains_top_level()
         {
             await AssertQuery<Customer>(cs =>
                 cs.Select(c => c.CustomerID).ContainsAsync("ALFKI"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Where_chain()
         {
             await AssertQuery<Order>(order => order

--- a/test/EntityFramework.Core.FunctionalTests/ChangeTrackingTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/ChangeTrackingTestBase.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.FunctionalTests.TestModels.Northwind;
+using Microsoft.Data.Entity.FunctionalTests.TestUtilities.Xunit;
 using Xunit;
 
 namespace Microsoft.Data.Entity.FunctionalTests
@@ -303,7 +304,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
+        [MonoVersionCondition(Min = "4.2.0", SkipReason = "Queries fail on Mono < 4.2.0 due to differences in the implementation of LINQ")]
         public virtual void Precendence_of_tracking_modifiers3()
         {
             using (var context = CreateContext())
@@ -321,7 +323,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
+        [MonoVersionCondition(Min = "4.2.0", SkipReason = "Queries fail on Mono < 4.2.0 due to differences in the implementation of LINQ")]
         public virtual void Precendence_of_tracking_modifiers4()
         {
             using (var context = CreateContext())
@@ -339,7 +342,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
+        [MonoVersionCondition(Min = "4.2.0", SkipReason = "Queries fail on Mono < 4.2.0 due to differences in the implementation of LINQ")]
         public virtual void Precendence_of_tracking_modifiers5()
         {
             using (var context = CreateContext())

--- a/test/EntityFramework.Core.FunctionalTests/ComplexNavigationsQueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/ComplexNavigationsQueryTestBase.cs
@@ -4,11 +4,13 @@
 using System;
 using System.Linq;
 using Microsoft.Data.Entity.FunctionalTests.TestModels.ComplexNavigationsModel;
+using Microsoft.Data.Entity.FunctionalTests.TestUtilities.Xunit;
 using Xunit;
 using System.Collections.Generic;
 
 namespace Microsoft.Data.Entity.FunctionalTests
 {
+    [MonoVersionCondition(Min = "4.2.0", SkipReason = "Queries fail on Mono < 4.2.0 due to differences in the implementation of LINQ")]
     public abstract class ComplexNavigationsQueryTestBase<TTestStore, TFixture> : IClassFixture<TFixture>, IDisposable
         where TTestStore : TestStore
         where TFixture : ComplexNavigationsQueryFixtureBase<TTestStore>, new()
@@ -38,7 +40,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             TestStore.Dispose();
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Data_reader_is_closed_correct_number_of_times_for_include_queries_on_optional_navigations()
         {
             using (var context = CreateContext())
@@ -52,7 +54,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Multi_level_include_one_to_many_optional_and_one_to_many_optional_produces_valid_sql()
         {
             using (var context = CreateContext())
@@ -78,7 +80,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Multi_level_include_correct_PK_is_chosen_as_the_join_predicate_for_queries_that_join_same_table_multiple_times()
         {
             using (var context = CreateContext())
@@ -113,7 +115,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Multi_level_include_reads_key_values_from_data_reader_rather_than_incorrect_reader_deep_into_the_stack()
         {
             using (var context = CreateContext())
@@ -151,7 +153,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Multi_level_include_with_short_circuiting()
         {
             var fieldLabels = new Dictionary<string, string>();
@@ -230,7 +232,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         // issue #3186
-        ////[Fact]
+        ////[ConditionalFact]
         public virtual void Join_navigation_key_access_optional()
         {
             List<Level1> levelOnes;
@@ -263,7 +265,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Join_navigation_key_access_required()
         {
             List<Level1> levelOnes;
@@ -297,7 +299,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         // issue #3186
-        ////[Fact]
+        ////[ConditionalFact]
         public virtual void Navigation_key_access_optional_comparison()
         {
             List<Level2> levelTwos;
@@ -394,7 +396,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Join_navigation_in_outer_selector_translated_to_extra_join_nested()
         {
             List<Level1> levelOnes;
@@ -427,7 +429,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Join_navigation_in_inner_selector_translated_to_subquery()
         {
             List<Level1> levelOnes;
@@ -460,7 +462,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Join_navigation_translated_to_subquery_non_key_join()
         {
             List<Level1> levelOnes;
@@ -493,7 +495,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Join_navigation_translated_to_subquery_self_ref()
         {
             List<Level1> levelOnes1;
@@ -526,7 +528,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Join_navigation_translated_to_subquery_nested()
         {
             List<Level1> levelOnes;
@@ -559,7 +561,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Join_navigation_translated_to_subquery_deeply_nested_non_key_join()
         {
             List<Level1> levelOnes;
@@ -593,7 +595,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         // issue #3180
-        [Fact]
+        [ConditionalFact]
         public virtual void Multiple_complex_includes()
         {
             List<Level1> levelOnes;
@@ -639,7 +641,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         // issue #3180
-        [Fact]
+        [ConditionalFact]
         public virtual void Multiple_complex_includes_self_ref()
         {
             List<Level1> levelOnes1;
@@ -673,7 +675,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Multiple_complex_include_select()
         {
             List<Level1> levelOnes;
@@ -720,7 +722,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Select_nav_prop_collection_one_to_many_required()
         {
             List<List<int>> expected;

--- a/test/EntityFramework.Core.FunctionalTests/EntityFramework.Core.FunctionalTests.csproj
+++ b/test/EntityFramework.Core.FunctionalTests/EntityFramework.Core.FunctionalTests.csproj
@@ -171,6 +171,7 @@
     <Compile Include="TestUtilities\Xunit\ConditionalTheoryAttribute.cs" />
     <Compile Include="TestUtilities\Xunit\FrameworkSkipConditionAttribute.cs" />
     <Compile Include="TestUtilities\Xunit\ITestCondition.cs" />
+    <Compile Include="TestUtilities\Xunit\MonoVersionConditionAttribute.cs" />
     <Compile Include="TestUtilities\Xunit\RuntimeFrameworks.cs" />
     <Compile Include="TestUtilities\Xunit\SkipReasonTestCase.cs" />
     <Compile Include="TestUtilities\Xunit\SkipXunitTheoryTestCase.cs" />

--- a/test/EntityFramework.Core.FunctionalTests/GearsOfWarQueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/GearsOfWarQueryTestBase.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel;
+using Microsoft.Data.Entity.FunctionalTests.TestUtilities.Xunit;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -278,7 +279,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
+        [MonoVersionCondition(Min = "4.2.0", SkipReason = "Queries fail on Mono < 4.2.0 due to differences in the implementation of LINQ")]
         public virtual void Include_with_join_reference2()
         {
             using (var context = CreateContext())
@@ -312,7 +314,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
+        [MonoVersionCondition(Min = "4.2.0", SkipReason = "Queries fail on Mono < 4.2.0 due to differences in the implementation of LINQ")]
         public virtual void Include_with_join_collection2()
         {
             using (var context = CreateContext())
@@ -653,7 +656,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
+        [MonoVersionCondition(Min = "4.2.0", SkipReason = "Queries fail on Mono < 4.2.0 due to differences in the implementation of LINQ")]
         public virtual void Join_navigation_translated_to_subquery_composite_key()
         {
             List<Gear> gears;

--- a/test/EntityFramework.Core.FunctionalTests/IncludeTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/IncludeTestBase.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using Microsoft.Data.Entity.FunctionalTests.TestModels.Northwind;
+using Microsoft.Data.Entity.FunctionalTests.TestUtilities.Xunit;
 using Microsoft.Data.Entity.Internal;
 using Xunit;
 
@@ -252,7 +253,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
+        [MonoVersionCondition(Min = "4.2.0", SkipReason = "Queries fail on Mono < 4.2.0 due to differences in the implementation of LINQ")]
         public virtual void Include_collection_on_join_clause_with_filter()
         {
             using (var context = CreateContext())
@@ -271,7 +273,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
+        [MonoVersionCondition(Min = "4.2.0", SkipReason = "Queries fail on Mono < 4.2.0 due to differences in the implementation of LINQ")]
         public virtual void Include_collection_on_join_clause_with_order_by_and_filter()
         {
             using (var context = CreateContext())

--- a/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
@@ -9,6 +9,7 @@ using Microsoft.Data.Entity.FunctionalTests.TestModels.Northwind;
 using Microsoft.Data.Entity.Query;
 using Microsoft.Data.Entity.Query.Internal;
 using Microsoft.Data.Entity.Tests;
+using Microsoft.Data.Entity.FunctionalTests.TestUtilities.Xunit;
 using Xunit;
 // ReSharper disable ReplaceWithSingleCallToCount
 
@@ -16,10 +17,11 @@ using Xunit;
 
 namespace Microsoft.Data.Entity.FunctionalTests
 {
+    [MonoVersionCondition(Min = "4.2.0", SkipReason = "Queries fail on Mono < 4.2.0 due to differences in the implementation of LINQ")]
     public abstract class QueryTestBase<TFixture> : IClassFixture<TFixture>
         where TFixture : NorthwindQueryFixtureBase, new()
     {
-        [Fact]
+        [ConditionalFact]
         public virtual void Queryable_simple()
         {
             AssertQuery<Customer>(
@@ -27,7 +29,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Queryable_simple_anonymous()
         {
             AssertQuery<Customer>(
@@ -35,21 +37,21 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Queryable_simple_anonymous_projection_subquery()
         {
             AssertQuery<Customer>(
                 cs => cs.Take(91).Select(c => new { c }).Select(a => a.c.City));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Queryable_simple_anonymous_subquery()
         {
             AssertQuery<Customer>(
                 cs => cs.Select(c => new { c }).Take(91).Select(a => a.c));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Queryable_nested_simple()
         {
             AssertQuery<Customer>(
@@ -58,7 +60,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Take_simple()
         {
             AssertQuery<Customer>(
@@ -78,7 +80,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 10);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Take_simple_projection()
         {
             AssertQuery<Customer>(
@@ -86,7 +88,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 assertOrder: true);
         }
         
-        [Fact]
+        [ConditionalFact]
         public virtual void Take_subquery_projection()
         {
             AssertQuery<Customer>(
@@ -94,7 +96,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 assertOrder: true);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Skip()
         {
             AssertQuery<Customer>(
@@ -103,7 +105,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 86);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Skip_no_orderby()
         {
             AssertQuery<Customer>(
@@ -112,7 +114,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 asserter: (_, __) => { /* non-deterministic */ });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Take_Skip()
         {
             AssertQuery<Customer>(
@@ -121,7 +123,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 5);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Distinct_Skip()
         {
             AssertQuery<Customer>(
@@ -130,7 +132,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 86);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Skip_Take()
         {
             AssertQuery<Customer>(
@@ -139,7 +141,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 10);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Join_Customers_Orders_Skip_Take()
         {
             AssertQuery<Customer, Order>((cs, os) => (
@@ -149,7 +151,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c.ContactName, o.OrderID }).Skip(10).Take(5));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Join_Customers_Orders_Projection_With_String_Concat_Skip_Take()
         {
             AssertQuery<Customer, Order>((cs, os) => (
@@ -159,7 +161,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { Contact = c.ContactName + " " + c.ContactTitle, o.OrderID }).Skip(10).Take(5));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Distinct_Skip_Take()
         {
             AssertQuery<Customer>(
@@ -168,7 +170,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 10);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Skip_Distinct()
         {
             AssertQuery<Customer>(
@@ -176,7 +178,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 86);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Skip_Take_Distinct()
         {
             AssertQuery<Customer>(
@@ -184,7 +186,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 10);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Take_Skip_Distinct()
         {
             AssertQuery<Customer>(
@@ -204,7 +206,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 5);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Take_Distinct()
         {
             AssertQuery<Order>(
@@ -212,7 +214,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 5);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Distinct_Take()
         {
             AssertQuery<Order>(
@@ -221,56 +223,56 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 5);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Distinct_Take_Count()
         {
             AssertQuery<Order>(
                 os => os.Distinct().Take(5).Count());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Take_Distinct_Count()
         {
             AssertQuery<Order>(
                 os => os.Take(5).Distinct().Count());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Take_Where_Distinct_Count()
         {
             AssertQuery<Order>(
                 os => os.Where(o => o.CustomerID == "FRANK").Take(5).Distinct().Count());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Any_simple()
         {
             AssertQuery<Customer>(
                 cs => cs.Any());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void OrderBy_Take_Count()
         {
             AssertQuery<Order>(
                    os => os.OrderBy(o => o.OrderID).Take(5).Count());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Take_OrderBy_Count()
         {
             AssertQuery<Order>(
                    os => os.Take(5).OrderBy(o => o.OrderID).Count());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Any_predicate()
         {
             AssertQuery<Customer>(
                 cs => cs.Any(c => c.ContactName.StartsWith("A")));
         }
 
-        //[Fact]
+        //[ConditionalFact]
         public virtual void Any_nested_negated()
         {
             using (var context = CreateContext())
@@ -282,42 +284,42 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void All_top_level()
         {
             AssertQuery<Customer>(
                 cs => cs.All(c => c.ContactName.StartsWith("A")));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void All_top_level_subquery()
         {
             AssertQuery<Customer>(
                 cs => cs.All(c1 => cs.Any(c2 => cs.Any(c3 => c1.CustomerID == c3.CustomerID))));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void All_client()
         {
             AssertQuery<Customer>(
                 cs => cs.All(c => c.IsLondon));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void All_client_and_server_top_level()
         {
             AssertQuery<Customer>(
                 cs => cs.All(c => c.CustomerID != "Foo" && c.IsLondon));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void All_client_or_server_top_level()
         {
             AssertQuery<Customer>(
                 cs => cs.All(c => c.CustomerID != "Foo" || c.IsLondon));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Select_into()
         {
             AssertQuery<Customer>(
@@ -329,14 +331,14 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     select id);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Projection_when_arithmetic_expression_precendence()
         {
             AssertQuery<Order>(
                 os => os.Select(o => new { A = o.OrderID / (o.OrderID / 2), B = (o.OrderID / o.OrderID) / 2 }));
         }
 
-        //        [Fact]
+        //        [ConditionalFact]
         //        public virtual void Projection_when_arithmetic_expressions()
         //        {
         //            AssertQuery<Order>(
@@ -353,7 +355,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         //                entryCount: 830);
         //        }
         //
-        //        [Fact]
+        //        [ConditionalFact]
         //        public virtual void Projection_when_arithmetic_mixed()
         //        {
         //            AssertQuery<Order, Employee>((os, es) =>
@@ -370,7 +372,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         //                });
         //        }
         //
-        //        [Fact]
+        //        [ConditionalFact]
         //        public virtual void Projection_when_arithmetic_mixed_subqueries()
         //        {
         //            AssertQuery<Order, Employee>((os, es) =>
@@ -387,21 +389,21 @@ namespace Microsoft.Data.Entity.FunctionalTests
         //                });
         //        }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Projection_when_null_value()
         {
             AssertQuery<Customer>(
                 cs => cs.Select(c => c.Region));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Take_with_single()
         {
             AssertQuery<Customer>(
                 cs => cs.OrderBy(c => c.CustomerID).Take(1).Single());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Take_with_single_select_many()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -414,13 +416,13 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     .Single());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Cast_results_to_object()
         {
             AssertQuery<Customer>(cs => from c in cs.Cast<object>() select c, entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_simple()
         {
             AssertQuery<Customer>(
@@ -428,7 +430,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 6);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_simple_closure()
         {
             // ReSharper disable once ConvertToConstant.Local
@@ -439,7 +441,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 6);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_simple_closure_constant()
         {
             // ReSharper disable once ConvertToConstant.Local
@@ -450,7 +452,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_simple_closure_via_query_cache()
         {
             var city = "London";
@@ -493,7 +495,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_method_call_nullable_type_closure_via_query_cache()
         {
             var city = new City { Int = 2 };
@@ -509,7 +511,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 3);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_method_call_nullable_type_reverse_closure_via_query_cache()
         {
             var city = new City { NullableInt = 1 };
@@ -525,7 +527,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 4);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_method_call_closure_via_query_cache()
         {
             var city = new City { InstanceFieldValue = "London" };
@@ -541,7 +543,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_field_access_closure_via_query_cache()
         {
             var city = new City { InstanceFieldValue = "London" };
@@ -557,7 +559,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_property_access_closure_via_query_cache()
         {
             var city = new City { InstancePropertyValue = "London" };
@@ -573,7 +575,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_static_field_access_closure_via_query_cache()
         {
             City.StaticFieldValue = "London";
@@ -589,7 +591,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_static_property_access_closure_via_query_cache()
         {
             City.StaticPropertyValue = "London";
@@ -605,7 +607,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_nested_field_access_closure_via_query_cache()
         {
             var city = new City { Nested = new City { InstanceFieldValue = "London" } };
@@ -621,7 +623,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_nested_property_access_closure_via_query_cache()
         {
             var city = new City { Nested = new City { InstancePropertyValue = "London" } };
@@ -637,7 +639,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_nested_field_access_closure_via_query_cache_error_null()
         {
             var city = new City();
@@ -651,7 +653,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_nested_field_access_closure_via_query_cache_error_method_null()
         {
             var city = new City();
@@ -665,7 +667,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_new_instance_field_access_closure_via_query_cache()
         {
             AssertQuery<Customer>(
@@ -677,7 +679,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_simple_closure_via_query_cache_nullable_type()
         {
             int? reportsTo = 2;
@@ -699,7 +701,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_simple_closure_via_query_cache_nullable_type_reverse()
         {
             int? reportsTo = null;
@@ -721,7 +723,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 5);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_simple_shadow()
         {
             AssertQuery<Employee>(
@@ -729,7 +731,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 6);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_simple_shadow_projection()
         {
             AssertQuery<Employee>(
@@ -745,7 +747,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 6);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_simple_shadow_subquery()
         {
             AssertQuery<Employee>(
@@ -755,7 +757,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 3);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_shadow_subquery_first()
         {
             AssertQuery<Employee>(es =>
@@ -766,7 +768,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_client()
         {
             AssertQuery<Customer>(
@@ -774,7 +776,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 6);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_subquery_correlated()
         {
             AssertQuery<Customer>(
@@ -782,7 +784,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_subquery_correlated_client_eval()
         {
             AssertQuery<Customer>(
@@ -790,7 +792,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 6);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_client_and_server_top_level()
         {
             AssertQuery<Customer>(
@@ -798,7 +800,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 5);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_client_or_server_top_level()
         {
             AssertQuery<Customer>(
@@ -806,7 +808,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 7);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_client_and_server_non_top_level()
         {
             AssertQuery<Customer>(
@@ -814,7 +816,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 6);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_client_deep_inside_predicate_and_server_top_level()
         {
             AssertQuery<Customer>(
@@ -822,14 +824,14 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 5);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void First_client_predicate()
         {
             AssertQuery<Customer>(
                 cs => cs.OrderBy(c => c.CustomerID).First(c => c.IsLondon));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_equals_method_string()
         {
             AssertQuery<Customer>(
@@ -837,7 +839,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 6);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_equals_method_int()
         {
             AssertQuery<Employee>(
@@ -845,7 +847,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_equals_using_object_overload_on_mismatched_types()
         {
             long longPrm = 1;
@@ -855,7 +857,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 0);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_equals_using_int_overload_on_mismatched_types()
         {
             short shortPrm = 1;
@@ -865,7 +867,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_equals_on_mismatched_types_nullable_int_long()
         {
             long longPrm = 2;
@@ -879,7 +881,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 0);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_equals_on_mismatched_types_int_nullable_int()
         {
             int intPrm = 2;
@@ -894,7 +896,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_equals_on_mismatched_types_nullable_long_nullable_int()
         {
             long? nullableLongPrm = 2;
@@ -906,7 +908,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 es => es.Where(e => e.ReportsTo.Equals(nullableLongPrm)));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_equals_on_matched_nullable_int_types()
         {
             int? nullableIntPrm = 2;
@@ -920,7 +922,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 5);
         }
 
-        // [Fact] issue #3208
+        // [ConditionalFact] issue #3208
         public virtual void Where_equals_on_null_nullable_int_types()
         {
             int? nullableIntPrm = null;
@@ -934,7 +936,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_comparison_nullable_type_not_null()
         {
             AssertQuery<Employee>(
@@ -942,7 +944,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 5);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_comparison_nullable_type_null()
         {
             AssertQuery<Employee>(
@@ -950,7 +952,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_string_length()
         {
             AssertQuery<Customer>(
@@ -958,7 +960,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 20);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_datetime_now()
         {
             var myDatetime = new DateTime(2015, 4, 10);
@@ -967,7 +969,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
         
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_datetime_utcnow()
         {
             var myDatetime = new DateTime(2015, 4, 10);
@@ -976,7 +978,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_simple_reversed()
         {
             AssertQuery<Customer>(
@@ -984,14 +986,14 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 6);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_is_null()
         {
             AssertQuery<Customer>(
                 cs => cs.Where(c => c.City == null));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_null_is_null()
         {
             // ReSharper disable once EqualExpressionComparison
@@ -1000,14 +1002,14 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_constant_is_null()
         {
             AssertQuery<Customer>(
                 cs => cs.Where(c => "foo" == null));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_is_not_null()
         {
             AssertQuery<Customer>(
@@ -1015,7 +1017,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_null_is_not_null()
         {
             // ReSharper disable once EqualExpressionComparison
@@ -1023,7 +1025,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs => cs.Where(c => null != null));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_constant_is_not_null()
         {
             AssertQuery<Customer>(
@@ -1031,7 +1033,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_identity_comparison()
         {
             // ReSharper disable once EqualExpressionComparison
@@ -1040,7 +1042,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_select_many_or()
         {
             AssertQuery<Customer, Employee>((cs, es) =>
@@ -1051,7 +1053,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c, e });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_select_many_or2()
         {
             AssertQuery<Customer, Employee>((cs, es) =>
@@ -1062,7 +1064,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c, e });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_select_many_or3()
         {
             AssertQuery<Customer, Employee>((cs, es) =>
@@ -1074,7 +1076,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c, e });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_select_many_or4()
         {
             AssertQuery<Customer, Employee>((cs, es) =>
@@ -1087,7 +1089,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c, e });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_select_many_or_with_parameter()
         {
             var london = "London";
@@ -1103,7 +1105,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c, e });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_in_optimization_multiple()
         {
             AssertQuery<Customer, Employee>((cs, es) =>
@@ -1116,7 +1118,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c, e });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_not_in_optimization1()
         {
             AssertQuery<Customer, Employee>((cs, es) =>
@@ -1127,7 +1129,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c, e });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_not_in_optimization2()
         {
             AssertQuery<Customer, Employee>((cs, es) =>
@@ -1138,7 +1140,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c, e });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_not_in_optimization3()
         {
             AssertQuery<Customer, Employee>((cs, es) =>
@@ -1150,7 +1152,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c, e });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_not_in_optimization4()
         {
             AssertQuery<Customer, Employee>((cs, es) =>
@@ -1163,7 +1165,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c, e });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_select_many_and()
         {
             AssertQuery<Customer, Employee>((cs, es) =>
@@ -1175,14 +1177,14 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c, e });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_primitive()
         {
             AssertQuery<Employee>(
                 es => es.Select(e => e.EmployeeID).Take(9).Where(i => i == 5));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_primitive_tracked()
         {
             AssertQuery<Employee>(
@@ -1190,7 +1192,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_primitive_tracked2()
         {
             AssertQuery<Employee>(
@@ -1198,7 +1200,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_subquery_anon()
         {
             AssertQuery<Employee, Order>((es, os) =>
@@ -1208,19 +1210,19 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { e, o });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_bool_member()
         {
             AssertQuery<Product>(ps => ps.Where(p => p.Discontinued), entryCount: 8);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_bool_member_false()
         {
             AssertQuery<Product>(ps => ps.Where(p => !p.Discontinued), entryCount: 69);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_bool_client_side_negated()
         {
             AssertQuery<Product>(ps => ps.Where(p => !ClientFunc(p.ProductID) && p.Discontinued), entryCount: 8);
@@ -1231,7 +1233,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             return false;
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_bool_member_negated_twice()
         {
             // ReSharper disable once NegativeEqualityExpression
@@ -1240,94 +1242,94 @@ namespace Microsoft.Data.Entity.FunctionalTests
             AssertQuery<Product>(ps => ps.Where(p => !!(p.Discontinued == true)), entryCount: 8);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_bool_member_shadow()
         {
             AssertQuery<Product>(ps => ps.Where(p => EF.Property<bool>(p, "Discontinued")), entryCount: 8);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_bool_member_false_shadow()
         {
             AssertQuery<Product>(ps => ps.Where(p => !EF.Property<bool>(p, "Discontinued")), entryCount: 69);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_bool_member_equals_constant()
         {
             AssertQuery<Product>(ps => ps.Where(p => p.Discontinued.Equals(true)), entryCount: 8);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_bool_member_in_complex_predicate()
         {
             // ReSharper disable once RedundantBoolCompare
             AssertQuery<Product>(ps => ps.Where(p => p.ProductID > 100 && p.Discontinued || (p.Discontinued == true)), entryCount: 8);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_bool_member_compared_to_binary_expression()
         {
             AssertQuery<Product>(ps => ps.Where(p => p.Discontinued == (p.ProductID > 50)), entryCount: 44);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_not_bool_member_compared_to_not_bool_member()
         {
             AssertQuery<Product>(ps => ps.Where(p => !p.Discontinued == !p.Discontinued), entryCount: 77);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_negated_boolean_expression_compared_to_another_negated_boolean_expression()
         {
             AssertQuery<Product>(ps => ps.Where(p => !(p.ProductID > 50) == !(p.ProductID > 20)), entryCount: 47);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_not_bool_member_compared_to_binary_expression()
         {
             AssertQuery<Product>(ps => ps.Where(p => !p.Discontinued == (p.ProductID > 50)), entryCount: 33);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_bool_parameter_compared_to_binary_expression()
         {
             var prm = true;
             AssertQuery<Product>(ps => ps.Where(p => (p.ProductID > 50) != prm), entryCount: 50);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_bool_member_and_parameter_compared_to_binary_expression_nested()
         {
             var prm = true;
             AssertQuery<Product>(ps => ps.Where(p => p.Discontinued == ((p.ProductID > 50) != prm)), entryCount: 33);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_de_morgan_or_optimizated()
         {
             AssertQuery<Product>(ps => ps.Where(p => !(p.Discontinued || (p.ProductID < 20))), entryCount: 53);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_de_morgan_and_optimizated()
         {
             AssertQuery<Product>(ps => ps.Where(p => !(p.Discontinued && (p.ProductID < 20))), entryCount: 74);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_complex_negated_expression_optimized()
         {
             AssertQuery<Product>(ps => ps.Where(p => !(!(!p.Discontinued && (p.ProductID < 60)) || !(p.ProductID > 30))), entryCount: 27);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_short_member_comparison()
         {
             AssertQuery<Product>(ps => ps.Where(p => p.UnitsInStock > 10), entryCount: 63);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_true()
         {
             AssertQuery<Customer>(
@@ -1335,14 +1337,14 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_false()
         {
             AssertQuery<Customer>(
                 cs => cs.Where(c => false));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_bool_closure()
         {
             var boolean = false;
@@ -1357,7 +1359,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_poco_closure()
         {
             var customer = new Customer { CustomerID = "ALFKI" };
@@ -1371,7 +1373,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs => cs.Where(c => c.Equals(customer)).Select(c => c.CustomerID));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Select_bool_closure()
         {
             var boolean = false;
@@ -1387,7 +1389,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
         // TODO: Re-write entity ref equality to identity equality.
         //
-        // [Fact]
+        // [ConditionalFact]
         // public virtual void Where_compare_entity_equal()
         // {
         //     var alfki = NorthwindData.Customers.Single(c => c.CustomerID == "ALFKI");
@@ -1397,7 +1399,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         //         AssertQuery<Customer>(cs => cs.Where(c => c == alfki)));
         // }
         //
-        // [Fact]
+        // [ConditionalFact]
         // public virtual void Where_compare_entity_not_equal()
         // {
         //     var alfki = new Customer { CustomerID = "ALFKI" };
@@ -1406,7 +1408,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         //         // ReSharper disable once PossibleUnintendedReferenceComparison
         //         AssertQuery<Customer>(cs => cs.Where(c => c != alfki)));
         //
-        // [Fact]
+        // [ConditionalFact]
         // public virtual void Project_compare_entity_equal()
         // {
         //     var alfki = NorthwindData.Customers.Single(c => c.CustomerID == "ALFKI");
@@ -1416,7 +1418,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         //         AssertQuery<Customer>(cs => cs.Select(c => c == alfki)));
         // }
         //
-        // [Fact]
+        // [ConditionalFact]
         // public virtual void Project_compare_entity_not_equal()
         // {
         //     var alfki = new Customer { CustomerID = "ALFKI" };
@@ -1426,21 +1428,21 @@ namespace Microsoft.Data.Entity.FunctionalTests
         //         AssertQuery<Customer>(cs => cs.Select(c => c != alfki)));
         // }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_compare_constructed_equal()
         {
             AssertQuery<Customer>(
                 cs => cs.Where(c => new { x = c.City } == new { x = "London" }));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_compare_constructed_multi_value_equal()
         {
             AssertQuery<Customer>(
                 cs => cs.Where(c => new { x = c.City, y = c.Country } == new { x = "London", y = "UK" }));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_compare_constructed_multi_value_not_equal()
         {
             AssertQuery<Customer>(
@@ -1448,70 +1450,70 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_compare_constructed()
         {
             AssertQuery<Customer>(
                 cs => cs.Where(c => new { x = c.City } == new { x = "London" }));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_compare_null()
         {
             AssertQuery<Customer>(
                 cs => cs.Where(c => c.City == null && c.Country == "UK"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_projection()
         {
             AssertQuery<Customer>(
                 cs => cs.Where(c => c.City == "London").Select(c => c.CompanyName));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Select_scalar()
         {
             AssertQuery<Customer>(
                 cs => cs.Select(c => c.City));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Select_anonymous_one()
         {
             AssertQuery<Customer>(
                 cs => cs.Select(c => new { c.City }));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Select_anonymous_two()
         {
             AssertQuery<Customer>(
                 cs => cs.Select(c => new { c.City, c.Phone }));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Select_anonymous_three()
         {
             AssertQuery<Customer>(
                 cs => cs.Select(c => new { c.City, c.Phone, c.Country }));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Select_anonymous_bool_constant_true()
         {
             AssertQuery<Customer>(
                 cs => cs.Select(c => new { c.CustomerID, ConstantTrue = true }));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Select_anonymous_bool_constant_in_expression()
         {
             AssertQuery<Customer>(
                 cs => cs.Select(c => new { c.CustomerID, Expression = c.CustomerID.Length + 5 }));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Select_customer_table()
         {
             AssertQuery<Customer>(
@@ -1519,7 +1521,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Select_customer_identity()
         {
             AssertQuery<Customer>(
@@ -1527,7 +1529,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Select_anonymous_with_object()
         {
             AssertQuery<Customer>(
@@ -1535,39 +1537,39 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Select_anonymous_nested()
         {
             AssertQuery<Customer>(
                 cs => cs.Select(c => new { c.City, Country = new { c.Country } }));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Select_anonymous_empty()
         {
             AssertQuery<Customer>(
                 cs => cs.Select(c => new { }));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Select_anonymous_literal()
         {
             AssertQuery<Customer>(cs => cs.Select(c => new { X = 10 }));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Select_constant_int()
         {
             AssertQuery<Customer>(cs => cs.Select(c => 0));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Select_constant_null_string()
         {
             AssertQuery<Customer>(cs => cs.Select(c => (string)null));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Select_local()
         {
             // ReSharper disable once ConvertToConstant.Local
@@ -1576,21 +1578,21 @@ namespace Microsoft.Data.Entity.FunctionalTests
             AssertQuery<Customer>(cs => cs.Select(c => x));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Select_scalar_primitive()
         {
             AssertQuery<Employee>(
                 es => es.Select(e => e.EmployeeID));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Select_scalar_primitive_after_take()
         {
             AssertQuery<Employee>(
                 es => es.Take(9).Select(e => e.EmployeeID));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Select_project_filter()
         {
             AssertQuery<Customer>(
@@ -1600,7 +1602,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     select c.CompanyName);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Select_project_filter2()
         {
             AssertQuery<Customer>(
@@ -1610,7 +1612,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     select c.City);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Select_nested_collection()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -1637,7 +1639,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Select_correlated_subquery_projection()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -1661,7 +1663,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Select_correlated_subquery_ordered()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -1685,7 +1687,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         // TODO: Re-linq parser
-        // [Fact]
+        // [ConditionalFact]
         // public virtual void Select_nested_ordered_enumerable_collection()
         // {
         //     AssertQuery<Customer>(cs =>
@@ -1693,7 +1695,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         //         assertOrder: true);
         // }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Select_nested_collection_in_anonymous_type()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -1721,7 +1723,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Select_subquery_recursive_trivial()
         {
             AssertQuery<Employee>(
@@ -1748,7 +1750,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     });
         }
 
-        // TODO: [Fact] See #153
+        // TODO: [ConditionalFact] See #153
         public virtual void Where_subquery_on_collection()
         {
             AssertQuery<Product, OrderDetail>((pr, od) =>
@@ -1757,7 +1759,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select p);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_query_composition()
         {
             AssertQuery<Employee>(
@@ -1768,7 +1770,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_query_composition_is_null()
         {
             AssertQuery<Employee>(
@@ -1779,7 +1781,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_query_composition_is_not_null()
         {
             AssertQuery<Employee>(
@@ -1790,7 +1792,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 8);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_query_composition_entity_equality()
         {
             AssertQuery<Employee>(
@@ -1800,7 +1802,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     select e1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_query_composition2()
         {
             AssertQuery<Employee>(
@@ -1814,7 +1816,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_query_composition3()
         {
             AssertQuery<Customer>(
@@ -1825,7 +1827,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 6);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_query_composition4()
         {
             AssertQuery<Customer>(
@@ -1838,7 +1840,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_query_composition5()
         {
             AssertQuery<Customer>(
@@ -1849,7 +1851,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 85);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_query_composition6()
         {
             AssertQuery<Customer>(
@@ -1863,7 +1865,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 85);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_subquery_recursive_trivial()
         {
             AssertQuery<Employee>(
@@ -1880,7 +1882,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 9);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Select_nested_collection_deep()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -1912,7 +1914,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void OrderBy_scalar_primitive()
         {
             AssertQuery<Employee>(
@@ -1921,7 +1923,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 assertOrder: true);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void SelectMany_mixed()
         {
             AssertQuery<Employee, Customer>(
@@ -1931,7 +1933,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                             select new { e1, s, c });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void SelectMany_simple1()
         {
             AssertQuery<Employee, Customer>(
@@ -1940,7 +1942,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                             select new { c, e });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void SelectMany_simple_subquery()
         {
             AssertQuery<Employee, Customer>(
@@ -1949,7 +1951,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                             select new { c, e });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void SelectMany_simple2()
         {
             AssertQuery<Employee, Customer>(
@@ -1959,7 +1961,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                             select new { e1, c, e2.FirstName });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void SelectMany_entity_deep()
         {
             AssertQuery<Employee>(
@@ -1972,7 +1974,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 9);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void SelectMany_projection1()
         {
             AssertQuery<Employee>(
@@ -1981,7 +1983,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                       select new { e1.City, e2.Country });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void SelectMany_projection2()
         {
             AssertQuery<Employee>(
@@ -1991,7 +1993,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                       select new { e1.City, e2.Country, e3.FirstName });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void SelectMany_nested_simple()
         {
             AssertQuery<Customer>(
@@ -2005,7 +2007,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void SelectMany_correlated_simple()
         {
             AssertQuery<Customer, Employee>((cs, es) =>
@@ -2017,7 +2019,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 assertOrder: true);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void SelectMany_correlated_subquery_simple()
         {
             AssertQuery<Customer, Employee>(
@@ -2029,7 +2031,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 assertOrder: true);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void SelectMany_correlated_subquery_hard()
         {
             AssertQuery<Customer, Employee>(
@@ -2043,7 +2045,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     select new { c1, e1 });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void SelectMany_cartesian_product_with_ordering()
         {
             AssertQuery<Customer, Employee>(
@@ -2056,7 +2058,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 assertOrder: true);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void SelectMany_primitive()
         {
             AssertQuery<Employee>(
@@ -2066,7 +2068,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     select i);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void SelectMany_primitive_select_subquery()
         {
             AssertQuery<Employee>(
@@ -2076,7 +2078,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     select es.Any());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Join_customers_orders_projection()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -2085,7 +2087,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c.ContactName, o.OrderID });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Join_customers_orders_entities()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -2094,7 +2096,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c, o });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Join_select_many()
         {
             AssertQuery<Customer, Order, Employee>((cs, os, es) =>
@@ -2104,7 +2106,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c, o, e });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Client_Join_select_many()
         {
             AssertQuery<Employee>(es =>
@@ -2120,7 +2122,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             return employee.EmployeeID;
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Join_customers_orders_select()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -2131,7 +2133,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select p);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Join_customers_orders_with_subquery()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -2142,7 +2144,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c.ContactName, o1.OrderID });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Join_customers_orders_with_subquery_with_take()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -2153,7 +2155,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c.ContactName, o1.OrderID });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Join_customers_orders_with_subquery_anonymous_property_method()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -2164,7 +2166,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { o1, o1.o2, Shadow = EF.Property<DateTime?>(o1.o2, "OrderDate") });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Join_customers_orders_with_subquery_anonymous_property_method_with_take()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -2175,7 +2177,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { o1, o1.o2, Shadow = EF.Property<DateTime?>(o1.o2, "OrderDate") });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Join_customers_orders_with_subquery_predicate()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -2186,7 +2188,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c.ContactName, o1.OrderID });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Join_customers_orders_with_subquery_predicate_with_take()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -2197,7 +2199,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c.ContactName, o1.OrderID });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Join_composite_key()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -2207,7 +2209,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c, o });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Join_client_new_expression()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -2216,7 +2218,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c, o });
         }
         
-        [Fact]
+        [ConditionalFact]
         public virtual void Join_local_collection_int_closure_is_cached_correctly()
         {
             var ids = new[] { 1, 2 };
@@ -2234,7 +2236,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select e.EmployeeID);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Join_local_string_closure_is_cached_correctly()
         {
             var ids = "12";
@@ -2252,7 +2254,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select e.EmployeeID);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Join_local_bytes_closure_is_cached_correctly()
         {
             var ids = new byte[] { 1, 2 };
@@ -2271,7 +2273,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Join_Where_Count()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -2281,7 +2283,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                  select c).Count());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Multiple_joins_Where_Order_Any()
         {
             AssertQuery<Customer, Order, OrderDetail>((cs, os, ods) =>
@@ -2291,7 +2293,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     .Any());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Join_OrderBy_Count()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -2301,7 +2303,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                  select c).Count());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_join_select()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -2311,7 +2313,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                  select c));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_orderby_join_select()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -2322,7 +2324,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                  select c));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_join_orderby_join_select()
         {
             AssertQuery<Customer, Order, OrderDetail>((cs, os, ods) =>
@@ -2334,7 +2336,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                  select c));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_select_many()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -2344,7 +2346,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                  select c));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_orderby_select_many()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -2361,7 +2363,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             public string Bar { get; set; }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void GroupJoin_customers_orders()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -2380,7 +2382,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void GroupJoin_customers_orders_count()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -2389,7 +2391,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { cust = c, ords = orders.Count() });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Default_if_empty_top_level()
         {
             AssertQuery<Employee>(cs =>
@@ -2397,7 +2399,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select c);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Default_if_empty_top_level_arg()
         {
             AssertQuery<Employee>(cs =>
@@ -2406,7 +2408,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void GroupJoin_customers_employees_shadow()
         {
             AssertQuery<Customer, Employee>((cs, es) =>
@@ -2422,7 +2424,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                         }));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void GroupJoin_customers_employees_subquery_shadow()
         {
             AssertQuery<Customer, Employee>((cs, es) =>
@@ -2438,7 +2440,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                         }));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void GroupJoin_customers_employees_subquery_shadow_take()
         {
             AssertQuery<Customer, Employee>((cs, es) =>
@@ -2454,7 +2456,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                         }));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void SelectMany_customer_orders()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -2464,7 +2466,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c.ContactName, o.OrderID });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void SelectMany_Count()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -2473,7 +2475,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                  select c.CustomerID).Count());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void SelectMany_LongCount()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -2482,7 +2484,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                  select c.CustomerID).LongCount());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void SelectMany_OrderBy_ThenBy_Any()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -2494,7 +2496,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
         // TODO: Composite keys, slow..
 
-        //        [Fact]
+        //        [ConditionalFact]
         //        public virtual void Multiple_joins_with_join_conditions_in_where()
         //        {
         //            AssertQuery<Customer, Order, OrderDetail>((cs, os, ods) =>
@@ -2507,7 +2509,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         //                select od.ProductID,
         //                assertOrder: true);
         //        }
-        //        [Fact]
+        //        [ConditionalFact]
         //
         //        public virtual void TestMultipleJoinsWithMissingJoinCondition()
         //        {
@@ -2521,7 +2523,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         //                );
         //        }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void OrderBy()
         {
             AssertQuery<Customer>(
@@ -2530,7 +2532,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void OrderBy_anon()
         {
             AssertQuery<Customer>(
@@ -2538,7 +2540,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 assertOrder: true);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void OrderBy_anon2()
         {
             AssertQuery<Customer>(
@@ -2547,7 +2549,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void OrderBy_client_mixed()
         {
             AssertQuery<Customer>(
@@ -2556,7 +2558,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void OrderBy_multiple_queries()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -2566,7 +2568,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c, o });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void OrderBy_shadow()
         {
             AssertQuery<Employee>(
@@ -2575,7 +2577,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 9);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void OrderBy_ThenBy_predicate()
         {
             AssertQuery<Customer>(
@@ -2586,7 +2588,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 6);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void OrderBy_correlated_subquery_lol()
         {
             AssertQuery<Customer>(
@@ -2596,7 +2598,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void OrderBy_Select()
         {
             AssertQuery<Customer>(
@@ -2606,7 +2608,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 assertOrder: true);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void OrderBy_multiple()
         {
             AssertQuery<Customer>(
@@ -2618,7 +2620,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 assertOrder: true);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void OrderBy_ThenBy()
         {
             AssertQuery<Customer>(
@@ -2627,7 +2629,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 assertOrder: true);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void OrderByDescending()
         {
             AssertQuery<Customer>(
@@ -2636,7 +2638,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 assertOrder: true);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void OrderByDescending_ThenBy()
         {
             AssertQuery<Customer>(
@@ -2645,7 +2647,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 assertOrder: true);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void OrderByDescending_ThenByDescending()
         {
             AssertQuery<Customer>(
@@ -2654,14 +2656,14 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 assertOrder: true);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void OrderBy_ThenBy_Any()
         {
             AssertQuery<Customer>(
                 cs => cs.OrderBy(c => c.CustomerID).ThenBy(c => c.ContactName).Any());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void OrderBy_Join()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -2670,7 +2672,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c.CustomerID, o.OrderID });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void OrderBy_SelectMany()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -2682,7 +2684,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         // TODO: Need to figure out how to do this 
-        //        [Fact]
+        //        [ConditionalFact]
         //        public virtual void GroupBy_anonymous()
         //        {
         //            AssertQuery<Customer>(cs =>
@@ -2691,7 +2693,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         //                assertOrder: true);
         //        }
         //
-        //        [Fact]
+        //        [ConditionalFact]
         //        public virtual void GroupBy_anonymous_subquery()
         //        {
         //            AssertQuery<Customer>(cs =>
@@ -2700,7 +2702,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         //                assertOrder: true);
         //        }
         //
-        //        [Fact]
+        //        [ConditionalFact]
         //        public virtual void GroupBy_nested_order_by_enumerable()
         //        {
         //            AssertQuery<Customer>(cs =>
@@ -2711,7 +2713,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         //                assertOrder: true);
         //        }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void GroupBy_SelectMany()
         {
             AssertQuery<Customer>(
@@ -2719,7 +2721,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void GroupBy_simple()
         {
             AssertQuery<Order>(
@@ -2738,7 +2740,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void GroupBy_simple2()
         {
             AssertQuery<Order>(
@@ -2757,7 +2759,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void GroupBy_first()
         {
             AssertQuery<Order>(
@@ -2773,28 +2775,28 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 6);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void GroupBy_Sum()
         {
             AssertQuery<Order>(os =>
                 os.GroupBy(o => o.CustomerID).Select(g => g.Sum(o => o.OrderID)));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void GroupBy_Count()
         {
             AssertQuery<Order>(os =>
                 os.GroupBy(o => o.CustomerID).Select(g => g.Count()));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void GroupBy_LongCount()
         {
             AssertQuery<Order>(os =>
                 os.GroupBy(o => o.CustomerID).Select(g => g.LongCount()));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void GroupBy_Shadow()
         {
             AssertQuery<Employee>(es =>
@@ -2804,7 +2806,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     .Select(g => EF.Property<string>(g.First(), "Title")));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void GroupBy_Shadow2()
         {
             AssertQuery<Employee>(es =>
@@ -2814,7 +2816,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     .Select(g => g.First()));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void GroupBy_Shadow3()
         {
             AssertQuery<Employee>(es =>
@@ -2823,7 +2825,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     .Select(g => EF.Property<string>(g.First(), "Title")));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void GroupBy_Sum_Min_Max_Avg()
         {
             AssertQuery<Order>(os =>
@@ -2837,7 +2839,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     }));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void GroupBy_with_result_selector()
         {
             AssertQuery<Order>(os =>
@@ -2851,7 +2853,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     }));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void GroupBy_with_element_selector_sum()
         {
             AssertQuery<Order>(os =>
@@ -2860,7 +2862,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
 
 
-        [Fact]
+        [ConditionalFact]
         public virtual void GroupBy_with_element_selector()
         {
             AssertQuery<Order>(os =>
@@ -2882,7 +2884,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void GroupBy_with_element_selector2()
         {
             AssertQuery<Order>(os =>
@@ -2904,7 +2906,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void GroupBy_with_element_selector3()
         {
             AssertQuery<Employee>(es =>
@@ -2914,7 +2916,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 assertOrder: true);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void GroupBy_with_element_selector_sum_max()
         {
             AssertQuery<Order>(os =>
@@ -2922,7 +2924,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     .Select(g => new { Sum = g.Sum(), Max = g.Max() }));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void GroupBy_with_anonymous_element()
         {
             AssertQuery<Order>(os =>
@@ -2930,7 +2932,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     .Select(g => g.Sum(x => x.OrderID)));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void GroupBy_with_two_part_key()
         {
             AssertQuery<Order>(os =>
@@ -2938,7 +2940,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     .Select(g => g.Sum(o => o.OrderID)));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void OrderBy_GroupBy()
         {
             AssertQuery<Order>(os =>
@@ -2947,7 +2949,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     .Select(g => g.Sum(o => o.OrderID)));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void OrderBy_GroupBy_SelectMany()
         {
             AssertQuery<Order>(os =>
@@ -2957,7 +2959,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 830);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void OrderBy_GroupBy_SelectMany_shadow()
         {
             AssertQuery<Employee>(es =>
@@ -2967,158 +2969,158 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     .Select(g => EF.Property<string>(g, "Title")));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Sum_with_no_arg()
         {
             AssertQuery<Order>(os => os.Select(o => o.OrderID).Sum());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Sum_with_binary_expression()
         {
             AssertQuery<Order>(os => os.Select(o => o.OrderID * 2).Sum());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Sum_with_no_arg_empty()
         {
             AssertQuery<Order>(os => os.Where(o => o.OrderID == 42).Select(o => o.OrderID).Sum());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Sum_with_arg()
         {
             AssertQuery<Order>(os => os.Sum(o => o.OrderID));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Sum_with_arg_expression()
         {
             AssertQuery<Order>(os => os.Sum(o => o.OrderID + o.OrderID));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Min_with_no_arg()
         {
             AssertQuery<Order>(os => os.Select(o => o.OrderID).Min());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Min_with_arg()
         {
             AssertQuery<Order>(os => os.Min(o => o.OrderID));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Max_with_no_arg()
         {
             AssertQuery<Order>(os => os.Select(o => o.OrderID).Max());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Max_with_arg()
         {
             AssertQuery<Order>(os => os.Max(o => o.OrderID));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Count_with_no_predicate()
         {
             AssertQuery<Order>(os => os.Count());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Count_with_predicate()
         {
             AssertQuery<Order>(os =>
                 os.Count(o => o.CustomerID == "ALFKI"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Count_with_order_by()
         {
             AssertQuery<Order>(os => os.OrderBy(o => o.CustomerID).Count());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_OrderBy_Count()
         {
             AssertQuery<Order>(os => os.Where(o => o.CustomerID == "ALFKI").OrderBy(o => o.OrderID).Count());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void OrderBy_Where_Count()
         {
             AssertQuery<Order>(os => os.OrderBy(o => o.OrderID).Where(o => o.CustomerID == "ALFKI").Count());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void OrderBy_Count_with_predicate()
         {
             AssertQuery<Order>(os => os.OrderBy(o => o.OrderID).Count(o => o.CustomerID == "ALFKI"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void OrderBy_Where_Count_with_predicate()
         {
             AssertQuery<Order>(os => os.OrderBy(o => o.OrderID).Where(o => o.OrderID > 10).Count(o => o.CustomerID != "ALFKI"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_OrderBy_Count_client_eval()
         {
             AssertQuery<Order>(os => os.Where(o => ClientEvalPredicate(o)).OrderBy(o => ClientEvalSelectorStateless()).Count());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_OrderBy_Count_client_eval_mixed()
         {
             AssertQuery<Order>(os => os.Where(o => o.OrderID > 10).OrderBy(o => ClientEvalPredicate(o)).Count());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void OrderBy_Where_Count_client_eval()
         {
             AssertQuery<Order>(os => os.OrderBy(o => ClientEvalSelectorStateless()).Where(o => ClientEvalPredicate(o)).Count());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void OrderBy_Where_Count_client_eval_mixed()
         {
             AssertQuery<Order>(os => os.OrderBy(o => o.OrderID).Where(o => ClientEvalPredicate(o)).Count());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void OrderBy_Count_with_predicate_client_eval()
         {
             AssertQuery<Order>(os => os.OrderBy(o => ClientEvalSelectorStateless()).Count(o => ClientEvalPredicate(o)));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void OrderBy_Count_with_predicate_client_eval_mixed()
         {
             AssertQuery<Order>(os => os.OrderBy(o => o.OrderID).Count(o => ClientEvalPredicateStateless()));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void OrderBy_Where_Count_with_predicate_client_eval()
         {
             AssertQuery<Order>(os => os.OrderBy(o => ClientEvalSelectorStateless()).Where(o => ClientEvalPredicateStateless()).Count(o => ClientEvalPredicate(o)));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void OrderBy_Where_Count_with_predicate_client_eval_mixed()
         {
             AssertQuery<Order>(os => os.OrderBy(o => o.OrderID).Where(o => ClientEvalPredicate(o)).Count(o => o.CustomerID != "ALFKI"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void OrderBy_client_Take()
         {
             AssertQuery<Employee>(es => es.OrderBy(o => ClientEvalSelectorStateless()).Take(10), entryCount: 9);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void OrderBy_arithmetic()
         {
             AssertQuery<Employee>(
@@ -3134,7 +3136,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
         protected internal int ClientEvalSelector(Order order) => order.EmployeeID % 10 ?? 0;
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Distinct()
         {
             AssertQuery<Customer>(
@@ -3142,21 +3144,21 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Distinct_Scalar()
         {
             AssertQuery<Customer>(
                 cs => cs.Select(c => c.City).Distinct());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void OrderBy_Distinct()
         {
             AssertQuery<Customer>(
                 cs => cs.OrderBy(c => c.CustomerID).Select(c => c.City).Distinct());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Distinct_OrderBy()
         {
             AssertQuery<Customer>(
@@ -3164,7 +3166,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 assertOrder: true);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Distinct_OrderBy2()
         {
             AssertQuery<Customer>(
@@ -3173,7 +3175,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Distinct_OrderBy3()
         {
             AssertQuery<Customer>(
@@ -3181,7 +3183,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 assertOrder: true);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Distinct_GroupBy()
         {
             AssertQuery<Order>(os =>
@@ -3192,49 +3194,49 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 assertOrder: true);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void GroupBy_Distinct()
         {
             AssertQuery<Order>(os =>
                 os.GroupBy(o => o.CustomerID).Distinct().Select(g => g.Key));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Distinct_Count()
         {
             AssertQuery<Customer>(
                 cs => cs.Distinct().Count());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Select_Distinct_Count()
         {
             AssertQuery<Customer>(
                 cs => cs.Select(c => c.City).Distinct().Count());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Select_Select_Distinct_Count()
         {
             AssertQuery<Customer>(
                 cs => cs.Select(c => c.City).Select(c => c).Distinct().Count());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Single_Throws()
         {
             Assert.Throws<InvalidOperationException>(() =>
                 AssertQuery<Customer>(cs => cs.Single()));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Single_Predicate()
         {
             AssertQuery<Customer>(
                 cs => cs.Single(c => c.CustomerID == "ALFKI"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_Single()
         {
             AssertQuery<Customer>(
@@ -3242,7 +3244,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs => cs.Where(c => c.CustomerID == "ALFKI").Single());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void SingleOrDefault_Throws()
         {
             Assert.Throws<InvalidOperationException>(() =>
@@ -3250,14 +3252,14 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     cs => cs.SingleOrDefault()));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void SingleOrDefault_Predicate()
         {
             AssertQuery<Customer>(
                 cs => cs.SingleOrDefault(c => c.CustomerID == "ALFKI"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_SingleOrDefault()
         {
             AssertQuery<Customer>(
@@ -3265,21 +3267,21 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs => cs.Where(c => c.CustomerID == "ALFKI").SingleOrDefault());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void First()
         {
             AssertQuery<Customer>(
                 cs => cs.OrderBy(c => c.ContactName).First());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void First_Predicate()
         {
             AssertQuery<Customer>(
                 cs => cs.OrderBy(c => c.ContactName).First(c => c.City == "London"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_First()
         {
             AssertQuery<Customer>(
@@ -3287,21 +3289,21 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs => cs.OrderBy(c => c.ContactName).Where(c => c.City == "London").First());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void FirstOrDefault()
         {
             AssertQuery<Customer>(
                 cs => cs.OrderBy(c => c.ContactName).FirstOrDefault());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void FirstOrDefault_Predicate()
         {
             AssertQuery<Customer>(
                 cs => cs.OrderBy(c => c.ContactName).FirstOrDefault(c => c.City == "London"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_FirstOrDefault()
         {
             AssertQuery<Customer>(
@@ -3309,14 +3311,14 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs => cs.OrderBy(c => c.ContactName).Where(c => c.City == "London").FirstOrDefault());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Last()
         {
             AssertQuery<Customer>(
                 cs => cs.OrderBy(c => c.ContactName).Last());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Last_when_no_order_by()
         {
             AssertQuery<Customer>(
@@ -3324,14 +3326,14 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs => cs.Where(c => c.CustomerID == "ALFKI").Last());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Last_Predicate()
         {
             AssertQuery<Customer>(
                 cs => cs.OrderBy(c => c.ContactName).Last(c => c.City == "London"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_Last()
         {
             AssertQuery<Customer>(
@@ -3339,21 +3341,21 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs => cs.OrderBy(c => c.ContactName).Where(c => c.City == "London").Last());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void LastOrDefault()
         {
             AssertQuery<Customer>(
                 cs => cs.OrderBy(c => c.ContactName).LastOrDefault());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void LastOrDefault_Predicate()
         {
             AssertQuery<Customer>(
                 cs => cs.OrderBy(c => c.ContactName).LastOrDefault(c => c.City == "London"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_LastOrDefault()
         {
             AssertQuery<Customer>(
@@ -3361,7 +3363,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs => cs.OrderBy(c => c.ContactName).Where(c => c.City == "London").LastOrDefault());
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void String_StartsWith_Literal()
         {
             AssertQuery<Customer>(
@@ -3369,7 +3371,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 12);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void String_StartsWith_Identity()
         {
             AssertQuery<Customer>(
@@ -3377,7 +3379,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void String_StartsWith_Column()
         {
             AssertQuery<Customer>(
@@ -3385,7 +3387,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void String_StartsWith_MethodCall()
         {
             AssertQuery<Customer>(
@@ -3393,7 +3395,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 12);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void String_EndsWith_Literal()
         {
             AssertQuery<Customer>(
@@ -3401,7 +3403,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void String_EndsWith_Identity()
         {
             AssertQuery<Customer>(
@@ -3409,7 +3411,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void String_EndsWith_Column()
         {
             AssertQuery<Customer>(
@@ -3417,7 +3419,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void String_EndsWith_MethodCall()
         {
             AssertQuery<Customer>(
@@ -3425,7 +3427,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void String_Contains_Literal()
         {
             AssertQuery<Customer>(
@@ -3433,7 +3435,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 19);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void String_Contains_Identity()
         {
             AssertQuery<Customer>(
@@ -3441,7 +3443,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void String_Contains_Column()
         {
             AssertQuery<Customer>(
@@ -3449,7 +3451,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void String_Contains_MethodCall()
         {
             AssertQuery<Customer>(
@@ -3457,7 +3459,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 19);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void String_Compare_simple_zero()
         {
             AssertQuery<Customer>(
@@ -3485,7 +3487,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void String_Compare_simple_one()
         {
             AssertQuery<Customer>(
@@ -3513,7 +3515,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void String_Compare_simple_client()
         {
             AssertQuery<Customer>(
@@ -3529,7 +3531,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void String_Compare_nested()
         {
             AssertQuery<Customer>(
@@ -3557,7 +3559,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void String_Compare_multi_predicate()
         {
             AssertQuery<Customer>(
@@ -3579,7 +3581,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             return "m";
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_math_abs1()
         {
             AssertQuery<OrderDetail>(
@@ -3587,7 +3589,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1939);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_math_abs2()
         {
             AssertQuery<OrderDetail>(
@@ -3595,7 +3597,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1547);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_math_abs3()
         {
             AssertQuery<OrderDetail>(
@@ -3603,7 +3605,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1677);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_math_abs_uncorrelated()
         {
             AssertQuery<OrderDetail>(
@@ -3611,7 +3613,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1939);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_math_ceiling1()
         {
             AssertQuery<OrderDetail>(
@@ -3619,7 +3621,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 838);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_math_ceiling2()
         {
             AssertQuery<OrderDetail>(
@@ -3627,7 +3629,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1677);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_math_floor()
         {
             AssertQuery<OrderDetail>(
@@ -3635,7 +3637,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1658);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_math_power()
         {
             AssertQuery<OrderDetail>(
@@ -3643,7 +3645,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 154);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_math_round()
         {
             AssertQuery<OrderDetail>(
@@ -3651,7 +3653,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1662);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_math_truncate()
         {
             AssertQuery<OrderDetail>(
@@ -3659,7 +3661,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1658);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_guid_newguid()
         {
             AssertQuery<OrderDetail>(
@@ -3667,14 +3669,14 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 2155);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_string_to_upper()
         {
             AssertQuery<Customer>(
                 cs => cs.Where(c => c.CustomerID.ToUpper() == "ALFKI"),
                 entryCount: 1);
         }
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_string_to_lower()
         {
             AssertQuery<Customer>(
@@ -3682,7 +3684,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_functions_nested()
         {
             AssertQuery<Customer>(
@@ -3690,7 +3692,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Convert_ToByte()
         {
             var convertMethods = new List<Expression<Func<Order, bool>>>
@@ -3714,7 +3716,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Convert_ToDecimal()
         {
             var convertMethods = new List<Expression<Func<Order, bool>>>
@@ -3738,7 +3740,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Convert_ToDouble()
         {
             var convertMethods = new List<Expression<Func<Order, bool>>>
@@ -3762,7 +3764,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Convert_ToInt16()
         {
             var convertMethods = new List<Expression<Func<Order, bool>>>
@@ -3786,7 +3788,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Convert_ToInt32()
         {
             var convertMethods = new List<Expression<Func<Order, bool>>>
@@ -3810,7 +3812,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Convert_ToInt64()
         {
             var convertMethods = new List<Expression<Func<Order, bool>>>
@@ -3834,7 +3836,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        //[Fact]
+        //[ConditionalFact]
         public virtual void Convert_ToString()
         {
             var convertMethods = new List<Expression<Func<Order, bool>>>
@@ -3858,7 +3860,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void GroupJoin_simple()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -3868,7 +3870,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select o);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void GroupJoin_simple2()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -3878,7 +3880,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select c);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void GroupJoin_simple_ordering()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -3888,7 +3890,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select o);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void GroupJoin_simple_subquery()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -3898,7 +3900,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select o);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void GroupJoin_projection()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -3908,7 +3910,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c, o });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void GroupJoin_DefaultIfEmpty()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -3918,7 +3920,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c, o });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void GroupJoin_DefaultIfEmpty2()
         {
             AssertQuery<Employee, Order>((es, os) =>
@@ -3928,7 +3930,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { e, o });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void GroupJoin_DefaultIfEmpty3()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -3938,7 +3940,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select o);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void SelectMany_Joined()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -3947,7 +3949,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c.ContactName, o.OrderDate });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void SelectMany_Joined_DefaultIfEmpty()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -3956,7 +3958,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c.ContactName, o });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void SelectMany_Joined_Take()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -3965,7 +3967,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c.ContactName, o });
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void SelectMany_Joined_DefaultIfEmpty2()
         {
             AssertQuery<Customer, Order>((cs, os) =>
@@ -3974,35 +3976,35 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select o);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Select_many_cross_join_same_collection()
         {
             AssertQuery<Customer, Customer>((cs1, cs2) =>
                 cs1.SelectMany(c => cs2));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Join_same_collection_multiple()
         {
             AssertQuery<Customer, Customer, Customer>((cs1, cs2, cs3) =>
                 cs1.Join(cs2, o => o.CustomerID, i => i.CustomerID, (c1, c2) => new { c1, c2 }).Join(cs3, o => o.c1.CustomerID, i => i.CustomerID, (c12, c3) => c3));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Join_same_collection_force_alias_uniquefication()
         {
             AssertQuery<Order, Order>((os1, os2) =>
                 os1.Join(os2, o => o.CustomerID, i => i.CustomerID, (_, o) => new { _, o }));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Contains_with_subquery()
         {
             AssertQuery<Customer, Order>((cs, os) =>
                 cs.Where(c => os.Select(o => o.CustomerID).Contains(c.CustomerID)));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Contains_with_local_array_closure()
         {
             var ids = new[] { "ABCDE", "ALFKI" };
@@ -4016,7 +4018,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs.Where(c => ids.Contains(c.CustomerID)));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Contains_with_local_int_array_closure()
         {
             var ids = new[] { 0, 1 };
@@ -4030,14 +4032,14 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 es.Where(e => ids.Contains(e.EmployeeID)));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Contains_with_local_array_inline()
         {
             AssertQuery<Customer>(cs =>
                 cs.Where(c => new[] { "ABCDE", "ALFKI" }.Contains(c.CustomerID)), entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Contains_with_local_list_closure()
         {
             var ids = new List<string> { "ABCDE", "ALFKI" };
@@ -4045,14 +4047,14 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs.Where(c => ids.Contains(c.CustomerID)), entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Contains_with_local_list_inline()
         {
             AssertQuery<Customer>(cs =>
                 cs.Where(c => new List<string> { "ABCDE", "ALFKI" }.Contains(c.CustomerID)), entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Contains_with_local_list_inline_closure_mix()
         {
             var id = "ALFKI";
@@ -4066,7 +4068,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs.Where(c => new List<string> { "ABCDE", id }.Contains(c.CustomerID)), entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Contains_with_local_collection_false()
         {
             string[] ids = { "ABCDE", "ALFKI" };
@@ -4075,7 +4077,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs.Where(c => !ids.Contains(c.CustomerID)), entryCount: 90);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Contains_with_local_collection_complex_predicate_and()
         {
             string[] ids = { "ABCDE", "ALFKI" };
@@ -4084,7 +4086,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs.Where(c => (c.CustomerID == "ALFKI" || c.CustomerID == "ABCDE") && ids.Contains(c.CustomerID)), entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Contains_with_local_collection_complex_predicate_or()
         {
             string[] ids = { "ABCDE", "ALFKI" };
@@ -4093,7 +4095,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs.Where(c => ids.Contains(c.CustomerID) || (c.CustomerID == "ALFKI" || c.CustomerID == "ABCDE")), entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Contains_with_local_collection_complex_predicate_not_matching_ins1()
         {
             string[] ids = { "ABCDE", "ALFKI" };
@@ -4102,7 +4104,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs.Where(c => (c.CustomerID == "ALFKI" || c.CustomerID == "ABCDE") || !ids.Contains(c.CustomerID)), entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Contains_with_local_collection_complex_predicate_not_matching_ins2()
         {
             string[] ids = { "ABCDE", "ALFKI" };
@@ -4111,7 +4113,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs.Where(c => ids.Contains(c.CustomerID) && (c.CustomerID != "ALFKI" && c.CustomerID != "ABCDE")));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Contains_with_local_collection_sql_injection()
         {
             string[] ids = { "ALFKI", "ABC')); GO; DROP TABLE Orders; GO; --" };
@@ -4120,7 +4122,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs.Where(c => ids.Contains(c.CustomerID) || (c.CustomerID == "ALFKI" || c.CustomerID == "ABCDE")), entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Contains_with_local_collection_empty_closure()
         {
             var ids = new string[0];
@@ -4129,21 +4131,21 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs.Where(c => ids.Contains(c.CustomerID)));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Contains_with_local_collection_empty_inline()
         {
             AssertQuery<Customer>(cs =>
                 cs.Where(c => !(new List<string>().Contains(c.CustomerID))), entryCount: 91);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Contains_top_level()
         {
             AssertQuery<Customer>(cs =>
                 cs.Select(c => c.CustomerID).Contains("ALFKI"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_chain()
         {
             AssertQuery<Order>(order => order
@@ -4152,7 +4154,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
 
-        [Fact]
+        [ConditionalFact]
         public virtual void OrderBy_null_coalesce_operator()
         {
             AssertQuery<Customer>(customer => customer
@@ -4160,14 +4162,14 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact] //Issue 1798
+        [ConditionalFact] //Issue 1798
         public virtual void Select_null_coalesce_operator()
         {
             AssertQuery<Customer>(customer => customer
                 .Select(c => new { c.CustomerID, c.CompanyName, Region = c.Region ?? "ZZ" }).OrderBy(o => o.Region));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void OrderBy_conditional_operator()
         {
             AssertQuery<Customer>(customer => customer
@@ -4175,14 +4177,14 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 91);
         }
 
-        [Fact] //Issue 1798
+        [ConditionalFact] //Issue 1798
         public virtual void Projection_null_coalesce_operator()
         {
             AssertQuery<Customer>(customer => customer
                 .Select(c => new { c.CustomerID, c.CompanyName, Region = c.Region ?? "ZZ" }));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Filter_coalesce_operator()
         {
             AssertQuery<Customer>(customer => customer
@@ -4190,7 +4192,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Take_skip_null_coalesce_operator()
         {
             AssertQuery<Customer>(
@@ -4198,21 +4200,21 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 5);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Select_take_null_coalesce_operator()
         {
             AssertQuery<Customer>(
             cs => cs.Select(c => new { c.CustomerID, c.CompanyName, Region = c.Region ?? "ZZ" }).OrderBy(c => c.Region).Take(5));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Select_take_skip_null_coalesce_operator()
         {
             AssertQuery<Customer>(
             cs => cs.Select(c => new { c.CustomerID, c.CompanyName, Region = c.Region ?? "ZZ" }).OrderBy(c => c.Region).Take(10).Skip(5));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Select_Property_when_non_shadow()
         {
             AssertQuery<Order>(os =>
@@ -4220,7 +4222,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select EF.Property<int>(o, "OrderID"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_Property_when_non_shadow()
         {
             AssertQuery<Order>(os =>
@@ -4230,7 +4232,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 1);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Select_Property_when_shadow()
         {
             AssertQuery<Employee>(es =>
@@ -4238,7 +4240,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select EF.Property<string>(e, "Title"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Where_Property_when_shadow()
         {
             AssertQuery<Employee>(es =>
@@ -4248,7 +4250,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 6);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Selected_column_can_coalesce()
         {
             using (var context = CreateContext())
@@ -4262,7 +4264,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Can_cast_CreateQuery_result_to_IQueryable_T_bug_1730()
         {
             using (var context = CreateContext())
@@ -4274,7 +4276,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Can_execute_non_generic()
         {
             using (var context = CreateContext())
@@ -4288,7 +4290,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Select_Subquery_Single()
         {
             using (var context = CreateContext())
@@ -4305,7 +4307,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Select_Where_Subquery_Deep_Single()
         {
             using (var context = CreateContext())
@@ -4330,7 +4332,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Select_Where_Subquery_Deep_First()
         {
             using (var context = CreateContext())

--- a/test/EntityFramework.Core.FunctionalTests/TestUtilities/Xunit/FrameworkSkipConditionAttribute.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestUtilities/Xunit/FrameworkSkipConditionAttribute.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.PlatformAbstractions;
 
 namespace Microsoft.Data.Entity.FunctionalTests.TestUtilities.Xunit
 {
-    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false)]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = false)]
     public class FrameworkSkipConditionAttribute : Attribute, ITestCondition
     {
         private readonly RuntimeFrameworks _excludedFrameworks;

--- a/test/EntityFramework.Core.FunctionalTests/TestUtilities/Xunit/MonoVersionConditionAttribute.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestUtilities/Xunit/MonoVersionConditionAttribute.cs
@@ -1,0 +1,79 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+
+namespace Microsoft.Data.Entity.FunctionalTests.TestUtilities.Xunit
+{
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = false)]
+    public class MonoVersionConditionAttribute : Attribute, ITestCondition
+    {
+        private Version _min;
+        private Version _max;
+        private Version _skip;
+        public string Min { get { return _min.ToString(); } set { _min = new Version(value); } }
+        public string Max { get { return _max.ToString(); } set { _max = new Version(value); } }
+        public string Skip { get { return _skip.ToString(); } set { _skip = new Version(value); } }
+
+        private Version Current
+        {
+            get
+            {
+                var displayName = Type.GetType("Mono.Runtime")?.GetMethod("GetDisplayName", BindingFlags.NonPublic | BindingFlags.Static);
+                if (displayName == null)
+                {
+                    return null;
+                }
+                var fullVersion = displayName.Invoke(null, null) as string ?? string.Empty;
+                return new Version(fullVersion.Split(' ')[0]);
+            }
+        }
+
+        public bool IsMet
+        {
+            get
+            {
+                if (!TestPlatformHelper.IsMono)
+                {
+                    return true;
+                }
+
+                if (Current == _skip)
+                {
+                    return false;
+                }
+
+                if (_min == null && _max == null)
+                {
+                    return true;
+                }
+
+                if (_min == null)
+                {
+                    return Current <= _max;
+                }
+
+                if (_max == null)
+                {
+                    return Current >= _min;
+                }
+
+                return Current <= _max && Current >= _min;
+            }
+        }
+
+        private string _skipReason;
+
+        public string SkipReason
+        {
+            set { _skipReason = value; }
+            get
+            {
+                return _skipReason ??
+                        $"Test only runs for Mono versions >= { Min ?? "Any"} and <= { Max ?? "Any" }"
+                        + (Skip == null ? "" : "and skipping on " + Skip);
+            }
+        }
+    }
+}

--- a/test/EntityFramework.Core.Tests/ApiConsistencyTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ApiConsistencyTestBase.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.FunctionalTests.TestUtilities.Xunit;
 using Xunit;
 
 // ReSharper disable StringEndsWithIsCultureSpecific
@@ -15,6 +16,7 @@ using Xunit;
 
 namespace Microsoft.Data.Entity
 {
+    [MonoVersionCondition(Min = "4.2.0", SkipReason = "Mono < 4.2.0 does not implement reflection APIs used in this test")]
     public abstract class ApiConsistencyTestBase
     {
         protected const BindingFlags PublicInstance
@@ -23,7 +25,7 @@ namespace Microsoft.Data.Entity
         protected const BindingFlags AnyInstance
             = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
 
-        [Fact]
+        [ConditionalFact]
         public void Public_inheritable_apis_should_be_virtual()
         {
             var nonVirtualMethods
@@ -48,7 +50,7 @@ namespace Microsoft.Data.Entity
                 "\r\n-- Missing virtual APIs --\r\n" + string.Join(Environment.NewLine, nonVirtualMethods));
         }
 
-        [Fact]
+        [ConditionalFact]
         public void Public_api_arguments_should_have_not_null_annotation()
         {
             var parametersMissingAttribute
@@ -83,7 +85,7 @@ namespace Microsoft.Data.Entity
                 "\r\n-- Missing NotNull annotations --\r\n" + string.Join(Environment.NewLine, parametersMissingAttribute));
         }
 
-        [Fact]
+        [ConditionalFact]
         public void Async_methods_should_have_overload_with_cancellation_token_and_end_with_async_suffix()
         {
             var asyncMethods
@@ -131,7 +133,7 @@ namespace Microsoft.Data.Entity
                 "\r\n-- Missing async suffix --\r\n" + string.Join(Environment.NewLine, missingSuffixMethods));
         }
 
-        [Fact]
+        [ConditionalFact]
         public void Public_api_bool_parameters_should_not_be_prefixed()
         {
             var prefixes = new[]

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/Properties/TestAssemblyConditions.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/Properties/TestAssemblyConditions.cs
@@ -2,10 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Data.Entity.SqlServer.FunctionalTests;
+using Microsoft.Data.Entity.FunctionalTests.TestUtilities.Xunit;
 using Xunit;
 
 [assembly: TestFramework("ConditionalTestFramework", "EntityFramework.Core.FunctionalTests")]
 
 // Skip the entire assembly if not on Windows and no external SQL Server is configured
-
 [assembly: SqlServerConfiguredCondition]
+
+[assembly: FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "SqlClient on Mono is partially implemented. SQL Server functional tests are ineffective on Mono")]

--- a/test/EntityFramework.MicrosoftSqlServer.Tests/SqlServerDatabaseCreatorTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.Tests/SqlServerDatabaseCreatorTest.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.Entity.FunctionalTests.TestUtilities;
+using Microsoft.Data.Entity.FunctionalTests.TestUtilities.Xunit;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Storage;
@@ -24,39 +25,40 @@ using Xunit;
 
 namespace Microsoft.Data.Entity.SqlServer.Tests
 {
+    [MonoVersionCondition(Min = "4.2.0", SkipReason = "Cannot immitate SqlError on this version of Mono")]
     public class SqlServerDatabaseCreatorTest
     {
-        [Fact]
+        [ConditionalFact]
         public async Task Create_checks_for_existence_and_retries_if_no_proccess_until_it_passes()
         {
             await Create_checks_for_existence_and_retries_until_it_passes(233, async: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task Create_checks_for_existence_and_retries_if_timeout_until_it_passes()
         {
             await Create_checks_for_existence_and_retries_until_it_passes(-2, async: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task Create_checks_for_existence_and_retries_if_cannot_open_until_it_passes()
         {
             await Create_checks_for_existence_and_retries_until_it_passes(4060, async: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task CreateAsync_checks_for_existence_and_retries_if_no_proccess_until_it_passes()
         {
             await Create_checks_for_existence_and_retries_until_it_passes(233, async: true);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task CreateAsync_checks_for_existence_and_retries_if_timeout_until_it_passes()
         {
             await Create_checks_for_existence_and_retries_until_it_passes(-2, async: true);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task CreateAsync_checks_for_existence_and_retries_if_cannot_open_until_it_passes()
         {
             await Create_checks_for_existence_and_retries_until_it_passes(4060, async: true);
@@ -89,13 +91,13 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             Assert.Equal(5, connection.OpenCount);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task Create_checks_for_existence_and_ultimately_gives_up_waiting()
         {
             await Create_checks_for_existence_and_ultimately_gives_up_waiting_test(async: false);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task CreateAsync_checks_for_existence_and_ultimately_gives_up_waiting()
         {
             await Create_checks_for_existence_and_ultimately_gives_up_waiting_test(async: true);
@@ -236,7 +238,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             }
             else
             {
-                // On Windows-CoreClr, SqlError is type-forwarded to full .NET
+                // On Windows-CoreClr & Mono, SqlError is type-forwarded to full .NET
                 error = (SqlError)errorCtors.First(c => c.GetParameters().Length == 7)
                     .Invoke(new object[] { number, (byte)0, (byte)0, "Server", "ErrorMessage", "Procedure", 0 });
             }

--- a/test/EntityFramework.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
+++ b/test/EntityFramework.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using Microsoft.Data.Entity.FunctionalTests.TestUtilities.Xunit;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Migrations.Operations;
 using Xunit;
@@ -317,7 +318,8 @@ namespace Microsoft.Data.Entity.Migrations.Internal
                 });
         }
 
-        [Theory]
+        [ConditionalTheory]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono, SkipReason = "Mono's type comparisons for empty byte arrays is incorrect")]
         [InlineData(typeof(int), 0)]
         [InlineData(typeof(int?), 0)]
         [InlineData(typeof(string), "")]

--- a/test/EntityFramework.Relational.Tests/Storage/RelationalCommandTest.cs
+++ b/test/EntityFramework.Relational.Tests/Storage/RelationalCommandTest.cs
@@ -7,6 +7,7 @@ using System.Data;
 using System.Data.Common;
 using System.Diagnostics;
 using System.Threading.Tasks;
+using Microsoft.Data.Entity.FunctionalTests.TestUtilities.Xunit;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Storage.Internal;
@@ -378,7 +379,8 @@ namespace Microsoft.Data.Entity.Storage
             Assert.Equal(expectedCount, fakeDbConnection.CloseCount);
         }
 
-        [Theory]
+        [ConditionalTheory]
+        [MonoVersionCondition(Min = "4.2.0", SkipReason = "ExecuteReaderAsync is not implemented in Mono < 4.2.0")]
         [InlineData(true)]
         [InlineData(false)]
         public async Task Can_ExecuteReaderAsync(bool manageConnection)

--- a/test/EntityFramework.Sqlite.FunctionalTests/AsyncQuerySqliteTest.cs
+++ b/test/EntityFramework.Sqlite.FunctionalTests/AsyncQuerySqliteTest.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Data.Entity.FunctionalTests;
 using Microsoft.Data.Entity.FunctionalTests.TestModels.Northwind;
+using Microsoft.Data.Entity.FunctionalTests.TestUtilities.Xunit;
 using Xunit;
 
 #pragma warning disable 1998
@@ -52,7 +53,7 @@ namespace Microsoft.Data.Entity.Sqlite.FunctionalTests
             await Assert.ThrowsAsync<Exception>(async () => await AssertQuery<Customer>(cs => cs.Skip(5).Take(10)));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task Single_Predicate_Cancellation()
         {
             await Assert.ThrowsAsync<TaskCanceledException>(async () =>


### PR DESCRIPTION
Mono has numerous bugs in LINQ, SqlClient, remoting, and others. We thoroughly test on CoreCLR on X-Plat.

Passes on Mono 4.2.0.

Running korebuild does not work yet on Mono 4.0.x. Xunit hangs indefinitely on <4.2.0 (see https://github.com/xunit/xunit/issues/564) even with parallelization turned off.
