### PR TITLE
Use type mapper correctly in SQL Server batch updates

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalTypeMapper.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalTypeMapper.cs
@@ -28,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         // Not using IRelationalAnnotationProvider here because type mappers are Singletons
         protected abstract string GetColumnType([NotNull] IProperty property);
 
-        public virtual RelationalTypeMapping FindMapping([NotNull] IProperty property)
+        public virtual RelationalTypeMapping FindMapping(IProperty property)
         {
             Check.NotNull(property, nameof(property));
 
@@ -46,7 +46,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                    ?? FindMapping(property.ClrType);
         }
 
-        public virtual RelationalTypeMapping FindMapping([NotNull] Type clrType)
+        public virtual RelationalTypeMapping FindMapping(Type clrType)
         {
             Check.NotNull(clrType, nameof(clrType));
 

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Update/Internal/SqlServerUpdateSqlGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Update/Internal/SqlServerUpdateSqlGenerator.cs
@@ -277,16 +277,13 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
 
         private string GetTypeNameForCopy(IProperty property)
         {
-            var mapping = _typeMapper.GetMapping(property);
-            var typeName = mapping.DefaultTypeName;
-            if (property.IsConcurrencyToken
-                && (typeName.Equals("rowversion", StringComparison.OrdinalIgnoreCase)
-                    || typeName.Equals("timestamp", StringComparison.OrdinalIgnoreCase)))
-            {
-                return property.IsNullable ? "varbinary(8)" : "binary(8)";
-            }
+            var typeName = property.SqlServer().ColumnType
+                           ?? _typeMapper.GetMapping(property).DefaultTypeName;
 
-            return typeName;
+            return typeName.Equals("rowversion", StringComparison.OrdinalIgnoreCase)
+                   || typeName.Equals("timestamp", StringComparison.OrdinalIgnoreCase)
+                ? (property.IsNullable ? "varbinary(8)" : "binary(8)")
+                : typeName;
         }
 
         // ReSharper disable once ParameterTypeCanBeEnumerable.Local

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerFixture.cs
@@ -101,13 +101,39 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             MapSizedColumnTypes<MappedSizedDataTypes>(modelBuilder);
             MapSizedColumnTypes<MappedScaledDataTypes>(modelBuilder);
             MapPreciseColumnTypes<MappedPrecisionAndScaledDataTypes>(modelBuilder);
+
+            modelBuilder.Entity<MappedDataTypesWithIdentity>(b =>
+            {
+                b.HasKey(e => e.Id);
+            });
+
+            modelBuilder.Entity<MappedNullableDataTypesWithIdentity>(b =>
+            {
+                b.HasKey(e => e.Id);
+            });
+
+            modelBuilder.Entity<MappedSizedDataTypesWithIdentity>()
+                .Property(e => e.Id);
+
+            modelBuilder.Entity<MappedScaledDataTypesWithIdentity>()
+                .Property(e => e.Id);
+
+            modelBuilder.Entity<MappedPrecisionAndScaledDataTypesWithIdentity>()
+                .Property(e => e.Id);
+
+            MapColumnTypes<MappedDataTypesWithIdentity>(modelBuilder);
+            MapColumnTypes<MappedNullableDataTypesWithIdentity>(modelBuilder);
+
+            MapSizedColumnTypes<MappedSizedDataTypesWithIdentity>(modelBuilder);
+            MapSizedColumnTypes<MappedScaledDataTypesWithIdentity>(modelBuilder);
+            MapPreciseColumnTypes<MappedPrecisionAndScaledDataTypesWithIdentity>(modelBuilder);
         }
 
         private static void MapColumnTypes<TEntity>(ModelBuilder modelBuilder) where TEntity : class
         {
             var entityType = modelBuilder.Entity<TEntity>().Metadata;
 
-            foreach (var propertyInfo in entityType.ClrType.GetTypeInfo().DeclaredProperties)
+            foreach (var propertyInfo in entityType.ClrType.GetTypeInfo().DeclaredProperties.Where(p => p.Name != "Id"))
             {
                 var typeName = propertyInfo.Name;
 
@@ -126,7 +152,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
         {
             var entityType = modelBuilder.Entity<TEntity>().Metadata;
 
-            foreach (var propertyInfo in entityType.ClrType.GetTypeInfo().DeclaredProperties.Where(p => p.Name != "Id"))
+            foreach (var propertyInfo in entityType.ClrType.GetTypeInfo().DeclaredProperties
+                .Where(p => p.Name != "Id" && p.Name != "Int"))
             {
                 entityType.GetOrAddProperty(propertyInfo).Relational().ColumnType = propertyInfo.Name.Replace('_', ' ') + "(3)";
             }
@@ -136,7 +163,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
         {
             var entityType = modelBuilder.Entity<TEntity>().Metadata;
 
-            foreach (var propertyInfo in entityType.ClrType.GetTypeInfo().DeclaredProperties.Where(p => p.Name != "Id"))
+            foreach (var propertyInfo in entityType.ClrType.GetTypeInfo().DeclaredProperties
+                .Where(p => p.Name != "Id" && p.Name != "Int"))
             {
                 entityType.GetOrAddProperty(propertyInfo).Relational().ColumnType = propertyInfo.Name.Replace('_', ' ') + "(5, 2)";
             }
@@ -276,6 +304,152 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
         public byte[] VarbinaryMax { get; set; }
         public byte[] Binary_varyingMax { get; set; }
         public byte[] Image { get; set; }
+        public decimal? Decimal { get; set; }
+        public decimal? Dec { get; set; }
+        public decimal? Numeric { get; set; }
+    }
+
+    public class MappedDataTypesWithIdentity
+    {
+        public int Id { get; set; }
+
+        public int Int { get; set; }
+        public long Bigint { get; set; }
+        public short Smallint { get; set; }
+        public byte Tinyint { get; set; }
+        public bool Bit { get; set; }
+        public decimal Money { get; set; }
+        public decimal Smallmoney { get; set; }
+        public double Float { get; set; }
+        public float Real { get; set; }
+        public double Double_precision { get; set; }
+        public DateTime Date { get; set; }
+        public DateTimeOffset Datetimeoffset { get; set; }
+        public DateTime Datetime2 { get; set; }
+        public DateTime Smalldatetime { get; set; }
+        public DateTime Datetime { get; set; }
+        public TimeSpan Time { get; set; }
+        public string Char { get; set; }
+        public string Character { get; set; }
+        public string Varchar { get; set; }
+        public string Char_varying { get; set; }
+        public string Character_varying { get; set; }
+        public string VarcharMax { get; set; }
+        public string Char_varyingMax { get; set; }
+        public string Character_varyingMax { get; set; }
+        public string Nchar { get; set; }
+        public string National_character { get; set; }
+        public string Nvarchar { get; set; }
+        public string National_char_varying { get; set; }
+        public string National_character_varying { get; set; }
+        public string NvarcharMax { get; set; }
+        public string National_char_varyingMax { get; set; }
+        public string National_character_varyingMax { get; set; }
+        // See Issue #4478
+        //public string Text { get; set; }
+        //public string Ntext { get; set; }
+        public byte[] Binary { get; set; }
+        public byte[] Varbinary { get; set; }
+        public byte[] Binary_varying { get; set; }
+        public byte[] VarbinaryMax { get; set; }
+        public byte[] Binary_varyingMax { get; set; }
+        // See Issue #4478
+        //public byte[] Image { get; set; }
+        public decimal Decimal { get; set; }
+        public decimal Dec { get; set; }
+        public decimal Numeric { get; set; }
+    }
+
+    public class MappedSizedDataTypesWithIdentity
+    {
+        public int Id { get; set; }
+        public int Int { get; set; }
+
+        public string Char { get; set; }
+        public string Character { get; set; }
+        public string Varchar { get; set; }
+        public string Char_varying { get; set; }
+        public string Character_varying { get; set; }
+        public string Nchar { get; set; }
+        public string National_character { get; set; }
+        public string Nvarchar { get; set; }
+        public string National_char_varying { get; set; }
+        public string National_character_varying { get; set; }
+        public byte[] Binary { get; set; }
+        public byte[] Varbinary { get; set; }
+        public byte[] Binary_varying { get; set; }
+    }
+
+    public class MappedScaledDataTypesWithIdentity
+    {
+        public int Id { get; set; }
+        public int Int { get; set; }
+
+        public float Float { get; set; }
+        public float Double_precision { get; set; }
+        public DateTimeOffset Datetimeoffset { get; set; }
+        public DateTime Datetime2 { get; set; }
+        public decimal Decimal { get; set; }
+        public decimal Dec { get; set; }
+        public decimal Numeric { get; set; }
+    }
+
+    public class MappedPrecisionAndScaledDataTypesWithIdentity
+    {
+        public int Id { get; set; }
+        public int Int { get; set; }
+
+        public decimal Decimal { get; set; }
+        public decimal Dec { get; set; }
+        public decimal Numeric { get; set; }
+    }
+
+    public class MappedNullableDataTypesWithIdentity
+    {
+        public int Id { get; set; }
+
+        public int? Int { get; set; }
+        public long? Bigint { get; set; }
+        public short? Smallint { get; set; }
+        public byte? Tinyint { get; set; }
+        public bool? Bit { get; set; }
+        public decimal? Money { get; set; }
+        public decimal? Smallmoney { get; set; }
+        public double? Float { get; set; }
+        public float? Real { get; set; }
+        public double? Double_precision { get; set; }
+        public DateTime? Date { get; set; }
+        public DateTimeOffset? Datetimeoffset { get; set; }
+        public DateTime? Datetime2 { get; set; }
+        public DateTime? Smalldatetime { get; set; }
+        public DateTime? Datetime { get; set; }
+        public TimeSpan? Time { get; set; }
+        public string Char { get; set; }
+        public string Character { get; set; }
+        public string Varchar { get; set; }
+        public string Char_varying { get; set; }
+        public string Character_varying { get; set; }
+        public string VarcharMax { get; set; }
+        public string Char_varyingMax { get; set; }
+        public string Character_varyingMax { get; set; }
+        public string Nchar { get; set; }
+        public string National_character { get; set; }
+        public string Nvarchar { get; set; }
+        public string National_char_varying { get; set; }
+        public string National_character_varying { get; set; }
+        public string NvarcharMax { get; set; }
+        public string National_char_varyingMax { get; set; }
+        public string National_character_varyingMax { get; set; }
+        // See Issue #4478
+        //public string Text { get; set; }
+        //public string Ntext { get; set; }
+        public byte[] Binary { get; set; }
+        public byte[] Varbinary { get; set; }
+        public byte[] Binary_varying { get; set; }
+        public byte[] VarbinaryMax { get; set; }
+        public byte[] Binary_varyingMax { get; set; }
+        // See Issue #4478
+        //public byte[] Image { get; set; }
         public decimal? Decimal { get; set; }
         public decimal? Dec { get; set; }
         public decimal? Numeric { get; set; }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
@@ -348,271 +348,281 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
         {
             using (var context = CreateContext())
             {
-                context.Set<MappedDataTypes>().Add(
-                    new MappedDataTypes
-                        {
-                            Int = 77,
-                            Bigint = 78L,
-                            Smallint = 79,
-                            Tinyint = 80,
-                            Bit = true,
-                            Money = 81.1m,
-                            Smallmoney = 82.2m,
-                            Float = 83.3,
-                            Real = 84.4f,
-                            Double_precision = 85.5,
-                            Date = new DateTime(2015, 1, 2, 10, 11, 12),
-                            Datetimeoffset = new DateTimeOffset(new DateTime(2016, 1, 2, 11, 11, 12), TimeSpan.Zero),
-                            Datetime2 = new DateTime(2017, 1, 2, 12, 11, 12),
-                            Smalldatetime = new DateTime(2018, 1, 2, 13, 11, 12),
-                            Datetime = new DateTime(2019, 1, 2, 14, 11, 12),
-                            Time = new TimeSpan(11, 15, 12),
-                            Char = "A",
-                            Character = "B",
-                            Varchar = "I",
-                            Char_varying = "J",
-                            Character_varying = "K",
-                            VarcharMax = "C",
-                            Char_varyingMax = "Your",
-                            Character_varyingMax = "strong",
-                            Nchar = "D",
-                            National_character = "E",
-                            Nvarchar = "F",
-                            National_char_varying = "G",
-                            National_character_varying = "H",
-                            NvarcharMax = "don't",
-                            National_char_varyingMax = "help",
-                            National_character_varyingMax = "anyone!",
-                            Text = "Gumball Rules!",
-                            Ntext = "Gumball Rules OK!",
-                            Binary = new byte[] { 86 },
-                            Varbinary = new byte[] { 87 },
-                            Binary_varying = new byte[] { 88 },
-                            VarbinaryMax = new byte[] { 89, 90, 91, 92 },
-                            Binary_varyingMax = new byte[] { 93, 94, 95, 96 },
-                            Image = new byte[] { 97, 98, 99, 100 },
-                            Decimal = 101.1m,
-                            Dec = 102.2m,
-                            Numeric = 103.3m
-                        });
+                context.Set<MappedDataTypes>().Add(CreateMappedDataTypes(77));
 
                 Assert.Equal(1, context.SaveChanges());
             }
 
             using (var context = CreateContext())
             {
-                var entity = context.Set<MappedDataTypes>().Single(e => e.Int == 77);
-
-                Assert.Equal(77, entity.Int);
-                Assert.Equal(78, entity.Bigint);
-                Assert.Equal(79, entity.Smallint);
-                Assert.Equal(80, entity.Tinyint);
-                Assert.Equal(true, entity.Bit);
-                Assert.Equal(81.1m, entity.Money);
-                Assert.Equal(82.2m, entity.Smallmoney);
-                Assert.Equal(83.3, entity.Float);
-                Assert.Equal(84.4f, entity.Real);
-                Assert.Equal(85.5, entity.Double_precision);
-                Assert.Equal(new DateTime(2015, 1, 2), entity.Date);
-                Assert.Equal(new DateTimeOffset(new DateTime(2016, 1, 2, 11, 11, 12), TimeSpan.Zero), entity.Datetimeoffset);
-                Assert.Equal(new DateTime(2017, 1, 2, 12, 11, 12), entity.Datetime2);
-                Assert.Equal(new DateTime(2018, 1, 2, 13, 11, 00), entity.Smalldatetime);
-                Assert.Equal(new DateTime(2019, 1, 2, 14, 11, 12), entity.Datetime);
-                Assert.Equal(new TimeSpan(11, 15, 12), entity.Time);
-                Assert.Equal("A", entity.Char);
-                Assert.Equal("B", entity.Character);
-                Assert.Equal("I", entity.Varchar);
-                Assert.Equal("J", entity.Char_varying);
-                Assert.Equal("K", entity.Character_varying);
-                Assert.Equal("C", entity.VarcharMax);
-                Assert.Equal("Your", entity.Char_varyingMax);
-                Assert.Equal("strong", entity.Character_varyingMax);
-                Assert.Equal("D", entity.Nchar);
-                Assert.Equal("E", entity.National_character);
-                Assert.Equal("F", entity.Nvarchar);
-                Assert.Equal("G", entity.National_char_varying);
-                Assert.Equal("H", entity.National_character_varying);
-                Assert.Equal("don't", entity.NvarcharMax);
-                Assert.Equal("help", entity.National_char_varyingMax);
-                Assert.Equal("anyone!", entity.National_character_varyingMax);
-                Assert.Equal("Gumball Rules!", entity.Text);
-                Assert.Equal("Gumball Rules OK!", entity.Ntext);
-                Assert.Equal(new byte[] { 86 }, entity.Binary);
-                Assert.Equal(new byte[] { 87 }, entity.Varbinary);
-                Assert.Equal(new byte[] { 88 }, entity.Binary_varying);
-                Assert.Equal(new byte[] { 89, 90, 91, 92 }, entity.VarbinaryMax);
-                Assert.Equal(new byte[] { 93, 94, 95, 96 }, entity.Binary_varyingMax);
-                Assert.Equal(new byte[] { 97, 98, 99, 100 }, entity.Image);
-                Assert.Equal(101m, entity.Decimal);
-                Assert.Equal(102m, entity.Dec);
-                Assert.Equal(103m, entity.Numeric);
+                AssertMappedDataTypes(context.Set<MappedDataTypes>().Single(e => e.Int == 77), 77);
             }
         }
+
+        private static void AssertMappedDataTypes(MappedDataTypes entity, int id)
+        {
+            Assert.Equal(id, entity.Int);
+            Assert.Equal(78, entity.Bigint);
+            Assert.Equal(79, entity.Smallint);
+            Assert.Equal(80, entity.Tinyint);
+            Assert.Equal(true, entity.Bit);
+            Assert.Equal(81.1m, entity.Money);
+            Assert.Equal(82.2m, entity.Smallmoney);
+            Assert.Equal(83.3, entity.Float);
+            Assert.Equal(84.4f, entity.Real);
+            Assert.Equal(85.5, entity.Double_precision);
+            Assert.Equal(new DateTime(2015, 1, 2), entity.Date);
+            Assert.Equal(new DateTimeOffset(new DateTime(2016, 1, 2, 11, 11, 12), TimeSpan.Zero), entity.Datetimeoffset);
+            Assert.Equal(new DateTime(2017, 1, 2, 12, 11, 12), entity.Datetime2);
+            Assert.Equal(new DateTime(2018, 1, 2, 13, 11, 00), entity.Smalldatetime);
+            Assert.Equal(new DateTime(2019, 1, 2, 14, 11, 12), entity.Datetime);
+            Assert.Equal(new TimeSpan(11, 15, 12), entity.Time);
+            Assert.Equal("A", entity.Char);
+            Assert.Equal("B", entity.Character);
+            Assert.Equal("I", entity.Varchar);
+            Assert.Equal("J", entity.Char_varying);
+            Assert.Equal("K", entity.Character_varying);
+            Assert.Equal("C", entity.VarcharMax);
+            Assert.Equal("Your", entity.Char_varyingMax);
+            Assert.Equal("strong", entity.Character_varyingMax);
+            Assert.Equal("D", entity.Nchar);
+            Assert.Equal("E", entity.National_character);
+            Assert.Equal("F", entity.Nvarchar);
+            Assert.Equal("G", entity.National_char_varying);
+            Assert.Equal("H", entity.National_character_varying);
+            Assert.Equal("don't", entity.NvarcharMax);
+            Assert.Equal("help", entity.National_char_varyingMax);
+            Assert.Equal("anyone!", entity.National_character_varyingMax);
+            Assert.Equal("Gumball Rules!", entity.Text);
+            Assert.Equal("Gumball Rules OK!", entity.Ntext);
+            Assert.Equal(new byte[] { 86 }, entity.Binary);
+            Assert.Equal(new byte[] { 87 }, entity.Varbinary);
+            Assert.Equal(new byte[] { 88 }, entity.Binary_varying);
+            Assert.Equal(new byte[] { 89, 90, 91, 92 }, entity.VarbinaryMax);
+            Assert.Equal(new byte[] { 93, 94, 95, 96 }, entity.Binary_varyingMax);
+            Assert.Equal(new byte[] { 97, 98, 99, 100 }, entity.Image);
+            Assert.Equal(101m, entity.Decimal);
+            Assert.Equal(102m, entity.Dec);
+            Assert.Equal(103m, entity.Numeric);
+        }
+
+        private static MappedDataTypes CreateMappedDataTypes(int id)
+            => new MappedDataTypes
+            {
+                Int = id,
+                Bigint = 78L,
+                Smallint = 79,
+                Tinyint = 80,
+                Bit = true,
+                Money = 81.1m,
+                Smallmoney = 82.2m,
+                Float = 83.3,
+                Real = 84.4f,
+                Double_precision = 85.5,
+                Date = new DateTime(2015, 1, 2, 10, 11, 12),
+                Datetimeoffset = new DateTimeOffset(new DateTime(2016, 1, 2, 11, 11, 12), TimeSpan.Zero),
+                Datetime2 = new DateTime(2017, 1, 2, 12, 11, 12),
+                Smalldatetime = new DateTime(2018, 1, 2, 13, 11, 12),
+                Datetime = new DateTime(2019, 1, 2, 14, 11, 12),
+                Time = new TimeSpan(11, 15, 12),
+                Char = "A",
+                Character = "B",
+                Varchar = "I",
+                Char_varying = "J",
+                Character_varying = "K",
+                VarcharMax = "C",
+                Char_varyingMax = "Your",
+                Character_varyingMax = "strong",
+                Nchar = "D",
+                National_character = "E",
+                Nvarchar = "F",
+                National_char_varying = "G",
+                National_character_varying = "H",
+                NvarcharMax = "don't",
+                National_char_varyingMax = "help",
+                National_character_varyingMax = "anyone!",
+                Text = "Gumball Rules!",
+                Ntext = "Gumball Rules OK!",
+                Binary = new byte[] { 86 },
+                Varbinary = new byte[] { 87 },
+                Binary_varying = new byte[] { 88 },
+                VarbinaryMax = new byte[] { 89, 90, 91, 92 },
+                Binary_varyingMax = new byte[] { 93, 94, 95, 96 },
+                Image = new byte[] { 97, 98, 99, 100 },
+                Decimal = 101.1m,
+                Dec = 102.2m,
+                Numeric = 103.3m
+            };
 
         [Fact]
         public virtual void Can_insert_and_read_back_all_mapped_nullable_data_types()
         {
             using (var context = CreateContext())
             {
-                context.Set<MappedNullableDataTypes>().Add(
-                    new MappedNullableDataTypes
-                        {
-                            Int = 77,
-                            Bigint = 78L,
-                            Smallint = 79,
-                            Tinyint = 80,
-                            Bit = true,
-                            Money = 81.1m,
-                            Smallmoney = 82.2m,
-                            Float = 83.3,
-                            Real = 84.4f,
-                            Double_precision = 85.5,
-                            Date = new DateTime(2015, 1, 2, 10, 11, 12),
-                            Datetimeoffset = new DateTimeOffset(new DateTime(2016, 1, 2, 11, 11, 12), TimeSpan.Zero),
-                            Datetime2 = new DateTime(2017, 1, 2, 12, 11, 12),
-                            Smalldatetime = new DateTime(2018, 1, 2, 13, 11, 12),
-                            Datetime = new DateTime(2019, 1, 2, 14, 11, 12),
-                            Time = new TimeSpan(11, 15, 12),
-                            Char = "A",
-                            Character = "B",
-                            Varchar = "I",
-                            Char_varying = "J",
-                            Character_varying = "K",
-                            VarcharMax = "C",
-                            Char_varyingMax = "Your",
-                            Character_varyingMax = "strong",
-                            Nchar = "D",
-                            National_character = "E",
-                            Nvarchar = "F",
-                            National_char_varying = "G",
-                            National_character_varying = "H",
-                            NvarcharMax = "don't",
-                            National_char_varyingMax = "help",
-                            National_character_varyingMax = "anyone!",
-                            Text = "Gumball Rules!",
-                            Ntext = "Gumball Rules OK!",
-                            Binary = new byte[] { 86 },
-                            Varbinary = new byte[] { 87 },
-                            Binary_varying = new byte[] { 88 },
-                            VarbinaryMax = new byte[] { 89, 90, 91, 92 },
-                            Binary_varyingMax = new byte[] { 93, 94, 95, 96 },
-                            Image = new byte[] { 97, 98, 99, 100 },
-                            Decimal = 101.1m,
-                            Dec = 102.2m,
-                            Numeric = 103.3m
-                        });
+                context.Set<MappedNullableDataTypes>().Add(CreateMappedNullableDataTypes(77));
 
                 Assert.Equal(1, context.SaveChanges());
             }
 
             using (var context = CreateContext())
             {
-                var entity = context.Set<MappedNullableDataTypes>().Single(e => e.Int == 77);
-
-                Assert.Equal(77, entity.Int);
-                Assert.Equal(78, entity.Bigint);
-                Assert.Equal(79, entity.Smallint.Value);
-                Assert.Equal(80, entity.Tinyint.Value);
-                Assert.Equal(true, entity.Bit);
-                Assert.Equal(81.1m, entity.Money);
-                Assert.Equal(82.2m, entity.Smallmoney);
-                Assert.Equal(83.3, entity.Float);
-                Assert.Equal(84.4f, entity.Real);
-                Assert.Equal(85.5, entity.Double_precision);
-                Assert.Equal(new DateTime(2015, 1, 2), entity.Date);
-                Assert.Equal(new DateTimeOffset(new DateTime(2016, 1, 2, 11, 11, 12), TimeSpan.Zero), entity.Datetimeoffset);
-                Assert.Equal(new DateTime(2017, 1, 2, 12, 11, 12), entity.Datetime2);
-                Assert.Equal(new DateTime(2018, 1, 2, 13, 11, 00), entity.Smalldatetime);
-                Assert.Equal(new DateTime(2019, 1, 2, 14, 11, 12), entity.Datetime);
-                Assert.Equal(new TimeSpan(11, 15, 12), entity.Time);
-                Assert.Equal("A", entity.Char);
-                Assert.Equal("B", entity.Character);
-                Assert.Equal("I", entity.Varchar);
-                Assert.Equal("J", entity.Char_varying);
-                Assert.Equal("K", entity.Character_varying);
-                Assert.Equal("C", entity.VarcharMax);
-                Assert.Equal("Your", entity.Char_varyingMax);
-                Assert.Equal("strong", entity.Character_varyingMax);
-                Assert.Equal("D", entity.Nchar);
-                Assert.Equal("E", entity.National_character);
-                Assert.Equal("F", entity.Nvarchar);
-                Assert.Equal("G", entity.National_char_varying);
-                Assert.Equal("H", entity.National_character_varying);
-                Assert.Equal("don't", entity.NvarcharMax);
-                Assert.Equal("help", entity.National_char_varyingMax);
-                Assert.Equal("anyone!", entity.National_character_varyingMax);
-                Assert.Equal("Gumball Rules!", entity.Text);
-                Assert.Equal("Gumball Rules OK!", entity.Ntext);
-                Assert.Equal(new byte[] { 86 }, entity.Binary);
-                Assert.Equal(new byte[] { 87 }, entity.Varbinary);
-                Assert.Equal(new byte[] { 88 }, entity.Binary_varying);
-                Assert.Equal(new byte[] { 89, 90, 91, 92 }, entity.VarbinaryMax);
-                Assert.Equal(new byte[] { 93, 94, 95, 96 }, entity.Binary_varyingMax);
-                Assert.Equal(new byte[] { 97, 98, 99, 100 }, entity.Image);
-                Assert.Equal(101m, entity.Decimal);
-                Assert.Equal(102m, entity.Dec);
-                Assert.Equal(103m, entity.Numeric);
+                AssertMappedNullableDataTypes(context.Set<MappedNullableDataTypes>().Single(e => e.Int == 77), 77);
             }
         }
+
+        private static void AssertMappedNullableDataTypes(MappedNullableDataTypes entity, int id)
+        {
+            Assert.Equal(id, entity.Int);
+            Assert.Equal(78, entity.Bigint);
+            Assert.Equal(79, entity.Smallint.Value);
+            Assert.Equal(80, entity.Tinyint.Value);
+            Assert.Equal(true, entity.Bit);
+            Assert.Equal(81.1m, entity.Money);
+            Assert.Equal(82.2m, entity.Smallmoney);
+            Assert.Equal(83.3, entity.Float);
+            Assert.Equal(84.4f, entity.Real);
+            Assert.Equal(85.5, entity.Double_precision);
+            Assert.Equal(new DateTime(2015, 1, 2), entity.Date);
+            Assert.Equal(new DateTimeOffset(new DateTime(2016, 1, 2, 11, 11, 12), TimeSpan.Zero), entity.Datetimeoffset);
+            Assert.Equal(new DateTime(2017, 1, 2, 12, 11, 12), entity.Datetime2);
+            Assert.Equal(new DateTime(2018, 1, 2, 13, 11, 00), entity.Smalldatetime);
+            Assert.Equal(new DateTime(2019, 1, 2, 14, 11, 12), entity.Datetime);
+            Assert.Equal(new TimeSpan(11, 15, 12), entity.Time);
+            Assert.Equal("A", entity.Char);
+            Assert.Equal("B", entity.Character);
+            Assert.Equal("I", entity.Varchar);
+            Assert.Equal("J", entity.Char_varying);
+            Assert.Equal("K", entity.Character_varying);
+            Assert.Equal("C", entity.VarcharMax);
+            Assert.Equal("Your", entity.Char_varyingMax);
+            Assert.Equal("strong", entity.Character_varyingMax);
+            Assert.Equal("D", entity.Nchar);
+            Assert.Equal("E", entity.National_character);
+            Assert.Equal("F", entity.Nvarchar);
+            Assert.Equal("G", entity.National_char_varying);
+            Assert.Equal("H", entity.National_character_varying);
+            Assert.Equal("don't", entity.NvarcharMax);
+            Assert.Equal("help", entity.National_char_varyingMax);
+            Assert.Equal("anyone!", entity.National_character_varyingMax);
+            Assert.Equal("Gumball Rules!", entity.Text);
+            Assert.Equal("Gumball Rules OK!", entity.Ntext);
+            Assert.Equal(new byte[] { 86 }, entity.Binary);
+            Assert.Equal(new byte[] { 87 }, entity.Varbinary);
+            Assert.Equal(new byte[] { 88 }, entity.Binary_varying);
+            Assert.Equal(new byte[] { 89, 90, 91, 92 }, entity.VarbinaryMax);
+            Assert.Equal(new byte[] { 93, 94, 95, 96 }, entity.Binary_varyingMax);
+            Assert.Equal(new byte[] { 97, 98, 99, 100 }, entity.Image);
+            Assert.Equal(101m, entity.Decimal);
+            Assert.Equal(102m, entity.Dec);
+            Assert.Equal(103m, entity.Numeric);
+        }
+
+        private static MappedNullableDataTypes CreateMappedNullableDataTypes(int id)
+            => new MappedNullableDataTypes
+            {
+                Int = id,
+                Bigint = 78L,
+                Smallint = 79,
+                Tinyint = 80,
+                Bit = true,
+                Money = 81.1m,
+                Smallmoney = 82.2m,
+                Float = 83.3,
+                Real = 84.4f,
+                Double_precision = 85.5,
+                Date = new DateTime(2015, 1, 2, 10, 11, 12),
+                Datetimeoffset = new DateTimeOffset(new DateTime(2016, 1, 2, 11, 11, 12), TimeSpan.Zero),
+                Datetime2 = new DateTime(2017, 1, 2, 12, 11, 12),
+                Smalldatetime = new DateTime(2018, 1, 2, 13, 11, 12),
+                Datetime = new DateTime(2019, 1, 2, 14, 11, 12),
+                Time = new TimeSpan(11, 15, 12),
+                Char = "A",
+                Character = "B",
+                Varchar = "I",
+                Char_varying = "J",
+                Character_varying = "K",
+                VarcharMax = "C",
+                Char_varyingMax = "Your",
+                Character_varyingMax = "strong",
+                Nchar = "D",
+                National_character = "E",
+                Nvarchar = "F",
+                National_char_varying = "G",
+                National_character_varying = "H",
+                NvarcharMax = "don't",
+                National_char_varyingMax = "help",
+                National_character_varyingMax = "anyone!",
+                Text = "Gumball Rules!",
+                Ntext = "Gumball Rules OK!",
+                Binary = new byte[] { 86 },
+                Varbinary = new byte[] { 87 },
+                Binary_varying = new byte[] { 88 },
+                VarbinaryMax = new byte[] { 89, 90, 91, 92 },
+                Binary_varyingMax = new byte[] { 93, 94, 95, 96 },
+                Image = new byte[] { 97, 98, 99, 100 },
+                Decimal = 101.1m,
+                Dec = 102.2m,
+                Numeric = 103.3m
+            };
 
         [Fact]
         public virtual void Can_insert_and_read_back_all_mapped_data_types_set_to_null()
         {
             using (var context = CreateContext())
             {
-                context.Set<MappedNullableDataTypes>().Add(
-                    new MappedNullableDataTypes
-                        {
-                            Int = 78
-                        });
+                context.Set<MappedNullableDataTypes>().Add(new MappedNullableDataTypes { Int = 78 });
 
                 Assert.Equal(1, context.SaveChanges());
             }
 
             using (var context = CreateContext())
             {
-                var entity = context.Set<MappedNullableDataTypes>().Single(e => e.Int == 78);
-
-                Assert.Null(entity.Bigint);
-                Assert.Null(entity.Smallint);
-                Assert.Null(entity.Tinyint);
-                Assert.Null(entity.Bit);
-                Assert.Null(entity.Money);
-                Assert.Null(entity.Smallmoney);
-                Assert.Null(entity.Float);
-                Assert.Null(entity.Real);
-                Assert.Null(entity.Double_precision);
-                Assert.Null(entity.Date);
-                Assert.Null(entity.Datetimeoffset);
-                Assert.Null(entity.Datetime2);
-                Assert.Null(entity.Smalldatetime);
-                Assert.Null(entity.Datetime);
-                Assert.Null(entity.Time);
-                Assert.Null(entity.Char);
-                Assert.Null(entity.Character);
-                Assert.Null(entity.VarcharMax);
-                Assert.Null(entity.Char_varyingMax);
-                Assert.Null(entity.Character_varyingMax);
-                Assert.Null(entity.Nchar);
-                Assert.Null(entity.National_character);
-                Assert.Null(entity.Nvarchar);
-                Assert.Null(entity.National_char_varying);
-                Assert.Null(entity.National_character_varying);
-                Assert.Null(entity.NvarcharMax);
-                Assert.Null(entity.National_char_varyingMax);
-                Assert.Null(entity.National_character_varyingMax);
-                Assert.Null(entity.Text);
-                Assert.Null(entity.Ntext);
-                Assert.Null(entity.Binary);
-                Assert.Null(entity.Varbinary);
-                Assert.Null(entity.Binary_varying);
-                Assert.Null(entity.VarbinaryMax);
-                Assert.Null(entity.Binary_varyingMax);
-                Assert.Null(entity.Image);
-                Assert.Null(entity.Decimal);
-                Assert.Null(entity.Dec);
-                Assert.Null(entity.Numeric);
+                AssertNullMappedNullableDataTypes(context.Set<MappedNullableDataTypes>().Single(e => e.Int == 78), 78);
             }
+        }
+
+        private static void AssertNullMappedNullableDataTypes(MappedNullableDataTypes entity, int id)
+        {
+            Assert.Equal(id, entity.Int);
+            Assert.Null(entity.Bigint);
+            Assert.Null(entity.Smallint);
+            Assert.Null(entity.Tinyint);
+            Assert.Null(entity.Bit);
+            Assert.Null(entity.Money);
+            Assert.Null(entity.Smallmoney);
+            Assert.Null(entity.Float);
+            Assert.Null(entity.Real);
+            Assert.Null(entity.Double_precision);
+            Assert.Null(entity.Date);
+            Assert.Null(entity.Datetimeoffset);
+            Assert.Null(entity.Datetime2);
+            Assert.Null(entity.Smalldatetime);
+            Assert.Null(entity.Datetime);
+            Assert.Null(entity.Time);
+            Assert.Null(entity.Char);
+            Assert.Null(entity.Character);
+            Assert.Null(entity.VarcharMax);
+            Assert.Null(entity.Char_varyingMax);
+            Assert.Null(entity.Character_varyingMax);
+            Assert.Null(entity.Nchar);
+            Assert.Null(entity.National_character);
+            Assert.Null(entity.Nvarchar);
+            Assert.Null(entity.National_char_varying);
+            Assert.Null(entity.National_character_varying);
+            Assert.Null(entity.NvarcharMax);
+            Assert.Null(entity.National_char_varyingMax);
+            Assert.Null(entity.National_character_varyingMax);
+            Assert.Null(entity.Text);
+            Assert.Null(entity.Ntext);
+            Assert.Null(entity.Binary);
+            Assert.Null(entity.Varbinary);
+            Assert.Null(entity.Binary_varying);
+            Assert.Null(entity.VarbinaryMax);
+            Assert.Null(entity.Binary_varyingMax);
+            Assert.Null(entity.Image);
+            Assert.Null(entity.Decimal);
+            Assert.Null(entity.Dec);
+            Assert.Null(entity.Numeric);
         }
 
         [Fact]
@@ -620,80 +630,86 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
         {
             using (var context = CreateContext())
             {
-                context.Set<MappedSizedDataTypes>().Add(
-                    new MappedSizedDataTypes
-                        {
-                            Id = 77,
-                            Char = "Wor",
-                            Character = "Lon",
-                            Varchar = "Tha",
-                            Char_varying = "Thr",
-                            Character_varying = "Let",
-                            Nchar = "Won",
-                            National_character = "Squ",
-                            Nvarchar = "Int",
-                            National_char_varying = "The",
-                            National_character_varying = "Col",
-                            Binary = new byte[] { 10, 11, 12 },
-                            Varbinary = new byte[] { 11, 12, 13 },
-                            Binary_varying = new byte[] { 12, 13, 14 }
-                        });
+                context.Set<MappedSizedDataTypes>().Add(CreateMappedSizedDataTypes(77));
 
                 Assert.Equal(1, context.SaveChanges());
             }
 
             using (var context = CreateContext())
             {
-                var entity = context.Set<MappedSizedDataTypes>().Single(e => e.Id == 77);
-
-                Assert.Equal("Wor", entity.Char);
-                Assert.Equal("Lon", entity.Character);
-                Assert.Equal("Tha", entity.Varchar);
-                Assert.Equal("Thr", entity.Char_varying);
-                Assert.Equal("Let", entity.Character_varying);
-                Assert.Equal("Won", entity.Nchar);
-                Assert.Equal("Squ", entity.National_character);
-                Assert.Equal("Int", entity.Nvarchar);
-                Assert.Equal("The", entity.National_char_varying);
-                Assert.Equal("Col", entity.National_character_varying);
-                Assert.Equal(new byte[] { 10, 11, 12 }, entity.Binary);
-                Assert.Equal(new byte[] { 11, 12, 13 }, entity.Varbinary);
-                Assert.Equal(new byte[] { 12, 13, 14 }, entity.Binary_varying);
+                AssertMappedSizedDataTypes(context.Set<MappedSizedDataTypes>().Single(e => e.Id == 77), 77);
             }
         }
+
+        private static void AssertMappedSizedDataTypes(MappedSizedDataTypes entity, int id)
+        {
+            Assert.Equal(id, entity.Id);
+            Assert.Equal("Wor", entity.Char);
+            Assert.Equal("Lon", entity.Character);
+            Assert.Equal("Tha", entity.Varchar);
+            Assert.Equal("Thr", entity.Char_varying);
+            Assert.Equal("Let", entity.Character_varying);
+            Assert.Equal("Won", entity.Nchar);
+            Assert.Equal("Squ", entity.National_character);
+            Assert.Equal("Int", entity.Nvarchar);
+            Assert.Equal("The", entity.National_char_varying);
+            Assert.Equal("Col", entity.National_character_varying);
+            Assert.Equal(new byte[] { 10, 11, 12 }, entity.Binary);
+            Assert.Equal(new byte[] { 11, 12, 13 }, entity.Varbinary);
+            Assert.Equal(new byte[] { 12, 13, 14 }, entity.Binary_varying);
+        }
+
+        private static MappedSizedDataTypes CreateMappedSizedDataTypes(int id)
+            => new MappedSizedDataTypes
+            {
+                Id = id,
+                Char = "Wor",
+                Character = "Lon",
+                Varchar = "Tha",
+                Char_varying = "Thr",
+                Character_varying = "Let",
+                Nchar = "Won",
+                National_character = "Squ",
+                Nvarchar = "Int",
+                National_char_varying = "The",
+                National_character_varying = "Col",
+                Binary = new byte[] { 10, 11, 12 },
+                Varbinary = new byte[] { 11, 12, 13 },
+                Binary_varying = new byte[] { 12, 13, 14 }
+            };
 
         [Fact]
         public virtual void Can_insert_and_read_back_nulls_for_all_mapped_sized_data_types()
         {
             using (var context = CreateContext())
             {
-                context.Set<MappedSizedDataTypes>().Add(
-                    new MappedSizedDataTypes
-                        {
-                            Id = 78
-                        });
+                context.Set<MappedSizedDataTypes>().Add(new MappedSizedDataTypes { Id = 78 });
 
                 Assert.Equal(1, context.SaveChanges());
             }
 
             using (var context = CreateContext())
             {
-                var entity = context.Set<MappedSizedDataTypes>().Single(e => e.Id == 78);
-
-                Assert.Null(entity.Char);
-                Assert.Null(entity.Character);
-                Assert.Null(entity.Varchar);
-                Assert.Null(entity.Char_varying);
-                Assert.Null(entity.Character_varying);
-                Assert.Null(entity.Nchar);
-                Assert.Null(entity.National_character);
-                Assert.Null(entity.Nvarchar);
-                Assert.Null(entity.National_char_varying);
-                Assert.Null(entity.National_character_varying);
-                Assert.Null(entity.Binary);
-                Assert.Null(entity.Varbinary);
-                Assert.Null(entity.Binary_varying);
+                AssertNullMappedSizedDataTypes(context.Set<MappedSizedDataTypes>().Single(e => e.Id == 78), 78);
             }
+        }
+
+        private static void AssertNullMappedSizedDataTypes(MappedSizedDataTypes entity, int id)
+        {
+            Assert.Equal(id, entity.Id);
+            Assert.Null(entity.Char);
+            Assert.Null(entity.Character);
+            Assert.Null(entity.Varchar);
+            Assert.Null(entity.Char_varying);
+            Assert.Null(entity.Character_varying);
+            Assert.Null(entity.Nchar);
+            Assert.Null(entity.National_character);
+            Assert.Null(entity.Nvarchar);
+            Assert.Null(entity.National_char_varying);
+            Assert.Null(entity.National_character_varying);
+            Assert.Null(entity.Binary);
+            Assert.Null(entity.Varbinary);
+            Assert.Null(entity.Binary_varying);
         }
 
         [Fact]
@@ -701,60 +717,812 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
         {
             using (var context = CreateContext())
             {
-                context.Set<MappedScaledDataTypes>().Add(
-                    new MappedScaledDataTypes
-                        {
-                            Id = 77,
-                            Float = 83.3f,
-                            Double_precision = 85.5f,
-                            Datetimeoffset = new DateTimeOffset(new DateTime(2016, 1, 2, 11, 11, 12), TimeSpan.Zero),
-                            Datetime2 = new DateTime(2017, 1, 2, 12, 11, 12),
-                            Decimal = 101.1m,
-                            Dec = 102.2m,
-                            Numeric = 103.3m
-                        });
+                context.Set<MappedScaledDataTypes>().Add(CreateMappedScaledDataTypes(77));
 
                 Assert.Equal(1, context.SaveChanges());
             }
 
             using (var context = CreateContext())
             {
-                var entity = context.Set<MappedScaledDataTypes>().Single(e => e.Id == 77);
-
-                Assert.Equal(83.3f, entity.Float);
-                Assert.Equal(85.5f, entity.Double_precision);
-                Assert.Equal(new DateTimeOffset(new DateTime(2016, 1, 2, 11, 11, 12), TimeSpan.Zero), entity.Datetimeoffset);
-                Assert.Equal(new DateTime(2017, 1, 2, 12, 11, 12), entity.Datetime2);
-                Assert.Equal(101m, entity.Decimal);
-                Assert.Equal(102m, entity.Dec);
-                Assert.Equal(103m, entity.Numeric);
+                AssertMappedScaledDataTypes(context.Set<MappedScaledDataTypes>().Single(e => e.Id == 77), 77);
             }
         }
+
+        private static void AssertMappedScaledDataTypes(MappedScaledDataTypes entity, int id)
+        {
+            Assert.Equal(id, entity.Id);
+            Assert.Equal(83.3f, entity.Float);
+            Assert.Equal(85.5f, entity.Double_precision);
+            Assert.Equal(new DateTimeOffset(new DateTime(2016, 1, 2, 11, 11, 12), TimeSpan.Zero), entity.Datetimeoffset);
+            Assert.Equal(new DateTime(2017, 1, 2, 12, 11, 12), entity.Datetime2);
+            Assert.Equal(101m, entity.Decimal);
+            Assert.Equal(102m, entity.Dec);
+            Assert.Equal(103m, entity.Numeric);
+        }
+
+        private static MappedScaledDataTypes CreateMappedScaledDataTypes(int id)
+            => new MappedScaledDataTypes
+            {
+                Id = id,
+                Float = 83.3f,
+                Double_precision = 85.5f,
+                Datetimeoffset = new DateTimeOffset(new DateTime(2016, 1, 2, 11, 11, 12), TimeSpan.Zero),
+                Datetime2 = new DateTime(2017, 1, 2, 12, 11, 12),
+                Decimal = 101.1m,
+                Dec = 102.2m,
+                Numeric = 103.3m
+            };
 
         [Fact]
         public virtual void Can_insert_and_read_back_all_mapped_data_types_with_precision_and_scale()
         {
             using (var context = CreateContext())
             {
-                context.Set<MappedPrecisionAndScaledDataTypes>().Add(
-                    new MappedPrecisionAndScaledDataTypes
-                        {
-                            Id = 77,
-                            Decimal = 101.1m,
-                            Dec = 102.2m,
-                            Numeric = 103.3m
-                        });
+                context.Set<MappedPrecisionAndScaledDataTypes>().Add(CreateMappedPrecisionAndScaledDataTypes(77));
 
                 Assert.Equal(1, context.SaveChanges());
             }
 
             using (var context = CreateContext())
             {
-                var entity = context.Set<MappedPrecisionAndScaledDataTypes>().Single(e => e.Id == 77);
+                AssertMappedPrecisionAndScaledDataTypes(context.Set<MappedPrecisionAndScaledDataTypes>().Single(e => e.Id == 77), 77);
+            }
+        }
 
-                Assert.Equal(101.1m, entity.Decimal);
-                Assert.Equal(102.2m, entity.Dec);
-                Assert.Equal(103.3m, entity.Numeric);
+        private static void AssertMappedPrecisionAndScaledDataTypes(MappedPrecisionAndScaledDataTypes entity, int id)
+        {
+            Assert.Equal(id, entity.Id);
+            Assert.Equal(101.1m, entity.Decimal);
+            Assert.Equal(102.2m, entity.Dec);
+            Assert.Equal(103.3m, entity.Numeric);
+        }
+
+        private static MappedPrecisionAndScaledDataTypes CreateMappedPrecisionAndScaledDataTypes(int id)
+            => new MappedPrecisionAndScaledDataTypes
+            {
+                Id = id,
+                Decimal = 101.1m,
+                Dec = 102.2m,
+                Numeric = 103.3m
+            };
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_data_types_with_identity()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<MappedDataTypesWithIdentity>().Add(CreateMappedDataTypesWithIdentity(77));
+
+                Assert.Equal(1, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                AssertMappedDataTypesWithIdentity(context.Set<MappedDataTypesWithIdentity>().Single(e => e.Int == 77), 77);
+            }
+        }
+
+        private static void AssertMappedDataTypesWithIdentity(MappedDataTypesWithIdentity entity, int id)
+        {
+            Assert.Equal(id, entity.Int);
+            Assert.Equal(78, entity.Bigint);
+            Assert.Equal(79, entity.Smallint);
+            Assert.Equal(80, entity.Tinyint);
+            Assert.Equal(true, entity.Bit);
+            Assert.Equal(81.1m, entity.Money);
+            Assert.Equal(82.2m, entity.Smallmoney);
+            Assert.Equal(83.3, entity.Float);
+            Assert.Equal(84.4f, entity.Real);
+            Assert.Equal(85.5, entity.Double_precision);
+            Assert.Equal(new DateTime(2015, 1, 2), entity.Date);
+            Assert.Equal(new DateTimeOffset(new DateTime(2016, 1, 2, 11, 11, 12), TimeSpan.Zero), entity.Datetimeoffset);
+            Assert.Equal(new DateTime(2017, 1, 2, 12, 11, 12), entity.Datetime2);
+            Assert.Equal(new DateTime(2018, 1, 2, 13, 11, 00), entity.Smalldatetime);
+            Assert.Equal(new DateTime(2019, 1, 2, 14, 11, 12), entity.Datetime);
+            Assert.Equal(new TimeSpan(11, 15, 12), entity.Time);
+            Assert.Equal("A", entity.Char);
+            Assert.Equal("B", entity.Character);
+            Assert.Equal("I", entity.Varchar);
+            Assert.Equal("J", entity.Char_varying);
+            Assert.Equal("K", entity.Character_varying);
+            Assert.Equal("C", entity.VarcharMax);
+            Assert.Equal("Your", entity.Char_varyingMax);
+            Assert.Equal("strong", entity.Character_varyingMax);
+            Assert.Equal("D", entity.Nchar);
+            Assert.Equal("E", entity.National_character);
+            Assert.Equal("F", entity.Nvarchar);
+            Assert.Equal("G", entity.National_char_varying);
+            Assert.Equal("H", entity.National_character_varying);
+            Assert.Equal("don't", entity.NvarcharMax);
+            Assert.Equal("help", entity.National_char_varyingMax);
+            Assert.Equal("anyone!", entity.National_character_varyingMax);
+            // See Issue #4478
+            //Assert.Equal("Gumball Rules!", entity.Text);
+            //Assert.Equal("Gumball Rules OK!", entity.Ntext);
+            Assert.Equal(new byte[] { 86 }, entity.Binary);
+            Assert.Equal(new byte[] { 87 }, entity.Varbinary);
+            Assert.Equal(new byte[] { 88 }, entity.Binary_varying);
+            Assert.Equal(new byte[] { 89, 90, 91, 92 }, entity.VarbinaryMax);
+            Assert.Equal(new byte[] { 93, 94, 95, 96 }, entity.Binary_varyingMax);
+            // See Issue #4478
+            //Assert.Equal(new byte[] { 97, 98, 99, 100 }, entity.Image);
+            Assert.Equal(101m, entity.Decimal);
+            Assert.Equal(102m, entity.Dec);
+            Assert.Equal(103m, entity.Numeric);
+        }
+
+        private static MappedDataTypesWithIdentity CreateMappedDataTypesWithIdentity(int id)
+            => new MappedDataTypesWithIdentity
+            {
+                Int = id,
+                Bigint = 78L,
+                Smallint = 79,
+                Tinyint = 80,
+                Bit = true,
+                Money = 81.1m,
+                Smallmoney = 82.2m,
+                Float = 83.3,
+                Real = 84.4f,
+                Double_precision = 85.5,
+                Date = new DateTime(2015, 1, 2, 10, 11, 12),
+                Datetimeoffset = new DateTimeOffset(new DateTime(2016, 1, 2, 11, 11, 12), TimeSpan.Zero),
+                Datetime2 = new DateTime(2017, 1, 2, 12, 11, 12),
+                Smalldatetime = new DateTime(2018, 1, 2, 13, 11, 12),
+                Datetime = new DateTime(2019, 1, 2, 14, 11, 12),
+                Time = new TimeSpan(11, 15, 12),
+                Char = "A",
+                Character = "B",
+                Varchar = "I",
+                Char_varying = "J",
+                Character_varying = "K",
+                VarcharMax = "C",
+                Char_varyingMax = "Your",
+                Character_varyingMax = "strong",
+                Nchar = "D",
+                National_character = "E",
+                Nvarchar = "F",
+                National_char_varying = "G",
+                National_character_varying = "H",
+                NvarcharMax = "don't",
+                National_char_varyingMax = "help",
+                National_character_varyingMax = "anyone!",
+                // See Issue #4478
+                //Text = "Gumball Rules!",
+                //Ntext = "Gumball Rules OK!",
+                Binary = new byte[] { 86 },
+                Varbinary = new byte[] { 87 },
+                Binary_varying = new byte[] { 88 },
+                VarbinaryMax = new byte[] { 89, 90, 91, 92 },
+                Binary_varyingMax = new byte[] { 93, 94, 95, 96 },
+                // See Issue #4478
+                //Image = new byte[] { 97, 98, 99, 100 },
+                Decimal = 101.1m,
+                Dec = 102.2m,
+                Numeric = 103.3m
+            };
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_nullable_data_types_with_identity()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<MappedNullableDataTypesWithIdentity>().Add(CreateMappedNullableDataTypesWithIdentity(77));
+
+                Assert.Equal(1, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                AssertMappedNullableDataTypesWithIdentity(context.Set<MappedNullableDataTypesWithIdentity>().Single(e => e.Int == 77), 77);
+            }
+        }
+
+        private static void AssertMappedNullableDataTypesWithIdentity(MappedNullableDataTypesWithIdentity entity, int id)
+        {
+            Assert.Equal(id, entity.Int);
+            Assert.Equal(78, entity.Bigint);
+            Assert.Equal(79, entity.Smallint.Value);
+            Assert.Equal(80, entity.Tinyint.Value);
+            Assert.Equal(true, entity.Bit);
+            Assert.Equal(81.1m, entity.Money);
+            Assert.Equal(82.2m, entity.Smallmoney);
+            Assert.Equal(83.3, entity.Float);
+            Assert.Equal(84.4f, entity.Real);
+            Assert.Equal(85.5, entity.Double_precision);
+            Assert.Equal(new DateTime(2015, 1, 2), entity.Date);
+            Assert.Equal(new DateTimeOffset(new DateTime(2016, 1, 2, 11, 11, 12), TimeSpan.Zero), entity.Datetimeoffset);
+            Assert.Equal(new DateTime(2017, 1, 2, 12, 11, 12), entity.Datetime2);
+            Assert.Equal(new DateTime(2018, 1, 2, 13, 11, 00), entity.Smalldatetime);
+            Assert.Equal(new DateTime(2019, 1, 2, 14, 11, 12), entity.Datetime);
+            Assert.Equal(new TimeSpan(11, 15, 12), entity.Time);
+            Assert.Equal("A", entity.Char);
+            Assert.Equal("B", entity.Character);
+            Assert.Equal("I", entity.Varchar);
+            Assert.Equal("J", entity.Char_varying);
+            Assert.Equal("K", entity.Character_varying);
+            Assert.Equal("C", entity.VarcharMax);
+            Assert.Equal("Your", entity.Char_varyingMax);
+            Assert.Equal("strong", entity.Character_varyingMax);
+            Assert.Equal("D", entity.Nchar);
+            Assert.Equal("E", entity.National_character);
+            Assert.Equal("F", entity.Nvarchar);
+            Assert.Equal("G", entity.National_char_varying);
+            Assert.Equal("H", entity.National_character_varying);
+            Assert.Equal("don't", entity.NvarcharMax);
+            Assert.Equal("help", entity.National_char_varyingMax);
+            Assert.Equal("anyone!", entity.National_character_varyingMax);
+            // See Issue #4478
+            //Assert.Equal("Gumball Rules!", entity.Text);
+            //Assert.Equal("Gumball Rules OK!", entity.Ntext);
+            Assert.Equal(new byte[] { 86 }, entity.Binary);
+            Assert.Equal(new byte[] { 87 }, entity.Varbinary);
+            Assert.Equal(new byte[] { 88 }, entity.Binary_varying);
+            Assert.Equal(new byte[] { 89, 90, 91, 92 }, entity.VarbinaryMax);
+            Assert.Equal(new byte[] { 93, 94, 95, 96 }, entity.Binary_varyingMax);
+            // See Issue #4478
+            //Assert.Equal(new byte[] { 97, 98, 99, 100 }, entity.Image);
+            Assert.Equal(101m, entity.Decimal);
+            Assert.Equal(102m, entity.Dec);
+            Assert.Equal(103m, entity.Numeric);
+        }
+
+        private static MappedNullableDataTypesWithIdentity CreateMappedNullableDataTypesWithIdentity(int id)
+            => new MappedNullableDataTypesWithIdentity
+            {
+                Int = id,
+                Bigint = 78L,
+                Smallint = 79,
+                Tinyint = 80,
+                Bit = true,
+                Money = 81.1m,
+                Smallmoney = 82.2m,
+                Float = 83.3,
+                Real = 84.4f,
+                Double_precision = 85.5,
+                Date = new DateTime(2015, 1, 2, 10, 11, 12),
+                Datetimeoffset = new DateTimeOffset(new DateTime(2016, 1, 2, 11, 11, 12), TimeSpan.Zero),
+                Datetime2 = new DateTime(2017, 1, 2, 12, 11, 12),
+                Smalldatetime = new DateTime(2018, 1, 2, 13, 11, 12),
+                Datetime = new DateTime(2019, 1, 2, 14, 11, 12),
+                Time = new TimeSpan(11, 15, 12),
+                Char = "A",
+                Character = "B",
+                Varchar = "I",
+                Char_varying = "J",
+                Character_varying = "K",
+                VarcharMax = "C",
+                Char_varyingMax = "Your",
+                Character_varyingMax = "strong",
+                Nchar = "D",
+                National_character = "E",
+                Nvarchar = "F",
+                National_char_varying = "G",
+                National_character_varying = "H",
+                NvarcharMax = "don't",
+                National_char_varyingMax = "help",
+                National_character_varyingMax = "anyone!",
+                // See Issue #4478
+                //Text = "Gumball Rules!",
+                //Ntext = "Gumball Rules OK!",
+                Binary = new byte[] { 86 },
+                Varbinary = new byte[] { 87 },
+                Binary_varying = new byte[] { 88 },
+                VarbinaryMax = new byte[] { 89, 90, 91, 92 },
+                Binary_varyingMax = new byte[] { 93, 94, 95, 96 },
+                // See Issue #4478
+                //Image = new byte[] { 97, 98, 99, 100 },
+                Decimal = 101.1m,
+                Dec = 102.2m,
+                Numeric = 103.3m
+            };
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_data_types_set_to_null_with_identity()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<MappedNullableDataTypesWithIdentity>().Add(new MappedNullableDataTypesWithIdentity { Int = 78 });
+
+                Assert.Equal(1, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                AssertNullMappedNullableDataTypesWithIdentity(context.Set<MappedNullableDataTypesWithIdentity>().Single(e => e.Int == 78), 78);
+            }
+        }
+
+        private static void AssertNullMappedNullableDataTypesWithIdentity(MappedNullableDataTypesWithIdentity entity, int id)
+        {
+            Assert.Equal(id, entity.Int);
+            Assert.Null(entity.Bigint);
+            Assert.Null(entity.Smallint);
+            Assert.Null(entity.Tinyint);
+            Assert.Null(entity.Bit);
+            Assert.Null(entity.Money);
+            Assert.Null(entity.Smallmoney);
+            Assert.Null(entity.Float);
+            Assert.Null(entity.Real);
+            Assert.Null(entity.Double_precision);
+            Assert.Null(entity.Date);
+            Assert.Null(entity.Datetimeoffset);
+            Assert.Null(entity.Datetime2);
+            Assert.Null(entity.Smalldatetime);
+            Assert.Null(entity.Datetime);
+            Assert.Null(entity.Time);
+            Assert.Null(entity.Char);
+            Assert.Null(entity.Character);
+            Assert.Null(entity.VarcharMax);
+            Assert.Null(entity.Char_varyingMax);
+            Assert.Null(entity.Character_varyingMax);
+            Assert.Null(entity.Nchar);
+            Assert.Null(entity.National_character);
+            Assert.Null(entity.Nvarchar);
+            Assert.Null(entity.National_char_varying);
+            Assert.Null(entity.National_character_varying);
+            Assert.Null(entity.NvarcharMax);
+            Assert.Null(entity.National_char_varyingMax);
+            Assert.Null(entity.National_character_varyingMax);
+            // See Issue #4478
+            //Assert.Null(entity.Text);
+            //Assert.Null(entity.Ntext);
+            Assert.Null(entity.Binary);
+            Assert.Null(entity.Varbinary);
+            Assert.Null(entity.Binary_varying);
+            Assert.Null(entity.VarbinaryMax);
+            Assert.Null(entity.Binary_varyingMax);
+            // See Issue #4478
+            //Assert.Null(entity.Image);
+            Assert.Null(entity.Decimal);
+            Assert.Null(entity.Dec);
+            Assert.Null(entity.Numeric);
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_sized_data_types_with_identity()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<MappedSizedDataTypesWithIdentity>().Add(CreateMappedSizedDataTypesWithIdentity(77));
+
+                Assert.Equal(1, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                AssertMappedSizedDataTypesWithIdentity(context.Set<MappedSizedDataTypesWithIdentity>().Single(e => e.Int == 77), 77);
+            }
+        }
+
+        private static void AssertMappedSizedDataTypesWithIdentity(MappedSizedDataTypesWithIdentity entity, int id)
+        {
+            Assert.Equal(id, entity.Int);
+            Assert.Equal("Wor", entity.Char);
+            Assert.Equal("Lon", entity.Character);
+            Assert.Equal("Tha", entity.Varchar);
+            Assert.Equal("Thr", entity.Char_varying);
+            Assert.Equal("Let", entity.Character_varying);
+            Assert.Equal("Won", entity.Nchar);
+            Assert.Equal("Squ", entity.National_character);
+            Assert.Equal("Int", entity.Nvarchar);
+            Assert.Equal("The", entity.National_char_varying);
+            Assert.Equal("Col", entity.National_character_varying);
+            Assert.Equal(new byte[] { 10, 11, 12 }, entity.Binary);
+            Assert.Equal(new byte[] { 11, 12, 13 }, entity.Varbinary);
+            Assert.Equal(new byte[] { 12, 13, 14 }, entity.Binary_varying);
+        }
+
+        private static MappedSizedDataTypesWithIdentity CreateMappedSizedDataTypesWithIdentity(int id)
+            => new MappedSizedDataTypesWithIdentity
+            {
+                Int = id,
+                Char = "Wor",
+                Character = "Lon",
+                Varchar = "Tha",
+                Char_varying = "Thr",
+                Character_varying = "Let",
+                Nchar = "Won",
+                National_character = "Squ",
+                Nvarchar = "Int",
+                National_char_varying = "The",
+                National_character_varying = "Col",
+                Binary = new byte[] { 10, 11, 12 },
+                Varbinary = new byte[] { 11, 12, 13 },
+                Binary_varying = new byte[] { 12, 13, 14 }
+            };
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_nulls_for_all_mapped_sized_data_types_with_identity()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<MappedSizedDataTypesWithIdentity>().Add(new MappedSizedDataTypesWithIdentity { Int = 78 });
+
+                Assert.Equal(1, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                AssertNullMappedSizedDataTypesWithIdentity(context.Set<MappedSizedDataTypesWithIdentity>().Single(e => e.Int == 78), 78);
+            }
+        }
+
+        private static void AssertNullMappedSizedDataTypesWithIdentity(MappedSizedDataTypesWithIdentity entity, int id)
+        {
+            Assert.Equal(id, entity.Int);
+            Assert.Null(entity.Char);
+            Assert.Null(entity.Character);
+            Assert.Null(entity.Varchar);
+            Assert.Null(entity.Char_varying);
+            Assert.Null(entity.Character_varying);
+            Assert.Null(entity.Nchar);
+            Assert.Null(entity.National_character);
+            Assert.Null(entity.Nvarchar);
+            Assert.Null(entity.National_char_varying);
+            Assert.Null(entity.National_character_varying);
+            Assert.Null(entity.Binary);
+            Assert.Null(entity.Varbinary);
+            Assert.Null(entity.Binary_varying);
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_data_types_with_scale_with_identity()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<MappedScaledDataTypesWithIdentity>().Add(CreateMappedScaledDataTypesWithIdentity(77));
+
+                Assert.Equal(1, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                AssertMappedScaledDataTypesWithIdentity(context.Set<MappedScaledDataTypesWithIdentity>().Single(e => e.Int == 77), 77);
+            }
+        }
+
+        private static void AssertMappedScaledDataTypesWithIdentity(MappedScaledDataTypesWithIdentity entity, int id)
+        {
+            Assert.Equal(id, entity.Int);
+            Assert.Equal(83.3f, entity.Float);
+            Assert.Equal(85.5f, entity.Double_precision);
+            Assert.Equal(new DateTimeOffset(new DateTime(2016, 1, 2, 11, 11, 12), TimeSpan.Zero), entity.Datetimeoffset);
+            Assert.Equal(new DateTime(2017, 1, 2, 12, 11, 12), entity.Datetime2);
+            Assert.Equal(101m, entity.Decimal);
+            Assert.Equal(102m, entity.Dec);
+            Assert.Equal(103m, entity.Numeric);
+        }
+
+        private static MappedScaledDataTypesWithIdentity CreateMappedScaledDataTypesWithIdentity(int id)
+            => new MappedScaledDataTypesWithIdentity
+            {
+                Int = id,
+                Float = 83.3f,
+                Double_precision = 85.5f,
+                Datetimeoffset = new DateTimeOffset(new DateTime(2016, 1, 2, 11, 11, 12), TimeSpan.Zero),
+                Datetime2 = new DateTime(2017, 1, 2, 12, 11, 12),
+                Decimal = 101.1m,
+                Dec = 102.2m,
+                Numeric = 103.3m
+            };
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_data_types_with_precision_and_scale_with_identity()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<MappedPrecisionAndScaledDataTypesWithIdentity>().Add(
+                    CreateMappedPrecisionAndScaledDataTypesWithIdentity(77));
+
+                Assert.Equal(1, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                AssertMappedPrecisionAndScaledDataTypesWithIdentity(
+                    context.Set<MappedPrecisionAndScaledDataTypesWithIdentity>().Single(e => e.Int == 77), 77);
+            }
+        }
+
+        private static void AssertMappedPrecisionAndScaledDataTypesWithIdentity(MappedPrecisionAndScaledDataTypesWithIdentity entity, int id)
+        {
+            Assert.Equal(id, entity.Int);
+            Assert.Equal(101.1m, entity.Decimal);
+            Assert.Equal(102.2m, entity.Dec);
+            Assert.Equal(103.3m, entity.Numeric);
+        }
+
+        private static MappedPrecisionAndScaledDataTypesWithIdentity CreateMappedPrecisionAndScaledDataTypesWithIdentity(int id)
+            => new MappedPrecisionAndScaledDataTypesWithIdentity
+            {
+                Int = id,
+                Decimal = 101.1m,
+                Dec = 102.2m,
+                Numeric = 103.3m
+            };
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_data_types_in_batch()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<MappedDataTypes>().Add(CreateMappedDataTypes(177));
+                context.Set<MappedDataTypes>().Add(CreateMappedDataTypes(178));
+                context.Set<MappedDataTypes>().Add(CreateMappedDataTypes(179));
+
+                Assert.Equal(3, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                AssertMappedDataTypes(context.Set<MappedDataTypes>().Single(e => e.Int == 177), 177);
+                AssertMappedDataTypes(context.Set<MappedDataTypes>().Single(e => e.Int == 178), 178);
+                AssertMappedDataTypes(context.Set<MappedDataTypes>().Single(e => e.Int == 179), 179);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_nullable_data_types_in_batch()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<MappedNullableDataTypes>().Add(CreateMappedNullableDataTypes(177));
+                context.Set<MappedNullableDataTypes>().Add(CreateMappedNullableDataTypes(178));
+                context.Set<MappedNullableDataTypes>().Add(CreateMappedNullableDataTypes(179));
+
+                Assert.Equal(3, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                AssertMappedNullableDataTypes(context.Set<MappedNullableDataTypes>().Single(e => e.Int == 177), 177);
+                AssertMappedNullableDataTypes(context.Set<MappedNullableDataTypes>().Single(e => e.Int == 178), 178);
+                AssertMappedNullableDataTypes(context.Set<MappedNullableDataTypes>().Single(e => e.Int == 179), 179);
+            }
+        }
+
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_data_types_set_to_null_in_batch()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<MappedNullableDataTypes>().Add(new MappedNullableDataTypes { Int = 278 });
+                context.Set<MappedNullableDataTypes>().Add(new MappedNullableDataTypes { Int = 279 });
+                context.Set<MappedNullableDataTypes>().Add(new MappedNullableDataTypes { Int = 280 });
+
+                Assert.Equal(3, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                AssertNullMappedNullableDataTypes(context.Set<MappedNullableDataTypes>().Single(e => e.Int == 278), 278);
+                AssertNullMappedNullableDataTypes(context.Set<MappedNullableDataTypes>().Single(e => e.Int == 279), 279);
+                AssertNullMappedNullableDataTypes(context.Set<MappedNullableDataTypes>().Single(e => e.Int == 280), 280);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_sized_data_types_in_batch()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<MappedSizedDataTypes>().Add(CreateMappedSizedDataTypes(177));
+                context.Set<MappedSizedDataTypes>().Add(CreateMappedSizedDataTypes(178));
+                context.Set<MappedSizedDataTypes>().Add(CreateMappedSizedDataTypes(179));
+
+                Assert.Equal(3, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                AssertMappedSizedDataTypes(context.Set<MappedSizedDataTypes>().Single(e => e.Id == 177), 177);
+                AssertMappedSizedDataTypes(context.Set<MappedSizedDataTypes>().Single(e => e.Id == 178), 178);
+                AssertMappedSizedDataTypes(context.Set<MappedSizedDataTypes>().Single(e => e.Id == 179), 179);
+            }
+        }
+
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_nulls_for_all_mapped_sized_data_types_in_batch()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<MappedSizedDataTypes>().Add(new MappedSizedDataTypes { Id = 278 });
+                context.Set<MappedSizedDataTypes>().Add(new MappedSizedDataTypes { Id = 279 });
+                context.Set<MappedSizedDataTypes>().Add(new MappedSizedDataTypes { Id = 280 });
+
+                Assert.Equal(3, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                AssertNullMappedSizedDataTypes(context.Set<MappedSizedDataTypes>().Single(e => e.Id == 278), 278);
+                AssertNullMappedSizedDataTypes(context.Set<MappedSizedDataTypes>().Single(e => e.Id == 279), 279);
+                AssertNullMappedSizedDataTypes(context.Set<MappedSizedDataTypes>().Single(e => e.Id == 280), 280);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_data_types_with_scale_in_batch()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<MappedScaledDataTypes>().Add(CreateMappedScaledDataTypes(177));
+                context.Set<MappedScaledDataTypes>().Add(CreateMappedScaledDataTypes(178));
+                context.Set<MappedScaledDataTypes>().Add(CreateMappedScaledDataTypes(179));
+
+                Assert.Equal(3, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                AssertMappedScaledDataTypes(context.Set<MappedScaledDataTypes>().Single(e => e.Id == 177), 177);
+                AssertMappedScaledDataTypes(context.Set<MappedScaledDataTypes>().Single(e => e.Id == 178), 178);
+                AssertMappedScaledDataTypes(context.Set<MappedScaledDataTypes>().Single(e => e.Id == 179), 179);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_data_types_with_precision_and_scale_in_batch()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<MappedPrecisionAndScaledDataTypes>().Add(CreateMappedPrecisionAndScaledDataTypes(177));
+                context.Set<MappedPrecisionAndScaledDataTypes>().Add(CreateMappedPrecisionAndScaledDataTypes(178));
+                context.Set<MappedPrecisionAndScaledDataTypes>().Add(CreateMappedPrecisionAndScaledDataTypes(179));
+
+                Assert.Equal(3, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                AssertMappedPrecisionAndScaledDataTypes(context.Set<MappedPrecisionAndScaledDataTypes>().Single(e => e.Id == 177), 177);
+                AssertMappedPrecisionAndScaledDataTypes(context.Set<MappedPrecisionAndScaledDataTypes>().Single(e => e.Id == 178), 178);
+                AssertMappedPrecisionAndScaledDataTypes(context.Set<MappedPrecisionAndScaledDataTypes>().Single(e => e.Id == 179), 179);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_data_types_with_identity_in_batch()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<MappedDataTypesWithIdentity>().Add(CreateMappedDataTypesWithIdentity(177));
+                context.Set<MappedDataTypesWithIdentity>().Add(CreateMappedDataTypesWithIdentity(178));
+                context.Set<MappedDataTypesWithIdentity>().Add(CreateMappedDataTypesWithIdentity(179));
+
+                Assert.Equal(3, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                AssertMappedDataTypesWithIdentity(context.Set<MappedDataTypesWithIdentity>().Single(e => e.Int == 177), 177);
+                AssertMappedDataTypesWithIdentity(context.Set<MappedDataTypesWithIdentity>().Single(e => e.Int == 178), 178);
+                AssertMappedDataTypesWithIdentity(context.Set<MappedDataTypesWithIdentity>().Single(e => e.Int == 179), 179);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_nullable_data_types_with_identity_in_batch()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<MappedNullableDataTypesWithIdentity>().Add(CreateMappedNullableDataTypesWithIdentity(177));
+                context.Set<MappedNullableDataTypesWithIdentity>().Add(CreateMappedNullableDataTypesWithIdentity(178));
+                context.Set<MappedNullableDataTypesWithIdentity>().Add(CreateMappedNullableDataTypesWithIdentity(179));
+
+                Assert.Equal(3, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                AssertMappedNullableDataTypesWithIdentity(context.Set<MappedNullableDataTypesWithIdentity>().Single(e => e.Int == 177), 177);
+                AssertMappedNullableDataTypesWithIdentity(context.Set<MappedNullableDataTypesWithIdentity>().Single(e => e.Int == 178), 178);
+                AssertMappedNullableDataTypesWithIdentity(context.Set<MappedNullableDataTypesWithIdentity>().Single(e => e.Int == 179), 179);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_data_types_set_to_null_with_identity_in_batch_in_batch()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<MappedNullableDataTypesWithIdentity>().Add(new MappedNullableDataTypesWithIdentity { Int = 278 });
+                context.Set<MappedNullableDataTypesWithIdentity>().Add(new MappedNullableDataTypesWithIdentity { Int = 279 });
+                context.Set<MappedNullableDataTypesWithIdentity>().Add(new MappedNullableDataTypesWithIdentity { Int = 280 });
+
+                Assert.Equal(3, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                AssertNullMappedNullableDataTypesWithIdentity(context.Set<MappedNullableDataTypesWithIdentity>().Single(e => e.Int == 278), 278);
+                AssertNullMappedNullableDataTypesWithIdentity(context.Set<MappedNullableDataTypesWithIdentity>().Single(e => e.Int == 279), 279);
+                AssertNullMappedNullableDataTypesWithIdentity(context.Set<MappedNullableDataTypesWithIdentity>().Single(e => e.Int == 280), 280);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_sized_data_types_with_identity_in_batch()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<MappedSizedDataTypesWithIdentity>().Add(CreateMappedSizedDataTypesWithIdentity(177));
+                context.Set<MappedSizedDataTypesWithIdentity>().Add(CreateMappedSizedDataTypesWithIdentity(178));
+                context.Set<MappedSizedDataTypesWithIdentity>().Add(CreateMappedSizedDataTypesWithIdentity(179));
+
+                Assert.Equal(3, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                AssertMappedSizedDataTypesWithIdentity(context.Set<MappedSizedDataTypesWithIdentity>().Single(e => e.Int == 177), 177);
+                AssertMappedSizedDataTypesWithIdentity(context.Set<MappedSizedDataTypesWithIdentity>().Single(e => e.Int == 178), 178);
+                AssertMappedSizedDataTypesWithIdentity(context.Set<MappedSizedDataTypesWithIdentity>().Single(e => e.Int == 179), 179);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_nulls_for_all_mapped_sized_data_types_with_identity_in_batch()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<MappedSizedDataTypesWithIdentity>().Add(new MappedSizedDataTypesWithIdentity { Int = 278 });
+                context.Set<MappedSizedDataTypesWithIdentity>().Add(new MappedSizedDataTypesWithIdentity { Int = 279 });
+                context.Set<MappedSizedDataTypesWithIdentity>().Add(new MappedSizedDataTypesWithIdentity { Int = 280 });
+
+                Assert.Equal(3, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                AssertNullMappedSizedDataTypesWithIdentity(context.Set<MappedSizedDataTypesWithIdentity>().Single(e => e.Int == 278), 278);
+                AssertNullMappedSizedDataTypesWithIdentity(context.Set<MappedSizedDataTypesWithIdentity>().Single(e => e.Int == 279), 279);
+                AssertNullMappedSizedDataTypesWithIdentity(context.Set<MappedSizedDataTypesWithIdentity>().Single(e => e.Int == 280), 280);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_data_types_with_scale_with_identity_in_batch()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<MappedScaledDataTypesWithIdentity>().Add(CreateMappedScaledDataTypesWithIdentity(177));
+                context.Set<MappedScaledDataTypesWithIdentity>().Add(CreateMappedScaledDataTypesWithIdentity(178));
+                context.Set<MappedScaledDataTypesWithIdentity>().Add(CreateMappedScaledDataTypesWithIdentity(179));
+
+                Assert.Equal(3, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                AssertMappedScaledDataTypesWithIdentity(context.Set<MappedScaledDataTypesWithIdentity>().Single(e => e.Int == 177), 177);
+                AssertMappedScaledDataTypesWithIdentity(context.Set<MappedScaledDataTypesWithIdentity>().Single(e => e.Int == 178), 178);
+                AssertMappedScaledDataTypesWithIdentity(context.Set<MappedScaledDataTypesWithIdentity>().Single(e => e.Int == 179), 179);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_data_types_with_precision_and_scale_with_identity_in_batch()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<MappedPrecisionAndScaledDataTypesWithIdentity>().Add(CreateMappedPrecisionAndScaledDataTypesWithIdentity(177));
+                context.Set<MappedPrecisionAndScaledDataTypesWithIdentity>().Add(CreateMappedPrecisionAndScaledDataTypesWithIdentity(178));
+                context.Set<MappedPrecisionAndScaledDataTypesWithIdentity>().Add(CreateMappedPrecisionAndScaledDataTypesWithIdentity(179));
+
+                Assert.Equal(3, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                AssertMappedPrecisionAndScaledDataTypesWithIdentity(
+                    context.Set<MappedPrecisionAndScaledDataTypesWithIdentity>().Single(e => e.Int == 177), 177);
+                AssertMappedPrecisionAndScaledDataTypesWithIdentity(
+                    context.Set<MappedPrecisionAndScaledDataTypesWithIdentity>().Single(e => e.Int == 178), 178);
+                AssertMappedPrecisionAndScaledDataTypesWithIdentity(
+                    context.Set<MappedPrecisionAndScaledDataTypesWithIdentity>().Single(e => e.Int == 179), 179);
             }
         }
 
@@ -939,6 +1707,47 @@ MappedDataTypes.Varbinary ---> [varbinary] [MaxLength = 1]
 MappedDataTypes.VarbinaryMax ---> [varbinary] [MaxLength = -1]
 MappedDataTypes.Varchar ---> [varchar] [MaxLength = 1]
 MappedDataTypes.VarcharMax ---> [varchar] [MaxLength = -1]
+MappedDataTypesWithIdentity.Bigint ---> [bigint] [Precision = 19 Scale = 0]
+MappedDataTypesWithIdentity.Binary ---> [nullable binary] [MaxLength = 1]
+MappedDataTypesWithIdentity.Binary_varying ---> [nullable varbinary] [MaxLength = 1]
+MappedDataTypesWithIdentity.Binary_varyingMax ---> [nullable varbinary] [MaxLength = -1]
+MappedDataTypesWithIdentity.Bit ---> [bit]
+MappedDataTypesWithIdentity.Char ---> [nullable char] [MaxLength = 1]
+MappedDataTypesWithIdentity.Char_varying ---> [nullable varchar] [MaxLength = 1]
+MappedDataTypesWithIdentity.Char_varyingMax ---> [nullable varchar] [MaxLength = -1]
+MappedDataTypesWithIdentity.Character ---> [nullable char] [MaxLength = 1]
+MappedDataTypesWithIdentity.Character_varying ---> [nullable varchar] [MaxLength = 1]
+MappedDataTypesWithIdentity.Character_varyingMax ---> [nullable varchar] [MaxLength = -1]
+MappedDataTypesWithIdentity.Date ---> [date] [Precision = 0]
+MappedDataTypesWithIdentity.Datetime ---> [datetime] [Precision = 3]
+MappedDataTypesWithIdentity.Datetime2 ---> [datetime2] [Precision = 7]
+MappedDataTypesWithIdentity.Datetimeoffset ---> [datetimeoffset] [Precision = 7]
+MappedDataTypesWithIdentity.Dec ---> [decimal] [Precision = 18 Scale = 0]
+MappedDataTypesWithIdentity.Decimal ---> [decimal] [Precision = 18 Scale = 0]
+MappedDataTypesWithIdentity.Double_precision ---> [float] [Precision = 53]
+MappedDataTypesWithIdentity.Float ---> [float] [Precision = 53]
+MappedDataTypesWithIdentity.Id ---> [int] [Precision = 10 Scale = 0]
+MappedDataTypesWithIdentity.Int ---> [int] [Precision = 10 Scale = 0]
+MappedDataTypesWithIdentity.Money ---> [money] [Precision = 19 Scale = 4]
+MappedDataTypesWithIdentity.National_char_varying ---> [nullable nvarchar] [MaxLength = 1]
+MappedDataTypesWithIdentity.National_char_varyingMax ---> [nullable nvarchar] [MaxLength = -1]
+MappedDataTypesWithIdentity.National_character ---> [nullable nchar] [MaxLength = 1]
+MappedDataTypesWithIdentity.National_character_varying ---> [nullable nvarchar] [MaxLength = 1]
+MappedDataTypesWithIdentity.National_character_varyingMax ---> [nullable nvarchar] [MaxLength = -1]
+MappedDataTypesWithIdentity.Nchar ---> [nullable nchar] [MaxLength = 1]
+MappedDataTypesWithIdentity.Numeric ---> [numeric] [Precision = 18 Scale = 0]
+MappedDataTypesWithIdentity.Nvarchar ---> [nullable nvarchar] [MaxLength = 1]
+MappedDataTypesWithIdentity.NvarcharMax ---> [nullable nvarchar] [MaxLength = -1]
+MappedDataTypesWithIdentity.Real ---> [real] [Precision = 24]
+MappedDataTypesWithIdentity.Smalldatetime ---> [smalldatetime] [Precision = 0]
+MappedDataTypesWithIdentity.Smallint ---> [smallint] [Precision = 5 Scale = 0]
+MappedDataTypesWithIdentity.Smallmoney ---> [smallmoney] [Precision = 10 Scale = 4]
+MappedDataTypesWithIdentity.Time ---> [time] [Precision = 7]
+MappedDataTypesWithIdentity.Tinyint ---> [tinyint] [Precision = 3 Scale = 0]
+MappedDataTypesWithIdentity.Varbinary ---> [nullable varbinary] [MaxLength = 1]
+MappedDataTypesWithIdentity.VarbinaryMax ---> [nullable varbinary] [MaxLength = -1]
+MappedDataTypesWithIdentity.Varchar ---> [nullable varchar] [MaxLength = 1]
+MappedDataTypesWithIdentity.VarcharMax ---> [nullable varchar] [MaxLength = -1]
 MappedNullableDataTypes.Bigint ---> [nullable bigint] [Precision = 19 Scale = 0]
 MappedNullableDataTypes.Binary ---> [nullable binary] [MaxLength = 1]
 MappedNullableDataTypes.Binary_varying ---> [nullable varbinary] [MaxLength = 1]
@@ -982,10 +1791,56 @@ MappedNullableDataTypes.Varbinary ---> [nullable varbinary] [MaxLength = 1]
 MappedNullableDataTypes.VarbinaryMax ---> [nullable varbinary] [MaxLength = -1]
 MappedNullableDataTypes.Varchar ---> [nullable varchar] [MaxLength = 1]
 MappedNullableDataTypes.VarcharMax ---> [nullable varchar] [MaxLength = -1]
+MappedNullableDataTypesWithIdentity.Bigint ---> [nullable bigint] [Precision = 19 Scale = 0]
+MappedNullableDataTypesWithIdentity.Binary ---> [nullable binary] [MaxLength = 1]
+MappedNullableDataTypesWithIdentity.Binary_varying ---> [nullable varbinary] [MaxLength = 1]
+MappedNullableDataTypesWithIdentity.Binary_varyingMax ---> [nullable varbinary] [MaxLength = -1]
+MappedNullableDataTypesWithIdentity.Bit ---> [nullable bit]
+MappedNullableDataTypesWithIdentity.Char ---> [nullable char] [MaxLength = 1]
+MappedNullableDataTypesWithIdentity.Char_varying ---> [nullable varchar] [MaxLength = 1]
+MappedNullableDataTypesWithIdentity.Char_varyingMax ---> [nullable varchar] [MaxLength = -1]
+MappedNullableDataTypesWithIdentity.Character ---> [nullable char] [MaxLength = 1]
+MappedNullableDataTypesWithIdentity.Character_varying ---> [nullable varchar] [MaxLength = 1]
+MappedNullableDataTypesWithIdentity.Character_varyingMax ---> [nullable varchar] [MaxLength = -1]
+MappedNullableDataTypesWithIdentity.Date ---> [nullable date] [Precision = 0]
+MappedNullableDataTypesWithIdentity.Datetime ---> [nullable datetime] [Precision = 3]
+MappedNullableDataTypesWithIdentity.Datetime2 ---> [nullable datetime2] [Precision = 7]
+MappedNullableDataTypesWithIdentity.Datetimeoffset ---> [nullable datetimeoffset] [Precision = 7]
+MappedNullableDataTypesWithIdentity.Dec ---> [nullable decimal] [Precision = 18 Scale = 0]
+MappedNullableDataTypesWithIdentity.Decimal ---> [nullable decimal] [Precision = 18 Scale = 0]
+MappedNullableDataTypesWithIdentity.Double_precision ---> [nullable float] [Precision = 53]
+MappedNullableDataTypesWithIdentity.Float ---> [nullable float] [Precision = 53]
+MappedNullableDataTypesWithIdentity.Id ---> [int] [Precision = 10 Scale = 0]
+MappedNullableDataTypesWithIdentity.Int ---> [nullable int] [Precision = 10 Scale = 0]
+MappedNullableDataTypesWithIdentity.Money ---> [nullable money] [Precision = 19 Scale = 4]
+MappedNullableDataTypesWithIdentity.National_char_varying ---> [nullable nvarchar] [MaxLength = 1]
+MappedNullableDataTypesWithIdentity.National_char_varyingMax ---> [nullable nvarchar] [MaxLength = -1]
+MappedNullableDataTypesWithIdentity.National_character ---> [nullable nchar] [MaxLength = 1]
+MappedNullableDataTypesWithIdentity.National_character_varying ---> [nullable nvarchar] [MaxLength = 1]
+MappedNullableDataTypesWithIdentity.National_character_varyingMax ---> [nullable nvarchar] [MaxLength = -1]
+MappedNullableDataTypesWithIdentity.Nchar ---> [nullable nchar] [MaxLength = 1]
+MappedNullableDataTypesWithIdentity.Numeric ---> [nullable numeric] [Precision = 18 Scale = 0]
+MappedNullableDataTypesWithIdentity.Nvarchar ---> [nullable nvarchar] [MaxLength = 1]
+MappedNullableDataTypesWithIdentity.NvarcharMax ---> [nullable nvarchar] [MaxLength = -1]
+MappedNullableDataTypesWithIdentity.Real ---> [nullable real] [Precision = 24]
+MappedNullableDataTypesWithIdentity.Smalldatetime ---> [nullable smalldatetime] [Precision = 0]
+MappedNullableDataTypesWithIdentity.Smallint ---> [nullable smallint] [Precision = 5 Scale = 0]
+MappedNullableDataTypesWithIdentity.Smallmoney ---> [nullable smallmoney] [Precision = 10 Scale = 4]
+MappedNullableDataTypesWithIdentity.Time ---> [nullable time] [Precision = 7]
+MappedNullableDataTypesWithIdentity.Tinyint ---> [nullable tinyint] [Precision = 3 Scale = 0]
+MappedNullableDataTypesWithIdentity.Varbinary ---> [nullable varbinary] [MaxLength = 1]
+MappedNullableDataTypesWithIdentity.VarbinaryMax ---> [nullable varbinary] [MaxLength = -1]
+MappedNullableDataTypesWithIdentity.Varchar ---> [nullable varchar] [MaxLength = 1]
+MappedNullableDataTypesWithIdentity.VarcharMax ---> [nullable varchar] [MaxLength = -1]
 MappedPrecisionAndScaledDataTypes.Dec ---> [decimal] [Precision = 5 Scale = 2]
 MappedPrecisionAndScaledDataTypes.Decimal ---> [decimal] [Precision = 5 Scale = 2]
 MappedPrecisionAndScaledDataTypes.Id ---> [int] [Precision = 10 Scale = 0]
 MappedPrecisionAndScaledDataTypes.Numeric ---> [numeric] [Precision = 5 Scale = 2]
+MappedPrecisionAndScaledDataTypesWithIdentity.Dec ---> [decimal] [Precision = 5 Scale = 2]
+MappedPrecisionAndScaledDataTypesWithIdentity.Decimal ---> [decimal] [Precision = 5 Scale = 2]
+MappedPrecisionAndScaledDataTypesWithIdentity.Id ---> [int] [Precision = 10 Scale = 0]
+MappedPrecisionAndScaledDataTypesWithIdentity.Int ---> [int] [Precision = 10 Scale = 0]
+MappedPrecisionAndScaledDataTypesWithIdentity.Numeric ---> [numeric] [Precision = 5 Scale = 2]
 MappedScaledDataTypes.Datetime2 ---> [datetime2] [Precision = 3]
 MappedScaledDataTypes.Datetimeoffset ---> [datetimeoffset] [Precision = 3]
 MappedScaledDataTypes.Dec ---> [decimal] [Precision = 3 Scale = 0]
@@ -994,6 +1849,15 @@ MappedScaledDataTypes.Double_precision ---> [real] [Precision = 24]
 MappedScaledDataTypes.Float ---> [real] [Precision = 24]
 MappedScaledDataTypes.Id ---> [int] [Precision = 10 Scale = 0]
 MappedScaledDataTypes.Numeric ---> [numeric] [Precision = 3 Scale = 0]
+MappedScaledDataTypesWithIdentity.Datetime2 ---> [datetime2] [Precision = 3]
+MappedScaledDataTypesWithIdentity.Datetimeoffset ---> [datetimeoffset] [Precision = 3]
+MappedScaledDataTypesWithIdentity.Dec ---> [decimal] [Precision = 3 Scale = 0]
+MappedScaledDataTypesWithIdentity.Decimal ---> [decimal] [Precision = 3 Scale = 0]
+MappedScaledDataTypesWithIdentity.Double_precision ---> [real] [Precision = 24]
+MappedScaledDataTypesWithIdentity.Float ---> [real] [Precision = 24]
+MappedScaledDataTypesWithIdentity.Id ---> [int] [Precision = 10 Scale = 0]
+MappedScaledDataTypesWithIdentity.Int ---> [int] [Precision = 10 Scale = 0]
+MappedScaledDataTypesWithIdentity.Numeric ---> [numeric] [Precision = 3 Scale = 0]
 MappedSizedDataTypes.Binary ---> [nullable binary] [MaxLength = 3]
 MappedSizedDataTypes.Binary_varying ---> [nullable varbinary] [MaxLength = 3]
 MappedSizedDataTypes.Char ---> [nullable char] [MaxLength = 3]
@@ -1008,6 +1872,21 @@ MappedSizedDataTypes.Nchar ---> [nullable nchar] [MaxLength = 3]
 MappedSizedDataTypes.Nvarchar ---> [nullable nvarchar] [MaxLength = 3]
 MappedSizedDataTypes.Varbinary ---> [nullable varbinary] [MaxLength = 3]
 MappedSizedDataTypes.Varchar ---> [nullable varchar] [MaxLength = 3]
+MappedSizedDataTypesWithIdentity.Binary ---> [nullable binary] [MaxLength = 3]
+MappedSizedDataTypesWithIdentity.Binary_varying ---> [nullable varbinary] [MaxLength = 3]
+MappedSizedDataTypesWithIdentity.Char ---> [nullable char] [MaxLength = 3]
+MappedSizedDataTypesWithIdentity.Char_varying ---> [nullable varchar] [MaxLength = 3]
+MappedSizedDataTypesWithIdentity.Character ---> [nullable char] [MaxLength = 3]
+MappedSizedDataTypesWithIdentity.Character_varying ---> [nullable varchar] [MaxLength = 3]
+MappedSizedDataTypesWithIdentity.Id ---> [int] [Precision = 10 Scale = 0]
+MappedSizedDataTypesWithIdentity.Int ---> [int] [Precision = 10 Scale = 0]
+MappedSizedDataTypesWithIdentity.National_char_varying ---> [nullable nvarchar] [MaxLength = 3]
+MappedSizedDataTypesWithIdentity.National_character ---> [nullable nchar] [MaxLength = 3]
+MappedSizedDataTypesWithIdentity.National_character_varying ---> [nullable nvarchar] [MaxLength = 3]
+MappedSizedDataTypesWithIdentity.Nchar ---> [nullable nchar] [MaxLength = 3]
+MappedSizedDataTypesWithIdentity.Nvarchar ---> [nullable nvarchar] [MaxLength = 3]
+MappedSizedDataTypesWithIdentity.Varbinary ---> [nullable varbinary] [MaxLength = 3]
+MappedSizedDataTypesWithIdentity.Varchar ---> [nullable varchar] [MaxLength = 3]
 MaxLengthDataTypes.ByteArray5 ---> [nullable varbinary] [MaxLength = 5]
 MaxLengthDataTypes.ByteArray9000 ---> [nullable varbinary] [MaxLength = -1]
 MaxLengthDataTypes.Id ---> [int] [Precision = 10 Scale = 0]

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/BuiltInDataTypesSqliteFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/BuiltInDataTypesSqliteFixture.cs
@@ -49,6 +49,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
 
             modelBuilder.Entity<MappedDataTypes>(b =>
                 {
+                    b.Property(e => e.Id).ValueGeneratedNever();
                     b.Property(e => e.Integer).HasColumnType("Integer");
                     b.Property(e => e.Real).HasColumnType("Real");
                     b.Property(e => e.Text).HasColumnType("Text").IsRequired();
@@ -59,6 +60,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
 
             modelBuilder.Entity<MappedNullableDataTypes>(b =>
                 {
+                    b.Property(e => e.Id).ValueGeneratedNever();
                     b.Property(e => e.Integer).HasColumnType("Integer");
                     b.Property(e => e.Real).HasColumnType("Real");
                     b.Property(e => e.Text).HasColumnType("Text");
@@ -69,19 +71,64 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
 
             modelBuilder.Entity<MappedSizedDataTypes>(b =>
                 {
+                    b.Property(e => e.Id).ValueGeneratedNever();
                     b.Property(e => e.Nvarchar).HasColumnType("nvarchar(3)");
                     b.Property(e => e.Binary).HasColumnType("varbinary(3)");
                 });
 
             modelBuilder.Entity<MappedScaledDataTypes>(b =>
                 {
+                    b.Property(e => e.Id).ValueGeneratedNever();
                     b.Property(e => e.Float).HasColumnType("real(3)");
                     b.Property(e => e.Datetimeoffset).HasColumnType("datetimeoffset(3)");
                     b.Property(e => e.Datetime2).HasColumnType("datetime2(3)");
                     b.Property(e => e.Decimal).HasColumnType("decimal(3)");
                 });
 
-            modelBuilder.Entity<MappedPrecisionAndScaledDataTypes>(b => { b.Property(e => e.Decimal).HasColumnType("decimal(5, 2)"); });
+            modelBuilder.Entity<MappedPrecisionAndScaledDataTypes>(b =>
+                {
+                    b.Property(e => e.Id).ValueGeneratedNever();
+                    b.Property(e => e.Decimal).HasColumnType("decimal(5, 2)");
+                });
+
+            modelBuilder.Entity<MappedDataTypesWithIdentity>(b =>
+            {
+                b.Property(e => e.Integer).HasColumnType("Integer");
+                b.Property(e => e.Real).HasColumnType("Real");
+                b.Property(e => e.Text).HasColumnType("Text").IsRequired();
+                b.Property(e => e.Blob).HasColumnType("Blob").IsRequired();
+                b.Property(e => e.SomeString).HasColumnType("SomeString").IsRequired();
+                b.Property(e => e.Int).HasColumnType("Int");
+            });
+
+            modelBuilder.Entity<MappedNullableDataTypesWithIdentity>(b =>
+            {
+                b.Property(e => e.Integer).HasColumnType("Integer");
+                b.Property(e => e.Real).HasColumnType("Real");
+                b.Property(e => e.Text).HasColumnType("Text");
+                b.Property(e => e.Blob).HasColumnType("Blob");
+                b.Property(e => e.SomeString).HasColumnType("SomeString");
+                b.Property(e => e.Int).HasColumnType("Int");
+            });
+
+            modelBuilder.Entity<MappedSizedDataTypesWithIdentity>(b =>
+            {
+                b.Property(e => e.Nvarchar).HasColumnType("nvarchar(3)");
+                b.Property(e => e.Binary).HasColumnType("varbinary(3)");
+            });
+
+            modelBuilder.Entity<MappedScaledDataTypesWithIdentity>(b =>
+            {
+                b.Property(e => e.Float).HasColumnType("real(3)");
+                b.Property(e => e.Datetimeoffset).HasColumnType("datetimeoffset(3)");
+                b.Property(e => e.Datetime2).HasColumnType("datetime2(3)");
+                b.Property(e => e.Decimal).HasColumnType("decimal(3)");
+            });
+
+            modelBuilder.Entity<MappedPrecisionAndScaledDataTypesWithIdentity>(b =>
+            {
+                b.Property(e => e.Decimal).HasColumnType("decimal(5, 2)");
+            });
         }
 
         public override void Dispose() => _testStore.Dispose();
@@ -127,6 +174,55 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
     public class MappedNullableDataTypes
     {
         public int Id { get; set; }
+        public long? Integer { get; set; }
+        public double? Real { get; set; }
+        public string Text { get; set; }
+        public byte[] Blob { get; set; }
+        public string SomeString { get; set; }
+        public int? Int { get; set; }
+    }
+
+    public class MappedDataTypesWithIdentity
+    {
+        public int Id { get; set; }
+        public int AltId { get; set; }
+        public long Integer { get; set; }
+        public double Real { get; set; }
+        public string Text { get; set; }
+        public byte[] Blob { get; set; }
+        public string SomeString { get; set; }
+        public int Int { get; set; }
+    }
+
+    public class MappedSizedDataTypesWithIdentity
+    {
+        public int Id { get; set; }
+        public int AltId { get; set; }
+        public string Nvarchar { get; set; }
+        public byte[] Binary { get; set; }
+    }
+
+    public class MappedScaledDataTypesWithIdentity
+    {
+        public int Id { get; set; }
+        public int AltId { get; set; }
+        public float Float { get; set; }
+        public DateTimeOffset Datetimeoffset { get; set; }
+        public DateTime Datetime2 { get; set; }
+        public decimal Decimal { get; set; }
+    }
+
+    public class MappedPrecisionAndScaledDataTypesWithIdentity
+    {
+        public int Id { get; set; }
+        public int AltId { get; set; }
+        public decimal Decimal { get; set; }
+    }
+
+    public class MappedNullableDataTypesWithIdentity
+    {
+        public int Id { get; set; }
+        public int AltId { get; set; }
         public long? Integer { get; set; }
         public double? Real { get; set; }
         public string Text { get; set; }

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/BuiltInDataTypesSqliteTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/BuiltInDataTypesSqliteTest.cs
@@ -20,92 +20,102 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
         {
             using (var context = CreateContext())
             {
-                context.Set<MappedDataTypes>().Add(
-                    new MappedDataTypes
-                    {
-                        Id = 66,
-                        Int = 77,
-                        Integer = 78L,
-                        Real = 84.4,
-                        SomeString = "don't",
-                        Text = "G",
-                        Blob = new byte[] { 86 }
-                    });
+                context.Set<MappedDataTypes>().Add(CreateMappedDataTypes(66));
 
                 Assert.Equal(1, context.SaveChanges());
             }
 
             using (var context = CreateContext())
             {
-                var entity = context.Set<MappedDataTypes>().Single(e => e.Id == 66);
-
-                Assert.Equal(77, entity.Int);
-                Assert.Equal(78L, entity.Integer);
-                Assert.Equal(84.4, entity.Real);
-                Assert.Equal("don't", entity.SomeString);
-                Assert.Equal("G", entity.Text);
-                Assert.Equal(new byte[] { 86 }, entity.Blob);
+                AssertMappedDataTypes(context.Set<MappedDataTypes>().Single(e => e.Id == 66), 66);
             }
         }
+
+        private static void AssertMappedDataTypes(MappedDataTypes entity, int id)
+        {
+            Assert.Equal(id, entity.Id);
+            Assert.Equal(78L, entity.Integer);
+            Assert.Equal(84.4, entity.Real);
+            Assert.Equal("don't", entity.SomeString);
+            Assert.Equal("G", entity.Text);
+            Assert.Equal(new byte[] { 86 }, entity.Blob);
+        }
+
+        private static MappedDataTypes CreateMappedDataTypes(int id)
+            => new MappedDataTypes
+            {
+                Id = id,
+                Int = 77,
+                Integer = 78L,
+                Real = 84.4,
+                SomeString = "don't",
+                Text = "G",
+                Blob = new byte[] { 86 }
+            };
 
         [Fact]
         public virtual void Can_insert_and_read_back_all_mapped_nullable_data_types()
         {
             using (var context = CreateContext())
             {
-                context.Set<MappedNullableDataTypes>().Add(
-                    new MappedNullableDataTypes
-                    {
-                        Id = 69,
-                        Int = 77,
-                        Integer = 78L,
-                        Real = 84.4,
-                        SomeString = "don't",
-                        Text = "G",
-                        Blob = new byte[] { 86 }
-                    });
+                context.Set<MappedNullableDataTypes>().Add(CreateMappedNullableDataTypes(69));
 
                 Assert.Equal(1, context.SaveChanges());
             }
 
             using (var context = CreateContext())
             {
-                var entity = context.Set<MappedNullableDataTypes>().Single(e => e.Id == 69);
-
-                Assert.Equal(77, entity.Int);
-                Assert.Equal(78L, entity.Integer);
-                Assert.Equal(84.4, entity.Real);
-                Assert.Equal("don't", entity.SomeString);
-                Assert.Equal("G", entity.Text);
-                Assert.Equal(new byte[] { 86 }, entity.Blob);
+                AssertMappedNullableDataTypes(context.Set<MappedNullableDataTypes>().Single(e => e.Id == 69), 69);
             }
         }
+
+        private static void AssertMappedNullableDataTypes(MappedNullableDataTypes entity, int id)
+        {
+            Assert.Equal(id, entity.Id);
+            Assert.Equal(78L, entity.Integer);
+            Assert.Equal(84.4, entity.Real);
+            Assert.Equal("don't", entity.SomeString);
+            Assert.Equal("G", entity.Text);
+            Assert.Equal(new byte[] { 86 }, entity.Blob);
+        }
+
+        private static MappedNullableDataTypes CreateMappedNullableDataTypes(int id)
+            => new MappedNullableDataTypes
+            {
+                Id = id,
+                Int = 77,
+                Integer = 78L,
+                Real = 84.4,
+                SomeString = "don't",
+                Text = "G",
+                Blob = new byte[] { 86 }
+            };
 
         [Fact]
         public virtual void Can_insert_and_read_back_all_mapped_data_types_set_to_null()
         {
             using (var context = CreateContext())
             {
-                context.Set<MappedNullableDataTypes>().Add(
-                    new MappedNullableDataTypes
-                    {
-                        Id = 78
-                    });
+                context.Set<MappedNullableDataTypes>().Add(new MappedNullableDataTypes { Id = 78 });
 
                 Assert.Equal(1, context.SaveChanges());
             }
 
             using (var context = CreateContext())
             {
-                var entity = context.Set<MappedNullableDataTypes>().Single(e => e.Id == 78);
-
-                Assert.Null(entity.Integer);
-                Assert.Null(entity.Real);
-                Assert.Null(entity.Text);
-                Assert.Null(entity.SomeString);
-                Assert.Null(entity.Blob);
-                Assert.Null(entity.Int);
+                AssertNullMappedNullableDataTypes(context.Set<MappedNullableDataTypes>().Single(e => e.Id == 78), 78);
             }
+        }
+
+        private static void AssertNullMappedNullableDataTypes(MappedNullableDataTypes entity, int id)
+        {
+            Assert.Equal(id, entity.Id);
+            Assert.Null(entity.Integer);
+            Assert.Null(entity.Real);
+            Assert.Null(entity.Text);
+            Assert.Null(entity.SomeString);
+            Assert.Null(entity.Blob);
+            Assert.Null(entity.Int);
         }
 
         [Fact]
@@ -115,47 +125,53 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
 
             using (var context = CreateContext())
             {
-                context.Set<MappedSizedDataTypes>().Add(
-                    new MappedSizedDataTypes
-                    {
-                        Id = 77,
-                        Nvarchar = "Into",
-                        Binary = new byte[] { 10, 11, 12, 13 }
-                    });
+                context.Set<MappedSizedDataTypes>().Add(CreateMappedSizedDataTypes(77));
 
                 Assert.Equal(1, context.SaveChanges());
             }
 
             using (var context = CreateContext())
             {
-                var entity = context.Set<MappedSizedDataTypes>().Single(e => e.Id == 77);
-
-                Assert.Equal("Into", entity.Nvarchar);
-                Assert.Equal(new byte[] { 10, 11, 12, 13 }, entity.Binary);
+                AssertMappedSizedDataTypes(context.Set<MappedSizedDataTypes>().Single(e => e.Id == 77), 77);
             }
         }
+
+        private static void AssertMappedSizedDataTypes(MappedSizedDataTypes entity, int id)
+        {
+            Assert.Equal(id, entity.Id);
+            Assert.Equal("Into", entity.Nvarchar);
+            Assert.Equal(new byte[] { 10, 11, 12, 13 }, entity.Binary);
+        }
+
+        private static MappedSizedDataTypes CreateMappedSizedDataTypes(int id)
+            => new MappedSizedDataTypes
+            {
+                Id = id,
+                Nvarchar = "Into",
+                Binary = new byte[] { 10, 11, 12, 13 }
+            };
 
         [Fact]
         public virtual void Can_insert_and_read_back_nulls_for_all_mapped_sized_data_types()
         {
             using (var context = CreateContext())
             {
-                context.Set<MappedSizedDataTypes>().Add(
-                    new MappedSizedDataTypes
-                    {
-                        Id = 78
-                    });
+                context.Set<MappedSizedDataTypes>().Add(new MappedSizedDataTypes { Id = 78 });
 
                 Assert.Equal(1, context.SaveChanges());
             }
 
             using (var context = CreateContext())
             {
-                var entity = context.Set<MappedSizedDataTypes>().Single(e => e.Id == 78);
-
-                Assert.Null(entity.Nvarchar);
-                Assert.Null(entity.Binary);
+                AssertNullMappedSizedDataTypes(context.Set<MappedSizedDataTypes>().Single(e => e.Id == 78), 78);
             }
+        }
+
+        private static void AssertNullMappedSizedDataTypes(MappedSizedDataTypes entity, int id)
+        {
+            Assert.Equal(id, entity.Id);
+            Assert.Null(entity.Nvarchar);
+            Assert.Null(entity.Binary);
         }
 
         [Fact]
@@ -165,29 +181,35 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
 
             using (var context = CreateContext())
             {
-                context.Set<MappedScaledDataTypes>().Add(
-                    new MappedScaledDataTypes
-                    {
-                        Id = 77,
-                        Float = 83.3f,
-                        Datetimeoffset = new DateTimeOffset(new DateTime(2016, 1, 2, 11, 11, 12), TimeSpan.Zero),
-                        Datetime2 = new DateTime(2017, 1, 2, 12, 11, 12),
-                        Decimal = 101.1m
-                    });
+                context.Set<MappedScaledDataTypes>().Add(CreateMappedScaledDataTypes(77));
 
                 Assert.Equal(1, context.SaveChanges());
             }
 
             using (var context = CreateContext())
             {
-                var entity = context.Set<MappedScaledDataTypes>().Single(e => e.Id == 77);
-
-                Assert.Equal(83.3f, entity.Float);
-                Assert.Equal(new DateTimeOffset(new DateTime(2016, 1, 2, 11, 11, 12), TimeSpan.Zero), entity.Datetimeoffset);
-                Assert.Equal(new DateTime(2017, 1, 2, 12, 11, 12), entity.Datetime2);
-                Assert.Equal(101.1m, entity.Decimal);
+                AssertMappedScaledDataTypes(context.Set<MappedScaledDataTypes>().Single(e => e.Id == 77), 77);
             }
         }
+
+        private static void AssertMappedScaledDataTypes(MappedScaledDataTypes entity, int id)
+        {
+            Assert.Equal(id, entity.Id);
+            Assert.Equal(83.3f, entity.Float);
+            Assert.Equal(new DateTimeOffset(new DateTime(2016, 1, 2, 11, 11, 12), TimeSpan.Zero), entity.Datetimeoffset);
+            Assert.Equal(new DateTime(2017, 1, 2, 12, 11, 12), entity.Datetime2);
+            Assert.Equal(101.1m, entity.Decimal);
+        }
+
+        private static MappedScaledDataTypes CreateMappedScaledDataTypes(int id)
+            => new MappedScaledDataTypes
+            {
+                Id = id,
+                Float = 83.3f,
+                Datetimeoffset = new DateTimeOffset(new DateTime(2016, 1, 2, 11, 11, 12), TimeSpan.Zero),
+                Datetime2 = new DateTime(2017, 1, 2, 12, 11, 12),
+                Decimal = 101.1m
+            };
 
         [Fact]
         public virtual void Can_insert_and_read_back_all_mapped_data_types_with_precision_and_scale()
@@ -210,6 +232,562 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
             {
                 var entity = context.Set<MappedPrecisionAndScaledDataTypes>().Single(e => e.Id == 77);
 
+                Assert.Equal(101.1m, entity.Decimal);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_data_types_with_Identity()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<MappedDataTypesWithIdentity>().Add(CreateMappedDataTypesWithIdentity(66));
+
+                Assert.Equal(1, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                AssertMappedDataTypesWithIdentity(context.Set<MappedDataTypesWithIdentity>().Single(e => e.AltId == 66), 66);
+            }
+        }
+
+        private static void AssertMappedDataTypesWithIdentity(MappedDataTypesWithIdentity entity, int id)
+        {
+            Assert.Equal(id, entity.AltId);
+            Assert.Equal(78L, entity.Integer);
+            Assert.Equal(84.4, entity.Real);
+            Assert.Equal("don't", entity.SomeString);
+            Assert.Equal("G", entity.Text);
+            Assert.Equal(new byte[] { 86 }, entity.Blob);
+        }
+
+        private static MappedDataTypesWithIdentity CreateMappedDataTypesWithIdentity(int id)
+            => new MappedDataTypesWithIdentity
+            {
+                AltId = id,
+                Int = 77,
+                Integer = 78L,
+                Real = 84.4,
+                SomeString = "don't",
+                Text = "G",
+                Blob = new byte[] { 86 }
+            };
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_nullable_data_types_with_Identity()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<MappedNullableDataTypesWithIdentity>().Add(CreateMappedNullableDataTypesWithIdentity(69));
+
+                Assert.Equal(1, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                AssertMappedNullableDataTypesWithIdentity(context.Set<MappedNullableDataTypesWithIdentity>().Single(e => e.AltId == 69), 69);
+            }
+        }
+
+        private static void AssertMappedNullableDataTypesWithIdentity(MappedNullableDataTypesWithIdentity entity, int id)
+        {
+            Assert.Equal(id, entity.AltId);
+            Assert.Equal(78L, entity.Integer);
+            Assert.Equal(84.4, entity.Real);
+            Assert.Equal("don't", entity.SomeString);
+            Assert.Equal("G", entity.Text);
+            Assert.Equal(new byte[] { 86 }, entity.Blob);
+        }
+
+        private static MappedNullableDataTypesWithIdentity CreateMappedNullableDataTypesWithIdentity(int id)
+            => new MappedNullableDataTypesWithIdentity
+            {
+                AltId = id,
+                Int = 77,
+                Integer = 78L,
+                Real = 84.4,
+                SomeString = "don't",
+                Text = "G",
+                Blob = new byte[] { 86 }
+            };
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_data_types_set_to_null_with_Identity()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<MappedNullableDataTypesWithIdentity>().Add(new MappedNullableDataTypesWithIdentity { AltId = 78 });
+
+                Assert.Equal(1, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                AssertNullMappedNullableDataTypesWithIdentity(context.Set<MappedNullableDataTypesWithIdentity>().Single(e => e.AltId == 78), 78);
+            }
+        }
+
+        private static void AssertNullMappedNullableDataTypesWithIdentity(MappedNullableDataTypesWithIdentity entity, int id)
+        {
+            Assert.Equal(id, entity.AltId);
+            Assert.Null(entity.Integer);
+            Assert.Null(entity.Real);
+            Assert.Null(entity.Text);
+            Assert.Null(entity.SomeString);
+            Assert.Null(entity.Blob);
+            Assert.Null(entity.Int);
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_sized_data_types_with_Identity()
+        {
+            // Size expected to be ignored, but everything should still work
+
+            using (var context = CreateContext())
+            {
+                context.Set<MappedSizedDataTypesWithIdentity>().Add(CreateMappedSizedDataTypesWithIdentity(77));
+
+                Assert.Equal(1, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                AssertMappedSizedDataTypesWithIdentity(context.Set<MappedSizedDataTypesWithIdentity>().Single(e => e.AltId == 77), 77);
+            }
+        }
+
+        private static void AssertMappedSizedDataTypesWithIdentity(MappedSizedDataTypesWithIdentity entity, int id)
+        {
+            Assert.Equal(id, entity.AltId);
+            Assert.Equal("Into", entity.Nvarchar);
+            Assert.Equal(new byte[] { 10, 11, 12, 13 }, entity.Binary);
+        }
+
+        private static MappedSizedDataTypesWithIdentity CreateMappedSizedDataTypesWithIdentity(int id)
+            => new MappedSizedDataTypesWithIdentity
+            {
+                AltId = id,
+                Nvarchar = "Into",
+                Binary = new byte[] { 10, 11, 12, 13 }
+            };
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_nulls_for_all_mapped_sized_data_types_with_Identity()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<MappedSizedDataTypesWithIdentity>().Add(new MappedSizedDataTypesWithIdentity { AltId = 78 });
+
+                Assert.Equal(1, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                AssertNullMappedSizedDataTypesWithIdentity(context.Set<MappedSizedDataTypesWithIdentity>().Single(e => e.AltId == 78), 78);
+            }
+        }
+
+        private static void AssertNullMappedSizedDataTypesWithIdentity(MappedSizedDataTypesWithIdentity entity, int id)
+        {
+            Assert.Equal(id, entity.AltId);
+            Assert.Null(entity.Nvarchar);
+            Assert.Null(entity.Binary);
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_data_types_with_scale_with_Identity()
+        {
+            // Scale expected to be ignored, but everything should still work
+
+            using (var context = CreateContext())
+            {
+                context.Set<MappedScaledDataTypesWithIdentity>().Add(CreateMappedScaledDataTypesWithIdentity(77));
+
+                Assert.Equal(1, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                AssertMappedScaledDataTypesWithIdentity(context.Set<MappedScaledDataTypesWithIdentity>().Single(e => e.AltId == 77), 77);
+            }
+        }
+
+        private static void AssertMappedScaledDataTypesWithIdentity(MappedScaledDataTypesWithIdentity entity, int id)
+        {
+            Assert.Equal(id, entity.AltId);
+            Assert.Equal(83.3f, entity.Float);
+            Assert.Equal(new DateTimeOffset(new DateTime(2016, 1, 2, 11, 11, 12), TimeSpan.Zero), entity.Datetimeoffset);
+            Assert.Equal(new DateTime(2017, 1, 2, 12, 11, 12), entity.Datetime2);
+            Assert.Equal(101.1m, entity.Decimal);
+        }
+
+        private static MappedScaledDataTypesWithIdentity CreateMappedScaledDataTypesWithIdentity(int id)
+            => new MappedScaledDataTypesWithIdentity
+            {
+                AltId = id,
+                Float = 83.3f,
+                Datetimeoffset = new DateTimeOffset(new DateTime(2016, 1, 2, 11, 11, 12), TimeSpan.Zero),
+                Datetime2 = new DateTime(2017, 1, 2, 12, 11, 12),
+                Decimal = 101.1m
+            };
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_data_types_with_precision_and_scale_with_Identity()
+        {
+            // Precision and scale expected to be ignored, but everything should still work
+
+            using (var context = CreateContext())
+            {
+                context.Set<MappedPrecisionAndScaledDataTypesWithIdentity>().Add(
+                    new MappedPrecisionAndScaledDataTypesWithIdentity
+                    {
+                        AltId = 77,
+                        Decimal = 101.1m
+                    });
+
+                Assert.Equal(1, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                var entity = context.Set<MappedPrecisionAndScaledDataTypesWithIdentity>().Single(e => e.AltId == 77);
+
+                Assert.Equal(101.1m, entity.Decimal);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_data_types_in_batch()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<MappedDataTypes>().Add(CreateMappedDataTypes(166));
+                context.Set<MappedDataTypes>().Add(CreateMappedDataTypes(167));
+                context.Set<MappedDataTypes>().Add(CreateMappedDataTypes(168));
+
+                Assert.Equal(3, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                AssertMappedDataTypes(context.Set<MappedDataTypes>().Single(e => e.Id == 166), 166);
+                AssertMappedDataTypes(context.Set<MappedDataTypes>().Single(e => e.Id == 167), 167);
+                AssertMappedDataTypes(context.Set<MappedDataTypes>().Single(e => e.Id == 168), 168);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_nullable_data_types_in_batch()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<MappedNullableDataTypes>().Add(CreateMappedNullableDataTypes(169));
+                context.Set<MappedNullableDataTypes>().Add(CreateMappedNullableDataTypes(170));
+                context.Set<MappedNullableDataTypes>().Add(CreateMappedNullableDataTypes(171));
+
+                Assert.Equal(3, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                AssertMappedNullableDataTypes(context.Set<MappedNullableDataTypes>().Single(e => e.Id == 169), 169);
+                AssertMappedNullableDataTypes(context.Set<MappedNullableDataTypes>().Single(e => e.Id == 170), 170);
+                AssertMappedNullableDataTypes(context.Set<MappedNullableDataTypes>().Single(e => e.Id == 171), 171);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_data_types_set_to_null_in_batch()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<MappedNullableDataTypes>().Add(new MappedNullableDataTypes { Id = 278 });
+                context.Set<MappedNullableDataTypes>().Add(new MappedNullableDataTypes { Id = 279 });
+                context.Set<MappedNullableDataTypes>().Add(new MappedNullableDataTypes { Id = 280 });
+
+                Assert.Equal(3, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                AssertNullMappedNullableDataTypes(context.Set<MappedNullableDataTypes>().Single(e => e.Id == 278), 278);
+                AssertNullMappedNullableDataTypes(context.Set<MappedNullableDataTypes>().Single(e => e.Id == 279), 279);
+                AssertNullMappedNullableDataTypes(context.Set<MappedNullableDataTypes>().Single(e => e.Id == 280), 280);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_sized_data_types_in_batch()
+        {
+            // Size expected to be ignored, but everything should still work
+
+            using (var context = CreateContext())
+            {
+                context.Set<MappedSizedDataTypes>().Add(CreateMappedSizedDataTypes(177));
+                context.Set<MappedSizedDataTypes>().Add(CreateMappedSizedDataTypes(178));
+                context.Set<MappedSizedDataTypes>().Add(CreateMappedSizedDataTypes(179));
+
+                Assert.Equal(3, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                AssertMappedSizedDataTypes(context.Set<MappedSizedDataTypes>().Single(e => e.Id == 177), 177);
+                AssertMappedSizedDataTypes(context.Set<MappedSizedDataTypes>().Single(e => e.Id == 178), 178);
+                AssertMappedSizedDataTypes(context.Set<MappedSizedDataTypes>().Single(e => e.Id == 179), 179);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_nulls_for_all_mapped_sized_data_types_in_batch()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<MappedSizedDataTypes>().Add(new MappedSizedDataTypes { Id = 278 });
+                context.Set<MappedSizedDataTypes>().Add(new MappedSizedDataTypes { Id = 279 });
+                context.Set<MappedSizedDataTypes>().Add(new MappedSizedDataTypes { Id = 280 });
+
+                Assert.Equal(3, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                AssertNullMappedSizedDataTypes(context.Set<MappedSizedDataTypes>().Single(e => e.Id == 278), 278);
+                AssertNullMappedSizedDataTypes(context.Set<MappedSizedDataTypes>().Single(e => e.Id == 279), 279);
+                AssertNullMappedSizedDataTypes(context.Set<MappedSizedDataTypes>().Single(e => e.Id == 280), 280);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_data_types_with_scale_in_batch()
+        {
+            // Scale expected to be ignored, but everything should still work
+
+            using (var context = CreateContext())
+            {
+                context.Set<MappedScaledDataTypes>().Add(CreateMappedScaledDataTypes(177));
+                context.Set<MappedScaledDataTypes>().Add(CreateMappedScaledDataTypes(178));
+                context.Set<MappedScaledDataTypes>().Add(CreateMappedScaledDataTypes(179));
+
+                Assert.Equal(3, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                AssertMappedScaledDataTypes(context.Set<MappedScaledDataTypes>().Single(e => e.Id == 177), 177);
+                AssertMappedScaledDataTypes(context.Set<MappedScaledDataTypes>().Single(e => e.Id == 178), 178);
+                AssertMappedScaledDataTypes(context.Set<MappedScaledDataTypes>().Single(e => e.Id == 179), 179);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_data_types_with_precision_and_scale_in_batch()
+        {
+            // Precision and scale expected to be ignored, but everything should still work
+
+            using (var context = CreateContext())
+            {
+                context.Set<MappedPrecisionAndScaledDataTypes>().Add(
+                    new MappedPrecisionAndScaledDataTypes
+                    {
+                        Id = 177,
+                        Decimal = 101.1m
+                    });
+                context.Set<MappedPrecisionAndScaledDataTypes>().Add(
+                    new MappedPrecisionAndScaledDataTypes
+                    {
+                        Id = 178,
+                        Decimal = 101.1m
+                    });
+                context.Set<MappedPrecisionAndScaledDataTypes>().Add(
+                    new MappedPrecisionAndScaledDataTypes
+                    {
+                        Id = 179,
+                        Decimal = 101.1m
+                    });
+
+                Assert.Equal(3, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                var entity = context.Set<MappedPrecisionAndScaledDataTypes>().Single(e => e.Id == 177);
+
+                Assert.Equal(101.1m, entity.Decimal);
+
+                entity = context.Set<MappedPrecisionAndScaledDataTypes>().Single(e => e.Id == 178);
+
+                Assert.Equal(101.1m, entity.Decimal);
+
+                entity = context.Set<MappedPrecisionAndScaledDataTypes>().Single(e => e.Id == 179);
+
+                Assert.Equal(101.1m, entity.Decimal);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_data_types_with_Identity_in_batch()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<MappedDataTypesWithIdentity>().Add(CreateMappedDataTypesWithIdentity(166));
+                context.Set<MappedDataTypesWithIdentity>().Add(CreateMappedDataTypesWithIdentity(167));
+                context.Set<MappedDataTypesWithIdentity>().Add(CreateMappedDataTypesWithIdentity(168));
+
+                Assert.Equal(3, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                AssertMappedDataTypesWithIdentity(context.Set<MappedDataTypesWithIdentity>().Single(e => e.AltId == 166), 166);
+                AssertMappedDataTypesWithIdentity(context.Set<MappedDataTypesWithIdentity>().Single(e => e.AltId == 167), 167);
+                AssertMappedDataTypesWithIdentity(context.Set<MappedDataTypesWithIdentity>().Single(e => e.AltId == 168), 168);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_nullable_data_types_with_Identity_in_batch()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<MappedNullableDataTypesWithIdentity>().Add(CreateMappedNullableDataTypesWithIdentity(169));
+                context.Set<MappedNullableDataTypesWithIdentity>().Add(CreateMappedNullableDataTypesWithIdentity(170));
+                context.Set<MappedNullableDataTypesWithIdentity>().Add(CreateMappedNullableDataTypesWithIdentity(171));
+
+                Assert.Equal(3, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                AssertMappedNullableDataTypesWithIdentity(context.Set<MappedNullableDataTypesWithIdentity>().Single(e => e.AltId == 169), 169);
+                AssertMappedNullableDataTypesWithIdentity(context.Set<MappedNullableDataTypesWithIdentity>().Single(e => e.AltId == 170), 170);
+                AssertMappedNullableDataTypesWithIdentity(context.Set<MappedNullableDataTypesWithIdentity>().Single(e => e.AltId == 171), 171);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_data_types_set_to_null_with_Identity_in_batch()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<MappedNullableDataTypesWithIdentity>().Add(new MappedNullableDataTypesWithIdentity { AltId = 278 });
+                context.Set<MappedNullableDataTypesWithIdentity>().Add(new MappedNullableDataTypesWithIdentity { AltId = 279 });
+                context.Set<MappedNullableDataTypesWithIdentity>().Add(new MappedNullableDataTypesWithIdentity { AltId = 280 });
+
+                Assert.Equal(3, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                AssertNullMappedNullableDataTypesWithIdentity(context.Set<MappedNullableDataTypesWithIdentity>().Single(e => e.AltId == 278), 278);
+                AssertNullMappedNullableDataTypesWithIdentity(context.Set<MappedNullableDataTypesWithIdentity>().Single(e => e.AltId == 279), 279);
+                AssertNullMappedNullableDataTypesWithIdentity(context.Set<MappedNullableDataTypesWithIdentity>().Single(e => e.AltId == 280), 280);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_sized_data_types_with_Identity_in_batch()
+        {
+            // Size expected to be ignored, but everything should still work
+
+            using (var context = CreateContext())
+            {
+                context.Set<MappedSizedDataTypesWithIdentity>().Add(CreateMappedSizedDataTypesWithIdentity(177));
+                context.Set<MappedSizedDataTypesWithIdentity>().Add(CreateMappedSizedDataTypesWithIdentity(178));
+                context.Set<MappedSizedDataTypesWithIdentity>().Add(CreateMappedSizedDataTypesWithIdentity(179));
+
+                Assert.Equal(3, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                AssertMappedSizedDataTypesWithIdentity(context.Set<MappedSizedDataTypesWithIdentity>().Single(e => e.AltId == 177), 177);
+                AssertMappedSizedDataTypesWithIdentity(context.Set<MappedSizedDataTypesWithIdentity>().Single(e => e.AltId == 178), 178);
+                AssertMappedSizedDataTypesWithIdentity(context.Set<MappedSizedDataTypesWithIdentity>().Single(e => e.AltId == 179), 179);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_nulls_for_all_mapped_sized_data_types_with_Identity_in_batch()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<MappedSizedDataTypesWithIdentity>().Add(new MappedSizedDataTypesWithIdentity { AltId = 278 });
+                context.Set<MappedSizedDataTypesWithIdentity>().Add(new MappedSizedDataTypesWithIdentity { AltId = 279 });
+                context.Set<MappedSizedDataTypesWithIdentity>().Add(new MappedSizedDataTypesWithIdentity { AltId = 280 });
+
+                Assert.Equal(3, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                AssertNullMappedSizedDataTypesWithIdentity(context.Set<MappedSizedDataTypesWithIdentity>().Single(e => e.AltId == 278), 278);
+                AssertNullMappedSizedDataTypesWithIdentity(context.Set<MappedSizedDataTypesWithIdentity>().Single(e => e.AltId == 279), 279);
+                AssertNullMappedSizedDataTypesWithIdentity(context.Set<MappedSizedDataTypesWithIdentity>().Single(e => e.AltId == 280), 280);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_data_types_with_scale_with_Identity_in_batch()
+        {
+            // Scale expected to be ignored, but everything should still work
+
+            using (var context = CreateContext())
+            {
+                context.Set<MappedScaledDataTypesWithIdentity>().Add(CreateMappedScaledDataTypesWithIdentity(177));
+                context.Set<MappedScaledDataTypesWithIdentity>().Add(CreateMappedScaledDataTypesWithIdentity(178));
+                context.Set<MappedScaledDataTypesWithIdentity>().Add(CreateMappedScaledDataTypesWithIdentity(179));
+
+                Assert.Equal(3, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                AssertMappedScaledDataTypesWithIdentity(context.Set<MappedScaledDataTypesWithIdentity>().Single(e => e.AltId == 177), 177);
+                AssertMappedScaledDataTypesWithIdentity(context.Set<MappedScaledDataTypesWithIdentity>().Single(e => e.AltId == 178), 178);
+                AssertMappedScaledDataTypesWithIdentity(context.Set<MappedScaledDataTypesWithIdentity>().Single(e => e.AltId == 179), 179);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_mapped_data_types_with_precision_and_scale_with_Identity_in_batch()
+        {
+            // Precision and scale expected to be ignored, but everything should still work
+
+            using (var context = CreateContext())
+            {
+                context.Set<MappedPrecisionAndScaledDataTypesWithIdentity>().Add(
+                    new MappedPrecisionAndScaledDataTypesWithIdentity
+                    {
+                        AltId = 177,
+                        Decimal = 101.1m
+                    });
+                context.Set<MappedPrecisionAndScaledDataTypesWithIdentity>().Add(
+                    new MappedPrecisionAndScaledDataTypesWithIdentity
+                    {
+                        AltId = 178,
+                        Decimal = 101.1m
+                    });
+                context.Set<MappedPrecisionAndScaledDataTypesWithIdentity>().Add(
+                    new MappedPrecisionAndScaledDataTypesWithIdentity
+                    {
+                        AltId = 179,
+                        Decimal = 101.1m
+                    });
+
+                Assert.Equal(3, context.SaveChanges());
+            }
+
+            using (var context = CreateContext())
+            {
+                var entity = context.Set<MappedPrecisionAndScaledDataTypesWithIdentity>().Single(e => e.AltId == 177);
+                Assert.Equal(101.1m, entity.Decimal);
+
+                entity = context.Set<MappedPrecisionAndScaledDataTypesWithIdentity>().Single(e => e.AltId == 178);
+                Assert.Equal(101.1m, entity.Decimal);
+
+                entity = context.Set<MappedPrecisionAndScaledDataTypesWithIdentity>().Single(e => e.AltId == 179);
                 Assert.Equal(101.1m, entity.Decimal);
             }
         }


### PR DESCRIPTION
See Issue #4399

The issue was that the update pipeline was always asking the type mapper for the type to use even if a type had been explicitly set for the property. Fixed this and added tests for inserting all mapped types as both single inserts and multiple inserts both with and without Identity columns.