### PR TITLE
Ensure notification entities brought in by query are tracked as Uncha…

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.InMemory/Query/Internal/InMemoryQueryContextFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore.InMemory/Query/Internal/InMemoryQueryContextFactory.cs
@@ -15,8 +15,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         public InMemoryQueryContextFactory(
             [NotNull] IStateManager stateManager,
             [NotNull] IConcurrencyDetector concurrencyDetector,
-            [NotNull] IInMemoryDatabase database)
-            : base(stateManager, concurrencyDetector)
+            [NotNull] IInMemoryDatabase database,
+            [NotNull] IChangeDetector changeDetector)
+            : base(stateManager, concurrencyDetector, changeDetector)
         {
             Check.NotNull(database, nameof(database));
 

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalQueryContextFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalQueryContextFactory.cs
@@ -14,8 +14,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         public RelationalQueryContextFactory(
             [NotNull] IStateManager stateManager,
             [NotNull] IConcurrencyDetector concurrencyDetector,
-            [NotNull] IRelationalConnection connection)
-            : base(stateManager, concurrencyDetector)
+            [NotNull] IRelationalConnection connection,
+            [NotNull] IChangeDetector changeDetector)
+            : base(stateManager, concurrencyDetector, changeDetector)
         {
             _connection = connection;
         }

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/IChangeDetector.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/IChangeDetector.cs
@@ -9,5 +9,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
     {
         void DetectChanges([NotNull] IStateManager stateManager);
         void DetectChanges([NotNull] InternalEntityEntry entry);
+
+        void Suspend();
+        void Resume();
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Query/QueryContextFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/QueryContextFactory.cs
@@ -12,17 +12,22 @@ namespace Microsoft.EntityFrameworkCore.Query
     {
         protected QueryContextFactory(
             [NotNull] IStateManager stateManager,
-            [NotNull] IConcurrencyDetector concurrencyDetector)
+            [NotNull] IConcurrencyDetector concurrencyDetector,
+            [NotNull] IChangeDetector changeDetector)
         {
             Check.NotNull(stateManager, nameof(stateManager));
             Check.NotNull(concurrencyDetector, nameof(concurrencyDetector));
+            Check.NotNull(changeDetector, nameof(changeDetector));
 
             StateManager = stateManager;
             ConcurrencyDetector = concurrencyDetector;
+            ChangeDetector = changeDetector;
         }
 
         protected virtual IQueryBuffer CreateQueryBuffer()
-            => new QueryBuffer(StateManager);
+            => new QueryBuffer(StateManager, ChangeDetector);
+
+        protected virtual IChangeDetector ChangeDetector { get; }
 
         protected virtual IStateManager StateManager { get; }
 

--- a/test/Microsoft.EntityFrameworkCore.FunctionalTests/NotificationEntitiesTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.FunctionalTests/NotificationEntitiesTestBase.cs
@@ -1,0 +1,153 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Linq;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.FunctionalTests
+{
+    public abstract class NotificationEntitiesTestBase<TFixture> : IClassFixture<TFixture>
+        where TFixture : NotificationEntitiesTestBase<TFixture>.NotificationEntitiesFixtureBase, new()
+    {
+        protected NotificationEntitiesTestBase(TFixture fixture)
+        {
+            Fixture = fixture;
+        }
+
+        protected virtual TFixture Fixture { get; }
+
+        protected DbContext CreateContext() => Fixture.CreateContext();
+
+        [Fact] // Issue #4020
+        public virtual void Include_brings_entities_referenced_from_already_tracked_notification_entities_as_Unchanged()
+        {
+            using (var context = CreateContext())
+            {
+                var postA = context.Set<Post>().Single(e => e.Id == 1);
+                var postB = context.Set<Post>().Where(e => e.Id == 1).Include(e => e.Blog).ToArray().Single();
+
+                Assert.Same(postA, postB);
+
+                Assert.Equal(EntityState.Unchanged, context.Entry(postA).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(postA.Blog).State);
+            }
+        }
+
+        [Fact] // Issue #4020
+        public virtual void Include_brings_colelctions_referenced_from_already_tracked_notification_entities_as_Unchanged()
+        {
+            using (var context = CreateContext())
+            {
+                var blogA = context.Set<Blog>().Single(e => e.Id == 1);
+                var blogB = context.Set<Blog>().Where(e => e.Id == 1).Include(e => e.Posts).ToArray().Single();
+
+                Assert.Same(blogA, blogB);
+
+                Assert.Equal(EntityState.Unchanged, context.Entry(blogA).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(blogA.Posts.First()).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(blogA.Posts.Skip(1).First()).State);
+            }
+        }
+
+        protected class Blog : NotificationEntity
+        {
+            private int _id;
+            private ICollection<Post> _posts;
+
+            public int Id
+            {
+                get { return _id; }
+                set { SetWithNotify(value, ref _id); }
+            }
+
+            public ICollection<Post> Posts
+            {
+                get { return _posts; }
+                set { SetWithNotify(value, ref _posts); }
+            }
+        }
+
+        protected class Post : NotificationEntity
+        {
+            private int _id;
+            private int _postId;
+            private Blog _blog;
+
+            public int Id
+            {
+                get { return _id; }
+                set { SetWithNotify(value, ref _id); }
+            }
+
+            public int PostId
+            {
+                get { return _postId; }
+                set { SetWithNotify(value, ref _postId); }
+            }
+
+            public Blog Blog
+            {
+                get { return _blog; }
+                set { SetWithNotify(value, ref _blog); }
+            }
+        }
+
+        protected class NotificationEntity : INotifyPropertyChanged
+        {
+            public event PropertyChangedEventHandler PropertyChanged;
+
+            private void NotifyChanged(string propertyName) 
+                => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+
+            protected void SetWithNotify<T>(T value, ref T field, [CallerMemberName] string propertyName = "")
+            {
+                if (!StructuralComparisons.StructuralEqualityComparer.Equals(field, value))
+                {
+                    field = value;
+                    NotifyChanged(propertyName);
+                }
+            }
+        }
+
+        public abstract class NotificationEntitiesFixtureBase : IDisposable
+        {
+            public abstract DbContext CreateContext();
+
+            public virtual void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<Blog>().Property(e => e.Id).ValueGeneratedNever();
+                modelBuilder.Entity<Post>().Property(e => e.Id).ValueGeneratedNever();
+            }
+
+            protected void EnsureCreated()
+            {
+                using (var context = CreateContext())
+                {
+                    if (context.Database.EnsureCreated())
+                    {
+                        context.Add(new Blog
+                        {
+                            Id = 1,
+                            Posts = new List<Post> { new Post { Id = 1 }, new Post { Id = 2 } }
+                        });
+
+                        context.SaveChanges();
+                    }
+                }
+            }
+
+            public void Dispose()
+            {
+                using (var context = CreateContext())
+                {
+                    context.Database.EnsureDeleted();
+                }
+            }
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/NotificationEntitiesInMemoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/NotificationEntitiesInMemoryTest.cs
@@ -1,0 +1,44 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore.FunctionalTests;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
+{
+    public class NotificationEntitiesInMemoryTest
+        : NotificationEntitiesTestBase<NotificationEntitiesInMemoryTest.NotificationEntitiesInMemoryFixture>
+    {
+        public NotificationEntitiesInMemoryTest(NotificationEntitiesInMemoryFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        public class NotificationEntitiesInMemoryFixture : NotificationEntitiesFixtureBase
+        {
+            private readonly IServiceProvider _serviceProvider;
+            private readonly DbContextOptions _options;
+
+            public NotificationEntitiesInMemoryFixture()
+            {
+                _serviceProvider = new ServiceCollection()
+                    .AddEntityFramework()
+                    .AddInMemoryDatabase()
+                    .ServiceCollection()
+                    .AddSingleton(TestInMemoryModelSource.GetFactory(OnModelCreating))
+                    .BuildServiceProvider();
+
+                var optionsBuilder = new DbContextOptionsBuilder();
+                optionsBuilder.UseInMemoryDatabase();
+                _options = optionsBuilder.Options;
+
+                EnsureCreated();
+            }
+
+            public override DbContext CreateContext()
+                => new DbContext(_serviceProvider, _options);
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/NotificationEntitiesSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/NotificationEntitiesSqlServerTest.cs
@@ -1,0 +1,44 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore.FunctionalTests;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
+{
+    public class NotificationEntitiesSqlServerTest 
+        : NotificationEntitiesTestBase<NotificationEntitiesSqlServerTest.NotificationEntitiesSqlServerFixture>
+    {
+        public NotificationEntitiesSqlServerTest(NotificationEntitiesSqlServerFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        public class NotificationEntitiesSqlServerFixture : NotificationEntitiesFixtureBase
+        {
+            private readonly IServiceProvider _serviceProvider;
+            private readonly DbContextOptions _options;
+
+            public NotificationEntitiesSqlServerFixture()
+            {
+                _serviceProvider = new ServiceCollection()
+                    .AddEntityFramework()
+                    .AddSqlServer()
+                    .ServiceCollection()
+                    .AddSingleton(TestSqlServerModelSource.GetFactory(OnModelCreating))
+                    .BuildServiceProvider();
+
+                var optionsBuilder = new DbContextOptionsBuilder();
+                optionsBuilder.UseSqlServer(SqlServerTestStore.CreateConnectionString("NotificationEntities"));
+                _options = optionsBuilder.Options;
+
+                EnsureCreated();
+            }
+
+            public override DbContext CreateContext() 
+                => new DbContext(_serviceProvider, _options);
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/NotificationEntitiesSqliteTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/NotificationEntitiesSqliteTest.cs
@@ -1,0 +1,44 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore.FunctionalTests;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
+{
+    public class NotificationEntitiesSqliteTest
+        : NotificationEntitiesTestBase<NotificationEntitiesSqliteTest.NotificationEntitiesSqliteFixture>
+    {
+        public NotificationEntitiesSqliteTest(NotificationEntitiesSqliteFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        public class NotificationEntitiesSqliteFixture : NotificationEntitiesFixtureBase
+        {
+            private readonly IServiceProvider _serviceProvider;
+            private readonly DbContextOptions _options;
+
+            public NotificationEntitiesSqliteFixture()
+            {
+                _serviceProvider = new ServiceCollection()
+                    .AddEntityFramework()
+                    .AddSqlite()
+                    .ServiceCollection()
+                    .AddSingleton(TestSqliteModelSource.GetFactory(OnModelCreating))
+                    .BuildServiceProvider();
+
+                var optionsBuilder = new DbContextOptionsBuilder();
+                optionsBuilder.UseSqlite(SqliteTestStore.CreateConnectionString("NotificationEntities"));
+                _options = optionsBuilder.Options;
+
+                EnsureCreated();
+            }
+
+            public override DbContext CreateContext()
+                => new DbContext(_serviceProvider, _options);
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.Tests/DbContextTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/DbContextTest.cs
@@ -362,6 +362,14 @@ namespace Microsoft.EntityFrameworkCore.Tests
             public void PropertyChanging(InternalEntityEntry entry, IPropertyBase property)
             {
             }
+
+            public virtual void Suspend()
+            {
+            }
+
+            public virtual void Resume()
+            {
+            }
         }
 
         [Fact]


### PR DESCRIPTION
…nged

Issue #4020

The issue is that when query sets the navigation property this is detected by the change tracker and the new entity is marked as Added. There doesn't seem to be a clean way to prevent this, although it possibly could be done by looking at the stack or by setting some kind of thread-local flag to tell the change tracker that query is making the changes. Instead, when query is done and tells EF to start tracking the entity we now explicitly set the state to Unchanged even if the entity is already being tracked.