### PR TITLE
Commands: Include types without default constructors in searches

### DIFF
--- a/src/Shared/SharedTypeExtensions.cs
+++ b/src/Shared/SharedTypeExtensions.cs
@@ -209,7 +209,6 @@ namespace System
         public static IEnumerable<TypeInfo> GetConstructibleTypes(this Assembly assembly)
             => assembly.DefinedTypes.Where(
                 t => !t.IsAbstract
-                     && !t.IsGenericType
-                     && t.DeclaredConstructors.Any(c => (c.GetParameters().Length == 0) && c.IsPublic));
+                    && !t.IsGenericTypeDefinition);
     }
 }


### PR DESCRIPTION
Instead of not finding anything, this will inform the user that a default constructor is missing (fixes #3752). This also avoids looking at constructor parameters whose types may not be available on UWP projects (fixes #3803).

Verification: In addition to the automated test, I manual verified the specific scenarios.