### PR TITLE
RevEng: Generate Properties in same order as columns in DB

### DIFF
--- a/src/EntityFramework.Commands/Scaffolding/Internal/EntityTypeWriter.cs
+++ b/src/EntityFramework.Commands/Scaffolding/Internal/EntityTypeWriter.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Internal;
+using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Scaffolding.Internal.Configuration;
 using Microsoft.Data.Entity.Utilities;
 
@@ -104,7 +105,7 @@ namespace Microsoft.Data.Entity.Scaffolding.Internal
 
         public virtual void AddProperties()
         {
-            foreach (var property in ScaffoldingUtilities.OrderedProperties(_entity.EntityType))
+            foreach (var property in _entity.EntityType.GetProperties().OrderBy(p => p.Scaffolding().ColumnOrdinal))
             {
                 PropertyConfiguration propertyConfiguration = _entity.FindPropertyConfiguration(property);
                 if (propertyConfiguration != null)

--- a/src/EntityFramework.Relational.Design/EntityFramework.Relational.Design.csproj
+++ b/src/EntityFramework.Relational.Design/EntityFramework.Relational.Design.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Metadata\IndexColumnModel.cs" />
     <Compile Include="Metadata\IndexModel.cs" />
     <Compile Include="Metadata\ScaffoldingModelAnnotations.cs" />
+    <Compile Include="Metadata\ScaffoldingPropertyAnnotations.cs" />
     <Compile Include="Metadata\SequenceModel.cs" />
     <Compile Include="Metadata\TableModel.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/EntityFramework.Relational.Design/Metadata/Internal/ScaffoldingAnnotationNames.cs
+++ b/src/EntityFramework.Relational.Design/Metadata/Internal/ScaffoldingAnnotationNames.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Data.Entity.Scaffolding.Metadata.Internal
     {
         public const string AnnotationPrefix = "Scaffolding:";
         public const string UseProviderMethodName = AnnotationPrefix + "UseProviderMethodName";
+        public const string ColumnOrdinal = AnnotationPrefix + "ColumnOrdinal";
         public const string DependentEndNavigation = AnnotationPrefix + "DependentEndNavigation";
         public const string PrincipalEndNavigation = AnnotationPrefix + "PrincipalEndNavigation";
         public const string EntityTypeErrors = AnnotationPrefix + "EntityTypeErrors";

--- a/src/EntityFramework.Relational.Design/Metadata/ScaffoldingMetadataExtensions.cs
+++ b/src/EntityFramework.Relational.Design/Metadata/ScaffoldingMetadataExtensions.cs
@@ -15,6 +15,9 @@ namespace Microsoft.Data.Entity.Metadata
         public static ScaffoldingModelAnnotations Scaffolding([NotNull] this IModel model)
             => new ScaffoldingModelAnnotations(Check.NotNull(model, nameof(model)), ScaffoldingAnnotationNames.AnnotationPrefix);
 
+        public static ScaffoldingPropertyAnnotations Scaffolding([NotNull] this IProperty property)
+            => new ScaffoldingPropertyAnnotations(Check.NotNull(property, nameof(property)), ScaffoldingAnnotationNames.AnnotationPrefix);
+
         public static ScaffoldingForeignKeyAnnotations Scaffolding([NotNull] this IForeignKey foreignKey)
             => new ScaffoldingForeignKeyAnnotations(Check.NotNull(foreignKey, nameof(foreignKey)), ScaffoldingAnnotationNames.AnnotationPrefix);
     }

--- a/src/EntityFramework.Relational.Design/Metadata/ScaffoldingPropertyAnnotations.cs
+++ b/src/EntityFramework.Relational.Design/Metadata/ScaffoldingPropertyAnnotations.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Scaffolding.Metadata.Internal;
+
+namespace Microsoft.Data.Entity.Scaffolding.Metadata
+{
+    public class ScaffoldingPropertyAnnotations : RelationalPropertyAnnotations
+    {
+        public ScaffoldingPropertyAnnotations([NotNull] IProperty property, [CanBeNull] string providerPrefix)
+            : base(property, providerPrefix)
+        {
+        }
+
+        public virtual int ColumnOrdinal
+        {
+            get { return (int)Annotations.GetAnnotation(ScaffoldingAnnotationNames.ColumnOrdinal); }
+            set { Annotations.SetAnnotation(ScaffoldingAnnotationNames.ColumnOrdinal, value); }
+        }
+    }
+}

--- a/src/EntityFramework.Relational.Design/RelationalScaffoldingModelFactory.cs
+++ b/src/EntityFramework.Relational.Design/RelationalScaffoldingModelFactory.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Data.Entity.Scaffolding
 
             var table = column.Table ?? _nullTable;
             var usedNames = new List<string>();
-            // TODO - need to clean up the way CSharpNamer & CSharpUniqueNamer work (see issue #3711)
+            // TODO - need to clean up the way CSharpNamer & CSharpUniqueNamer work (see issue #1671)
             if (column.Table != null)
             {
                 usedNames.Add(_tableNamer.GetName(table));
@@ -311,6 +311,7 @@ namespace Microsoft.Data.Entity.Scaffolding
                 property.IsRequired(!column.IsNullable);
             }
 
+            property.Metadata.Scaffolding().ColumnOrdinal = column.Ordinal;
             return property;
         }
 

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/AllDataTypes.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/AllDataTypes.expected
@@ -7,35 +7,35 @@ namespace E2ETest.Namespace
     {
         public int AllDataTypesID { get; set; }
         public long bigintColumn { get; set; }
-        public byte[] binaryColumn { get; set; }
         public bool bitColumn { get; set; }
-        public string charColumn { get; set; }
-        public DateTime dateColumn { get; set; }
-        public DateTime? datetime24Column { get; set; }
-        public DateTime? datetime2Column { get; set; }
-        public DateTime? datetimeColumn { get; set; }
-        public DateTimeOffset? datetimeoffset5Column { get; set; }
-        public DateTimeOffset? datetimeoffsetColumn { get; set; }
         public decimal decimalColumn { get; set; }
-        public double floatColumn { get; set; }
-        public byte[] imageColumn { get; set; }
         public int intColumn { get; set; }
         public decimal moneyColumn { get; set; }
-        public string ncharColumn { get; set; }
-        public string ntextColumn { get; set; }
         public decimal numericColumn { get; set; }
-        public string nvarcharColumn { get; set; }
-        public float? realColumn { get; set; }
-        public DateTime? smalldatetimeColumn { get; set; }
         public short smallintColumn { get; set; }
         public decimal smallmoneyColumn { get; set; }
-        public string textColumn { get; set; }
-        public TimeSpan? time4Column { get; set; }
-        public TimeSpan? timeColumn { get; set; }
-        public byte[] timestampColumn { get; set; }
         public byte tinyintColumn { get; set; }
-        public Guid? uniqueidentifierColumn { get; set; }
-        public byte[] varbinaryColumn { get; set; }
+        public double floatColumn { get; set; }
+        public float? realColumn { get; set; }
+        public DateTime dateColumn { get; set; }
+        public DateTime? datetimeColumn { get; set; }
+        public DateTime? datetime2Column { get; set; }
+        public DateTime? datetime24Column { get; set; }
+        public DateTimeOffset? datetimeoffsetColumn { get; set; }
+        public DateTimeOffset? datetimeoffset5Column { get; set; }
+        public DateTime? smalldatetimeColumn { get; set; }
+        public TimeSpan? timeColumn { get; set; }
+        public TimeSpan? time4Column { get; set; }
+        public string charColumn { get; set; }
+        public string textColumn { get; set; }
         public string varcharColumn { get; set; }
+        public string ncharColumn { get; set; }
+        public string ntextColumn { get; set; }
+        public string nvarcharColumn { get; set; }
+        public byte[] binaryColumn { get; set; }
+        public byte[] imageColumn { get; set; }
+        public byte[] varbinaryColumn { get; set; }
+        public byte[] timestampColumn { get; set; }
+        public Guid? uniqueidentifierColumn { get; set; }
     }
 }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/OneToManyDependent.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/OneToManyDependent.expected
@@ -7,9 +7,9 @@ namespace E2ETest.Namespace
     {
         public int OneToManyDependentID1 { get; set; }
         public int OneToManyDependentID2 { get; set; }
-        public int? OneToManyDependentFK1 { get; set; }
-        public int? OneToManyDependentFK2 { get; set; }
         public string SomeDependentEndColumn { get; set; }
+        public int? OneToManyDependentFK2 { get; set; }
+        public int? OneToManyDependentFK1 { get; set; }
 
         public virtual OneToManyPrincipal OneToManyDependentFK { get; set; }
     }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/OneToOneFKToUniqueKeyDependent.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/OneToOneFKToUniqueKeyDependent.expected
@@ -7,9 +7,9 @@ namespace E2ETest.Namespace
     {
         public int OneToOneFKToUniqueKeyDependentID1 { get; set; }
         public int OneToOneFKToUniqueKeyDependentID2 { get; set; }
+        public string SomeColumn { get; set; }
         public int? OneToOneFKToUniqueKeyDependentFK1 { get; set; }
         public int? OneToOneFKToUniqueKeyDependentFK2 { get; set; }
-        public string SomeColumn { get; set; }
 
         public virtual OneToOneFKToUniqueKeyPrincipal OneToOneFKToUniqueKeyDependentFK { get; set; }
     }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/OneToOneFKToUniqueKeyPrincipal.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/OneToOneFKToUniqueKeyPrincipal.expected
@@ -7,9 +7,9 @@ namespace E2ETest.Namespace
     {
         public int OneToOneFKToUniqueKeyPrincipalID1 { get; set; }
         public int OneToOneFKToUniqueKeyPrincipalID2 { get; set; }
+        public string SomePrincipalColumn { get; set; }
         public int OneToOneFKToUniqueKeyPrincipalUniqueKey1 { get; set; }
         public int OneToOneFKToUniqueKeyPrincipalUniqueKey2 { get; set; }
-        public string SomePrincipalColumn { get; set; }
 
         public virtual OneToOneFKToUniqueKeyDependent OneToOneFKToUniqueKeyDependent { get; set; }
     }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/OneToOneSeparateFKDependent.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/OneToOneSeparateFKDependent.expected
@@ -7,9 +7,9 @@ namespace E2ETest.Namespace
     {
         public int OneToOneSeparateFKDependentID1 { get; set; }
         public int OneToOneSeparateFKDependentID2 { get; set; }
+        public string SomeDependentEndColumn { get; set; }
         public int? OneToOneSeparateFKDependentFK1 { get; set; }
         public int? OneToOneSeparateFKDependentFK2 { get; set; }
-        public string SomeDependentEndColumn { get; set; }
 
         public virtual OneToOneSeparateFKPrincipal OneToOneSeparateFKDependentFK { get; set; }
     }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/PropertyConfiguration.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/PropertyConfiguration.expected
@@ -6,18 +6,18 @@ namespace E2ETest.Namespace
     public partial class PropertyConfiguration
     {
         public byte PropertyConfigurationID { get; set; }
-        public int A { get; set; }
-        public int B { get; set; }
-        public int? PropertyConfiguration1 { get; set; }
-        public byte[] RowversionColumn { get; set; }
-        public int? SumOfAAndB { get; set; }
         public DateTime WithDateDefaultExpression { get; set; }
         public DateTime WithDateFixedDefault { get; set; }
         public DateTime? WithDateNullDefault { get; set; }
-        public int WithDefaultValue { get; set; }
         public Guid WithGuidDefaultExpression { get; set; }
-        public decimal WithMoneyDefaultValue { get; set; }
-        public short? WithNullDefaultValue { get; set; }
         public string WithVarcharNullDefaultValue { get; set; }
+        public int WithDefaultValue { get; set; }
+        public short? WithNullDefaultValue { get; set; }
+        public decimal WithMoneyDefaultValue { get; set; }
+        public int A { get; set; }
+        public int B { get; set; }
+        public int? SumOfAAndB { get; set; }
+        public byte[] RowversionColumn { get; set; }
+        public int? PropertyConfiguration1 { get; set; }
     }
 }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/SelfReferencing.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/SelfReferencing.expected
@@ -6,8 +6,8 @@ namespace E2ETest.Namespace
     public partial class SelfReferencing
     {
         public int SelfReferencingID { get; set; }
-        public string Description { get; set; }
         public string Name { get; set; }
+        public string Description { get; set; }
         public int? SelfReferenceFK { get; set; }
 
         public virtual SelfReferencing SelfReferenceFKNavigation { get; set; }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/Test_Spaces_Keywords_Table.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/Test_Spaces_Keywords_Table.expected
@@ -6,17 +6,17 @@ namespace E2ETest.Namespace
     public partial class Test_Spaces_Keywords_Table
     {
         public int Test_Spaces_Keywords_TableID { get; set; }
-        public int? @AtSymbolAtStartOfColumn { get; set; }
-        public int @Multiple_At_Symbols_In_Column { get; set; }
-        public int? Commas_In_Column { get; set; }
-        public int? Spaces_In_Column { get; set; }
-        public int Tabs_In_Column { get; set; }
-        public int? _Backslashes_In_Column { get; set; }
-        public int _Dollar_Sign_Column { get; set; }
-        public int? _Double_Quotes_Column { get; set; }
-        public int? _Exclamation_Mark_Column { get; set; }
         public int _abstract { get; set; }
         public int? _class { get; set; }
         public int _volatile { get; set; }
+        public int? Spaces_In_Column { get; set; }
+        public int Tabs_In_Column { get; set; }
+        public int? @AtSymbolAtStartOfColumn { get; set; }
+        public int @Multiple_At_Symbols_In_Column { get; set; }
+        public int? Commas_In_Column { get; set; }
+        public int _Dollar_Sign_Column { get; set; }
+        public int? _Exclamation_Mark_Column { get; set; }
+        public int? _Double_Quotes_Column { get; set; }
+        public int? _Backslashes_In_Column { get; set; }
     }
 }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/AllDataTypes.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/AllDataTypes.expected
@@ -9,41 +9,41 @@ namespace E2ETest.Namespace
     {
         public int AllDataTypesID { get; set; }
         public long bigintColumn { get; set; }
-        [MaxLength(1)]
-        public byte[] binaryColumn { get; set; }
         public bool bitColumn { get; set; }
-        [MaxLength(1)]
-        public string charColumn { get; set; }
-        public DateTime dateColumn { get; set; }
-        public DateTime? datetime24Column { get; set; }
-        public DateTime? datetime2Column { get; set; }
-        public DateTime? datetimeColumn { get; set; }
-        public DateTimeOffset? datetimeoffset5Column { get; set; }
-        public DateTimeOffset? datetimeoffsetColumn { get; set; }
         public decimal decimalColumn { get; set; }
-        public double floatColumn { get; set; }
-        public byte[] imageColumn { get; set; }
         public int intColumn { get; set; }
         public decimal moneyColumn { get; set; }
+        public decimal numericColumn { get; set; }
+        public short smallintColumn { get; set; }
+        public decimal smallmoneyColumn { get; set; }
+        public byte tinyintColumn { get; set; }
+        public double floatColumn { get; set; }
+        public float? realColumn { get; set; }
+        public DateTime dateColumn { get; set; }
+        public DateTime? datetimeColumn { get; set; }
+        public DateTime? datetime2Column { get; set; }
+        public DateTime? datetime24Column { get; set; }
+        public DateTimeOffset? datetimeoffsetColumn { get; set; }
+        public DateTimeOffset? datetimeoffset5Column { get; set; }
+        public DateTime? smalldatetimeColumn { get; set; }
+        public TimeSpan? timeColumn { get; set; }
+        public TimeSpan? time4Column { get; set; }
+        [MaxLength(1)]
+        public string charColumn { get; set; }
+        public string textColumn { get; set; }
+        [MaxLength(1)]
+        public string varcharColumn { get; set; }
         [MaxLength(1)]
         public string ncharColumn { get; set; }
         public string ntextColumn { get; set; }
-        public decimal numericColumn { get; set; }
         [MaxLength(1)]
         public string nvarcharColumn { get; set; }
-        public float? realColumn { get; set; }
-        public DateTime? smalldatetimeColumn { get; set; }
-        public short smallintColumn { get; set; }
-        public decimal smallmoneyColumn { get; set; }
-        public string textColumn { get; set; }
-        public TimeSpan? time4Column { get; set; }
-        public TimeSpan? timeColumn { get; set; }
-        public byte[] timestampColumn { get; set; }
-        public byte tinyintColumn { get; set; }
-        public Guid? uniqueidentifierColumn { get; set; }
+        [MaxLength(1)]
+        public byte[] binaryColumn { get; set; }
+        public byte[] imageColumn { get; set; }
         [MaxLength(1)]
         public byte[] varbinaryColumn { get; set; }
-        [MaxLength(1)]
-        public string varcharColumn { get; set; }
+        public byte[] timestampColumn { get; set; }
+        public Guid? uniqueidentifierColumn { get; set; }
     }
 }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/OneToManyDependent.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/OneToManyDependent.expected
@@ -9,11 +9,11 @@ namespace E2ETest.Namespace
     {
         public int OneToManyDependentID1 { get; set; }
         public int OneToManyDependentID2 { get; set; }
-        public int? OneToManyDependentFK1 { get; set; }
-        public int? OneToManyDependentFK2 { get; set; }
         [Required]
         [MaxLength(20)]
         public string SomeDependentEndColumn { get; set; }
+        public int? OneToManyDependentFK2 { get; set; }
+        public int? OneToManyDependentFK1 { get; set; }
 
         [ForeignKey("OneToManyDependentFK1,OneToManyDependentFK2")]
         [InverseProperty("OneToManyDependent")]

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/OneToOneFKToUniqueKeyDependent.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/OneToOneFKToUniqueKeyDependent.expected
@@ -10,12 +10,12 @@ namespace E2ETest.Namespace
         public int OneToOneFKToUniqueKeyDependentID1 { get; set; }
         public int OneToOneFKToUniqueKeyDependentID2 { get; set; }
         [Required]
+        [MaxLength(20)]
+        public string SomeColumn { get; set; }
+        [Required]
         public int? OneToOneFKToUniqueKeyDependentFK1 { get; set; }
         [Required]
         public int? OneToOneFKToUniqueKeyDependentFK2 { get; set; }
-        [Required]
-        [MaxLength(20)]
-        public string SomeColumn { get; set; }
 
         public virtual OneToOneFKToUniqueKeyPrincipal OneToOneFKToUniqueKeyDependentFK { get; set; }
     }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/OneToOneFKToUniqueKeyPrincipal.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/OneToOneFKToUniqueKeyPrincipal.expected
@@ -9,11 +9,11 @@ namespace E2ETest.Namespace
     {
         public int OneToOneFKToUniqueKeyPrincipalID1 { get; set; }
         public int OneToOneFKToUniqueKeyPrincipalID2 { get; set; }
-        public int OneToOneFKToUniqueKeyPrincipalUniqueKey1 { get; set; }
-        public int OneToOneFKToUniqueKeyPrincipalUniqueKey2 { get; set; }
         [Required]
         [MaxLength(20)]
         public string SomePrincipalColumn { get; set; }
+        public int OneToOneFKToUniqueKeyPrincipalUniqueKey1 { get; set; }
+        public int OneToOneFKToUniqueKeyPrincipalUniqueKey2 { get; set; }
 
         public virtual OneToOneFKToUniqueKeyDependent OneToOneFKToUniqueKeyDependent { get; set; }
     }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/OneToOneSeparateFKDependent.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/OneToOneSeparateFKDependent.expected
@@ -10,12 +10,12 @@ namespace E2ETest.Namespace
         public int OneToOneSeparateFKDependentID1 { get; set; }
         public int OneToOneSeparateFKDependentID2 { get; set; }
         [Required]
+        [MaxLength(20)]
+        public string SomeDependentEndColumn { get; set; }
+        [Required]
         public int? OneToOneSeparateFKDependentFK1 { get; set; }
         [Required]
         public int? OneToOneSeparateFKDependentFK2 { get; set; }
-        [Required]
-        [MaxLength(20)]
-        public string SomeDependentEndColumn { get; set; }
 
         [ForeignKey("OneToOneSeparateFKDependentFK1,OneToOneSeparateFKDependentFK2")]
         [InverseProperty("OneToOneSeparateFKDependent")]

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/PropertyConfiguration.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/PropertyConfiguration.expected
@@ -8,21 +8,21 @@ namespace E2ETest.Namespace
     public partial class PropertyConfiguration
     {
         public byte PropertyConfigurationID { get; set; }
-        public int A { get; set; }
-        public int B { get; set; }
-        [Column("PropertyConfiguration")]
-        public int? PropertyConfiguration1 { get; set; }
-        [Required]
-        public byte[] RowversionColumn { get; set; }
-        public int? SumOfAAndB { get; set; }
         public DateTime WithDateDefaultExpression { get; set; }
         public DateTime WithDateFixedDefault { get; set; }
         public DateTime? WithDateNullDefault { get; set; }
-        public int WithDefaultValue { get; set; }
         public Guid WithGuidDefaultExpression { get; set; }
-        public decimal WithMoneyDefaultValue { get; set; }
-        public short? WithNullDefaultValue { get; set; }
         [MaxLength(1)]
         public string WithVarcharNullDefaultValue { get; set; }
+        public int WithDefaultValue { get; set; }
+        public short? WithNullDefaultValue { get; set; }
+        public decimal WithMoneyDefaultValue { get; set; }
+        public int A { get; set; }
+        public int B { get; set; }
+        public int? SumOfAAndB { get; set; }
+        [Required]
+        public byte[] RowversionColumn { get; set; }
+        [Column("PropertyConfiguration")]
+        public int? PropertyConfiguration1 { get; set; }
     }
 }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/SelfReferencing.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/SelfReferencing.expected
@@ -9,11 +9,11 @@ namespace E2ETest.Namespace
     {
         public int SelfReferencingID { get; set; }
         [Required]
-        [MaxLength(100)]
-        public string Description { get; set; }
-        [Required]
         [MaxLength(20)]
         public string Name { get; set; }
+        [Required]
+        [MaxLength(100)]
+        public string Description { get; set; }
         public int? SelfReferenceFK { get; set; }
 
         [ForeignKey("SelfReferenceFK")]

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/Test_Spaces_Keywords_Table.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/Test_Spaces_Keywords_Table.expected
@@ -10,28 +10,28 @@ namespace E2ETest.Namespace
     {
         [Column("Test Spaces Keywords TableID")]
         public int Test_Spaces_Keywords_TableID { get; set; }
-        public int? @AtSymbolAtStartOfColumn { get; set; }
-        [Column("@Multiple@At@Symbols@In@Column")]
-        public int @Multiple_At_Symbols_In_Column { get; set; }
-        [Column("Commas,In,Column")]
-        public int? Commas_In_Column { get; set; }
-        [Column("Spaces In Column")]
-        public int? Spaces_In_Column { get; set; }
-        [Column("Tabs\tIn\tColumn")]
-        public int Tabs_In_Column { get; set; }
-        [Column("\\Backslashes\\In\\Column")]
-        public int? _Backslashes_In_Column { get; set; }
-        [Column("$Dollar$Sign$Column")]
-        public int _Dollar_Sign_Column { get; set; }
-        [Column("\"Double\"Quotes\"Column")]
-        public int? _Double_Quotes_Column { get; set; }
-        [Column("!Exclamation!Mark!Column")]
-        public int? _Exclamation_Mark_Column { get; set; }
         [Column("abstract")]
         public int _abstract { get; set; }
         [Column("class")]
         public int? _class { get; set; }
         [Column("volatile")]
         public int _volatile { get; set; }
+        [Column("Spaces In Column")]
+        public int? Spaces_In_Column { get; set; }
+        [Column("Tabs\tIn\tColumn")]
+        public int Tabs_In_Column { get; set; }
+        public int? @AtSymbolAtStartOfColumn { get; set; }
+        [Column("@Multiple@At@Symbols@In@Column")]
+        public int @Multiple_At_Symbols_In_Column { get; set; }
+        [Column("Commas,In,Column")]
+        public int? Commas_In_Column { get; set; }
+        [Column("$Dollar$Sign$Column")]
+        public int _Dollar_Sign_Column { get; set; }
+        [Column("!Exclamation!Mark!Column")]
+        public int? _Exclamation_Mark_Column { get; set; }
+        [Column("\"Double\"Quotes\"Column")]
+        public int? _Double_Quotes_Column { get; set; }
+        [Column("\\Backslashes\\In\\Column")]
+        public int? _Backslashes_In_Column { get; set; }
     }
 }

--- a/test/EntityFramework.Relational.Design.Tests/EntityFramework.Relational.Design.Tests.csproj
+++ b/test/EntityFramework.Relational.Design.Tests/EntityFramework.Relational.Design.Tests.csproj
@@ -35,7 +35,7 @@
     <Compile Include="CSharpNamerTest.cs" />
     <Compile Include="CSharpUniqueNamerTest.cs" />
     <Compile Include="NullLogger.cs" />
-    <Compile Include="RelationalDatabaseModelFactoryTest.cs" />
+    <Compile Include="RelationalScaffoldingModelFactoryTest.cs" />
     <Compile Include="ScaffoldingMetadataExtenstionsTest.cs" />
     <Compile Include="TestLogger.cs" />
     <None Include="project.json" />

--- a/test/EntityFramework.Relational.Design.Tests/RelationalScaffoldingModelFactoryTest.cs
+++ b/test/EntityFramework.Relational.Design.Tests/RelationalScaffoldingModelFactoryTest.cs
@@ -174,8 +174,56 @@ namespace Microsoft.Data.Entity.Relational.Design
                     }
                 }
             };
+
             var property = (Property)_factory.Create(info).FindEntityType("A").FindProperty("Col");
+
             Assert.Equal(expectedColumnType, property.Relational().ColumnType);
+        }
+
+        [Fact]
+        public void Column_ordinal_annotation()
+        {
+            var info = new DatabaseModel
+            {
+                Tables =
+                {
+                    new TableModel
+                    {
+                        Name = "A",
+                        Columns =
+                        {
+                            new ColumnModel
+                            {
+                                Name = "Col1",
+                                DataType = "string",
+                                PrimaryKeyOrdinal = 1,
+                                Ordinal = 1
+                            },
+                            new ColumnModel
+                            {
+                                Name = "Col2",
+                                DataType = "string",
+                                Ordinal = 2
+                            },
+                            new ColumnModel
+                            {
+                                Name = "Col3",
+                                DataType = "string",
+                                Ordinal = 3
+                            }
+                        }
+                    }
+                }
+            };
+
+            var entityTypeA = _factory.Create(info).FindEntityType("A");
+            var property1 = (Property)entityTypeA.FindProperty("Col1");
+            var property2 = (Property)entityTypeA.FindProperty("Col2");
+            var property3 = (Property)entityTypeA.FindProperty("Col3");
+
+            Assert.Equal(1, property1.Scaffolding().ColumnOrdinal);
+            Assert.Equal(2, property2.Scaffolding().ColumnOrdinal);
+            Assert.Equal(3, property3.Scaffolding().ColumnOrdinal);
         }
 
         [Theory]

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/FkToAltKey/Comment.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/FkToAltKey/Comment.expected
@@ -6,8 +6,8 @@ namespace E2E.Sqlite
     public partial class Comment
     {
         public long Id { get; set; }
-        public string Contents { get; set; }
         public long UserAltId { get; set; }
+        public string Contents { get; set; }
 
         public virtual User UserAlt { get; set; }
     }

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/ManyToMany/Users_Groups.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/ManyToMany/Users_Groups.expected
@@ -6,8 +6,8 @@ namespace E2E.Sqlite
     public partial class Users_Groups
     {
         public string Id { get; set; }
-        public string GroupId { get; set; }
         public string UserId { get; set; }
+        public string GroupId { get; set; }
 
         public virtual Groups Group { get; set; }
         public virtual Users User { get; set; }

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/OneToMany/OneToManyDependent.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/OneToMany/OneToManyDependent.expected
@@ -7,9 +7,9 @@ namespace E2E.Sqlite
     {
         public long OneToManyDependentID1 { get; set; }
         public long OneToManyDependentID2 { get; set; }
+        public string SomeDependentEndColumn { get; set; }
         public long? OneToManyDependentFK1 { get; set; }
         public long? OneToManyDependentFK2 { get; set; }
-        public string SomeDependentEndColumn { get; set; }
 
         public virtual OneToManyPrincipal OneToManyDependentFK { get; set; }
     }

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/FkToAltKey/Comment.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/FkToAltKey/Comment.expected
@@ -8,8 +8,8 @@ namespace E2E.Sqlite
     public partial class Comment
     {
         public long Id { get; set; }
-        public string Contents { get; set; }
         public long UserAltId { get; set; }
+        public string Contents { get; set; }
 
         public virtual User UserAlt { get; set; }
     }

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/ManyToMany/Users_Groups.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/ManyToMany/Users_Groups.expected
@@ -9,9 +9,9 @@ namespace E2E.Sqlite
     {
         public string Id { get; set; }
         [Required]
-        public string GroupId { get; set; }
-        [Required]
         public string UserId { get; set; }
+        [Required]
+        public string GroupId { get; set; }
 
         [ForeignKey("GroupId")]
         [InverseProperty("Users_Groups")]

--- a/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/OneToMany/OneToManyDependent.expected
+++ b/test/EntityFramework.Sqlite.Design.FunctionalTests/ReverseEngineering/Expected/UseAttributesInsteadOfFluentApi/OneToMany/OneToManyDependent.expected
@@ -9,10 +9,10 @@ namespace E2E.Sqlite
     {
         public long OneToManyDependentID1 { get; set; }
         public long OneToManyDependentID2 { get; set; }
-        public long? OneToManyDependentFK1 { get; set; }
-        public long? OneToManyDependentFK2 { get; set; }
         [Required]
         public string SomeDependentEndColumn { get; set; }
+        public long? OneToManyDependentFK1 { get; set; }
+        public long? OneToManyDependentFK2 { get; set; }
 
         [ForeignKey("OneToManyDependentFK1,OneToManyDependentFK2")]
         [InverseProperty("OneToManyDependent")]


### PR DESCRIPTION
Fixes #4062. 

Note: this uses a Scaffolding-only ColumnOrdinal annotation for now. If we decide to add column ordering in a more general way to the model as a whole (see discussion in #2272) then we should change this code to use that instead.