### PR TITLE
Stop using IKeyValue in update pipeline

### DIFF
--- a/src/EntityFramework.Core/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -257,12 +257,13 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
             => _storeGeneratedValues.GetValue<T>(currentValue, storeGeneratedIndex);
 
         internal static readonly MethodInfo GetCurrentValueMethod
-            = typeof(InternalEntityEntry).GetTypeInfo().GetDeclaredMethod(nameof(GetCurrentValue));
+            = typeof(InternalEntityEntry).GetMethods()
+                .Single(m => m.Name == nameof(GetCurrentValue) && m.IsGenericMethod);
 
-        public virtual TProperty GetCurrentValue<TProperty>([NotNull] IPropertyBase propertyBase)
+        public virtual TProperty GetCurrentValue<TProperty>(IPropertyBase propertyBase)
             => ((Func<InternalEntityEntry, TProperty>)propertyBase.GetPropertyAccessors().CurrentValueGetter)(this);
 
-        public virtual TProperty GetOriginalValue<TProperty>([NotNull] IProperty property)
+        public virtual TProperty GetOriginalValue<TProperty>(IProperty property)
             => ((Func<InternalEntityEntry, TProperty>)property.GetPropertyAccessors().OriginalValueGetter)(this);
 
         public virtual TProperty GetRelationshipSnapshotValue<TProperty>([NotNull] IPropertyBase propertyBase)
@@ -282,7 +283,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
             propertyBase.GetSetter().SetClrValue(Entity, value);
         }
 
-        public virtual object GetValue(IPropertyBase propertyBase, ValueSource valueSource = ValueSource.Current)
+        public virtual object GetValue([NotNull] IPropertyBase propertyBase, ValueSource valueSource = ValueSource.Current)
         {
             switch (valueSource)
             {
@@ -294,7 +295,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
             return this[propertyBase];
         }
 
-        public virtual void SetValue(IPropertyBase propertyBase, object value, ValueSource valueSource = ValueSource.Current)
+        public virtual void SetValue([NotNull] IPropertyBase propertyBase, [CanBeNull] object value, ValueSource valueSource = ValueSource.Current)
         {
             switch (valueSource)
             {
@@ -311,6 +312,15 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
                     break;
             }
         }
+
+        public virtual object GetCurrentValue(IPropertyBase propertyBase)
+            => this[propertyBase];
+
+        public virtual object GetOriginalValue(IPropertyBase propertyBase)
+            => _originalValues.GetValue(this, (IProperty)propertyBase);
+
+        public virtual void SetCurrentValue(IPropertyBase propertyBase, object value) 
+            => this[propertyBase] = value;
 
         public virtual void EnsureOriginalValues()
         {
@@ -348,16 +358,16 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
             return CreateKey(key, key.Properties, valueSource);
         }
 
-        public virtual IKeyValue GetPrincipalKeyValue(IKey key, ValueSource valueSource = ValueSource.Current)
+        public virtual IKeyValue GetPrincipalKeyValue([NotNull] IKey key, ValueSource valueSource = ValueSource.Current)
             => CreateKey(key, key.Properties, valueSource);
 
-        public virtual IKeyValue GetPrincipalKeyValue(IForeignKey foreignKey, ValueSource valueSource = ValueSource.Current)
+        public virtual IKeyValue GetPrincipalKeyValue([NotNull] IForeignKey foreignKey, ValueSource valueSource = ValueSource.Current)
         {
             var key = foreignKey.PrincipalKey;
             return CreateKey(key, key.Properties, valueSource);
         }
 
-        public virtual IKeyValue GetDependentKeyValue(IForeignKey foreignKey, ValueSource valueSource = ValueSource.Current)
+        public virtual IKeyValue GetDependentKeyValue([NotNull] IForeignKey foreignKey, ValueSource valueSource = ValueSource.Current)
         {
             var key = foreignKey.PrincipalKey;
             return CreateKey(key, foreignKey.Properties, valueSource);

--- a/src/EntityFramework.Core/Update/IUpdateEntry.cs
+++ b/src/EntityFramework.Core/Update/IUpdateEntry.cs
@@ -3,7 +3,6 @@
 
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking;
-using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 
 namespace Microsoft.Data.Entity.Update
@@ -48,64 +47,38 @@ namespace Microsoft.Data.Entity.Update
         ///     Gets the value assigned to the property.
         /// </summary>
         /// <param name="propertyBase"> The property to get the value for. </param>
-        /// <param name="valueSource">
-        ///     A value indicating whether to get the current, original, or relationship snapshot value.
-        /// </param>
         /// <returns> The value for the property. </returns>
-        object GetValue([NotNull] IPropertyBase propertyBase, ValueSource valueSource = ValueSource.Current);
+        object GetCurrentValue([NotNull] IPropertyBase propertyBase);
+
+        /// <summary>
+        ///     Gets the value assigned to the property when it was retrieved from the database.
+        /// </summary>
+        /// <param name="propertyBase"> The property to get the value for. </param>
+        /// <returns> The value for the property. </returns>
+        object GetOriginalValue([NotNull] IPropertyBase propertyBase);
+
+        /// <summary>
+        ///     Gets the value assigned to the property.
+        /// </summary>
+        /// <param name="propertyBase"> The property to get the value for. </param>
+        /// <typeparam name="TProperty"> The type of the property. </typeparam>
+        /// <returns> The value for the property. </returns>
+        TProperty GetCurrentValue<TProperty>([NotNull] IPropertyBase propertyBase);
+
+        /// <summary>
+        ///     Gets the value assigned to the property when it was retrieved from the database.
+        /// </summary>
+        /// <param name="property"> The property to get the value for. </param>
+        /// <typeparam name="TProperty"> The type of the property. </typeparam>
+        /// <returns> The value for the property. </returns>
+        TProperty GetOriginalValue<TProperty>([NotNull] IProperty property);
 
         /// <summary>
         ///     Gets the value assigned to the property.
         /// </summary>
         /// <param name="propertyBase"> The property to set the value for. </param>
         /// <param name="value"> The value to set. </param>
-        /// <param name="valueSource">
-        ///     A value indicating whether to set the current, original, or relationship snapshot value.
-        /// </param>
-        void SetValue([NotNull] IPropertyBase propertyBase, [CanBeNull] object value, ValueSource valueSource = ValueSource.Current);
-
-        /// <summary>
-        ///     Gets an object representing the values assigned to the primary key.
-        ///     <see cref="IKeyValue" /> is typically used to test the equivalence of key values.
-        /// </summary>
-        /// <param name="valueSource">
-        ///     A value indicating whether to get the current, original, or relationship snapshot value.
-        /// </param>
-        /// <returns> The values assigned to the primary key. </returns>
-        IKeyValue GetPrimaryKeyValue(ValueSource valueSource = ValueSource.Current);
-
-        /// <summary>
-        ///     Gets an object representing the values assigned to the principal key that a foreign key references.
-        ///     <see cref="IKeyValue" /> is typically used to test the equivalence of key values.
-        /// </summary>
-        /// <param name="foreignKey"> The foreign key to get the principal key values for. </param>
-        /// <param name="valueSource">
-        ///     A value indicating whether to get the current, original, or relationship snapshot value.
-        /// </param>
-        /// <returns> The values assigned to the key. </returns>
-        IKeyValue GetPrincipalKeyValue([NotNull] IForeignKey foreignKey, ValueSource valueSource = ValueSource.Current);
-
-        /// <summary>
-        ///     Gets an object representing the values assigned to the principal key.
-        ///     <see cref="IKeyValue" /> is typically used to test the equivalence of key values.
-        /// </summary>
-        /// <param name="key"> The prinicipal key to get values for. </param>
-        /// <param name="valueSource">
-        ///     A value indicating whether to get the current, original, or relationship snapshot value.
-        /// </param>
-        /// <returns> The values assigned to the key. </returns>
-        IKeyValue GetPrincipalKeyValue([NotNull] IKey key, ValueSource valueSource = ValueSource.Current);
-
-        /// <summary>
-        ///     Gets an object representing the values assigned to a foreign key.
-        ///     <see cref="IKeyValue" /> is typically used to test the equivalence of key values.
-        /// </summary>
-        /// <param name="foreignKey"> The foreign key to get values for. </param>
-        /// <param name="valueSource">
-        ///     A value indicating whether to get the current, original, or relationship snapshot value.
-        /// </param>
-        /// <returns> The values assigned to the key. </returns>
-        IKeyValue GetDependentKeyValue([NotNull] IForeignKey foreignKey, ValueSource valueSource = ValueSource.Current);
+        void SetCurrentValue([NotNull] IPropertyBase propertyBase, [CanBeNull] object value);
 
         /// <summary>
         ///     Gets an <see cref="EntityEntry" /> for the entity being saved. <see cref="EntityEntry" /> is an API optimized for

--- a/src/EntityFramework.InMemory/Storage/Internal/InMemoryTable.cs
+++ b/src/EntityFramework.InMemory/Storage/Internal/InMemoryTable.cs
@@ -36,6 +36,6 @@ namespace Microsoft.Data.Entity.Storage.Internal
             => _keyValueFactory.CreateFromCurrentValues((InternalEntityEntry)entry);
 
         private static object[] CreateValueBuffer(IUpdateEntry entry)
-            => entry.EntityType.GetProperties().Select(p => entry.GetValue(p)).ToArray();
+            => entry.EntityType.GetProperties().Select(p => entry.GetCurrentValue(p)).ToArray();
     }
 }

--- a/src/EntityFramework.Relational/EntityFramework.Relational.csproj
+++ b/src/EntityFramework.Relational/EntityFramework.Relational.csproj
@@ -330,6 +330,12 @@
     <Compile Include="Storage\IParameterNameGeneratorFactory.cs" />
     <Compile Include="Update\Internal\BatchExecutor.cs" />
     <Compile Include="Update\Internal\CommandBatchPreparer.cs" />
+    <Compile Include="Update\Internal\IKeyValueIndex.cs" />
+    <Compile Include="Update\Internal\IKeyValueIndexFactory.cs" />
+    <Compile Include="Update\Internal\IKeyValueIndexFactorySource.cs" />
+    <Compile Include="Update\Internal\KeyValueIndex.cs" />
+    <Compile Include="Update\Internal\KeyValueIndexFactory.cs" />
+    <Compile Include="Update\Internal\KeyValueIndexFactorySource.cs" />
     <Compile Include="Update\Internal\ModificationCommandComparer.cs" />
     <Compile Include="Update\IUpdateSqlGenerator.cs" />
     <Compile Include="Update\ModificationCommand.cs" />

--- a/src/EntityFramework.Relational/Infrastructure/RelationalEntityFrameworkServicesBuilderExtensions.cs
+++ b/src/EntityFramework.Relational/Infrastructure/RelationalEntityFrameworkServicesBuilderExtensions.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Data.Entity.Infrastructure
                     .AddSingleton<ParameterNameGeneratorFactory>()
                     .AddSingleton<IComparer<ModificationCommand>, ModificationCommandComparer>()
                     .AddSingleton<IMigrationsIdGenerator, MigrationsIdGenerator>()
+                    .AddSingleton<IKeyValueIndexFactorySource, KeyValueIndexFactorySource>()
                     .AddSingleton<UntypedRelationalValueBufferFactoryFactory>()
                     .AddSingleton<TypedRelationalValueBufferFactoryFactory>()
                     .AddSingleton<MigrationsAnnotationProvider>()

--- a/src/EntityFramework.Relational/Update/ColumnModification.cs
+++ b/src/EntityFramework.Relational/Update/ColumnModification.cs
@@ -73,12 +73,12 @@ namespace Microsoft.Data.Entity.Update
 
         public virtual string ColumnName { get; }
 
-        public virtual object OriginalValue => Entry.GetValue(Property, ValueSource.Original);
+        public virtual object OriginalValue => Entry.GetOriginalValue(Property);
 
         public virtual object Value
         {
-            get { return Entry.GetValue(Property); }
-            [param: CanBeNull] set { Entry.SetValue(Property, value); }
+            get { return Entry.GetCurrentValue(Property); }
+            [param: CanBeNull] set { Entry.SetCurrentValue(Property, value); }
         }
     }
 }

--- a/src/EntityFramework.Relational/Update/Internal/IKeyValueIndex.cs
+++ b/src/EntityFramework.Relational/Update/Internal/IKeyValueIndex.cs
@@ -1,0 +1,10 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Data.Entity.Update.Internal
+{
+    public interface IKeyValueIndex
+    {
+        IKeyValueIndex WithOriginalValuesFlag();
+    }
+}

--- a/src/EntityFramework.Relational/Update/Internal/IKeyValueIndexFactory.cs
+++ b/src/EntityFramework.Relational/Update/Internal/IKeyValueIndexFactory.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.ChangeTracking.Internal;
+using Microsoft.Data.Entity.Metadata;
+
+namespace Microsoft.Data.Entity.Update.Internal
+{
+    public interface IKeyValueIndexFactory
+    {
+        IKeyValueIndex CreatePrincipalKeyValue([NotNull] InternalEntityEntry entry, [NotNull] IForeignKey foreignKey);
+        IKeyValueIndex CreatePrincipalKeyValueFromOriginalValues([NotNull] InternalEntityEntry entry, [NotNull] IForeignKey foreignKey);
+        IKeyValueIndex CreateDependentKeyValue([NotNull] InternalEntityEntry entry, [NotNull] IForeignKey foreignKey);
+        IKeyValueIndex CreateDependentKeyValueFromOriginalValues([NotNull] InternalEntityEntry entry, [NotNull] IForeignKey foreignKey);
+    }
+}

--- a/src/EntityFramework.Relational/Update/Internal/IKeyValueIndexFactorySource.cs
+++ b/src/EntityFramework.Relational/Update/Internal/IKeyValueIndexFactorySource.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+
+namespace Microsoft.Data.Entity.Update.Internal
+{
+    public interface IKeyValueIndexFactorySource
+    {
+        IKeyValueIndexFactory GetKeyValueIndexFactory([NotNull] IKey key);
+    }
+}

--- a/src/EntityFramework.Relational/Update/Internal/KeyValueIndex.cs
+++ b/src/EntityFramework.Relational/Update/Internal/KeyValueIndex.cs
@@ -1,0 +1,41 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+
+namespace Microsoft.Data.Entity.Update.Internal
+{
+    public sealed class KeyValueIndex<TKey> : IKeyValueIndex
+    {
+        private readonly IForeignKey _foreignKey;
+        private readonly TKey _keyValue;
+        private readonly bool _fromOriginalValues;
+
+        public KeyValueIndex([NotNull] IForeignKey foreignKey, [NotNull] TKey keyValue, bool fromOriginalValues)
+        {
+            _foreignKey = foreignKey;
+            _keyValue = keyValue;
+            _fromOriginalValues = fromOriginalValues;
+        }
+
+        public IKeyValueIndex WithOriginalValuesFlag()
+            => new KeyValueIndex<TKey>(_foreignKey, _keyValue, fromOriginalValues: true);
+
+        private bool Equals(KeyValueIndex<TKey> other)
+            => other._fromOriginalValues == _fromOriginalValues
+               && other._foreignKey == _foreignKey
+               && other._keyValue.Equals(_keyValue);
+
+        public override bool Equals(object obj)
+            => !ReferenceEquals(null, obj)
+               && (ReferenceEquals(this, obj)
+                   || (obj.GetType() == GetType()
+                       && Equals((KeyValueIndex<TKey>)obj)));
+
+        public override int GetHashCode()
+            => (((_fromOriginalValues.GetHashCode() * 397)
+                 ^ _foreignKey.GetHashCode()) * 397)
+               ^ _keyValue.GetHashCode();
+    }
+}

--- a/src/EntityFramework.Relational/Update/Internal/KeyValueIndexFactory.cs
+++ b/src/EntityFramework.Relational/Update/Internal/KeyValueIndexFactory.cs
@@ -1,0 +1,59 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.ChangeTracking.Internal;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Metadata.Internal;
+
+namespace Microsoft.Data.Entity.Update.Internal
+{
+    public class KeyValueIndexFactory<TKey> : IKeyValueIndexFactory
+    {
+        private readonly IPrincipalKeyValueFactory<TKey> _principalKeyValueFactory;
+
+        public KeyValueIndexFactory([NotNull] IPrincipalKeyValueFactory<TKey> principalKeyValueFactory)
+        {
+            _principalKeyValueFactory = principalKeyValueFactory;
+        }
+
+        public virtual IKeyValueIndex CreatePrincipalKeyValue(InternalEntityEntry entry, IForeignKey foreignKey)
+        {
+            var principalKeyValue = _principalKeyValueFactory.CreateFromCurrentValues(entry);
+
+            return new KeyValueIndex<TKey>(foreignKey, principalKeyValue, fromOriginalValues: false);
+        }
+
+        public virtual IKeyValueIndex CreatePrincipalKeyValueFromOriginalValues(InternalEntityEntry entry, IForeignKey foreignKey)
+        {
+            var principalKeyValue = _principalKeyValueFactory.CreateFromOriginalValues(entry);
+
+            return new KeyValueIndex<TKey>(foreignKey, principalKeyValue, fromOriginalValues: false);
+        }
+
+        public virtual IKeyValueIndex CreateDependentKeyValue(InternalEntityEntry entry, IForeignKey foreignKey)
+        {
+            TKey keyValue;
+            return GetDependentKeyValueFactory(foreignKey).TryCreateFromCurrentValues(entry, out keyValue)
+                ? new KeyValueIndex<TKey>(foreignKey, keyValue, fromOriginalValues: false)
+                : null;
+        }
+
+        public virtual IKeyValueIndex CreateDependentKeyValueFromOriginalValues(InternalEntityEntry entry, IForeignKey foreignKey)
+        {
+            TKey keyValue;
+            return GetDependentKeyValueFactory(foreignKey).TryCreateFromOriginalValues(entry, out keyValue)
+                ? new KeyValueIndex<TKey>(foreignKey, keyValue, fromOriginalValues: false)
+                : null;
+        }
+
+        private static IDependentKeyValueFactory<TKey> GetDependentKeyValueFactory(IForeignKey foreignKey)
+        {
+            var factorySource = foreignKey as IDependentKeyValueFactorySource;
+
+            return factorySource != null
+                ? (IDependentKeyValueFactory<TKey>)factorySource.DependentKeyValueFactory
+                : new DependentKeyValueFactoryFactory().Create<TKey>(foreignKey);
+        }
+    }
+}

--- a/src/EntityFramework.Relational/Update/Internal/KeyValueIndexFactorySource.cs
+++ b/src/EntityFramework.Relational/Update/Internal/KeyValueIndexFactorySource.cs
@@ -1,0 +1,32 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.ChangeTracking.Internal;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Metadata.Internal;
+
+namespace Microsoft.Data.Entity.Update.Internal
+{
+    public class KeyValueIndexFactorySource : IdentityMapFactoryFactoryBase, IKeyValueIndexFactorySource
+    {
+        private readonly ConcurrentDictionary<IKey, IKeyValueIndexFactory> _factories
+            = new ConcurrentDictionary<IKey, IKeyValueIndexFactory>();
+
+        public virtual IKeyValueIndexFactory GetKeyValueIndexFactory(IKey key)
+            => _factories.GetOrAdd(key, Create);
+
+        public virtual IKeyValueIndexFactory Create([NotNull] IKey key)
+            => (IKeyValueIndexFactory)typeof(KeyValueIndexFactorySource).GetTypeInfo()
+                .GetDeclaredMethods(nameof(CreateFactory)).Single()
+                .MakeGenericMethod(GetKeyType(key))
+                .Invoke(null, new object[] { key });
+
+        [UsedImplicitly]
+        private static IKeyValueIndexFactory CreateFactory<TKey>(IKey key)
+            => new KeyValueIndexFactory<TKey>(key.GetPrincipalKeyValueFactory<TKey>());
+    }
+}

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
@@ -54,13 +54,13 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             Assert.Equal(77, entry.GetValue(property, ValueSource.RelationshipSnapshot));
             Assert.Equal(77, entry.GetValue(property, ValueSource.Original));
-            Assert.Equal(77, entry.GetValue(property));
+            Assert.Equal(77, entry.GetCurrentValue(property));
 
             entity.DependentId = 777;
 
             Assert.Equal(77, entry.GetValue(property, ValueSource.RelationshipSnapshot));
             Assert.Equal(77, entry.GetValue(property, ValueSource.Original));
-            Assert.Equal(777, entry.GetValue(property));
+            Assert.Equal(777, entry.GetCurrentValue(property));
         }
 
         [Fact]
@@ -80,13 +80,13 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             Assert.Equal("Cheese", entry.GetValue(property, ValueSource.RelationshipSnapshot));
             Assert.Equal("Cheese", entry.GetValue(property, ValueSource.Original));
-            Assert.Equal("Cheese", entry.GetValue(property));
+            Assert.Equal("Cheese", entry.GetCurrentValue(property));
 
             entity.Name = "Pickle";
 
             Assert.Equal("Pickle", entry.GetValue(property, ValueSource.RelationshipSnapshot));
             Assert.Equal("Pickle", entry.GetValue(property, ValueSource.Original));
-            Assert.Equal("Pickle", entry.GetValue(property));
+            Assert.Equal("Pickle", entry.GetCurrentValue(property));
         }
 
         [Fact]
@@ -109,12 +109,12 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             Assert.True(entry.HasRelationshipSnapshot);
 
             Assert.Same(category, entry.GetValue(navigation, ValueSource.RelationshipSnapshot));
-            Assert.Same(category, entry.GetValue(navigation));
+            Assert.Same(category, entry.GetCurrentValue(navigation));
 
             entity.Category = new CategoryWithChanging();
 
             Assert.Same(category, entry.GetValue(navigation, ValueSource.RelationshipSnapshot));
-            Assert.NotSame(category, entry.GetValue(navigation));
+            Assert.NotSame(category, entry.GetCurrentValue(navigation));
         }
 
         [Fact]
@@ -137,13 +137,13 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             Assert.Equal(77, entry.GetValue(property, ValueSource.RelationshipSnapshot));
             Assert.Equal(77, entry.GetValue(property, ValueSource.Original));
-            Assert.Equal(77, entry.GetValue(property));
+            Assert.Equal(77, entry.GetCurrentValue(property));
 
             entity.Id = 777;
 
             Assert.Equal(77, entry.GetValue(property, ValueSource.RelationshipSnapshot));
             Assert.Equal(777, entry.GetValue(property, ValueSource.Original));
-            Assert.Equal(777, entry.GetValue(property));
+            Assert.Equal(777, entry.GetCurrentValue(property));
         }
 
         [Fact]

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntityEntryTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntityEntryTestBase.cs
@@ -759,7 +759,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         }
 
         private static object[] CreateValueBuffer(IUpdateEntry entry)
-            => entry.EntityType.GetProperties().Select(p => entry.GetValue(p)).ToArray();
+            => entry.EntityType.GetProperties().Select(p => entry.GetCurrentValue(p)).ToArray();
 
         [Fact]
         public virtual void All_original_values_can_be_accessed_for_entity_that_does_full_change_tracking_if_eager_values_on()

--- a/test/EntityFramework.Relational.Tests/Update/ColumnModificationTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/ColumnModificationTest.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Data.Entity.Tests.Update
 
             var value = columnModification.Value;
 
-            internalEntryMock.Verify(m => m.GetValue(It.IsAny<IPropertyBase>(), ValueSource.Current), Times.Once);
+            internalEntryMock.Verify(m => m.GetCurrentValue(It.IsAny<IPropertyBase>()), Times.Once);
         }
 
         [Fact]
@@ -73,7 +73,7 @@ namespace Microsoft.Data.Entity.Tests.Update
 
             columnModification.Value = value;
 
-            internalEntryMock.Verify(m => m.SetValue(property, It.IsAny<object>(), ValueSource.Current), Times.Once);
+            internalEntryMock.Verify(m => m.SetCurrentValue(property, It.IsAny<object>()), Times.Once);
         }
 
         private static Mock<InternalEntityEntry> CreateInternalEntryMock(IProperty property)

--- a/test/EntityFramework.Relational.Tests/Update/CommandBatchPreparerTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/CommandBatchPreparerTest.cs
@@ -330,7 +330,8 @@ namespace Microsoft.Data.Entity.Tests.Update
             return new CommandBatchPreparer(modificationCommandBatchFactory,
                 new ParameterNameGeneratorFactory(),
                 new ModificationCommandComparer(),
-                new TestAnnotationProvider());
+                new TestAnnotationProvider(),
+                new KeyValueIndexFactorySource());
         }
 
         private static IModel CreateSimpleFKModel()


### PR DESCRIPTION
Switched to use same key factories as other parts of the stack. This currently reuses internal code used in the core, but it could be changed to duplicate some of that code and only use public APIs.