### PR TITLE
[SMALL] Improve HasKey on derived type exception message

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
@@ -653,7 +653,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
-        /// The derived type '{derivedType}' cannot have keys other than those declared on the root type '{rootType}'.
+        /// A key cannot be configured on '{derivedType}' because it is a derived type. The key must be configured on the root type '{rootType}'. If you did not intend for '{rootType}' to be included in the model, ensure that it is not included in a DbSet property on your context, referenced in a configuration call to ModelBuilder, or referenced from a navigation property on a type that is included in the model.
         /// </summary>
         public static string DerivedEntityTypeKey([CanBeNull] object derivedType, [CanBeNull] object rootType)
         {

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
@@ -358,7 +358,7 @@
     <value>The '{factory}' cannot create a value generator for property '{property}' on entity type '{entityType}'. Only integer properties are supported.</value>
   </data>
   <data name="DerivedEntityTypeKey" xml:space="preserve">
-    <value>The derived type '{derivedType}' cannot have keys other than those declared on the root type '{rootType}'.</value>
+    <value>A key cannot be configured on '{derivedType}' because it is a derived type. The key must be configured on the root type '{rootType}'. If you did not intend for '{rootType}' to be included in the model, ensure that it is not included in a DbSet property on your context, referenced in a configuration call to ModelBuilder, or referenced from a navigation property on a type that is included in the model.</value>
   </data>
   <data name="CircularInheritance" xml:space="preserve">
     <value>The entity type '{entityType}' cannot inherit from '{baseEntityType}' because '{baseEntityType}' is a descendent of '{entityType}'.</value>


### PR DESCRIPTION
Resolve #3863

A common cause of this exception is unintentionally including a base
type in the model. Adding info about how to stop this happening to the
exception message.

**Old Message:** The derived type 'Address' cannot have keys other than
those declared on the root type 'AddressBase'.

**New Message:** A key cannot be configured on 'Address' because it is a
derived type. The key must be configured on the root type 'AddressBase'.
If you did not intend for 'AddressBase' to be included in the model,
ensure that it is not included in a DbSet property on your context,
referenced in a configuration call to ModelBuilder, or referenced from a
navigation property on a type that is included in the model.