### PR TITLE
[TINY] Fixes for benchmark CI

### DIFF
--- a/test/Microsoft.EntityFrameworkCore.Microbenchmarks.EF6/Properties/AssemblyInfo.cs
+++ b/test/Microsoft.EntityFrameworkCore.Microbenchmarks.EF6/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using Xunit;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 
@@ -18,8 +18,8 @@ using Xunit;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 
 [assembly: ComVisible(false)]
@@ -31,15 +31,14 @@ using Xunit;
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: TestFramework("Microsoft.EntityFrameworkCore.Microbenchmarks.Core.PerfTestFramework", "Microsoft.EntityFrameworkCore.Microbenchmarks.Core")]
 [assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/test/Microsoft.EntityFrameworkCore.Microbenchmarks.EF6/project.json
+++ b/test/Microsoft.EntityFrameworkCore.Microbenchmarks.EF6/project.json
@@ -3,6 +3,7 @@
     "EntityFramework": "6.1.2",
     "Microsoft.EntityFrameworkCore.Microbenchmarks.Core": "1.0.0"
   },
+  "content": "config.json",
   "testRunner": "xunit",
   "commands": {
     "test": "xunit.runner.aspnet"

--- a/test/Microsoft.EntityFrameworkCore.Microbenchmarks/project.json
+++ b/test/Microsoft.EntityFrameworkCore.Microbenchmarks/project.json
@@ -3,6 +3,7 @@
     "Microsoft.EntityFrameworkCore.SqlServer": "1.0.0-*",
     "Microsoft.EntityFrameworkCore.Microbenchmarks.Core": "1.0.0-*"
   },
+  "content": "config.json",
   "testRunner": "xunit",
   "commands": {
     "test": "xunit.runner.aspnet"


### PR DESCRIPTION
Because we now consume artifacts from the central CI build (rather than
cloning and building on the perf agent), we need to copy config files so
that they are part of the artifacts from the build.

Also removing redundant TestFramework attribute from EF6 tests.