### PR TITLE
Split out query compilation benchmarks

### DIFF
--- a/test/EntityFramework.Microbenchmarks.EF6/EntityFramework.Microbenchmarks.EF6.csproj
+++ b/test/EntityFramework.Microbenchmarks.EF6/EntityFramework.Microbenchmarks.EF6.csproj
@@ -46,6 +46,7 @@
     <Compile Include="Models\Orders\OrdersFixture.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Query\FuncletizationTests.cs" />
+    <Compile Include="Query\QueryCompilationTests.cs" />
     <Compile Include="Query\SimpleQueryTests.cs" />
     <Compile Include="UpdatePipeline\SimpleUpdatePipelineTests.cs" />
   </ItemGroup>

--- a/test/EntityFramework.Microbenchmarks.EF6/Extensions.cs
+++ b/test/EntityFramework.Microbenchmarks.EF6/Extensions.cs
@@ -16,20 +16,18 @@ namespace EntityFramework.Microbenchmarks.EF6
             .GetProperty("ObjectQuery")
             .GetMethod;
 
-        public static IQueryable<TEntity> ApplyCaching<TEntity>(this IQueryable<TEntity> query, bool caching)
+        public static IQueryable<TEntity> DisableQueryCache<TEntity>(this IQueryable<TEntity> query)
             where TEntity : class
         {
-            if (!caching)
-            {
-                var internalQuery = typeof(DbQuery<TEntity>)
-                    .GetProperty("System.Data.Entity.Internal.Linq.IInternalQueryAdapter.InternalQuery", BindingFlags.NonPublic | BindingFlags.Instance)
-                    .GetMethod
-                    .Invoke(query, new object[0]);
 
-                var objectQuery = (ObjectQuery)_getObjectQueryMethodInfo.Invoke(internalQuery, new object[0]);
+            var internalQuery = typeof(DbQuery<TEntity>)
+                .GetProperty("System.Data.Entity.Internal.Linq.IInternalQueryAdapter.InternalQuery", BindingFlags.NonPublic | BindingFlags.Instance)
+                .GetMethod
+                .Invoke(query, new object[0]);
 
-                objectQuery.EnablePlanCaching = false;
-            }
+            var objectQuery = (ObjectQuery)_getObjectQueryMethodInfo.Invoke(internalQuery, new object[0]);
+
+            objectQuery.EnablePlanCaching = false;
 
             return query;
         }

--- a/test/EntityFramework.Microbenchmarks.EF6/Models/Orders/OrdersFixture.cs
+++ b/test/EntityFramework.Microbenchmarks.EF6/Models/Orders/OrdersFixture.cs
@@ -27,7 +27,7 @@ namespace EntityFramework.Microbenchmarks.EF6.Models.Orders
             EnsureDatabaseCreated();
         }
 
-        public OrdersContext CreateContext()
+        public virtual OrdersContext CreateContext()
         {
             return new OrdersContext(_connectionString);
         }

--- a/test/EntityFramework.Microbenchmarks.EF6/Query/QueryCompilationTests.cs
+++ b/test/EntityFramework.Microbenchmarks.EF6/Query/QueryCompilationTests.cs
@@ -1,0 +1,81 @@
+﻿using EntityFramework.Microbenchmarks.Core;
+using EntityFramework.Microbenchmarks.EF6.Models.Orders;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace EntityFramework.Microbenchmarks.EF6.Query
+{
+    class QueryCompilationTests : IClassFixture<QueryCompilationTests.QueryCompilationFixture>
+    {
+        private readonly QueryCompilationFixture _fixture;
+
+        public QueryCompilationTests(QueryCompilationFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Benchmark]
+        [BenchmarkVariation("Default (10 queries)")]
+        public void ToList(IMetricCollector collector)
+        {
+            using (var context = _fixture.CreateContext())
+            {
+                var query = context.Products
+                    .AsNoTracking()
+                    .DisableQueryCache();
+
+                using (collector.StartCollection())
+                {
+                    for (var i = 0; i < 10; i++)
+                    {
+                        query.ToList();
+                    }
+                }
+
+                Assert.Equal(0, query.Count());
+            }
+        }
+
+        [Benchmark]
+        [BenchmarkVariation("Default (10 queries)")]
+        public void FilterOrderProject(IMetricCollector collector)
+        {
+            using (var context = _fixture.CreateContext())
+            {
+                var query = context.Products
+                    .AsNoTracking()
+                    .DisableQueryCache()
+                    .Where(p => p.Retail < 1000)
+                    .OrderBy(p => p.Name).ThenBy(p => p.Retail)
+                    .Select(p => new
+                    {
+                        p.ProductId,
+                        p.Name,
+                        p.Description,
+                        p.ActualStockLevel,
+                        p.SKU,
+                        Savings = p.Retail - p.CurrentPrice,
+                        Surplus = p.ActualStockLevel - p.TargetStockLevel
+                    });
+
+                using (collector.StartCollection())
+                {
+                    for (var i = 0; i < 10; i++)
+                    {
+                        query.ToList();
+                    }
+                }
+
+                Assert.Equal(0, query.Count());
+            }
+        }
+
+        public class QueryCompilationFixture : OrdersFixture
+        {
+            public QueryCompilationFixture()
+                : base("Perf_Query_Compilation_EF6", 0, 0, 0, 0)
+            { }
+        }
+    }
+}

--- a/test/EntityFramework.Microbenchmarks.EF6/Query/SimpleQueryTests.cs
+++ b/test/EntityFramework.Microbenchmarks.EF6/Query/SimpleQueryTests.cs
@@ -20,16 +20,13 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
         }
 
         [Benchmark]
-        [BenchmarkVariation("Tracking On (1 query)", true, true, 1)]
-        [BenchmarkVariation("Tracking Off (10 queries)", false, true, 10)]
-        [BenchmarkVariation("Tracking On, Query Cache Off (1 query)", true, false, 1)]
-        [BenchmarkVariation("Tracking Off, Query Cache Off (10 queries)", false, false, 10)]
-        public void LoadAll(IMetricCollector collector, bool tracking, bool caching, int queriesPerIteration)
+        [BenchmarkVariation("Tracking On (1 query)", true, 1)]
+        [BenchmarkVariation("Tracking Off (10 queries)", false, 10)]
+        public void LoadAll(IMetricCollector collector, bool tracking, int queriesPerIteration)
         {
             using (var context = _fixture.CreateContext())
             {
                 var query = context.Products
-                    .ApplyCaching(caching)
                     .ApplyTracking(tracking);
 
                 using (collector.StartCollection())
@@ -46,16 +43,13 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
         }
 
         [Benchmark]
-        [BenchmarkVariation("Tracking On (1 query)", true, true, 1)]
-        [BenchmarkVariation("Tracking Off (10 queries)", false, true, 10)]
-        [BenchmarkVariation("Tracking On, Query Cache Off (1 query)", true, false, 1)]
-        [BenchmarkVariation("Tracking Off, Query Cache Off (10 queries)", false, false, 10)]
-        public void Where(IMetricCollector collector, bool tracking, bool caching, int queriesPerIteration)
+        [BenchmarkVariation("Tracking On (1 query)", true, 1)]
+        [BenchmarkVariation("Tracking Off (10 queries)", false, 10)]
+        public void Where(IMetricCollector collector, bool tracking, int queriesPerIteration)
         {
             using (var context = _fixture.CreateContext())
             {
                 var query = context.Products
-                    .ApplyCaching(caching)
                     .ApplyTracking(tracking)
                     .Where(p => p.Retail < 15);
 
@@ -73,16 +67,13 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
         }
 
         [Benchmark]
-        [BenchmarkVariation("Tracking On (1 query)", true, true, 1)]
-        [BenchmarkVariation("Tracking Off (10 queries)", false, true, 10)]
-        [BenchmarkVariation("Tracking On, Query Cache Off  (1 query)", true, false, 1)]
-        [BenchmarkVariation("Tracking Off, Query Cache Off (10 queries)", false, false, 10)]
-        public void OrderBy(IMetricCollector collector, bool tracking, bool caching, int queriesPerIteration)
+        [BenchmarkVariation("Tracking On (1 query)", true, 1)]
+        [BenchmarkVariation("Tracking Off (10 queries)", false, 10)]
+        public void OrderBy(IMetricCollector collector, bool tracking, int queriesPerIteration)
         {
             using (var context = _fixture.CreateContext())
             {
                 var query = context.Products
-                    .ApplyCaching(caching)
                     .ApplyTracking(tracking)
                     .OrderBy(p => p.Retail);
 
@@ -100,14 +91,12 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
         }
 
         [Benchmark]
-        [BenchmarkVariation("Default (100 queries)", true, 100)]
-        [BenchmarkVariation("Query Cache Off (100 queries)", false, 100)]
-        public void Count(IMetricCollector collector, bool caching, int queriesPerIteration)
+        [BenchmarkVariation("Default (100 queries)", 100)]
+        public void Count(IMetricCollector collector, int queriesPerIteration)
         {
             using (var context = _fixture.CreateContext())
             {
-                var query = context.Products
-                    .ApplyCaching(caching);
+                var query = context.Products;
 
                 using (collector.StartCollection())
                 {
@@ -122,16 +111,13 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
         }
 
         [Benchmark]
-        [BenchmarkVariation("Tracking On (1 query)", true, true, 1)]
-        [BenchmarkVariation("Tracking Off (10 queries)", false, true, 10)]
-        [BenchmarkVariation("Tracking On, Query Cache Off  (1 query)", true, false, 1)]
-        [BenchmarkVariation("Tracking Off, Query Cache Off (10 queries)", false, false, 10)]
-        public void SkipTake(IMetricCollector collector, bool tracking, bool caching, int queriesPerIteration)
+        [BenchmarkVariation("Tracking On (1 query)", true, 1)]
+        [BenchmarkVariation("Tracking Off (10 queries)", false, 10)]
+        public void SkipTake(IMetricCollector collector, bool tracking, int queriesPerIteration)
         {
             using (var context = _fixture.CreateContext())
             {
                 var query = context.Products
-                    .ApplyCaching(caching)
                     .ApplyTracking(tracking)
                     .OrderBy(p => p.ProductId)
                     .Skip(500).Take(500);
@@ -150,14 +136,12 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
         }
 
         [Benchmark]
-        [BenchmarkVariation("Default (10 queries)", true, 10)]
-        [BenchmarkVariation("Query Cache Off (10 queries)", false, 10)]
-        public void GroupBy(IMetricCollector collector, bool caching, int queriesPerIteration)
+        [BenchmarkVariation("Default (10 queries)", 10)]
+        public void GroupBy(IMetricCollector collector, int queriesPerIteration)
         {
             using (var context = _fixture.CreateContext())
             {
                 var query = context.Products
-                    .ApplyCaching(caching)
                     .GroupBy(p => p.Retail)
                     .Select(g => new
                     {
@@ -180,16 +164,13 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
         }
 
         [Benchmark]
-        [BenchmarkVariation("Tracking On (1 query)", true, true, 1)]
-        [BenchmarkVariation("Tracking Off (1 query)", false, true, 1)]
-        [BenchmarkVariation("Tracking On, Query Cache Off  (1 query)", true, false, 1)]
-        [BenchmarkVariation("Tracking Off, Query Cache Off  (1 query)", false, false, 1)]
-        public void Include(IMetricCollector collector, bool tracking, bool caching, int queriesPerIteration)
+        [BenchmarkVariation("Tracking On (1 query)", true, 1)]
+        [BenchmarkVariation("Tracking Off (1 query)", false, 1)]
+        public void Include(IMetricCollector collector, bool tracking, int queriesPerIteration)
         {
             using (var context = _fixture.CreateContext())
             {
                 var query = context.Customers
-                    .ApplyCaching(caching)
                     .ApplyTracking(tracking)
                     .Include(c => c.Orders);
 
@@ -209,14 +190,12 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
         }
 
         [Benchmark]
-        [BenchmarkVariation("Default (10 queries)", true, 10)]
-        [BenchmarkVariation("Query Cache Off (10 queries)", false, 10)]
-        public void Projection(IMetricCollector collector, bool caching, int queriesPerIteration)
+        [BenchmarkVariation("Default (10 queries)", 10)]
+        public void Projection(IMetricCollector collector, int queriesPerIteration)
         {
             using (var context = _fixture.CreateContext())
             {
                 var query = context.Products
-                    .ApplyCaching(caching)
                     .Select(p => new
                     {
                         p.ProductId,
@@ -241,14 +220,12 @@ namespace EntityFramework.Microbenchmarks.EF6.Query
         }
 
         [Benchmark]
-        [BenchmarkVariation("Default (10 queries)", true, 10)]
-        [BenchmarkVariation("Query Cache Off (10 queries)", false, 10)]
-        public void ProjectionAcrossNavigation(IMetricCollector collector, bool caching, int queriesPerIteration)
+        [BenchmarkVariation("Default (10 queries)", 10)]
+        public void ProjectionAcrossNavigation(IMetricCollector collector, int queriesPerIteration)
         {
             using (var context = _fixture.CreateContext())
             {
                 var query = context.Orders
-                    .ApplyCaching(caching)
                     .Select(o => new
                     {
                         CustomerTitle = o.Customer.Title,

--- a/test/EntityFramework.Microbenchmarks/EntityFramework.Microbenchmarks.csproj
+++ b/test/EntityFramework.Microbenchmarks/EntityFramework.Microbenchmarks.csproj
@@ -47,6 +47,7 @@
     <Compile Include="CalibrationTests.cs" />
     <Compile Include="Query\FuncletizationTests.cs" />
     <Compile Include="Query\Profile.cs" />
+    <Compile Include="Query\QueryCompilationTests.cs" />
     <Compile Include="Query\SimpleQueryTests.cs" />
     <Compile Include="UpdatePipeline\SimpleUpdatePipelineTests.cs" />
   </ItemGroup>

--- a/test/EntityFramework.Microbenchmarks/Models/Orders/OrdersFixture.cs
+++ b/test/EntityFramework.Microbenchmarks/Models/Orders/OrdersFixture.cs
@@ -31,9 +31,9 @@ namespace EntityFramework.Microbenchmarks.Models.Orders
 
         public string ConnectionString { get; }
 
-        public OrdersContext CreateContext(bool disableBatching = false)
+        public virtual OrdersContext CreateContext()
         {
-            return new OrdersContext(ConnectionString, disableBatching);
+            return new OrdersContext(ConnectionString);
         }
 
         private void EnsureDatabaseCreated()

--- a/test/EntityFramework.Microbenchmarks/Query/QueryCompilationTests.cs
+++ b/test/EntityFramework.Microbenchmarks/Query/QueryCompilationTests.cs
@@ -1,0 +1,121 @@
+﻿using EntityFramework.Microbenchmarks.Core;
+using EntityFramework.Microbenchmarks.Models.Orders;
+using Microsoft.Data.Entity;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace EntityFramework.Microbenchmarks.Query
+{
+    class QueryCompilationTests : IClassFixture<QueryCompilationTests.QueryCompilationFixture>
+    {
+        private readonly QueryCompilationFixture _fixture;
+
+        public QueryCompilationTests(QueryCompilationFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Benchmark]
+        [BenchmarkVariation("Default (10 queries)")]
+        public void ToList(IMetricCollector collector)
+        {
+            using (var context = _fixture.CreateContext())
+            {
+                var query = context.Products
+                    .AsNoTracking();
+
+                using (collector.StartCollection())
+                {
+                    for (var i = 0; i < 10; i++)
+                    {
+                        query.ToList();
+                    }
+                }
+
+                Assert.Equal(0, query.Count());
+            }
+        }
+
+        [Benchmark]
+        [BenchmarkVariation("Default (10 queries)")]
+        public void FilterOrderProject(IMetricCollector collector)
+        {
+            using (var context = _fixture.CreateContext())
+            {
+                var query = context.Products
+                    .AsNoTracking()
+                    .Where(p => p.Retail < 1000)
+                    .OrderBy(p => p.Name).ThenBy(p => p.Retail)
+                    .Select(p => new
+                    {
+                        p.ProductId,
+                        p.Name,
+                        p.Description,
+                        p.ActualStockLevel,
+                        p.SKU,
+                        Savings = p.Retail - p.CurrentPrice,
+                        Surplus = p.ActualStockLevel - p.TargetStockLevel
+                    });
+
+                using (collector.StartCollection())
+                {
+                    for (var i = 0; i < 10; i++)
+                    {
+                        query.ToList();
+                    }
+                }
+
+                Assert.Equal(0, query.Count());
+            }
+        }
+
+        public class QueryCompilationFixture : OrdersFixture
+        {
+            private readonly IServiceProvider _noQueryCacheServiceProvider;
+
+            public QueryCompilationFixture()
+                : base("Perf_Query_Compilation", 0, 0, 0, 0)
+            {
+                var collection = new ServiceCollection();
+                collection.AddEntityFramework().AddSqlServer();
+                collection.AddSingleton<IMemoryCache, NonCachingMemoryCache>();
+                _noQueryCacheServiceProvider = collection.BuildServiceProvider();
+            }
+
+            public override OrdersContext CreateContext()
+            {
+                return new OrdersContext(_noQueryCacheServiceProvider, ConnectionString);
+            }
+
+            private class NonCachingMemoryCache : IMemoryCache
+            {
+                public bool TryGetValue(object key, out object value)
+                {
+                    value = null;
+                    return false;
+                }
+
+                public object Set(object key, object value, MemoryCacheEntryOptions options)
+                {
+                    return value;
+                }
+
+                public void Remove(object key)
+                {
+                }
+
+                public IEntryLink CreateLinkingScope()
+                {
+                    throw new NotImplementedException();
+                }
+
+                public void Dispose()
+                {
+                }
+            }
+        }
+    }
+}

--- a/test/EntityFramework.Microbenchmarks/Query/SimpleQueryTests.cs
+++ b/test/EntityFramework.Microbenchmarks/Query/SimpleQueryTests.cs
@@ -6,8 +6,6 @@ using System.Linq;
 using EntityFramework.Microbenchmarks.Core;
 using EntityFramework.Microbenchmarks.Models.Orders;
 using Microsoft.Data.Entity;
-using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace EntityFramework.Microbenchmarks.Query
@@ -23,13 +21,11 @@ namespace EntityFramework.Microbenchmarks.Query
         }
 
         [Benchmark]
-        [BenchmarkVariation("Tracking On (1 query)", true, true, 1)]
-        [BenchmarkVariation("Tracking Off (10 queries)", false, true, 10)]
-        [BenchmarkVariation("Tracking On, Query Cache Off (1 query)", true, false, 1)]
-        [BenchmarkVariation("Tracking Off, Query Cache Off (10 queries)", false, false, 10)]
-        public void LoadAll(IMetricCollector collector, bool tracking, bool caching, int queriesPerIteration)
+        [BenchmarkVariation("Tracking On (1 query)", true, 1)]
+        [BenchmarkVariation("Tracking Off (10 queries)", false, 10)]
+        public void LoadAll(IMetricCollector collector, bool tracking, int queriesPerIteration)
         {
-            using (var context = _fixture.CreateContext(queryCachingEnabled: caching))
+            using (var context = _fixture.CreateContext())
             {
                 var query = context.Products.ApplyTracking(tracking);
 
@@ -47,13 +43,11 @@ namespace EntityFramework.Microbenchmarks.Query
         }
 
         [Benchmark]
-        [BenchmarkVariation("Tracking On (1 query)", true, true, 1)]
-        [BenchmarkVariation("Tracking Off (10 queries)", false, true, 10)]
-        [BenchmarkVariation("Tracking On, Query Cache Off (1 query)", true, false, 1)]
-        [BenchmarkVariation("Tracking Off, Query Cache Off (10 queries)", false, false, 10)]
-        public void Where(IMetricCollector collector, bool tracking, bool caching, int queriesPerIteration)
+        [BenchmarkVariation("Tracking On (1 query)", true, 1)]
+        [BenchmarkVariation("Tracking Off (10 queries)", false, 10)]
+        public void Where(IMetricCollector collector, bool tracking, int queriesPerIteration)
         {
-            using (var context = _fixture.CreateContext(queryCachingEnabled: caching))
+            using (var context = _fixture.CreateContext())
             {
                 var query = context.Products
                     .ApplyTracking(tracking)
@@ -73,13 +67,11 @@ namespace EntityFramework.Microbenchmarks.Query
         }
 
         [Benchmark]
-        [BenchmarkVariation("Tracking On (1 query)", true, true, 1)]
-        [BenchmarkVariation("Tracking Off (10 queries)", false, true, 10)]
-        [BenchmarkVariation("Tracking On, Query Cache Off  (1 query)", true, false, 1)]
-        [BenchmarkVariation("Tracking Off, Query Cache Off (10 queries)", false, false, 10)]
-        public void OrderBy(IMetricCollector collector, bool tracking, bool caching, int queriesPerIteration)
+        [BenchmarkVariation("Tracking On (1 query)", true, 1)]
+        [BenchmarkVariation("Tracking Off (10 queries)", false, 10)]
+        public void OrderBy(IMetricCollector collector, bool tracking, int queriesPerIteration)
         {
-            using (var context = _fixture.CreateContext(queryCachingEnabled: caching))
+            using (var context = _fixture.CreateContext())
             {
                 var query = context.Products
                     .ApplyTracking(tracking)
@@ -99,11 +91,10 @@ namespace EntityFramework.Microbenchmarks.Query
         }
 
         [Benchmark]
-        [BenchmarkVariation("Default (100 queries)", true, 100)]
-        [BenchmarkVariation("Query Cache Off (100 queries)", false, 100)]
-        public void Count(IMetricCollector collector, bool caching, int queriesPerIteration)
+        [BenchmarkVariation("Default (100 queries)", 100)]
+        public void Count(IMetricCollector collector, int queriesPerIteration)
         {
-            using (var context = _fixture.CreateContext(queryCachingEnabled: caching))
+            using (var context = _fixture.CreateContext())
             {
                 var query = context.Products;
 
@@ -120,13 +111,11 @@ namespace EntityFramework.Microbenchmarks.Query
         }
 
         [Benchmark]
-        [BenchmarkVariation("Tracking On (1 query)", true, true, 1)]
-        [BenchmarkVariation("Tracking Off (10 queries)", false, true, 10)]
-        [BenchmarkVariation("Tracking On, Query Cache Off  (1 query)", true, false, 1)]
-        [BenchmarkVariation("Tracking Off, Query Cache Off (10 queries)", false, false, 10)]
-        public void SkipTake(IMetricCollector collector, bool tracking, bool caching, int queriesPerIteration)
+        [BenchmarkVariation("Tracking On (1 query)", true, 1)]
+        [BenchmarkVariation("Tracking Off (10 queries)", false, 10)]
+        public void SkipTake(IMetricCollector collector, bool tracking, int queriesPerIteration)
         {
-            using (var context = _fixture.CreateContext(queryCachingEnabled: caching))
+            using (var context = _fixture.CreateContext())
             {
                 var query = context.Products
                     .ApplyTracking(tracking)
@@ -147,11 +136,10 @@ namespace EntityFramework.Microbenchmarks.Query
         }
 
         [Benchmark]
-        [BenchmarkVariation("Default (10 queries)", true, 10)]
-        [BenchmarkVariation("Query Cache Off (10 queries)", false, 10)]
-        public void GroupBy(IMetricCollector collector, bool caching, int queriesPerIteration)
+        [BenchmarkVariation("Default (10 queries)", 10)]
+        public void GroupBy(IMetricCollector collector, int queriesPerIteration)
         {
-            using (var context = _fixture.CreateContext(queryCachingEnabled: caching))
+            using (var context = _fixture.CreateContext())
             {
                 var query = context.Products
                     .GroupBy(p => p.Retail)
@@ -176,13 +164,11 @@ namespace EntityFramework.Microbenchmarks.Query
         }
 
         [Benchmark]
-        [BenchmarkVariation("Tracking On (1 query)", true, true, 1)]
-        [BenchmarkVariation("Tracking Off (1 query)", false, true, 1)]
-        [BenchmarkVariation("Tracking On, Query Cache Off  (1 query)", true, false, 1)]
-        [BenchmarkVariation("Tracking Off, Query Cache Off  (1 query)", false, false, 1)]
-        public void Include(IMetricCollector collector, bool tracking, bool caching, int queriesPerIteration)
+        [BenchmarkVariation("Tracking On (1 query)", true, 1)]
+        [BenchmarkVariation("Tracking Off (1 query)", false, 1)]
+        public void Include(IMetricCollector collector, bool tracking, int queriesPerIteration)
         {
-            using (var context = _fixture.CreateContext(queryCachingEnabled: caching))
+            using (var context = _fixture.CreateContext())
             {
                 var query = context.Customers
                     .ApplyTracking(tracking)
@@ -204,11 +190,10 @@ namespace EntityFramework.Microbenchmarks.Query
         }
 
         [Benchmark]
-        [BenchmarkVariation("Default (10 queries)", true, 10)]
-        [BenchmarkVariation("Query Cache Off (10 queries)", false, 10)]
-        public void Projection(IMetricCollector collector, bool caching, int queriesPerIteration)
+        [BenchmarkVariation("Default (10 queries)", 10)]
+        public void Projection(IMetricCollector collector, int queriesPerIteration)
         {
-            using (var context = _fixture.CreateContext(queryCachingEnabled: caching))
+            using (var context = _fixture.CreateContext())
             {
                 var query = context.Products
                     .Select(p => new
@@ -235,11 +220,10 @@ namespace EntityFramework.Microbenchmarks.Query
         }
 
         [Benchmark]
-        [BenchmarkVariation("Default (10 queries)", true, 10)]
-        [BenchmarkVariation("Query Cache Off (10 queries)", false, 10)]
-        public void ProjectionAcrossNavigation(IMetricCollector collector, bool caching, int queriesPerIteration)
+        [BenchmarkVariation("Default (10 queries)", 10)]
+        public void ProjectionAcrossNavigation(IMetricCollector collector, int queriesPerIteration)
         {
-            using (var context = _fixture.CreateContext(queryCachingEnabled: caching))
+            using (var context = _fixture.CreateContext())
             {
                 var query = context.Orders
                     .Select(o => new
@@ -271,49 +255,7 @@ namespace EntityFramework.Microbenchmarks.Query
 
             public SimpleQueryFixture()
                 : base("Perf_Query_Simple", 1000, 1000, 2, 2)
-            {
-                var collection = new ServiceCollection();
-                collection.AddEntityFramework().AddSqlServer();
-                collection.AddSingleton<IMemoryCache, NonCachingMemoryCache>();
-                _noQueryCacheServiceProvider = collection.BuildServiceProvider();
-            }
-
-            public OrdersContext CreateContext(bool disableBatching = false, bool queryCachingEnabled = true)
-            {
-                if (!queryCachingEnabled)
-                {
-                    return new OrdersContext(_noQueryCacheServiceProvider, ConnectionString, disableBatching);
-                }
-
-                return base.CreateContext(disableBatching);
-            }
-
-            private class NonCachingMemoryCache : IMemoryCache
-            {
-                public bool TryGetValue(object key, out object value)
-                {
-                    value = null;
-                    return false;
-                }
-
-                public object Set(object key, object value, MemoryCacheEntryOptions options)
-                {
-                    return value;
-                }
-
-                public void Remove(object key)
-                {
-                }
-
-                public IEntryLink CreateLinkingScope()
-                {
-                    throw new NotImplementedException();
-                }
-
-                public void Dispose()
-                {
-                }
-            }
+            { }
         }
     }
 }

--- a/test/EntityFramework.Microbenchmarks/UpdatePipeline/SimpleUpdatePipelineTests.cs
+++ b/test/EntityFramework.Microbenchmarks/UpdatePipeline/SimpleUpdatePipelineTests.cs
@@ -121,6 +121,11 @@ namespace EntityFramework.Microbenchmarks.UpdatePipeline
                 : base("Perf_UpdatePipeline_Simple", 0, 1000, 0, 0)
             {
             }
+
+            public OrdersContext CreateContext(bool disableBatching)
+            {
+                return new OrdersContext(ConnectionString, disableBatching);
+            }
         }
     }
 }


### PR DESCRIPTION
Removing compilation from general query tests and adding a separate
class with more targeted tests (we can add more as needed in the
future).

Also restructuring fixtures a little, so that scenario specific settings
(like disabling batching and disabling query cache) are handled in the
test class specific fixtures.