### PR TITLE
[Tiny] :bug: Do not run relationship discovery convention on entity type whi…

### DIFF
--- a/src/EntityFramework.Core/Metadata/Conventions/Internal/RelationshipDiscoveryConvention.cs
+++ b/src/EntityFramework.Core/Metadata/Conventions/Internal/RelationshipDiscoveryConvention.cs
@@ -293,7 +293,10 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
 
         public virtual bool Apply(InternalEntityTypeBuilder entityTypeBuilder, EntityType oldBaseType)
         {
-            var oldBaseTypeBuilder = oldBaseType?.Builder;
+            var oldBaseTypeBuilder = oldBaseType != null
+                && !entityTypeBuilder.ModelBuilder.IsIgnored(oldBaseType.Name, ConfigurationSource.Convention)
+                ? oldBaseType.Builder
+                : null;
             if (oldBaseTypeBuilder != null)
             {
                 ApplyOnRelatedEntityTypes(entityTypeBuilder.ModelBuilder, oldBaseTypeBuilder.Metadata);
@@ -313,7 +316,7 @@ namespace Microsoft.Data.Entity.Metadata.Conventions.Internal
 
             foreach (var relatedEntityType in relatedEntityTypes)
             {
-                var relatedEntityTypeBuilder = modelBuilder.Entity(relatedEntityType.Name, ConfigurationSource.Convention);
+                var relatedEntityTypeBuilder = relatedEntityType.Builder;
                 Apply(relatedEntityTypeBuilder);
             }
         }

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/InheritanceTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/InheritanceTestBase.cs
@@ -176,8 +176,20 @@ namespace Microsoft.Data.Entity.Tests
                 var modelBuilder = CreateModelBuilder();
                 modelBuilder.Entity<Book>();
                 modelBuilder.Ignore<SpecialBookLabel>();
+                modelBuilder.Ignore<AnotherBookLabel>();
 
                 Assert.Empty(modelBuilder.Model.FindEntityType(typeof(BookLabel).FullName).GetDirectlyDerivedTypes());
+            }
+
+            [Fact]
+            public virtual void Do_not_run_relationship_discovery_on_entity_type_while_removing_it()
+            {
+                var modelBuilder = CreateModelBuilder();
+                modelBuilder.Entity<SpecialBookLabel>();
+                modelBuilder.Entity<AnotherBookLabel>();
+                modelBuilder.Ignore<BookLabel>();
+
+                Assert.Null(modelBuilder.Model.FindEntityType(typeof(BookLabel).FullName));
             }
         }
     }

--- a/test/EntityFramework.Core.Tests/ModelBuilderTest/TestModel.cs
+++ b/test/EntityFramework.Core.Tests/ModelBuilderTest/TestModel.cs
@@ -219,11 +219,17 @@ namespace Microsoft.Data.Entity.Tests
             public int BookId { get; set; }
 
             public SpecialBookLabel SpecialBookLabel { get; set; }
+
+            public AnotherBookLabel AnotherBookLabel { get; set; }
         }
 
         private class SpecialBookLabel : BookLabel
         {
             public ICollection<BookLabel> BookLabels { get; set; }
+        }
+
+        private class AnotherBookLabel : BookLabel
+        {
         }
 
         private class Post


### PR DESCRIPTION
…le it is being removed

Resolves #3845 
The issue: While removing entity type, we reset base type for all directly derived types. Setting base type triggers relationship discovery convention on oldbasetype and current entityType both. Since we were using `oldBaseType.Builder` which is set to null after base type is set for all derived types. It discovered relationships with ignored entity type too and added them to model again. The exception only appears when there is another derived type which gets foreign key with ignored type due to conventions. Since the related entity type builder is found using model builder, it returned null for ignored type.