### PR TITLE
Fix #4308 - InvalidCastException for decimal without significant digits

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalSqlGenerationHelper.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalSqlGenerationHelper.cs
@@ -14,6 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
     public class RelationalSqlGenerationHelper : ISqlGenerationHelper
     {
         protected virtual string FloatingPointFormat => "{0}E0";
+        protected virtual string DecimalFormat => "0.0###########################";
         protected virtual string DateTimeFormat => @"yyyy-MM-dd HH\:mm\:ss.fffffff";
         protected virtual string DateTimeOffsetFormat => @"yyyy-MM-dd HH\:mm\:ss.fffffffzzz";
 
@@ -68,7 +69,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             => value.ToString();
 
         protected virtual string GenerateLiteralValue(decimal value)
-            => string.Format(value.ToString(CultureInfo.InvariantCulture));
+            => string.Format(value.ToString(DecimalFormat, CultureInfo.InvariantCulture));
 
         protected virtual string GenerateLiteralValue(double value)
             => string.Format(CultureInfo.InvariantCulture, FloatingPointFormat, value);

--- a/test/Microsoft.EntityFrameworkCore.FunctionalTests/QueryTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.FunctionalTests/QueryTestBase.cs
@@ -3250,6 +3250,24 @@ namespace Microsoft.EntityFrameworkCore.FunctionalTests
         }
 
         [ConditionalFact]
+        public virtual void Sum_with_division_on_decimal()
+        {
+            AssertQuery<OrderDetail>(
+                ods => ods.Sum(od => od.Quantity / 2.09m),
+                asserter: (l2o, ef)
+                    => Assert.InRange((decimal)l2o - (decimal)ef, -0.1m, 0.1m));
+        }
+
+        [ConditionalFact]
+        public virtual void Sum_with_division_on_decimal_no_significant_digits()
+        {
+            AssertQuery<OrderDetail>(
+                ods => ods.Sum(od => od.Quantity / 2m),
+                asserter: (l2o, ef)
+                    => Assert.InRange((decimal)l2o - (decimal)ef, -0.1m, 0.1m));
+        }
+
+        [ConditionalFact]
         public virtual void Min_with_no_arg()
         {
             AssertQuery<Order>(os => os.Select(o => o.OrderID).Min());

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
@@ -452,7 +452,7 @@ FROM [Customers] AS [c]",
         WHEN EXISTS (
             SELECT 1
             FROM [Order Details] AS [od1]
-            WHERE ([od1].[UnitPrice] > 10) AND ([o].[OrderID] = [od1].[OrderID]))
+            WHERE ([od1].[UnitPrice] > 10.0) AND ([o].[OrderID] = [od1].[OrderID]))
         THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
     END
 ), CASE

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -777,6 +777,22 @@ FROM [Orders] AS [o]",
                 Sql);
         }
 
+        public override void Sum_with_division_on_decimal()
+        {
+            base.Sum_with_division_on_decimal();
+
+            Assert.Equal(@"SELECT SUM([od].[Quantity] / 2.09)
+FROM [Order Details] AS [od]", Sql);
+        }
+
+        public override void Sum_with_division_on_decimal_no_significant_digits()
+        {
+            base.Sum_with_division_on_decimal_no_significant_digits();
+
+            Assert.Equal(@"SELECT SUM([od].[Quantity] / 2.0)
+FROM [Order Details] AS [od]", Sql);
+        }
+
         public override void Min_with_no_arg()
         {
             base.Min_with_no_arg();
@@ -3703,7 +3719,7 @@ WHERE ABS([od].[Quantity]) > 10",
             Assert.Equal(
                 @"SELECT [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice]
 FROM [Order Details] AS [od]
-WHERE ABS([od].[UnitPrice]) > 10",
+WHERE ABS([od].[UnitPrice]) > 10.0",
                 Sql);
         }
 
@@ -3736,7 +3752,7 @@ WHERE CEILING([od].[Discount]) > 0E0",
             Assert.Equal(
                 @"SELECT [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice]
 FROM [Order Details] AS [od]
-WHERE CEILING([od].[UnitPrice]) > 10",
+WHERE CEILING([od].[UnitPrice]) > 10.0",
                 Sql);
         }
 
@@ -3747,7 +3763,7 @@ WHERE CEILING([od].[UnitPrice]) > 10",
             Assert.Equal(
                 @"SELECT [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice]
 FROM [Order Details] AS [od]
-WHERE FLOOR([od].[UnitPrice]) > 10",
+WHERE FLOOR([od].[UnitPrice]) > 10.0",
                 Sql);
         }
 
@@ -3786,7 +3802,7 @@ WHERE POWER([od].[Discount], 2E0) > 0.0500000007450581E0",
             Assert.Equal(
                 @"SELECT [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice]
 FROM [Order Details] AS [od]
-WHERE ROUND([od].[UnitPrice], 0) > 10",
+WHERE ROUND([od].[UnitPrice], 0) > 10.0",
                 Sql);
         }
 
@@ -3797,7 +3813,7 @@ WHERE ROUND([od].[UnitPrice], 0) > 10",
             Assert.Equal(
                 @"SELECT [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice]
 FROM [Order Details] AS [od]
-WHERE ROUND([od].[UnitPrice], 0, 1) > 10",
+WHERE ROUND([od].[UnitPrice], 0, 1) > 10.0",
                 Sql);
         }
 
@@ -3891,35 +3907,35 @@ WHERE ([o].[CustomerID] = 'ALFKI') AND (CONVERT(tinyint, CONVERT(nvarchar, [o].[
             Assert.Equal(
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE ([o].[CustomerID] = 'ALFKI') AND (CONVERT(decimal, CONVERT(tinyint, [o].[OrderID] % 1)) >= 0)
+WHERE ([o].[CustomerID] = 'ALFKI') AND (CONVERT(decimal, CONVERT(tinyint, [o].[OrderID] % 1)) >= 0.0)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE ([o].[CustomerID] = 'ALFKI') AND (CONVERT(decimal, CONVERT(decimal, [o].[OrderID] % 1)) >= 0)
+WHERE ([o].[CustomerID] = 'ALFKI') AND (CONVERT(decimal, CONVERT(decimal, [o].[OrderID] % 1)) >= 0.0)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE ([o].[CustomerID] = 'ALFKI') AND (CONVERT(decimal, CONVERT(float, [o].[OrderID] % 1)) >= 0)
+WHERE ([o].[CustomerID] = 'ALFKI') AND (CONVERT(decimal, CONVERT(float, [o].[OrderID] % 1)) >= 0.0)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE ([o].[CustomerID] = 'ALFKI') AND (CONVERT(decimal, CONVERT(float, [o].[OrderID] % 1)) >= 0)
+WHERE ([o].[CustomerID] = 'ALFKI') AND (CONVERT(decimal, CONVERT(float, [o].[OrderID] % 1)) >= 0.0)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE ([o].[CustomerID] = 'ALFKI') AND (CONVERT(decimal, CONVERT(smallint, [o].[OrderID] % 1)) >= 0)
+WHERE ([o].[CustomerID] = 'ALFKI') AND (CONVERT(decimal, CONVERT(smallint, [o].[OrderID] % 1)) >= 0.0)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE ([o].[CustomerID] = 'ALFKI') AND (CONVERT(decimal, CONVERT(int, [o].[OrderID] % 1)) >= 0)
+WHERE ([o].[CustomerID] = 'ALFKI') AND (CONVERT(decimal, CONVERT(int, [o].[OrderID] % 1)) >= 0.0)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE ([o].[CustomerID] = 'ALFKI') AND (CONVERT(decimal, CONVERT(bigint, [o].[OrderID] % 1)) >= 0)
+WHERE ([o].[CustomerID] = 'ALFKI') AND (CONVERT(decimal, CONVERT(bigint, [o].[OrderID] % 1)) >= 0.0)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE ([o].[CustomerID] = 'ALFKI') AND (CONVERT(decimal, CONVERT(nvarchar, [o].[OrderID] % 1)) >= 0)",
+WHERE ([o].[CustomerID] = 'ALFKI') AND (CONVERT(decimal, CONVERT(nvarchar, [o].[OrderID] % 1)) >= 0.0)",
                 Sql);
         }
 


### PR DESCRIPTION
Corrects issue where generated SQL for `decimal` types did not always include digits following the decimal (invalid cast from boxed `int` to `decimal` and incorrect use of integer math on server-side computations).
CC: @bricelam @natemcmaster @anpete