### PR TITLE
Fix #3704 - Remove values from RelationalCommand construction

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -349,6 +349,22 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
+        /// The argument '{argumentName}' can not be null when parameters have been configured.
+        /// </summary>
+        public static string NullParameterValue([CanBeNull] object argumentName)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("NullParameterValue", "argumentName"), argumentName);
+        }
+
+        /// <summary>
+        /// No value provided for requred parameter '{parameter}'.
+        /// </summary>
+        public static string MissingParameterValue([CanBeNull] object parameter)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("MissingParameterValue", "parameter"), parameter);
+        }
+
+        /// <summary>
         /// Executed DbCommand ({elapsed}ms) [Parameters=[{parameters}], CommandType='{commandType}', CommandTimeout='{commandTimeout}']{newLine}{commandText}
         /// </summary>
         public static string RelationalLoggerExecutedCommand([CanBeNull] object elapsed, [CanBeNull] object parameters, [CanBeNull] object commandType, [CanBeNull] object commandTimeout, [CanBeNull] object newLine, [CanBeNull] object commandText)

--- a/src/Microsoft.EntityFrameworkCore.Relational/Properties/RelationalStrings.resx
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Properties/RelationalStrings.resx
@@ -244,6 +244,12 @@
   <data name="ClientEvalWarning" xml:space="preserve">
     <value>The LINQ expression '{expression}' could not be translated and will be evaluated locally.</value>
   </data>
+  <data name="NullParameterValue" xml:space="preserve">
+    <value>The argument '{argumentName}' can not be null when parameters have been configured.</value>
+  </data>
+  <data name="MissingParameterValue" xml:space="preserve">
+    <value>No value provided for requred parameter '{parameter}'.</value>
+  </data>
   <data name="RelationalLoggerExecutedCommand" xml:space="preserve">
     <value>Executed DbCommand ({elapsed}ms) [Parameters=[{parameters}], CommandType='{commandType}', CommandTimeout='{commandTimeout}']{newLine}{commandText}</value>
   </data>

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/AsyncQueryingEnumerable.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/AsyncQueryingEnumerable.cs
@@ -70,8 +70,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         _dataReader
                             = await relationalCommand.ExecuteReaderAsync(
                                 _queryingEnumerable._relationalQueryContext.Connection,
+                                _queryingEnumerable._relationalQueryContext.ParameterValues,
                                 manageConnection: false,
-                                parameterValues: _queryingEnumerable._relationalQueryContext.ParameterValues,
                                 cancellationToken: cancellationToken);
 
                         _dbDataReader = _dataReader.DbDataReader;

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/QueryingEnumerable.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/QueryingEnumerable.cs
@@ -69,8 +69,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         _dataReader
                             = relationalCommand.ExecuteReader(
                                 _queryingEnumerable._relationalQueryContext.Connection,
-                                manageConnection: false,
-                                parameterValues: _queryingEnumerable._relationalQueryContext.ParameterValues);
+                                _queryingEnumerable._relationalQueryContext.ParameterValues,
+                                manageConnection: false);
 
                         _dbDataReader = _dataReader.DbDataReader;
                         _queryingEnumerable._shaperCommandContext.NotifyReaderCreated(_dbDataReader);

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -351,11 +351,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
                             relationalParameters[i]
                                 = _relationalCommandBuilder
                                     .CreateParameter(
+                                        parameterName,
                                         substitutions[i],
-                                        value,
                                         t => t.GetMappingForValue(value),
-                                        value?.GetType().IsNullableType(),
-                                        parameterName);
+                                        value?.GetType().IsNullableType());
                         }
 
                         _relationalCommandBuilder.AddParameter(

--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/IRelationalCommand.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/IRelationalCommand.cs
@@ -14,33 +14,39 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
         IReadOnlyList<IRelationalParameter> Parameters { get; }
 
+        IReadOnlyDictionary<string, object> CachedParameterValues { get; [param: CanBeNull] set; }
+
         int ExecuteNonQuery(
             [NotNull] IRelationalConnection connection,
+            [CanBeNull] IReadOnlyDictionary<string, object> parameterValues = null,
             bool manageConnection = true);
 
         Task<int> ExecuteNonQueryAsync(
             [NotNull] IRelationalConnection connection,
+            [CanBeNull] IReadOnlyDictionary<string, object> parameterValues = null,
             bool manageConnection = true,
             CancellationToken cancellationToken = default(CancellationToken));
 
         object ExecuteScalar(
             [NotNull] IRelationalConnection connection,
+            [CanBeNull] IReadOnlyDictionary<string, object> parameterValues = null,
             bool manageConnection = true);
 
         Task<object> ExecuteScalarAsync(
             [NotNull] IRelationalConnection connection,
+            [CanBeNull] IReadOnlyDictionary<string, object> parameterValues = null,
             bool manageConnection = true,
             CancellationToken cancellationToken = default(CancellationToken));
 
         RelationalDataReader ExecuteReader(
             [NotNull] IRelationalConnection connection,
-            bool manageConnection = true,
-            [CanBeNull] IReadOnlyDictionary<string, object> parameterValues = null);
+            [CanBeNull] IReadOnlyDictionary<string, object> parameterValues = null,
+            bool manageConnection = true);
 
         Task<RelationalDataReader> ExecuteReaderAsync(
             [NotNull] IRelationalConnection connection,
-            bool manageConnection = true,
             [CanBeNull] IReadOnlyDictionary<string, object> parameterValues = null,
+            bool manageConnection = true,
             CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/IRelationalCommandBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/IRelationalCommandBuilder.cs
@@ -13,11 +13,10 @@ namespace Microsoft.EntityFrameworkCore.Storage
         void AddParameter([NotNull] IRelationalParameter relationalParameter);
 
         IRelationalParameter CreateParameter(
+            [CanBeNull] string invariantName,
             [NotNull] string name,
-            [CanBeNull] object value,
             [NotNull] Func<IRelationalTypeMapper, RelationalTypeMapping> mapType,
-            bool? nullable,
-            [CanBeNull] string invariantName);
+            bool? nullable);
 
         IRelationalCommand Build();
     }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/Internal/RawSqlCommandBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/Internal/RawSqlCommandBuilder.cs
@@ -33,6 +33,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
 
             var relationalCommandBuilder = _relationalCommandBuilderFactory.Create();
 
+            var parameterValues = new Dictionary<string, object>();
+
             if (parameters != null)
             {
                 var substitutions = new string[parameters.Count];
@@ -49,13 +51,19 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                         substitutions[i],
                         parameters[i],
                         parameterName);
+
+                    parameterValues[parameterName] = parameters[i];
                 }
 
                 // ReSharper disable once CoVariantArrayConversion
                 sql = string.Format(sql, substitutions);
             }
 
-            return relationalCommandBuilder.Append(sql).Build();
+            var command = relationalCommandBuilder.Append(sql).Build();
+
+            command.CachedParameterValues = parameterValues;
+
+            return command;
         }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/Internal/RelationalCommand.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/Internal/RelationalCommand.cs
@@ -41,76 +41,86 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
 
         public virtual IReadOnlyList<IRelationalParameter> Parameters { get; }
 
+        public virtual IReadOnlyDictionary<string, object> CachedParameterValues { get; set; }
+
         public virtual int ExecuteNonQuery(
             IRelationalConnection connection,
+            IReadOnlyDictionary<string, object> parameterValues = null,
             bool manageConnection = true)
             => (int)Execute(
                 Check.NotNull(connection, nameof(connection)),
                 nameof(ExecuteNonQuery),
+                parameterValues ?? CachedParameterValues,
                 openConnection: manageConnection,
                 closeConnection: manageConnection);
 
         public virtual Task<int> ExecuteNonQueryAsync(
             IRelationalConnection connection,
+            IReadOnlyDictionary<string, object> parameterValues = null,
             bool manageConnection = true,
             CancellationToken cancellationToken = default(CancellationToken))
             => ExecuteAsync(
                 Check.NotNull(connection, nameof(connection)),
                 nameof(ExecuteNonQuery),
+                parameterValues ?? CachedParameterValues,
                 openConnection: manageConnection,
                 closeConnection: manageConnection,
                 cancellationToken: cancellationToken).Cast<object, int>();
 
         public virtual object ExecuteScalar(
             IRelationalConnection connection,
+            IReadOnlyDictionary<string, object> parameterValues = null,
             bool manageConnection = true)
             => Execute(
                 Check.NotNull(connection, nameof(connection)),
                 nameof(ExecuteScalar),
+                parameterValues ?? CachedParameterValues,
                 openConnection: manageConnection,
                 closeConnection: manageConnection);
 
         public virtual Task<object> ExecuteScalarAsync(
             IRelationalConnection connection,
+            IReadOnlyDictionary<string, object> parameterValues = null,
             bool manageConnection = true,
             CancellationToken cancellationToken = default(CancellationToken))
             => ExecuteAsync(
                 Check.NotNull(connection, nameof(connection)),
                 nameof(ExecuteScalar),
+                parameterValues ?? CachedParameterValues,
                 openConnection: manageConnection,
                 closeConnection: manageConnection,
                 cancellationToken: cancellationToken);
 
         public virtual RelationalDataReader ExecuteReader(
             IRelationalConnection connection,
-            bool manageConnection = true,
-            IReadOnlyDictionary<string, object> parameterValues = null)
+            IReadOnlyDictionary<string, object> parameterValues = null,
+            bool manageConnection = true)
             => (RelationalDataReader)Execute(
                 Check.NotNull(connection, nameof(connection)),
                 nameof(ExecuteReader),
+                parameterValues ?? CachedParameterValues,
                 openConnection: manageConnection,
-                closeConnection: false,
-                parameterValues: parameterValues);
+                closeConnection: false);
 
         public virtual Task<RelationalDataReader> ExecuteReaderAsync(
             IRelationalConnection connection,
-            bool manageConnection = true,
             IReadOnlyDictionary<string, object> parameterValues = null,
+            bool manageConnection = true,
             CancellationToken cancellationToken = default(CancellationToken))
             => ExecuteAsync(
                     Check.NotNull(connection, nameof(connection)),
                     nameof(ExecuteReader),
+                    parameterValues ?? CachedParameterValues,
                     openConnection: manageConnection,
                     closeConnection: false,
-                    cancellationToken: cancellationToken,
-                    parameterValues: parameterValues).Cast<object, RelationalDataReader>();
+                    cancellationToken: cancellationToken).Cast<object, RelationalDataReader>();
 
         protected virtual object Execute(
             [NotNull] IRelationalConnection connection,
             [NotNull] string executeMethod,
+            [CanBeNull] IReadOnlyDictionary<string, object> parameterValues,
             bool openConnection,
-            bool closeConnection,
-            [CanBeNull] IReadOnlyDictionary<string, object> parameterValues = null)
+            bool closeConnection)
         {
             var dbCommand = CreateCommand(connection, parameterValues);
 
@@ -223,10 +233,11 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         protected virtual async Task<object> ExecuteAsync(
             [NotNull] IRelationalConnection connection,
             [NotNull] string executeMethod,
+            [CanBeNull] IReadOnlyDictionary<string, object> parameterValues,
             bool openConnection,
             bool closeConnection,
-            CancellationToken cancellationToken = default(CancellationToken),
-            [CanBeNull] IReadOnlyDictionary<string, object> parameterValues = null)
+            CancellationToken cancellationToken = default(CancellationToken)
+            )
         {
             var dbCommand = CreateCommand(connection, parameterValues);
 
@@ -367,13 +378,28 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                 command.CommandTimeout = (int)connection.CommandTimeout;
             }
 
-            foreach (var parameter in Parameters)
+            if (Parameters.Count > 0)
             {
-                parameter.AddDbParameter(
-                    command,
-                    parameterValues?.Count > 0
-                        ? parameterValues[parameter.InvariantName]
-                        : null);
+                if (parameterValues != null)
+                {
+                    foreach (var parameter in Parameters)
+                    {
+                        object parameterValue;
+
+                        if(parameterValues.TryGetValue(parameter.InvariantName, out parameterValue))
+                        {
+                            parameter.AddDbParameter(command, parameterValue);
+                        }
+                        else
+                        {
+                            throw new InvalidOperationException(RelationalStrings.MissingParameterValue(parameter.InvariantName));
+                        }
+                    }
+                }
+                else
+                {
+                    throw new InvalidOperationException(RelationalStrings.NullParameterValue(nameof(parameterValues)));
+                }
             }
 
             return command;

--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/Internal/RelationalCommandBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/Internal/RelationalCommandBuilder.cs
@@ -39,17 +39,15 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             => _commandTextBuilder;
 
         public virtual IRelationalParameter CreateParameter(
+            string invariantName,
             string name,
-            object value,
             Func<IRelationalTypeMapper, RelationalTypeMapping> mapType,
-            bool? nullable,
-            string invariantName)
+            bool? nullable)
             => new RelationalParameter(
+                invariantName,
                 name,
-                value,
                 mapType(_typeMapper),
-                nullable,
-                invariantName);
+                nullable);
 
         public virtual void AddParameter(IRelationalParameter relationalParameter)
         {

--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalCommandBuilderExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalCommandBuilderExtensions.cs
@@ -108,6 +108,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             Check.NotNull(commandBuilder, nameof(commandBuilder));
             Check.NotEmpty(name, nameof(name));
             Check.NotNull(type, nameof(type));
+            Check.NotEmpty(invariantName, nameof(invariantName));
 
             bool? isNullable = null;
 
@@ -133,18 +134,20 @@ namespace Microsoft.EntityFrameworkCore.Storage
             [NotNull] this IRelationalCommandBuilder commandBuilder,
             [NotNull] string name,
             [CanBeNull] object value,
-            [NotNull] IProperty property)
+            [NotNull] IProperty property,
+            [NotNull] string invariantName)
         {
             Check.NotNull(commandBuilder, nameof(commandBuilder));
             Check.NotEmpty(name, nameof(name));
             Check.NotNull(property, nameof(property));
+            Check.NotEmpty(invariantName, nameof(invariantName));
 
             commandBuilder.AddParameter(
                 name,
                 value,
                 t => t.GetMapping(property),
                 property.IsNullable,
-                invariantName: null);
+                invariantName);
 
             return commandBuilder;
         }
@@ -155,14 +158,15 @@ namespace Microsoft.EntityFrameworkCore.Storage
             [CanBeNull] object value,
             [NotNull] Func<IRelationalTypeMapper, RelationalTypeMapping> mapType,
             bool? nullable,
-            [CanBeNull] string invariantName)
+            [NotNull] string invariantName)
         {
             Check.NotEmpty(name, nameof(name));
             Check.NotNull(mapType, nameof(mapType));
+            Check.NotEmpty(invariantName, nameof(invariantName));
 
             commandBuilder.AddParameter(
                 commandBuilder.CreateParameter(
-                    name, value, mapType, nullable, invariantName));
+                    invariantName, name, mapType, nullable));
         }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalParameter.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Storage/RelationalParameter.cs
@@ -10,29 +10,30 @@ namespace Microsoft.EntityFrameworkCore.Storage
     public class RelationalParameter : IRelationalParameter
     {
         private readonly string _name;
-        private readonly object _value;
         private readonly RelationalTypeMapping _relationalTypeMapping;
         private readonly bool? _nullable;
 
         public RelationalParameter(
+            [NotNull] string invariantName,
             [NotNull] string name,
-            [CanBeNull] object value,
             [NotNull] RelationalTypeMapping relationalTypeMapping,
-            [CanBeNull] bool? nullable,
-            [CanBeNull] string invariantName)
+            [CanBeNull] bool? nullable)
         {
+            Check.NotEmpty(invariantName, nameof(invariantName));
             Check.NotEmpty(name, nameof(name));
             Check.NotNull(relationalTypeMapping, nameof(relationalTypeMapping));
 
+            InvariantName = invariantName;
             _name = name;
-            _value = value;
             _relationalTypeMapping = relationalTypeMapping;
             _nullable = nullable;
-
-            InvariantName = invariantName;
         }
 
         public virtual string InvariantName { get; }
+
+        public virtual RelationalTypeMapping RelationalTypeMapping => _relationalTypeMapping;
+
+        public virtual bool? Nullable => _nullable;
 
         public virtual void AddDbParameter(DbCommand command, object value)
         {
@@ -40,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
             command.Parameters
                 .Add(_relationalTypeMapping
-                    .CreateParameter(command, _name, value ?? _value, _nullable));
+                    .CreateParameter(command, _name, value, _nullable));
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Relational.FunctionalTests/FromSqlQueryTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.FunctionalTests/FromSqlQueryTestBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Data.Common;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.FunctionalTests.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.Internal;

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
@@ -632,8 +632,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.Update
 
             public void AddParameter(IRelationalParameter relationalParameter) => _parameters.Add(relationalParameter);
 
-            public IRelationalParameter CreateParameter(string name, object value, Func<IRelationalTypeMapper, RelationalTypeMapping> mapType, bool? nullable, string invariantName) 
-                => new RelationalParameter(name, value, new RelationalTypeMapping("name", typeof(Type)), null, invariantName);
+            public IRelationalParameter CreateParameter(string invariantName, string name, Func<IRelationalTypeMapper, RelationalTypeMapping> mapType, bool? nullable) 
+                => new RelationalParameter(invariantName, name, new RelationalTypeMapping("name", typeof(Type)), null);
 
             public IRelationalCommand Build()
                 => new FakeRelationalCommand(
@@ -661,30 +661,53 @@ namespace Microsoft.EntityFrameworkCore.Tests.Update
 
             public IReadOnlyList<IRelationalParameter> Parameters { get; }
 
-            public int ExecuteNonQuery(IRelationalConnection connection, bool manageConnection = true)
+            public IReadOnlyDictionary<string, object> CachedParameterValues { get; set; }
+
+            public int ExecuteNonQuery(
+                IRelationalConnection connection,
+                IReadOnlyDictionary<string, object> parameterValues = null,
+                bool manageConnection = true)
             {
                 throw new NotImplementedException();
             }
 
-            public Task<int> ExecuteNonQueryAsync(IRelationalConnection connection, bool manageConnection = true, CancellationToken cancellationToken = default(CancellationToken))
+            public Task<int> ExecuteNonQueryAsync(
+                IRelationalConnection connection,
+                IReadOnlyDictionary<string, object> parameterValues = null,
+                bool manageConnection = true,
+                CancellationToken cancellationToken = default(CancellationToken))
             {
                 throw new NotImplementedException();
             }
 
-            public object ExecuteScalar(IRelationalConnection connection, bool manageConnection = true)
+            public object ExecuteScalar(
+                IRelationalConnection connection,
+                IReadOnlyDictionary<string, object> parameterValues = null,
+                bool manageConnection = true)
             {
                 throw new NotImplementedException();
             }
 
-            public Task<object> ExecuteScalarAsync(IRelationalConnection connection, bool manageConnection = true, CancellationToken cancellationToken = default(CancellationToken))
+            public Task<object> ExecuteScalarAsync(
+                IRelationalConnection connection,
+                IReadOnlyDictionary<string, object> parameterValues = null,
+                bool manageConnection = true,
+                CancellationToken cancellationToken = default(CancellationToken))
             {
                 throw new NotImplementedException();
             }
 
-            public RelationalDataReader ExecuteReader(IRelationalConnection connection, bool manageConnection = true, IReadOnlyDictionary<string, object> parameters = null)
+            public RelationalDataReader ExecuteReader(
+                IRelationalConnection connection,
+                IReadOnlyDictionary<string, object> parameterValues = null,
+                bool manageConnection = true)
                 => new RelationalDataReader(null, new FakeDbCommand(), _reader);
 
-            public Task<RelationalDataReader> ExecuteReaderAsync(IRelationalConnection connection, bool manageConnection = true, IReadOnlyDictionary<string, object> parameters = null, CancellationToken cancellationToken = default(CancellationToken))
+            public Task<RelationalDataReader> ExecuteReaderAsync(
+                IRelationalConnection connection,
+                IReadOnlyDictionary<string, object> parameterValues = null,
+                bool manageConnection = true,
+                CancellationToken cancellationToken = default(CancellationToken))
                 => Task.FromResult(new RelationalDataReader(null, new FakeDbCommand(), _reader));
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerDatabaseCreatorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerDatabaseCreatorTest.cs
@@ -179,7 +179,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
                 throw new NotImplementedException();
             }
 
-            public IRelationalParameter CreateParameter(string name, object value, Func<IRelationalTypeMapper, RelationalTypeMapping> mapType, bool? nullable, string invariantName)
+            public IRelationalParameter CreateParameter(string invariantName, string name, Func<IRelationalTypeMapper, RelationalTypeMapping> mapType, bool? nullable)
             {
                 throw new NotImplementedException();
             }
@@ -193,30 +193,57 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
 
             public IReadOnlyList<IRelationalParameter> Parameters { get; }
 
-            public int ExecuteNonQuery(IRelationalConnection connection, bool manageConnection = true)
+            public IReadOnlyDictionary<string, object> CachedParameterValues
+            {
+                get { throw new NotImplementedException(); }
+                set { throw new NotImplementedException(); }
+            }
+
+            public int ExecuteNonQuery(
+                IRelationalConnection connection,
+                IReadOnlyDictionary<string, object> parameterValues = null,
+                bool manageConnection = true)
             {
                 return 0;
             }
 
-            public Task<int> ExecuteNonQueryAsync(IRelationalConnection connection, bool manageConnection = true, CancellationToken cancellationToken = default(CancellationToken))
+            public Task<int> ExecuteNonQueryAsync(
+                IRelationalConnection connection,
+                IReadOnlyDictionary<string, object> parameterValues = null,
+                bool manageConnection = true,
+                CancellationToken cancellationToken = default(CancellationToken))
                 => Task.FromResult(0);
 
-            public RelationalDataReader ExecuteReader(IRelationalConnection connection, bool manageConnection = true, IReadOnlyDictionary<string, object> parameters = null)
+            public RelationalDataReader ExecuteReader(
+                IRelationalConnection connection,
+                IReadOnlyDictionary<string, object> parameterValues = null,
+                bool manageConnection = true)
             {
                 throw new NotImplementedException();
             }
 
-            public Task<RelationalDataReader> ExecuteReaderAsync(IRelationalConnection connection, bool manageConnection = true, IReadOnlyDictionary<string, object> parameters = null, CancellationToken cancellationToken = default(CancellationToken))
+            public Task<RelationalDataReader> ExecuteReaderAsync(
+                IRelationalConnection connection,
+                IReadOnlyDictionary<string, object> parameterValues = null,
+                bool manageConnection = true,
+                CancellationToken cancellationToken = default(CancellationToken))
             {
                 throw new NotImplementedException();
             }
 
-            public object ExecuteScalar(IRelationalConnection connection, bool manageConnection = true)
+            public object ExecuteScalar(
+                IRelationalConnection connection,
+                IReadOnlyDictionary<string, object> parameterValues = null,
+                bool manageConnection = true)
             {
                 throw new NotImplementedException();
             }
 
-            public Task<object> ExecuteScalarAsync(IRelationalConnection connection, bool manageConnection = true, CancellationToken cancellationToken = default(CancellationToken))
+            public Task<object> ExecuteScalarAsync(
+                IRelationalConnection connection,
+                IReadOnlyDictionary<string, object> parameterValues = null,
+                bool manageConnection = true,
+                CancellationToken cancellationToken = default(CancellationToken))
             {
                 throw new NotImplementedException();
             }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
@@ -181,28 +181,54 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
 
                 public IReadOnlyList<IRelationalParameter> Parameters { get { throw new NotImplementedException(); } }
 
-                public int ExecuteNonQuery(IRelationalConnection connection, bool manageConnection = true)
+                public IReadOnlyDictionary<string, object> CachedParameterValues {
+                    get { throw new NotImplementedException(); }
+                    set { throw new NotImplementedException(); }
+                }
+
+                public int ExecuteNonQuery(
+                    IRelationalConnection connection,
+                    IReadOnlyDictionary<string, object> parameterValues = null,
+                    bool manageConnection = true)
                 {
                     throw new NotImplementedException();
                 }
 
-                public Task<int> ExecuteNonQueryAsync(IRelationalConnection connection, bool manageConnection = true, CancellationToken cancellationToken = default(CancellationToken))
+                public Task<int> ExecuteNonQueryAsync(
+                    IRelationalConnection connection,
+                    IReadOnlyDictionary<string, object> parameterValues = null,
+                    bool manageConnection = true,
+                    CancellationToken cancellationToken = default(CancellationToken))
                 {
                     throw new NotImplementedException();
                 }
 
-                public object ExecuteScalar(IRelationalConnection connection, bool manageConnection = true)
+                public object ExecuteScalar(
+                    IRelationalConnection connection,
+                    IReadOnlyDictionary<string, object> parameterValues = null,
+                    bool manageConnection = true)
                     => Interlocked.Add(ref _commandBuilder._current, _commandBuilder._blockSize);
 
-                public Task<object> ExecuteScalarAsync(IRelationalConnection connection, bool manageConnection = true, CancellationToken cancellationToken = default(CancellationToken))
+                public Task<object> ExecuteScalarAsync(
+                    IRelationalConnection connection,
+                    IReadOnlyDictionary<string, object> parameterValues = null,
+                    bool manageConnection = true,
+                    CancellationToken cancellationToken = default(CancellationToken))
                     => Task.FromResult<object>(Interlocked.Add(ref _commandBuilder._current, _commandBuilder._blockSize));
 
-                public RelationalDataReader ExecuteReader(IRelationalConnection connection, bool manageConnection = true, IReadOnlyDictionary<string, object> parameters = null)
+                public RelationalDataReader ExecuteReader(
+                    IRelationalConnection connection,
+                    IReadOnlyDictionary<string, object> parameterValues = null,
+                    bool manageConnection = true)
                 {
                     throw new NotImplementedException();
                 }
 
-                public Task<RelationalDataReader> ExecuteReaderAsync(IRelationalConnection connection, bool manageConnection = true, IReadOnlyDictionary<string, object> parameters = null, CancellationToken cancellationToken = default(CancellationToken))
+                public Task<RelationalDataReader> ExecuteReaderAsync(
+                    IRelationalConnection connection,
+                    IReadOnlyDictionary<string, object> parameterValues = null,
+                    bool manageConnection = true,
+                    CancellationToken cancellationToken = default(CancellationToken))
                 {
                     throw new NotImplementedException();
                 }


### PR DESCRIPTION
Allow providing parameter values as arguments or cached property value

Cleans up `RelationalCommand`:
 - When the `RelationalCommand` is built, no parameter values are referenced (query scenario)
 - Values can be added to the command after building (other scenarios)
  - Cached values will be used by default
  - If values are passed in, they will override the cached values (all or none)

These changes are an incremental step for #3115. Changes for that issue will include command and parameter building API consistency and extensibility cleanup.

@divega @maumar @anpete
