### PR TITLE
RevEng: Fix for issue #4168 (part 1)

### DIFF
--- a/src/EntityFramework.MicrosoftSqlServer.Design/SqlServerTableSelectionSetExtensions.cs
+++ b/src/EntityFramework.MicrosoftSqlServer.Design/SqlServerTableSelectionSetExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using JetBrains.Annotations;
 
@@ -8,26 +9,26 @@ namespace Microsoft.Data.Entity.Scaffolding
 {
     internal static class SqlServerTableSelectionSetExtensions
     {
-        public static bool Allows(this TableSelectionSet _tableSelectionSet, [NotNull] string schemaName, [NotNull] string tableName)
+        public static bool Allows(this TableSelectionSet tableSelectionSet, [NotNull] string schemaName, [NotNull] string tableName)
         {
-            if (_tableSelectionSet == null
-                || (_tableSelectionSet.Schemas.Count == 0
-                && _tableSelectionSet.Tables.Count == 0))
+            if ((tableSelectionSet == null)
+                || ((tableSelectionSet.Schemas.Count == 0)
+                && (tableSelectionSet.Tables.Count == 0)))
             {
                 return true;
             }
 
-            if (_tableSelectionSet.Schemas.Contains(schemaName))
+            if (tableSelectionSet.Schemas.Contains(schemaName))
             {
                 return true;
             }
 
-            return _tableSelectionSet.Tables.Contains($"{schemaName}.{tableName}")
-                || _tableSelectionSet.Tables.Contains($"[{schemaName}].[{tableName}]")
-                || _tableSelectionSet.Tables.Contains($"{schemaName}.[{tableName}]")
-                || _tableSelectionSet.Tables.Contains($"[{schemaName}].{tableName}")
-                || _tableSelectionSet.Tables.Contains($"{tableName}")
-                || _tableSelectionSet.Tables.Contains($"[{tableName}]");
+            return tableSelectionSet.Tables.Contains($"{schemaName}.{tableName}", StringComparer.OrdinalIgnoreCase)
+                || tableSelectionSet.Tables.Contains($"[{schemaName}].[{tableName}]", StringComparer.OrdinalIgnoreCase)
+                || tableSelectionSet.Tables.Contains($"{schemaName}.[{tableName}]", StringComparer.OrdinalIgnoreCase)
+                || tableSelectionSet.Tables.Contains($"[{schemaName}].{tableName}", StringComparer.OrdinalIgnoreCase)
+                || tableSelectionSet.Tables.Contains($"{tableName}", StringComparer.OrdinalIgnoreCase)
+                || tableSelectionSet.Tables.Contains($"[{tableName}]", StringComparer.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/EntityFramework.Sqlite.Design/SqliteTableSelectionSetExtensions.cs
+++ b/src/EntityFramework.Sqlite.Design/SqliteTableSelectionSetExtensions.cs
@@ -10,8 +10,8 @@ namespace Microsoft.Data.Entity.Scaffolding
     {
         public static bool Allows(this TableSelectionSet tableSet, string tableName)
         {
-            if (tableSet == null
-                || tableSet.Tables.Count == 0)
+            if ((tableSet == null)
+                || (tableSet.Tables.Count == 0))
             {
                 return true;
             }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/SqlServerE2ETests.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/SqlServerE2ETests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Data.Entity.SqlServer.Design.FunctionalTests.ReverseEngineer
                 "OneToOneFKToUniqueKeyPrincipal",
                 "ReferredToByTableWithUnmappablePrimaryKeyColumn",
                 "TableWithUnmappablePrimaryKeyColumn",
-                "SelfReferencing",
+                "selfreferencing",
             });
 
         public SqlServerE2ETests(SqlServerE2EFixture fixture, ITestOutputHelper output)


### PR DESCRIPTION
- Make TableSelectionSetExtension implementation case insensitive
- Fix R# warnings
- Update test to work with case-insensitive table name