### PR TITLE
Create cache for dependent entries when requested first time

### DIFF
--- a/src/EntityFramework.Core/ChangeTracking/Internal/ChangeDetector.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/ChangeDetector.cs
@@ -151,6 +151,11 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
                     if (foreignKeys.Count > 0)
                     {
                         stateManager.Notify.ForeignKeyPropertyChanged(entry, property, snapshotValue, currentValue);
+
+                        foreach (var foreignKey in foreignKeys)
+                        {
+                            stateManager.UpdateDependentMap(entry, foreignKey);
+                        }
                     }
 
                     if (keys.Count > 0)

--- a/src/EntityFramework.Core/ChangeTracking/Internal/DependentsMap.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/DependentsMap.cs
@@ -1,0 +1,99 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+
+namespace Microsoft.Data.Entity.ChangeTracking.Internal
+{
+    public class DependentsMap<TKey> : IDependentsMap
+    {
+        private readonly IEntityType _entityType;
+        private readonly IPrincipalKeyValueFactory<TKey> _principalKeyValueFactory;
+        private readonly IDependentKeyValueFactory<TKey> _dependentKeyValueFactory;
+        private readonly Dictionary<TKey, List<InternalEntityEntry>> _map;
+
+        public DependentsMap(
+            [NotNull] IForeignKey foreignKey,
+            [NotNull] IPrincipalKeyValueFactory<TKey> principalKeyValueFactory,
+            [NotNull] IDependentKeyValueFactory<TKey> dependentKeyValueFactory)
+        {
+            _entityType = foreignKey.DeclaringEntityType;
+            _principalKeyValueFactory = principalKeyValueFactory;
+            _dependentKeyValueFactory = dependentKeyValueFactory;
+            _map = new Dictionary<TKey, List<InternalEntityEntry>>(principalKeyValueFactory.EqualityComparer);
+        }
+
+        public virtual void Add(InternalEntityEntry entry)
+        {
+            TKey key;
+            if (_entityType.IsAssignableFrom(entry.EntityType)
+                && _dependentKeyValueFactory.TryCreateFromCurrentValues(entry, out key))
+            {
+                List<InternalEntityEntry> dependents;
+                if (!_map.TryGetValue(key, out dependents))
+                {
+                    dependents = new List<InternalEntityEntry>();
+                    _map[key] = dependents;
+                }
+                dependents.Add(entry);
+            }
+        }
+
+        public virtual void Remove(InternalEntityEntry entry)
+        {
+            TKey key;
+            if (_entityType.IsAssignableFrom(entry.EntityType)
+                && _dependentKeyValueFactory.TryCreateFromCurrentValues(entry, out key))
+            {
+                List<InternalEntityEntry> dependents;
+                if (_map.TryGetValue(key, out dependents))
+                {
+                    dependents.Remove(entry);
+                }
+            }
+        }
+
+        public virtual void Update(InternalEntityEntry entry)
+        {
+            if (_entityType.IsAssignableFrom(entry.EntityType))
+            {
+                TKey key;
+                List<InternalEntityEntry> dependents;
+                if (_dependentKeyValueFactory.TryCreateFromRelationshipSnapshot(entry, out key)
+                    && _map.TryGetValue(key, out dependents))
+                {
+                    dependents.Remove(entry);
+                }
+
+                if (_dependentKeyValueFactory.TryCreateFromCurrentValues(entry, out key))
+                {
+                    if (!_map.TryGetValue(key, out dependents))
+                    {
+                        dependents = new List<InternalEntityEntry>();
+                        _map[key] = dependents;
+                    }
+                    dependents.Add(entry);
+                }
+            }
+        }
+
+        public virtual IEnumerable<InternalEntityEntry> GetDependents(InternalEntityEntry principalEntry)
+        {
+            List<InternalEntityEntry> dependents;
+            return _map.TryGetValue(_principalKeyValueFactory.CreateFromCurrentValues(principalEntry), out dependents)
+                ? dependents
+                : Enumerable.Empty<InternalEntityEntry>();
+        }
+
+        public virtual IEnumerable<InternalEntityEntry> GetDependentsUsingRelationshipSnapshot(InternalEntityEntry principalEntry)
+        {
+            List<InternalEntityEntry> dependents;
+            return _map.TryGetValue(_principalKeyValueFactory.CreateFromRelationshipSnapshot(principalEntry), out dependents)
+                ? dependents
+                : Enumerable.Empty<InternalEntityEntry>();
+        }
+    }
+}

--- a/src/EntityFramework.Core/ChangeTracking/Internal/DependentsMapFactoryFactory.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/DependentsMapFactoryFactory.cs
@@ -1,0 +1,30 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Metadata.Internal;
+
+namespace Microsoft.Data.Entity.ChangeTracking.Internal
+{
+    public class DependentsMapFactoryFactory : IdentityMapFactoryFactoryBase
+    {
+        public virtual Func<IDependentsMap> Create([NotNull] IForeignKey foreignKey)
+            => (Func<IDependentsMap>)typeof(DependentsMapFactoryFactory).GetTypeInfo()
+                .GetDeclaredMethods(nameof(CreateFactory)).Single()
+                .MakeGenericMethod(GetKeyType(foreignKey.PrincipalKey))
+                .Invoke(null, new object[] { foreignKey });
+
+        [UsedImplicitly]
+        private static Func<IDependentsMap> CreateFactory<TKey>(IForeignKey foreignKey)
+        {
+            var principalKeyValueFactory = foreignKey.PrincipalKey.GetPrincipalKeyValueFactory<TKey>();
+            var dependentKeyValueFactory = foreignKey.GetDependentKeyValueFactory<TKey>();
+
+            return () => new DependentsMap<TKey>(foreignKey, principalKeyValueFactory, dependentKeyValueFactory);
+        }
+    }
+}

--- a/src/EntityFramework.Core/ChangeTracking/Internal/IDependentsMap.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/IDependentsMap.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using JetBrains.Annotations;
+
+namespace Microsoft.Data.Entity.ChangeTracking.Internal
+{
+    public interface IDependentsMap
+    {
+        void Add([NotNull] InternalEntityEntry entry);
+        void Update([NotNull] InternalEntityEntry entry);
+        void Remove([NotNull] InternalEntityEntry entry);
+        IEnumerable<InternalEntityEntry> GetDependents([NotNull] InternalEntityEntry principalEntry);
+        IEnumerable<InternalEntityEntry> GetDependentsUsingRelationshipSnapshot([NotNull] InternalEntityEntry principalEntry);
+    }
+}

--- a/src/EntityFramework.Core/ChangeTracking/Internal/IIdentityMap.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/IIdentityMap.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
@@ -30,16 +29,8 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
         void RemoveUsingRelationshipSnapshot([NotNull] InternalEntityEntry entry);
 
-        IEnumerable<InternalEntityEntry> GetMatchingDependentsFromRelationshipSnapshot(
-            [NotNull] IForeignKey foreignKey,
-            [NotNull] InternalEntityEntry principalEntry,
-            [NotNull] IEnumerable<InternalEntityEntry> candidateDependents);
+        IDependentsMap GetDependentsMap([NotNull] IForeignKey foreignKey);
 
-        IEnumerable<InternalEntityEntry> GetMatchingDependents(
-            [NotNull] IForeignKey foreignKey,
-            [NotNull] InternalEntityEntry principalEntry,
-            [NotNull] IEnumerable<InternalEntityEntry> candidateDependents);
-
-        IEnumerable<InternalEntityEntry> Entries { get; }
+        IDependentsMap FindDependentsMap([NotNull] IForeignKey foreignKey);
     }
 }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/IStateManager.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/IStateManager.cs
@@ -39,6 +39,8 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
         void UpdateIdentityMap([NotNull] InternalEntityEntry entry, [NotNull] IKey principalKey);
 
+        void UpdateDependentMap([NotNull] InternalEntityEntry entry, [NotNull] IForeignKey foreignKey);
+
         IEnumerable<InternalEntityEntry> GetDependentsFromNavigation([NotNull] InternalEntityEntry principalEntry, [NotNull] IForeignKey foreignKey);
 
         IEnumerable<InternalEntityEntry> GetDependents([NotNull] InternalEntityEntry principalEntry, [NotNull] IForeignKey foreignKey);

--- a/src/EntityFramework.Core/ChangeTracking/Internal/KeyValueFactoryFactory.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/KeyValueFactoryFactory.cs
@@ -19,33 +19,54 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
         private static SimplePrincipalKeyValueFactory<TKey> CreateSimpleFactory<TKey>(IKey key)
         {
             var dependentFactory = new DependentKeyValueFactoryFactory();
+            var principalKeyValueFactory 
+                = new SimplePrincipalKeyValueFactory<TKey>(key.Properties.Single().GetPropertyAccessors());
 
             foreach (var foreignKey in key.FindReferencingForeignKeys())
             {
+                var dependentKeyValueFactory = dependentFactory.CreateSimple<TKey>(foreignKey);
+
                 var factorySource = foreignKey as IDependentKeyValueFactorySource;
                 if (factorySource != null)
                 {
-                    factorySource.DependentKeyValueFactory = dependentFactory.CreateSimple<TKey>(foreignKey);
+                    factorySource.DependentKeyValueFactory = dependentKeyValueFactory;
+                }
+
+                var mapSource = foreignKey as IDependentsMapFactorySource;
+                if (mapSource != null)
+                {
+                    mapSource.DependentsMapFactory = () => new DependentsMap<TKey>(
+                        foreignKey, principalKeyValueFactory, dependentKeyValueFactory);
                 }
             }
 
-            return new SimplePrincipalKeyValueFactory<TKey>(key.Properties.Single().GetPropertyAccessors());
+            return principalKeyValueFactory;
         }
 
         private static CompositePrincipalKeyValueFactory CreateCompositeFactory(IKey key)
         {
             var dependentFactory = new DependentKeyValueFactoryFactory();
+            var principalKeyValueFactory = new CompositePrincipalKeyValueFactory(key);
 
             foreach (var foreignKey in key.FindReferencingForeignKeys())
             {
+                var dependentKeyValueFactory = dependentFactory.CreateComposite(foreignKey);
+
                 var factorySource = foreignKey as IDependentKeyValueFactorySource;
                 if (factorySource != null)
                 {
-                    factorySource.DependentKeyValueFactory = dependentFactory.CreateComposite(foreignKey);
+                    factorySource.DependentKeyValueFactory = dependentKeyValueFactory;
+                }
+
+                var mapSource = foreignKey as IDependentsMapFactorySource;
+                if (mapSource != null)
+                {
+                    mapSource.DependentsMapFactory = () => new DependentsMap<object[]>(
+                        foreignKey, principalKeyValueFactory, dependentKeyValueFactory);
                 }
             }
 
-            return new CompositePrincipalKeyValueFactory(key);
+            return principalKeyValueFactory;
         }
     }
 }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/NullableKeyIdentityMap.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/NullableKeyIdentityMap.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
 
             if (key != null)
             {
-                Remove(key);
+                Remove(key, entry);
             }
         }
     }

--- a/src/EntityFramework.Core/ChangeTracking/Internal/StateManager.cs
+++ b/src/EntityFramework.Core/ChangeTracking/Internal/StateManager.cs
@@ -290,37 +290,34 @@ namespace Microsoft.Data.Entity.ChangeTracking.Internal
             identityMap.Add(entry);
         }
 
+        public virtual void UpdateDependentMap(InternalEntityEntry entry, IForeignKey foreignKey)
+        {
+            if (entry.EntityState == EntityState.Detached)
+            {
+                return;
+            }
+
+            FindIdentityMap(foreignKey.DeclaringEntityType.FindPrimaryKey())
+                ?.FindDependentsMap(foreignKey)
+                ?.Update(entry);
+        }
+
         public virtual IEnumerable<InternalEntityEntry> GetDependents(
             InternalEntityEntry principalEntry, IForeignKey foreignKey)
         {
             var dependentIdentityMap = FindIdentityMap(foreignKey.DeclaringEntityType.FindPrimaryKey());
-            if (dependentIdentityMap != null)
-            {
-                var principalIdentityMap = FindIdentityMap(foreignKey.PrincipalKey);
-                if (principalIdentityMap != null)
-                {
-                    return principalIdentityMap.GetMatchingDependents(foreignKey, principalEntry, dependentIdentityMap.Entries);
-                }
-            }
-
-            return Enumerable.Empty<InternalEntityEntry>();
+            return dependentIdentityMap != null 
+                ? dependentIdentityMap.GetDependentsMap(foreignKey).GetDependents(principalEntry) 
+                : Enumerable.Empty<InternalEntityEntry>();
         }
 
         public virtual IEnumerable<InternalEntityEntry> GetDependentsUsingRelationshipSnapshot(
             InternalEntityEntry principalEntry, IForeignKey foreignKey)
         {
             var dependentIdentityMap = FindIdentityMap(foreignKey.DeclaringEntityType.FindPrimaryKey());
-            if (dependentIdentityMap != null)
-            {
-                var principalIdentityMap = FindIdentityMap(foreignKey.PrincipalKey);
-                if (principalIdentityMap != null)
-                {
-                    return principalIdentityMap.GetMatchingDependentsFromRelationshipSnapshot(
-                        foreignKey, principalEntry, dependentIdentityMap.Entries);
-                }
-            }
-
-            return Enumerable.Empty<InternalEntityEntry>();
+            return dependentIdentityMap != null
+                ? dependentIdentityMap.GetDependentsMap(foreignKey).GetDependentsUsingRelationshipSnapshot(principalEntry)
+                : Enumerable.Empty<InternalEntityEntry>();
         }
 
         public virtual IEnumerable<InternalEntityEntry> GetDependentsFromNavigation(InternalEntityEntry principalEntry, IForeignKey foreignKey)

--- a/src/EntityFramework.Core/EntityFramework.Core.csproj
+++ b/src/EntityFramework.Core/EntityFramework.Core.csproj
@@ -63,12 +63,15 @@
     <Compile Include="ChangeTracking\Internal\CompositeDependentValueFactory.cs" />
     <Compile Include="ChangeTracking\Internal\CompositePrincipalKeyValueFactory.cs" />
     <Compile Include="ChangeTracking\Internal\DependentKeyValueFactoryFactory.cs" />
+    <Compile Include="ChangeTracking\Internal\DependentsMap.cs" />
+    <Compile Include="ChangeTracking\Internal\DependentsMapFactoryFactory.cs" />
     <Compile Include="ChangeTracking\Internal\EmptyShadowValuesFactoryFactory.cs" />
     <Compile Include="ChangeTracking\Internal\EntityGraphAttacher.cs" />
     <Compile Include="ChangeTracking\Internal\IdentityMap.cs" />
     <Compile Include="ChangeTracking\Internal\IdentityMapFactoryFactory.cs" />
     <Compile Include="ChangeTracking\Internal\IdentityMapFactoryFactoryBase.cs" />
     <Compile Include="ChangeTracking\Internal\IDependentKeyValueFactory.cs" />
+    <Compile Include="ChangeTracking\Internal\IDependentsMap.cs" />
     <Compile Include="ChangeTracking\Internal\IIdentityMap.cs" />
     <Compile Include="ChangeTracking\Internal\IPrincipalKeyValueFactory.cs" />
     <Compile Include="ChangeTracking\Internal\ISnapshot.cs" />
@@ -121,6 +124,7 @@
     <Compile Include="Metadata\Internal\ConventionalAnnotation.cs" />
     <Compile Include="Metadata\Internal\ICanGetNavigations.cs" />
     <Compile Include="Metadata\Internal\IDependentKeyValueFactorySource.cs" />
+    <Compile Include="Metadata\Internal\IDependentsMapFactorySource.cs" />
     <Compile Include="Metadata\Internal\IIdentityMapFactorySource.cs" />
     <Compile Include="Metadata\Internal\INavigationAccessors.cs" />
     <Compile Include="Metadata\Internal\IPrincipalKeyValueFactorySource.cs" />

--- a/src/EntityFramework.Core/Metadata/Internal/ForeignKey.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/ForeignKey.cs
@@ -5,12 +5,14 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Metadata.Internal
 {
-    public class ForeignKey : ConventionalAnnotatable, IMutableForeignKey, IDependentKeyValueFactorySource
+    public class ForeignKey 
+        : ConventionalAnnotatable, IMutableForeignKey, IDependentKeyValueFactorySource, IDependentsMapFactorySource
     {
         private DeleteBehavior? _deleteBehavior;
         private bool? _isUnique;
@@ -465,5 +467,8 @@ namespace Microsoft.Data.Entity.Metadata.Internal
 
         // Note: This is set and used only by IdentityMapFactoryFactory, which ensures thread-safety
         public virtual object DependentKeyValueFactory { get; set; }
+
+        // Note: This is set and used only by IdentityMapFactoryFactory, which ensures thread-safety
+        public virtual Func<IDependentsMap> DependentsMapFactory { get; set; }
     }
 }

--- a/src/EntityFramework.Core/Metadata/Internal/ForeignKeyExtensions.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/ForeignKeyExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.ChangeTracking.Internal;
 using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Utilities;
 
@@ -216,6 +217,25 @@ namespace Microsoft.Data.Entity.Metadata.Internal
             return foreignKey.DeclaringEntityType.IsAssignableFrom(entityType)
                 ? foreignKey.DeclaringEntityType
                 : foreignKey.PrincipalEntityType;
+        }
+
+        public static IDependentKeyValueFactory<TKey> GetDependentKeyValueFactory<TKey>(
+            [NotNull] this IForeignKey foreignKey)
+        {
+            var factorySource = foreignKey as IDependentKeyValueFactorySource;
+
+            return factorySource != null
+                ? (IDependentKeyValueFactory<TKey>)factorySource.DependentKeyValueFactory
+                : new DependentKeyValueFactoryFactory().Create<TKey>(foreignKey);
+        }
+
+        public static IDependentsMap CreateDependentsMapFactory([NotNull] this IForeignKey foreignKey)
+        {
+            var factorySource = foreignKey as IDependentsMapFactorySource;
+
+            return factorySource != null
+                ? factorySource.DependentsMapFactory()
+                : new DependentsMapFactoryFactory().Create(foreignKey)();
         }
     }
 }

--- a/src/EntityFramework.Core/Metadata/Internal/IDependentsMapFactorySource.cs
+++ b/src/EntityFramework.Core/Metadata/Internal/IDependentsMapFactorySource.cs
@@ -1,0 +1,14 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.ChangeTracking.Internal;
+
+namespace Microsoft.Data.Entity.Metadata.Internal
+{
+    public interface IDependentsMapFactorySource
+    {
+        Func<IDependentsMap> DependentsMapFactory { get; [param: NotNull] set; }
+    }
+}

--- a/src/EntityFramework.Core/Query/Internal/WeakReferenceIdentityMap.cs
+++ b/src/EntityFramework.Core/Query/Internal/WeakReferenceIdentityMap.cs
@@ -77,14 +77,14 @@ namespace Microsoft.Data.Entity.Query.Internal
             if (navigation.IsDependentToPrincipal())
             {
                 TKey keyValue;
-                return GetDependentKeyValueFactory(navigation.ForeignKey).TryCreateFromBuffer(valueBuffer, out keyValue) 
+                return navigation.ForeignKey.GetDependentKeyValueFactory<TKey>().TryCreateFromBuffer(valueBuffer, out keyValue) 
                     ? (IIncludeKeyComparer)new DependentToPrincipalIncludeComparer<TKey>(keyValue, PrincipalKeyValueFactory) 
                     : new NullIncludeComparer();
             }
 
             return new PrincipalToDependentIncludeComparer<TKey>(
                 (TKey)PrincipalKeyValueFactory.CreateFromBuffer(valueBuffer),
-                GetDependentKeyValueFactory(navigation.ForeignKey),
+                navigation.ForeignKey.GetDependentKeyValueFactory<TKey>(),
                 PrincipalKeyValueFactory);
         }
 
@@ -93,24 +93,15 @@ namespace Microsoft.Data.Entity.Query.Internal
             if (navigation.IsDependentToPrincipal())
             {
                 TKey keyValue;
-                return GetDependentKeyValueFactory(navigation.ForeignKey).TryCreateFromCurrentValues(entry, out keyValue)
+                return navigation.ForeignKey.GetDependentKeyValueFactory<TKey>().TryCreateFromCurrentValues(entry, out keyValue)
                     ? new DependentToPrincipalIncludeComparer<TKey>(keyValue, PrincipalKeyValueFactory)
                     : (IIncludeKeyComparer)new NullIncludeComparer();
             }
 
             return new PrincipalToDependentIncludeComparer<TKey>(
                 PrincipalKeyValueFactory.CreateFromCurrentValues(entry),
-                GetDependentKeyValueFactory(navigation.ForeignKey),
+                navigation.ForeignKey.GetDependentKeyValueFactory<TKey>(),
                 PrincipalKeyValueFactory);
-        }
-
-        private static IDependentKeyValueFactory<TKey> GetDependentKeyValueFactory(IForeignKey foreignKey)
-        {
-            var factorySource = foreignKey as IDependentKeyValueFactorySource;
-
-            return factorySource != null
-                ? (IDependentKeyValueFactory<TKey>)factorySource.DependentKeyValueFactory
-                : new DependentKeyValueFactoryFactory().Create<TKey>(foreignKey);
         }
     }
 }

--- a/src/EntityFramework.Relational/Update/Internal/KeyValueIndexFactory.cs
+++ b/src/EntityFramework.Relational/Update/Internal/KeyValueIndexFactory.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Data.Entity.Update.Internal
         public virtual IKeyValueIndex CreateDependentKeyValue(InternalEntityEntry entry, IForeignKey foreignKey)
         {
             TKey keyValue;
-            return GetDependentKeyValueFactory(foreignKey).TryCreateFromCurrentValues(entry, out keyValue)
+            return foreignKey.GetDependentKeyValueFactory<TKey>().TryCreateFromCurrentValues(entry, out keyValue)
                 ? new KeyValueIndex<TKey>(foreignKey, keyValue, _principalKeyValueFactory.EqualityComparer, fromOriginalValues: false)
                 : null;
         }
@@ -42,18 +42,9 @@ namespace Microsoft.Data.Entity.Update.Internal
         public virtual IKeyValueIndex CreateDependentKeyValueFromOriginalValues(InternalEntityEntry entry, IForeignKey foreignKey)
         {
             TKey keyValue;
-            return GetDependentKeyValueFactory(foreignKey).TryCreateFromOriginalValues(entry, out keyValue)
+            return foreignKey.GetDependentKeyValueFactory<TKey>().TryCreateFromOriginalValues(entry, out keyValue)
                 ? new KeyValueIndex<TKey>(foreignKey, keyValue, _principalKeyValueFactory.EqualityComparer, fromOriginalValues: true)
                 : null;
-        }
-
-        private static IDependentKeyValueFactory<TKey> GetDependentKeyValueFactory(IForeignKey foreignKey)
-        {
-            var factorySource = foreignKey as IDependentKeyValueFactorySource;
-
-            return factorySource != null
-                ? (IDependentKeyValueFactory<TKey>)factorySource.DependentKeyValueFactory
-                : new DependentKeyValueFactoryFactory().Create<TKey>(foreignKey);
         }
     }
 }

--- a/test/EntityFramework.Core.Tests/DbContextTest.cs
+++ b/test/EntityFramework.Core.Tests/DbContextTest.cs
@@ -230,6 +230,11 @@ namespace Microsoft.Data.Entity.Tests
                 throw new NotImplementedException();
             }
 
+            public void UpdateDependentMap(InternalEntityEntry entry, IForeignKey foreignKey)
+            {
+                throw new NotImplementedException();
+            }
+
             public IEnumerable<InternalEntityEntry> GetDependents(InternalEntityEntry principalEntry, IForeignKey foreignKey)
             {
                 throw new NotImplementedException();


### PR DESCRIPTION
This greatly improves perf for querying dependents first, followed by principals.