### PR TITLE
Remove many-to-many relationship from database model

### DIFF
--- a/src/EntityFramework.Relational.Design/EntityFramework.Relational.Design.csproj
+++ b/src/EntityFramework.Relational.Design/EntityFramework.Relational.Design.csproj
@@ -53,7 +53,9 @@
     <Compile Include="Internal\ModelUtilities.cs" />
     <Compile Include="Metadata\ColumnModel.cs" />
     <Compile Include="Metadata\DatabaseModel.cs" />
+    <Compile Include="Metadata\ForeignKeyColumnModel.cs" />
     <Compile Include="Metadata\ForeignKeyModel.cs" />
+    <Compile Include="Metadata\IndexColumnModel.cs" />
     <Compile Include="Metadata\IndexModel.cs" />
     <Compile Include="Metadata\ScaffoldingModelAnnotations.cs" />
     <Compile Include="Metadata\SequenceModel.cs" />

--- a/src/EntityFramework.Relational.Design/Metadata/ColumnModel.cs
+++ b/src/EntityFramework.Relational.Design/Metadata/ColumnModel.cs
@@ -1,10 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using JetBrains.Annotations;
-using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
 
 namespace Microsoft.Data.Entity.Scaffolding.Metadata
 {

--- a/src/EntityFramework.Relational.Design/Metadata/DatabaseModel.cs
+++ b/src/EntityFramework.Relational.Design/Metadata/DatabaseModel.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Data.Entity.Scaffolding.Metadata
         [CanBeNull]
         public virtual string DefaultSchemaName { get; [param: CanBeNull] set; }
 
-        public virtual IList<TableModel> Tables { get; } = new List<TableModel>();
-        public virtual IList<SequenceModel> Sequences { get; } = new List<SequenceModel>();
+        public virtual ICollection<TableModel> Tables { get; } = new List<TableModel>();
+        public virtual ICollection<SequenceModel> Sequences { get; } = new List<SequenceModel>();
     }
 }

--- a/src/EntityFramework.Relational.Design/Metadata/ForeignKeyColumnModel.cs
+++ b/src/EntityFramework.Relational.Design/Metadata/ForeignKeyColumnModel.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
+
+namespace Microsoft.Data.Entity.Scaffolding.Metadata
+{
+    public class ForeignKeyColumnModel : Annotatable
+    {
+        public virtual int Ordinal { get; [param: NotNull] set; }
+        public virtual ColumnModel Column { get; [param: NotNull] set; }
+        public virtual ColumnModel PrincipalColumn { get; [param: CanBeNull] set; }
+    }
+}

--- a/src/EntityFramework.Relational.Design/Metadata/ForeignKeyModel.cs
+++ b/src/EntityFramework.Relational.Design/Metadata/ForeignKeyModel.cs
@@ -17,8 +17,7 @@ namespace Microsoft.Data.Entity.Scaffolding.Metadata
         [CanBeNull]
         public virtual TableModel PrincipalTable { get; [param: CanBeNull] set; }
 
-        public virtual IList<ColumnModel> Columns { get; } = new List<ColumnModel>();
-        public virtual IList<ColumnModel> PrincipalColumns { get; } = new List<ColumnModel>();
+        public virtual ICollection<ForeignKeyColumnModel> Columns { get; } = new List<ForeignKeyColumnModel>();
 
         [NotNull]
         public virtual string Name { get; [param: CanBeNull] set; }
@@ -29,6 +28,6 @@ namespace Microsoft.Data.Entity.Scaffolding.Metadata
         //public virtual ReferentialAction OnUpdate { get; [param: NotNull] set; }
 
         public virtual string DisplayName
-            => Table?.DisplayName + "(" + string.Join(",", Columns.Select(f => f.Name)) + ")";
+            => Table?.DisplayName + "(" + string.Join(",", Columns.OrderBy(f => f.Ordinal).Select(f => f.Column.Name)) + ")";
     }
 }

--- a/src/EntityFramework.Relational.Design/Metadata/IndexColumnModel.cs
+++ b/src/EntityFramework.Relational.Design/Metadata/IndexColumnModel.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
+
+namespace Microsoft.Data.Entity.Scaffolding.Metadata
+{
+    public class IndexColumnModel : Annotatable
+    {
+        public virtual int Ordinal { get; [param: NotNull] set; }
+        public virtual ColumnModel Column { get; [param: NotNull] set; }
+        public virtual IndexModel Index { get; [param: NotNull] set; }
+
+        // TODO index column sorting. See https://github.com/aspnet/EntityFramework/issues/4150
+    }
+}

--- a/src/EntityFramework.Relational.Design/Metadata/IndexModel.cs
+++ b/src/EntityFramework.Relational.Design/Metadata/IndexModel.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Data.Entity.Scaffolding.Metadata
         public virtual TableModel Table { get; [param: CanBeNull] set; }
 
         public virtual string Name { get; [param: NotNull] set; }
-        public virtual IList<ColumnModel> Columns { get; [param: NotNull] set; } = new List<ColumnModel>();
+        public virtual ICollection<IndexColumnModel> IndexColumns { get; [param: NotNull] set; } = new List<IndexColumnModel>();
         public virtual bool IsUnique { get; [param: NotNull] set; }
     }
 }

--- a/src/EntityFramework.Relational.Design/Metadata/ScaffoldingForeignKeyAnnotations.cs
+++ b/src/EntityFramework.Relational.Design/Metadata/ScaffoldingForeignKeyAnnotations.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Data.Entity.Scaffolding.Metadata
         public virtual string DependentEndNavigation
         {
             get { return (string)Annotations.GetAnnotation(ScaffoldingAnnotationNames.DependentEndNavigation); }
-            [param: CanBeNull] set { Annotations.SetAnnotation(ScaffoldingAnnotationNames.DependentEndNavigation, Check.NullButNotEmpty(value, nameof(value)));  }
+            [param: CanBeNull] set { Annotations.SetAnnotation(ScaffoldingAnnotationNames.DependentEndNavigation, Check.NullButNotEmpty(value, nameof(value))); }
         }
 
         public virtual string PrincipalEndNavigation

--- a/src/EntityFramework.Relational.Design/Metadata/ScaffoldingMetadataExtensions.cs
+++ b/src/EntityFramework.Relational.Design/Metadata/ScaffoldingMetadataExtensions.cs
@@ -7,14 +7,15 @@ using Microsoft.Data.Entity.Scaffolding.Metadata.Internal;
 using Microsoft.Data.Entity.Utilities;
 
 // ReSharper disable once CheckNamespace
+
 namespace Microsoft.Data.Entity.Metadata
 {
     public static class ScaffoldingMetadataExtensions
     {
         public static ScaffoldingModelAnnotations Scaffolding([NotNull] this IModel model)
-        => new ScaffoldingModelAnnotations(Check.NotNull(model, nameof(model)), ScaffoldingAnnotationNames.AnnotationPrefix);
+            => new ScaffoldingModelAnnotations(Check.NotNull(model, nameof(model)), ScaffoldingAnnotationNames.AnnotationPrefix);
 
         public static ScaffoldingForeignKeyAnnotations Scaffolding([NotNull] this IForeignKey foreignKey)
-          => new ScaffoldingForeignKeyAnnotations(Check.NotNull(foreignKey, nameof(foreignKey)), ScaffoldingAnnotationNames.AnnotationPrefix);
+            => new ScaffoldingForeignKeyAnnotations(Check.NotNull(foreignKey, nameof(foreignKey)), ScaffoldingAnnotationNames.AnnotationPrefix);
     }
 }

--- a/src/EntityFramework.Relational.Design/Metadata/SequenceModel.cs
+++ b/src/EntityFramework.Relational.Design/Metadata/SequenceModel.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
 

--- a/src/EntityFramework.Relational.Design/Metadata/TableModel.cs
+++ b/src/EntityFramework.Relational.Design/Metadata/TableModel.cs
@@ -14,9 +14,9 @@ namespace Microsoft.Data.Entity.Scaffolding.Metadata
         [CanBeNull]
         public virtual string SchemaName { get; [param: CanBeNull] set; }
 
-        public virtual IList<ColumnModel> Columns { get; [param: NotNull] set; } = new List<ColumnModel>();
-        public virtual IList<IndexModel> Indexes { get; } = new List<IndexModel>();
-        public virtual IList<ForeignKeyModel> ForeignKeys { get; } = new List<ForeignKeyModel>();
+        public virtual ICollection<ColumnModel> Columns { get; [param: NotNull] set; } = new List<ColumnModel>();
+        public virtual ICollection<IndexModel> Indexes { get; } = new List<IndexModel>();
+        public virtual ICollection<ForeignKeyModel> ForeignKeys { get; } = new List<ForeignKeyModel>();
 
         public virtual string DisplayName
             => (!string.IsNullOrEmpty(SchemaName) ? SchemaName + "." : "") + Name;

--- a/test/EntityFramework.Relational.Design.Tests/RelationalDatabaseModelFactoryTest.cs
+++ b/test/EntityFramework.Relational.Design.Tests/RelationalDatabaseModelFactoryTest.cs
@@ -194,9 +194,9 @@ namespace Microsoft.Data.Entity.Relational.Design
                 }
             };
 
-            info.Tables[0].Columns.Add(new ColumnModel
+            info.Tables.First().Columns.Add(new ColumnModel
             {
-                Table = info.Tables[0],
+                Table = info.Tables.First(),
                 Name = "Coli",
                 DataType = dataType
             });
@@ -241,10 +241,38 @@ namespace Microsoft.Data.Entity.Relational.Design
                     new ColumnModel { Name = "C3", DataType = "long" }
                 }
             };
-            table.Indexes.Add(new IndexModel { Name = "IDX_C1", Columns = { table.Columns[0] }, IsUnique = false });
-            table.Indexes.Add(new IndexModel { Name = "UNQ_C2", Columns = { table.Columns[1] }, IsUnique = true });
-            table.Indexes.Add(new IndexModel { Name = "IDX_C2_C1", Columns = { table.Columns[1], table.Columns[0] }, IsUnique = false });
-            table.Indexes.Add(new IndexModel { /*Name ="UNQ_C3_C1",*/ Columns = { table.Columns[2], table.Columns[0] }, IsUnique = true });
+            table.Indexes.Add(new IndexModel
+            {
+                Name = "IDX_C1",
+                IndexColumns = { new IndexColumnModel { Column = table.Columns.ElementAt(0) } },
+                IsUnique = false
+            });
+            table.Indexes.Add(new IndexModel
+            {
+                Name = "UNQ_C2",
+                IndexColumns = { new IndexColumnModel { Column = table.Columns.ElementAt(1) } },
+                IsUnique = true
+            });
+            table.Indexes.Add(new IndexModel
+            {
+                Name = "IDX_C2_C1",
+                IndexColumns = {
+                    new IndexColumnModel { Column = table.Columns.ElementAt(1) },
+                    new IndexColumnModel { Column = table.Columns.ElementAt(0) }
+                },
+                IsUnique = false
+            });
+            table.Indexes.Add(new IndexModel
+            {
+                /*Name ="UNQ_C3_C1",*/
+                IndexColumns =
+                {
+                    new IndexColumnModel { Column = table.Columns.ElementAt(2) },
+                    new IndexColumnModel { Column = table.Columns.ElementAt(0) }
+                },
+                IsUnique = true
+            });
+
             var info = new DatabaseModel { Tables = { table } };
 
             var entityType = (EntityType)_factory.Create(info).GetEntityTypes().Single();
@@ -299,10 +327,17 @@ namespace Microsoft.Data.Entity.Relational.Design
             childrenTable.ForeignKeys.Add(new ForeignKeyModel
             {
                 Table = childrenTable,
-                Columns = { childrenTable.Columns[1] },
                 PrincipalTable = parentTable,
-                PrincipalColumns = { parentTable.Columns[0] },
-                OnDelete = Migrations.ReferentialAction.Cascade
+                OnDelete = Migrations.ReferentialAction.Cascade,
+                Columns = 
+                {
+                    new ForeignKeyColumnModel 
+                    {
+                        Ordinal = 1,
+                        Column = childrenTable.Columns.ElementAt(1),
+                        PrincipalColumn = parentTable.Columns.ElementAt(0)
+                    }
+                }
             });
 
             var model = _factory.Create(new DatabaseModel { Tables = { parentTable, childrenTable } });
@@ -331,10 +366,17 @@ namespace Microsoft.Data.Entity.Relational.Design
             childrenTable.ForeignKeys.Add(new ForeignKeyModel
             {
                 Table = childrenTable,
-                Columns = { childrenTable.Columns[0] },
                 PrincipalTable = parentTable,
-                PrincipalColumns = { parentTable.Columns[0] },
-                OnDelete = Migrations.ReferentialAction.NoAction
+                OnDelete = Migrations.ReferentialAction.NoAction,
+                Columns =
+                {
+                    new ForeignKeyColumnModel
+                    {
+                        Ordinal = 1,
+                        Column = childrenTable.Columns.ElementAt(0),
+                        PrincipalColumn = parentTable.Columns.ElementAt(0)
+                    }
+                }
             });
 
             var model = _factory.Create(new DatabaseModel { Tables = { parentTable, childrenTable } });
@@ -372,10 +414,23 @@ namespace Microsoft.Data.Entity.Relational.Design
             childrenTable.ForeignKeys.Add(new ForeignKeyModel
             {
                 Table = childrenTable,
-                Columns = { childrenTable.Columns[1], childrenTable.Columns[2] },
                 PrincipalTable = parentTable,
-                PrincipalColumns = { parentTable.Columns[0], parentTable.Columns[1] },
-                OnDelete = Migrations.ReferentialAction.SetNull
+                OnDelete = Migrations.ReferentialAction.SetNull,
+                Columns =
+                {
+                    new ForeignKeyColumnModel
+                    {
+                        Ordinal = 1,
+                        Column = childrenTable.Columns.ElementAt(1),
+                        PrincipalColumn = parentTable.Columns.ElementAt(0)
+                    },
+                    new ForeignKeyColumnModel
+                    {
+                        Ordinal = 1,
+                        Column = childrenTable.Columns.ElementAt(2),
+                        PrincipalColumn = parentTable.Columns.ElementAt(1)
+                    },
+                }
             });
 
             var model = _factory.Create(new DatabaseModel { Tables = { parentTable, childrenTable } });
@@ -413,9 +468,16 @@ namespace Microsoft.Data.Entity.Relational.Design
             table.ForeignKeys.Add(new ForeignKeyModel
             {
                 Table = table,
-                Columns = { table.Columns[1] },
                 PrincipalTable = table,
-                PrincipalColumns = { table.Columns[0] }
+                Columns =
+                {
+                    new ForeignKeyColumnModel
+                    {
+                        Ordinal = 1,
+                        Column = table.Columns.ElementAt(1),
+                        PrincipalColumn = table.Columns.ElementAt(0)
+                    }
+                }
             });
 
             var model = _factory.Create(new DatabaseModel { Tables = { table } });
@@ -453,16 +515,23 @@ namespace Microsoft.Data.Entity.Relational.Design
             childrenTable.ForeignKeys.Add(new ForeignKeyModel
             {
                 Table = childrenTable,
-                Columns = { childrenTable.Columns[1] },
                 PrincipalTable = parentTable,
-                PrincipalColumns = { parentTable.Columns[1] }
+                Columns =
+                {
+                    new ForeignKeyColumnModel
+                    {
+                        Ordinal = 1,
+                        Column = childrenTable.Columns.ElementAt(1),
+                        PrincipalColumn = parentTable.Columns.ElementAt(1)
+                    }
+                }
             });
 
             _factory.Create(new DatabaseModel { Tables = { parentTable, childrenTable } });
 
             Assert.Contains("Warning: " +
                             RelationalDesignStrings.ForeignKeyScaffoldErrorPrincipalKeyNotFound(
-                                childrenTable.ForeignKeys[0].DisplayName, "NotPkId", "Parent"),
+                                childrenTable.ForeignKeys.ElementAt(0).DisplayName, "NotPkId", "Parent"),
                 _logger.FullLog);
         }
 
@@ -478,13 +547,24 @@ namespace Microsoft.Data.Entity.Relational.Design
                     new ColumnModel { Name = "BuddyId", DataType = "long", IsNullable = false }
                 }
             };
-            table.Indexes.Add(new IndexModel { Columns = { table.Columns[1] }, IsUnique = true });
+            table.Indexes.Add(new IndexModel
+            {
+                IndexColumns = { new IndexColumnModel { Column = table.Columns.ElementAt(1) } },
+                IsUnique = true
+            });
             table.ForeignKeys.Add(new ForeignKeyModel
             {
                 Table = table,
-                Columns = { table.Columns[1] },
                 PrincipalTable = table,
-                PrincipalColumns = { table.Columns[0] }
+                Columns =
+                {
+                    new ForeignKeyColumnModel
+                    {
+                        Ordinal = 1,
+                        Column = table.Columns.ElementAt(1),
+                        PrincipalColumn = table.Columns.ElementAt(0)
+                    }
+                }
             });
 
             var model = _factory.Create(new DatabaseModel { Tables = { table } }).FindEntityType("Friends");
@@ -517,13 +597,33 @@ namespace Microsoft.Data.Entity.Relational.Design
                     new ColumnModel { Name = "ParentId_B", DataType = "long" }
                 }
             };
-            childrenTable.Indexes.Add(new IndexModel { IsUnique = true, Columns = { childrenTable.Columns[1], childrenTable.Columns[2] } });
+            childrenTable.Indexes.Add(new IndexModel
+            {
+                IsUnique = true,
+                IndexColumns = {
+                    new IndexColumnModel { Column = childrenTable.Columns.ElementAt(1) },
+                    new IndexColumnModel { Column = childrenTable.Columns.ElementAt(2) }
+                }
+            });
             childrenTable.ForeignKeys.Add(new ForeignKeyModel
             {
                 Table = childrenTable,
-                Columns = { childrenTable.Columns[1], childrenTable.Columns[2] },
                 PrincipalTable = parentTable,
-                PrincipalColumns = { parentTable.Columns[0], parentTable.Columns[1] }
+                Columns =
+                {
+                    new ForeignKeyColumnModel
+                    {
+                        Ordinal = 1,
+                        Column = childrenTable.Columns.ElementAt(1),
+                        PrincipalColumn = parentTable.Columns.ElementAt(0)
+                    },
+                    new ForeignKeyColumnModel
+                    {
+                        Ordinal = 1,
+                        Column = childrenTable.Columns.ElementAt(2),
+                        PrincipalColumn = parentTable.Columns.ElementAt(1)
+                    },
+                }
             });
 
             var model = _factory.Create(new DatabaseModel { Tables = { parentTable, childrenTable } });
@@ -555,8 +655,8 @@ namespace Microsoft.Data.Entity.Relational.Design
                 }
             };
 
-            info.Tables[0].Columns.Add(new ColumnModel { Name = "Id", DataType = "long", PrimaryKeyOrdinal = 0, Table = info.Tables[0] });
-            info.Tables[1].Columns.Add(new ColumnModel { Name = "Id", DataType = "long", PrimaryKeyOrdinal = 0, Table = info.Tables[1] });
+            info.Tables.ElementAt(0).Columns.Add(new ColumnModel { Name = "Id", DataType = "long", PrimaryKeyOrdinal = 0, Table = info.Tables.ElementAt(0) });
+            info.Tables.ElementAt(1).Columns.Add(new ColumnModel { Name = "Id", DataType = "long", PrimaryKeyOrdinal = 0, Table = info.Tables.ElementAt(1) });
 
             var model = _factory.Create(info);
 

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/EntityFramework.Sqlite.Design.FunctionalTests.csproj
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/EntityFramework.Sqlite.Design.FunctionalTests.csproj
@@ -143,7 +143,9 @@
     <Compile Include="ReverseEngineering\SqliteAllFluentApiE2ETest.cs" />
     <Compile Include="ReverseEngineering\SqliteAttributesInsteadOfFluentApiE2ETest.cs" />
     <Compile Include="ReverseEngineering\SqliteE2ETestBase.cs" />
+    <Compile Include="SqliteScaffoldingModelFactoryTest.cs" />
     <Compile Include="SqliteDatabaseModelFactoryTest.cs" />
+    <Compile Include="TestLogger.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/SqliteDatabaseModelFactoryTest.cs
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/SqliteDatabaseModelFactoryTest.cs
@@ -4,346 +4,187 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using Microsoft.Data.Entity.FunctionalTests;
-using Microsoft.Data.Entity.Internal;
-using Microsoft.Data.Entity.Metadata;
-using Microsoft.Data.Entity.Metadata.Internal;
+using Microsoft.Data.Entity.Migrations;
 using Microsoft.Data.Entity.Scaffolding;
-using Microsoft.Data.Entity.Scaffolding.Internal;
+using Microsoft.Data.Entity.Scaffolding.Metadata;
 using Microsoft.Data.Entity.Sqlite.FunctionalTests;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Sqlite.Design.FunctionalTests
 {
     public class SqliteDatabaseModelFactoryTest : IDisposable
     {
-        private readonly RelationalScaffoldingModelFactory _scaffoldingModelFactory;
         private readonly SqliteTestStore _testStore;
-        private readonly TestLogger _logger;
+        private readonly SqliteDatabaseModelFactory _factory;
 
         public SqliteDatabaseModelFactoryTest()
         {
             _testStore = SqliteTestStore.CreateScratch();
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddLogging();
-            new SqliteDesignTimeServices().ConfigureDesignTimeServices(serviceCollection);
-            serviceCollection.AddSingleton<IFileService, FileSystemFileService>();
-
-            var serviceProvider = serviceCollection
-                .BuildServiceProvider();
-
-            _logger = new TestLogger();
-            serviceProvider.GetService<ILoggerFactory>().AddProvider(new TestLoggerProvider(_logger));
-
-            _scaffoldingModelFactory = serviceProvider
-                .GetService<IScaffoldingModelFactory>() as RelationalScaffoldingModelFactory;
+            _factory = new SqliteDatabaseModelFactory();
         }
 
         [Fact]
-        public void It_loads_column_types()
+        public void It_reads_tables()
         {
-            var entityType = GetModel(@"CREATE TABLE ""Column Types"" (
-                                        col1 text PRIMARY KEY,
-                                        col2 unsigned big int );").FindEntityType("Column_Types");
+            var sql = @"CREATE TABLE [Everest] ( id int );  CREATE TABLE [Denali] ( id int );";
 
-            Assert.NotNull(entityType);
-            Assert.Equal("Column Types", entityType.Sqlite().TableName);
+            var dbModel = CreateModel(sql);
 
-            Assert.Equal("text", entityType.FindProperty("col1").Sqlite().ColumnType);
-            Assert.Equal(typeof(string), entityType.FindProperty("col1").ClrType);
-
-            Assert.Equal("unsigned big int", entityType.FindProperty("col2").Sqlite().ColumnType);
-            Assert.Equal(typeof(long?), entityType.FindProperty("col2").ClrType);
+            Assert.Collection(dbModel.Tables.OrderBy(t => t.Name),
+                d => Assert.Equal("Denali", d.Name),
+                e => Assert.Equal("Everest", e.Name));
         }
 
         [Fact]
-        public void It_loads_default_values()
+        public void It_reads_foreign_keys()
         {
-            var entityType = GetModel(@"CREATE TABLE Jobs (
-                                            id PRIMARY KEY,
-                                            occupation text default ""dev"",
-                                            pay int default 2,
-                                            hiredate datetime default current_timestamp,
-                                            iq float default (100 + 19.4),
-                                            name text
-                                            );").FindEntityType("Jobs");
+            var sql = "CREATE TABLE Ranges ( Id INT IDENTITY (1,1) PRIMARY KEY);" +
+                      "CREATE TABLE Mountains ( RangeId INT NOT NULL, FOREIGN KEY (RangeId) REFERENCES Ranges(Id) ON DELETE CASCADE)";
 
-            Assert.NotNull(entityType);
+            var dbModel = CreateModel(sql);
 
-            Assert.Equal("\"dev\"", entityType.FindProperty("occupation").Sqlite().GeneratedValueSql);
-            Assert.Equal("2", entityType.FindProperty("pay").Sqlite().GeneratedValueSql);
-            Assert.Equal("current_timestamp", entityType.FindProperty("hiredate").Sqlite().GeneratedValueSql);
-            Assert.Equal("100 + 19.4", entityType.FindProperty("iq").Sqlite().GeneratedValueSql);
-            Assert.Null(entityType.FindProperty("name").Sqlite().GeneratedValueSql);
+            var fk = Assert.Single(dbModel.Tables.Single(t => t.ForeignKeys.Count > 0).ForeignKeys);
+
+            Assert.Equal("Mountains", fk.Table.Name);
+            Assert.Equal("Ranges", fk.PrincipalTable.Name);
+            Assert.Equal(0, fk.Columns.Single().Ordinal);
+            Assert.Equal("RangeId", fk.Columns.Single().Column.Name);
+            Assert.Equal("Id", fk.Columns.Single().PrincipalColumn.Name);
+            Assert.Equal(ReferentialAction.Cascade, fk.OnDelete);
         }
 
         [Fact]
-        public void It_identifies_not_null()
+        public void It_reads_composite_foreign_keys()
         {
-            var entityType = GetModel(@"CREATE TABLE Restaurants (
-                                        Id int primary key,
-                                        Name text not null,
-                                        MenuUrl text );").FindEntityType("Restaurants");
+            var sql = "CREATE TABLE Ranges ( Id INT IDENTITY (1,1), AltId INT, PRIMARY KEY(Id, AltId));" +
+                      "CREATE TABLE Mountains ( RangeId INT NOT NULL, RangeAltId INT NOT NULL, FOREIGN KEY (RangeId, RangeAltId) " +
+                      " REFERENCES Ranges(Id, AltId) ON DELETE NO ACTION)";
+            var dbModel = CreateModel(sql);
 
-            Assert.NotNull(entityType);
+            var fk = Assert.Single(dbModel.Tables.Single(t => t.ForeignKeys.Count > 0).ForeignKeys);
 
-            Assert.False(entityType.FindProperty("Name").IsNullable);
-            Assert.True(entityType.FindProperty("MenuUrl").IsNullable);
-        }
-
-        [Theory]
-        [InlineData("Id INT PRIMARY KEY", new[] { "Id" })]
-        [InlineData("Id INT, AltId INT, PRIMARY KEY (Id, AltId)", new[] { "Id", "AltId" })]
-        public void It_loads_primary_key(string def, string[] keys)
-        {
-            var entityType = GetModel($"CREATE TABLE Keys ({def});").FindEntityType("Keys");
-
-            Assert.NotNull(entityType);
-            Assert.Equal(keys, entityType.GetKeys().First().Properties.Select(p => p.Sqlite().ColumnName).ToArray());
-        }
-
-        [Theory]
-        [InlineData(new[] { "Id" }, "CREATE TABLE t (Id int, AltId int PRIMARY KEY, Unique(id))")]
-        [InlineData(new[] { "Id" }, "CREATE TABLE t (Id int, AltId int PRIMARY KEY); CREATE UNIQUE INDEX idx_1 on t (id);")]
-        [InlineData(new[] { "Qu\"oted" }, "CREATE TABLE t (\"Qu\"\"oted\" text, AltId int PRIMARY KEY, Unique(\"Qu\"\"oted\"))")]
-        [InlineData(new[] { "Qu\"oted" }, "CREATE TABLE t (\"Qu\"\"oted\" text UNIQUE, AltId int PRIMARY KEY);")]
-        [InlineData(new[] { "Qu\"oted" }, "CREATE TABLE t (\"Qu\"\"oted\" text, AltId int PRIMARY KEY); CREATE Unique INDEX idx_1 on t(\"Qu\"\"oted\");")]
-        [InlineData(new[] { "a", "b" }, "CREATE TABLE t (a int, b int, AltId int PRIMARY KEY, UNIQUE(a,b));")]
-        [InlineData(new[] { "z", "y" }, "CREATE TABLE t (y int, z int, AltId int PRIMARY KEY, UNIQUE(z,y));")]
-        public void It_gets_unique_indexes(string[] columns, string create)
-        {
-            var entityType = GetModel(create).FindEntityType("t");
-
-            var idx = entityType.GetIndexes().Last();
-            Assert.True(idx.IsUnique);
-            Assert.Equal(
-                columns,
-                idx.Properties.Select(c => c.Sqlite().ColumnName).ToArray());
-
-            var props = columns.Select(c => entityType.GetProperties().First(p => p.Sqlite().ColumnName == c)).ToArray();
-            var key = entityType.FindKey(props);
-
-            Assert.NotNull(key);
+            Assert.Equal("Mountains", fk.Table.Name);
+            Assert.Equal("Ranges", fk.PrincipalTable.Name);
+            Assert.Equal(0, fk.Columns.First().Ordinal);
+            Assert.Equal(1, fk.Columns.Last().Ordinal);
+            Assert.Equal(new[] { "RangeId", "RangeAltId" }, fk.Columns.Select(c => c.Column.Name).ToArray());
+            Assert.Equal(new[] { "Id", "AltId" }, fk.Columns.Select(c => c.PrincipalColumn.Name).ToArray());
+            Assert.Equal(ReferentialAction.NoAction, fk.OnDelete);
         }
 
         [Fact]
-        public void It_gets_indexes()
+        public void It_reads_indexes()
         {
-            var entityType = GetModel("CREATE TABLE t (Id int, A text PRIMARY KEY); CREATE INDEX idx_1 on t (id, a);").FindEntityType("t");
+            var sql = "CREATE TABLE Place ( Id int PRIMARY KEY, Name int UNIQUE, Location int);" +
+                      "CREATE INDEX IX_Location_Name ON Place (Location, Name);";
 
-            var idx = entityType.GetIndexes().Last();
-            Assert.False(idx.IsUnique);
-            Assert.Equal(
-                new[] { "Id", "A" },
-                idx.Properties.Select(c => c.Sqlite().ColumnName).ToArray());
+            var dbModel = CreateModel(sql);
 
-            Assert.Single(entityType.GetKeys());
-        }
+            var indexes = dbModel.Tables.Single().Indexes;
 
-        [Fact]
-        public void It_loads_simple_references()
-        {
-            var sql = @"CREATE TABLE Parent ( Id INT PRIMARY KEY );
-                        CREATE TABLE Children (
-                            Id INT PRIMARY KEY,
-                            ParentId INT,
-                            FOREIGN KEY (parentid) REFERENCES parent (id)
-                        );";
-
-            var model = GetModel(sql);
-            var parent = model.FindEntityType("Parent");
-            var children = model.FindEntityType("Children");
-
-            Assert.NotEmpty(parent.GetReferencingForeignKeys());
-            Assert.NotEmpty(children.GetForeignKeys());
-
-            var principalKey = children.FindForeignKeys(children.FindProperty("ParentId")).SingleOrDefault().PrincipalKey;
-            Assert.Equal("Parent", principalKey.DeclaringEntityType.Name);
-            Assert.Equal("Id", principalKey.Properties[0].Name);
-        }
-
-        [Fact]
-        public void It_loads_multiple_key_references()
-        {
-            var sql = @"CREATE TABLE Parent ( Id_A INT, Id_B INT, PRIMARY KEY (ID_A, id_b) );
-                        CREATE TABLE Children (
-                            Id INT PRIMARY KEY,
-                            ParentId_A INT,
-                            ParentId_B INT,
-                            FOREIGN KEY (parentid_A, parentid_B) REFERENCES parent (id_a, id_b)
-                        );";
-
-            var model = GetModel(sql);
-            var parent = model.FindEntityType("Parent");
-            var children = model.FindEntityType("Children");
-
-            Assert.NotEmpty(parent.GetReferencingForeignKeys());
-            Assert.NotEmpty(children.GetForeignKeys());
-
-            var propList = new List<Property>
+            Assert.All(indexes, c =>
             {
-                (Property)children.FindProperty("ParentId_A"),
-                (Property)children.FindProperty("ParentId_B")
-            };
-            var principalKey = children.FindForeignKeys(propList.AsReadOnly()).SingleOrDefault().PrincipalKey;
-            Assert.Equal("Parent", principalKey.DeclaringEntityType.Name);
-            Assert.Equal("Id_A", principalKey.Properties[0].Name);
-            Assert.Equal("Id_B", principalKey.Properties[1].Name);
+                Assert.Equal("Place", c.Table.Name);
+            });
+
+            Assert.Collection(indexes.OrderBy(i => i.Name),
+                index =>
+                {
+                    Assert.Equal("IX_Location_Name", index.Name);
+                    Assert.False(index.IsUnique);
+                    Assert.Equal(new List<string> { "Location", "Name" }, index.IndexColumns.Select(ic => ic.Column.Name).ToList());
+                    Assert.Equal(new List<int> { 0, 1 }, index.IndexColumns.Select(ic => ic.Ordinal).ToList());
+                },
+                pkIndex =>
+                {
+                    Assert.True(pkIndex.IsUnique);
+                    Assert.Equal(new List<string> { "Id" }, pkIndex.IndexColumns.Select(ic => ic.Column.Name).ToList());
+                },
+                unique =>
+                {
+                    Assert.True(unique.IsUnique);
+                    Assert.Equal("Name", unique.IndexColumns.Single().Column.Name);
+                });
         }
 
         [Fact]
-        public void It_loads_self_referencing_foreign_key()
-        {
-            var sql = @"CREATE TABLE ItemsList (
-                            Id INT PRIMARY KEY,
-                            ParentId INT,
-                            FOREIGN KEY (ParentId) REFERENCES ItemsList (Id)
-                        );";
-
-            var model = GetModel(sql);
-            var list = model.FindEntityType("ItemsList");
-
-            Assert.NotEmpty(list.GetReferencingForeignKeys());
-            Assert.NotEmpty(list.GetForeignKeys());
-
-            var principalKey = list.FindForeignKeys(list.FindProperty("ParentId")).SingleOrDefault().PrincipalKey;
-            Assert.Equal("ItemsList", principalKey.DeclaringEntityType.Name);
-            Assert.Equal("Id", principalKey.Properties[0].Name);
-        }
-
-        [Fact]
-        public void It_logs_warning_for_bad_foreign_key()
-        {
-            // will fail because Id is not found
-            var sql = @"CREATE TABLE Parent ( Name PRIMARY KEY);
-                        CREATE TABLE Children (
-                            Id INT PRIMARY KEY,
-                            ParentId INT,
-                            FOREIGN KEY (ParentId) REFERENCES Parent (Id)
-                        );";
-
-            GetModel(sql);
-
-            Assert.Contains("Warning: " +
-                RelationalDesignStrings.ForeignKeyScaffoldErrorPropertyNotFound("Children(ParentId)"),
-                _logger.FullLog);
-        }
-
-        [Fact]
-        public void It_assigns_uniqueness_to_foreign_key()
-        {
-            var sql = @"CREATE TABLE Friends (
-    Id PRIMARY KEY,
-    BuddyId UNIQUE,
-    FOREIGN KEY (BuddyId) REFERENCES Friends(Id)
-);";
-            var table = GetModel(sql).FindEntityType("Friends");
-
-            var fk = table.FindForeignKeys(new[] { table.FindProperty("BuddyId") }).SingleOrDefault();
-
-            Assert.True(fk.IsUnique);
-            Assert.Equal(table.FindPrimaryKey(), fk.PrincipalKey);
-        }
-
-        [Fact]
-        public void It_assigns_uniqueness_to_pk_foreign_key()
+        public void It_reads_columns()
         {
             var sql = @"
-CREATE TABLE Family (Id PRIMARY KEY);
-CREATE TABLE Friends (
-    Id PRIMARY KEY,
-    FOREIGN KEY (Id) REFERENCES Family(Id)
+CREATE TABLE [MountainsColumns] (
+    Id integer primary key,
+    Name string NOT NULL,
+    Latitude numeric DEFAULT 0.0,
+    Created datetime DEFAULT('October 20, 2015 11am')
 );";
-            var table = GetModel(sql).FindEntityType("Friends");
+            var dbModel = CreateModel(sql);
 
-            var fk = table.FindForeignKeys(new[] { table.FindProperty("Id") }).SingleOrDefault();
+            var columns = dbModel.Tables.Single().Columns.OrderBy(c => c.Ordinal);
 
-            Assert.True(fk.IsUnique);
+            Assert.All(columns, c =>
+            {
+                Assert.Equal("MountainsColumns", c.Table.Name);
+            });
+
+            Assert.Collection(columns,
+                id =>
+                {
+                    Assert.Equal("Id", id.Name);
+                    Assert.Equal("integer", id.DataType);
+                    Assert.Equal(1, id.PrimaryKeyOrdinal);
+                    Assert.False(id.IsNullable);
+                    Assert.Equal(0, id.Ordinal);
+                    Assert.Null(id.DefaultValue);
+                },
+                name =>
+                {
+                    Assert.Equal("Name", name.Name);
+                    Assert.Equal("string", name.DataType);
+                    Assert.Null(name.PrimaryKeyOrdinal);
+                    Assert.False(name.IsNullable);
+                    Assert.Equal(1, name.Ordinal);
+                    Assert.Null(name.DefaultValue);
+                },
+                lat =>
+                {
+                    Assert.Equal("Latitude", lat.Name);
+                    Assert.Equal("numeric", lat.DataType);
+                    Assert.Null(lat.PrimaryKeyOrdinal);
+                    Assert.True(lat.IsNullable);
+                    Assert.Equal(2, lat.Ordinal);
+                    Assert.Equal("0.0", lat.DefaultValue);
+                    Assert.Null(lat.Precision);
+                    Assert.Null(lat.Scale);
+                    Assert.Null(lat.MaxLength);
+                },
+                created =>
+                {
+                    Assert.Equal("Created", created.Name);
+                    Assert.Equal("datetime", created.DataType);
+                    Assert.Equal("'October 20, 2015 11am'", created.DefaultValue);
+                });
         }
 
         [Fact]
-        public void It_does_not_assigns_uniqueness_to_foreign_key()
+        public void It_filters_tables()
         {
-            var sql = @"CREATE TABLE Friends (
-    Id PRIMARY KEY,
-    BuddyId,
-    FOREIGN KEY (BuddyId) REFERENCES Friends(Id)
-);";
-            var table = GetModel(sql).FindEntityType("Friends");
+            var sql = @"CREATE TABLE [K2] ( Id int);
+CREATE TABLE [Kilimanjaro] ( Id int);";
 
-            var fk = table.FindForeignKeys(new[] { table.FindProperty("BuddyId") }).SingleOrDefault();
+            var selectionSet = new TableSelectionSet(new List<string> { "K2" });
 
-            Assert.False(fk.IsUnique);
+            var dbModel = CreateModel(sql, selectionSet);
+            var table = Assert.Single(dbModel.Tables);
+            Assert.Equal("K2", table.Name);
         }
 
-        [Fact]
-        public void It_assigns_uniqueness_to_composite_foreign_key()
-        {
-            var sql = @"CREATE TABLE DoubleMint ( A , B, PRIMARY KEY (A,B));
-CREATE TABLE Gum ( A, B PRIMARY KEY,
-    UNIQUE (A,B),
-    FOREIGN KEY (A, B) REFERENCES DoubleMint (A, B)
-);";
-            var dependent = GetModel(sql).FindEntityType("Gum");
-            var foreignKey = dependent.FindForeignKeys(new[] { dependent.FindProperty("A"), dependent.FindProperty("B") }).SingleOrDefault();
-
-            Assert.True(foreignKey.IsUnique);
-        }
-
-        [Fact]
-        public void It_does_not_assign_uniqueness_to_composite_foreign_key()
-        {
-            var sql = @"CREATE TABLE DoubleMint ( A , B PRIMARY KEY, UNIQUE (A,B));
-CREATE TABLE Gum ( A, B PRIMARY KEY,
-    FOREIGN KEY (A, B) REFERENCES DoubleMint (A, B)
-);";
-            var dependent = GetModel(sql).FindEntityType("Gum");
-            var foreignKey = dependent.FindForeignKeys(new[] { dependent.FindProperty("A"), dependent.FindProperty("B") }).SingleOrDefault();
-
-            Assert.False(foreignKey.IsUnique);
-        }
-
-        private IModel GetModel(string createSql)
+        public DatabaseModel CreateModel(string createSql, TableSelectionSet selection = null)
         {
             _testStore.ExecuteNonQuery(createSql);
-            return _scaffoldingModelFactory.Create(_testStore.Connection.ConnectionString, TableSelectionSet.All);
+
+            return _factory.Create(_testStore.Connection.ConnectionString, selection ?? TableSelectionSet.All);
         }
 
         public void Dispose() => _testStore.Dispose();
-    }
-
-    public class TestLoggerProvider : ILoggerProvider
-    {
-        private readonly ILogger _logger;
-
-        public TestLoggerProvider(ILogger logger)
-        {
-            _logger = logger;
-        }
-
-        public ILogger CreateLogger(string name) => _logger;
-
-        public void Dispose()
-        {
-        }
-    }
-
-    public class TestLogger : ILogger
-    {
-        public IDisposable BeginScopeImpl(object state) => NullScope.Instance;
-        public string FullLog => _sb.ToString();
-        private readonly StringBuilder _sb = new StringBuilder();
-
-        public bool IsEnabled(LogLevel logLevel) => true;
-
-        public void Log(LogLevel logLevel, int eventId, object state, Exception exception, Func<object, Exception, string> formatter)
-        {
-            _sb.Append(logLevel)
-                .Append(": ")
-                .Append(formatter(state, exception));
-        }
     }
 }

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/SqliteScaffoldingModelFactoryTest.cs
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/SqliteScaffoldingModelFactoryTest.cs
@@ -1,0 +1,290 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Data.Entity.Internal;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Metadata.Internal;
+using Microsoft.Data.Entity.Scaffolding;
+using Microsoft.Data.Entity.Scaffolding.Internal;
+using Microsoft.Data.Entity.Sqlite.FunctionalTests;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Sqlite.Design.FunctionalTests
+{
+    public class SqliteScaffoldingModelFactoryTest : IDisposable
+    {
+        private readonly RelationalScaffoldingModelFactory _scaffoldingModelFactory;
+        private readonly SqliteTestStore _testStore;
+        private readonly TestLogger _logger;
+
+        public SqliteScaffoldingModelFactoryTest()
+        {
+            _testStore = SqliteTestStore.CreateScratch();
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddLogging();
+            new SqliteDesignTimeServices().ConfigureDesignTimeServices(serviceCollection);
+            serviceCollection.AddSingleton<IFileService, FileSystemFileService>();
+
+            var serviceProvider = serviceCollection
+                .BuildServiceProvider();
+
+            _logger = new TestLogger();
+            serviceProvider.GetService<ILoggerFactory>().AddProvider(new TestLoggerProvider(_logger));
+
+            _scaffoldingModelFactory = serviceProvider
+                .GetService<IScaffoldingModelFactory>() as RelationalScaffoldingModelFactory;
+        }
+
+        [Fact]
+        public void It_loads_column_types()
+        {
+            var entityType = GetModel(@"CREATE TABLE ""Column Types"" (
+                                        col1 text PRIMARY KEY,
+                                        col2 unsigned big int );").FindEntityType("Column_Types");
+
+            Assert.NotNull(entityType);
+            Assert.Equal("Column Types", entityType.Sqlite().TableName);
+
+            Assert.Equal("text", entityType.FindProperty("col1").Sqlite().ColumnType);
+            Assert.Equal(typeof(string), entityType.FindProperty("col1").ClrType);
+
+            Assert.Equal("unsigned big int", entityType.FindProperty("col2").Sqlite().ColumnType);
+            Assert.Equal(typeof(long?), entityType.FindProperty("col2").ClrType);
+        }
+
+        [Fact]
+        public void It_loads_default_values()
+        {
+            var entityType = GetModel(@"CREATE TABLE Jobs (
+                                            id PRIMARY KEY,
+                                            occupation text default ""dev"",
+                                            pay int default 2,
+                                            hiredate datetime default current_timestamp,
+                                            iq float default (100 + 19.4),
+                                            name text
+                                            );").FindEntityType("Jobs");
+
+            Assert.NotNull(entityType);
+
+            Assert.Equal("\"dev\"", entityType.FindProperty("occupation").Sqlite().GeneratedValueSql);
+            Assert.Equal("2", entityType.FindProperty("pay").Sqlite().GeneratedValueSql);
+            Assert.Equal("current_timestamp", entityType.FindProperty("hiredate").Sqlite().GeneratedValueSql);
+            Assert.Equal("100 + 19.4", entityType.FindProperty("iq").Sqlite().GeneratedValueSql);
+            Assert.Null(entityType.FindProperty("name").Sqlite().GeneratedValueSql);
+        }
+
+        [Fact]
+        public void It_identifies_not_null()
+        {
+            var entityType = GetModel(@"CREATE TABLE Restaurants (
+                                        Id int primary key,
+                                        Name text not null,
+                                        MenuUrl text );").FindEntityType("Restaurants");
+
+            Assert.NotNull(entityType);
+
+            Assert.False(entityType.FindProperty("Name").IsNullable);
+            Assert.True(entityType.FindProperty("MenuUrl").IsNullable);
+        }
+
+        [Fact]
+        public void It_gets_unique_indexes()
+        {
+            var sql = "CREATE TABLE t (Id int, AltId int PRIMARY KEY, Unique(id))";
+            var entityType = GetModel(sql).FindEntityType("t");
+
+            var idx = entityType.GetIndexes().Last();
+            Assert.True(idx.IsUnique);
+        }
+
+        [Fact]
+        public void It_gets_indexes()
+        {
+            var entityType = GetModel("CREATE TABLE t (Id int, A text PRIMARY KEY); CREATE INDEX idx_1 on t (id, a);").FindEntityType("t");
+
+            var idx = entityType.GetIndexes().Last();
+            Assert.False(idx.IsUnique);
+            Assert.Equal(
+                new[] { "Id", "A" },
+                idx.Properties.Select(c => c.Sqlite().ColumnName).ToArray());
+
+            Assert.Single(entityType.GetKeys());
+        }
+
+        [Fact]
+        public void It_loads_simple_references()
+        {
+            var sql = @"CREATE TABLE Parent ( Id INT PRIMARY KEY );
+                        CREATE TABLE Children (
+                            Id INT PRIMARY KEY,
+                            ParentId INT,
+                            FOREIGN KEY (parentid) REFERENCES parent (id)
+                        );";
+
+            var model = GetModel(sql);
+            var parent = model.FindEntityType("Parent");
+            var children = model.FindEntityType("Children");
+
+            Assert.NotEmpty(parent.GetReferencingForeignKeys());
+            Assert.NotEmpty(children.GetForeignKeys());
+
+            var principalKey = children.FindForeignKeys(children.FindProperty("ParentId")).SingleOrDefault().PrincipalKey;
+            Assert.Equal("Parent", principalKey.DeclaringEntityType.Name);
+            Assert.Equal("Id", principalKey.Properties[0].Name);
+        }
+
+        [Fact]
+        public void It_loads_composite_key_references()
+        {
+            var sql = @"CREATE TABLE Parent ( Id_A INT, Id_B INT, PRIMARY KEY (ID_A, id_b) );
+                        CREATE TABLE Children (
+                            Id INT PRIMARY KEY,
+                            ParentId_A INT,
+                            ParentId_B INT,
+                            FOREIGN KEY (parentid_A, parentid_B) REFERENCES parent (id_a, id_b)
+                        );";
+
+            var model = GetModel(sql);
+            var parent = model.FindEntityType("Parent");
+            var children = model.FindEntityType("Children");
+
+            Assert.NotEmpty(parent.GetReferencingForeignKeys());
+            Assert.NotEmpty(children.GetForeignKeys());
+
+            var propList = new List<Property>
+            {
+                (Property)children.FindProperty("ParentId_A"),
+                (Property)children.FindProperty("ParentId_B")
+            };
+            var principalKey = children.FindForeignKeys(propList.AsReadOnly()).SingleOrDefault().PrincipalKey;
+            Assert.Equal("Parent", principalKey.DeclaringEntityType.Name);
+            Assert.Equal("Id_A", principalKey.Properties[0].Name);
+            Assert.Equal("Id_B", principalKey.Properties[1].Name);
+        }
+
+        [Fact]
+        public void It_loads_self_referencing_foreign_key()
+        {
+            var sql = @"CREATE TABLE ItemsList (
+                            Id INT PRIMARY KEY,
+                            ParentId INT,
+                            FOREIGN KEY (ParentId) REFERENCES ItemsList (Id)
+                        );";
+
+            var model = GetModel(sql);
+            var list = model.FindEntityType("ItemsList");
+
+            Assert.NotEmpty(list.GetReferencingForeignKeys());
+            Assert.NotEmpty(list.GetForeignKeys());
+
+            var principalKey = list.FindForeignKeys(list.FindProperty("ParentId")).SingleOrDefault().PrincipalKey;
+            Assert.Equal("ItemsList", principalKey.DeclaringEntityType.Name);
+            Assert.Equal("Id", principalKey.Properties[0].Name);
+        }
+
+        [Fact]
+        public void It_logs_warning_for_bad_foreign_key()
+        {
+            // will fail because Id is not found
+            var sql = @"CREATE TABLE Parent ( Name PRIMARY KEY);
+                        CREATE TABLE Children (
+                            Id INT PRIMARY KEY,
+                            ParentId INT,
+                            FOREIGN KEY (ParentId) REFERENCES Parent (Id)
+                        );";
+
+            GetModel(sql);
+
+            Assert.Contains("Warning: " +
+                RelationalDesignStrings.ForeignKeyScaffoldErrorPropertyNotFound("Children(ParentId)"),
+                _logger.FullLog);
+        }
+
+        [Fact]
+        public void It_assigns_uniqueness_to_foreign_key()
+        {
+            var sql = @"CREATE TABLE Friends (
+    Id PRIMARY KEY,
+    BuddyId UNIQUE,
+    FOREIGN KEY (BuddyId) REFERENCES Friends(Id)
+);";
+            var table = GetModel(sql).FindEntityType("Friends");
+
+            var fk = table.FindForeignKeys(new[] { table.FindProperty("BuddyId") }).SingleOrDefault();
+
+            Assert.True(fk.IsUnique);
+            Assert.Equal(table.FindPrimaryKey(), fk.PrincipalKey);
+        }
+
+        [Fact]
+        public void It_assigns_uniqueness_to_pk_foreign_key()
+        {
+            var sql = @"
+CREATE TABLE Family (Id PRIMARY KEY);
+CREATE TABLE Friends (
+    Id PRIMARY KEY,
+    FOREIGN KEY (Id) REFERENCES Family(Id)
+);";
+            var table = GetModel(sql).FindEntityType("Friends");
+
+            var fk = table.FindForeignKeys(new[] { table.FindProperty("Id") }).SingleOrDefault();
+
+            Assert.True(fk.IsUnique);
+        }
+
+        [Fact]
+        public void It_does_not_assign_uniqueness_to_foreign_key()
+        {
+            var sql = @"CREATE TABLE Friends (
+    Id PRIMARY KEY,
+    BuddyId,
+    FOREIGN KEY (BuddyId) REFERENCES Friends(Id)
+);";
+            var table = GetModel(sql).FindEntityType("Friends");
+
+            var fk = table.FindForeignKeys(new[] { table.FindProperty("BuddyId") }).SingleOrDefault();
+
+            Assert.False(fk.IsUnique);
+        }
+
+        [Fact]
+        public void It_assigns_uniqueness_to_composite_foreign_key()
+        {
+            var sql = @"CREATE TABLE DoubleMint ( A , B, PRIMARY KEY (A,B));
+CREATE TABLE Gum ( A, B PRIMARY KEY,
+    UNIQUE (A,B),
+    FOREIGN KEY (A, B) REFERENCES DoubleMint (A, B)
+);";
+            var dependent = GetModel(sql).FindEntityType("Gum");
+            var foreignKey = dependent.FindForeignKeys(new[] { dependent.FindProperty("A"), dependent.FindProperty("B") }).SingleOrDefault();
+
+            Assert.True(foreignKey.IsUnique);
+        }
+
+        [Fact]
+        public void It_does_not_assign_uniqueness_to_composite_foreign_key()
+        {
+            var sql = @"CREATE TABLE DoubleMint ( A , B PRIMARY KEY, UNIQUE (A,B));
+CREATE TABLE Gum ( A, B PRIMARY KEY,
+    FOREIGN KEY (A, B) REFERENCES DoubleMint (A, B)
+);";
+            var dependent = GetModel(sql).FindEntityType("Gum");
+            var foreignKey = dependent.FindForeignKeys(new[] { dependent.FindProperty("A"), dependent.FindProperty("B") }).SingleOrDefault();
+
+            Assert.False(foreignKey.IsUnique);
+        }
+
+        private IModel GetModel(string createSql)
+        {
+            _testStore.ExecuteNonQuery(createSql);
+            return _scaffoldingModelFactory.Create(_testStore.Connection.ConnectionString, TableSelectionSet.All);
+        }
+
+        public void Dispose() => _testStore.Dispose();
+    }
+}

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/TestLogger.cs
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/TestLogger.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Text;
+using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Data.Entity.Sqlite.Design.FunctionalTests
+{
+
+    public class TestLoggerProvider : ILoggerProvider
+    {
+        private readonly ILogger _logger;
+
+        public TestLoggerProvider(ILogger logger)
+        {
+            _logger = logger;
+        }
+
+        public ILogger CreateLogger(string name) => _logger;
+
+        public void Dispose()
+        {
+        }
+    }
+
+    public class TestLogger : ILogger
+    {
+        public IDisposable BeginScopeImpl(object state) => NullScope.Instance;
+        public string FullLog => _sb.ToString();
+        private readonly StringBuilder _sb = new StringBuilder();
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log(LogLevel logLevel, int eventId, object state, Exception exception, Func<object, Exception, string> formatter)
+        {
+            _sb.Append(logLevel)
+                .Append(": ")
+                .Append(formatter(state, exception));
+        }
+    }
+}


### PR DESCRIPTION
Removes implicit column ordering in index and foreign models e.g. ~~`IList`~~ => `ICollection`

Fix #3996

cc @divega @lajones 