### PR TITLE
Fix issue #4036 - DbContext.X.Where(x => x.YRef.ID == 1) throws "The binary operator Equal is not defined for the types Nullable..."

### DIFF
--- a/src/EntityFramework.Core/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
+++ b/src/EntityFramework.Core/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
@@ -261,8 +261,7 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors.Internal
                             if (navigations.Any())
                             {
                                 if ((navigations.Count == 1)
-                                    && navigations[0].IsDependentToPrincipal() 
-                                    && navigations[0].ForeignKey.IsRequired)
+                                    && navigations[0].IsDependentToPrincipal())
                                 {
                                     var foreignKeyMemberAccess = CreateForeignKeyMemberAccess(node, navigations[0]);
                                     if (foreignKeyMemberAccess != null)
@@ -298,11 +297,12 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors.Internal
             var principalKey = navigation.ForeignKey.PrincipalKey;
             if (principalKey.Properties.Count == 1)
             {
-                var principalKeyProperty = principalKey.Properties[0];
-                if (principalKeyProperty.Name == memberExpression.Member.Name)
-                {
-                    Debug.Assert(navigation.ForeignKey.Properties.Count == 1);
+                Debug.Assert(navigation.ForeignKey.Properties.Count == 1);
 
+                var principalKeyProperty = principalKey.Properties[0];
+                if (principalKeyProperty.Name == memberExpression.Member.Name 
+                    && principalKeyProperty.ClrType == navigation.ForeignKey.Properties[0].ClrType)
+                {
                     var declaringExpression = ((MemberExpression)memberExpression.Expression).Expression;
                     var foreignKeyPropertyExpression = CreateKeyAccessExpression(declaringExpression, navigation.ForeignKey.Properties);
 

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
@@ -563,8 +563,7 @@ FROM [Orders] AS [o]",
             Assert.Equal(
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-INNER JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
-WHERE [o.Customer].[CustomerID] IN ('ALFKI')",
+WHERE [o].[CustomerID] IN ('ALFKI')",
                 Sql);
         }
 


### PR DESCRIPTION
Issue was that the navigation property -> foreign key optimization was too aggressive. Problem with the optimization is that sometimes FK is of different type than PK, and it may cause type inconsistencies.
We incorrectly assumed that it can be performed for required navigations. However one can declare required navigation that has nullable FK, while PK is non-nullable.

Fix is to compare types of PK and FK instead.