### PR TITLE
HasDefaultValueSql should update ValueGeneratedOnAdd if not set explicitly

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/RelationalPropertyBuilderExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/RelationalPropertyBuilderExtensions.cs
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 // ReSharper disable once CheckNamespace
@@ -52,7 +54,12 @@ namespace Microsoft.EntityFrameworkCore
             Check.NotNull(propertyBuilder, nameof(propertyBuilder));
             Check.NullButNotEmpty(sql, nameof(sql));
 
-            propertyBuilder.ValueGeneratedOnAdd();
+            var property = (Property)propertyBuilder.Metadata;
+            if (ConfigurationSource.Convention.Overrides(property.GetValueGeneratedConfigurationSource()))
+            {
+                property.SetValueGenerated(ValueGenerated.OnAdd, ConfigurationSource.Convention);
+            }
+
             propertyBuilder.Metadata.Relational().GeneratedValueSql = sql;
 
             return propertyBuilder;
@@ -70,7 +77,12 @@ namespace Microsoft.EntityFrameworkCore
             Check.NotNull(propertyBuilder, nameof(propertyBuilder));
             Check.NullButNotEmpty(sql, nameof(sql));
 
-            propertyBuilder.ValueGeneratedOnAddOrUpdate();
+            var property = (Property)propertyBuilder.Metadata;
+            if (ConfigurationSource.Convention.Overrides(property.GetValueGeneratedConfigurationSource()))
+            {
+                property.SetValueGenerated(ValueGenerated.OnAddOrUpdate, ConfigurationSource.Convention);
+            }
+
             propertyBuilder.Metadata.Relational().GeneratedValueSql = sql;
 
             return propertyBuilder;
@@ -86,6 +98,12 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] object value)
         {
             Check.NotNull(propertyBuilder, nameof(propertyBuilder));
+
+            var property = (Property)propertyBuilder.Metadata;
+            if (ConfigurationSource.Convention.Overrides(property.GetValueGeneratedConfigurationSource()))
+            {
+                property.SetValueGenerated(ValueGenerated.OnAdd, ConfigurationSource.Convention);
+            }
 
             propertyBuilder.Metadata.Relational().DefaultValue = value;
 

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Extensions/SqlServerPropertyBuilderExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Extensions/SqlServerPropertyBuilderExtensions.cs
@@ -54,7 +54,12 @@ namespace Microsoft.EntityFrameworkCore
             Check.NotNull(propertyBuilder, nameof(propertyBuilder));
             Check.NullButNotEmpty(sql, nameof(sql));
 
-            propertyBuilder.ValueGeneratedOnAdd();
+            var property = (Property)propertyBuilder.Metadata;
+            if (ConfigurationSource.Convention.Overrides(property.GetValueGeneratedConfigurationSource()))
+            {
+                property.SetValueGenerated(ValueGenerated.OnAdd, ConfigurationSource.Convention);
+            }
+
             propertyBuilder.Metadata.SqlServer().GeneratedValueSql = sql;
 
             return propertyBuilder;
@@ -70,6 +75,12 @@ namespace Microsoft.EntityFrameworkCore
             [CanBeNull] object value)
         {
             Check.NotNull(propertyBuilder, nameof(propertyBuilder));
+
+            var property = (Property)propertyBuilder.Metadata;
+            if (ConfigurationSource.Convention.Overrides(property.GetValueGeneratedConfigurationSource()))
+            {
+                property.SetValueGenerated(ValueGenerated.OnAdd, ConfigurationSource.Convention);
+            }
 
             propertyBuilder.Metadata.SqlServer().DefaultValue = value;
 
@@ -88,7 +99,12 @@ namespace Microsoft.EntityFrameworkCore
             Check.NotNull(propertyBuilder, nameof(propertyBuilder));
             Check.NullButNotEmpty(sql, nameof(sql));
 
-            propertyBuilder.ValueGeneratedOnAddOrUpdate();
+            var property = (Property)propertyBuilder.Metadata;
+            if (ConfigurationSource.Convention.Overrides(property.GetValueGeneratedConfigurationSource()))
+            {
+                property.SetValueGenerated(ValueGenerated.OnAddOrUpdate, ConfigurationSource.Convention);
+            }
+
             propertyBuilder.Metadata.SqlServer().GeneratedValueSql = sql;
 
             return propertyBuilder;

--- a/src/Microsoft.EntityFrameworkCore.Sqlite/Metadata/Builders/SqlitePropertyBuilderExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite/Metadata/Builders/SqlitePropertyBuilderExtensions.cs
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 // ReSharper disable once CheckNamespace
@@ -11,55 +13,80 @@ namespace Microsoft.EntityFrameworkCore
 {
     public static class SqlitePropertyBuilderExtensions
     {
-        public static PropertyBuilder ForSqliteHasColumnName([NotNull] this PropertyBuilder builder, [CanBeNull] string name)
+        public static PropertyBuilder ForSqliteHasColumnName([NotNull] this PropertyBuilder propertyBuilder, [CanBeNull] string name)
         {
-            Check.NotNull(builder, nameof(builder));
+            Check.NotNull(propertyBuilder, nameof(propertyBuilder));
             Check.NullButNotEmpty(name, nameof(name));
 
-            builder.Metadata.Sqlite().ColumnName = name;
+            propertyBuilder.Metadata.Sqlite().ColumnName = name;
 
-            return builder;
+            return propertyBuilder;
         }
 
-        public static PropertyBuilder<TEntity> ForSqliteHasColumnName<TEntity>(
-            [NotNull] this PropertyBuilder<TEntity> builder,
+        public static PropertyBuilder<TProperty> ForSqliteHasColumnName<TProperty>(
+            [NotNull] this PropertyBuilder<TProperty> propertyBuilder,
             [CanBeNull] string name)
-            where TEntity : class
-            => (PropertyBuilder<TEntity>)((PropertyBuilder)builder).ForSqliteHasColumnName(name);
+            => (PropertyBuilder<TProperty>)((PropertyBuilder)propertyBuilder).ForSqliteHasColumnName(name);
 
-        public static PropertyBuilder ForSqliteHasColumnType([NotNull] this PropertyBuilder builder, [CanBeNull] string type)
+        public static PropertyBuilder ForSqliteHasColumnType([NotNull] this PropertyBuilder propertyBuilder, [CanBeNull] string type)
         {
-            Check.NotNull(builder, nameof(builder));
+            Check.NotNull(propertyBuilder, nameof(propertyBuilder));
             Check.NullButNotEmpty(type, nameof(type));
 
-            builder.Metadata.Sqlite().ColumnType = type;
+            propertyBuilder.Metadata.Sqlite().ColumnType = type;
 
-            return builder;
+            return propertyBuilder;
         }
 
-        public static PropertyBuilder<TEntity> ForSqliteHasColumnType<TEntity>(
-            [NotNull] this PropertyBuilder<TEntity> builder,
+        public static PropertyBuilder<TProperty> ForSqliteHasColumnType<TProperty>(
+            [NotNull] this PropertyBuilder<TProperty> propertyBuilder,
             [CanBeNull] string type)
-            where TEntity : class
-            => (PropertyBuilder<TEntity>)((PropertyBuilder)builder).ForSqliteHasColumnType(type);
+            => (PropertyBuilder<TProperty>)((PropertyBuilder)propertyBuilder).ForSqliteHasColumnType(type);
 
         public static PropertyBuilder ForSqliteHasDefaultValueSql(
-            [NotNull] this PropertyBuilder builder,
+            [NotNull] this PropertyBuilder propertyBuilder,
             [CanBeNull] string sql)
         {
-            Check.NotNull(builder, nameof(builder));
+            Check.NotNull(propertyBuilder, nameof(propertyBuilder));
             Check.NullButNotEmpty(sql, nameof(sql));
 
-            builder.ValueGeneratedOnAdd();
-            builder.Metadata.Sqlite().GeneratedValueSql = sql;
+            var property = (Property)propertyBuilder.Metadata;
+            if (ConfigurationSource.Convention.Overrides(property.GetValueGeneratedConfigurationSource()))
+            {
+                property.SetValueGenerated(ValueGenerated.OnAdd, ConfigurationSource.Convention);
+            }
 
-            return builder;
+            propertyBuilder.Metadata.Sqlite().GeneratedValueSql = sql;
+
+            return propertyBuilder;
         }
 
-        public static PropertyBuilder<TEntity> ForSqliteHasDefaultValueSql<TEntity>(
-            [NotNull] this PropertyBuilder<TEntity> builder,
+        public static PropertyBuilder<TProperty> ForSqliteHasDefaultValueSql<TProperty>(
+            [NotNull] this PropertyBuilder<TProperty> propertyBuilder,
             [CanBeNull] string sql)
-            where TEntity : class
-            => (PropertyBuilder<TEntity>)((PropertyBuilder)builder).ForSqliteHasDefaultValueSql(sql);
+            => (PropertyBuilder<TProperty>)((PropertyBuilder)propertyBuilder).ForSqliteHasDefaultValueSql(sql);
+
+        public static PropertyBuilder ForSqliteHasDefaultValue(
+            [NotNull] this PropertyBuilder propertyBuilder,
+            [CanBeNull] object value)
+        {
+            Check.NotNull(propertyBuilder, nameof(propertyBuilder));
+
+            var property = (Property)propertyBuilder.Metadata;
+            if (ConfigurationSource.Convention.Overrides(property.GetValueGeneratedConfigurationSource()))
+            {
+                property.SetValueGenerated(ValueGenerated.OnAdd, ConfigurationSource.Convention);
+            }
+
+            propertyBuilder.Metadata.Sqlite().DefaultValue = value;
+
+            return propertyBuilder;
+        }
+
+        public static PropertyBuilder<TProperty> ForSqliteHasDefaultValue<TProperty>(
+            [NotNull] this PropertyBuilder<TProperty> propertyBuilder,
+            [CanBeNull] object value)
+            => (PropertyBuilder<TProperty>)((PropertyBuilder)propertyBuilder).ForSqliteHasDefaultValue(value);
+
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Metadata/RelationalBuilderExtensionsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Metadata/RelationalBuilderExtensionsTest.cs
@@ -61,6 +61,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Tests
         }
 
         [Fact]
+        public void Setting_column_default_expression_does_not_modify_explicitly_set_value_generated()
+        {
+            var modelBuilder = CreateConventionModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ValueGeneratedOnAddOrUpdate()
+                .HasDefaultValueSql("CherryCoke");
+
+            var property = modelBuilder.Model.FindEntityType(typeof(Customer)).FindProperty("Name");
+
+            Assert.Equal("CherryCoke", property.Relational().GeneratedValueSql);
+            Assert.Equal(ValueGenerated.OnAddOrUpdate, property.ValueGenerated);
+        }
+
+        [Fact]
         public void Can_set_column_computed_expression()
         {
             var modelBuilder = CreateConventionModelBuilder();
@@ -77,6 +94,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Tests
         }
 
         [Fact]
+        public void Setting_column_computed_expression_does_not_modify_explicitly_set_value_generated()
+        {
+            var modelBuilder = CreateConventionModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ValueGeneratedNever()
+                .HasComputedColumnSql("CherryCoke");
+
+            var property = modelBuilder.Model.FindEntityType(typeof(Customer)).FindProperty("Name");
+
+            Assert.Equal("CherryCoke", property.Relational().GeneratedValueSql);
+            Assert.Equal(ValueGenerated.Never, property.ValueGenerated);
+        }
+
+        [Fact]
         public void Can_set_column_default_value()
         {
             var modelBuilder = CreateConventionModelBuilder();
@@ -90,6 +124,25 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Tests
             var property = modelBuilder.Model.FindEntityType(typeof(Customer)).FindProperty("Name");
 
             Assert.Equal(stringValue, property.Relational().DefaultValue);
+            Assert.Equal(ValueGenerated.OnAdd, property.ValueGenerated);
+        }
+
+        [Fact]
+        public void Setting_column_default_value_does_not_modify_explicitly_set_value_generated()
+        {
+            var modelBuilder = CreateConventionModelBuilder();
+            var stringValue = "DefaultValueString";
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ValueGeneratedOnAddOrUpdate()
+                .HasDefaultValue(stringValue);
+
+            var property = modelBuilder.Model.FindEntityType(typeof(Customer)).FindProperty("Name");
+
+            Assert.Equal(stringValue, property.Relational().DefaultValue);
+            Assert.Equal(ValueGenerated.OnAddOrUpdate, property.ValueGenerated);
         }
 
         [Fact]

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Metadata/SqlServerBuilderExtensionsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Metadata/SqlServerBuilderExtensionsTest.cs
@@ -82,6 +82,31 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests.Metadata
         }
 
         [Fact]
+        public void Setting_column_default_expression_does_not_modify_explicitly_set_value_generated()
+        {
+            var modelBuilder = CreateConventionModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ValueGeneratedNever()
+                .ForSqlServerHasDefaultValueSql("VanillaCoke");
+
+            var property = modelBuilder.Model.FindEntityType(typeof(Customer)).FindProperty("Name");
+
+            Assert.Equal(ValueGenerated.Never, property.ValueGenerated);
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .HasDefaultValueSql("CherryCoke");
+
+            Assert.Equal("CherryCoke", property.Relational().GeneratedValueSql);
+            Assert.Equal("VanillaCoke", property.SqlServer().GeneratedValueSql);
+            Assert.Equal(ValueGenerated.Never, property.ValueGenerated);
+        }
+
+        [Fact]
         public void Can_set_column_computed_expression()
         {
             var modelBuilder = CreateConventionModelBuilder();
@@ -106,6 +131,31 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests.Metadata
         }
 
         [Fact]
+        public void Setting_column_column_computed_expression_does_not_modify_explicitly_set_value_generated()
+        {
+            var modelBuilder = CreateConventionModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ValueGeneratedNever()
+                .ForSqlServerHasComputedColumnSql("VanillaCoke");
+
+            var property = modelBuilder.Model.FindEntityType(typeof(Customer)).FindProperty("Name");
+
+            Assert.Equal(ValueGenerated.Never, property.ValueGenerated);
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .HasComputedColumnSql("CherryCoke");
+
+            Assert.Equal("CherryCoke", property.Relational().GeneratedValueSql);
+            Assert.Equal("VanillaCoke", property.SqlServer().GeneratedValueSql);
+            Assert.Equal(ValueGenerated.Never, property.ValueGenerated);
+        }
+
+        [Fact]
         public void Can_set_column_default_value()
         {
             var modelBuilder = CreateConventionModelBuilder();
@@ -124,6 +174,29 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests.Metadata
 
             Assert.Equal(new DateTimeOffset(1973, 9, 3, 0, 10, 0, new TimeSpan(1, 0, 0)), property.Relational().DefaultValue);
             Assert.Equal(new DateTimeOffset(2006, 9, 19, 19, 0, 0, new TimeSpan(-8, 0, 0)), property.SqlServer().DefaultValue);
+        }
+
+        [Fact]
+        public void Setting_column_default_value_does_not_modify_explicitly_set_value_generated()
+        {
+            var modelBuilder = CreateConventionModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Offset)
+                .ValueGeneratedOnAddOrUpdate()
+                .HasDefaultValue(new DateTimeOffset(1973, 9, 3, 0, 10, 0, new TimeSpan(1, 0, 0)));
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Offset)
+                .ForSqlServerHasDefaultValue(new DateTimeOffset(2006, 9, 19, 19, 0, 0, new TimeSpan(-8, 0, 0)));
+
+            var property = modelBuilder.Model.FindEntityType(typeof(Customer)).FindProperty("Offset");
+
+            Assert.Equal(new DateTimeOffset(1973, 9, 3, 0, 10, 0, new TimeSpan(1, 0, 0)), property.Relational().DefaultValue);
+            Assert.Equal(new DateTimeOffset(2006, 9, 19, 19, 0, 0, new TimeSpan(-8, 0, 0)), property.SqlServer().DefaultValue);
+            Assert.Equal(ValueGenerated.OnAddOrUpdate, property.ValueGenerated);
         }
 
         [Fact]

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Metadata/SqlServerInternalMetadataBuilderExtensionsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Metadata/SqlServerInternalMetadataBuilderExtensionsTest.cs
@@ -4,13 +4,12 @@
 using System;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.Metadata;
-using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Tests.Metadata
 {
-    public class InternalSqlServerMetadataBuilderExtensionsTest
+    public class SqlServerInternalMetadataBuilderExtensionsTest
     {
         private InternalModelBuilder CreateBuilder()
             => new InternalModelBuilder(new Model());

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Tests/Metadata/Builders/SqliteBuilderExtensionsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Tests/Metadata/Builders/SqliteBuilderExtensionsTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Xunit;
 
@@ -77,6 +78,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Metadata.Builders
                 .Metadata;
 
             Assert.Equal("VanillaCoke", property.Sqlite().GeneratedValueSql);
+            Assert.Equal(ValueGenerated.OnAdd, property.ValueGenerated);
         }
 
         [Fact]
@@ -91,6 +93,105 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Metadata.Builders
                 .Metadata;
 
             Assert.Equal("VanillaCoke", property.Sqlite().GeneratedValueSql);
+            Assert.Equal(ValueGenerated.OnAdd, property.ValueGenerated);
+        }
+
+        [Fact]
+        public void Setting_column_default_expression_does_not_modify_explicitly_set_value_generated()
+        {
+            var modelBuilder = new ModelBuilder(new ConventionSet());
+
+            var property = modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ValueGeneratedNever()
+                .ForSqliteHasDefaultValueSql("VanillaCoke")
+                .Metadata;
+
+            Assert.Equal("VanillaCoke", property.Sqlite().GeneratedValueSql);
+            Assert.Equal(ValueGenerated.Never, property.ValueGenerated);
+        }
+
+        [Fact]
+        public void Setting_column_default_expression_does_not_modify_explicitly_set_value_generated_non_generic()
+        {
+            var modelBuilder = new ModelBuilder(new ConventionSet());
+
+            var property = modelBuilder
+                .Entity<Customer>()
+                .Property<string>("Name")
+                .ValueGeneratedNever()
+                .ForSqliteHasDefaultValueSql("VanillaCoke")
+                .Metadata;
+
+            Assert.Equal("VanillaCoke", property.Sqlite().GeneratedValueSql);
+            Assert.Equal(ValueGenerated.Never, property.ValueGenerated);
+        }
+
+        [Fact]
+        public void Can_set_column_default_value()
+        {
+            var modelBuilder = new ModelBuilder(new ConventionSet());
+            var valueString = "DefaultValue";
+
+            var property = modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForSqliteHasDefaultValue(valueString)
+                .Metadata;
+
+            Assert.Equal(valueString, property.Sqlite().DefaultValue);
+            Assert.Equal(ValueGenerated.OnAdd, property.ValueGenerated);
+        }
+
+        [Fact]
+        public void Can_set_column_default_value_non_generic()
+        {
+            var modelBuilder = new ModelBuilder(new ConventionSet());
+            var valueString = "DefaultValue";
+
+            var property = modelBuilder
+                .Entity<Customer>()
+                .Property<string>("Name")
+                .ForSqliteHasDefaultValue(valueString)
+                .Metadata;
+
+            Assert.Equal(valueString, property.Sqlite().DefaultValue);
+            Assert.Equal(ValueGenerated.OnAdd, property.ValueGenerated);
+        }
+
+        [Fact]
+        public void Setting_column_default_value_does_not_modify_explicitly_set_value_generated()
+        {
+            var modelBuilder = new ModelBuilder(new ConventionSet());
+            var valueString = "DefaultValue";
+
+            var property = modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ValueGeneratedNever()
+                .ForSqliteHasDefaultValue(valueString)
+                .Metadata;
+
+            Assert.Equal(valueString, property.Sqlite().DefaultValue);
+            Assert.Equal(ValueGenerated.Never, property.ValueGenerated);
+        }
+
+        [Fact]
+        public void Setting_column_default_value_does_not_modify_explicitly_set_value_generated_non_generic()
+        {
+            var modelBuilder = new ModelBuilder(new ConventionSet());
+            var valueString = "DefaultValue";
+
+            var property = modelBuilder
+                .Entity<Customer>()
+                .Property<string>("Name")
+                .ValueGeneratedNever()
+                .ForSqliteHasDefaultValue(valueString)
+                .Metadata;
+
+            Assert.Equal(valueString, property.Sqlite().DefaultValue);
+            Assert.Equal(ValueGenerated.Never, property.ValueGenerated);
         }
 
         [Fact]


### PR DESCRIPTION
resolves #4328 
If user has set ValueGenerated for property explicitly HasDefaultValueSql will not modify it.