### PR TITLE
Query: Relational: Fixes #3235 and #3317

### DIFF
--- a/src/EntityFramework.Relational/Extensions/ExpressionExtensions.cs
+++ b/src/EntityFramework.Relational/Extensions/ExpressionExtensions.cs
@@ -41,12 +41,5 @@ namespace System.Linq.Expressions
                    || unwrappedExpression is LiteralExpression
                    || unwrappedExpression.IsAliasWithColumnExpression();
         }
-
-        public static bool IsSelectExpression([NotNull] this Expression expression)
-        {
-            var unwrappedExpression = expression.RemoveConvert();
-
-            return unwrappedExpression is SelectExpression;
-        }
     }
 }

--- a/src/EntityFramework.Relational/Extensions/ExpressionExtensions.cs
+++ b/src/EntityFramework.Relational/Extensions/ExpressionExtensions.cs
@@ -41,5 +41,12 @@ namespace System.Linq.Expressions
                    || unwrappedExpression is LiteralExpression
                    || unwrappedExpression.IsAliasWithColumnExpression();
         }
+
+        public static bool IsSelectExpression([NotNull] this Expression expression)
+        {
+            var unwrappedExpression = expression.RemoveConvert();
+
+            return unwrappedExpression is SelectExpression;
+        }
     }
 }

--- a/src/EntityFramework.Relational/Query/ExpressionVisitors/Internal/BufferedEntityShaper`.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionVisitors/Internal/BufferedEntityShaper`.cs
@@ -52,6 +52,14 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors.Internal
             return null;
         }
 
+        public override IShaper<TDerived> Cast<TDerived>()
+            => new BufferedOffsetEntityShaper<TDerived>(
+                QuerySource,
+                EntityType,
+                IsTrackingQuery,
+                KeyValueFactory,
+                Materializer);
+
         public override EntityShaper WithOffset(int offset)
             => new BufferedOffsetEntityShaper<TEntity>(
                 QuerySource,

--- a/src/EntityFramework.Relational/Query/ExpressionVisitors/Internal/EntityShaper.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionVisitors/Internal/EntityShaper.cs
@@ -32,6 +32,8 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors.Internal
         protected virtual bool AllowNullResult { get; private set; }
         protected virtual int ValueBufferOffset { get; private set; }
 
+        public abstract IShaper<TDerived> Cast<TDerived>() where TDerived : class;
+        
         public abstract EntityShaper WithOffset(int offset);
 
         protected virtual EntityShaper SetOffset(int offset)

--- a/src/EntityFramework.Relational/Query/ExpressionVisitors/Internal/UnbufferedEntityShaper.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionVisitors/Internal/UnbufferedEntityShaper.cs
@@ -51,6 +51,14 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors.Internal
             return (TEntity)Materializer(valueBuffer);
         }
 
+        public override IShaper<TDerived> Cast<TDerived>()
+            => new UnbufferedOffsetEntityShaper<TDerived>(
+                QuerySource,
+                EntityType,
+                IsTrackingQuery,
+                KeyValueFactory,
+                Materializer);
+
         public override EntityShaper WithOffset(int offset)
             => new UnbufferedOffsetEntityShaper<TEntity>(
                 QuerySource,

--- a/test/EntityFramework.Core.FunctionalTests/GearsOfWarQueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/GearsOfWarQueryTestBase.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel;
 using Microsoft.Data.Entity.FunctionalTests.TestUtilities.Xunit;
 using Xunit;
-using Xunit.Abstractions;
+// ReSharper disable ReplaceWithSingleCallToSingle
 
 namespace Microsoft.Data.Entity.FunctionalTests
 {
@@ -83,7 +83,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
                 Assert.Equal(5, result.Count);
 
-                var cities = result.Select(g => g.CityOfBirth);
+                var cities = result.Select(g => g.CityOfBirth).ToList();
                 Assert.True(cities.All(c => c != null));
                 Assert.True(cities.All(c => c.BornGears != null));
             }
@@ -269,9 +269,9 @@ namespace Microsoft.Data.Entity.FunctionalTests
             {
                 var query = context.Gears.Join(
                     context.Tags,
-                    g => new { SquadId = (int?)g.SquadId, Nickname = g.Nickname },
+                    g => new { SquadId = (int?)g.SquadId, g.Nickname },
                     t => new { SquadId = t.GearSquadId, Nickname = t.GearNickName },
-                    (Gear g, CogTag t) => g).Include(g => g.CityOfBirth);
+                    (g, t) => g).Include(g => g.CityOfBirth);
 
                 var result = query.ToList();
                 Assert.Equal(5, result.Count);
@@ -288,8 +288,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 var query = context.Tags.Join(
                     context.Gears,
                     t => new { SquadId = t.GearSquadId, Nickname = t.GearNickName },
-                    g => new { SquadId = (int?)g.SquadId, Nickname = g.Nickname },
-                    (CogTag t, Gear g) => g).Include(g => g.CityOfBirth);
+                    g => new { SquadId = (int?)g.SquadId, g.Nickname },
+                    (t, g) => g).Include(g => g.CityOfBirth);
 
                 var result = query.ToList();
                 Assert.Equal(5, result.Count);
@@ -304,9 +304,9 @@ namespace Microsoft.Data.Entity.FunctionalTests
             {
                 var query = context.Gears.Join(
                     context.Tags,
-                    g => new { SquadId = (int?)g.SquadId, Nickname = g.Nickname },
+                    g => new { SquadId = (int?)g.SquadId, g.Nickname },
                     t => new { SquadId = t.GearSquadId, Nickname = t.GearNickName },
-                    (Gear g, CogTag t) => g).Include(g => g.Weapons);
+                    (g, t) => g).Include(g => g.Weapons);
 
                 var result = query.ToList();
                 Assert.Equal(5, result.Count);
@@ -323,8 +323,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 var query = context.Tags.Join(
                     context.Gears,
                     t => new { SquadId = t.GearSquadId, Nickname = t.GearNickName },
-                    g => new { SquadId = (int?)g.SquadId, Nickname = g.Nickname },
-                    (CogTag t, Gear g) => g).Include(g => g.Weapons);
+                    g => new { SquadId = (int?)g.SquadId, g.Nickname },
+                    (t, g) => g).Include(g => g.Weapons);
 
                 var result = query.ToList();
                 Assert.Equal(5, result.Count);
@@ -339,9 +339,9 @@ namespace Microsoft.Data.Entity.FunctionalTests
             {
                 var query = context.Gears.Join(
                     context.Tags,
-                    g => new { SquadId = (int?)g.SquadId, Nickname = g.Nickname },
+                    g => new { SquadId = (int?)g.SquadId, g.Nickname },
                     t => new { SquadId = t.GearSquadId, Nickname = t.GearNickName },
-                    (Gear g, CogTag t) => g).Include(g => g.CityOfBirth.StationedGears);
+                    (g, t) => g).Include(g => g.CityOfBirth.StationedGears);
 
                 var result = query.ToList();
                 Assert.Equal(5, result.Count);
@@ -349,8 +349,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        // issue #3235
-        //[Fact]
+        [Fact]
         public virtual void Include_with_join_and_inheritance1()
         {
             using (var context = CreateContext())
@@ -358,8 +357,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 var query = context.Tags.Join(
                     context.Gears.OfType<Officer>(),
                     t => new { SquadId = t.GearSquadId, Nickname = t.GearNickName },
-                    o => new { SquadId = (int?)o.SquadId, Nickname = o.Nickname },
-                    (CogTag t, Officer o) => o).Include(o => o.CityOfBirth);
+                    o => new { SquadId = (int?)o.SquadId, o.Nickname },
+                    (t, o) => o).Include(o => o.CityOfBirth);
 
                 var result = query.ToList();
                 Assert.Equal(2, result.Count);
@@ -367,17 +366,16 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        // issue #3235
-        //[Fact]
+        [Fact]
         public virtual void Include_with_join_and_inheritance2()
         {
             using (var context = CreateContext())
             {
                 var query = context.Gears.OfType<Officer>().Join(
                     context.Tags,
-                    o => new { SquadId = (int?)o.SquadId, Nickname = o.Nickname },
+                    o => new { SquadId = (int?)o.SquadId, o.Nickname },
                     t => new { SquadId = t.GearSquadId, Nickname = t.GearNickName },
-                    (Officer o, CogTag t) => o).Include(g => g.Weapons);
+                    (o, t) => o).Include(g => g.Weapons);
 
                 var result = query.ToList();
                 Assert.Equal(2, result.Count);
@@ -385,8 +383,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        // issue #3235
-        //[Fact]
+        [Fact]
         public virtual void Include_with_join_and_inheritance3()
         {
             using (var context = CreateContext())
@@ -394,11 +391,11 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 var query = context.Tags.Join(
                     context.Gears.OfType<Officer>(),
                     t => new { SquadId = t.GearSquadId, Nickname = t.GearNickName },
-                    g => new { SquadId = (int?)g.SquadId, Nickname = g.Nickname },
-                    (CogTag t, Officer o) => o).Include(o => o.Reports);
+                    g => new { SquadId = (int?)g.SquadId, g.Nickname },
+                    (t, o) => o).Include(o => o.Reports);
 
                 var result = query.ToList();
-                Assert.Equal(1, result.Count);
+                Assert.Equal(2, result.Count);
                 Assert.True(result.All(o => o.Reports.Count > 0));
             }
         }

--- a/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
@@ -12,7 +12,7 @@ using Microsoft.Data.Entity.Tests;
 using Microsoft.Data.Entity.FunctionalTests.TestUtilities.Xunit;
 using Xunit;
 // ReSharper disable ReplaceWithSingleCallToCount
-
+// ReSharper disable StringStartsWithIsCultureSpecific
 // ReSharper disable AccessToModifiedClosure
 
 namespace Microsoft.Data.Entity.FunctionalTests
@@ -69,7 +69,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 10);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Take_simple_parameterized()
         {
             var take = 10;
@@ -194,7 +194,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 entryCount: 5);
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Take_Skip_Distinct_Caching()
         {
             AssertQuery<Customer>(
@@ -272,16 +272,50 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 cs => cs.Any(c => c.ContactName.StartsWith("A")));
         }
 
-        //[ConditionalFact]
+        [ConditionalFact]
         public virtual void Any_nested_negated()
         {
-            using (var context = CreateContext())
-            {
-                var query = context.Customers.Where(c => !c.Orders.Any(o => o.CustomerID.StartsWith("A")));
-                var result = query.ToList();
+            AssertQuery<Customer, Order>(
+                (cs, os) => cs.Where(c => !os.Any(o => o.CustomerID.StartsWith("A"))));
+        }
 
-                Assert.Equal(4, result.Count);
+        [ConditionalFact]
+        public virtual void Any_nested_negated2()
+            {
+            AssertQuery<Customer, Order>(
+                (cs, os) => cs.Where(c => c.City != "London"
+                                          && !os.Any(o => o.CustomerID.StartsWith("A"))));
+        }
+
+        [ConditionalFact]
+        public virtual void Any_nested_negated3()
+        {
+            AssertQuery<Customer, Order>(
+                (cs, os) => cs.Where(c => !os.Any(o => o.CustomerID.StartsWith("A"))
+                                          && c.City != "London"));
             }
+
+        [ConditionalFact]
+        public virtual void Any_nested()
+        {
+            AssertQuery<Customer, Order>(
+                (cs, os) => cs.Where(c => os.Any(o => o.CustomerID.StartsWith("A"))));
+        }
+
+        [ConditionalFact]
+        public virtual void Any_nested2()
+        {
+            AssertQuery<Customer, Order>(
+                (cs, os) => cs.Where(c => c.City != "London"
+                                          && os.Any(o => o.CustomerID.StartsWith("A"))));
+        }
+
+        [ConditionalFact]
+        public virtual void Any_nested3()
+        {
+            AssertQuery<Customer, Order>(
+                (cs, os) => cs.Where(c => os.Any(o => o.CustomerID.StartsWith("A"))
+                                          && c.City != "London"));
         }
 
         [ConditionalFact]

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -391,7 +391,14 @@ ORDER BY [c].[Name]",
             base.Include_with_join_and_inheritance1();
 
             Assert.Equal(
-                @"",
+                @"SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOrBirthName], [t0].[Discriminator], [t0].[FullName], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [c].[Name], [c].[Location]
+FROM [CogTag] AS [t]
+INNER JOIN (
+    SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+    FROM [Gear] AS [g]
+    WHERE [g].[Discriminator] = 'Officer'
+) AS [t0] ON ([t].[GearSquadId] = [t0].[SquadId]) AND ([t].[GearNickName] = [t0].[Nickname])
+INNER JOIN [City] AS [c] ON [t0].[CityOrBirthName] = [c].[Name]",
                 Sql);
         }
 
@@ -400,7 +407,27 @@ ORDER BY [c].[Name]",
             base.Include_with_join_and_inheritance2();
 
             Assert.Equal(
-                @"",
+                @"SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOrBirthName], [t0].[Discriminator], [t0].[FullName], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank]
+FROM (
+    SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+    FROM [Gear] AS [g]
+    WHERE [g].[Discriminator] = 'Officer'
+) AS [t0]
+INNER JOIN [CogTag] AS [t] ON ([t0].[SquadId] = [t].[GearSquadId]) AND ([t0].[Nickname] = [t].[GearNickName])
+ORDER BY [t0].[FullName]
+
+SELECT [w].[Id], [w].[AmmunitionType], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapon] AS [w]
+INNER JOIN (
+    SELECT DISTINCT [t0].[FullName]
+    FROM (
+        SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+        FROM [Gear] AS [g]
+        WHERE [g].[Discriminator] = 'Officer'
+    ) AS [t0]
+    INNER JOIN [CogTag] AS [t] ON ([t0].[SquadId] = [t].[GearSquadId]) AND ([t0].[Nickname] = [t].[GearNickName])
+) AS [t0] ON [w].[OwnerFullName] = [t0].[FullName]
+ORDER BY [t0].[FullName]",
                 Sql);
         }
 
@@ -409,7 +436,28 @@ ORDER BY [c].[Name]",
             base.Include_with_join_and_inheritance3();
 
             Assert.Equal(
-                @"",
+                @"SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOrBirthName], [t0].[Discriminator], [t0].[FullName], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank]
+FROM [CogTag] AS [t]
+INNER JOIN (
+    SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+    FROM [Gear] AS [g]
+    WHERE [g].[Discriminator] = 'Officer'
+) AS [t0] ON ([t].[GearSquadId] = [t0].[SquadId]) AND ([t].[GearNickName] = [t0].[Nickname])
+ORDER BY [t0].[Nickname], [t0].[SquadId]
+
+SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+FROM [Gear] AS [g]
+INNER JOIN (
+    SELECT DISTINCT [t0].[Nickname], [t0].[SquadId]
+    FROM [CogTag] AS [t]
+    INNER JOIN (
+        SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+        FROM [Gear] AS [g]
+        WHERE [g].[Discriminator] = 'Officer'
+    ) AS [t0] ON ([t].[GearSquadId] = [t0].[SquadId]) AND ([t].[GearNickName] = [t0].[Nickname])
+) AS [t0] ON ([g].[LeaderNickname] = [t0].[Nickname]) AND ([g].[LeaderSquadId] = [t0].[SquadId])
+WHERE ([g].[Discriminator] = 'Officer') OR ([g].[Discriminator] = 'Gear')
+ORDER BY [t0].[Nickname], [t0].[SquadId]",
                 Sql);
         }
 

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -1155,7 +1155,110 @@ END",
             base.Any_nested_negated();
 
             Assert.Equal(
-                @"",
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE (
+    SELECT CASE
+        WHEN EXISTS (
+            SELECT 1
+            FROM [Orders] AS [o]
+            WHERE [o].[CustomerID] LIKE 'A' + '%')
+        THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+    END
+) = 0",
+                Sql);
+        }        public override void Any_nested_negated2()
+        {
+            base.Any_nested_negated2();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE (([c].[City] <> 'London') OR [c].[City] IS NULL) AND (
+    SELECT CASE
+        WHEN EXISTS (
+            SELECT 1
+            FROM [Orders] AS [o]
+            WHERE [o].[CustomerID] LIKE 'A' + '%')
+        THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+    END
+) = 0",
+                Sql);
+        }
+
+        public override void Any_nested_negated3()
+        {
+            base.Any_nested_negated3();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE (
+    SELECT CASE
+        WHEN EXISTS (
+            SELECT 1
+            FROM [Orders] AS [o]
+            WHERE [o].[CustomerID] LIKE 'A' + '%')
+        THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+    END
+) = 0 AND (([c].[City] <> 'London') OR [c].[City] IS NULL)",
+                Sql);
+        }
+
+        public override void Any_nested()
+        {
+            base.Any_nested();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE (
+    SELECT CASE
+        WHEN EXISTS (
+            SELECT 1
+            FROM [Orders] AS [o]
+            WHERE [o].[CustomerID] LIKE 'A' + '%')
+        THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+    END
+) = 1",
+                Sql);
+        }
+
+        public override void Any_nested2()
+        {
+            base.Any_nested2();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE (([c].[City] <> 'London') OR [c].[City] IS NULL) AND (
+    SELECT CASE
+        WHEN EXISTS (
+            SELECT 1
+            FROM [Orders] AS [o]
+            WHERE [o].[CustomerID] LIKE 'A' + '%')
+        THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+    END
+) = 1",
+                Sql);
+        }
+
+        public override void Any_nested3()
+        {
+            base.Any_nested3();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE (
+    SELECT CASE
+        WHEN EXISTS (
+            SELECT 1
+            FROM [Orders] AS [o]
+            WHERE [o].[CustomerID] LIKE 'A' + '%')
+        THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+    END
+) = 1 AND (([c].[City] <> 'London') OR [c].[City] IS NULL)",
                 Sql);
         }
 


### PR DESCRIPTION
Query: Relational: Fixes #3235 and #3317
- Merged PR #3469 (Thanks multiarc!)
- Removed Cast operator composition from relational OfType handling. Adjust shaper instead.