### PR TITLE
Push work of getting dependents into the state manager identity map

### DIFF
--- a/src/EntityFramework.Core/ChangeTracking/Internal/IIdentityMap.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/IIdentityMap.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
@@ -28,5 +29,17 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         void Remove([NotNull] InternalEntityEntry entry);
 
         void RemoveUsingRelationshipSnapshot([NotNull] InternalEntityEntry entry);
+
+        IEnumerable<InternalEntityEntry> GetMatchingDependentsFromRelationshipSnapshot(
+            [NotNull] IForeignKey foreignKey,
+            [NotNull] InternalEntityEntry principalEntry,
+            [NotNull] IEnumerable<InternalEntityEntry> candidateDependents);
+
+        IEnumerable<InternalEntityEntry> GetMatchingDependents(
+            [NotNull] IForeignKey foreignKey,
+            [NotNull] InternalEntityEntry principalEntry,
+            [NotNull] IEnumerable<InternalEntityEntry> candidateDependents);
+
+        IEnumerable<InternalEntityEntry> Entries { get; }
     }
 }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/IStateManager.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/IStateManager.cs
@@ -8,7 +8,6 @@ using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Data.Entity.Update;
 
 namespace Microsoft.Data.Entity.ChangeTracking.Internal
 {
@@ -43,6 +42,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         IEnumerable<InternalEntityEntry> GetDependentsFromNavigation([NotNull] InternalEntityEntry principalEntry, [NotNull] IForeignKey foreignKey);
 
         IEnumerable<InternalEntityEntry> GetDependents([NotNull] InternalEntityEntry principalEntry, [NotNull] IForeignKey foreignKey);
+
+        IEnumerable<InternalEntityEntry> GetDependentsUsingRelationshipSnapshot(
+            [NotNull] InternalEntityEntry principalEntry, [NotNull] IForeignKey foreignKey);
 
         int SaveChanges(bool acceptAllChangesOnSuccess);
 

--- a/src/EntityFramework.Core/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/NavigationFixer.cs
@@ -10,7 +10,6 @@ using JetBrains.Annotations;
 using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Metadata.Internal;
-using Microsoft.Data.Entity.Update;
 
 namespace Microsoft.Data.Entity.ChangeTracking.Internal
 {
@@ -150,15 +149,9 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
             {
                 var newKeyValues = foreignKey.PrincipalKey.Properties.Select(p => entry[p]).ToList();
 
-                var oldKey = entry.GetPrincipalKeyValue(foreignKey, ValueSource.RelationshipSnapshot);
-                if (!oldKey.IsInvalid)
+                foreach (var dependentEntry in entry.StateManager.GetDependentsUsingRelationshipSnapshot(entry, foreignKey).ToList())
                 {
-                    foreach (var dependent in entry.StateManager.Entries.Where(
-                        e => foreignKey.DeclaringEntityType.IsAssignableFrom(e.EntityType)
-                             && oldKey.Equals(e.GetDependentKeyValue(foreignKey))).ToList())
-                    {
-                        SetForeignKeyValue(foreignKey, dependent, newKeyValues);
-                    }
+                    SetForeignKeyValue(foreignKey, dependentEntry, newKeyValues);
                 }
             }
         }

--- a/test/EntityFramework.Core.Tests/DbContextTest.cs
+++ b/test/EntityFramework.Core.Tests/DbContextTest.cs
@@ -235,6 +235,11 @@ namespace Microsoft.Data.Entity.Tests
                 throw new NotImplementedException();
             }
 
+            public IEnumerable<InternalEntityEntry> GetDependentsUsingRelationshipSnapshot(InternalEntityEntry principalEntry, IForeignKey foreignKey)
+            {
+                throw new NotImplementedException();
+            }
+
             public IEnumerable<InternalEntityEntry> GetDependentsFromNavigation(InternalEntityEntry principalEntry, IForeignKey foreignKey)
             {
                 throw new NotImplementedException();


### PR DESCRIPTION
This is faster and also means we no longer user IKeyValue here.