### PR TITLE
Match compatible PK as FK properly

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/ConventionSet.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/ConventionSet.cs
@@ -16,6 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         public virtual IList<IKeyConvention> KeyAddedConventions { get; } = new List<IKeyConvention>();
         public virtual IList<IKeyRemovedConvention> KeyRemovedConventions { get; } = new List<IKeyRemovedConvention>();
         public virtual IList<IPrimaryKeyConvention> PrimaryKeySetConventions { get; } = new List<IPrimaryKeyConvention>();
+        public virtual IList<IPrincipalEndConvention> PrincipalEndSetConventions { get; } = new List<IPrincipalEndConvention>();
         public virtual IList<IModelConvention> ModelBuiltConventions { get; } = new List<IModelConvention>();
         public virtual IList<IModelConvention> ModelInitializedConventions { get; } = new List<IModelConvention>();
         public virtual IList<INavigationConvention> NavigationAddedConventions { get; } = new List<INavigationConvention>();

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/ConventionDispatcher.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/ConventionDispatcher.cs
@@ -205,6 +205,22 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             }
         }
 
+        public virtual InternalRelationshipBuilder OnPrincipalEndSet([NotNull] InternalRelationshipBuilder relationshipBuilder)
+        {
+            Check.NotNull(relationshipBuilder, nameof(relationshipBuilder));
+
+            foreach (var relationshipConvention in _conventionSet.PrincipalEndSetConventions)
+            {
+                relationshipBuilder = relationshipConvention.Apply(relationshipBuilder);
+                if (relationshipBuilder == null)
+                {
+                    break;
+                }
+            }
+
+            return relationshipBuilder;
+        }
+
         public virtual InternalPropertyBuilder OnPropertyAdded([NotNull] InternalPropertyBuilder propertyBuilder)
         {
             Check.NotNull(propertyBuilder, nameof(propertyBuilder));

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
@@ -66,6 +66,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             conventionSet.PropertyNullableChangedConventions.Add(cascadeDeleteConvention);
 
+            conventionSet.PrincipalEndSetConventions.Add(foreignKeyPropertyDiscoveryConvention);
+
             return conventionSet;
         }
     }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/ForeignKeyPropertyDiscoveryConvention.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/ForeignKeyPropertyDiscoveryConvention.cs
@@ -9,7 +9,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 {
-    public class ForeignKeyPropertyDiscoveryConvention : IForeignKeyConvention, INavigationConvention, IPropertyConvention
+    public class ForeignKeyPropertyDiscoveryConvention : IForeignKeyConvention, INavigationConvention, IPropertyConvention, IPrincipalEndConvention
     {
         public virtual InternalRelationshipBuilder Apply(InternalRelationshipBuilder relationshipBuilder)
         {

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/IPrincipalEndConvention.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/IPrincipalEndConvention.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
+{
+    public interface IPrincipalEndConvention
+    {
+        InternalRelationshipBuilder Apply([NotNull] InternalRelationshipBuilder relationshipBuilder);
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityType.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityType.cs
@@ -602,7 +602,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             if (runConventions)
             {
-                foreignKey = Model.ConventionDispatcher.OnForeignKeyAdded(foreignKey.Builder)?.Metadata;
+                var builder = Model.ConventionDispatcher.OnForeignKeyAdded(foreignKey.Builder);
+                if (builder != null)
+                {
+                    builder = Model.ConventionDispatcher.OnPrincipalEndSet(builder);
+                }
+                foreignKey = builder?.Metadata;
             }
 
             return foreignKey;

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/KeyPropagatorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/KeyPropagatorTest.cs
@@ -247,7 +247,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             builder.Entity<OrderLine>(b =>
                 {
                     b.HasKey(e => new { e.OrderId, e.ProductId });
-                    b.HasOne(e => e.Detail).WithOne(e => e.OrderLine);
+                    b.HasOne(e => e.Detail).WithOne(e => e.OrderLine).HasForeignKey<OrderLineDetail>(e => new { e.OrderId, e.ProductId});
                 });
 
             return builder.Model;

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/ForeignKeyPropertyDiscoveryConventionTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/ForeignKeyPropertyDiscoveryConventionTest.cs
@@ -306,7 +306,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions
         }
 
         [Fact]
-        public void Matches_dependent_PK_for_unique_FK()
+        public void Matches_dependent_PK_for_unique_FK_set_by_higher_source_than_convention()
         {
             var fkProperty = DependentType.Metadata.FindPrimaryKey().Properties.Single();
             var relationshipBuilder = DependentType.Relationship(
@@ -314,7 +314,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions
                 "SomeNav",
                 "InverseReferenceNav",
                 ConfigurationSource.Convention)
-                .IsUnique(true, ConfigurationSource.Convention)
+                .IsUnique(true, ConfigurationSource.DataAnnotation)
                 .DependentEntityType(DependentType, ConfigurationSource.DataAnnotation);
 
             var newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder);

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/OneToOneTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/OneToOneTestBase.cs
@@ -3151,8 +3151,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.Equal("Id", modelBuilder.Model.FindEntityType(typeof(Book)).FindNavigation(Book.BookdDetailsNavigation.Name).ForeignKey.Properties.Single().Name);
             }
 
-            // TODO: See issue #4451
-            //[Fact]
+            [Fact]
             public virtual void Does_not_use_pk_as_fk_if_principal_end_is_not_specified()
             {
                 var modelBuilder = CreateModelBuilder();


### PR DESCRIPTION
resolves #4451 

Conditions
- One-to-One relationship (non-self-PK-referencing)
- No matching properties on either side
Either of following two
- Principal Key is set with source higher than convention, or
- Principal End & Uniqueness set with source higher than convention

Issue 1: For one-to-one relationship configured conventionally, we don't match compatible PK since principal end is ambiguous. If on such relationship, `HasPrincipalKey` is used then principal end is specified by user and we should try matching PK. But if the `HasPrincipalKey` calls the same principal key as the current one then conventions are not run.

Issue 2: Using `HasOne` API sets principal end explicitly. So we may use half-configured relationship to determine side and assign FK properties even though when relationship is full-configured it can be ambiguous. Therefore check for principal end CS should happen with Unique CS since `WithOne` or `WithMany` sets uniqueness.