### PR TITLE
Query: Fix #3668 - Subqueries with parameters skip parameterization

### DIFF
--- a/test/EntityFramework.Core.FunctionalTests/GearsOfWarQueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/GearsOfWarQueryTestBase.cs
@@ -687,29 +687,35 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-        //[Fact]
+        [Fact]
         public virtual void Collection_with_inheritance_and_join_include_joined()
         {
             using (var context = CreateContext())
             {
                 var query = (from t in context.Tags
-                             join g in context.Gears.OfType<Officer>() on new { id1 = t.GearSquadId, id2 = t.GearNickName } equals new { id1 = (int?)g.SquadId, id2 = g.Nickname }
+                             join g in context.Gears.OfType<Officer>() on new { id1 = t.GearSquadId, id2 = t.GearNickName } 
+                                equals new { id1 = (int?)g.SquadId, id2 = g.Nickname }
                              select g).Include(g => g.Tag);
 
                 var result = query.ToList();
+
+                Assert.NotNull(result);
             }
         }
 
-        //[Fact]
+        [Fact]
         public virtual void Collection_with_inheritance_and_join_include_source()
         {
             using (var context = CreateContext())
             {
                 var query = (from g in context.Gears.OfType<Officer>()
-                             join t in context.Tags on new { id1 = (int?)g.SquadId, id2 = g.Nickname } equals new { id1 = t.GearSquadId, id2 = t.GearNickName }
+                             join t in context.Tags on new { id1 = (int?)g.SquadId, id2 = g.Nickname } 
+                                equals new { id1 = t.GearSquadId, id2 = t.GearNickName }
                              select g).Include(g => g.Tag);
 
                 var result = query.ToList();
+
+                Assert.NotNull(result);
             }
         }
 

--- a/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
@@ -758,6 +758,29 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [ConditionalFact]
+        public virtual void Where_subquery_closure_via_query_cache()
+        {
+            using (var context = CreateContext())
+            {
+                string customerID = null;
+
+                var orders = context.Orders.Where(o => o.CustomerID == customerID);
+
+                customerID = "ALFKI";
+
+                var customers = context.Customers.Where(c => orders.Any(o => o.CustomerID == c.CustomerID)).ToList();
+
+                Assert.Equal(1, customers.Count);
+
+                customerID = "ANATR";
+
+                customers = context.Customers.Where(c => orders.Any(o => o.CustomerID == c.CustomerID)).ToList();
+
+                Assert.Equal("ANATR", customers.Single().CustomerID);
+            }
+        }
+
+        [ConditionalFact]
         public virtual void Where_simple_shadow()
         {
             AssertQuery<Employee>(

--- a/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
@@ -281,7 +281,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
         [ConditionalFact]
         public virtual void Any_nested_negated2()
-            {
+        {
             AssertQuery<Customer, Order>(
                 (cs, os) => cs.Where(c => c.City != "London"
                                           && !os.Any(o => o.CustomerID.StartsWith("A"))));
@@ -293,7 +293,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             AssertQuery<Customer, Order>(
                 (cs, os) => cs.Where(c => !os.Any(o => o.CustomerID.StartsWith("A"))
                                           && c.City != "London"));
-            }
+        }
 
         [ConditionalFact]
         public virtual void Any_nested()

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -683,7 +683,14 @@ INNER JOIN [CogTag] AS [t] ON [g].[FullName] = (
             base.Collection_with_inheritance_and_join_include_joined();
 
             Assert.Equal(
-                @"",
+                @"SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOrBirthName], [t0].[Discriminator], [t0].[FullName], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [c].[Id], [c].[GearNickName], [c].[GearSquadId], [c].[Note]
+FROM [CogTag] AS [t]
+INNER JOIN (
+    SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+    FROM [Gear] AS [g]
+    WHERE [g].[Discriminator] = 'Officer'
+) AS [t0] ON ([t].[GearSquadId] = [t0].[SquadId]) AND ([t].[GearNickName] = [t0].[Nickname])
+LEFT JOIN [CogTag] AS [c] ON ([c].[GearNickName] = [t0].[Nickname]) AND ([c].[GearSquadId] = [t0].[SquadId])",
                 Sql);
         }
 
@@ -692,7 +699,14 @@ INNER JOIN [CogTag] AS [t] ON [g].[FullName] = (
             base.Collection_with_inheritance_and_join_include_source();
 
             Assert.Equal(
-                @"",
+                @"SELECT [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOrBirthName], [t0].[Discriminator], [t0].[FullName], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank], [c].[Id], [c].[GearNickName], [c].[GearSquadId], [c].[Note]
+FROM (
+    SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+    FROM [Gear] AS [g]
+    WHERE [g].[Discriminator] = 'Officer'
+) AS [t0]
+INNER JOIN [CogTag] AS [t] ON ([t0].[SquadId] = [t].[GearSquadId]) AND ([t0].[Nickname] = [t].[GearNickName])
+LEFT JOIN [CogTag] AS [c] ON ([c].[GearNickName] = [t0].[Nickname]) AND ([c].[GearSquadId] = [t0].[SquadId])",
                 Sql);
         }
 

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -508,6 +508,41 @@ WHERE [c].[City] = @__city_0",
                 Sql);
         }
 
+        public override void Where_subquery_closure_via_query_cache()
+        {
+            base.Where_subquery_closure_via_query_cache();
+
+            Assert.Equal(
+                @"@__customerID_0: ALFKI
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE (
+    SELECT CASE
+        WHEN EXISTS (
+            SELECT 1
+            FROM [Orders] AS [o]
+            WHERE ([o].[CustomerID] = @__customerID_0) AND ([o].[CustomerID] = [c].[CustomerID]))
+        THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+    END
+) = 1
+
+@__customerID_0: ANATR
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE (
+    SELECT CASE
+        WHEN EXISTS (
+            SELECT 1
+            FROM [Orders] AS [o]
+            WHERE ([o].[CustomerID] = @__customerID_0) AND ([o].[CustomerID] = [c].[CustomerID]))
+        THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+    END
+) = 1",
+                Sql);
+        }
+
         public override void Count_with_predicate()
         {
             base.Count_with_predicate();


### PR DESCRIPTION
- When queryables are captures in the closure, during parameterization we need to eval the member expression and then visit the sub-expression.