### PR TITLE
[Tiny] :bug: Generate entity types with relationship declared on them

### DIFF
--- a/src/EntityFramework.Commands/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EntityFramework.Commands/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Data.Entity.Migrations.Design
                 GenerateEntityType(builderName, entityType, stringBuilder);
             }
 
-            foreach (var entityType in entityTypes.Where(e => e.GetForeignKeys().Any()))
+            foreach (var entityType in entityTypes.Where(e => e.GetDeclaredForeignKeys().Any()))
             {
                 stringBuilder.AppendLine();
 
@@ -105,7 +105,6 @@ namespace Microsoft.Data.Entity.Migrations.Design
 
                 using (stringBuilder.Indent())
                 {
-
                     GenerateBaseType(entityType.BaseType, stringBuilder);
 
                     GenerateTableName(entityType, stringBuilder);


### PR DESCRIPTION
@bricelam - Minor typo.
It was generating empty entity type declaration for derived type even if the relationship is defined in the base type only. e.g.
````
            modelBuilder.Entity("TestApp.ApiDescriptionBase", b =>
                {
                    b.HasOne("TestApp.ApiDescriptionBase")
                        .WithMany()
                        .HasForeignKey("ParentId");
                });

            modelBuilder.Entity("TestApp.ApiGroupDescription", b =>
                {
                });
````