### PR TITLE
Boolean in select

### DIFF
--- a/src/EntityFramework.Relational/Extensions/ExpressionExtensions.cs
+++ b/src/EntityFramework.Relational/Extensions/ExpressionExtensions.cs
@@ -19,6 +19,18 @@ namespace System.Linq.Expressions
                    || (expression.NodeType == ExpressionType.OrElse);
         }
 
+        public static bool IsComparisonOperation([NotNull] this Expression expression)
+        {
+            Check.NotNull(expression, nameof(expression));
+
+            return expression.NodeType == ExpressionType.Equal
+                || expression.NodeType == ExpressionType.NotEqual
+                || expression.NodeType == ExpressionType.LessThan
+                || expression.NodeType == ExpressionType.LessThanOrEqual
+                || expression.NodeType == ExpressionType.GreaterThan
+                || expression.NodeType == ExpressionType.GreaterThanOrEqual;
+        }
+
         public static ColumnExpression TryGetColumnExpression([NotNull] this Expression expression)
             => (expression as AliasExpression)?.TryGetColumnExpression();
 

--- a/src/EntityFramework.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/EntityFramework.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Data.Entity.Query.Sql
                     _relationalCommandBuilder.Append(", ");
                 }
 
-                VisitJoin(selectExpression.Projection);
+                VisitProjection(selectExpression.Projection);
 
                 projectionAdded = true;
             }
@@ -225,6 +225,13 @@ namespace Microsoft.Data.Entity.Query.Sql
             }
 
             return selectExpression;
+        }
+
+        protected virtual void VisitProjection([NotNull] IReadOnlyList<Expression> projections)
+        {
+            var nullComparisonTransformer = new NullComparisonTransformingVisitor(_parametersValues);
+
+            VisitJoin(projections.Select(e => nullComparisonTransformer.Visit(e)).ToList());
         }
 
         protected virtual void GenerateOrderBy([NotNull] IReadOnlyList<Ordering> orderings)

--- a/test/EntityFramework.Core.FunctionalTests/AsyncQueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/AsyncQueryTestBase.cs
@@ -1217,6 +1217,13 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [ConditionalFact]
+        public virtual async Task Select_anonymous_conditional_expression()
+        {
+            await AssertQuery<Product>(
+                ps => ps.Select(p => new { p.ProductID, IsAvailable = p.UnitsInStock > 0 }));
+        }
+
+        [ConditionalFact]
         public virtual async Task Select_customer_table()
         {
             await AssertQuery<Customer>(

--- a/test/EntityFramework.Core.FunctionalTests/GearsOfWarQueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/GearsOfWarQueryTestBase.cs
@@ -503,6 +503,72 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [ConditionalFact]
+        public virtual void Select_inverted_boolean()
+        {
+            using (var context = CreateContext())
+            {
+                var automaticWeapons = context.Weapons
+                    .Where(w => w.IsAutomatic)
+                    .Select(w => new { w.Id, Manual = !w.IsAutomatic })
+                    .ToList();
+
+                Assert.True(automaticWeapons.All(t => t.Manual == false));
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Select_comparison_with_null()
+        {
+            AmmunitionType? ammunitionType = AmmunitionType.Cartridge;
+            using (var context = CreateContext())
+            {
+                var cartidgeWeapons = context.Weapons
+                    .Where(w => w.AmmunitionType == ammunitionType)
+                    .Select(w => new { w.Id, Cartidge = w.AmmunitionType == ammunitionType })
+                    .ToList();
+
+                Assert.True(cartidgeWeapons.All(t => t.Cartidge == true));
+            }
+
+            ammunitionType = null;
+            using (var context = CreateContext())
+            {
+                var cartidgeWeapons = context.Weapons
+                    .Where(w => w.AmmunitionType == ammunitionType)
+                    .Select(w => new { w.Id, Cartidge = w.AmmunitionType == ammunitionType })
+                    .ToList();
+
+                Assert.True(cartidgeWeapons.All(t => t.Cartidge == true));
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Select_ternary_operation_with_boolean()
+        {
+            using (var context = CreateContext())
+            {
+                var weapons = context.Weapons
+                    .Select(w => new { w.Id, Num = w.IsAutomatic ? 1 : 0})
+                    .ToList();
+
+                Assert.Equal(3, weapons.Count(w => w.Num == 1));
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Select_ternary_operation_with_inverted_boolean()
+        {
+            using (var context = CreateContext())
+            {
+                var weapons = context.Weapons
+                    .Select(w => new { w.Id, Num = !w.IsAutomatic ? 1 : 0 })
+                    .ToList();
+
+                Assert.Equal(7, weapons.Count(w => w.Num == 1));
+            }
+        }
+
+        [ConditionalFact]
         public virtual void Select_Where_Navigation()
         {
             using (var context = CreateContext())

--- a/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
@@ -1230,7 +1230,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             AssertQuery<Customer, Employee>((cs, es) =>
                 from c in cs
                 from e in es
-                // ReSharper disable ArrangeRedundantParentheses
+                    // ReSharper disable ArrangeRedundantParentheses
                 where (c.City == "London" && c.Country == "UK")
                         && (e.City == "London" && e.Country == "UK")
                 select new { c, e });
@@ -1595,6 +1595,13 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             AssertQuery<Customer>(
                 cs => cs.Select(c => new { c.CustomerID, Expression = c.CustomerID.Length + 5 }));
+        }
+
+        [ConditionalFact]
+        public virtual void Select_anonymous_conditional_expression()
+        {
+            AssertQuery<Product>(
+                ps => ps.Select(p => new { p.ProductID, IsAvailable = p.UnitsInStock > 0 }));
         }
 
         [ConditionalFact]
@@ -4474,7 +4481,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         public virtual void Select_take_skip_null_coalesce_operator3()
         {
             AssertQuery<Customer>(
-                cs => cs.OrderBy(c => c.Region ?? "ZZ").Take(10).Skip(5), 
+                cs => cs.OrderBy(c => c.Region ?? "ZZ").Take(10).Skip(5),
                 entryCount: 5);
         }
 
@@ -4561,9 +4568,9 @@ namespace Microsoft.Data.Entity.FunctionalTests
             {
                 var orderDetails
                     = (from od in context.Set<OrderDetail>()
-                        select (from o in context.Set<Order>()
-                            where od.OrderID == o.OrderID
-                            select o).First())
+                       select (from o in context.Set<Order>()
+                               where od.OrderID == o.OrderID
+                               select o).First())
                         .Take(2)
                         .ToList();
 

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/GearsOfWarModel/GearsOfWarModelInitializer.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/GearsOfWarModel/GearsOfWarModelInitializer.cs
@@ -66,61 +66,71 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel
                 var marcusLancer = new Weapon
                     {
                         Name = "Marcus' Lancer",
-                        AmmunitionType = AmmunitionType.Cartridge
+                        AmmunitionType = AmmunitionType.Cartridge,
+                        IsAutomatic = true
                     };
 
                 var marcusGnasher = new Weapon
                     {
                         Name = "Marcus' Gnasher",
                         AmmunitionType = AmmunitionType.Shell,
+                        IsAutomatic = false,
                         SynergyWith = marcusLancer
                     };
 
                 var domsHammerburst = new Weapon
                     {
                         Name = "Dom's Hammerburst",
-                        AmmunitionType = AmmunitionType.Cartridge
+                        AmmunitionType = AmmunitionType.Cartridge,
+                        IsAutomatic = false
                     };
 
                 var domsGnasher = new Weapon
                     {
                         Name = "Dom's Gnasher",
-                        AmmunitionType = AmmunitionType.Shell
+                        AmmunitionType = AmmunitionType.Shell,
+                        IsAutomatic = false
                     };
 
                 var colesGnasher = new Weapon
                     {
                         Name = "Cole's Gnasher",
-                        AmmunitionType = AmmunitionType.Shell
+                        AmmunitionType = AmmunitionType.Shell,
+                        IsAutomatic = false
                     };
 
                 var colesMulcher = new Weapon
                     {
                         Name = "Cole's Mulcher",
-                        AmmunitionType = AmmunitionType.Cartridge
+                        AmmunitionType = AmmunitionType.Cartridge,
+                        IsAutomatic = true
                     };
 
                 var bairdsLancer = new Weapon
                     {
                         Name = "Baird's Lancer",
-                        AmmunitionType = AmmunitionType.Cartridge
+                        AmmunitionType = AmmunitionType.Cartridge,
+                        IsAutomatic = true
                     };
 
                 var bairdsGnasher = new Weapon
                     {
                         Name = "Baird's Gnasher",
-                        AmmunitionType = AmmunitionType.Shell
+                        AmmunitionType = AmmunitionType.Shell,
+                        IsAutomatic = false
                     };
 
                 var paduksMarkza = new Weapon
                     {
                         Name = "Paduk's Markza",
-                        AmmunitionType = AmmunitionType.Cartridge
+                        AmmunitionType = AmmunitionType.Cartridge,
+                        IsAutomatic = false
                     };
 
                 var maulersFlail = new Weapon
                     {
-                        Name = "Mauler's Flail"
+                        Name = "Mauler's Flail",
+                        IsAutomatic = false
                     };
 
                 context.Weapons.Add(marcusLancer);
@@ -228,7 +238,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel
                     };
 
                 var marcus = new Officer
-                {
+                    {
                         Nickname = "Marcus",
                         FullName = "Marcus Fenix",
                         SquadId = deltaSquad.Id,

--- a/test/EntityFramework.Core.FunctionalTests/TestModels/GearsOfWarModel/Weapon.cs
+++ b/test/EntityFramework.Core.FunctionalTests/TestModels/GearsOfWarModel/Weapon.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel
         public int Id { get; set; }
         public string Name { get; set; }
         public AmmunitionType? AmmunitionType { get; set; }
+        public bool IsAutomatic { get; set; }
 
         // 1 - 1 self reference
         public int? SynergyWithId { get; set; }

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/GearsOfWarFromSqlQuerySqlServerTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/GearsOfWarFromSqlQuerySqlServerTest.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             base.From_sql_queryable_simple_columns_out_of_order();
 
             Assert.Equal(
-                @"SELECT ""Id"", ""Name"", ""AmmunitionType"", ""OwnerFullName"", ""SynergyWithId"" FROM ""Weapon"" ORDER BY ""Name""",
+                @"SELECT ""Id"", ""Name"", ""IsAutomatic"", ""AmmunitionType"", ""OwnerFullName"", ""SynergyWithId"" FROM ""Weapon"" ORDER BY ""Name""",
                 Sql);
         }
 

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -23,7 +23,7 @@ LEFT JOIN (
 ) AS [g] ON ([t].[GearNickName] = [g].[Nickname]) AND ([t].[GearSquadId] = [g].[SquadId])
 ORDER BY [g].[FullName]
 
-SELECT [w].[Id], [w].[AmmunitionType], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapon] AS [w]
 INNER JOIN (
     SELECT DISTINCT [g].[FullName]
@@ -52,7 +52,7 @@ LEFT JOIN (
 ) AS [g] ON ([t].[GearNickName] = [g].[Nickname]) AND ([t].[GearSquadId] = [g].[SquadId])
 ORDER BY [g].[FullName]
 
-SELECT [w].[Id], [w].[AmmunitionType], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapon] AS [w]
 INNER JOIN (
     SELECT DISTINCT [g].[FullName]
@@ -171,7 +171,7 @@ FROM [Gear] AS [g]
 WHERE [g].[Discriminator] IN ('Officer', 'Gear') AND ([g].[Nickname] = 'Marcus')
 ORDER BY [g].[FullName]
 
-SELECT [w].[Id], [w].[AmmunitionType], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapon] AS [w]
 INNER JOIN (
     SELECT DISTINCT [g].[FullName]
@@ -327,7 +327,7 @@ INNER JOIN [CogTag] AS [t] ON ([g].[SquadId] = [t].[GearSquadId]) AND ([g].[Nick
 WHERE [g].[Discriminator] IN ('Officer', 'Gear')
 ORDER BY [g].[FullName]
 
-SELECT [w].[Id], [w].[AmmunitionType], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapon] AS [w]
 INNER JOIN (
     SELECT DISTINCT [g].[FullName]
@@ -349,7 +349,7 @@ FROM [CogTag] AS [t]
 INNER JOIN [Gear] AS [g] ON ([t].[GearSquadId] = [g].[SquadId]) AND ([t].[GearNickName] = [g].[Nickname])
 ORDER BY [g].[FullName]
 
-SELECT [w].[Id], [w].[AmmunitionType], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapon] AS [w]
 INNER JOIN (
     SELECT DISTINCT [g].[FullName]
@@ -416,7 +416,7 @@ FROM (
 INNER JOIN [CogTag] AS [t] ON ([t0].[SquadId] = [t].[GearSquadId]) AND ([t0].[Nickname] = [t].[GearNickName])
 ORDER BY [t0].[FullName]
 
-SELECT [w].[Id], [w].[AmmunitionType], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapon] AS [w]
 INNER JOIN (
     SELECT DISTINCT [t0].[FullName]
@@ -466,7 +466,7 @@ ORDER BY [t0].[Nickname], [t0].[SquadId]",
             base.Include_with_nested_navigation_in_order_by();
 
             Assert.Equal(
-                @"SELECT [w].[Id], [w].[AmmunitionType], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+                @"SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId], [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Weapon] AS [w]
 INNER JOIN [Gear] AS [w.Owner] ON [w].[OwnerFullName] = [w.Owner].[FullName]
 INNER JOIN [City] AS [w.Owner.CityOfBirth] ON [w.Owner].[CityOrBirthName] = [w.Owner.CityOfBirth].[Name]
@@ -495,7 +495,7 @@ WHERE [g].[Discriminator] IN ('Officer', 'Gear') AND ([g].[Rank] = 2)",
             base.Where_nullable_enum_with_constant();
 
             Assert.Equal(
-                @"SELECT [w].[Id], [w].[AmmunitionType], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+                @"SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapon] AS [w]
 WHERE [w].[AmmunitionType] = 1",
                 Sql);
@@ -506,7 +506,7 @@ WHERE [w].[AmmunitionType] = 1",
             base.Where_nullable_enum_with_null_constant();
 
             Assert.Equal(
-                @"SELECT [w].[Id], [w].[AmmunitionType], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+                @"SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapon] AS [w]
 WHERE [w].[AmmunitionType] IS NULL",
                 Sql);
@@ -532,13 +532,77 @@ WHERE [w].[AmmunitionType] = @__p_0",
             Assert.Equal(
                 @"@__ammunitionType_0: Cartridge
 
-SELECT [w].[Id], [w].[AmmunitionType], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapon] AS [w]
 WHERE [w].[AmmunitionType] = @__ammunitionType_0
 
-SELECT [w].[Id], [w].[AmmunitionType], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
 FROM [Weapon] AS [w]
 WHERE [w].[AmmunitionType] IS NULL",
+                Sql);
+        }
+
+        public override void Select_inverted_boolean()
+        {
+            base.Select_inverted_boolean();
+
+            Assert.Equal(
+                @"SELECT [w].[Id], CASE
+    WHEN [w].[IsAutomatic] = 0
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END
+FROM [Weapon] AS [w]
+WHERE [w].[IsAutomatic] = 1",
+                Sql);
+        }
+
+        public override void Select_comparison_with_null()
+        {
+            base.Select_comparison_with_null();
+
+            Assert.Equal(
+                @"@__ammunitionType_1: Cartridge
+@__ammunitionType_0: Cartridge
+
+SELECT [w].[Id], CASE
+    WHEN [w].[AmmunitionType] = @__ammunitionType_1
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END
+FROM [Weapon] AS [w]
+WHERE [w].[AmmunitionType] = @__ammunitionType_0
+
+SELECT [w].[Id], CASE
+    WHEN [w].[AmmunitionType] IS NULL
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END
+FROM [Weapon] AS [w]
+WHERE [w].[AmmunitionType] IS NULL",
+                Sql);
+        }
+
+        public override void Select_ternary_operation_with_boolean()
+        {
+            base.Select_ternary_operation_with_boolean();
+
+            Assert.Equal(
+                @"SELECT [w].[Id], CASE
+    WHEN [w].[IsAutomatic] = 1
+    THEN 1 ELSE 0
+END
+FROM [Weapon] AS [w]",
+                Sql);
+        }
+
+        public override void Select_ternary_operation_with_inverted_boolean()
+        {
+            base.Select_ternary_operation_with_inverted_boolean();
+
+            Assert.Equal(
+                @"SELECT [w].[Id], CASE
+    WHEN [w].[IsAutomatic] = 0
+    THEN 1 ELSE 0
+END
+FROM [Weapon] AS [w]",
                 Sql);
         }
 

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -1372,6 +1372,19 @@ FROM [Customers] AS [c]",
                 Sql);
         }
 
+        public override void Select_anonymous_conditional_expression()
+        {
+            base.Select_anonymous_conditional_expression();
+
+            Assert.Equal(
+                @"SELECT [p].[ProductID], CASE
+    WHEN [p].[UnitsInStock] > 0
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END
+FROM [Products] AS [p]",
+                Sql);
+        }
+
         public override void Select_scalar_primitive_after_take()
         {
             base.Select_scalar_primitive_after_take();

--- a/test/EntityFramework.Relational.FunctionalTests/GearsOfWarFromSqlQueryTestBase.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/GearsOfWarFromSqlQueryTestBase.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             using (var context = CreateContext())
             {
                 var actual = context.Set<Weapon>()
-                    .FromSql(@"SELECT ""Id"", ""Name"", ""AmmunitionType"", ""OwnerFullName"", ""SynergyWithId"" FROM ""Weapon"" ORDER BY ""Name""")
+                    .FromSql(@"SELECT ""Id"", ""Name"", ""IsAutomatic"", ""AmmunitionType"", ""OwnerFullName"", ""SynergyWithId"" FROM ""Weapon"" ORDER BY ""Name""")
                     .ToArray();
 
                 Assert.Equal(10, actual.Length);


### PR DESCRIPTION
resolves #3703 
Issue: SQL does not allow not operation on Boolean type directly. They must be compared with true or false. Fix is to convert unary operations on Boolean type to comparison operation.
resolves  #3618 
Issue: SQL does not allow comparison operation into projection. They must be wrapped in `Case When Then` block.
Fix: Whenever there is comparison operation into projection, convert it to conditional expression.
If comparison operation is inside conditional expression already then do no convert.
Issue: Comparison follows null semantics.
Implementation: While processing `SelectExpression` process the projection accordingly.
resolves #649 for projections