### PR TITLE
Allow conventions to create one-to-one relationship with single reference navigation

### DIFF
--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/OneToManyTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/OneToManyTestBase.cs
@@ -1798,6 +1798,117 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.Null(model.FindEntityType(typeof(Alpha)).FindNavigation("Thetas").ForeignKey.DependentToPrincipal);
                 Assert.Equal("Id", model.FindEntityType(typeof(Alpha)).FindNavigation("Thetas").ForeignKey.Properties.First().Name);
             }
+
+            [Fact]
+            public virtual void Creates_one_to_many_relationship_with_single_ref_as_dependent_to_principal_if_no_matching_properties_either_side()
+            {
+                var modelBuilder = CreateModelBuilder();
+                modelBuilder.Entity<OneToOnePrincipalEntity>(b =>
+                {
+                    b.Ignore(e => e.NavOneToOneDependentEntityId);
+                    b.Ignore(e => e.OneToOneDependentEntityId);
+                });
+                modelBuilder.Entity<OneToOneDependentEntity>(b =>
+                {
+                    b.Ignore(e => e.NavOneToOnePrincipalEntityId);
+                    b.Ignore(e => e.OneToOnePrincipalEntityId);
+                });
+
+                modelBuilder.Entity<OneToOneDependentEntity>().HasOne(e => e.NavOneToOnePrincipalEntity);
+
+                modelBuilder.Validate();
+
+                var fk = modelBuilder.Model.FindEntityType(typeof(OneToOneDependentEntity)).FindNavigation(OneToOneDependentEntity.NavigationProperty).ForeignKey;
+
+                Assert.Equal(typeof(OneToOnePrincipalEntity), fk.PrincipalEntityType.ClrType);
+                Assert.Equal(typeof(OneToOneDependentEntity), fk.DeclaringEntityType.ClrType);
+                Assert.False(fk.IsUnique);
+                Assert.Null(fk.PrincipalToDependent);
+                Assert.True(fk.Properties.Single().IsShadowProperty);
+            }
+
+            [Fact]
+            public virtual void Creates_one_to_many_relationship_with_single_ref_as_dependent_to_principal_if_matching_navigation_name_properties_are_on_navigation_side()
+            {
+                var modelBuilder = CreateModelBuilder();
+                modelBuilder.Entity<OneToOnePrincipalEntity>(b =>
+                {
+                    b.Ignore(e => e.NavOneToOneDependentEntityId);
+                    b.Ignore(e => e.OneToOneDependentEntityId);
+                });
+                modelBuilder.Entity<OneToOneDependentEntity>(b =>
+                {
+                    b.Ignore(e => e.OneToOnePrincipalEntityId);
+                });
+
+                modelBuilder.Entity<OneToOneDependentEntity>().HasOne(e => e.NavOneToOnePrincipalEntity);
+
+                modelBuilder.Validate();
+
+                var fk = modelBuilder.Model.FindEntityType(typeof(OneToOneDependentEntity)).FindNavigation(OneToOneDependentEntity.NavigationProperty).ForeignKey;
+
+                Assert.Equal(typeof(OneToOnePrincipalEntity), fk.PrincipalEntityType.ClrType);
+                Assert.Equal(typeof(OneToOneDependentEntity), fk.DeclaringEntityType.ClrType);
+                Assert.False(fk.IsUnique);
+                Assert.Null(fk.PrincipalToDependent);
+                Assert.False(fk.Properties.Single().IsShadowProperty);
+                Assert.Equal(OneToOneDependentEntity.NavigationMatchingProperty.Name, fk.Properties.Single().Name);
+            }
+
+            [Fact]
+            public virtual void Creates_one_to_many_relationship_with_single_ref_as_dependent_to_principal_if_matching_entity_name_properties_are_on_navigation_side()
+            {
+                var modelBuilder = CreateModelBuilder();
+                modelBuilder.Entity<OneToOnePrincipalEntity>(b =>
+                {
+                    b.Ignore(e => e.NavOneToOneDependentEntityId);
+                    b.Ignore(e => e.OneToOneDependentEntityId);
+                });
+                modelBuilder.Entity<OneToOneDependentEntity>(b =>
+                {
+                    b.Ignore(e => e.NavOneToOnePrincipalEntityId);
+                });
+
+                modelBuilder.Entity<OneToOneDependentEntity>().HasOne(e => e.NavOneToOnePrincipalEntity);
+
+                modelBuilder.Validate();
+
+                var fk = modelBuilder.Model.FindEntityType(typeof(OneToOneDependentEntity)).FindNavigation(OneToOneDependentEntity.NavigationProperty).ForeignKey;
+
+                Assert.Equal(typeof(OneToOnePrincipalEntity), fk.PrincipalEntityType.ClrType);
+                Assert.Equal(typeof(OneToOneDependentEntity), fk.DeclaringEntityType.ClrType);
+                Assert.False(fk.IsUnique);
+                Assert.Null(fk.PrincipalToDependent);
+                Assert.False(fk.Properties.Single().IsShadowProperty);
+                Assert.Equal(OneToOneDependentEntity.EntityMatchingProperty.Name, fk.Properties.Single().Name);
+            }
+
+            [Fact]
+            public virtual void Creates_one_to_many_relationship_with_single_ref_as_dependent_to_principal_if_matching_properties_are_on_both_side()
+            {
+                var modelBuilder = CreateModelBuilder();
+                modelBuilder.Entity<OneToOnePrincipalEntity>(b =>
+                {
+                    b.Ignore(e => e.NavOneToOneDependentEntityId);
+                });
+                modelBuilder.Entity<OneToOneDependentEntity>(b =>
+                {
+                    b.Ignore(e => e.NavOneToOnePrincipalEntityId);
+                });
+
+                modelBuilder.Entity<OneToOneDependentEntity>().HasOne(e => e.NavOneToOnePrincipalEntity);
+
+                modelBuilder.Validate();
+
+                var fk = modelBuilder.Model.FindEntityType(typeof(OneToOneDependentEntity)).FindNavigation(OneToOneDependentEntity.NavigationProperty).ForeignKey;
+
+                Assert.Equal(typeof(OneToOnePrincipalEntity), fk.PrincipalEntityType.ClrType);
+                Assert.Equal(typeof(OneToOneDependentEntity), fk.DeclaringEntityType.ClrType);
+                Assert.False(fk.IsUnique);
+                Assert.Null(fk.PrincipalToDependent);
+                Assert.False(fk.Properties.Single().IsShadowProperty);
+                Assert.Equal(OneToOneDependentEntity.EntityMatchingProperty.Name, fk.Properties.Single().Name);
+            }
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/TestModel.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/TestModel.cs
@@ -438,6 +438,8 @@ namespace Microsoft.EntityFrameworkCore.Tests
         protected class OneToOnePrincipalEntity
         {
             public static readonly PropertyInfo NavigationProperty = typeof(OneToOnePrincipalEntity).GetProperty("NavOneToOneDependentEntity");
+            public static readonly PropertyInfo EntityMatchingProperty = typeof(OneToOnePrincipalEntity).GetProperty("OneToOneDependentEntityId");
+            public static readonly PropertyInfo NavigationMatchingProperty = typeof(OneToOnePrincipalEntity).GetProperty("NavOneToOneDependentEntityId");
 
             public int Id { get; set; }
 
@@ -452,6 +454,8 @@ namespace Microsoft.EntityFrameworkCore.Tests
         protected class OneToOneDependentEntity
         {
             public static readonly PropertyInfo NavigationProperty = typeof(OneToOneDependentEntity).GetProperty("NavOneToOnePrincipalEntity");
+            public static readonly PropertyInfo EntityMatchingProperty = typeof(OneToOneDependentEntity).GetProperty("OneToOnePrincipalEntityId");
+            public static readonly PropertyInfo NavigationMatchingProperty = typeof(OneToOneDependentEntity).GetProperty("NavOneToOnePrincipalEntityId");
 
             public int Id { get; set; }
 


### PR DESCRIPTION
Resolves #4313 

If a relationship
- Has dependent to principal navigation of reference type
- Has principal to dependent navigation set as null
- Has matching property(-ies) on principal side
- Has no matching property(-ies) on dependent side
Then conventions will try to invert and make one-to-one relationship using the single navigation

Conventions will not match "Id" as a matching property since it is ambiguous.
If "Id" is PK for dependent entity then conventions will use PK property for FK as per existing rules