### PR TITLE
Re-enable installation on net451

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/project.json
+++ b/src/Microsoft.EntityFrameworkCore.Relational/project.json
@@ -24,6 +24,9 @@
     "net451": {
       "frameworkAssemblies": {
         "System.Data": "",
+        "System.Diagnostics.Tracing": { "type": "build" },
+        "System.Runtime": { "type": "build" },
+        "System.Threading": { "type": "build" },
         "System.Transactions": ""
       }
     },

--- a/src/Microsoft.EntityFrameworkCore/project.json
+++ b/src/Microsoft.EntityFrameworkCore/project.json
@@ -14,7 +14,7 @@
     "Microsoft.Extensions.Caching.Memory": "1.0.0-*",
     "Microsoft.Extensions.DependencyInjection": "1.0.0-*",
     "Microsoft.Extensions.Logging": "1.0.0-*",
-    "Remotion.Linq": "2.0.1"
+    "Remotion.Linq": "2.0.2"
   },
   "compile": "..\\Shared\\*.cs",
   "namedResource": {
@@ -26,18 +26,7 @@
   "frameworks": {
     "net451": {
       "frameworkAssemblies": {
-        "System.Collections": "",
-        "System.ComponentModel.DataAnnotations": "",
-        "System.Diagnostics.Debug": "",
-        "System.Linq": "",
-        "System.Linq.Expressions": "",
-        "System.Linq.Queryable": "",
-        "System.ObjectModel": "",
-        "System.Reflection": "",
-        "System.Reflection.Extensions": "",
-        "System.Runtime": "",
-        "System.Runtime.Extensions": "",
-        "System.Threading": ""
+        "System.ComponentModel.DataAnnotations": ""
       }
     },
     "dotnet5.4": {

--- a/test/Microsoft.EntityFrameworkCore.FunctionalTests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.FunctionalTests/project.json
@@ -16,9 +16,17 @@
   "frameworks": {
     "net451": {
       "frameworkAssemblies": {
-        "System.Globalization": "",
-        "System.Text.RegularExpressions": "",
-        "System.Threading.Tasks": ""
+        "System.Collections": { "type": "build" },
+        "System.Diagnostics.Debug": { "type": "build" },
+        "System.Globalization": { "type": "build" },
+        "System.Linq": { "type": "build" },
+        "System.ObjectModel": { "type": "build" },
+        "System.Reflection": { "type": "build" },
+        "System.Reflection.Extensions": { "type": "build" },
+        "System.Runtime": { "type": "build" },
+        "System.Runtime.Extensions": { "type": "build" },
+        "System.Text.RegularExpressions": { "type": "build" },
+        "System.Threading.Tasks": { "type": "build" }
       }
     },
     "dnx451": {
@@ -27,15 +35,12 @@
         "System.Diagnostics.Debug": "",
         "System.Globalization": "",
         "System.Linq": "",
-        "System.Linq.Expressions": "",
-        "System.Linq.Queryable": "",
         "System.ObjectModel": "",
         "System.Reflection": "",
         "System.Reflection.Extensions": "",
         "System.Runtime": "",
         "System.Runtime.Extensions": "",
         "System.Text.RegularExpressions": "",
-        "System.Threading": "",
         "System.Threading.Tasks": ""
       },
       "dependencies": {

--- a/test/Microsoft.EntityFrameworkCore.Microbenchmarks.Core/project.json
+++ b/test/Microsoft.EntityFrameworkCore.Microbenchmarks.Core/project.json
@@ -23,8 +23,18 @@
         "xunit.runner.aspnet": "2.0.0-aspnet-*"
       },
       "frameworkAssemblies": {
+        "System.Collections": "",
         "System.Data": "",
-        "System.Reflection": ""
+        "System.Diagnostics.Debug": "",
+        "System.Globalization": "",
+        "System.Linq": "",
+        "System.ObjectModel": "",
+        "System.Reflection": "",
+        "System.Reflection.Extensions": "",
+        "System.Runtime": "",
+        "System.Runtime.Extensions": "",
+        "System.Text.RegularExpressions": "",
+        "System.Threading.Tasks": ""
       }
     }
   }

--- a/test/Microsoft.EntityFrameworkCore.Relational.Design.FunctionalTests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Design.FunctionalTests/project.json
@@ -13,24 +13,40 @@
   "frameworks": {
     "net451": {
       "frameworkAssemblies": {
-        "System.Diagnostics.Tracing": "",
-        "System.IO": "",
-        "System.Reflection.Primitives": "",
-        "System.Resources.ResourceManager": "",
-        "System.Runtime.InteropServices": "",
-        "System.Text.Encoding": "",
-        "System.Text.Encoding.Extensions": ""
+        "System.Collections.Concurrent": { "type": "build" },
+        "System.Diagnostics.Tools": { "type": "build" },
+        "System.Dynamic.Runtime": { "type": "build" },
+        "System.IO": { "type": "build" },
+        "System.Reflection.Primitives": { "type": "build" },
+        "System.Resources.ResourceManager": { "type": "build" },
+        "System.Runtime.InteropServices": { "type": "build" },
+        "System.Runtime.Numerics": { "type": "build" },
+        "System.Runtime.Serialization.Json": { "type": "build" },
+        "System.Text.Encoding": { "type": "build" },
+        "System.Text.Encoding.Extensions": { "type": "build" },
+        "System.Threading": { "type": "build" },
+        "System.Threading.Tasks.Parallel": { "type": "build" },
+        "System.Xml.ReaderWriter": { "type": "build" },
+        "System.Xml.XDocument": { "type": "build" }
       }
     },
     "dnx451": {
       "frameworkAssemblies": {
-        "System.Diagnostics.Tracing": "",
+        "System.Collections.Concurrent": "",
+        "System.Diagnostics.Tools": "",
+        "System.Dynamic.Runtime": "",
         "System.IO": "",
         "System.Reflection.Primitives": "",
         "System.Resources.ResourceManager": "",
         "System.Runtime.InteropServices": "",
+        "System.Runtime.Numerics": "",
+        "System.Runtime.Serialization.Json": "",
         "System.Text.Encoding": "",
-        "System.Text.Encoding.Extensions": ""
+        "System.Text.Encoding.Extensions": "",
+        "System.Threading": "",
+        "System.Threading.Tasks.Parallel": "",
+        "System.Xml.ReaderWriter": "",
+        "System.Xml.XDocument": ""
       },
       "dependencies": {
         "Microsoft.Dnx.Runtime": "1.0.0-*"


### PR DESCRIPTION
...again.

Note, dotnet/cli#1012 didn't help us much here because `Remotion.Linq`, `System.Diagnostics.DiagnosticSource`, `xunit.abstractions`, `xunit.assert`, and `xunit.extensibility.core` fall outside of its rules.

@victorhurdugaci 