### PR TITLE
Stop using IKeyValue for composite keys

### DIFF
--- a/src/EntityFramework.Core/ChangeTracking/Internal/ChangeDetector.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/ChangeDetector.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
             foreach (var property in entityType.GetProperties())
             {
                 if ((property.GetOriginalValueIndex() >= 0)
-                    && !Equals(entry[property], entry.GetValue(property, ValueSource.Original)))
+                    && !Equals(entry[property], entry.GetOriginalValue(property)))
                 {
                     entry.SetPropertyModified(property);
                 }
@@ -139,7 +139,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
             if ((keys.Count > 0)
                 || (foreignKeys.Count > 0))
             {
-                var snapshotValue = entry.GetValue(property, ValueSource.RelationshipSnapshot);
+                var snapshotValue = entry.GetRelationshipSnapshotValue(property);
                 var currentValue = entry[property];
 
                 // Note that mutation of a byte[] key is not supported or detected, but two different instances
@@ -163,14 +163,14 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
                         stateManager.Notify.PrincipalKeyPropertyChanged(entry, property, snapshotValue, currentValue);
                     }
 
-                    entry.SetValue(property, currentValue, ValueSource.RelationshipSnapshot);
+                    entry.SetRelationshipSnapshotValue(property, currentValue);
                 }
             }
         }
 
         private void DetectNavigationChange(InternalEntityEntry entry, INavigation navigation)
         {
-            var snapshotValue = entry.GetValue(navigation, ValueSource.RelationshipSnapshot);
+            var snapshotValue = entry.GetRelationshipSnapshotValue(navigation);
             var currentValue = entry[navigation];
             var stateManager = entry.StateManager;
 
@@ -226,7 +226,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
                     added.Add(currentValue);
                 }
 
-                entry.SetValue(navigation, currentValue, ValueSource.RelationshipSnapshot);
+                entry.SetRelationshipSnapshotValue(navigation, currentValue);
             }
 
             foreach (var addedEntity in added)

--- a/src/EntityFramework.Core/ChangeTracking/Internal/CompositeDependentValueFactory.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/CompositeDependentValueFactory.cs
@@ -1,45 +1,68 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
 using JetBrains.Annotations;
-using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Data.Entity.Update;
 
 namespace Microsoft.Data.Entity.ChangeTracking.Internal
 {
-    public class CompositeDependentValueFactory : IDependentKeyValueFactory<IKeyValue>
+    public class CompositeDependentValueFactory : IDependentKeyValueFactory<object[]>
     {
-        private readonly IForeignKey _foreignKey;
+        private readonly IReadOnlyList<IProperty> _properties;
 
         public CompositeDependentValueFactory([NotNull] IForeignKey foreignKey)
         {
-            _foreignKey = foreignKey;
+            _properties = foreignKey.Properties;
         }
 
-        public virtual bool TryCreateFromBuffer(ValueBuffer valueBuffer, out IKeyValue key)
+        public virtual bool TryCreateFromBuffer(ValueBuffer valueBuffer, out object[] key)
         {
-            key = new CompositeKeyValueFactory(_foreignKey.PrincipalKey).Create(_foreignKey.Properties, valueBuffer);
-            return !key.IsInvalid;
+            key = new object[_properties.Count];
+            var index = 0;
+
+            foreach (var property in _properties)
+            {
+                if ((key[index++] = valueBuffer[property.GetIndex()]) == null)
+                {
+                    key = null;
+                    return false;
+                }
+            }
+
+            return true;
         }
 
-        public virtual bool TryCreateFromCurrentValues(InternalEntityEntry entry, out IKeyValue key)
-        {
-            key = entry.GetDependentKeyValue(_foreignKey);
-            return !key.IsInvalid;
-        }
+        public virtual bool TryCreateFromCurrentValues(InternalEntityEntry entry, out object[] key)
+            => TryCreateFromEntry(entry, (e, p) => e.GetCurrentValue(p), out key);
 
-        public virtual bool TryCreateFromOriginalValues(InternalEntityEntry entry, out IKeyValue key)
-        {
-            key = entry.GetDependentKeyValue(_foreignKey, ValueSource.Original);
-            return !key.IsInvalid;
-        }
+        public virtual bool TryCreateFromOriginalValues(InternalEntityEntry entry, out object[] key)
+            => TryCreateFromEntry(entry, (e, p) => e.GetOriginalValue(p), out key);
 
-        public virtual bool TryCreateFromRelationshipSnapshot(InternalEntityEntry entry, out IKeyValue key)
+        public virtual bool TryCreateFromRelationshipSnapshot(InternalEntityEntry entry, out object[] key)
+            => TryCreateFromEntry(entry, (e, p) => e.GetRelationshipSnapshotValue(p), out key);
+
+        private bool TryCreateFromEntry(
+            InternalEntityEntry entry,
+            Func<InternalEntityEntry, IProperty, object> getValue,
+            out object[] key)
         {
-            key = entry.GetDependentKeyValue(_foreignKey, ValueSource.RelationshipSnapshot);
-            return !key.IsInvalid;
+            key = new object[_properties.Count];
+            var index = 0;
+
+            foreach (var property in _properties)
+            {
+                if ((key[index++] = getValue(entry, property)) == null)
+                {
+                    key = null;
+                    return false;
+                }
+            }
+
+            return true;
         }
     }
 }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/CompositePrincipalKeyValueFactory.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/CompositePrincipalKeyValueFactory.cs
@@ -1,37 +1,152 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using JetBrains.Annotations;
-using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Data.Entity.Update;
 
 namespace Microsoft.Data.Entity.ChangeTracking.Internal
 {
-    public class CompositePrincipalKeyValueFactory : IPrincipalKeyValueFactory<IKeyValue>
+    public class CompositePrincipalKeyValueFactory : IPrincipalKeyValueFactory<object[]>
     {
-        private readonly IKey _key;
+        private readonly IReadOnlyList<IProperty> _properties;
 
         public CompositePrincipalKeyValueFactory([NotNull] IKey key)
         {
-            _key = key;
+            _properties = key.Properties;
+
+            var structuralTypeInfo = typeof(IStructuralEquatable).GetTypeInfo();
+
+            EqualityComparer = _properties.Any(p => structuralTypeInfo.IsAssignableFrom(p.ClrType.GetTypeInfo()))
+                ? (IEqualityComparer<object[]>)new StructuralCompositeComparer()
+                : new CompositeComparer();
         }
 
         public virtual object CreateFromBuffer(ValueBuffer valueBuffer)
         {
-            var value = new CompositeKeyValueFactory(_key).Create(valueBuffer);
-            return value.IsInvalid ? null : value;
+            var values = new object[_properties.Count];
+            var index = 0;
+
+            foreach (var property in _properties)
+            {
+                if ((values[index++] = valueBuffer[property.GetIndex()]) == null)
+                {
+                    return null;
+                }
+            }
+
+            return values;
         }
 
-        public virtual IKeyValue CreateFromCurrentValues(InternalEntityEntry entry)
-            => entry.GetPrincipalKeyValue(_key);
+        public virtual object[] CreateFromCurrentValues(InternalEntityEntry entry)
+            => CreateFromEntry(entry, (e, p) => e.GetCurrentValue(p));
 
-        public virtual IKeyValue CreateFromOriginalValues(InternalEntityEntry entry)
-            => entry.GetPrincipalKeyValue(_key, ValueSource.Original);
+        public virtual object[] CreateFromOriginalValues(InternalEntityEntry entry)
+            => CreateFromEntry(entry, (e, p) => e.GetOriginalValue(p));
 
-        public virtual IKeyValue CreateFromRelationshipSnapshot(InternalEntityEntry entry)
-            => entry.GetPrincipalKeyValue(_key, ValueSource.RelationshipSnapshot);
+        public virtual object[] CreateFromRelationshipSnapshot(InternalEntityEntry entry)
+            => CreateFromEntry(entry, (e, p) => e.GetRelationshipSnapshotValue(p));
+
+        private object[] CreateFromEntry(
+            InternalEntityEntry entry,
+            Func<InternalEntityEntry, IProperty, object> getValue)
+        {
+            var values = new object[_properties.Count];
+            var index = 0;
+
+            foreach (var property in _properties)
+            {
+                values[index++] = getValue(entry, property);
+            }
+
+            return values;
+        }
+
+        public virtual IEqualityComparer<object[]> EqualityComparer { get; }
+
+        private sealed class CompositeComparer : IEqualityComparer<object[]>
+        {
+            public bool Equals(object[] x, object[] y)
+            {
+                if (ReferenceEquals(x, y))
+                {
+                    return true;
+                }
+
+                if (x.Length != y.Length)
+                {
+                    return false;
+                }
+
+                for (var i = 0; i < x.Length; i++)
+                {
+                    if (!x[i].Equals(y[i]))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            public int GetHashCode(object[] obj)
+            {
+                var hashCode = 0;
+
+                for (var i = 0; i < obj.Length; i++)
+                {
+                    hashCode = (hashCode * 397) ^ obj[i].GetHashCode();
+                }
+
+                return hashCode;
+            }
+        }
+
+        private sealed class StructuralCompositeComparer : IEqualityComparer<object[]>
+        {
+            private readonly IEqualityComparer _structuralEqualityComparer
+                = StructuralComparisons.StructuralEqualityComparer;
+
+            public bool Equals(object[] x, object[] y)
+            {
+                if (ReferenceEquals(x, y))
+                {
+                    return true;
+                }
+
+                if (x.Length != y.Length)
+                {
+                    return false;
+                }
+
+                for (var i = 0; i < x.Length; i++)
+                {
+                    if (!_structuralEqualityComparer.Equals(x[i], y[i]))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            public int GetHashCode(object[] obj)
+            {
+                var hashCode = 0;
+
+                for (var i = 0; i < obj.Length; i++)
+                {
+                    hashCode = (hashCode * 397) ^ _structuralEqualityComparer.GetHashCode(obj[i]);
+                }
+
+                return hashCode;
+            }
+        }
     }
 }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/DependentKeyValueFactoryFactory.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/DependentKeyValueFactoryFactory.cs
@@ -2,11 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections;
 using System.Linq;
-using System.Reflection;
 using JetBrains.Annotations;
-using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Metadata.Internal;
 
@@ -15,18 +12,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
     public class DependentKeyValueFactoryFactory
     {
         public virtual IDependentKeyValueFactory<TKey> Create<TKey>([NotNull] IForeignKey foreignKey)
-        {
-            if (foreignKey.Properties.Count == 1)
-            {
-                var keyType = foreignKey.PrincipalKey.Properties.Single().ClrType;
-                if (!typeof(IStructuralEquatable).GetTypeInfo().IsAssignableFrom(keyType.GetTypeInfo()))
-                {
-                    return CreateSimple<TKey>(foreignKey);
-                }
-            }
-
-            return (IDependentKeyValueFactory<TKey>)CreateComposite(foreignKey);
-        }
+            => foreignKey.Properties.Count == 1
+                ? CreateSimple<TKey>(foreignKey)
+                : (IDependentKeyValueFactory<TKey>)CreateComposite(foreignKey);
 
         public virtual IDependentKeyValueFactory<TKey> CreateSimple<TKey>([NotNull] IForeignKey foreignKey)
         {
@@ -34,7 +22,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
             var principalType = foreignKey.PrincipalKey.Properties.Single().ClrType;
             var propertyAccessors = dependentProperty.GetPropertyAccessors();
 
-            if (dependentProperty.ClrType.IsNullableType() 
+            if (dependentProperty.ClrType.IsNullableType()
                 && principalType.IsNullableType())
             {
                 return new SimpleFullyNullableDependentKeyValueFactory<TKey>(propertyAccessors);
@@ -57,7 +45,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
             return new SimpleNonNullableDependentKeyValueFactory<TKey>(propertyAccessors);
         }
 
-        public virtual IDependentKeyValueFactory<IKeyValue> CreateComposite([NotNull] IForeignKey foreignKey)
+        public virtual IDependentKeyValueFactory<object[]> CreateComposite([NotNull] IForeignKey foreignKey)
             => new CompositeDependentValueFactory(foreignKey);
     }
 }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/IDependentKeyValueFactory.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/IDependentKeyValueFactory.cs
@@ -8,9 +8,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 {
     public interface IDependentKeyValueFactory<TKey>
     {
-        bool TryCreateFromBuffer(ValueBuffer valueBuffer, [NotNull] out TKey key);
-        bool TryCreateFromCurrentValues([NotNull] InternalEntityEntry entry, [NotNull] out TKey key);
-        bool TryCreateFromOriginalValues([NotNull] InternalEntityEntry entry, [NotNull] out TKey key);
-        bool TryCreateFromRelationshipSnapshot([NotNull] InternalEntityEntry entry, [NotNull] out TKey key);
+        bool TryCreateFromBuffer(ValueBuffer valueBuffer, [CanBeNull] out TKey key);
+        bool TryCreateFromCurrentValues([NotNull] InternalEntityEntry entry, [CanBeNull] out TKey key);
+        bool TryCreateFromOriginalValues([NotNull] InternalEntityEntry entry, [CanBeNull] out TKey key);
+        bool TryCreateFromRelationshipSnapshot([NotNull] InternalEntityEntry entry, [CanBeNull] out TKey key);
     }
 }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/IPrincipalKeyValueFactory.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/IPrincipalKeyValueFactory.cs
@@ -1,16 +1,18 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Storage;
 
 namespace Microsoft.Data.Entity.ChangeTracking.Internal
 {
-    public interface IPrincipalKeyValueFactory<out TKey>
+    public interface IPrincipalKeyValueFactory<TKey>
     {
         object CreateFromBuffer(ValueBuffer valueBuffer);
         TKey CreateFromCurrentValues([NotNull] InternalEntityEntry entry);
         TKey CreateFromOriginalValues([NotNull] InternalEntityEntry entry);
         TKey CreateFromRelationshipSnapshot([NotNull] InternalEntityEntry entry);
+        IEqualityComparer<TKey> EqualityComparer { get; }
     }
 }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/IdentityMap.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/IdentityMap.cs
@@ -13,8 +13,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 {
     public class IdentityMap<TKey> : IIdentityMap
     {
-        private readonly Dictionary<TKey, InternalEntityEntry> _identityMap
-            = new Dictionary<TKey, InternalEntityEntry>();
+        private readonly Dictionary<TKey, InternalEntityEntry> _identityMap;
         
         public IdentityMap(
             [NotNull] IKey key,
@@ -22,6 +21,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         {
             Key = key;
             PrincipalKeyValueFactory = principalKeyValueFactory;
+            _identityMap = new Dictionary<TKey, InternalEntityEntry>(principalKeyValueFactory.EqualityComparer);
         }
 
         protected virtual IPrincipalKeyValueFactory<TKey> PrincipalKeyValueFactory { get; }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/IdentityMapFactoryFactoryBase.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/IdentityMapFactoryFactoryBase.cs
@@ -2,11 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections;
 using System.Linq;
-using System.Reflection;
 using JetBrains.Annotations;
-using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 
 namespace Microsoft.Data.Entity.ChangeTracking.Internal
@@ -14,12 +11,6 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
     public abstract class IdentityMapFactoryFactoryBase
     {
         protected virtual Type GetKeyType([NotNull] IKey key)
-        {
-            var keyType = key.Properties.First().ClrType;
-            return key.Properties.Count > 1
-                   || typeof(IStructuralEquatable).GetTypeInfo().IsAssignableFrom(keyType.GetTypeInfo())
-                ? typeof(IKeyValue)
-                : keyType;
-        }
+            => key.Properties.Count > 1 ? typeof(object[]) : key.Properties.First().ClrType;
     }
 }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/KeyValueFactoryFactory.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/KeyValueFactoryFactory.cs
@@ -1,9 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections;
 using System.Linq;
-using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Metadata.Internal;
@@ -13,18 +11,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
     public class KeyValueFactoryFactory
     {
         public virtual IPrincipalKeyValueFactory<TKey> Create<TKey>([NotNull] IKey key)
-        {
-            if (key.Properties.Count == 1)
-            {
-                var keyType = key.Properties.Single().ClrType;
-                if (!typeof(IStructuralEquatable).GetTypeInfo().IsAssignableFrom(keyType.GetTypeInfo()))
-                {
-                    return CreateSimpleFactory<TKey>(key);
-                }
-            }
-
-            return (IPrincipalKeyValueFactory<TKey>)CreateCompositeFactory(key);
-        }
+            => key.Properties.Count == 1
+                ? CreateSimpleFactory<TKey>(key)
+                : (IPrincipalKeyValueFactory<TKey>)CreateCompositeFactory(key);
 
         [UsedImplicitly]
         private static SimplePrincipalKeyValueFactory<TKey> CreateSimpleFactory<TKey>(IKey key)

--- a/src/EntityFramework.Core/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/NavigationFixer.cs
@@ -353,7 +353,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
                     foreach (var dependent in dependentEntries)
                     {
                         setter.SetClrValue(dependent.Entity, principalEntry.Entity);
-                        dependent.SetValue(navigation, principalEntry.Entity, ValueSource.RelationshipSnapshot);
+                        dependent.SetRelationshipSnapshotValue(navigation, principalEntry.Entity);
                     }
                 }
                 else
@@ -378,7 +378,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
                         // Issue #739
                         var value = dependentEntries.Single().Entity;
                         navigation.GetSetter().SetClrValue(principalEntry.Entity, value);
-                        principalEntry.SetValue(navigation, value, ValueSource.RelationshipSnapshot);
+                        principalEntry.SetRelationshipSnapshotValue(navigation, value);
                     }
                 }
             }
@@ -400,7 +400,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
             {
                 navigation.GetSetter().SetClrValue(dependentEntity, null);
 
-                dependentEntry.SetValue(navigation, null, ValueSource.RelationshipSnapshot);
+                dependentEntry.SetRelationshipSnapshotValue(navigation, null);
             }
             else
             {
@@ -416,7 +416,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
                 else
                 {
                     navigation.GetSetter().SetClrValue(oldPrincipalEntry.Entity, null);
-                    oldPrincipalEntry.SetValue(navigation, null, ValueSource.RelationshipSnapshot);
+                    oldPrincipalEntry.SetRelationshipSnapshotValue(navigation, null);
                 }
             }
         }
@@ -427,7 +427,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
             if (navigation != null)
             {
                 navigation.GetSetter().SetClrValue(dependentEntry.Entity, null);
-                dependentEntry.SetValue(navigation, null, ValueSource.RelationshipSnapshot);
+                dependentEntry.SetRelationshipSnapshotValue(navigation, null);
             }
 
             foreach (var property in foreignKey.Properties.Where(p => p.IsNullable).ToList())
@@ -452,7 +452,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
                 {
                     var dependentProperty = foreignKey.Properties[i];
                     dependentEntry[dependentProperty] = principalValue;
-                    dependentEntry.SetValue(dependentProperty, principalValue, ValueSource.RelationshipSnapshot);
+                    dependentEntry.SetRelationshipSnapshotValue(dependentProperty, principalValue);
                 }
             }
         }
@@ -477,7 +477,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
             foreach (var dependentProperty in dependentProperties)
             {
                 dependentEntry[dependentProperty] = null;
-                dependentEntry.SetValue(dependentProperty, null, ValueSource.RelationshipSnapshot);
+                dependentEntry.SetRelationshipSnapshotValue(dependentProperty, null);
             }
         }
 
@@ -518,7 +518,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
                     }
 
                     inverse.GetSetter().SetClrValue(entity, entry.Entity);
-                    inverseEntry.SetValue(inverse, entry.Entity, ValueSource.RelationshipSnapshot);
+                    inverseEntry.SetRelationshipSnapshotValue(inverse, entry.Entity);
                 }
             }
         }
@@ -539,7 +539,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
                     if (ReferenceEquals(inverse.GetGetter().GetClrValue(entity), entry.Entity))
                     {
                         inverse.GetSetter().SetClrValue(entity, null);
-                        entry.StateManager.GetOrCreateEntry(entity).SetValue(inverse, null, ValueSource.RelationshipSnapshot);
+                        entry.StateManager.GetOrCreateEntry(entity).SetRelationshipSnapshotValue(inverse, null);
                     }
                 }
             }

--- a/src/EntityFramework.Core/ChangeTracking/PropertyEntry.cs
+++ b/src/EntityFramework.Core/ChangeTracking/PropertyEntry.cs
@@ -86,8 +86,8 @@ namespace Microsoft.Data.Entity.ChangeTracking
         /// </summary>
         public virtual object OriginalValue
         {
-            get { return _internalEntry.GetValue(Metadata, ValueSource.Original); }
-            [param: CanBeNull] set { _internalEntry.SetValue(Metadata, value, ValueSource.Original); }
+            get { return _internalEntry.GetOriginalValue(Metadata); }
+            [param: CanBeNull] set { _internalEntry.SetOriginalValue(Metadata, value); }
         }
 
         InternalEntityEntry IInfrastructure<InternalEntityEntry>.Instance => _internalEntry;

--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -319,6 +319,7 @@
     <Compile Include="Query\Internal\ICompiledQueryCache.cs" />
     <Compile Include="Query\Internal\IIncludeKeyComparer.cs" />
     <Compile Include="Query\Internal\IWeakReferenceIdentityMap.cs" />
+    <Compile Include="Query\Internal\NullIncludeComparer.cs" />
     <Compile Include="Query\Internal\PrincipalToDependentIncludeComparer.cs" />
     <Compile Include="Query\Internal\QueryAnnotationExtractor.cs" />
     <Compile Include="Query\Internal\QueryBuffer.cs" />

--- a/src/EntityFramework.Core/Query/Internal/DependentToPrincipalIncludeComparer.cs
+++ b/src/EntityFramework.Core/Query/Internal/DependentToPrincipalIncludeComparer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Storage;
@@ -11,6 +12,7 @@ namespace Microsoft.Data.Entity.Query.Internal
     {
         private readonly TKey _dependentKeyValue;
         private readonly IPrincipalKeyValueFactory<TKey> _principalKeyValueFactory;
+        private readonly IEqualityComparer<TKey> _equalityComparer;
 
         public DependentToPrincipalIncludeComparer(
             [NotNull] TKey dependentKeyValue,
@@ -18,9 +20,12 @@ namespace Microsoft.Data.Entity.Query.Internal
         {
             _dependentKeyValue = dependentKeyValue;
             _principalKeyValueFactory = principalKeyValueFactory;
+            _equalityComparer = principalKeyValueFactory.EqualityComparer;
         }
 
         public virtual bool ShouldInclude(ValueBuffer valueBuffer)
-            => ((TKey)_principalKeyValueFactory.CreateFromBuffer(valueBuffer)).Equals(_dependentKeyValue);
+            => _equalityComparer.Equals(
+                (TKey)_principalKeyValueFactory.CreateFromBuffer(valueBuffer),
+                _dependentKeyValue);
     }
 }

--- a/src/EntityFramework.Core/Query/Internal/NullIncludeComparer.cs
+++ b/src/EntityFramework.Core/Query/Internal/NullIncludeComparer.cs
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Storage;
+
+namespace Microsoft.Data.Entity.Query.Internal
+{
+    public class NullIncludeComparer : IIncludeKeyComparer
+    {
+        public virtual bool ShouldInclude(ValueBuffer valueBuffer) => false;
+    }
+}

--- a/src/EntityFramework.Core/Query/Internal/PrincipalToDependentIncludeComparer.cs
+++ b/src/EntityFramework.Core/Query/Internal/PrincipalToDependentIncludeComparer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Storage;
@@ -11,20 +12,23 @@ namespace Microsoft.Data.Entity.Query.Internal
     {
         private readonly TKey _principalKeyValue;
         private readonly IDependentKeyValueFactory<TKey> _dependentKeyValueFactory;
+        private readonly IEqualityComparer<TKey> _equalityComparer;
 
         public PrincipalToDependentIncludeComparer(
             [NotNull] TKey principalKeyValue,
-            [NotNull] IDependentKeyValueFactory<TKey> dependentKeyValueFactory)
+            [NotNull] IDependentKeyValueFactory<TKey> dependentKeyValueFactory,
+            [NotNull] IPrincipalKeyValueFactory<TKey> principalKeyValueFactory)
         {
             _principalKeyValue = principalKeyValue;
             _dependentKeyValueFactory = dependentKeyValueFactory;
+            _equalityComparer = principalKeyValueFactory.EqualityComparer;
         }
 
         public virtual bool ShouldInclude(ValueBuffer valueBuffer)
         {
             TKey key;
             return _dependentKeyValueFactory.TryCreateFromBuffer(valueBuffer, out key)
-                   && key.Equals(_principalKeyValue);
+                   && _equalityComparer.Equals(key, _principalKeyValue);
         }
     }
 }

--- a/src/EntityFramework.InMemory/Query/ExpressionVisitors/Internal/InMemoryEntityQueryableExpressionVisitor.cs
+++ b/src/EntityFramework.InMemory/Query/ExpressionVisitors/Internal/InMemoryEntityQueryableExpressionVisitor.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
-using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Query.Internal;
 using Microsoft.Data.Entity.Utilities;
@@ -15,24 +14,20 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors.Internal
     public class InMemoryEntityQueryableExpressionVisitor : EntityQueryableExpressionVisitor
     {
         private readonly IModel _model;
-        private readonly IKeyValueFactorySource _keyValueFactorySource;
         private readonly IMaterializerFactory _materializerFactory;
         private readonly IQuerySource _querySource;
 
         public InMemoryEntityQueryableExpressionVisitor(
             [NotNull] IModel model,
-            [NotNull] IKeyValueFactorySource keyValueFactorySource,
             [NotNull] IMaterializerFactory materializerFactory,
             [NotNull] EntityQueryModelVisitor entityQueryModelVisitor,
             [CanBeNull] IQuerySource querySource)
             : base(Check.NotNull(entityQueryModelVisitor, nameof(entityQueryModelVisitor)))
         {
             Check.NotNull(model, nameof(model));
-            Check.NotNull(keyValueFactorySource, nameof(keyValueFactorySource));
             Check.NotNull(materializerFactory, nameof(materializerFactory));
 
             _model = model;
-            _keyValueFactorySource = keyValueFactorySource;
             _materializerFactory = materializerFactory;
             _querySource = querySource;
         }

--- a/src/EntityFramework.InMemory/Query/ExpressionVisitors/Internal/InMemoryEntityQueryableExpressionVisitorFactory.cs
+++ b/src/EntityFramework.InMemory/Query/ExpressionVisitors/Internal/InMemoryEntityQueryableExpressionVisitorFactory.cs
@@ -3,7 +3,6 @@
 
 using System.Linq.Expressions;
 using JetBrains.Annotations;
-using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Query.Internal;
 using Microsoft.Data.Entity.Utilities;
@@ -14,20 +13,16 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors.Internal
     public class InMemoryEntityQueryableExpressionVisitorFactory : IEntityQueryableExpressionVisitorFactory
     {
         private readonly IModel _model;
-        private readonly IKeyValueFactorySource _keyValueFactorySource;
         private readonly IMaterializerFactory _materializerFactory;
 
         public InMemoryEntityQueryableExpressionVisitorFactory(
             [NotNull] IModel model,
-            [NotNull] IKeyValueFactorySource keyValueFactorySource,
             [NotNull] IMaterializerFactory materializerFactory)
         {
             Check.NotNull(model, nameof(model));
-            Check.NotNull(keyValueFactorySource, nameof(keyValueFactorySource));
             Check.NotNull(materializerFactory, nameof(materializerFactory));
 
             _model = model;
-            _keyValueFactorySource = keyValueFactorySource;
             _materializerFactory = materializerFactory;
         }
 
@@ -35,7 +30,6 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors.Internal
             EntityQueryModelVisitor queryModelVisitor, IQuerySource querySource)
             => new InMemoryEntityQueryableExpressionVisitor(
                 _model,
-                _keyValueFactorySource,
                 _materializerFactory,
                 Check.NotNull(queryModelVisitor, nameof(queryModelVisitor)),
                 querySource);

--- a/src/EntityFramework.InMemory/Storage/Internal/InMemoryTable.cs
+++ b/src/EntityFramework.InMemory/Storage/Internal/InMemoryTable.cs
@@ -12,12 +12,12 @@ namespace Microsoft.Data.Entity.Storage.Internal
     public class InMemoryTable<TKey> : IInMemoryTable
     {
         private readonly IPrincipalKeyValueFactory<TKey> _keyValueFactory;
-
-        private readonly Dictionary<TKey, object[]> _rows = new Dictionary<TKey, object[]>();
+        private readonly Dictionary<TKey, object[]> _rows;
 
         public InMemoryTable([NotNull] IPrincipalKeyValueFactory<TKey> keyValueFactory)
         {
             _keyValueFactory = keyValueFactory;
+            _rows = new Dictionary<TKey, object[]>(keyValueFactory.EqualityComparer);
         }
 
         public virtual IReadOnlyList<object[]> SnapshotRows()
@@ -36,6 +36,6 @@ namespace Microsoft.Data.Entity.Storage.Internal
             => _keyValueFactory.CreateFromCurrentValues((InternalEntityEntry)entry);
 
         private static object[] CreateValueBuffer(IUpdateEntry entry)
-            => entry.EntityType.GetProperties().Select(p => entry.GetCurrentValue(p)).ToArray();
+            => entry.EntityType.GetProperties().Select(entry.GetCurrentValue).ToArray();
     }
 }

--- a/src/EntityFramework.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
-using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Metadata.Internal;
@@ -25,7 +24,6 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
     public class RelationalEntityQueryableExpressionVisitor : EntityQueryableExpressionVisitor
     {
         private readonly IModel _model;
-        private readonly IKeyValueFactorySource _keyValueFactorySource;
         private readonly ISelectExpressionFactory _selectExpressionFactory;
         private readonly IMaterializerFactory _materializerFactory;
         private readonly IShaperCommandContextFactory _shaperCommandContextFactory;
@@ -34,7 +32,6 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
 
         public RelationalEntityQueryableExpressionVisitor(
             [NotNull] IModel model,
-            [NotNull] IKeyValueFactorySource keyValueFactorySource,
             [NotNull] ISelectExpressionFactory selectExpressionFactory,
             [NotNull] IMaterializerFactory materializerFactory,
             [NotNull] IShaperCommandContextFactory shaperCommandContextFactory,
@@ -44,14 +41,12 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
             : base(Check.NotNull(queryModelVisitor, nameof(queryModelVisitor)))
         {
             Check.NotNull(model, nameof(model));
-            Check.NotNull(keyValueFactorySource, nameof(keyValueFactorySource));
             Check.NotNull(selectExpressionFactory, nameof(selectExpressionFactory));
             Check.NotNull(materializerFactory, nameof(materializerFactory));
             Check.NotNull(shaperCommandContextFactory, nameof(shaperCommandContextFactory));
             Check.NotNull(relationalAnnotationProvider, nameof(relationalAnnotationProvider));
 
             _model = model;
-            _keyValueFactorySource = keyValueFactorySource;
             _selectExpressionFactory = selectExpressionFactory;
             _materializerFactory = materializerFactory;
             _shaperCommandContextFactory = shaperCommandContextFactory;

--- a/src/EntityFramework.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitorFactory.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitorFactory.cs
@@ -3,7 +3,6 @@
 
 using System.Linq.Expressions;
 using JetBrains.Annotations;
-using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Query.Expressions;
 using Microsoft.Data.Entity.Query.ExpressionVisitors.Internal;
@@ -16,7 +15,6 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
     public class RelationalEntityQueryableExpressionVisitorFactory : IEntityQueryableExpressionVisitorFactory
     {
         private readonly IModel _model;
-        private readonly IKeyValueFactorySource _keyValueFactorySource;
         private readonly ISelectExpressionFactory _selectExpressionFactory;
         private readonly IMaterializerFactory _materializerFactory;
         private readonly IShaperCommandContextFactory _shaperCommandContextFactory;
@@ -24,21 +22,18 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
 
         public RelationalEntityQueryableExpressionVisitorFactory(
             [NotNull] IModel model,
-            [NotNull] IKeyValueFactorySource keyValueFactorySource,
             [NotNull] ISelectExpressionFactory selectExpressionFactory,
             [NotNull] IMaterializerFactory materializerFactory,
             [NotNull] IShaperCommandContextFactory shaperCommandContextFactory,
             [NotNull] IRelationalAnnotationProvider relationalAnnotationProvider)
         {
             Check.NotNull(model, nameof(model));
-            Check.NotNull(keyValueFactorySource, nameof(keyValueFactorySource));
             Check.NotNull(selectExpressionFactory, nameof(selectExpressionFactory));
             Check.NotNull(materializerFactory, nameof(materializerFactory));
             Check.NotNull(shaperCommandContextFactory, nameof(shaperCommandContextFactory));
             Check.NotNull(relationalAnnotationProvider, nameof(relationalAnnotationProvider));
 
             _model = model;
-            _keyValueFactorySource = keyValueFactorySource;
             _selectExpressionFactory = selectExpressionFactory;
             _materializerFactory = materializerFactory;
             _shaperCommandContextFactory = shaperCommandContextFactory;
@@ -49,7 +44,6 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
             EntityQueryModelVisitor queryModelVisitor, IQuerySource querySource)
             => new RelationalEntityQueryableExpressionVisitor(
                 _model,
-                _keyValueFactorySource,
                 _selectExpressionFactory,
                 _materializerFactory,
                 _shaperCommandContextFactory,

--- a/src/EntityFramework.Relational/Update/Internal/KeyValueIndexFactory.cs
+++ b/src/EntityFramework.Relational/Update/Internal/KeyValueIndexFactory.cs
@@ -18,24 +18,24 @@ namespace Microsoft.Data.Entity.Update.Internal
         }
 
         public virtual IKeyValueIndex CreatePrincipalKeyValue(InternalEntityEntry entry, IForeignKey foreignKey)
-        {
-            var principalKeyValue = _principalKeyValueFactory.CreateFromCurrentValues(entry);
-
-            return new KeyValueIndex<TKey>(foreignKey, principalKeyValue, fromOriginalValues: false);
-        }
+            => new KeyValueIndex<TKey>(
+                foreignKey,
+                _principalKeyValueFactory.CreateFromCurrentValues(entry),
+                _principalKeyValueFactory.EqualityComparer,
+                fromOriginalValues: false);
 
         public virtual IKeyValueIndex CreatePrincipalKeyValueFromOriginalValues(InternalEntityEntry entry, IForeignKey foreignKey)
-        {
-            var principalKeyValue = _principalKeyValueFactory.CreateFromOriginalValues(entry);
-
-            return new KeyValueIndex<TKey>(foreignKey, principalKeyValue, fromOriginalValues: true);
-        }
+            => new KeyValueIndex<TKey>(
+                foreignKey,
+                _principalKeyValueFactory.CreateFromOriginalValues(entry),
+                _principalKeyValueFactory.EqualityComparer,
+                fromOriginalValues: true);
 
         public virtual IKeyValueIndex CreateDependentKeyValue(InternalEntityEntry entry, IForeignKey foreignKey)
         {
             TKey keyValue;
             return GetDependentKeyValueFactory(foreignKey).TryCreateFromCurrentValues(entry, out keyValue)
-                ? new KeyValueIndex<TKey>(foreignKey, keyValue, fromOriginalValues: false)
+                ? new KeyValueIndex<TKey>(foreignKey, keyValue, _principalKeyValueFactory.EqualityComparer, fromOriginalValues: false)
                 : null;
         }
 
@@ -43,7 +43,7 @@ namespace Microsoft.Data.Entity.Update.Internal
         {
             TKey keyValue;
             return GetDependentKeyValueFactory(foreignKey).TryCreateFromOriginalValues(entry, out keyValue)
-                ? new KeyValueIndex<TKey>(foreignKey, keyValue, fromOriginalValues: true)
+                ? new KeyValueIndex<TKey>(foreignKey, keyValue, _principalKeyValueFactory.EqualityComparer, fromOriginalValues: true)
                 : null;
         }
 

--- a/test/EntityFramework.Core.FunctionalTests/OptimisticConcurrencyTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/OptimisticConcurrencyTestBase.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             foreach (var value in values)
             {
-                internalEntry.SetValue(value.Key, value.Value, ValueSource.Original);
+                internalEntry.SetOriginalValue(value.Key, value.Value);
             }
         }
 

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
@@ -52,14 +52,14 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             Assert.True(entry.HasRelationshipSnapshot);
 
-            Assert.Equal(77, entry.GetValue(property, ValueSource.RelationshipSnapshot));
-            Assert.Equal(77, entry.GetValue(property, ValueSource.Original));
+            Assert.Equal(77, entry.GetRelationshipSnapshotValue(property));
+            Assert.Equal(77, entry.GetOriginalValue(property));
             Assert.Equal(77, entry.GetCurrentValue(property));
 
             entity.DependentId = 777;
 
-            Assert.Equal(77, entry.GetValue(property, ValueSource.RelationshipSnapshot));
-            Assert.Equal(77, entry.GetValue(property, ValueSource.Original));
+            Assert.Equal(77, entry.GetRelationshipSnapshotValue(property));
+            Assert.Equal(77, entry.GetOriginalValue(property));
             Assert.Equal(777, entry.GetCurrentValue(property));
         }
 
@@ -78,14 +78,14 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
                 .GetRequiredService<IChangeDetector>()
                 .PropertyChanging(entry, property);
 
-            Assert.Equal("Cheese", entry.GetValue(property, ValueSource.RelationshipSnapshot));
-            Assert.Equal("Cheese", entry.GetValue(property, ValueSource.Original));
+            Assert.Equal("Cheese", entry.GetRelationshipSnapshotValue(property));
+            Assert.Equal("Cheese", entry.GetOriginalValue(property));
             Assert.Equal("Cheese", entry.GetCurrentValue(property));
 
             entity.Name = "Pickle";
 
-            Assert.Equal("Pickle", entry.GetValue(property, ValueSource.RelationshipSnapshot));
-            Assert.Equal("Pickle", entry.GetValue(property, ValueSource.Original));
+            Assert.Equal("Pickle", entry.GetRelationshipSnapshotValue(property));
+            Assert.Equal("Pickle", entry.GetOriginalValue(property));
             Assert.Equal("Pickle", entry.GetCurrentValue(property));
         }
 
@@ -108,12 +108,12 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             Assert.True(entry.HasRelationshipSnapshot);
 
-            Assert.Same(category, entry.GetValue(navigation, ValueSource.RelationshipSnapshot));
+            Assert.Same(category, entry.GetRelationshipSnapshotValue(navigation));
             Assert.Same(category, entry.GetCurrentValue(navigation));
 
             entity.Category = new CategoryWithChanging();
 
-            Assert.Same(category, entry.GetValue(navigation, ValueSource.RelationshipSnapshot));
+            Assert.Same(category, entry.GetRelationshipSnapshotValue(navigation));
             Assert.NotSame(category, entry.GetCurrentValue(navigation));
         }
 
@@ -135,14 +135,14 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             Assert.True(entry.HasRelationshipSnapshot);
 
-            Assert.Equal(77, entry.GetValue(property, ValueSource.RelationshipSnapshot));
-            Assert.Equal(77, entry.GetValue(property, ValueSource.Original));
+            Assert.Equal(77, entry.GetRelationshipSnapshotValue(property));
+            Assert.Equal(77, entry.GetOriginalValue(property));
             Assert.Equal(77, entry.GetCurrentValue(property));
 
             entity.Id = 777;
 
-            Assert.Equal(77, entry.GetValue(property, ValueSource.RelationshipSnapshot));
-            Assert.Equal(777, entry.GetValue(property, ValueSource.Original));
+            Assert.Equal(77, entry.GetRelationshipSnapshotValue(property));
+            Assert.Equal(777, entry.GetOriginalValue(property));
             Assert.Equal(777, entry.GetCurrentValue(property));
         }
 
@@ -200,7 +200,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             changeDetector.DetectChanges(entry);
 
-            Assert.Equal(78, entry.GetValue(entry.EntityType.FindProperty("PrincipalId"), ValueSource.RelationshipSnapshot));
+            Assert.Equal(78, entry.GetRelationshipSnapshotValue(entry.EntityType.FindProperty("PrincipalId")));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -236,7 +236,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             changeDetector.DetectChanges(entry);
 
-            Assert.Equal(77, entry.GetValue(entry.EntityType.FindProperty("PrincipalId"), ValueSource.RelationshipSnapshot));
+            Assert.Equal(77, entry.GetRelationshipSnapshotValue(entry.EntityType.FindProperty("PrincipalId")));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -271,7 +271,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             changeDetector.DetectChanges(entry);
 
-            Assert.Equal(78, entry.GetValue(property, ValueSource.RelationshipSnapshot));
+            Assert.Equal(78, entry.GetRelationshipSnapshotValue(property));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -303,7 +303,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             changeDetector.DetectChanges(entry);
 
-            Assert.Equal(78, entry.GetValue(entry.EntityType.FindProperty("Id"), ValueSource.RelationshipSnapshot));
+            Assert.Equal(78, entry.GetRelationshipSnapshotValue(entry.EntityType.FindProperty("Id")));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -338,7 +338,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             changeDetector.DetectChanges(entry);
 
-            Assert.Equal(78, entry.GetValue(property, ValueSource.RelationshipSnapshot));
+            Assert.Equal(78, entry.GetRelationshipSnapshotValue(property));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -370,7 +370,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             changeDetector.DetectChanges(entry);
 
-            Assert.Equal(77, entry.GetValue(entry.EntityType.FindProperty("PrincipalId"), ValueSource.RelationshipSnapshot));
+            Assert.Equal(77, entry.GetRelationshipSnapshotValue(entry.EntityType.FindProperty("PrincipalId")));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -401,7 +401,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             changeDetector.DetectChanges(entry);
 
-            Assert.Equal(77, entry.GetValue(property, ValueSource.RelationshipSnapshot));
+            Assert.Equal(77, entry.GetRelationshipSnapshotValue(property));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -430,7 +430,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             changeDetector.DetectChanges(entry);
 
             Assert.Equal(EntityState.Modified, entry.EntityState);
-            Assert.Equal(78, entry.GetValue(entry.EntityType.FindProperty("DependentId"), ValueSource.RelationshipSnapshot));
+            Assert.Equal(78, entry.GetRelationshipSnapshotValue(entry.EntityType.FindProperty("DependentId")));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -467,7 +467,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             changeDetector.DetectChanges(entry);
 
             Assert.Equal(EntityState.Modified, entry.EntityState);
-            Assert.Equal(77, entry.GetValue(entry.EntityType.FindProperty("DependentId"), ValueSource.RelationshipSnapshot));
+            Assert.Equal(77, entry.GetRelationshipSnapshotValue(entry.EntityType.FindProperty("DependentId")));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -502,7 +502,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             changeDetector.DetectChanges(entry);
 
             Assert.Equal(EntityState.Modified, entry.EntityState);
-            Assert.Equal(78, entry.GetValue(property, ValueSource.RelationshipSnapshot));
+            Assert.Equal(78, entry.GetRelationshipSnapshotValue(property));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -535,7 +535,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             changeDetector.DetectChanges(entry);
 
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
-            Assert.Equal(77, entry.GetValue(entry.EntityType.FindProperty("DependentId"), ValueSource.RelationshipSnapshot));
+            Assert.Equal(77, entry.GetRelationshipSnapshotValue(entry.EntityType.FindProperty("DependentId")));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -566,7 +566,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             changeDetector.DetectChanges(entry);
 
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
-            Assert.Equal(77, entry.GetValue(property, ValueSource.RelationshipSnapshot));
+            Assert.Equal(77, entry.GetRelationshipSnapshotValue(property));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -597,7 +597,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             changeDetector.DetectChanges(entry);
 
             Assert.Equal(EntityState.Modified, entry.EntityState);
-            Assert.Equal(newCategory, entry.GetValue(entry.EntityType.FindNavigation("Category"), ValueSource.RelationshipSnapshot));
+            Assert.Equal(newCategory, entry.GetRelationshipSnapshotValue(entry.EntityType.FindNavigation("Category")));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -640,7 +640,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             changeDetector.DetectChanges(entry);
 
             Assert.Equal(EntityState.Modified, entry.EntityState);
-            Assert.Equal(originalCategory, entry.GetValue(entry.EntityType.FindNavigation("Category"), ValueSource.RelationshipSnapshot));
+            Assert.Equal(originalCategory, entry.GetRelationshipSnapshotValue(entry.EntityType.FindNavigation("Category")));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -678,7 +678,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             changeDetector.DetectChanges(entry);
 
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
-            Assert.Equal(category, entry.GetValue(entry.EntityType.FindNavigation("Category"), ValueSource.RelationshipSnapshot));
+            Assert.Equal(category, entry.GetRelationshipSnapshotValue(entry.EntityType.FindNavigation("Category")));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -712,7 +712,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
             Assert.Equal(
                 new[] { product1, product2, product3 },
-                ((ICollection<object>)entry.GetValue(entry.EntityType.FindNavigation("Products"), ValueSource.RelationshipSnapshot))
+                ((ICollection<object>)entry.GetRelationshipSnapshotValue(entry.EntityType.FindNavigation("Products")))
                     .Cast<Product>()
                     .OrderBy(e => e.DependentId));
 
@@ -751,7 +751,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
             Assert.Equal(
                 new[] { product2 },
-                ((ICollection<object>)entry.GetValue(entry.EntityType.FindNavigation("Products"), ValueSource.RelationshipSnapshot))
+                ((ICollection<object>)entry.GetRelationshipSnapshotValue(entry.EntityType.FindNavigation("Products")))
                     .Cast<Product>()
                     .OrderBy(e => e.DependentId));
 
@@ -795,7 +795,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
             Assert.Equal(
                 new[] { product1, product2 },
-                ((ICollection<object>)entry.GetValue(entry.EntityType.FindNavigation("Products"), ValueSource.RelationshipSnapshot))
+                ((ICollection<object>)entry.GetRelationshipSnapshotValue(entry.EntityType.FindNavigation("Products")))
                     .Cast<Product>()
                     .OrderBy(e => e.DependentId));
 
@@ -825,7 +825,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             changeDetector.DetectChanges(entry);
 
-            Assert.Equal(77, entry.GetValue(entry.EntityType.FindProperty("Id"), ValueSource.RelationshipSnapshot));
+            Assert.Equal(77, entry.GetRelationshipSnapshotValue(entry.EntityType.FindProperty("Id")));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -853,7 +853,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             changeDetector.DetectChanges(entry);
 
-            Assert.Equal(77, entry.GetValue(entry.EntityType.FindProperty("DependentId"), ValueSource.RelationshipSnapshot));
+            Assert.Equal(77, entry.GetRelationshipSnapshotValue(entry.EntityType.FindProperty("DependentId")));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -883,7 +883,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             changeDetector.DetectChanges(entry);
 
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
-            Assert.Equal(category, entry.GetValue(entry.EntityType.FindNavigation("Category"), ValueSource.RelationshipSnapshot));
+            Assert.Equal(category, entry.GetRelationshipSnapshotValue(entry.EntityType.FindNavigation("Category")));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -922,7 +922,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
             Assert.Equal(
                 new[] { product1, product2, product3 },
-                ((ICollection<object>)entry.GetValue(entry.EntityType.FindNavigation("Products"), ValueSource.RelationshipSnapshot))
+                ((ICollection<object>)entry.GetRelationshipSnapshotValue(entry.EntityType.FindNavigation("Products")))
                     .Cast<ProductWithChanged>()
                     .OrderBy(e => e.DependentId));
 
@@ -966,7 +966,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
             Assert.Equal(
                 new[] { product1, product2, product3 },
-                ((ICollection<object>)entry.GetValue(entry.EntityType.FindNavigation("Products"), ValueSource.RelationshipSnapshot))
+                ((ICollection<object>)entry.GetRelationshipSnapshotValue(entry.EntityType.FindNavigation("Products")))
                     .Cast<ProductWithChanged>()
                     .OrderBy(e => e.DependentId));
 
@@ -1003,7 +1003,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             changeDetector.DetectChanges(stateManager);
 
             Assert.Equal(EntityState.Modified, entry.EntityState);
-            Assert.Equal(newCategory, entry.GetValue(entry.EntityType.FindNavigation("Category"), ValueSource.RelationshipSnapshot));
+            Assert.Equal(newCategory, entry.GetRelationshipSnapshotValue(entry.EntityType.FindNavigation("Category")));
 
             Assert.Equal(newCategory.PrincipalId, product.DependentId);
             Assert.Same(newCategory, product.Category);
@@ -1037,7 +1037,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             changeDetector.DetectChanges(stateManager);
 
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
-            Assert.Equal(tag, entry.GetValue(entry.EntityType.FindNavigation("Tag"), ValueSource.RelationshipSnapshot));
+            Assert.Equal(tag, entry.GetRelationshipSnapshotValue(entry.EntityType.FindNavigation("Tag")));
 
             Assert.Equal(category.TagId, 77);
             Assert.Equal(tag.CategoryId, 77);
@@ -1065,7 +1065,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             changeDetector.DetectChanges(stateManager);
 
             Assert.Equal(EntityState.Modified, entry.EntityState);
-            Assert.Equal(category, entry.GetValue(entry.EntityType.FindNavigation("Category"), ValueSource.RelationshipSnapshot));
+            Assert.Equal(category, entry.GetRelationshipSnapshotValue(entry.EntityType.FindNavigation("Category")));
 
             Assert.Equal(category.TagId, 77);
             Assert.Equal(tag.CategoryId, 77);
@@ -1127,7 +1127,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             changeDetector.DetectChanges(stateManager);
 
             Assert.Equal(EntityState.Added, entry.EntityState);
-            Assert.Equal(husband, entry.GetValue(entry.EntityType.FindNavigation("Husband"), ValueSource.RelationshipSnapshot));
+            Assert.Equal(husband, entry.GetRelationshipSnapshotValue(entry.EntityType.FindNavigation("Husband")));
 
             Assert.NotEqual(0, husband.Id);
             Assert.NotEqual(0, wife.Id);
@@ -1157,7 +1157,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             changeDetector.DetectChanges(stateManager);
 
             Assert.Equal(EntityState.Added, entry.EntityState);
-            Assert.Equal(wife, entry.GetValue(entry.EntityType.FindNavigation("Wife"), ValueSource.RelationshipSnapshot));
+            Assert.Equal(wife, entry.GetRelationshipSnapshotValue(entry.EntityType.FindNavigation("Wife")));
 
             Assert.NotEqual(0, husband.Id);
             Assert.NotEqual(0, wife.Id);
@@ -1212,7 +1212,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             category.PrincipalId = 78;
             category.PrincipalId = 77;
 
-            Assert.Equal(77, entry.GetValue(entry.EntityType.FindProperty("PrincipalId"), ValueSource.RelationshipSnapshot));
+            Assert.Equal(77, entry.GetRelationshipSnapshotValue(entry.EntityType.FindProperty("PrincipalId")));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -1242,7 +1242,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             category.Id = 78;
 
-            Assert.Equal(78, entry.GetValue(entry.EntityType.FindProperty("Id"), ValueSource.RelationshipSnapshot));
+            Assert.Equal(78, entry.GetRelationshipSnapshotValue(entry.EntityType.FindProperty("Id")));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -1272,7 +1272,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             category.PrincipalId = 77;
 
-            Assert.Equal(77, entry.GetValue(entry.EntityType.FindProperty("PrincipalId"), ValueSource.RelationshipSnapshot));
+            Assert.Equal(77, entry.GetRelationshipSnapshotValue(entry.EntityType.FindProperty("PrincipalId")));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -1299,7 +1299,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             product.DependentId = 78;
 
             Assert.Equal(EntityState.Modified, entry.EntityState);
-            Assert.Equal(78, entry.GetValue(entry.EntityType.FindProperty("DependentId"), ValueSource.RelationshipSnapshot));
+            Assert.Equal(78, entry.GetRelationshipSnapshotValue(entry.EntityType.FindProperty("DependentId")));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -1331,7 +1331,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             product.DependentId = 77;
 
             Assert.Equal(EntityState.Modified, entry.EntityState);
-            Assert.Equal(77, entry.GetValue(entry.EntityType.FindProperty("DependentId"), ValueSource.RelationshipSnapshot));
+            Assert.Equal(77, entry.GetRelationshipSnapshotValue(entry.EntityType.FindProperty("DependentId")));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -1362,7 +1362,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             product.DependentId = 77;
 
             Assert.Equal(EntityState.Modified, entry.EntityState);
-            Assert.Equal(77, entry.GetValue(entry.EntityType.FindProperty("DependentId"), ValueSource.RelationshipSnapshot));
+            Assert.Equal(77, entry.GetRelationshipSnapshotValue(entry.EntityType.FindProperty("DependentId")));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -1391,7 +1391,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             product.Category = newCategory;
 
             Assert.Equal(EntityState.Modified, entry.EntityState);
-            Assert.Equal(newCategory, entry.GetValue(entry.EntityType.FindNavigation("Category"), ValueSource.RelationshipSnapshot));
+            Assert.Equal(newCategory, entry.GetRelationshipSnapshotValue(entry.EntityType.FindNavigation("Category")));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -1430,7 +1430,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             product.Category = originalCategory;
 
             Assert.Equal(EntityState.Modified, entry.EntityState);
-            Assert.Equal(originalCategory, entry.GetValue(entry.EntityType.FindNavigation("Category"), ValueSource.RelationshipSnapshot));
+            Assert.Equal(originalCategory, entry.GetRelationshipSnapshotValue(entry.EntityType.FindNavigation("Category")));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -1466,7 +1466,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             product.Category = category;
 
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
-            Assert.Equal(category, entry.GetValue(entry.EntityType.FindNavigation("Category"), ValueSource.RelationshipSnapshot));
+            Assert.Equal(category, entry.GetRelationshipSnapshotValue(entry.EntityType.FindNavigation("Category")));
 
             var testListener = contextServices.GetRequiredService<TestRelationshipListener>();
 
@@ -1501,7 +1501,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
             Assert.Equal(
                 new[] { product1, product2, product3 },
-                ((ICollection<object>)entry.GetValue(entry.EntityType.FindNavigation("Products"), ValueSource.RelationshipSnapshot))
+                ((ICollection<object>)entry.GetRelationshipSnapshotValue(entry.EntityType.FindNavigation("Products")))
                     .Cast<NotifyingProduct>()
                     .OrderBy(e => e.DependentId));
 
@@ -1548,7 +1548,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
             Assert.Equal(
                 new[] { product2 },
-                ((ICollection<object>)entry.GetValue(entry.EntityType.FindNavigation("Products"), ValueSource.RelationshipSnapshot))
+                ((ICollection<object>)entry.GetRelationshipSnapshotValue(entry.EntityType.FindNavigation("Products")))
                     .Cast<NotifyingProduct>()
                     .OrderBy(e => e.DependentId));
 
@@ -1590,7 +1590,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             product.Category = newCategory;
 
             Assert.Equal(EntityState.Modified, entry.EntityState);
-            Assert.Equal(newCategory, entry.GetValue(entry.EntityType.FindNavigation("Category"), ValueSource.RelationshipSnapshot));
+            Assert.Equal(newCategory, entry.GetRelationshipSnapshotValue(entry.EntityType.FindNavigation("Category")));
 
             Assert.Equal(newCategory.PrincipalId, product.DependentId);
             Assert.Same(newCategory, product.Category);
@@ -1616,7 +1616,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             category.Tag = tag;
 
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
-            Assert.Equal(tag, entry.GetValue(entry.EntityType.FindNavigation("Tag"), ValueSource.RelationshipSnapshot));
+            Assert.Equal(tag, entry.GetRelationshipSnapshotValue(entry.EntityType.FindNavigation("Tag")));
 
             Assert.Equal(category.TagId, 77);
             Assert.Equal(tag.CategoryId, 77);
@@ -1641,7 +1641,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             tag.Category = category;
 
             Assert.Equal(EntityState.Modified, entry.EntityState);
-            Assert.Equal(category, entry.GetValue(entry.EntityType.FindNavigation("Category"), ValueSource.RelationshipSnapshot));
+            Assert.Equal(category, entry.GetRelationshipSnapshotValue(entry.EntityType.FindNavigation("Category")));
 
             Assert.Equal(category.TagId, 77);
             Assert.Equal(tag.CategoryId, 77);
@@ -1696,7 +1696,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             wife.Husband = husband;
 
             Assert.Equal(EntityState.Added, entry.EntityState);
-            Assert.Equal(husband, entry.GetValue(entry.EntityType.FindNavigation("Husband"), ValueSource.RelationshipSnapshot));
+            Assert.Equal(husband, entry.GetRelationshipSnapshotValue(entry.EntityType.FindNavigation("Husband")));
 
             Assert.NotEqual(0, husband.Id);
             Assert.NotEqual(0, wife.Id);
@@ -1723,7 +1723,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
             husband.Wife = wife;
 
             Assert.Equal(EntityState.Added, entry.EntityState);
-            Assert.Equal(wife, entry.GetValue(entry.EntityType.FindNavigation("Wife"), ValueSource.RelationshipSnapshot));
+            Assert.Equal(wife, entry.GetRelationshipSnapshotValue(entry.EntityType.FindNavigation("Wife")));
 
             Assert.NotEqual(0, husband.Id);
             Assert.NotEqual(0, wife.Id);

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntityEntryTestBase.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntityEntryTestBase.cs
@@ -507,7 +507,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var entry = CreateInternalEntry(configuration, entityType, new SomeDependentEntity());
             entry[fkProperty] = 77;
-            entry.SetValue(fkProperty, 78, ValueSource.RelationshipSnapshot);
+            entry.SetRelationshipSnapshotValue(fkProperty, 78);
 
             var keyValue = entry.GetDependentKeyValue(fk);
             Assert.IsType<KeyValue<int>>(keyValue);
@@ -526,7 +526,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var entry = CreateInternalEntry(configuration, entityType, new SomeDependentEntity());
             entry[fkProperty] = 77;
-            entry.SetValue(fkProperty, 78, ValueSource.RelationshipSnapshot);
+            entry.SetRelationshipSnapshotValue(fkProperty, 78);
 
             var keyValue = entry.GetDependentKeyValue(fk, ValueSource.RelationshipSnapshot);
             Assert.IsType<KeyValue<int>>(keyValue);
@@ -562,7 +562,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var entry = CreateInternalEntry(configuration, entityType, new SomeDependentEntity());
             entry[fkProperty] = 77;
-            entry.SetValue(fkProperty, 78, ValueSource.RelationshipSnapshot);
+            entry.SetRelationshipSnapshotValue(fkProperty, 78);
 
             entry[fkProperty] = 79;
 
@@ -581,7 +581,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var entry = CreateInternalEntry(configuration, entityType, new SomeDependentEntity());
             entry[fkProperty] = 77;
-            entry.SetValue(fkProperty, 78, ValueSource.RelationshipSnapshot);
+            entry.SetRelationshipSnapshotValue(fkProperty, 78);
 
             entry[fkProperty] = 77;
 
@@ -785,23 +785,23 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             entry.SetEntityState(EntityState.Unchanged);
 
-            Assert.Equal(1, entry.GetValue(idProperty, ValueSource.Original));
-            Assert.Equal("Kool", entry.GetValue(nameProperty, ValueSource.Original));
+            Assert.Equal(1, entry.GetOriginalValue(idProperty));
+            Assert.Equal("Kool", entry.GetOriginalValue(nameProperty));
             Assert.Equal(1, entry[idProperty]);
             Assert.Equal("Kool", entry[nameProperty]);
 
             entry[nameProperty] = "Beans";
 
-            Assert.Equal(1, entry.GetValue(idProperty, ValueSource.Original));
-            Assert.Equal("Kool", entry.GetValue(nameProperty, ValueSource.Original));
+            Assert.Equal(1, entry.GetOriginalValue(idProperty));
+            Assert.Equal("Kool", entry.GetOriginalValue(nameProperty));
             Assert.Equal(1, entry[idProperty]);
             Assert.Equal("Beans", entry[nameProperty]);
 
-            entry.SetValue(idProperty, 3, ValueSource.Original);
-            entry.SetValue(nameProperty, "Franks", ValueSource.Original);
+            entry.SetOriginalValue(idProperty, 3);
+            entry.SetOriginalValue(nameProperty, "Franks");
 
-            Assert.Equal(3, entry.GetValue(idProperty, ValueSource.Original));
-            Assert.Equal("Franks", entry.GetValue(nameProperty, ValueSource.Original));
+            Assert.Equal(3, entry.GetOriginalValue(idProperty));
+            Assert.Equal("Franks", entry.GetOriginalValue(nameProperty));
             Assert.Equal(1, entry[idProperty]);
             Assert.Equal("Beans", entry[nameProperty]);
         }
@@ -835,17 +835,17 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var entry = CreateInternalEntry(configuration, entityType, entity, new ValueBuffer(new object[] { 1, "Kool" }));
             entry.SetEntityState(EntityState.Unchanged);
 
-            Assert.Equal("Kool", entry.GetValue(nameProperty, ValueSource.Original));
+            Assert.Equal("Kool", entry.GetOriginalValue(nameProperty));
             Assert.Equal("Kool", entry[nameProperty]);
 
             entry[nameProperty] = "Beans";
 
-            Assert.Equal("Kool", entry.GetValue(nameProperty, ValueSource.Original));
+            Assert.Equal("Kool", entry.GetOriginalValue(nameProperty));
             Assert.Equal("Beans", entry[nameProperty]);
 
-            entry.SetValue(nameProperty, "Franks", ValueSource.Original);
+            entry.SetOriginalValue(nameProperty, "Franks");
 
-            Assert.Equal("Franks", entry.GetValue(nameProperty, ValueSource.Original));
+            Assert.Equal("Franks", entry.GetOriginalValue(nameProperty));
             Assert.Equal("Beans", entry[nameProperty]);
         }
 
@@ -886,7 +886,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             Assert.Equal("Kool", entry.GetOriginalValue<string>(nameProperty));
             Assert.Equal("Beans", entry.GetCurrentValue<string>(nameProperty));
 
-            entry.SetValue(nameProperty, "Franks", ValueSource.Original);
+            entry.SetOriginalValue(nameProperty, "Franks");
 
             Assert.Equal("Franks", entry.GetOriginalValue<string>(nameProperty));
             Assert.Equal("Beans", entry.GetCurrentValue<string>(nameProperty));
@@ -921,22 +921,22 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var entry = CreateInternalEntry(configuration, entityType, entity, new ValueBuffer(new object[] { 1, null }));
             entry.SetEntityState(EntityState.Unchanged);
 
-            Assert.Null(entry.GetValue(nameProperty, ValueSource.Original));
+            Assert.Null(entry.GetOriginalValue(nameProperty));
             Assert.Null(entry[nameProperty]);
 
             entry[nameProperty] = "Beans";
 
-            Assert.Null(entry.GetValue(nameProperty, ValueSource.Original));
+            Assert.Null(entry.GetOriginalValue(nameProperty));
             Assert.Equal("Beans", entry[nameProperty]);
 
-            entry.SetValue(nameProperty, "Franks", ValueSource.Original);
+            entry.SetOriginalValue(nameProperty, "Franks");
 
-            Assert.Equal("Franks", entry.GetValue(nameProperty, ValueSource.Original));
+            Assert.Equal("Franks", entry.GetOriginalValue(nameProperty));
             Assert.Equal("Beans", entry[nameProperty]);
 
-            entry.SetValue(nameProperty, null, ValueSource.Original);
+            entry.SetOriginalValue(nameProperty, null);
 
-            Assert.Null(entry.GetValue(nameProperty, ValueSource.Original));
+            Assert.Null(entry.GetOriginalValue(nameProperty));
             Assert.Equal("Beans", entry[nameProperty]);
         }
 
@@ -978,12 +978,12 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             Assert.Null(entry.GetOriginalValue<string>(nameProperty));
             Assert.Equal("Beans", entry.GetCurrentValue<string>(nameProperty));
 
-            entry.SetValue(nameProperty, "Franks", ValueSource.Original);
+            entry.SetOriginalValue(nameProperty, "Franks");
 
             Assert.Equal("Franks", entry.GetOriginalValue<string>(nameProperty));
             Assert.Equal("Beans", entry.GetCurrentValue<string>(nameProperty));
 
-            entry.SetValue(nameProperty, null, ValueSource.Original);
+            entry.SetOriginalValue(nameProperty, null);
 
             Assert.Null(entry.GetOriginalValue<string>(nameProperty));
             Assert.Equal("Beans", entry.GetCurrentValue<string>(nameProperty));
@@ -1114,13 +1114,13 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             entry.SetEntityState(entityState);
 
             entry[nameProperty] = "Pickle";
-            entry.SetValue(nameProperty, "Cheese", ValueSource.Original);
+            entry.SetOriginalValue(nameProperty, "Cheese");
 
             entry.AcceptChanges();
 
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
             Assert.Equal("Pickle", entry[nameProperty]);
-            Assert.Equal("Pickle", entry.GetValue(nameProperty, ValueSource.Original));
+            Assert.Equal("Pickle", entry.GetOriginalValue(nameProperty));
         }
 
         [Fact]
@@ -1145,7 +1145,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
             Assert.Equal("Pickle", entry[nameProperty]);
-            Assert.Equal("Pickle", entry.GetValue(nameProperty, ValueSource.Original));
+            Assert.Equal("Pickle", entry.GetOriginalValue(nameProperty));
         }
 
         [Fact]
@@ -1185,7 +1185,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             Assert.Equal(1, entry[idProperty]);
             Assert.Equal("Kool", entry[nameProperty]);
 
-            entry.SetValue(idProperty, 7, ValueSource.Original);
+            entry.SetOriginalValue(idProperty, 7);
 
             Assert.Equal(1, entry[idProperty]);
             Assert.Equal("Kool", entry[nameProperty]);

--- a/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntryEntrySubscriberTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/Internal/InternalEntryEntrySubscriberTest.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Metadata;
-using Microsoft.Data.Entity.Update;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -28,11 +27,11 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking.Internal
 
             Assert.True(entry.HasRelationshipSnapshot);
 
-            Assert.Equal("Palmer", entry.GetValue(entry.EntityType.FindProperty("Name"), ValueSource.Original));
+            Assert.Equal("Palmer", entry.GetOriginalValue(entry.EntityType.FindProperty("Name")));
 
             entity.Name = "Luckey";
 
-            Assert.Equal("Palmer", entry.GetValue(entry.EntityType.FindProperty("Name"), ValueSource.Original));
+            Assert.Equal("Palmer", entry.GetOriginalValue(entry.EntityType.FindProperty("Name")));
         }
 
         [Fact]

--- a/test/EntityFramework.Relational.Tests/Update/CommandBatchPreparerTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/CommandBatchPreparerTest.cs
@@ -195,7 +195,7 @@ namespace Microsoft.Data.Entity.Tests.Update
 
             var relatedentry = stateManager.GetOrCreateEntry(new RelatedFakeEntity { Id = 1, RelatedId = 3 });
             relatedentry.SetEntityState(EntityState.Modified);
-            relatedentry.SetValue(relatedentry.EntityType.FindProperty("RelatedId"), 42, ValueSource.Original);
+            relatedentry.SetOriginalValue(relatedentry.EntityType.FindProperty("RelatedId"), 42);
             relatedentry.SetPropertyModified(relatedentry.EntityType.FindPrimaryKey().Properties.Single(), isModified: false);
 
             var commandBatches = CreateCommandBatchPreparer().BatchCommands(new[] { relatedentry, previousParent, newParent }).ToArray();


### PR DESCRIPTION
Instead using object[] directly in identity maps, with appropriate equality comparer. No major gains from this, but it will allow us to remove IKeyValue which ultimately will be deleted.

Also, using custom compares for simple keys for perf and to reduce boxing.