### PR TITLE
[uwp] Add build error if runtime directives are not present

### DIFF
--- a/src/EntityFramework.Commands/build/netcore50/EntityFramework.Commands.props
+++ b/src/EntityFramework.Commands/build/netcore50/EntityFramework.Commands.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <!-- TODO: Consider alternate solutions for working with project.json -->
     <CopyNuGetImplementations>true</CopyNuGetImplementations>
+    <_EfCommandsReferenced>true</_EfCommandsReferenced>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="$(MSBuildThisFileDirectory)..\..\lib\net451\**">

--- a/src/EntityFramework.Core/build/netcore50/EntityFramework.Core.targets
+++ b/src/EntityFramework.Core/build/netcore50/EntityFramework.Core.targets
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Target Name="EnsureEntityFrameworkRdXml" BeforeTargets="Build; BeforeBuild" Condition="'$(UseDotNetNativeToolchain)' != ''">
+        <PropertyGroup>
+            <_GenerateInstruction>Generate this file by executing 'Scaffold-Directives' command from the Package Manager Console.</_GenerateInstruction>
+            <_GenerateInstruction Condition="'$(_EfCommandsReferenced)' == ''">Install the EntityFramework.Commands package and execute 'Scaffold-Directives' from the Package Manager Console.</_GenerateInstruction>
+        </PropertyGroup>
+        <Error
+            Text="Missing Properties/EntityFramework.g.rd.xml. This file is necessary for .NET Native to execute correctly. $(_GenerateInstruction) See http://go.microsoft.com/fwlink/?LinkId=722449 for more details."
+            Condition="!Exists('Properties\EntityFramework.g.rd.xml')" />
+    </Target>
+</Project>

--- a/src/EntityFramework.Core/project.json
+++ b/src/EntityFramework.Core/project.json
@@ -105,5 +105,8 @@
         "System.Threading.Tasks": "4.0.10"
       }
     }
+  },
+  "packInclude": {
+    "build/": "build/**",
   }
 }


### PR DESCRIPTION
We stripped out automatic inference in #4197. UWP projects *will fail* without generating runtime directives. We can help users catch this early with msbuild

(If this idea get's approved, I will replace the URL in the error message to a fwlink)

cc @bricelam 