### PR TITLE
Fix #3732 - Include and Take generate incorrect SQL without Skip

### DIFF
--- a/src/EntityFramework.Relational/Query/ExpressionVisitors/Internal/IncludeExpressionVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionVisitors/Internal/IncludeExpressionVisitor.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors.Internal
                     = ((ConstantExpression)node.Arguments[2]).Value
                         as Shaper;
 
-                if ((entityShaper != null)
+                if (entityShaper != null
                     && entityShaper.IsShaperForQuerySource(_querySource))
                 {
                     var resultType = node.Method.GetGenericArguments()[0];
@@ -124,6 +124,7 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors.Internal
 
             var canProduceInnerJoin = true;
             var navigationCount = 0;
+
             foreach (var navigation in navigationPath)
             {
                 var queryIndex = _queryIndexes[navigationCount];
@@ -331,7 +332,11 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors.Internal
                 targetSelectExpression.AddToOrderBy(new Ordering(newExpression, ordering.OrderingDirection));
             }
 
-            innerJoinSelectExpression.ClearOrderBy();
+            if (innerJoinSelectExpression.Limit == null
+                && innerJoinSelectExpression.Offset == null)
+            {
+                innerJoinSelectExpression.ClearOrderBy();
+            }
         }
 
         private Expression BuildJoinEqualityExpression(

--- a/src/EntityFramework.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
@@ -67,8 +67,8 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
         {
             var translatedExpression = _compositeExpressionFragmentTranslator.Translate(expression);
 
-            if ((translatedExpression != null)
-                && (translatedExpression != expression))
+            if (translatedExpression != null
+                && translatedExpression != expression)
             {
                 return Visit(translatedExpression);
             }
@@ -80,6 +80,7 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
         {
             Check.NotNull(expression, nameof(expression));
 
+            // ReSharper disable once SwitchStatementMissingSomeCases
             switch (expression.NodeType)
             {
                 case ExpressionType.Coalesce:
@@ -116,8 +117,8 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
 
                         if (expression == _topLevelPredicate)
                         {
-                            if ((left != null)
-                                && (right != null))
+                            if (left != null
+                                && right != null)
                             {
                                 return Expression.AndAlso(left, right);
                             }
@@ -137,7 +138,7 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
                             return null;
                         }
 
-                        return (left != null) && (right != null)
+                        return left != null && right != null
                             ? Expression.AndAlso(left, right)
                             : null;
                     }
@@ -152,8 +153,8 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
                         var leftExpression = Visit(expression.Left);
                         var rightExpression = Visit(expression.Right);
 
-                        return (leftExpression != null)
-                               && (rightExpression != null)
+                        return leftExpression != null
+                               && rightExpression != null
                             ? Expression.MakeBinary(
                                 expression.NodeType,
                                 leftExpression,
@@ -175,9 +176,9 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
             var ifTrue = Visit(expression.IfTrue);
             var ifFalse = Visit(expression.IfFalse);
 
-            if ((test != null)
-                && (ifTrue != null)
-                && (ifFalse != null))
+            if (test != null
+                && ifTrue != null
+                && ifFalse != null)
             {
                 return expression.Update(test, ifTrue, ifFalse);
             }
@@ -193,9 +194,9 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
             var rightConstantExpression = binaryExpression?.Right as ConstantExpression;
             var rightExpressions = rightConstantExpression?.Value as Expression[];
 
-            if ((leftExpressions != null)
-                && (rightConstantExpression != null)
-                && (rightConstantExpression.Value == null))
+            if (leftExpressions != null
+                && rightConstantExpression != null
+                && rightConstantExpression.Value == null)
             {
                 rightExpressions
                     = Enumerable
@@ -203,9 +204,9 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
                         .ToArray();
             }
 
-            if ((rightExpressions != null)
-                && (leftConstantExpression != null)
-                && (leftConstantExpression.Value == null))
+            if (rightExpressions != null
+                && leftConstantExpression != null
+                && leftConstantExpression.Value == null)
             {
                 leftExpressions
                     = Enumerable
@@ -213,9 +214,9 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
                         .ToArray();
             }
 
-            if ((leftExpressions != null)
-                && (rightExpressions != null)
-                && (leftExpressions.Length == rightExpressions.Length))
+            if (leftExpressions != null
+                && rightExpressions != null
+                && leftExpressions.Length == rightExpressions.Length)
             {
                 return leftExpressions
                     .Zip(rightExpressions, (l, r) =>
@@ -235,8 +236,8 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
             var leftExpression = Visit(binaryExpression.Left);
             var rightExpression = Visit(binaryExpression.Right);
 
-            if ((leftExpression == null)
-                || (rightExpression == null))
+            if (leftExpression == null
+                || rightExpression == null)
             {
                 return null;
             }
@@ -251,15 +252,15 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
         private static Expression TransformNullComparison(
             Expression left, Expression right, ExpressionType expressionType)
         {
-            if ((expressionType == ExpressionType.Equal)
-                || (expressionType == ExpressionType.NotEqual))
+            if (expressionType == ExpressionType.Equal
+                || expressionType == ExpressionType.NotEqual)
             {
                 var constantExpression
                     = right as ConstantExpression
                       ?? left as ConstantExpression;
 
-                if ((constantExpression != null)
-                    && (constantExpression.Value == null))
+                if (constantExpression != null
+                    && constantExpression.Value == null)
                 {
                     var columnExpression
                         = left.RemoveConvert().TryGetColumnExpression()
@@ -283,8 +284,8 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
 
             var operand = Visit(expression.Object);
 
-            if ((operand != null)
-                || (expression.Object == null))
+            if (operand != null
+                || expression.Object == null)
             {
                 var arguments
                     = expression.Arguments
@@ -315,7 +316,7 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
                 = _queryModelVisitor
                     .BindMethodCallExpression(expression, CreateAliasedColumnExpression);
 
-            if ((aliasExpression == null)
+            if (aliasExpression == null
                 && _bindParentQueries)
             {
                 aliasExpression
@@ -335,8 +336,8 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
             {
                 var newExpression = Visit(expression.Expression);
 
-                if ((newExpression != null)
-                    || (expression.Expression == null))
+                if (newExpression != null
+                    || expression.Expression == null)
                 {
                     var newMemberExpression
                         = newExpression != expression.Expression
@@ -356,7 +357,7 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
                 = _queryModelVisitor
                     .BindMemberExpression(expression, CreateAliasedColumnExpression);
 
-            if ((aliasExpression == null)
+            if (aliasExpression == null
                 && _bindParentQueries)
             {
                 aliasExpression
@@ -390,8 +391,8 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
         private AliasExpression CreateAliasedColumnExpression(
             IProperty property, IQuerySource querySource, SelectExpression selectExpression)
         {
-            if ((_targetSelectExpression != null)
-                && (selectExpression != _targetSelectExpression))
+            if (_targetSelectExpression != null
+                && selectExpression != _targetSelectExpression)
             {
                 selectExpression?.AddToProjection(
                     _relationalAnnotationProvider.For(property).ColumnName,
@@ -447,9 +448,9 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
         {
             Check.NotNull(expression, nameof(expression));
 
-            if ((expression.Members != null)
+            if (expression.Members != null
                 && expression.Arguments.Any()
-                && (expression.Arguments.Count == expression.Members.Count))
+                && expression.Arguments.Count == expression.Members.Count)
             {
                 var memberBindings
                     = expression.Arguments
@@ -489,7 +490,7 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
             var subQueryModel = expression.QueryModel;
 
             if (subQueryModel.IsIdentityQuery()
-                && (subQueryModel.ResultOperators.Count == 1))
+                && subQueryModel.ResultOperators.Count == 1)
             {
                 var contains = subQueryModel.ResultOperators.First() as ContainsResultOperator;
 
@@ -535,7 +536,7 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
                 var querySourceReferenceExpression
                     = subQueryModel.SelectClause.Selector as QuerySourceReferenceExpression;
 
-                if ((querySourceReferenceExpression == null)
+                if (querySourceReferenceExpression == null
                     || _inProjection
                     || !_queryModelVisitor.QueryCompilationContext
                         .QuerySourceRequiresMaterialization(querySourceReferenceExpression.ReferencedQuerySource))
@@ -546,7 +547,7 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
 
                     queryModelVisitor.VisitSubQueryModel(subQueryModel);
 
-                    if ((queryModelVisitor.Queries.Count == 1)
+                    if (queryModelVisitor.Queries.Count == 1
                         && !queryModelVisitor.RequiresClientFilter
                         && !queryModelVisitor.RequiresClientProjection
                         && !queryModelVisitor.RequiresClientResultOperator)
@@ -633,13 +634,13 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
                 var newLeft = Visit(stringCompare.Left);
                 var newRight = Visit(stringCompare.Right);
 
-                if ((newLeft == null)
-                    || (newRight == null))
+                if (newLeft == null
+                    || newRight == null)
                 {
                     return null;
                 }
 
-                return (newLeft != stringCompare.Left) || (newRight != stringCompare.Right)
+                return newLeft != stringCompare.Left || newRight != stringCompare.Right
                     ? new StringCompareExpression(stringCompare.Operator, newLeft, newRight)
                     : expression;
             }

--- a/src/EntityFramework.Relational/Query/Expressions/AliasExpression.cs
+++ b/src/EntityFramework.Relational/Query/Expressions/AliasExpression.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Data.Entity.Query.Expressions
         {
             get { return _alias; }
             [param: NotNull]
+            // TODO: Remove mutability here
             set
             {
                 Check.NotNull(value, nameof(value));
@@ -88,8 +89,8 @@ namespace Microsoft.Data.Entity.Query.Expressions
                 : this;
         }
 
-        public override string ToString()
-            => this.TryGetColumnExpression()?.ToString() ?? Expression.NodeType + " " + Alias;
+        public override string ToString() 
+            => Alias != null ? "(" + _expression + ") AS " + Alias : _expression.ToString();
 
         public override bool Equals(object obj)
         {
@@ -103,7 +104,7 @@ namespace Microsoft.Data.Entity.Query.Expressions
                 return true;
             }
 
-            return (obj.GetType() == GetType())
+            return obj.GetType() == GetType()
                    && Equals((AliasExpression)obj);
         }
 

--- a/src/EntityFramework.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EntityFramework.Relational/Query/RelationalQueryModelVisitor.cs
@@ -292,12 +292,12 @@ namespace Microsoft.Data.Entity.Query
 
             var selectExpression = TryGetQuery(fromClause);
 
-            if ((selectExpression != null)
-                && (selectExpression.Tables.Count == 1))
+            if (selectExpression != null
+                && selectExpression.Tables.Count == 1)
             {
                 var previousQuerySource = FindPreviousQuerySource(queryModel, index);
 
-                if ((previousQuerySource != null)
+                if (previousQuerySource != null
                     && !RequiresClientJoin)
                 {
                     var previousSelectExpression = TryGetQuery(previousQuerySource);
@@ -563,7 +563,7 @@ namespace Microsoft.Data.Entity.Query
 
             subQueryModelVisitor.VisitSubQueryModel(subQueryExpression.QueryModel);
 
-            if ((subQueryModelVisitor.Queries.Count == 1)
+            if (subQueryModelVisitor.Queries.Count == 1
                 && !subQueryModelVisitor.RequiresClientEval
                 && !subQueryModelVisitor.RequiresClientSelectMany
                 && !subQueryModelVisitor.RequiresClientJoin
@@ -575,8 +575,10 @@ namespace Microsoft.Data.Entity.Query
                 var subSelectExpression = subQueryModelVisitor.Queries.First();
 
                 if ((!subSelectExpression.OrderBy.Any()
-                     || (subSelectExpression.Limit != null))
-                    && (QueryCompilationContext.IsLateralJoinSupported || !subSelectExpression.IsCorrelated() || !(querySource is AdditionalFromClause)))
+                     || subSelectExpression.Limit != null)
+                    && (QueryCompilationContext.IsLateralJoinSupported 
+                        || !subSelectExpression.IsCorrelated() 
+                        || !(querySource is AdditionalFromClause)))
                 {
                     subSelectExpression.PushDownSubquery().QuerySource = querySource;
 
@@ -661,7 +663,7 @@ namespace Microsoft.Data.Entity.Query
 
                     if (methodCallExpression.Method.MethodIsClosedFormOf(
                         _linqOperatorProvider.Cast)
-                        && (arguments[0].Type.GetSequenceType() == typeof(ValueBuffer)))
+                        && arguments[0].Type.GetSequenceType() == typeof(ValueBuffer))
                     {
                         return arguments[0];
                     }
@@ -710,8 +712,8 @@ namespace Microsoft.Data.Entity.Query
                     requiresClientFilter = true;
                 }
 
-                if ((sqlTranslatingExpressionVisitor.ClientEvalPredicate != null)
-                    && (selectExpression.Predicate != null))
+                if (sqlTranslatingExpressionVisitor.ClientEvalPredicate != null
+                    && selectExpression.Predicate != null)
                 {
                     requiresClientFilter = true;
                     whereClause = new WhereClause(sqlTranslatingExpressionVisitor.ClientEvalPredicate);
@@ -903,7 +905,7 @@ namespace Microsoft.Data.Entity.Query
             {
                 var selectExpression = TryGetQuery(querySource);
 
-                if ((selectExpression == null)
+                if (selectExpression == null
                     && bindSubQueries)
                 {
                     RelationalQueryModelVisitor subQueryModelVisitor;

--- a/src/EntityFramework.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/EntityFramework.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -243,7 +243,8 @@ namespace Microsoft.Data.Entity.Query.Sql
 
                             if (columnExpression != null)
                             {
-                                _relationalCommandBuilder.Append(_sqlGenerationHelper.DelimitIdentifier(columnExpression.TableAlias))
+                                _relationalCommandBuilder
+                                    .Append(_sqlGenerationHelper.DelimitIdentifier(columnExpression.TableAlias))
                                     .Append(".");
                             }
 

--- a/test/EntityFramework.Core.FunctionalTests/IncludeTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/IncludeTestBase.cs
@@ -1124,7 +1124,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
-         [Fact]
+        [Fact]
         public virtual void Include_references_then_include_multi_level()
         {
             using (var context = CreateContext())
@@ -1136,6 +1136,22 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
                 Assert.True(orderDetails.Count > 0);
                 Assert.True(orderDetails.All(od => od.Order.Customer != null));
+            }
+        }
+
+        [Fact]
+        public virtual void Include_with_take()
+        {
+            using (var context = CreateContext())
+            {
+                var customers 
+                    = context.Set<Customer>()
+                        .OrderByDescending(c => c.City)
+                        .Include(c => c.Orders)
+                        .Take(10)
+                        .ToList();
+
+                Assert.True(customers.All(c => c.Orders.Count > 0));
             }
         }
     }

--- a/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
@@ -4354,14 +4354,29 @@ namespace Microsoft.Data.Entity.FunctionalTests
         public virtual void Select_take_null_coalesce_operator()
         {
             AssertQuery<Customer>(
-            cs => cs.Select(c => new { c.CustomerID, c.CompanyName, Region = c.Region ?? "ZZ" }).OrderBy(c => c.Region).Take(5));
+                cs => cs.Select(c => new { c.CustomerID, c.CompanyName, Region = c.Region ?? "ZZ" }).OrderBy(c => c.Region).Take(5));
         }
 
         [ConditionalFact]
         public virtual void Select_take_skip_null_coalesce_operator()
         {
             AssertQuery<Customer>(
-            cs => cs.Select(c => new { c.CustomerID, c.CompanyName, Region = c.Region ?? "ZZ" }).OrderBy(c => c.Region).Take(10).Skip(5));
+                cs => cs.Select(c => new { c.CustomerID, c.CompanyName, Region = c.Region ?? "ZZ" }).OrderBy(c => c.Region).Take(10).Skip(5));
+        }
+
+        [ConditionalFact]
+        public virtual void Select_take_skip_null_coalesce_operator2()
+        {
+            AssertQuery<Customer>(
+                cs => cs.Select(c => new { c.CustomerID, c.CompanyName, c.Region }).OrderBy(c => c.Region ?? "ZZ").Take(10).Skip(5));
+        }
+
+        [ConditionalFact]
+        public virtual void Select_take_skip_null_coalesce_operator3()
+        {
+            AssertQuery<Customer>(
+                cs => cs.OrderBy(c => c.Region ?? "ZZ").Take(10).Skip(5), 
+                entryCount: 5);
         }
 
         [ConditionalFact]

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/IncludeSqlServerTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/IncludeSqlServerTest.cs
@@ -153,6 +153,7 @@ INNER JOIN (
     FROM [Orders] AS [o]
     LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
     WHERE [o].[OrderID] = 10248
+    ORDER BY [c].[CustomerID]
 ) AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 ORDER BY [c].[CustomerID]",
                 Sql);
@@ -174,6 +175,7 @@ INNER JOIN (
     SELECT DISTINCT TOP(2) [o].[OrderID]
     FROM [Orders] AS [o]
     WHERE [o].[OrderID] = 10248
+    ORDER BY [o].[OrderID]
 ) AS [o0] ON [o].[OrderID] = [o0].[OrderID]
 INNER JOIN [Products] AS [p] ON [o].[ProductID] = [p].[ProductID]
 ORDER BY [o0].[OrderID]",
@@ -276,6 +278,7 @@ INNER JOIN (
     SELECT DISTINCT TOP(2) [c].[CustomerID]
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] = 'ALFKI'
+    ORDER BY [c].[CustomerID]
 ) AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 ORDER BY [c].[CustomerID]",
                 Sql);
@@ -301,6 +304,7 @@ INNER JOIN (
     SELECT DISTINCT TOP(2) [c].[CustomerID]
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] = 'ALFKI'
+    ORDER BY [c].[CustomerID]
 ) AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 ORDER BY [c].[CustomerID]",
                 Sql);
@@ -576,6 +580,7 @@ INNER JOIN (
         ORDER BY [c].[CustomerID]
         OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
     ) AS [t1]
+    ORDER BY [t0].[CustomerID], [t1].[CustomerID]
 ) AS [t1] ON [o].[CustomerID] = [t1].[CustomerID0]
 ORDER BY [t1].[CustomerID], [t1].[CustomerID0]
 
@@ -597,6 +602,7 @@ INNER JOIN (
         ORDER BY [c].[CustomerID]
         OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
     ) AS [t1]
+    ORDER BY [t0].[CustomerID]
 ) AS [t0] ON [o].[CustomerID] = [t0].[CustomerID]
 ORDER BY [t0].[CustomerID]",
                     Sql);
@@ -684,6 +690,7 @@ INNER JOIN (
         ORDER BY [c].[CustomerID]
         OFFSET 2 ROWS FETCH NEXT 2 ROWS ONLY
     ) AS [t1]
+    ORDER BY [t0].[CustomerID]
 ) AS [t0] ON [o].[CustomerID] = [t0].[CustomerID]
 ORDER BY [t0].[CustomerID]",
                     Sql);
@@ -857,6 +864,7 @@ INNER JOIN (
     SELECT DISTINCT TOP(2) [c].[CustomerID]
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] = 'ALFKI'
+    ORDER BY [c].[CustomerID]
 ) AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 ORDER BY [c].[CustomerID]",
                 Sql);
@@ -882,6 +890,7 @@ INNER JOIN (
     SELECT DISTINCT TOP(2) [c].[CustomerID]
     FROM [Customers] AS [c]
     WHERE [c].[CustomerID] = 'ALFKI'
+    ORDER BY [c].[CustomerID]
 ) AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 ORDER BY [c].[CustomerID]",
                 Sql);
@@ -931,8 +940,33 @@ FROM [Orders] AS [o]
 INNER JOIN (
     SELECT DISTINCT TOP(@__p_0) [c].[CustomerID]
     FROM [Customers] AS [c]
+    ORDER BY [c].[CustomerID]
 ) AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 ORDER BY [c].[CustomerID]",
+                Sql);
+        }
+
+        public override void Include_with_take()
+        {
+            base.Include_with_take();
+
+            Assert.Equal(
+                @"@__p_0: 10
+
+SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY [c].[City] DESC, [c].[CustomerID]
+
+@__p_0: 10
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+INNER JOIN (
+    SELECT DISTINCT TOP(@__p_0) [c].[City], [c].[CustomerID]
+    FROM [Customers] AS [c]
+    ORDER BY [c].[City] DESC, [c].[CustomerID]
+) AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+ORDER BY [c].[City] DESC, [c].[CustomerID]",
                 Sql);
         }
 

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/InheritanceSqlServerTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/InheritanceSqlServerTest.cs
@@ -191,6 +191,7 @@ INNER JOIN (
     SELECT DISTINCT TOP(2) [e].[Species]
     FROM [Animal] AS [e]
     WHERE [e].[Discriminator] = 'Eagle'
+    ORDER BY [e].[Species]
 ) AS [e] ON [a].[EagleId] = [e].[Species]
 WHERE ([a].[Discriminator] = 'Kiwi') OR ([a].[Discriminator] = 'Eagle')
 ORDER BY [e].[Species]",

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -4461,6 +4461,48 @@ OFFSET @__p_1 ROWS",
                 Sql);
         }
 
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.SupportsOffset)]
+        public override void Select_take_skip_null_coalesce_operator2()
+        {
+            base.Select_take_skip_null_coalesce_operator2();
+
+            Assert.Equal(
+                @"@__p_0: 10
+@__p_1: 5
+
+SELECT [t0].*
+FROM (
+    SELECT TOP(@__p_0) [c].[CustomerID], [c].[CompanyName], [c].[Region]
+    FROM [Customers] AS [c]
+    ORDER BY COALESCE([c].[Region], 'ZZ')
+) AS [t0]
+ORDER BY COALESCE([t0].[Region], 'ZZ')
+OFFSET @__p_1 ROWS",
+                Sql);
+        }
+
+        [ConditionalFact]
+        [SqlServerCondition(SqlServerCondition.SupportsOffset)]
+        public override void Select_take_skip_null_coalesce_operator3()
+        {
+            base.Select_take_skip_null_coalesce_operator3();
+
+            Assert.Equal(
+                @"@__p_0: 10
+@__p_1: 5
+
+SELECT [t0].*
+FROM (
+    SELECT TOP(@__p_0) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+    ORDER BY COALESCE([c].[Region], 'ZZ')
+) AS [t0]
+ORDER BY COALESCE([t0].[Region], 'ZZ')
+OFFSET @__p_1 ROWS",
+                Sql);
+        }
+
         public override void Selected_column_can_coalesce()
         {
             base.Selected_column_can_coalesce();


### PR DESCRIPTION
When lifting OrderBys on Include subqueries we were always clearing the OrderBy on the subquery. However, if the subquery has a limit or offset specified, then we need to leave the OrderBy intact.