### PR TITLE
[RevEng]: For SQL Server also use type aliases to determine data type

### DIFF
--- a/src/EntityFramework.MicrosoftSqlServer.Design/Metadata/SqlServerDatabaseModelAnnotationNames.cs
+++ b/src/EntityFramework.MicrosoftSqlServer.Design/Metadata/SqlServerDatabaseModelAnnotationNames.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Data.Entity.Scaffolding.Metadata
     public static class SqlServerDatabaseModelAnnotationNames
     {
         public const string Prefix = "SqlServerDatabaseModel:";
+        public const string TypeAliases = Prefix + "TypeAliases";
         public const string IsIdentity = Prefix + "IsIdentity";
         public const string IsClustered = Prefix + "IsClustered";
         public const string DateTimePrecision = Prefix + "DateTimePrecision";

--- a/src/EntityFramework.MicrosoftSqlServer.Design/Metadata/SqlServerDatabaseModelAnnotations.cs
+++ b/src/EntityFramework.MicrosoftSqlServer.Design/Metadata/SqlServerDatabaseModelAnnotations.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Scaffolding.Metadata
+{
+    public class SqlServerDatabaseModelAnnotations
+    {
+        private readonly DatabaseModel _databaseModel;
+
+        public SqlServerDatabaseModelAnnotations([NotNull] DatabaseModel databaseModel)
+        {
+            Check.NotNull(databaseModel, nameof(databaseModel));
+
+            _databaseModel = databaseModel;
+        }
+
+        public virtual Dictionary<string, string> TypeAliases
+        {
+            get
+            {
+                return _databaseModel[SqlServerDatabaseModelAnnotationNames.TypeAliases] as Dictionary<string, string>;
+            }
+            [param: NotNull]
+            set { _databaseModel[SqlServerDatabaseModelAnnotationNames.TypeAliases] = value; }
+        }
+    }
+}

--- a/src/EntityFramework.MicrosoftSqlServer.Design/Metadata/SqlServerDatabaseModelExtensions.cs
+++ b/src/EntityFramework.MicrosoftSqlServer.Design/Metadata/SqlServerDatabaseModelExtensions.cs
@@ -12,5 +12,8 @@ namespace Microsoft.Data.Entity.Scaffolding.Metadata
 
         public static SqlServerIndexModelAnnotations SqlServer([NotNull] this IndexModel index)
             => new SqlServerIndexModelAnnotations(index);
+
+        public static SqlServerDatabaseModelAnnotations SqlServer([NotNull] this DatabaseModel databaseModel)
+            => new SqlServerDatabaseModelAnnotations(databaseModel);
     }
 }

--- a/src/EntityFramework.MicrosoftSqlServer.Design/SqlServerScaffoldingModelFactory.cs
+++ b/src/EntityFramework.MicrosoftSqlServer.Design/SqlServerScaffoldingModelFactory.cs
@@ -49,6 +49,29 @@ namespace Microsoft.Data.Entity.Scaffolding
             return propertyBuilder;
         }
 
+        protected override Type GetTypeMapping([NotNull] ColumnModel column)
+        {
+            RelationalTypeMapping mapping = null;
+            if (column.DataType != null)
+            {
+                string underlyingDataType = null;
+                var typeAliases = column.Table.Database.SqlServer().TypeAliases;
+                if (typeAliases != null)
+                {
+                    typeAliases.TryGetValue(column.DataType, out underlyingDataType);
+                }
+
+                mapping = TypeMapper.FindMapping(underlyingDataType ?? column.DataType);
+            }
+
+            if (mapping?.ClrType == null)
+            {
+                return null;
+            }
+
+            return column.IsNullable ? mapping.ClrType.MakeNullable() : mapping.ClrType;
+        }
+
         protected override KeyBuilder VisitPrimaryKey([NotNull] EntityTypeBuilder builder, [NotNull] TableModel table)
         {
             var keyBuilder = base.VisitPrimaryKey(builder, table);

--- a/src/EntityFramework.Relational.Design/Metadata/SequenceModel.cs
+++ b/src/EntityFramework.Relational.Design/Metadata/SequenceModel.cs
@@ -8,6 +8,8 @@ namespace Microsoft.Data.Entity.Scaffolding.Metadata
 {
     public class SequenceModel : Annotatable
     {
+        public virtual DatabaseModel Database { get; [param: NotNull] set; }
+
         public virtual string Name { get; [param: NotNull] set; }
         public virtual string SchemaName { get; [param: CanBeNull] set; }
         public virtual string DataType { get; [param: CanBeNull] set; }

--- a/src/EntityFramework.Relational.Design/Metadata/TableModel.cs
+++ b/src/EntityFramework.Relational.Design/Metadata/TableModel.cs
@@ -9,6 +9,8 @@ namespace Microsoft.Data.Entity.Scaffolding.Metadata
 {
     public class TableModel : Annotatable
     {
+        public virtual DatabaseModel Database { get; [param: NotNull] set; }
+
         public virtual string Name { get; [param: NotNull] set; }
 
         [CanBeNull]

--- a/src/EntityFramework.Sqlite.Design/SqliteDatabaseModelFactory.cs
+++ b/src/EntityFramework.Sqlite.Design/SqliteDatabaseModelFactory.cs
@@ -84,6 +84,7 @@ namespace Microsoft.Data.Entity.Scaffolding
                     {
                         var table = new TableModel
                         {
+                            Database = _databaseModel,
                             Name = name
                         };
                         _databaseModel.Tables.Add(table);

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/E2E.sql
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/E2E.sql
@@ -38,6 +38,10 @@ if exists (select * from sysobjects where id = object_id('dbo.AllDataTypes') and
 	DROP TABLE "dbo"."AllDataTypes"
 GO
 
+if exists (select * from systypes where name = 'TestTypeAlias')
+	drop TYPE "dbo"."TestTypeAlias"
+GO
+
 if exists (select * from sysobjects where id = object_id('dbo.PropertyConfiguration') and sysstat & 0xf = 3)
 	DROP TABLE "dbo"."PropertyConfiguration"
 GO
@@ -94,6 +98,9 @@ if exists (select * from sysobjects where id = object_id('dbo.FilteredOut') and 
 	drop table "dbo"."FilteredOut"
 GO
 
+CREATE TYPE TestTypeAlias FROM nvarchar(max)
+GO
+
 CREATE TABLE "dbo"."AllDataTypes" (
 	"AllDataTypesID" "int" IDENTITY(1, 1) PRIMARY KEY,
 	"bigintColumn" "bigint" NOT NULL,
@@ -132,6 +139,7 @@ CREATE TABLE "dbo"."AllDataTypes" (
 	"xmlColumn" "xml" NULL,
 	"geographyColumn" "geography" NULL,
 	"geometryColumn" "geometry" NULL,
+	"typeAliasColumn" "TestTypeAlias" NULL,
 )
 
 GO

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/AllDataTypes.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/AllDataTypes.expected
@@ -37,5 +37,6 @@ namespace E2ETest.Namespace
         public byte[] varbinaryColumn { get; set; }
         public byte[] timestampColumn { get; set; }
         public Guid? uniqueidentifierColumn { get; set; }
+        public string typeAliasColumn { get; set; }
     }
 }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/SqlServerReverseEngineerTestE2EContext.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_AllFluentApi/SqlServerReverseEngineerTestE2EContext.expected
@@ -58,6 +58,8 @@ namespace E2ETest.Namespace
                     .HasColumnType("timestamp")
                     .ValueGeneratedOnAddOrUpdate();
 
+                entity.Property(e => e.typeAliasColumn).HasColumnType("TestTypeAlias");
+
                 entity.Property(e => e.varbinaryColumn)
                     .HasMaxLength(1)
                     .HasColumnType("varbinary");

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/AllDataTypes.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/AllDataTypes.expected
@@ -45,5 +45,6 @@ namespace E2ETest.Namespace
         public byte[] varbinaryColumn { get; set; }
         public byte[] timestampColumn { get; set; }
         public Guid? uniqueidentifierColumn { get; set; }
+        public string typeAliasColumn { get; set; }
     }
 }

--- a/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/AttributesContext.expected
+++ b/test/EntityFramework.MicrosoftSqlServer.Design.FunctionalTests/ReverseEngineering/ExpectedResults/E2E_UseAttributesInsteadOfFluentApi/AttributesContext.expected
@@ -50,6 +50,8 @@ namespace E2ETest.Namespace
                     .HasColumnType("timestamp")
                     .ValueGeneratedOnAddOrUpdate();
 
+                entity.Property(e => e.typeAliasColumn).HasColumnType("TestTypeAlias");
+
                 entity.Property(e => e.varbinaryColumn).HasColumnType("varbinary");
 
                 entity.Property(e => e.varcharColumn).HasColumnType("varchar");


### PR DESCRIPTION
Fix for #3843. Now we have the annotation approach in place use that approach and make using type aliases specific to the SQL Server provider. (But I'll mark as "Providers Beware" in case other providers (@ErikEJ?) would like to do similar things).