### PR TITLE
Map indexed properties to fit within SQL Server 900-byte limitation

### DIFF
--- a/src/EntityFramework.MicrosoftSqlServer/Storage/Internal/SqlServerTypeMapper.cs
+++ b/src/EntityFramework.MicrosoftSqlServer/Storage/Internal/SqlServerTypeMapper.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Linq;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Utilities;
 
@@ -144,5 +145,9 @@ namespace Microsoft.Data.Entity.Storage.Internal
                         _varbinarymax, _varbinarymax, _varbinary900, _rowversion)
                     : null;
         }
+
+        // indexes in SQL Server have a max size of 900 bytes
+        protected override bool RequiresKeyMapping(IProperty property)
+            => base.RequiresKeyMapping(property) || property.FindContainingIndexes().Any();
     }
 }

--- a/src/EntityFramework.Relational/Storage/RelationalTypeMapper.cs
+++ b/src/EntityFramework.Relational/Storage/RelationalTypeMapper.cs
@@ -86,6 +86,9 @@ namespace Microsoft.Data.Entity.Storage
             throw new NotSupportedException(RelationalStrings.UnsupportedType(property.ClrType.Name));
         }
 
+        protected virtual bool RequiresKeyMapping([NotNull] IProperty property)
+            => property.IsKey() || property.FindContainingEntityTypes().Any(property.IsForeignKey);
+
         protected virtual RelationalTypeMapping GetStringMapping(
             [NotNull] IProperty property,
             int maxBoundedLength,
@@ -104,7 +107,7 @@ namespace Microsoft.Data.Entity.Storage
                     ? _boundedStringMappings.GetOrAdd(maxLength.Value, boundedMapping)
                     : unboundedMapping
                 : ((keyMapping != null)
-                   && (property.IsKey() || property.FindContainingEntityTypes().Any(property.IsForeignKey))
+                   && RequiresKeyMapping(property)
                     ? keyMapping
                     : defaultMapping);
         }
@@ -135,7 +138,7 @@ namespace Microsoft.Data.Entity.Storage
                     ? _boundedBinaryMappings.GetOrAdd(maxLength.Value, boundedMapping)
                     : unboundedMapping
                 : ((keyMapping != null)
-                   && (property.IsKey() || property.FindContainingEntityTypes().Any(property.IsForeignKey))
+                   && RequiresKeyMapping(property)
                     ? keyMapping
                     : defaultMapping);
         }

--- a/test/EntityFramework.MicrosoftSqlServer.Tests/SqlServerTypeMapperTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.Tests/SqlServerTypeMapperTest.cs
@@ -257,6 +257,20 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         }
 
         [Fact]
+        public void Does_indexed_column_SQL_Server_string_mapping()
+        {
+            var entityType = CreateEntityType();
+            var property = entityType.AddProperty("MyProp", typeof(string));
+            entityType.AddIndex(property);
+
+            var typeMapping = new SqlServerTypeMapper().GetMapping(property);
+
+            Assert.Null(typeMapping.StoreType);
+            Assert.Equal("nvarchar(450)", typeMapping.DefaultTypeName);
+            Assert.Equal(4000, typeMapping.CreateParameter(new TestCommand(), "Name", "Value").Size);
+        }
+
+        [Fact]
         public void Does_non_key_SQL_Server_binary_mapping()
         {
             var typeMapping = GetTypeMapping(typeof(byte[]));
@@ -352,6 +366,22 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             Assert.Equal("varbinary(900)", typeMapping.DefaultTypeName);
             Assert.Equal(8000, typeMapping.CreateParameter(new TestCommand(), "Name", new byte[3]).Size);
         }
+
+
+        [Fact]
+        public void Does_indexed_column_SQL_Server_binary_mapping()
+        {
+            var entityType = CreateEntityType();
+            var property = entityType.AddProperty("MyProp", typeof(byte[]));
+            entityType.AddIndex(property);
+
+            var typeMapping = new SqlServerTypeMapper().GetMapping(property);
+
+            Assert.Equal(DbType.Binary, typeMapping.StoreType);
+            Assert.Equal("varbinary(900)", typeMapping.DefaultTypeName);
+            Assert.Equal(8000, typeMapping.CreateParameter(new TestCommand(), "Name", "Value").Size);
+        }
+
 
         [Fact]
         public void Does_non_key_SQL_Server_rowversion_mapping()


### PR DESCRIPTION
Fix #1071 

Ref: https://msdn.microsoft.com/en-us/library/ms188783.aspx

cc @ajcvickers 