### PR TITLE
Avoid recursively copied content

### DIFF
--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/project.json
@@ -7,14 +7,13 @@
     "Microsoft.EntityFrameworkCore.SqlServer.Design": "1.0.0-*",
     "Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests": "1.0.0"
   },
-  "exclude": ".testPublish/**",
-  "content": "**/*.expected",
+  "content": "ReverseEngineering/**/*.expected",
   "testRunner": "xunit",
   "commands": {
     "test": "xunit.runner.aspnet"
   },
   "frameworks": {
-    "dnx451": {},
+    "dnx451": { },
     "dnxcore50": {
       "imports": "portable-net452+win81",
       "dependencies": {

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/project.json
@@ -7,13 +7,13 @@
     "Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests": "1.0.0",
     "Microsoft.EntityFrameworkCore.Sqlite.Design": "1.0.0-*"
   },
-  "content": "**/*.expected",
+  "content": "ReverseEngineering/**/*.expected",
   "testRunner": "xunit",
   "commands": {
     "test": "xunit.runner.aspnet"
   },
   "frameworks": {
-    "dnx451": {},
+    "dnx451": { },
     "dnxcore50": {
       "imports": "portable-net452+win81",
       "dependencies": {


### PR DESCRIPTION
The issue: When we build our design functional tests we copy .expected files to bin & .testpublish folders. On the subsequent runs it copies files from those folders too. Hence recursively creating more and more folders inside bin & .testpublish. All this works fine till the path becomes too long at which point build-tests phase fails.

Fix: We are restricting our scope to ReverseEngineering folder where we have created files. Exclude syntax in project.json is not able to work correctly somehow. I am trying to create a standalone repro to file bug on dotnet cli.