### PR TITLE
Switch off auto DetectChanges for EF6 fixup tests

### DIFF
--- a/test/EntityFramework.Microbenchmarks.EF6/ChangeTracker/FixupTests.cs
+++ b/test/EntityFramework.Microbenchmarks.EF6/ChangeTracker/FixupTests.cs
@@ -30,6 +30,8 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
 
                 Assert.All(orders, o => Assert.Null(o.Customer));
 
+                context.Configuration.AutoDetectChangesEnabled = false;
+
                 using (collector.StartCollection())
                 {
                     foreach (var order in orders)
@@ -56,6 +58,8 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
 
                 Assert.All(orders, o => Assert.Null(o.Customer));
 
+                context.Configuration.AutoDetectChangesEnabled = false;
+
                 using (collector.StartCollection())
                 {
                     foreach (var order in orders)
@@ -78,6 +82,8 @@ namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
                 orders.ForEach(o => context.Orders.Attach(o));
 
                 Assert.All(customers, c => Assert.Null(c.Orders));
+
+                context.Configuration.AutoDetectChangesEnabled = false;
 
                 using (collector.StartCollection())
                 {


### PR DESCRIPTION
Because it doesn't happen in EF7 and dominates the time in the EF6 runs.