### PR TITLE
Change numeric temp value generators to use values that are even less likely to be used as real keys

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryByteValueGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryByteValueGenerator.cs
@@ -1,10 +1,14 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading;
+
 namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
 {
-    public abstract class TemporaryNumberValueGenerator<TValue> : ValueGenerator<TValue>
+    public class TemporaryByteValueGenerator : TemporaryNumberValueGenerator<byte>
     {
-        public override bool GeneratesTemporaryValues => true;
+        private int _current;
+
+        public override byte Next() => (byte)Interlocked.Decrement(ref _current);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryCharValueGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryCharValueGenerator.cs
@@ -1,10 +1,14 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading;
+
 namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
 {
-    public abstract class TemporaryNumberValueGenerator<TValue> : ValueGenerator<TValue>
+    public class TemporaryCharValueGenerator : TemporaryNumberValueGenerator<char>
     {
-        public override bool GeneratesTemporaryValues => true;
+        private int _current = char.MaxValue - 100;
+
+        public override char Next() => (char)Interlocked.Decrement(ref _current);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryDecimalValueGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryDecimalValueGenerator.cs
@@ -1,10 +1,14 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading;
+
 namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
 {
-    public abstract class TemporaryNumberValueGenerator<TValue> : ValueGenerator<TValue>
+    public class TemporaryDecimalValueGenerator : TemporaryNumberValueGenerator<decimal>
     {
-        public override bool GeneratesTemporaryValues => true;
+        private int _current = int.MinValue + 1000;
+
+        public override decimal Next() => (Interlocked.Increment(ref _current));
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryDoubleValueGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryDoubleValueGenerator.cs
@@ -1,10 +1,14 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading;
+
 namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
 {
-    public abstract class TemporaryNumberValueGenerator<TValue> : ValueGenerator<TValue>
+    public class TemporaryDoubleValueGenerator : TemporaryNumberValueGenerator<double>
     {
-        public override bool GeneratesTemporaryValues => true;
+        private int _current = int.MinValue + 1000;
+
+        public override double Next() => (Interlocked.Increment(ref _current));
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryFloatValueGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryFloatValueGenerator.cs
@@ -1,10 +1,14 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading;
+
 namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
 {
-    public abstract class TemporaryNumberValueGenerator<TValue> : ValueGenerator<TValue>
+    public class TemporaryFloatValueGenerator : TemporaryNumberValueGenerator<float>
     {
-        public override bool GeneratesTemporaryValues => true;
+        private int _current = int.MinValue + 1000;
+
+        public override float Next() => (Interlocked.Increment(ref _current));
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryIntValueGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryIntValueGenerator.cs
@@ -1,10 +1,14 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading;
+
 namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
 {
-    public abstract class TemporaryNumberValueGenerator<TValue> : ValueGenerator<TValue>
+    public class TemporaryIntValueGenerator : TemporaryNumberValueGenerator<int>
     {
-        public override bool GeneratesTemporaryValues => true;
+        private int _current = int.MinValue + 1000;
+
+        public override int Next() => Interlocked.Increment(ref _current);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryLongValueGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryLongValueGenerator.cs
@@ -1,10 +1,14 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading;
+
 namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
 {
-    public abstract class TemporaryNumberValueGenerator<TValue> : ValueGenerator<TValue>
+    public class TemporaryLongValueGenerator : TemporaryNumberValueGenerator<long>
     {
-        public override bool GeneratesTemporaryValues => true;
+        private long _current = long.MinValue + 1000;
+
+        public override long Next() => Interlocked.Increment(ref _current);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryNumberValueGeneratorFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryNumberValueGeneratorFactory.cs
@@ -14,64 +14,64 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
         {
             var type = property.ClrType.UnwrapNullableType().UnwrapEnumType();
 
-            if (type == typeof(long))
-            {
-                return new TemporaryNumberValueGenerator<long>();
-            }
-
             if (type == typeof(int))
             {
-                return new TemporaryNumberValueGenerator<int>();
+                return new TemporaryIntValueGenerator();
+            }
+
+            if (type == typeof(long))
+            {
+                return new TemporaryLongValueGenerator();
             }
 
             if (type == typeof(short))
             {
-                return new TemporaryNumberValueGenerator<short>();
+                return new TemporaryShortValueGenerator();
             }
 
             if (type == typeof(byte))
             {
-                return new TemporaryNumberValueGenerator<byte>();
+                return new TemporaryByteValueGenerator();
             }
 
             if (type == typeof(char))
             {
-                return new TemporaryNumberValueGenerator<char>();
+                return new TemporaryCharValueGenerator();
             }
 
             if (type == typeof(ulong))
             {
-                return new TemporaryNumberValueGenerator<ulong>();
+                return new TemporaryULongValueGenerator();
             }
 
             if (type == typeof(uint))
             {
-                return new TemporaryNumberValueGenerator<uint>();
+                return new TemporaryUIntValueGenerator();
             }
 
             if (type == typeof(ushort))
             {
-                return new TemporaryNumberValueGenerator<ushort>();
+                return new TemporaryUShortValueGenerator();
             }
 
             if (type == typeof(sbyte))
             {
-                return new TemporaryNumberValueGenerator<sbyte>();
+                return new TemporarySByteValueGenerator();
             }
 
             if (type == typeof(decimal))
             {
-                return new TemporaryNumberValueGenerator<decimal>();
+                return new TemporaryDecimalValueGenerator();
             }
 
             if (type == typeof(float))
             {
-                return new TemporaryNumberValueGenerator<float>();
+                return new TemporaryFloatValueGenerator();
             }
 
             if (type == typeof(double))
             {
-                return new TemporaryNumberValueGenerator<double>();
+                return new TemporaryDoubleValueGenerator();
             }
 
             throw new ArgumentException(CoreStrings.InvalidValueGeneratorFactoryProperty(

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporarySByteValueGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporarySByteValueGenerator.cs
@@ -1,10 +1,14 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading;
+
 namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
 {
-    public abstract class TemporaryNumberValueGenerator<TValue> : ValueGenerator<TValue>
+    public class TemporarySByteValueGenerator : TemporaryNumberValueGenerator<sbyte>
     {
-        public override bool GeneratesTemporaryValues => true;
+        private int _current = sbyte.MinValue;
+
+        public override sbyte Next() => (sbyte)Interlocked.Increment(ref _current);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryShortValueGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryShortValueGenerator.cs
@@ -1,10 +1,14 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading;
+
 namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
 {
-    public abstract class TemporaryNumberValueGenerator<TValue> : ValueGenerator<TValue>
+    public class TemporaryShortValueGenerator : TemporaryNumberValueGenerator<short>
     {
-        public override bool GeneratesTemporaryValues => true;
+        private int _current = short.MinValue + 100;
+
+        public override short Next() => (short)Interlocked.Increment(ref _current);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryUIntValueGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryUIntValueGenerator.cs
@@ -1,10 +1,14 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading;
+
 namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
 {
-    public abstract class TemporaryNumberValueGenerator<TValue> : ValueGenerator<TValue>
+    public class TemporaryUIntValueGenerator : TemporaryNumberValueGenerator<uint>
     {
-        public override bool GeneratesTemporaryValues => true;
+        private int _current = int.MinValue + 1000;
+
+        public override uint Next() => (uint)Interlocked.Increment(ref _current);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryULongValueGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryULongValueGenerator.cs
@@ -1,10 +1,14 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading;
+
 namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
 {
-    public abstract class TemporaryNumberValueGenerator<TValue> : ValueGenerator<TValue>
+    public class TemporaryULongValueGenerator : TemporaryNumberValueGenerator<ulong>
     {
-        public override bool GeneratesTemporaryValues => true;
+        private long _current = long.MinValue + 1000;
+
+        public override ulong Next() => (ulong)Interlocked.Increment(ref _current);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryUShortValueGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore/ValueGeneration/Internal/TemporaryUShortValueGenerator.cs
@@ -1,0 +1,14 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+
+namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
+{
+    public class TemporaryUShortValueGenerator : TemporaryNumberValueGenerator<ushort>
+    {
+        private int _current = short.MinValue + 100;
+
+        public override ushort Next() => (ushort)Interlocked.Increment(ref _current);
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerValueGeneratorCacheTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerValueGeneratorCacheTest.cs
@@ -23,13 +23,13 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
             var property2 = GetProperty2(model);
             var cache = SqlServerTestHelpers.Instance.CreateContextServices(model).GetRequiredService<ISqlServerValueGeneratorCache>();
 
-            var generator1 = cache.GetOrAdd(property1, entityType, (p, et) => new TemporaryNumberValueGenerator<int>());
+            var generator1 = cache.GetOrAdd(property1, entityType, (p, et) => new TemporaryIntValueGenerator());
             Assert.NotNull(generator1);
-            Assert.Same(generator1, cache.GetOrAdd(property1, entityType, (p, et) => new TemporaryNumberValueGenerator<int>()));
+            Assert.Same(generator1, cache.GetOrAdd(property1, entityType, (p, et) => new TemporaryIntValueGenerator()));
 
-            var generator2 = cache.GetOrAdd(property2, entityType, (p, et) => new TemporaryNumberValueGenerator<int>());
+            var generator2 = cache.GetOrAdd(property2, entityType, (p, et) => new TemporaryIntValueGenerator());
             Assert.NotNull(generator2);
-            Assert.Same(generator2, cache.GetOrAdd(property2, entityType, (p, et) => new TemporaryNumberValueGenerator<int>()));
+            Assert.Same(generator2, cache.GetOrAdd(property2, entityType, (p, et) => new TemporaryIntValueGenerator()));
             Assert.NotSame(generator1, generator2);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerValueGeneratorSelectorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerValueGeneratorSelectorTest.cs
@@ -23,20 +23,20 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
 
             var selector = SqlServerTestHelpers.Instance.CreateContextServices(model).GetRequiredService<IValueGeneratorSelector>();
 
-            Assert.IsType<TemporaryNumberValueGenerator<int>>(selector.Select(entityType.FindProperty("Id"), entityType));
-            Assert.IsType<TemporaryNumberValueGenerator<long>>(selector.Select(entityType.FindProperty("Long"), entityType));
-            Assert.IsType<TemporaryNumberValueGenerator<short>>(selector.Select(entityType.FindProperty("Short"), entityType));
-            Assert.IsType<TemporaryNumberValueGenerator<byte>>(selector.Select(entityType.FindProperty("Byte"), entityType));
-            Assert.IsType<TemporaryNumberValueGenerator<char>>(selector.Select(entityType.FindProperty("Char"), entityType));
-            Assert.IsType<TemporaryNumberValueGenerator<int>>(selector.Select(entityType.FindProperty("NullableInt"), entityType));
-            Assert.IsType<TemporaryNumberValueGenerator<long>>(selector.Select(entityType.FindProperty("NullableLong"), entityType));
-            Assert.IsType<TemporaryNumberValueGenerator<short>>(selector.Select(entityType.FindProperty("NullableShort"), entityType));
-            Assert.IsType<TemporaryNumberValueGenerator<byte>>(selector.Select(entityType.FindProperty("NullableByte"), entityType));
-            Assert.IsType<TemporaryNumberValueGenerator<char>>(selector.Select(entityType.FindProperty("NullableChar"), entityType));
+            Assert.IsType<TemporaryIntValueGenerator>(selector.Select(entityType.FindProperty("Id"), entityType));
+            Assert.IsType<TemporaryLongValueGenerator>(selector.Select(entityType.FindProperty("Long"), entityType));
+            Assert.IsType<TemporaryShortValueGenerator>(selector.Select(entityType.FindProperty("Short"), entityType));
+            Assert.IsType<TemporaryByteValueGenerator>(selector.Select(entityType.FindProperty("Byte"), entityType));
+            Assert.IsType<TemporaryCharValueGenerator>(selector.Select(entityType.FindProperty("Char"), entityType));
+            Assert.IsType<TemporaryIntValueGenerator>(selector.Select(entityType.FindProperty("NullableInt"), entityType));
+            Assert.IsType<TemporaryLongValueGenerator>(selector.Select(entityType.FindProperty("NullableLong"), entityType));
+            Assert.IsType<TemporaryShortValueGenerator>(selector.Select(entityType.FindProperty("NullableShort"), entityType));
+            Assert.IsType<TemporaryByteValueGenerator>(selector.Select(entityType.FindProperty("NullableByte"), entityType));
+            Assert.IsType<TemporaryCharValueGenerator>(selector.Select(entityType.FindProperty("NullableChar"), entityType));
             Assert.IsType<TemporaryStringValueGenerator>(selector.Select(entityType.FindProperty("String"), entityType));
             Assert.IsType<TemporaryGuidValueGenerator>(selector.Select(entityType.FindProperty("Guid"), entityType));
             Assert.IsType<TemporaryBinaryValueGenerator>(selector.Select(entityType.FindProperty("Binary"), entityType));
-            Assert.IsType<TemporaryNumberValueGenerator<int>>(selector.Select(entityType.FindProperty("AlwaysIdentity"), entityType));
+            Assert.IsType<TemporaryIntValueGenerator>(selector.Select(entityType.FindProperty("AlwaysIdentity"), entityType));
             Assert.IsType<SqlServerSequenceHiLoValueGenerator<int>>(selector.Select(entityType.FindProperty("AlwaysSequence"), entityType));
         }
 
@@ -81,7 +81,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
             Assert.IsType<TemporaryStringValueGenerator>(selector.Select(entityType.FindProperty("String"), entityType));
             Assert.IsType<SequentialGuidValueGenerator>(selector.Select(entityType.FindProperty("Guid"), entityType));
             Assert.IsType<TemporaryBinaryValueGenerator>(selector.Select(entityType.FindProperty("Binary"), entityType));
-            Assert.IsType<TemporaryNumberValueGenerator<int>>(selector.Select(entityType.FindProperty("AlwaysIdentity"), entityType));
+            Assert.IsType<TemporaryIntValueGenerator>(selector.Select(entityType.FindProperty("AlwaysIdentity"), entityType));
             Assert.IsType<SqlServerSequenceHiLoValueGenerator<int>>(selector.Select(entityType.FindProperty("AlwaysSequence"), entityType));
         }
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/ValueGeneration/TemporaryNumberValueGeneratorFactoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ValueGeneration/TemporaryNumberValueGeneratorFactoryTest.cs
@@ -18,28 +18,26 @@ namespace Microsoft.EntityFrameworkCore.Tests.ValueGeneration
         {
             var entityType = _model.FindEntityType(typeof(AnEntity));
 
-            Assert.Equal(-1, CreateAndUseFactory(entityType.FindProperty("Id")));
-            Assert.Equal(-1L, CreateAndUseFactory(entityType.FindProperty("Long")));
-            Assert.Equal((short)-1, CreateAndUseFactory(entityType.FindProperty("Short")));
-            Assert.Equal(unchecked((byte)-1), CreateAndUseFactory(entityType.FindProperty("Byte")));
-            Assert.Equal((int?)-1, CreateAndUseFactory(entityType.FindProperty("NullableInt")));
-            Assert.Equal((long?)-1, CreateAndUseFactory(entityType.FindProperty("NullableLong")));
-            Assert.Equal((short?)-1, CreateAndUseFactory(entityType.FindProperty("NullableShort")));
-            Assert.Equal(unchecked((byte?)-1), CreateAndUseFactory(entityType.FindProperty("NullableByte")));
-            Assert.Equal(unchecked((uint)-1), CreateAndUseFactory(entityType.FindProperty("UInt")));
-            Assert.Equal(unchecked((ulong)-1), CreateAndUseFactory(entityType.FindProperty("ULong")));
-            Assert.Equal(unchecked((ushort)-1), CreateAndUseFactory(entityType.FindProperty("UShort")));
-            Assert.Equal((sbyte)-1, CreateAndUseFactory(entityType.FindProperty("SByte")));
-            Assert.Equal(unchecked((uint?)-1), CreateAndUseFactory(entityType.FindProperty("NullableUInt")));
-            Assert.Equal(unchecked((ulong?)-1), CreateAndUseFactory(entityType.FindProperty("NullableULong")));
-            Assert.Equal(unchecked((ushort?)-1), CreateAndUseFactory(entityType.FindProperty("NullableUShort")));
-            Assert.Equal((sbyte?)-1, CreateAndUseFactory(entityType.FindProperty("NullableSByte")));
+            Assert.Equal(int.MinValue + 1001, CreateAndUseFactory(entityType.FindProperty("Id")));
+            Assert.Equal(long.MinValue + 1001, CreateAndUseFactory(entityType.FindProperty("Long")));
+            Assert.Equal((short)(short.MinValue + 101), CreateAndUseFactory(entityType.FindProperty("Short")));
+            Assert.Equal((byte)255, CreateAndUseFactory(entityType.FindProperty("Byte")));
+            Assert.Equal(int.MinValue + 1001, CreateAndUseFactory(entityType.FindProperty("NullableInt")));
+            Assert.Equal(long.MinValue + 1001, CreateAndUseFactory(entityType.FindProperty("NullableLong")));
+            Assert.Equal((short)(short.MinValue + 101), CreateAndUseFactory(entityType.FindProperty("NullableShort")));
+            Assert.Equal((byte)255, CreateAndUseFactory(entityType.FindProperty("NullableByte")));
+            Assert.Equal(unchecked((uint)(int.MinValue + 1001)), CreateAndUseFactory(entityType.FindProperty("UInt")));
+            Assert.Equal(unchecked((ulong)(long.MinValue + 1001)), CreateAndUseFactory(entityType.FindProperty("ULong")));
+            Assert.Equal(unchecked((ushort)(short.MinValue + 101)), CreateAndUseFactory(entityType.FindProperty("UShort")));
+            Assert.Equal((sbyte)-127, CreateAndUseFactory(entityType.FindProperty("SByte")));
+            Assert.Equal(unchecked((uint)(int.MinValue + 1001)), CreateAndUseFactory(entityType.FindProperty("NullableUInt")));
+            Assert.Equal(unchecked((ulong)(long.MinValue + 1001)), CreateAndUseFactory(entityType.FindProperty("NullableULong")));
+            Assert.Equal(unchecked((ushort)(short.MinValue + 101)), CreateAndUseFactory(entityType.FindProperty("NullableUShort")));
+            Assert.Equal((sbyte)-127, CreateAndUseFactory(entityType.FindProperty("NullableSByte")));
         }
 
-        private static object CreateAndUseFactory(IProperty property)
-        {
-            return new TemporaryNumberValueGeneratorFactory().Create(property).Next();
-        }
+        private static object CreateAndUseFactory(IProperty property) 
+            => new TemporaryNumberValueGeneratorFactory().Create(property).Next();
 
         [Fact]
         public void Throws_for_non_integer_property()

--- a/test/Microsoft.EntityFrameworkCore.Tests/ValueGeneration/TemporaryNumberValueGeneratorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ValueGeneration/TemporaryNumberValueGeneratorTest.cs
@@ -9,62 +9,137 @@ namespace Microsoft.EntityFrameworkCore.Tests.ValueGeneration
     public class TemporaryNumberValueGeneratorTest
     {
         [Fact]
-        public void Creates_negative_values()
+        public void Can_create_values_for_int_types()
         {
-            var generator = new TemporaryNumberValueGenerator<int>();
+            var generator = new TemporaryIntValueGenerator();
 
-            Assert.Equal(-1, generator.Next());
-            Assert.Equal(-2, generator.Next());
-            Assert.Equal(-3, generator.Next());
-            Assert.Equal(-4, generator.Next());
-            Assert.Equal(-5, generator.Next());
-            Assert.Equal(-6, generator.Next());
+            Assert.Equal(int.MinValue + 1001, generator.Next());
+            Assert.Equal(int.MinValue + 1002, generator.Next());
+            Assert.Equal(int.MinValue + 1003, generator.Next());
         }
 
         [Fact]
-        public void Can_create_values_for_all_integer_types()
+        public void Can_create_values_for_long_types()
         {
-            Assert.Equal(-1, new TemporaryNumberValueGenerator<int>().Next());
-            Assert.Equal(-1L, new TemporaryNumberValueGenerator<long>().Next());
-            Assert.Equal((short)-1, new TemporaryNumberValueGenerator<short>().Next());
-            Assert.Equal(unchecked((byte)-1), new TemporaryNumberValueGenerator<byte>().Next());
-            Assert.Equal(unchecked((uint)-1), new TemporaryNumberValueGenerator<uint>().Next());
-            Assert.Equal(unchecked((ulong)-1), new TemporaryNumberValueGenerator<ulong>().Next());
-            Assert.Equal(unchecked((ushort)-1), new TemporaryNumberValueGenerator<ushort>().Next());
-            Assert.Equal((sbyte)-1, new TemporaryNumberValueGenerator<sbyte>().Next());
+            var generator = new TemporaryLongValueGenerator();
+
+            Assert.Equal(long.MinValue + 1001, generator.Next());
+            Assert.Equal(long.MinValue + 1002, generator.Next());
+            Assert.Equal(long.MinValue + 1003, generator.Next());
+        }
+
+        [Fact]
+        public void Can_create_values_for_short_types()
+        {
+            var generator = new TemporaryShortValueGenerator();
+
+            Assert.Equal(short.MinValue + 101, generator.Next());
+            Assert.Equal(short.MinValue + 102, generator.Next());
+            Assert.Equal(short.MinValue + 103, generator.Next());
+        }
+
+        [Fact]
+        public void Can_create_values_for_byte_types()
+        {
+            var generator = new TemporaryByteValueGenerator();
+
+            Assert.Equal(255, generator.Next());
+            Assert.Equal(254, generator.Next());
+            Assert.Equal(253, generator.Next());
+        }
+
+        [Fact]
+        public void Can_create_values_for_uint_types()
+        {
+            var generator = new TemporaryUIntValueGenerator();
+
+            Assert.Equal(unchecked((uint)int.MinValue + 1001), generator.Next());
+            Assert.Equal(unchecked((uint)int.MinValue + 1002), generator.Next());
+            Assert.Equal(unchecked((uint)int.MinValue + 1003), generator.Next());
+        }
+
+        [Fact]
+        public void Can_create_values_for_ulong_types()
+        {
+            var generator = new TemporaryULongValueGenerator();
+
+            Assert.Equal(unchecked((ulong)long.MinValue + 1001), generator.Next());
+            Assert.Equal(unchecked((ulong)long.MinValue + 1002), generator.Next());
+            Assert.Equal(unchecked((ulong)long.MinValue + 1003), generator.Next());
+        }
+
+        [Fact]
+        public void Can_create_values_for_ushort_types()
+        {
+            var generator = new TemporaryUShortValueGenerator();
+
+            Assert.Equal(unchecked((ushort)short.MinValue + 101), generator.Next());
+            Assert.Equal(unchecked((ushort)short.MinValue + 102), generator.Next());
+            Assert.Equal(unchecked((ushort)short.MinValue + 103), generator.Next());
+        }
+
+        [Fact]
+        public void Can_create_values_for_sbyte_types()
+        {
+            var generator = new TemporarySByteValueGenerator();
+
+            Assert.Equal(-127, generator.Next());
+            Assert.Equal(-126, generator.Next());
+            Assert.Equal(-125, generator.Next());
+        }
+
+        [Fact]
+        public void Can_create_values_for_char_types()
+        {
+            var generator = new TemporaryCharValueGenerator();
+
+            Assert.Equal(char.MaxValue - 101, generator.Next());
+            Assert.Equal(char.MaxValue - 102, generator.Next());
+            Assert.Equal(char.MaxValue - 103, generator.Next());
         }
 
         [Fact]
         public void Can_create_values_for_decimal_types()
         {
-            var generator = new TemporaryNumberValueGenerator<decimal>();
+            var generator = new TemporaryDecimalValueGenerator();
 
-            Assert.Equal(-1m, generator.Next());
-            Assert.Equal(-2m, generator.Next());
+            Assert.Equal(-2147482647m, generator.Next());
+            Assert.Equal(-2147482646m, generator.Next());
         }
 
         [Fact]
         public void Can_create_values_for_float_types()
         {
-            var generator = new TemporaryNumberValueGenerator<float>();
+            var generator = new TemporaryFloatValueGenerator();
 
-            Assert.Equal(-1.0f, generator.Next());
-            Assert.Equal(-2.0f, generator.Next());
+            Assert.Equal(-2147482647.0f, generator.Next());
+            Assert.Equal(-2147482646.0f, generator.Next());
         }
 
         [Fact]
         public void Can_create_values_for_double_types()
         {
-            var generator = new TemporaryNumberValueGenerator<double>();
+            var generator = new TemporaryDoubleValueGenerator();
 
-            Assert.Equal(-1.0, generator.Next());
-            Assert.Equal(-2.0, generator.Next());
+            Assert.Equal(-2147482647.0, generator.Next());
+            Assert.Equal(-2147482646.0, generator.Next());
         }
 
         [Fact]
         public void Generates_temporary_values()
         {
-            Assert.True(new TemporaryNumberValueGenerator<int>().GeneratesTemporaryValues);
+            Assert.True(new TemporaryIntValueGenerator().GeneratesTemporaryValues);
+            Assert.True(new TemporaryLongValueGenerator().GeneratesTemporaryValues);
+            Assert.True(new TemporaryShortValueGenerator().GeneratesTemporaryValues);
+            Assert.True(new TemporaryByteValueGenerator().GeneratesTemporaryValues);
+            Assert.True(new TemporaryUIntValueGenerator().GeneratesTemporaryValues);
+            Assert.True(new TemporaryULongValueGenerator().GeneratesTemporaryValues);
+            Assert.True(new TemporaryUShortValueGenerator().GeneratesTemporaryValues);
+            Assert.True(new TemporarySByteValueGenerator().GeneratesTemporaryValues);
+            Assert.True(new TemporaryDecimalValueGenerator().GeneratesTemporaryValues);
+            Assert.True(new TemporaryDoubleValueGenerator().GeneratesTemporaryValues);
+            Assert.True(new TemporaryFloatValueGenerator().GeneratesTemporaryValues);
+            Assert.True(new TemporaryCharValueGenerator().GeneratesTemporaryValues);
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Tests/ValueGeneration/ValueGeneratorSelectorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ValueGeneration/ValueGeneratorSelectorTest.cs
@@ -22,34 +22,34 @@ namespace Microsoft.EntityFrameworkCore.Tests.ValueGeneration
             var contextServices = TestHelpers.Instance.CreateContextServices(model);
             var selector = contextServices.GetRequiredService<ValueGeneratorSelector>();
 
-            Assert.IsType<TemporaryNumberValueGenerator<int>>(selector.Select(entityType.FindProperty("Id"), entityType));
-            Assert.IsType<TemporaryNumberValueGenerator<long>>(selector.Select(entityType.FindProperty("Long"), entityType));
-            Assert.IsType<TemporaryNumberValueGenerator<short>>(selector.Select(entityType.FindProperty("Short"), entityType));
-            Assert.IsType<TemporaryNumberValueGenerator<byte>>(selector.Select(entityType.FindProperty("Byte"), entityType));
+            Assert.IsType<TemporaryIntValueGenerator>(selector.Select(entityType.FindProperty("Id"), entityType));
+            Assert.IsType<TemporaryLongValueGenerator>(selector.Select(entityType.FindProperty("Long"), entityType));
+            Assert.IsType<TemporaryShortValueGenerator>(selector.Select(entityType.FindProperty("Short"), entityType));
+            Assert.IsType<TemporaryByteValueGenerator>(selector.Select(entityType.FindProperty("Byte"), entityType));
 
-            Assert.IsType<TemporaryNumberValueGenerator<int>>(selector.Select(entityType.FindProperty("NullableInt"), entityType));
-            Assert.IsType<TemporaryNumberValueGenerator<long>>(selector.Select(entityType.FindProperty("NullableLong"), entityType));
-            Assert.IsType<TemporaryNumberValueGenerator<short>>(selector.Select(entityType.FindProperty("NullableShort"), entityType));
-            Assert.IsType<TemporaryNumberValueGenerator<byte>>(selector.Select(entityType.FindProperty("NullableByte"), entityType));
+            Assert.IsType<TemporaryIntValueGenerator>(selector.Select(entityType.FindProperty("NullableInt"), entityType));
+            Assert.IsType<TemporaryLongValueGenerator>(selector.Select(entityType.FindProperty("NullableLong"), entityType));
+            Assert.IsType<TemporaryShortValueGenerator>(selector.Select(entityType.FindProperty("NullableShort"), entityType));
+            Assert.IsType<TemporaryByteValueGenerator>(selector.Select(entityType.FindProperty("NullableByte"), entityType));
 
-            Assert.IsType<TemporaryNumberValueGenerator<uint>>(selector.Select(entityType.FindProperty("UInt"), entityType));
-            Assert.IsType<TemporaryNumberValueGenerator<ulong>>(selector.Select(entityType.FindProperty("ULong"), entityType));
-            Assert.IsType<TemporaryNumberValueGenerator<ushort>>(selector.Select(entityType.FindProperty("UShort"), entityType));
-            Assert.IsType<TemporaryNumberValueGenerator<sbyte>>(selector.Select(entityType.FindProperty("SByte"), entityType));
+            Assert.IsType<TemporaryUIntValueGenerator>(selector.Select(entityType.FindProperty("UInt"), entityType));
+            Assert.IsType<TemporaryULongValueGenerator>(selector.Select(entityType.FindProperty("ULong"), entityType));
+            Assert.IsType<TemporaryUShortValueGenerator>(selector.Select(entityType.FindProperty("UShort"), entityType));
+            Assert.IsType<TemporarySByteValueGenerator>(selector.Select(entityType.FindProperty("SByte"), entityType));
 
-            Assert.IsType<TemporaryNumberValueGenerator<uint>>(selector.Select(entityType.FindProperty("NullableUInt"), entityType));
-            Assert.IsType<TemporaryNumberValueGenerator<ulong>>(selector.Select(entityType.FindProperty("NullableULong"), entityType));
-            Assert.IsType<TemporaryNumberValueGenerator<ushort>>(selector.Select(entityType.FindProperty("NullableUShort"), entityType));
-            Assert.IsType<TemporaryNumberValueGenerator<sbyte>>(selector.Select(entityType.FindProperty("NullableSByte"), entityType));
+            Assert.IsType<TemporaryUIntValueGenerator>(selector.Select(entityType.FindProperty("NullableUInt"), entityType));
+            Assert.IsType<TemporaryULongValueGenerator>(selector.Select(entityType.FindProperty("NullableULong"), entityType));
+            Assert.IsType<TemporaryUShortValueGenerator>(selector.Select(entityType.FindProperty("NullableUShort"), entityType));
+            Assert.IsType<TemporarySByteValueGenerator>(selector.Select(entityType.FindProperty("NullableSByte"), entityType));
 
-            Assert.IsType<TemporaryNumberValueGenerator<decimal>>(selector.Select(entityType.FindProperty("Decimal"), entityType));
-            Assert.IsType<TemporaryNumberValueGenerator<decimal>>(selector.Select(entityType.FindProperty("NullableDecimal"), entityType));
+            Assert.IsType<TemporaryDecimalValueGenerator>(selector.Select(entityType.FindProperty("Decimal"), entityType));
+            Assert.IsType<TemporaryDecimalValueGenerator>(selector.Select(entityType.FindProperty("NullableDecimal"), entityType));
 
-            Assert.IsType<TemporaryNumberValueGenerator<float>>(selector.Select(entityType.FindProperty("Float"), entityType));
-            Assert.IsType<TemporaryNumberValueGenerator<float>>(selector.Select(entityType.FindProperty("NullableFloat"), entityType));
+            Assert.IsType<TemporaryFloatValueGenerator>(selector.Select(entityType.FindProperty("Float"), entityType));
+            Assert.IsType<TemporaryFloatValueGenerator>(selector.Select(entityType.FindProperty("NullableFloat"), entityType));
 
-            Assert.IsType<TemporaryNumberValueGenerator<double>>(selector.Select(entityType.FindProperty("Double"), entityType));
-            Assert.IsType<TemporaryNumberValueGenerator<double>>(selector.Select(entityType.FindProperty("NullableDouble"), entityType));
+            Assert.IsType<TemporaryDoubleValueGenerator>(selector.Select(entityType.FindProperty("Double"), entityType));
+            Assert.IsType<TemporaryDoubleValueGenerator>(selector.Select(entityType.FindProperty("NullableDouble"), entityType));
 
             Assert.IsType<TemporaryDateTimeValueGenerator>(selector.Select(entityType.FindProperty("DateTime"), entityType));
             Assert.IsType<TemporaryDateTimeValueGenerator>(selector.Select(entityType.FindProperty("NullableDateTime"), entityType));


### PR DESCRIPTION
See Issue #4488

This requires different start values and increment/decrement behavior for different types due to size limitations.