### PR TITLE
RevEng: Don't produce unnecessary HasIndex() API

### DIFF
--- a/src/EntityFramework.Commands/Scaffolding/Internal/Configuration/KeyFluentApiConfiguration.cs
+++ b/src/EntityFramework.Commands/Scaffolding/Internal/Configuration/KeyFluentApiConfiguration.cs
@@ -14,27 +14,40 @@ namespace Microsoft.Data.Entity.Scaffolding.Internal.Configuration
     {
         public KeyFluentApiConfiguration(
             [NotNull] string lambdaIdentifier,
-            [NotNull] IReadOnlyList<Property> properties)
+            [NotNull] Key key)
         {
             Check.NotEmpty(lambdaIdentifier, nameof(lambdaIdentifier));
-            Check.NotEmpty(properties, nameof(properties));
+            Check.NotNull(key, nameof(key));
 
             LambdaIdentifier = lambdaIdentifier;
-            Properties = new List<Property>(properties);
+            Key = key;
         }
 
         public virtual string LambdaIdentifier { get; }
-        public virtual IReadOnlyList<Property> Properties { get; }
+        public virtual Key Key { get; }
 
         public virtual bool HasAttributeEquivalent { get; set; }
 
-        public virtual ICollection<string> FluentApiLines =>
-            new List<string> { string.Format(
-                CultureInfo.InvariantCulture,
-                "{0}({1} => {2})",
-                nameof(EntityTypeBuilder.HasKey),
-                LambdaIdentifier,
-                new ScaffoldingUtilities().GenerateLambdaToKey(Properties, LambdaIdentifier))
-            };
+        public virtual ICollection<string> FluentApiLines
+        {
+            get
+            {
+                var lines = new List<string>();
+                lines.Add(string.Format(
+                    CultureInfo.InvariantCulture,
+                    "{0}({1} => {2})",
+                    nameof(EntityTypeBuilder.HasKey),
+                    LambdaIdentifier,
+                    new ScaffoldingUtilities().GenerateLambdaToKey(Key.Properties, LambdaIdentifier)));
+
+                if (Key.Relational().Name != null)
+                {
+                    lines.Add("." + nameof(RelationalKeyBuilderExtensions.HasName)
+                        + "(" + CSharpUtilities.Instance.DelimitString(Key.Relational().Name) + ")");
+                }
+
+                return lines;
+            }
+        }
     }
 }

--- a/src/EntityFramework.Commands/Scaffolding/Internal/Configuration/ModelConfiguration.cs
+++ b/src/EntityFramework.Commands/Scaffolding/Internal/Configuration/ModelConfiguration.cs
@@ -179,9 +179,10 @@ namespace Microsoft.Data.Entity.Scaffolding.Internal.Configuration
                 if (key.IsPrimaryKey())
                 {
                     var keyFluentApi = _configurationFactory
-                        .CreateKeyFluentApiConfiguration("e", key.Properties);
+                        .CreateKeyFluentApiConfiguration("e", key);
 
-                    if (key.Properties.Count == 1)
+                    if (key.Properties.Count == 1
+                        && key.Relational().Name == null)
                     {
                         keyFluentApi.HasAttributeEquivalent = true;
 
@@ -241,15 +242,9 @@ namespace Microsoft.Data.Entity.Scaffolding.Internal.Configuration
         {
             Check.NotNull(entityConfiguration, nameof(entityConfiguration));
 
-            var entityType = (EntityType)entityConfiguration.EntityType;
-            var primaryKeyProperties = entityType.FindPrimaryKey()?.Properties;
-            foreach (var index in entityType.GetIndexes())
+            foreach (var index in entityConfiguration.EntityType.GetIndexes().Cast<Index>())
             {
-                // do not add indexes for the primary key
-                if (!index.Properties.SequenceEqual(primaryKeyProperties))
-                {
-                    AddIndexConfiguration(entityConfiguration, index);
-                }
+                AddIndexConfiguration(entityConfiguration, index);
             }
         }
 

--- a/src/EntityFramework.Commands/Scaffolding/Internal/ConfigurationFactory.cs
+++ b/src/EntityFramework.Commands/Scaffolding/Internal/ConfigurationFactory.cs
@@ -124,12 +124,12 @@ namespace Microsoft.Data.Entity.Scaffolding.Internal
 
         public virtual KeyFluentApiConfiguration CreateKeyFluentApiConfiguration(
             [NotNull] string lambdaIdentifier,
-            [NotNull] IReadOnlyList<Property> properties)
+            [NotNull] Key key)
         {
             Check.NotEmpty(lambdaIdentifier, nameof(lambdaIdentifier));
-            Check.NotEmpty(properties, nameof(properties));
+            Check.NotNull(key, nameof(key));
 
-            return new KeyFluentApiConfiguration(lambdaIdentifier, properties);
+            return new KeyFluentApiConfiguration(lambdaIdentifier, key);
         }
 
         public virtual AttributeConfiguration CreateAttributeConfiguration(

--- a/src/EntityFramework.MicrosoftSqlServer.Design/SqlServerDatabaseModelFactory.cs
+++ b/src/EntityFramework.MicrosoftSqlServer.Design/SqlServerDatabaseModelFactory.cs
@@ -223,7 +223,6 @@ FROM sys.indexes i
     INNER JOIN sys.index_columns ic  ON i.object_id = ic.object_id AND i.index_id = ic.index_id
     INNER JOIN sys.columns c ON ic.object_id = c.object_id AND c.column_id = ic.column_id
 WHERE object_schema_name(i.object_id) <> 'sys'
-    AND i.is_primary_key <> 1
     AND object_name(i.object_id) <> '" + HistoryRepository.DefaultTableName + @"'
 ORDER BY object_schema_name(i.object_id), object_name(i.object_id), i.name, ic.key_ordinal";
 

--- a/src/EntityFramework.Relational/Metadata/RelationalIndexAnnotations.cs
+++ b/src/EntityFramework.Relational/Metadata/RelationalIndexAnnotations.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Metadata.Internal;
@@ -37,10 +38,13 @@ namespace Microsoft.Data.Entity.Metadata
         {
             var entityType = new RelationalEntityTypeAnnotations(Index.DeclaringEntityType, Annotations.ProviderPrefix);
 
-            return "IX_" +
-                entityType.TableName +
-                "_" +
-                string.Join("_", Index.Properties.Select(p => p.Name));
+            return GetDefaultIndexName(entityType.TableName, Index.Properties.Select(p => p.Name));
+        }
+
+        public static string GetDefaultIndexName(
+            [NotNull] string tableName, [NotNull] IEnumerable<string> propertyNames)
+        {
+            return "IX_" + tableName + "_" + string.Join("_", propertyNames);
         }
     }
 }

--- a/src/EntityFramework.Relational/Metadata/RelationalKeyAnnotations.cs
+++ b/src/EntityFramework.Relational/Metadata/RelationalKeyAnnotations.cs
@@ -43,14 +43,14 @@ namespace Microsoft.Data.Entity.Metadata
         }
 
         public static string GetDefaultKeyName(
-            [NotNull] string tableName, bool isPrimaryKey, [NotNull] IEnumerable<string> propertyNames)
+            [NotNull] string tableName, bool primaryKey, [NotNull] IEnumerable<string> propertyNames)
         {
             var builder = new StringBuilder();
             builder
-                .Append(isPrimaryKey ? "PK_" : "AK_")
+                .Append(primaryKey ? "PK_" : "AK_")
                 .Append(tableName);
 
-            if (!isPrimaryKey)
+            if (!primaryKey)
             {
                 builder
                     .Append("_")

--- a/src/EntityFramework.Relational/Metadata/RelationalKeyAnnotations.cs
+++ b/src/EntityFramework.Relational/Metadata/RelationalKeyAnnotations.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using JetBrains.Annotations;
@@ -36,18 +37,24 @@ namespace Microsoft.Data.Entity.Metadata
 
         protected virtual string GetDefaultName()
         {
-            var builder = new StringBuilder();
             var entityType = new RelationalEntityTypeAnnotations(Key.DeclaringEntityType, Annotations.ProviderPrefix);
 
-            builder
-                .Append(Key.IsPrimaryKey() ? "PK_" : "AK_")
-                .Append(entityType.TableName);
+            return GetDefaultKeyName(entityType.TableName, Key.IsPrimaryKey(), Key.Properties.Select(p => p.Name));
+        }
 
-            if (!Key.IsPrimaryKey())
+        public static string GetDefaultKeyName(
+            [NotNull] string tableName, bool isPrimaryKey, [NotNull] IEnumerable<string> propertyNames)
+        {
+            var builder = new StringBuilder();
+            builder
+                .Append(isPrimaryKey ? "PK_" : "AK_")
+                .Append(tableName);
+
+            if (!isPrimaryKey)
             {
                 builder
                     .Append("_")
-                    .Append(string.Join("_", Key.Properties.Select(p => p.Name)));
+                    .Append(string.Join("_", propertyNames));
             }
 
             return builder.ToString();

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/E2E.sql
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/E2E.sql
@@ -202,7 +202,7 @@ CREATE TABLE "OneToManyPrincipal" (
 	"OneToManyPrincipalID1" "int",
 	"OneToManyPrincipalID2" "int",
 	"Other" nvarchar(20) NOT NULL,
-	CONSTRAINT "PK_OneToManyPrincipal" PRIMARY KEY  CLUSTERED 
+	CONSTRAINT "PK_OneToManyPrincipal" PRIMARY KEY CLUSTERED 
 	(
 		"OneToManyPrincipalID1", "OneToManyPrincipalID2"
 	)
@@ -216,7 +216,7 @@ CREATE TABLE "OneToManyDependent" (
 	"SomeDependentEndColumn" nvarchar (20) NOT NULL,
 	"OneToManyDependentFK2" "int" NULL, -- deliberately put FK columns in other order to make sure we get correct order in key
 	"OneToManyDependentFK1" "int" NULL,
-	CONSTRAINT "PK_OneToManyDependent" PRIMARY KEY  CLUSTERED 
+	CONSTRAINT "PK_OneToManyDependent" PRIMARY KEY CLUSTERED 
 	(
 		"OneToManyDependentID1", "OneToManyDependentID2"
 	),
@@ -234,7 +234,7 @@ CREATE TABLE "OneToOnePrincipal" (
 	"OneToOnePrincipalID1" "int",
 	"OneToOnePrincipalID2" "int",
 	"SomeOneToOnePrincipalColumn" nvarchar (20) NOT NULL,
-	CONSTRAINT "PK_OneToOnePrincipal" PRIMARY KEY  CLUSTERED 
+	CONSTRAINT "PK_OneToOnePrincipal" PRIMARY KEY CLUSTERED 
 	(
 		"OneToOnePrincipalID1", "OneToOnePrincipalID2"
 	)
@@ -246,7 +246,7 @@ CREATE TABLE "OneToOneDependent" (
 	"OneToOneDependentID1" "int",
 	"OneToOneDependentID2" "int",
 	"SomeDependentEndColumn" nvarchar (20) NOT NULL,
-	CONSTRAINT "PK_OneToOneDependent" PRIMARY KEY  CLUSTERED 
+	CONSTRAINT "PK_OneToOneDependent" PRIMARY KEY CLUSTERED 
 	(
 		"OneToOneDependentID1", "OneToOneDependentID2"
 	),
@@ -264,7 +264,7 @@ CREATE TABLE "OneToOneSeparateFKPrincipal" (
 	"OneToOneSeparateFKPrincipalID1" "int",
 	"OneToOneSeparateFKPrincipalID2" "int",
 	"SomeOneToOneSeparateFKPrincipalColumn" nvarchar (20) NOT NULL,
-	CONSTRAINT "PK_OneToOneSeparateFKPrincipal" PRIMARY KEY  CLUSTERED 
+	CONSTRAINT "PK_OneToOneSeparateFKPrincipal" PRIMARY KEY CLUSTERED 
 	(
 		"OneToOneSeparateFKPrincipalID1", "OneToOneSeparateFKPrincipalID2"
 	)
@@ -278,7 +278,7 @@ CREATE TABLE "OneToOneSeparateFKDependent" (
 	"SomeDependentEndColumn" nvarchar (20) NOT NULL,
 	"OneToOneSeparateFKDependentFK1" "int" NULL,
 	"OneToOneSeparateFKDependentFK2" "int" NULL,
-	CONSTRAINT "PK_OneToOneSeparateFKDependent" PRIMARY KEY  CLUSTERED 
+	CONSTRAINT "PK_OneToOneSeparateFKDependent" PRIMARY KEY CLUSTERED 
 	(
 		"OneToOneSeparateFKDependentID1", "OneToOneSeparateFKDependentID2"
 	),
@@ -320,7 +320,7 @@ CREATE TABLE "OneToOneFKToUniqueKeyDependent" (
 	"SomeColumn" nvarchar (20) NOT NULL,
 	"OneToOneFKToUniqueKeyDependentFK1" "int" NULL,
 	"OneToOneFKToUniqueKeyDependentFK2" "int" NULL,
-	CONSTRAINT "PK_OneToOneFKToUniqueKeyDependent" PRIMARY KEY  CLUSTERED 
+	CONSTRAINT "PK_OneToOneFKToUniqueKeyDependent" PRIMARY KEY CLUSTERED 
 	(
 		"OneToOneFKToUniqueKeyDependentID1", "OneToOneFKToUniqueKeyDependentID2"
 	),

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/SqlServerReverseEngineerTestE2EContext.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/SqlServerReverseEngineerTestE2EContext.expected
@@ -69,7 +69,8 @@ namespace E2ETest.Namespace
 
             modelBuilder.Entity<OneToManyDependent>(entity =>
             {
-                entity.HasKey(e => new { e.OneToManyDependentID1, e.OneToManyDependentID2 });
+                entity.HasKey(e => new { e.OneToManyDependentID1, e.OneToManyDependentID2 })
+                    .HasName("PK_OneToManyDependent");
 
                 entity.Property(e => e.SomeDependentEndColumn)
                     .IsRequired()
@@ -82,7 +83,8 @@ namespace E2ETest.Namespace
 
             modelBuilder.Entity<OneToManyPrincipal>(entity =>
             {
-                entity.HasKey(e => new { e.OneToManyPrincipalID1, e.OneToManyPrincipalID2 });
+                entity.HasKey(e => new { e.OneToManyPrincipalID1, e.OneToManyPrincipalID2 })
+                    .HasName("PK_OneToManyPrincipal");
 
                 entity.Property(e => e.Other)
                     .IsRequired()
@@ -91,7 +93,8 @@ namespace E2ETest.Namespace
 
             modelBuilder.Entity<OneToOneDependent>(entity =>
             {
-                entity.HasKey(e => new { e.OneToOneDependentID1, e.OneToOneDependentID2 });
+                entity.HasKey(e => new { e.OneToOneDependentID1, e.OneToOneDependentID2 })
+                    .HasName("PK_OneToOneDependent");
 
                 entity.Property(e => e.SomeDependentEndColumn)
                     .IsRequired()
@@ -105,7 +108,8 @@ namespace E2ETest.Namespace
 
             modelBuilder.Entity<OneToOneFKToUniqueKeyDependent>(entity =>
             {
-                entity.HasKey(e => new { e.OneToOneFKToUniqueKeyDependentID1, e.OneToOneFKToUniqueKeyDependentID2 });
+                entity.HasKey(e => new { e.OneToOneFKToUniqueKeyDependentID1, e.OneToOneFKToUniqueKeyDependentID2 })
+                    .HasName("PK_OneToOneFKToUniqueKeyDependent");
 
                 entity.HasIndex(e => new { e.OneToOneFKToUniqueKeyDependentFK1, e.OneToOneFKToUniqueKeyDependentFK2 })
                     .HasName("UK_OneToOneFKToUniqueKeyDependent")
@@ -123,7 +127,8 @@ namespace E2ETest.Namespace
 
             modelBuilder.Entity<OneToOneFKToUniqueKeyPrincipal>(entity =>
             {
-                entity.HasKey(e => new { e.OneToOneFKToUniqueKeyPrincipalID1, e.OneToOneFKToUniqueKeyPrincipalID2 });
+                entity.HasKey(e => new { e.OneToOneFKToUniqueKeyPrincipalID1, e.OneToOneFKToUniqueKeyPrincipalID2 })
+                    .HasName("PK_OneToOneFKToUniqueKeyPrincipal");
 
                 entity.HasIndex(e => new { e.OneToOneFKToUniqueKeyPrincipalUniqueKey1, e.OneToOneFKToUniqueKeyPrincipalUniqueKey2 })
                     .HasName("UK_OneToOneFKToUniqueKeyPrincipal")
@@ -136,7 +141,8 @@ namespace E2ETest.Namespace
 
             modelBuilder.Entity<OneToOnePrincipal>(entity =>
             {
-                entity.HasKey(e => new { e.OneToOnePrincipalID1, e.OneToOnePrincipalID2 });
+                entity.HasKey(e => new { e.OneToOnePrincipalID1, e.OneToOnePrincipalID2 })
+                    .HasName("PK_OneToOnePrincipal");
 
                 entity.Property(e => e.SomeOneToOnePrincipalColumn)
                     .IsRequired()
@@ -145,7 +151,8 @@ namespace E2ETest.Namespace
 
             modelBuilder.Entity<OneToOneSeparateFKDependent>(entity =>
             {
-                entity.HasKey(e => new { e.OneToOneSeparateFKDependentID1, e.OneToOneSeparateFKDependentID2 });
+                entity.HasKey(e => new { e.OneToOneSeparateFKDependentID1, e.OneToOneSeparateFKDependentID2 })
+                    .HasName("PK_OneToOneSeparateFKDependent");
 
                 entity.HasIndex(e => new { e.OneToOneSeparateFKDependentFK1, e.OneToOneSeparateFKDependentFK2 })
                     .HasName("UK_OneToOneSeparateFKDependent")
@@ -162,7 +169,8 @@ namespace E2ETest.Namespace
 
             modelBuilder.Entity<OneToOneSeparateFKPrincipal>(entity =>
             {
-                entity.HasKey(e => new { e.OneToOneSeparateFKPrincipalID1, e.OneToOneSeparateFKPrincipalID2 });
+                entity.HasKey(e => new { e.OneToOneSeparateFKPrincipalID1, e.OneToOneSeparateFKPrincipalID2 })
+                    .HasName("PK_OneToOneSeparateFKPrincipal");
 
                 entity.Property(e => e.SomeOneToOneSeparateFKPrincipalColumn)
                     .IsRequired()

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/AttributesContext.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/AttributesContext.expected
@@ -57,22 +57,26 @@ namespace E2ETest.Namespace
 
             modelBuilder.Entity<OneToManyDependent>(entity =>
             {
-                entity.HasKey(e => new { e.OneToManyDependentID1, e.OneToManyDependentID2 });
+                entity.HasKey(e => new { e.OneToManyDependentID1, e.OneToManyDependentID2 })
+                    .HasName("PK_OneToManyDependent");
             });
 
             modelBuilder.Entity<OneToManyPrincipal>(entity =>
             {
-                entity.HasKey(e => new { e.OneToManyPrincipalID1, e.OneToManyPrincipalID2 });
+                entity.HasKey(e => new { e.OneToManyPrincipalID1, e.OneToManyPrincipalID2 })
+                    .HasName("PK_OneToManyPrincipal");
             });
 
             modelBuilder.Entity<OneToOneDependent>(entity =>
             {
-                entity.HasKey(e => new { e.OneToOneDependentID1, e.OneToOneDependentID2 });
+                entity.HasKey(e => new { e.OneToOneDependentID1, e.OneToOneDependentID2 })
+                    .HasName("PK_OneToOneDependent");
             });
 
             modelBuilder.Entity<OneToOneFKToUniqueKeyDependent>(entity =>
             {
-                entity.HasKey(e => new { e.OneToOneFKToUniqueKeyDependentID1, e.OneToOneFKToUniqueKeyDependentID2 });
+                entity.HasKey(e => new { e.OneToOneFKToUniqueKeyDependentID1, e.OneToOneFKToUniqueKeyDependentID2 })
+                    .HasName("PK_OneToOneFKToUniqueKeyDependent");
 
                 entity.HasIndex(e => new { e.OneToOneFKToUniqueKeyDependentFK1, e.OneToOneFKToUniqueKeyDependentFK2 })
                     .HasName("UK_OneToOneFKToUniqueKeyDependent")
@@ -86,7 +90,8 @@ namespace E2ETest.Namespace
 
             modelBuilder.Entity<OneToOneFKToUniqueKeyPrincipal>(entity =>
             {
-                entity.HasKey(e => new { e.OneToOneFKToUniqueKeyPrincipalID1, e.OneToOneFKToUniqueKeyPrincipalID2 });
+                entity.HasKey(e => new { e.OneToOneFKToUniqueKeyPrincipalID1, e.OneToOneFKToUniqueKeyPrincipalID2 })
+                    .HasName("PK_OneToOneFKToUniqueKeyPrincipal");
 
                 entity.HasIndex(e => new { e.OneToOneFKToUniqueKeyPrincipalUniqueKey1, e.OneToOneFKToUniqueKeyPrincipalUniqueKey2 })
                     .HasName("UK_OneToOneFKToUniqueKeyPrincipal")
@@ -95,12 +100,14 @@ namespace E2ETest.Namespace
 
             modelBuilder.Entity<OneToOnePrincipal>(entity =>
             {
-                entity.HasKey(e => new { e.OneToOnePrincipalID1, e.OneToOnePrincipalID2 });
+                entity.HasKey(e => new { e.OneToOnePrincipalID1, e.OneToOnePrincipalID2 })
+                    .HasName("PK_OneToOnePrincipal");
             });
 
             modelBuilder.Entity<OneToOneSeparateFKDependent>(entity =>
             {
-                entity.HasKey(e => new { e.OneToOneSeparateFKDependentID1, e.OneToOneSeparateFKDependentID2 });
+                entity.HasKey(e => new { e.OneToOneSeparateFKDependentID1, e.OneToOneSeparateFKDependentID2 })
+                    .HasName("PK_OneToOneSeparateFKDependent");
 
                 entity.HasIndex(e => new { e.OneToOneSeparateFKDependentFK1, e.OneToOneSeparateFKDependentFK2 })
                     .HasName("UK_OneToOneSeparateFKDependent")
@@ -109,7 +116,8 @@ namespace E2ETest.Namespace
 
             modelBuilder.Entity<OneToOneSeparateFKPrincipal>(entity =>
             {
-                entity.HasKey(e => new { e.OneToOneSeparateFKPrincipalID1, e.OneToOneSeparateFKPrincipalID2 });
+                entity.HasKey(e => new { e.OneToOneSeparateFKPrincipalID1, e.OneToOneSeparateFKPrincipalID2 })
+                    .HasName("PK_OneToOneSeparateFKPrincipal");
             });
 
             modelBuilder.Entity<PropertyConfiguration>(entity =>

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/SqlServerDatabaseModelFactoryTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/SqlServerDatabaseModelFactoryTest.cs
@@ -105,6 +105,13 @@ CREATE TABLE [dbo].[Denali] ( id int );";
                         Assert.True(clusteredIndex.IsClustered);
                         Assert.Equal(new List<string> { "Location", "Name" }, clusteredIndex.Columns.Select(c => c.Name).ToList());
                     },
+                pkIndex =>
+                {
+                    Assert.StartsWith("PK__Place", pkIndex.Name);
+                    Assert.True(pkIndex.IsUnique);
+                    Assert.False(pkIndex.IsClustered);
+                    Assert.Equal(new List<string> { "Id" }, pkIndex.Columns.Select(c => c.Name).ToList());
+                },
                 unique =>
                     {
                         Assert.True(unique.IsUnique);

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/OneToMany/OneToManyFluentApiContext.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/OneToMany/OneToManyFluentApiContext.expected
@@ -14,7 +14,8 @@ namespace E2E.Sqlite
         {
             modelBuilder.Entity<OneToManyDependent>(entity =>
             {
-                entity.HasKey(e => new { e.OneToManyDependentID1, e.OneToManyDependentID2 });
+                entity.HasKey(e => new { e.OneToManyDependentID1, e.OneToManyDependentID2 })
+                    .HasName("sqlite_autoindex_OneToManyDependent_1");
 
                 entity.Property(e => e.OneToManyDependentID1).HasColumnType("INT");
 
@@ -35,7 +36,8 @@ namespace E2E.Sqlite
 
             modelBuilder.Entity<OneToManyPrincipal>(entity =>
             {
-                entity.HasKey(e => new { e.OneToManyPrincipalID1, e.OneToManyPrincipalID2 });
+                entity.HasKey(e => new { e.OneToManyPrincipalID1, e.OneToManyPrincipalID2 })
+                    .HasName("sqlite_autoindex_OneToManyPrincipal_1");
 
                 entity.Property(e => e.OneToManyPrincipalID1).HasColumnType("INT");
 

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/OneToMany/OneToManyAttributesContext.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/OneToMany/OneToManyAttributesContext.expected
@@ -14,7 +14,8 @@ namespace E2E.Sqlite
         {
             modelBuilder.Entity<OneToManyDependent>(entity =>
             {
-                entity.HasKey(e => new { e.OneToManyDependentID1, e.OneToManyDependentID2 });
+                entity.HasKey(e => new { e.OneToManyDependentID1, e.OneToManyDependentID2 })
+                    .HasName("sqlite_autoindex_OneToManyDependent_1");
 
                 entity.Property(e => e.OneToManyDependentID1).HasColumnType("INT");
 
@@ -29,7 +30,8 @@ namespace E2E.Sqlite
 
             modelBuilder.Entity<OneToManyPrincipal>(entity =>
             {
-                entity.HasKey(e => new { e.OneToManyPrincipalID1, e.OneToManyPrincipalID2 });
+                entity.HasKey(e => new { e.OneToManyPrincipalID1, e.OneToManyPrincipalID2 })
+                    .HasName("sqlite_autoindex_OneToManyPrincipal_1");
 
                 entity.Property(e => e.OneToManyPrincipalID1).HasColumnType("INT");
 


### PR DESCRIPTION
If it would already be assumed due to it supporting a primary or foreign key, but make allowance for the extra API which is necessary if the default name of the index would be different.

Fix for #3710.