### PR TITLE
Fix a bug with concatenation of string and non-string, (e.g. c.Name + 5)

### DIFF
--- a/src/EntityFramework.MicrosoftSqlServer/Query/Sql/Internal/SqlServerQuerySqlGenerator.cs
+++ b/src/EntityFramework.MicrosoftSqlServer/Query/Sql/Internal/SqlServerQuerySqlGenerator.cs
@@ -17,8 +17,14 @@ namespace Microsoft.Data.Entity.Query.Sql.Internal
             [NotNull] IRelationalCommandBuilderFactory relationalCommandBuilderFactory,
             [NotNull] ISqlGenerationHelper sqlGenerationHelper,
             [NotNull] IParameterNameGeneratorFactory parameterNameGeneratorFactory,
+            [NotNull] IRelationalTypeMapper relationalTypeMapper,
             [NotNull] SelectExpression selectExpression)
-            : base(relationalCommandBuilderFactory, sqlGenerationHelper, parameterNameGeneratorFactory, selectExpression)
+            : base(
+                  relationalCommandBuilderFactory, 
+                  sqlGenerationHelper, 
+                  parameterNameGeneratorFactory, 
+                  relationalTypeMapper, 
+                  selectExpression)
         {
         }
 

--- a/src/EntityFramework.MicrosoftSqlServer/Query/Sql/Internal/SqlServerQuerySqlGeneratorFactory.cs
+++ b/src/EntityFramework.MicrosoftSqlServer/Query/Sql/Internal/SqlServerQuerySqlGeneratorFactory.cs
@@ -13,11 +13,13 @@ namespace Microsoft.Data.Entity.Query.Sql.Internal
         public SqlServerQuerySqlGeneratorFactory(
             [NotNull] IRelationalCommandBuilderFactory commandBuilderFactory,
             [NotNull] ISqlGenerationHelper sqlGenerationHelper,
-            [NotNull] IParameterNameGeneratorFactory parameterNameGeneratorFactory)
+            [NotNull] IParameterNameGeneratorFactory parameterNameGeneratorFactory,
+            [NotNull] IRelationalTypeMapper relationalTypeMapper)
             : base(
                 Check.NotNull(commandBuilderFactory, nameof(commandBuilderFactory)),
                 Check.NotNull(sqlGenerationHelper, nameof(sqlGenerationHelper)),
-                Check.NotNull(parameterNameGeneratorFactory, nameof(parameterNameGeneratorFactory)))
+                Check.NotNull(parameterNameGeneratorFactory, nameof(parameterNameGeneratorFactory)),
+                Check.NotNull(relationalTypeMapper, nameof(relationalTypeMapper)))
         {
         }
 
@@ -26,6 +28,7 @@ namespace Microsoft.Data.Entity.Query.Sql.Internal
                 CommandBuilderFactory,
                 SqlGenerationHelper,
                 ParameterNameGeneratorFactory,
+                RelationalTypeMapper,
                 Check.NotNull(selectExpression, nameof(selectExpression)));
     }
 }

--- a/src/EntityFramework.Relational/EntityFramework.Relational.csproj
+++ b/src/EntityFramework.Relational/EntityFramework.Relational.csproj
@@ -98,9 +98,11 @@
     <Compile Include="Migrations\MigrationAttribute.cs" />
     <Compile Include="Migrations\MigrationsAssemblyExtensions.cs" />
     <Compile Include="Query\Expressions\ColumnExpression.cs" />
+    <Compile Include="Query\Expressions\ExplicitCastExpression.cs" />
     <Compile Include="Query\Expressions\LateralJoinExpression.cs" />
     <Compile Include="Query\Expressions\ISelectExpressionFactory.cs" />
     <Compile Include="Query\Expressions\SelectExpressionFactory.cs" />
+    <Compile Include="Query\ExpressionTranslators\StringConcatTranslator.cs" />
     <Compile Include="Query\ExpressionVisitors\Internal\BufferedOffsetEntityShaper.cs" />
     <Compile Include="Query\ExpressionVisitors\Internal\EntityShaper.cs" />
     <Compile Include="Query\ExpressionVisitors\Internal\BufferedEntityShaper`.cs" />

--- a/src/EntityFramework.Relational/Query/ExpressionTranslators/RelationalCompositeExpressionFragmentTranslator.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionTranslators/RelationalCompositeExpressionFragmentTranslator.cs
@@ -12,7 +12,8 @@ namespace Microsoft.Data.Entity.Query.ExpressionTranslators
         private readonly List<IExpressionFragmentTranslator> _translators
             = new List<IExpressionFragmentTranslator>
             {
-                new StringCompareTranslator()
+                new StringCompareTranslator(),
+                new StringConcatTranslator(),
             };
 
         public virtual Expression Translate(Expression expression)

--- a/src/EntityFramework.Relational/Query/ExpressionTranslators/StringConcatTranslator.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionTranslators/StringConcatTranslator.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Query.Expressions;
+
+namespace Microsoft.Data.Entity.Query.ExpressionTranslators
+{
+    public class StringConcatTranslator : IExpressionFragmentTranslator
+    {
+        private static MethodInfo _stringConcatMethodInfo = typeof(string).GetTypeInfo().GetDeclaredMethods(nameof(string.Concat))
+            .Where(m => m.GetParameters().Count() == 2 && m.GetParameters()[0].ParameterType == typeof(object) && m.GetParameters()[1].ParameterType == typeof(object))
+            .Single();
+
+
+        public virtual Expression Translate([NotNull] Expression expression)
+        {
+            var binaryExpression = expression as BinaryExpression;
+            if (binaryExpression != null && binaryExpression.NodeType == ExpressionType.Add && binaryExpression.Method == _stringConcatMethodInfo)
+            {
+                var newLeft = binaryExpression.Left.Type != typeof(string)
+                    ? new ExplicitCastExpression(HandleNullTypedConstant(binaryExpression.Left.RemoveConvert()), typeof(string))
+                    : binaryExpression.Left;
+
+                var newRight = binaryExpression.Right.Type != typeof(string)
+                    ? new ExplicitCastExpression(HandleNullTypedConstant(binaryExpression.Right.RemoveConvert()), typeof(string))
+                    : binaryExpression.Right;
+
+                if (newLeft != binaryExpression.Left || newRight != binaryExpression.Right)
+                {
+                    return Expression.Add(newLeft, newRight, _stringConcatMethodInfo);
+                }
+            }
+
+            return null;
+        }
+
+        private static Expression HandleNullTypedConstant(Expression expression)
+        {
+            var constantExpression = expression as ConstantExpression;
+
+            var newExpression = constantExpression != null && constantExpression.Type == typeof(object) && constantExpression.Value != null
+                ? Expression.Constant(constantExpression.Value)
+                : expression;
+
+            return newExpression;
+        }
+    }
+}

--- a/src/EntityFramework.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
@@ -644,6 +644,16 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
                     : expression;
             }
 
+            var explicitCast = expression as ExplicitCastExpression;
+            if (explicitCast != null)
+            {
+                var newOperand = Visit(explicitCast.Operand);
+
+                return newOperand != explicitCast.Operand
+                    ? new ExplicitCastExpression(newOperand, explicitCast.Type)
+                    : expression;
+            }
+
             return base.VisitExtension(expression);
         }
 

--- a/src/EntityFramework.Relational/Query/Expressions/ExplicitCastExpression.cs
+++ b/src/EntityFramework.Relational/Query/Expressions/ExplicitCastExpression.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Query.Sql;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Query.Expressions
+{
+    public class ExplicitCastExpression : Expression
+    {
+        private Type _type;
+
+        public ExplicitCastExpression([NotNull] Expression operand, [NotNull] Type type)
+        {
+            Check.NotNull(operand, nameof(operand));
+            Check.NotNull(type, nameof(type));
+
+            Operand = operand;
+            _type = type;
+        }
+
+        public virtual Expression Operand { get; }
+
+        public override ExpressionType NodeType => ExpressionType.Extension;
+
+        public override Type Type => _type;
+
+        protected override Expression Accept(ExpressionVisitor visitor)
+        {
+            Check.NotNull(visitor, nameof(visitor));
+
+            var specificVisitor = visitor as ISqlExpressionVisitor;
+
+            return specificVisitor != null
+                ? specificVisitor.VisitExplicitCast(this)
+                : base.Accept(visitor);
+        }
+
+        protected override Expression VisitChildren(ExpressionVisitor visitor)
+        {
+            var newOperand = visitor.Visit(Operand);
+
+            return (newOperand != Operand)
+                ? new ExplicitCastExpression(newOperand, _type)
+                : this;
+        }
+
+        public override string ToString() => "CAST(" + Operand.ToString() + " AS " + _type.Name + ")";
+    }
+}

--- a/src/EntityFramework.Relational/Query/Sql/ISqlExpressionVisitor.cs
+++ b/src/EntityFramework.Relational/Query/Sql/ISqlExpressionVisitor.cs
@@ -29,5 +29,6 @@ namespace Microsoft.Data.Entity.Query.Sql
         Expression VisitIn([NotNull] InExpression inExpression);
         Expression VisitSqlFunction([NotNull] SqlFunctionExpression sqlFunctionExpression);
         Expression VisitStringCompare([NotNull] StringCompareExpression stringCompareExpression);
+        Expression VisitExplicitCast([NotNull] ExplicitCastExpression explicitCastExpression);
     }
 }

--- a/src/EntityFramework.Relational/Query/Sql/Internal/FromSqlNonComposedQuerySqlGenerator.cs
+++ b/src/EntityFramework.Relational/Query/Sql/Internal/FromSqlNonComposedQuerySqlGenerator.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Data.Entity.Query.Sql.Internal
             [NotNull] IRelationalCommandBuilderFactory relationalCommandBuilderFactory,
             [NotNull] ISqlGenerationHelper sqlGenerationHelper,
             [NotNull] IParameterNameGeneratorFactory parameterNameGeneratorFactory,
+            [NotNull] IRelationalTypeMapper relationalTypeMapper,
             [NotNull] SelectExpression selectExpression,
             [NotNull] string sql,
             [NotNull] Expression arguments)
@@ -29,6 +30,7 @@ namespace Microsoft.Data.Entity.Query.Sql.Internal
                 Check.NotNull(relationalCommandBuilderFactory, nameof(relationalCommandBuilderFactory)),
                 Check.NotNull(sqlGenerationHelper, nameof(sqlGenerationHelper)),
                 Check.NotNull(parameterNameGeneratorFactory, nameof(parameterNameGeneratorFactory)),
+                Check.NotNull(relationalTypeMapper, nameof(relationalTypeMapper)),
                 Check.NotNull(selectExpression, nameof(selectExpression)))
         {
             Check.NotEmpty(sql, nameof(sql));

--- a/src/EntityFramework.Relational/Query/Sql/QuerySqlGeneratorFactoryBase.cs
+++ b/src/EntityFramework.Relational/Query/Sql/QuerySqlGeneratorFactoryBase.cs
@@ -15,20 +15,24 @@ namespace Microsoft.Data.Entity.Query.Sql
         protected QuerySqlGeneratorFactoryBase(
             [NotNull] IRelationalCommandBuilderFactory commandBuilderFactory,
             [NotNull] ISqlGenerationHelper sqlGenerationHelper,
-            [NotNull] IParameterNameGeneratorFactory parameterNameGeneratorFactory)
+            [NotNull] IParameterNameGeneratorFactory parameterNameGeneratorFactory,
+            [NotNull] IRelationalTypeMapper relationalTypeMapper)
         {
             Check.NotNull(commandBuilderFactory, nameof(commandBuilderFactory));
             Check.NotNull(sqlGenerationHelper, nameof(sqlGenerationHelper));
             Check.NotNull(parameterNameGeneratorFactory, nameof(parameterNameGeneratorFactory));
+            Check.NotNull(relationalTypeMapper, nameof(relationalTypeMapper));
 
             CommandBuilderFactory = commandBuilderFactory;
             SqlGenerationHelper = sqlGenerationHelper;
             ParameterNameGeneratorFactory = parameterNameGeneratorFactory;
+            RelationalTypeMapper = relationalTypeMapper;
         }
 
         protected virtual IRelationalCommandBuilderFactory CommandBuilderFactory { get; }
         protected virtual ISqlGenerationHelper SqlGenerationHelper { get; }
         protected virtual IParameterNameGeneratorFactory ParameterNameGeneratorFactory { get; }
+        protected virtual IRelationalTypeMapper RelationalTypeMapper { get; }
 
         public abstract IQuerySqlGenerator CreateDefault(SelectExpression selectExpression);
 
@@ -40,6 +44,7 @@ namespace Microsoft.Data.Entity.Query.Sql
                 CommandBuilderFactory,
                 SqlGenerationHelper,
                 ParameterNameGeneratorFactory,
+                RelationalTypeMapper,
                 Check.NotNull(selectExpression, nameof(selectExpression)),
                 Check.NotEmpty(sql, nameof(sql)),
                 Check.NotNull(arguments, nameof(arguments)));

--- a/src/EntityFramework.Sqlite/Query/Sql/SqliteQuerySqlGenerator.cs
+++ b/src/EntityFramework.Sqlite/Query/Sql/SqliteQuerySqlGenerator.cs
@@ -17,8 +17,14 @@ namespace Microsoft.Data.Entity.Query.Sql
             [NotNull] IRelationalCommandBuilderFactory relationalCommandBuilderFactory,
             [NotNull] ISqlGenerationHelper sqlGenerationHelper,
             [NotNull] IParameterNameGeneratorFactory parameterNameGeneratorFactory,
+            [NotNull] IRelationalTypeMapper relationalTypeMapper,
             [NotNull] SelectExpression selectExpression)
-            : base(relationalCommandBuilderFactory, sqlGenerationHelper, parameterNameGeneratorFactory, selectExpression)
+            : base(
+                  relationalCommandBuilderFactory, 
+                  sqlGenerationHelper, 
+                  parameterNameGeneratorFactory, 
+                  relationalTypeMapper, 
+                  selectExpression)
         {
         }
 

--- a/src/EntityFramework.Sqlite/Query/Sql/SqliteQuerySqlGeneratorFactory.cs
+++ b/src/EntityFramework.Sqlite/Query/Sql/SqliteQuerySqlGeneratorFactory.cs
@@ -13,11 +13,13 @@ namespace Microsoft.Data.Entity.Query.Sql
         public SqliteQuerySqlGeneratorFactory(
             [NotNull] IRelationalCommandBuilderFactory commandBuilderFactory,
             [NotNull] ISqlGenerationHelper sqlGenerationHelper,
-            [NotNull] IParameterNameGeneratorFactory parameterNameGeneratorFactory)
+            [NotNull] IParameterNameGeneratorFactory parameterNameGeneratorFactory,
+            [NotNull] IRelationalTypeMapper relationalTypeMapper)
             : base(
                 Check.NotNull(commandBuilderFactory, nameof(commandBuilderFactory)),
                 Check.NotNull(sqlGenerationHelper, nameof(sqlGenerationHelper)),
-                Check.NotNull(parameterNameGeneratorFactory, nameof(parameterNameGeneratorFactory)))
+                Check.NotNull(parameterNameGeneratorFactory, nameof(parameterNameGeneratorFactory)),
+                Check.NotNull(relationalTypeMapper, nameof(relationalTypeMapper)))
         {
         }
 
@@ -26,6 +28,7 @@ namespace Microsoft.Data.Entity.Query.Sql
                 CommandBuilderFactory,
                 SqlGenerationHelper,
                 ParameterNameGeneratorFactory,
+                RelationalTypeMapper,
                 Check.NotNull(selectExpression, nameof(selectExpression)));
     }
 }

--- a/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
@@ -1431,6 +1431,31 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [ConditionalFact]
+        public virtual void Where_concat_string_int_comparison1()
+        {
+            int i = 10;
+            AssertQuery<Customer>(
+                cs => cs.Where(c => c.CustomerID + i == c.CompanyName).Select(c => c.CustomerID));
+        }
+
+        [ConditionalFact]
+        public virtual void Where_concat_string_int_comparison2()
+        {
+            int i = 10;
+            AssertQuery<Customer>(
+                cs => cs.Where(c => i + c.CustomerID == c.CompanyName).Select(c => c.CustomerID));
+        }
+
+        [ConditionalFact]
+        public virtual void Where_concat_string_int_comparison3()
+        {
+            var i = 10;
+            var j = 21;
+            AssertQuery<Customer>(
+                cs => cs.Where(c => i + 20 + c.CustomerID + j + 42 == c.CompanyName).Select(c => c.CustomerID));
+        }
+
+        [ConditionalFact]
         public virtual void Select_bool_closure()
         {
             var boolean = false;

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -2925,6 +2925,46 @@ WHERE 1 = 0",
                 Sql);
         }
 
+        public override void Where_concat_string_int_comparison1()
+        {
+            base.Where_concat_string_int_comparison1();
+
+            Assert.Equal(
+                @"@__i_0: 10
+
+SELECT [c].[CustomerID]
+FROM [Customers] AS [c]
+WHERE ([c].[CustomerID] + CAST(@__i_0 AS nvarchar(max))) = [c].[CompanyName]",
+                Sql);
+        }
+
+        public override void Where_concat_string_int_comparison2()
+        {
+            base.Where_concat_string_int_comparison2();
+
+            Assert.Equal(
+                @"@__i_0: 10
+
+SELECT [c].[CustomerID]
+FROM [Customers] AS [c]
+WHERE (CAST(@__i_0 AS nvarchar(max)) + [c].[CustomerID]) = [c].[CompanyName]",
+                Sql);
+        }
+
+        public override void Where_concat_string_int_comparison3()
+        {
+            base.Where_concat_string_int_comparison3();
+
+            Assert.Equal(
+    @"@__i_0: 10
+@__j_1: 21
+
+SELECT [c].[CustomerID]
+FROM [Customers] AS [c]
+WHERE (((CAST(@__i_0 + 20 AS nvarchar(max)) + [c].[CustomerID]) + CAST(@__j_1 AS nvarchar(max))) + CAST(42 AS nvarchar(max))) = [c].[CompanyName]",
+                Sql);
+        }
+
         public override void Where_primitive()
         {
             base.Where_primitive();


### PR DESCRIPTION
Problem is twofold - compiler translates this into a BinaryAdd operation, with a string Concat(object, object) method info, and casts the int into object. When we translate query and encounter a object-valued constant we don't know how to translate it. Another issue is that when generating SQL, we need to explicitly cast the non-string to varchar (so that types match). Currently we are always ignoring casts (were treating them as means to have consistently typed expression trees, but they were not needed in actual SQL generation).

Fix is to add fragment translator for the BinaryExpression.Add that recognizes concatenation of string with non-string, unboxing the non-string constant and wrapping it in a (new) ExplicitCast node. This node is then translated into proper CAST ([non-string] AS [string-type]). String-type name is determined using appropriate RelationalTypeMapper