### PR TITLE
Handle private setters in ClrPropertySetterFactory #753

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrPropertySetterFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrPropertySetterFactory.cs
@@ -10,18 +10,31 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     {
         public override IClrPropertySetter Create(PropertyInfo property)
         {
-            // TODO: Handle case where there is not setter or setter is private on a base type
-            // Issue #753
-
             var types = new[] { property.DeclaringType, property.PropertyType };
+            
+            var type = property.PropertyType.IsNullableType() && property.PropertyType.UnwrapNullableType().GetTypeInfo().IsEnum
+                    ? typeof(NullableEnumClrPropertySetter<,,>).MakeGenericType(property.DeclaringType, property.PropertyType, property.PropertyType.UnwrapNullableType())
+                    : typeof(ClrPropertySetter<,>).MakeGenericType(types);
 
-            return (IClrPropertySetter)Activator.CreateInstance(
-                property.PropertyType.IsNullableType()
-                && property.PropertyType.UnwrapNullableType().GetTypeInfo().IsEnum
-                    ? typeof(NullableEnumClrPropertySetter<,,>).MakeGenericType(
-                        property.DeclaringType, property.PropertyType, property.PropertyType.UnwrapNullableType())
-                    : typeof(ClrPropertySetter<,>).MakeGenericType(types),
-                property.SetMethod.CreateDelegate(typeof(Action<,>).MakeGenericType(types)));
+            var setterProperty = property;
+            while (setterProperty.SetMethod == null)
+            {
+                setterProperty = setterProperty.DeclaringType.GetProperty(property.Name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                if(setterProperty.SetMethod != null)
+                {
+                    break;
+                }
+                else
+                {
+                    setterProperty = setterProperty.DeclaringType.GetTypeInfo().BaseType.GetProperty(property.Name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                    if(setterProperty == null)
+                    {
+                        throw new InvalidOperationException($"Could not find setter for property {property.Name}");
+                    }
+                }
+            }
+
+            return (IClrPropertySetter)Activator.CreateInstance(type, setterProperty.SetMethod.CreateDelegate(typeof(Action<,>).MakeGenericType(types)));
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/ClrPropertySetterFactoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/ClrPropertySetterFactoryTest.cs
@@ -122,6 +122,90 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Assert.Equal(Flag.Two, customer.OptionalFlag);
         }
 
+        [Fact]
+        public void Delegate_setter_can_set_on_virtual_privatesetter_property_override_singlebasetype()
+        {
+            var entityType = new Model().AddEntityType(typeof(ConcreteEntity1));
+            var property = entityType.AddProperty(typeof(ConcreteEntity1).GetProperty(nameof(ConcreteEntity1.VirtualPrivateProperty_Override)));
+            var entity = new ConcreteEntity1();
+
+            new ClrPropertySetterFactory().Create(property).SetClrValue(entity, 100);
+            Assert.Equal(100, entity.VirtualPrivateProperty_Override);
+        }
+
+        [Fact]
+        public void Delegate_setter_can_set_on_virtual_privatesetter_property_override_multiplebasetypes()
+        {
+            var entityType = new Model().AddEntityType(typeof(ConcreteEntity2));
+            var property = entityType.AddProperty(typeof(ConcreteEntity2).GetProperty(nameof(ConcreteEntity2.VirtualPrivateProperty_Override)));
+            var entity = new ConcreteEntity2();
+
+            new ClrPropertySetterFactory().Create(property).SetClrValue(entity, 100);
+            Assert.Equal(100, entity.VirtualPrivateProperty_Override);
+        }
+
+        [Fact]
+        public void Delegate_setter_can_set_on_virtual_privatesetter_property_no_override_singlebasetype()
+        {
+            var entityType = new Model().AddEntityType(typeof(ConcreteEntity1));
+            var property = entityType.AddProperty(typeof(ConcreteEntity1).GetProperty(nameof(ConcreteEntity1.VirtualPrivateProperty_NoOverride)));
+            var entity = new ConcreteEntity1();
+
+            new ClrPropertySetterFactory().Create(property).SetClrValue(entity, 100);
+            Assert.Equal(100, entity.VirtualPrivateProperty_NoOverride);
+        }
+
+        [Fact]
+        public void Delegate_setter_can_set_on_virtual_privatesetter_property_no_override_multiplebasetypes()
+        {
+            var entityType = new Model().AddEntityType(typeof(ConcreteEntity2));
+            var property = entityType.AddProperty(typeof(ConcreteEntity2).GetProperty(nameof(ConcreteEntity2.VirtualPrivateProperty_NoOverride)));
+            var entity = new ConcreteEntity2();
+
+            new ClrPropertySetterFactory().Create(property).SetClrValue(entity, 100);
+            Assert.Equal(100, entity.VirtualPrivateProperty_NoOverride);
+        }
+
+        [Fact]
+        public void Delegate_setter_can_set_on_privatesetter_property_singlebasetype()
+        {
+            var entityType = new Model().AddEntityType(typeof(ConcreteEntity1));
+            var property = entityType.AddProperty(typeof(ConcreteEntity1).GetProperty(nameof(ConcreteEntity1.PrivateProperty)));
+            var entity = new ConcreteEntity1();
+
+            new ClrPropertySetterFactory().Create(property).SetClrValue(entity, 100);
+            Assert.Equal(100, entity.PrivateProperty);
+        }
+
+        [Fact]
+        public void Delegate_setter_can_set_on_privatesetter_property_multiplebasetypes()
+        {
+            var entityType = new Model().AddEntityType(typeof(ConcreteEntity2));
+            var property = entityType.AddProperty(typeof(ConcreteEntity2).GetProperty(nameof(ConcreteEntity2.PrivateProperty)));
+            var entity = new ConcreteEntity2();
+
+            new ClrPropertySetterFactory().Create(property).SetClrValue(entity, 100);
+            Assert.Equal(100, entity.PrivateProperty);
+        }
+
+        [Fact]
+        public void Delegate_setter_throws_if_no_setter_found()
+        {
+            var entityType = new Model().AddEntityType(typeof(ConcreteEntity1));
+            var property = entityType.AddProperty(typeof(ConcreteEntity1).GetProperty(nameof(ConcreteEntity1.NoSetterProperty)));
+            var entity = new ConcreteEntity1();
+
+            Assert.Throws<InvalidOperationException>(() =>
+                new ClrPropertySetterFactory().Create(property));
+
+            entityType = new Model().AddEntityType(typeof(ConcreteEntity2));
+            property = entityType.AddProperty(typeof(ConcreteEntity2).GetProperty(nameof(ConcreteEntity2.NoSetterProperty)));
+            entity = new ConcreteEntity2();
+
+            Assert.Throws<InvalidOperationException>(() =>
+                new ClrPropertySetterFactory().Create(property));
+        }
+
         #region Fixture
 
         private enum Flag
@@ -132,11 +216,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         private class Customer
         {
-            public static readonly PropertyInfo IdProperty = typeof(Customer).GetProperty("Id");
-            public static readonly PropertyInfo OptionalIntProperty = typeof(Customer).GetProperty("OptionalInt");
-            public static readonly PropertyInfo ContentProperty = typeof(Customer).GetProperty("Content");
-            public static readonly PropertyInfo FlagProperty = typeof(Customer).GetProperty("Flag");
-            public static readonly PropertyInfo OptionalFlagProperty = typeof(Customer).GetProperty("OptionalFlag");
+            public static readonly PropertyInfo IdProperty = typeof(Customer).GetProperty(nameof(Id));
+            public static readonly PropertyInfo OptionalIntProperty = typeof(Customer).GetProperty(nameof(OptionalInt));
+            public static readonly PropertyInfo ContentProperty = typeof(Customer).GetProperty(nameof(Content));
+            public static readonly PropertyInfo FlagProperty = typeof(Customer).GetProperty(nameof(Flag));
+            public static readonly PropertyInfo OptionalFlagProperty = typeof(Customer).GetProperty(nameof(OptionalFlag));
 
             public int Id { get; set; }
             public string Content { get; set; }
@@ -145,6 +229,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             public Flag? OptionalFlag { get; set; }
         }
 
+        private class ConcreteEntity2 : ConcreteEntity1
+        {
+            public override int VirtualPrivateProperty_Override { get { return base.VirtualPrivateProperty_Override; } }
+        }
+
+        private class ConcreteEntity1 : BaseEntity
+        {
+            public override int VirtualPrivateProperty_Override { get { return base.VirtualPrivateProperty_Override; } }
+        }
+
+        private class BaseEntity
+        {
+            public virtual int VirtualPrivateProperty_Override { get; private set; }
+            public virtual int VirtualPrivateProperty_NoOverride { get; private set; }
+            public int PrivateProperty { get; private set; }
+            public int NoSetterProperty { get; }
+        }
         #endregion
     }
 }


### PR DESCRIPTION
This is a fix for issue #753 (Handle creating delegates for private setters on base types)

As described in the original issue:

_"Properties can be defined in a base type with a private setter and then overridden. In such cases the setter does not show up in the .NET Reflection metadata for the property in the derived type. We therefore need to use special code to go down the hierarchy and find the private setter on the base type so it can be mapped to a delegate and called."_

The fix checks if a setter method can be found on the `PropertyInfo` instance passed to `Create()`.
If the setter is null, we first check if the property is defined on the *DeclaringType* (This is the case, if the property is not virtual and not overwritten). If this is not successfull, the code walks down the inheritance hierarchy to check if the setter is declared on a base type instead. I have also added an additional `InvalidOperationException` (former: `NullReferenceException`), so that there is more context if no setter could be found at all.

I have added various test cases for handling both virtual and non-virtual properties with private setters, both cases with 2 layers of inheritance to verify the hierarchy walking code.

Happy to hear your feedback :)