### PR TITLE
[TINY] Fix #4083, Fix #4085 - Query with Include and OrderBy does not lift o…

### DIFF
--- a/src/EntityFramework.Relational/Query/ExpressionVisitors/Internal/IncludeExpressionVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionVisitors/Internal/IncludeExpressionVisitor.cs
@@ -245,12 +245,13 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors.Internal
                                 .Last(o => o.IsAliasWithColumnExpression())
                                 .TryGetColumnExpression().TableAlias);
 
-                    innerJoinSelectExpression.IsDistinct = true;
                     innerJoinSelectExpression.ClearProjection();
 
                     var innerJoinExpression = targetSelectExpression.AddInnerJoin(innerJoinSelectExpression);
 
                     LiftOrderBy(innerJoinSelectExpression, targetSelectExpression, innerJoinExpression);
+
+                    innerJoinSelectExpression.IsDistinct = true;
 
                     innerJoinExpression.Predicate
                         = BuildJoinEqualityExpression(

--- a/test/EntityFramework.Core.FunctionalTests/IncludeTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/IncludeTestBase.cs
@@ -1154,5 +1154,21 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 Assert.True(customers.All(c => c.Orders.Count > 0));
             }
         }
+
+        [Fact]
+        public virtual void Include_with_skip()
+        {
+            using (var context = CreateContext())
+            {
+                var customers
+                    = context.Customers
+                        .Include(c => c.Orders)
+                        .OrderBy(c => c.ContactName)
+                        .Skip(80)
+                        .ToList();
+
+                Assert.True(customers.All(c => c.Orders.Count > 0));
+            }
+        }
     }
 }

--- a/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/IncludeSqlServerTest.cs
+++ b/test/EntityFramework.MicrosoftSqlServer.FunctionalTests/IncludeSqlServerTest.cs
@@ -970,6 +970,35 @@ ORDER BY [c].[City] DESC, [c].[CustomerID]",
                 Sql);
         }
 
+        public override void Include_with_skip()
+        {
+            base.Include_with_skip();
+
+            Assert.Equal(
+                @"@__p_0: 80
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY [c].[ContactName], [c].[CustomerID]
+OFFSET @__p_0 ROWS
+
+@__p_0: 80
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+INNER JOIN (
+    SELECT DISTINCT [t0].*
+    FROM (
+        SELECT [c].[ContactName], [c].[CustomerID]
+        FROM [Customers] AS [c]
+        ORDER BY [c].[ContactName], [c].[CustomerID]
+        OFFSET @__p_0 ROWS
+    ) AS [t0]
+) AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+ORDER BY [c].[ContactName], [c].[CustomerID]",
+                Sql);
+        }
+
         private static string Sql => TestSqlLoggerFactory.Sql;
     }
 }


### PR DESCRIPTION
…rder to outer query.

Ensure we set IsDistinct on collection Include subqueries _after_ doing OrderBy lifting.

@maumar 