### PR TITLE
Improve RelationalExpressionPrinter to also print shaper lambdas. 

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/BufferedEntityShaper`.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/BufferedEntityShaper`.cs
@@ -18,8 +18,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             [NotNull] string entityType,
             bool trackingQuery,
             [NotNull] IKey key,
-            [NotNull] Func<ValueBuffer, object> materializer)
-            : base(querySource, entityType, trackingQuery, key, materializer)
+            [NotNull] Func<ValueBuffer, object> materializer,
+            [NotNull] string materializerString)
+            : base(querySource, entityType, trackingQuery, key, materializer, materializerString)
         {
         }
 
@@ -45,7 +46,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 EntityType,
                 IsTrackingQuery,
                 Key,
-                Materializer);
+                Materializer,
+                MaterializerString);
 
         public override EntityShaper WithOffset(int offset)
             => new BufferedOffsetEntityShaper<TEntity>(
@@ -53,7 +55,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 EntityType,
                 IsTrackingQuery,
                 Key,
-                Materializer)
+                Materializer,
+                MaterializerString)
                 .SetOffset(offset);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/BufferedOffsetEntityShaper.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/BufferedOffsetEntityShaper.cs
@@ -17,8 +17,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             [NotNull] string entityType,
             bool trackingQuery,
             [NotNull] IKey key,
-            [NotNull] Func<ValueBuffer, object> materializer)
-            : base(querySource, entityType, trackingQuery, key, materializer)
+            [NotNull] Func<ValueBuffer, object> materializer,
+            [NotNull] string materializerString)
+            : base(querySource, entityType, trackingQuery, key, materializer, materializerString)
         {
         }
 

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/EntityShaper.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/EntityShaper.cs
@@ -16,19 +16,22 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             [NotNull] string entityType,
             bool trackingQuery,
             [NotNull] IKey key,
-            [NotNull] Func<ValueBuffer, object> materializer)
+            [NotNull] Func<ValueBuffer, object> materializer,
+            [NotNull] string materializerString)
             : base(querySource)
         {
             IsTrackingQuery = trackingQuery;
             EntityType = entityType;
             Key = key;
             Materializer = materializer;
+            MaterializerString = materializerString;
         }
 
         protected virtual string EntityType { get; }
         protected virtual bool IsTrackingQuery { get; }
         protected virtual IKey Key { get; }
         protected virtual Func<ValueBuffer, object> Materializer { get; }
+        protected virtual string MaterializerString { get; }
         protected virtual bool AllowNullResult { get; private set; }
         protected virtual int ValueBufferOffset { get; private set; }
 

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/UnbufferedEntityShaper.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/UnbufferedEntityShaper.cs
@@ -17,8 +17,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             [NotNull] string entityType,
             bool trackingQuery,
             [NotNull] IKey key,
-            [NotNull] Func<ValueBuffer, object> materializer)
-            : base(querySource, entityType, trackingQuery, key, materializer)
+            [NotNull] Func<ValueBuffer, object> materializer,
+            [NotNull] string materializerString)
+            : base(querySource, entityType, trackingQuery, key, materializer, materializerString)
         {
         }
 
@@ -45,7 +46,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 EntityType,
                 IsTrackingQuery,
                 Key,
-                Materializer);
+                Materializer,
+                MaterializerString);
 
         public override EntityShaper WithOffset(int offset)
             => new UnbufferedOffsetEntityShaper<TEntity>(
@@ -53,7 +55,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 EntityType,
                 IsTrackingQuery,
                 Key,
-                Materializer)
+                Materializer,
+                MaterializerString)
                 .SetOffset(offset);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/UnbufferedOffsetEntityShaper.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/UnbufferedOffsetEntityShaper.cs
@@ -17,8 +17,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             [NotNull] string entityType,
             bool trackingQuery,
             [NotNull] IKey key,
-            [NotNull] Func<ValueBuffer, object> materializer)
-            : base(querySource, entityType, trackingQuery, key, materializer)
+            [NotNull] Func<ValueBuffer, object> materializer,
+            [NotNull] string materializerString)
+            : base(querySource, entityType, trackingQuery, key, materializer, materializerString)
         {
         }
 

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitorFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitorFactory.cs
@@ -19,25 +19,29 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
         private readonly IMaterializerFactory _materializerFactory;
         private readonly IShaperCommandContextFactory _shaperCommandContextFactory;
         private readonly IRelationalAnnotationProvider _relationalAnnotationProvider;
+        private readonly IExpressionPrinter _expressionPrinter;
 
         public RelationalEntityQueryableExpressionVisitorFactory(
             [NotNull] IModel model,
             [NotNull] ISelectExpressionFactory selectExpressionFactory,
             [NotNull] IMaterializerFactory materializerFactory,
             [NotNull] IShaperCommandContextFactory shaperCommandContextFactory,
-            [NotNull] IRelationalAnnotationProvider relationalAnnotationProvider)
+            [NotNull] IRelationalAnnotationProvider relationalAnnotationProvider,
+            [NotNull] IExpressionPrinter expressionPrinter)
         {
             Check.NotNull(model, nameof(model));
             Check.NotNull(selectExpressionFactory, nameof(selectExpressionFactory));
             Check.NotNull(materializerFactory, nameof(materializerFactory));
             Check.NotNull(shaperCommandContextFactory, nameof(shaperCommandContextFactory));
             Check.NotNull(relationalAnnotationProvider, nameof(relationalAnnotationProvider));
+            Check.NotNull(expressionPrinter, nameof(expressionPrinter));
 
             _model = model;
             _selectExpressionFactory = selectExpressionFactory;
             _materializerFactory = materializerFactory;
             _shaperCommandContextFactory = shaperCommandContextFactory;
             _relationalAnnotationProvider = relationalAnnotationProvider;
+            _expressionPrinter = expressionPrinter;
         }
 
         public virtual ExpressionVisitor Create(
@@ -48,6 +52,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                 _materializerFactory,
                 _shaperCommandContextFactory,
                 _relationalAnnotationProvider,
+                _expressionPrinter,
                 (RelationalQueryModelVisitor)Check.NotNull(queryModelVisitor, nameof(queryModelVisitor)),
                 querySource);
     }

--- a/src/Microsoft.EntityFrameworkCore/Query/Internal/ExpressionPrinter.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/Internal/ExpressionPrinter.cs
@@ -51,7 +51,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             var queryPlan = PostProcess(_stringBuilder.ToString());
 
-            var result = "TRACKED: " + TrackedQuery + Environment.NewLine;
+            var result = TrackedQuery ? "TRACKED: " + TrackedQuery + Environment.NewLine : string.Empty;
+
             result += queryPlan;
 
             return result;

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryLoggingSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryLoggingSqlServerTest.cs
@@ -83,7 +83,26 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             FROM [Customers] AS [c]
             ORDER BY [c].[CustomerID]
         , 
-        shaper: BufferedEntityShaper`1
+        shaper: BufferedEntityShaper<Customer>: 
+            materializer: 
+                (ValueBuffer valueBuffer) => 
+                {
+                    var var1
+                    var1 = new Customer()
+                    var1.CustomerID = (string) object valueBuffer.get_Item(0)
+                    var1.Address = (string) object valueBuffer.get_Item(1)
+                    var1.City = (string) object valueBuffer.get_Item(2)
+                    var1.CompanyName = (string) object valueBuffer.get_Item(3)
+                    var1.ContactName = (string) object valueBuffer.get_Item(4)
+                    var1.ContactTitle = (string) object valueBuffer.get_Item(5)
+                    var1.Country = (string) object valueBuffer.get_Item(6)
+                    var1.Fax = (string) object valueBuffer.get_Item(7)
+                    var1.Phone = (string) object valueBuffer.get_Item(8)
+                    var1.PostalCode = (string) object valueBuffer.get_Item(9)
+                    var1.Region = (string) object valueBuffer.get_Item(10)
+                    var1
+                }
+
     )
     , 
     entityAccessor: default(System.Func`2[FunctionalTests.TestModels.Northwind.Customer,System.Object]), 


### PR DESCRIPTION
Since the lambdas are compiled into the expression we are now producing a string representation for them before compiling, and store it in the shaper.