### PR TITLE
Fix #3962 - Navigation with OfType results in null parameter

### DIFF
--- a/src/EntityFramework.Core/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
+++ b/src/EntityFramework.Core/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
@@ -146,6 +146,13 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors.Internal
             {
                 _entityQueryProvider
                     = (node.Value as IQueryable)?.Provider as IAsyncQueryProvider;
+
+                var parent = _parentvisitor;
+                while (parent != null)
+                {
+                    parent._entityQueryProvider = _entityQueryProvider;
+                    parent = parent._parentvisitor;
+                }
             }
 
             return node;

--- a/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
@@ -4272,6 +4272,37 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 .Where(o => o.OrderDate > new DateTime(1998, 1, 1)), entryCount: 8);
         }
 
+        [ConditionalFact]
+        public virtual void OfType_Select()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal(
+                    "Reims",
+                    context.Set<Order>()
+                        .OfType<Order>()
+                        .OrderBy(o => o.OrderID)
+                        .Select(o => o.Customer.City)
+                        .First());
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void OfType_Select_OfType_Select()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal(
+                    "Reims",
+                    context.Set<Order>()
+                        .OfType<Order>()
+                        .Select(o => o)
+                        .OfType<Order>()
+                        .OrderBy(o => o.OrderID)
+                        .Select(o => o.Customer.City)
+                        .First());
+            }
+        }
 
         [ConditionalFact]
         public virtual void OrderBy_null_coalesce_operator()

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -4114,6 +4114,39 @@ WHERE ([o].[CustomerID] = 'QUICK') AND ([o].[OrderDate] > '1998-01-01T00:00:00.0
                 Sql);
         }
 
+        public override void OfType_Select()
+        {
+            base.OfType_Select();
+
+            Assert.Equal(
+                @"SELECT TOP(1) [o.Customer].[City]
+FROM (
+    SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    FROM [Orders] AS [o]
+) AS [t0]
+INNER JOIN [Customers] AS [o.Customer] ON [t0].[CustomerID] = [o.Customer].[CustomerID]
+ORDER BY [t0].[OrderID]",
+                Sql);
+        }
+
+        public override void OfType_Select_OfType_Select()
+        {
+            base.OfType_Select_OfType_Select();
+
+            Assert.Equal(
+                @"SELECT TOP(1) [o.Customer].[City]
+FROM (
+    SELECT [t0].[OrderID], [t0].[CustomerID], [t0].[EmployeeID], [t0].[OrderDate]
+    FROM (
+        SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+        FROM [Orders] AS [o]
+    ) AS [t0]
+) AS [t1]
+INNER JOIN [Customers] AS [o.Customer] ON [t1].[CustomerID] = [o.Customer].[CustomerID]
+ORDER BY [t1].[OrderID]",
+                Sql);
+        }
+
         public override void OrderBy_null_coalesce_operator()
         {
             base.OrderBy_null_coalesce_operator();


### PR DESCRIPTION
Resolving #3962 by updating the `IAsyncQueryProvider` on all parent visitors when it is found. The `IQueryable` can be at an arbitrary depth depending on the shape of the original `Expression`.

A potential alternative would be to use a ThreadStatic field, though this is only ever done in `DbContextActivator` in the current code base.