### PR TITLE
Handle lifting of relationships between entity types in the same hierarchy

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/Extensions/EntityTypeExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/EntityTypeExtensions.cs
@@ -78,6 +78,27 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         /// <summary>
+        ///     Gets the least derived type between the specified two.
+        /// </summary>
+        /// <param name="entityType"> The type to compare. </param>
+        /// <param name="otherEntityType"> The other entity type to compare with. </param>
+        /// <returns>
+        ///     The least derived type between the specified two.
+        ///     If the given entity types are not related, then <c>null</c> is returned.
+        /// </returns>
+        public static IEntityType LeastDerivedType([NotNull] this IEntityType entityType, [NotNull] IEntityType otherEntityType)
+        {
+            Check.NotNull(entityType, nameof(entityType));
+            Check.NotNull(otherEntityType, nameof(otherEntityType));
+
+            return entityType.IsAssignableFrom(otherEntityType)
+                ? entityType
+                : otherEntityType.IsAssignableFrom(entityType)
+                    ? otherEntityType
+                    : null;
+        }
+
+        /// <summary>
         ///     Gets the primary or alternate key that is defined on the given property. Returns null if no key is defined
         ///     for the given property.
         /// </summary>

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/EntityTypeBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/EntityTypeBuilder.cs
@@ -219,6 +219,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             var relatedEntityType = Builder.ModelBuilder.Entity(relatedType, ConfigurationSource.Explicit).Metadata;
 
             return new ReferenceNavigationBuilder(
+                Builder.Metadata,
                 relatedEntityType,
                 navigationName,
                 ReferenceBuilder(relatedEntityType, navigationName));
@@ -254,6 +255,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             var relatedEntityType = Builder.ModelBuilder.Entity(relatedTypeName, ConfigurationSource.Explicit).Metadata;
 
             return new ReferenceNavigationBuilder(
+                Builder.Metadata,
                 relatedEntityType,
                 navigationName,
                 ReferenceBuilder(relatedEntityType, navigationName));
@@ -357,7 +359,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             [NotNull] EntityType relatedEntityType, [CanBeNull] string navigationName)
             => Builder.ModelBuilder.Entity(relatedEntityType.Name, ConfigurationSource.Explicit)
                 .Relationship(Builder, ConfigurationSource.Explicit)
-                .DependentEntityType(relatedEntityType, ConfigurationSource.Explicit)
+                .RelatedEntityTypes(Builder.Metadata, relatedEntityType, ConfigurationSource.Explicit)
                 .IsUnique(false, ConfigurationSource.Explicit)
                 .PrincipalToDependent(navigationName, ConfigurationSource.Explicit);
 

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/EntityTypeBuilder`.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/EntityTypeBuilder`.cs
@@ -227,6 +227,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             var navigationName = reference?.GetPropertyAccess().Name;
 
             return new ReferenceNavigationBuilder<TEntity, TRelatedEntity>(
+                Builder.Metadata,
                 relatedEntityType,
                 navigationName,
                 ReferenceBuilder(relatedEntityType, navigationName));

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/ReferenceNavigationBuilder`.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/ReferenceNavigationBuilder`.cs
@@ -35,6 +35,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///         and it is not designed to be directly constructed in your application code.
         ///     </para>
         /// </summary>
+        /// <param name="declaringEntityType"> The entity type that the reference is declared on. </param>
         /// <param name="relatedEntityType"> The entity type that the reference points to. </param>
         /// <param name="navigationName">
         ///     The name of the reference navigation property on the end of the relationship that configuration began
@@ -42,10 +43,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// </param>
         /// <param name="builder"> The internal builder being used to configure the relationship. </param>
         public ReferenceNavigationBuilder(
+            [NotNull] EntityType declaringEntityType,
             [NotNull] EntityType relatedEntityType,
             [CanBeNull] string navigationName,
             [NotNull] InternalRelationshipBuilder builder)
-            : base(relatedEntityType, navigationName, builder)
+            : base(declaringEntityType, relatedEntityType, navigationName, builder)
         {
         }
 
@@ -72,7 +74,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// </param>
         /// <returns> An object to further configure the relationship. </returns>
         public virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> WithOne([CanBeNull] Expression<Func<TRelatedEntity, TEntity>> reference)
-            => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(WithOneBuilder(reference?.GetPropertyAccess().Name));
+            => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
+                WithOneBuilder(reference?.GetPropertyAccess().Name),
+                DeclaringEntityType,
+                RelatedEntityType);
 
         /// <summary>
         ///     Configures this as a one-to-many relationship.
@@ -96,6 +101,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> An object to further configure the relationship. </returns>
         public new virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> WithOne([CanBeNull] string reference = null)
             => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
-                WithOneBuilder(Check.NullButNotEmpty(reference, nameof(reference))));
+                WithOneBuilder(Check.NullButNotEmpty(reference, nameof(reference))),
+                DeclaringEntityType,
+                RelatedEntityType);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/ReferenceReferenceBuilder`.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/ReferenceReferenceBuilder`.cs
@@ -34,8 +34,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     </para>
         /// </summary>
         /// <param name="builder"> The internal builder being used to configure this relationship. </param>
-        public ReferenceReferenceBuilder([NotNull] InternalRelationshipBuilder builder)
-            : base(builder)
+        /// <param name="declaringEntityType"> The first entity type in the relationship. </param>
+        /// <param name="relatedEntityType"> The second entity type in the relationship. </param>
+        public ReferenceReferenceBuilder(
+            [NotNull] InternalRelationshipBuilder builder,
+            [NotNull] EntityType declaringEntityType,
+            [NotNull] EntityType relatedEntityType)
+            : base(builder, declaringEntityType, relatedEntityType)
         {
         }
 

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/ForeignKeyAttributeConvention.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/ForeignKeyAttributeConvention.cs
@@ -106,7 +106,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var newRelationshipBuilder = relationshipBuilder;
             if (invert)
             {
-                newRelationshipBuilder = newRelationshipBuilder.DependentEntityType(foreignKey.PrincipalEntityType, ConfigurationSource.DataAnnotation);
+                newRelationshipBuilder = newRelationshipBuilder.RelatedEntityTypes(
+                    foreignKey.DeclaringEntityType, foreignKey.PrincipalEntityType, ConfigurationSource.DataAnnotation);
             }
             if (upgradeDependentToPrincipalNavigationSource)
             {

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/ForeignKeyPropertyDiscoveryConvention.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/ForeignKeyPropertyDiscoveryConvention.cs
@@ -35,7 +35,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                     {
                         // Invert only if principal side has matching property & dependent does not have
                         relationshipBuilder = relationshipBuilder
-                            .DependentEntityType(foreignKey.PrincipalEntityType, ConfigurationSource.Convention)
+                            .RelatedEntityTypes(foreignKey.DeclaringEntityType, foreignKey.PrincipalEntityType, ConfigurationSource.Convention)
                             .HasForeignKey(candidatePropertiesOnPrincipal, ConfigurationSource.Convention);
 
                         Debug.Assert(relationshipBuilder != null);
@@ -72,8 +72,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                     {
                         // Invert and set one to one if principal side has matching property & dependent side does not have
                         relationshipBuilder = relationshipBuilder
-                            .DependentEntityType(foreignKey.PrincipalEntityType, ConfigurationSource.Convention)
-                            .IsUnique(true, ConfigurationSource.Convention)
+                            .RelatedEntityTypes(foreignKey.DeclaringEntityType, foreignKey.PrincipalEntityType, ConfigurationSource.Convention)
                             .HasForeignKey(candidatePropertiesOnPrincipal, ConfigurationSource.Convention);
 
                         Debug.Assert(relationshipBuilder != null);
@@ -117,7 +116,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             foreach (var baseName in baseNames)
             {
-                var match = FindMatchingNonShadowProperties(foreignKey, baseName, onDependent);
+                var match = FindMatchingProperties(foreignKey, baseName, onDependent);
                 if (match != null)
                 {
                     return match;
@@ -144,7 +143,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             return null;
         }
 
-        private IReadOnlyList<Property> FindMatchingNonShadowProperties(
+        private IReadOnlyList<Property> FindMatchingProperties(
             ForeignKey foreignKey, string baseName, bool onDependent)
         {
             var dependentEntityType = onDependent
@@ -227,7 +226,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             foreach (var property in entityType.GetProperties())
             {
                 if (property.Name.Equals(name, StringComparison.OrdinalIgnoreCase)
-                    && !property.IsShadowProperty
+                    && (!property.IsShadowProperty || !ConfigurationSource.Convention.Overrides(property.GetConfigurationSource())) 
                     && (property.ClrType.UnwrapNullableType() == type))
                 {
                     return property;

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityTypeExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityTypeExtensions.cs
@@ -198,6 +198,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                    || secondEntityType.IsAssignableFrom(firstEntityType);
         }
 
+        public static EntityType LeastDerivedType([NotNull] this EntityType entityType, [NotNull] EntityType otherEntityType)
+            => (EntityType)((IEntityType)entityType).LeastDerivedType(otherEntityType);
+
         public static bool IsAbstract([NotNull] this IEntityType entityType)
         {
             Check.NotNull(entityType, nameof(entityType));

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
@@ -1092,12 +1092,20 @@ namespace Microsoft.EntityFrameworkCore.Internal
             return string.Format(CultureInfo.CurrentCulture, GetString("NullableKey", "entityType", "property"), entityType, property);
         }
 
-        // <summary>
-        // A second operation started on this context before a previous operation completed. Any instance members are not guaranteed to be thread safe.
-        // </summary>
+        /// <summary>
+        /// A second operation started on this context before a previous operation completed. Any instance members are not guaranteed to be thread safe.
+        /// </summary>
         public static string ConcurrentMethodInvocation
         {
             get { return GetString("ConcurrentMethodInvocation"); }
+        }
+
+        /// <summary>
+        /// The specified entity types '{invalidDependentType}' and '{invalidPrincipalType}' are invalid. They should be '{dependentType}' and '{principalType}' or entity types in the same hierarchy.
+        /// </summary>
+        public static string EntityTypesNotInRelationship([CanBeNull] object invalidDependentType, [CanBeNull] object invalidPrincipalType, [CanBeNull] object dependentType, [CanBeNull] object principalType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("EntityTypesNotInRelationship", "invalidDependentType", "invalidPrincipalType", "dependentType", "principalType"), invalidDependentType, invalidPrincipalType, dependentType, principalType);
         }
 
         // <summary>

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
@@ -525,6 +525,9 @@
   <data name="ConcurrentMethodInvocation" xml:space="preserve">
     <value>A second operation started on this context before a previous operation completed. Any instance members are not guaranteed to be thread safe.</value>
   </data>
+  <data name="EntityTypesNotInRelationship" xml:space="preserve">
+    <value>The specified entity types '{invalidDependentType}' and '{invalidPrincipalType}' are invalid. They should be '{dependentType}' and '{principalType}' or entity types in the same hierarchy.</value>
+  </data>
   <data name="InvalidSetType" xml:space="preserve">
     <value>Cannot create a DbSet for '{typeName}' because this type is not included in the model for the context.</value>
   </data>

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
@@ -204,7 +204,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         [Fact]
-        public void Replaces_derived_relationship_of_lower_or_equal_source()
+        public void Promotes_derived_relationship()
         {
             var modelBuilder = CreateModelBuilder();
             var principalEntityBuilder = modelBuilder.Entity(typeof(SpecialCustomer), ConfigurationSource.Explicit);
@@ -222,18 +222,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             dependentEntityBuilder.HasBaseType(baseDependentEntityBuilder.Metadata, ConfigurationSource.Explicit);
 
             Assert.Empty(baseDependentEntityBuilder.Metadata.GetForeignKeys());
-
-            Assert.Null(baseDependentEntityBuilder.Relationship(
-                basePrincipalEntityBuilder,
-                Order.CustomerProperty.Name,
-                Customer.OrdersProperty.Name,
-                ConfigurationSource.Convention));
-
+            
             var relationship = baseDependentEntityBuilder.Relationship(
                 basePrincipalEntityBuilder,
                 Order.CustomerProperty.Name,
                 Customer.OrdersProperty.Name,
-                ConfigurationSource.DataAnnotation);
+                ConfigurationSource.Convention);
 
             Assert.Same(relationship.Metadata, dependentEntityBuilder.Metadata.GetForeignKeys().Single());
             Assert.Same(relationship.Metadata, principalEntityBuilder.Metadata.GetNavigations().Single().ForeignKey);
@@ -1783,7 +1777,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var orderRelationship = dependentEntityBuilder.Relationship(principalEntityBuilder, Order.CustomerProperty.Name, null, ConfigurationSource.DataAnnotation);
             Assert.NotNull(orderRelationship);
             var customerRelationship = dependentEntityBuilder.Relationship(principalEntityBuilder, null, Customer.NotCollectionOrdersProperty.Name, ConfigurationSource.Convention)
-                .DependentEntityType(dependentEntityBuilder, ConfigurationSource.Convention);
+                .RelatedEntityTypes(principalEntityBuilder.Metadata, dependentEntityBuilder.Metadata, ConfigurationSource.Convention);
             Assert.NotNull(customerRelationship);
 
             Assert.Null(principalEntityBuilder.Relationship(dependentEntityBuilder, Customer.NotCollectionOrdersProperty.Name, Order.CustomerProperty.Name, ConfigurationSource.Convention));
@@ -1806,7 +1800,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var orderRelationship = dependentEntityBuilder.Relationship(principalEntityBuilder, Order.CustomerProperty, null, ConfigurationSource.Convention);
             Assert.NotNull(orderRelationship);
             var customerRelationship = dependentEntityBuilder.Relationship(principalEntityBuilder, null, Customer.NotCollectionOrdersProperty, ConfigurationSource.DataAnnotation)
-                .PrincipalEntityType(principalEntityBuilder, ConfigurationSource.DataAnnotation);
+                .RelatedEntityTypes(principalEntityBuilder.Metadata, dependentEntityBuilder.Metadata, ConfigurationSource.DataAnnotation);
             Assert.NotNull(customerRelationship);
 
             Assert.Null(dependentEntityBuilder.Relationship(principalEntityBuilder, Customer.NotCollectionOrdersProperty, Order.CustomerProperty, ConfigurationSource.Convention));
@@ -1944,12 +1938,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
             dependentEntityBuilder.Relationship(
                 principalEntityBuilder, Order.CustomerProperty.Name, null, ConfigurationSource.DataAnnotation)
-                .DependentEntityType(dependentEntityBuilder, ConfigurationSource.DataAnnotation);
+                .RelatedEntityTypes(principalEntityBuilder.Metadata, dependentEntityBuilder.Metadata, ConfigurationSource.DataAnnotation);
 
             var derivedDependentEntityBuilder = modelBuilder.Entity(typeof(SpecialOrder), ConfigurationSource.Convention);
             derivedDependentEntityBuilder.Relationship(
                 principalEntityBuilder, Order.CustomerProperty.Name, null, ConfigurationSource.Explicit)
-                .PrincipalEntityType(derivedDependentEntityBuilder, ConfigurationSource.Explicit);
+                .RelatedEntityTypes(derivedDependentEntityBuilder.Metadata, principalEntityBuilder.Metadata, ConfigurationSource.Explicit);
 
             Assert.Null(derivedDependentEntityBuilder.HasBaseType(dependentEntityBuilder.Metadata, ConfigurationSource.Convention));
             Assert.Null(derivedDependentEntityBuilder.Metadata.BaseType);

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/InternalRelationshipBuilderTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/InternalRelationshipBuilderTest.cs
@@ -483,28 +483,48 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
 
             Assert.Same(orderEntityBuilder.Metadata, relationshipBuilder.Metadata.DeclaringEntityType);
 
-            relationshipBuilder = relationshipBuilder.DependentEntityType(relationshipBuilder.Metadata.PrincipalEntityType, ConfigurationSource.DataAnnotation);
+            relationshipBuilder = relationshipBuilder.RelatedEntityTypes(
+                relationshipBuilder.Metadata.DeclaringEntityType,
+                relationshipBuilder.Metadata.PrincipalEntityType,
+                ConfigurationSource.DataAnnotation);
             Assert.Same(customerEntityBuilder.Metadata, relationshipBuilder.Metadata.DeclaringEntityType);
 
             relationshipBuilder = relationshipBuilder.HasPrincipalKey(
                 orderEntityBuilder.Metadata.GetKeys().Single().Properties,
-                ConfigurationSource.Convention);
+                ConfigurationSource.Convention)
+                .HasForeignKey(new[] { Customer.IdProperty }, ConfigurationSource.DataAnnotation);
 
-            Assert.Null(relationshipBuilder.DependentEntityType(relationshipBuilder.Metadata.PrincipalEntityType, ConfigurationSource.Convention));
+            Assert.Null(relationshipBuilder.DependentEntityType(relationshipBuilder.Metadata.PrincipalEntityType, ConfigurationSource.DataAnnotation));
+
+            Assert.Equal(CoreStrings.EntityTypesNotInRelationship(
+                relationshipBuilder.Metadata.PrincipalEntityType.DisplayName(),
+                relationshipBuilder.Metadata.PrincipalEntityType.DisplayName(),
+                relationshipBuilder.Metadata.DeclaringEntityType.DisplayName(),
+                relationshipBuilder.Metadata.PrincipalEntityType.DisplayName()),
+                Assert.Throws<InvalidOperationException>(() => relationshipBuilder.DependentEntityType(relationshipBuilder.Metadata.PrincipalEntityType, ConfigurationSource.Explicit)).Message);
+
+            Assert.Null(relationshipBuilder.PrincipalEntityType(relationshipBuilder.Metadata.DeclaringEntityType, ConfigurationSource.DataAnnotation));
+
+            Assert.Equal(CoreStrings.EntityTypesNotInRelationship(
+                relationshipBuilder.Metadata.DeclaringEntityType.DisplayName(),
+                relationshipBuilder.Metadata.DeclaringEntityType.DisplayName(),
+                relationshipBuilder.Metadata.DeclaringEntityType.DisplayName(),
+                relationshipBuilder.Metadata.PrincipalEntityType.DisplayName()),
+                Assert.Throws<InvalidOperationException>(() => relationshipBuilder.PrincipalEntityType(relationshipBuilder.Metadata.DeclaringEntityType, ConfigurationSource.Explicit)).Message);
+
+            Assert.Same(customerEntityBuilder.Metadata, relationshipBuilder.Metadata.DeclaringEntityType);
+            Assert.Same(orderEntityBuilder.Metadata, relationshipBuilder.Metadata.PrincipalEntityType);
+
+            Assert.Null(relationshipBuilder.RelatedEntityTypes(
+                relationshipBuilder.Metadata.DeclaringEntityType,
+                relationshipBuilder.Metadata.PrincipalEntityType,
+                ConfigurationSource.Convention));
             Assert.Same(customerEntityBuilder.Metadata, relationshipBuilder.Metadata.DeclaringEntityType);
 
-            relationshipBuilder = relationshipBuilder.DependentEntityType(relationshipBuilder.Metadata.PrincipalEntityType, ConfigurationSource.DataAnnotation);
-            Assert.Same(orderEntityBuilder.Metadata, relationshipBuilder.Metadata.DeclaringEntityType);
-
-            relationshipBuilder = relationshipBuilder.DependentEntityType(relationshipBuilder.Metadata.PrincipalEntityType, ConfigurationSource.DataAnnotation);
-            Assert.Same(customerEntityBuilder.Metadata, relationshipBuilder.Metadata.DeclaringEntityType);
-
-            Assert.Null(relationshipBuilder.DependentEntityType(relationshipBuilder.Metadata.PrincipalEntityType, ConfigurationSource.Convention));
-            Assert.Same(customerEntityBuilder.Metadata, relationshipBuilder.Metadata.DeclaringEntityType);
-
-            relationshipBuilder = relationshipBuilder.HasForeignKey(new[] { Customer.IdProperty }, ConfigurationSource.DataAnnotation);
-
-            relationshipBuilder = relationshipBuilder.DependentEntityType(relationshipBuilder.Metadata.PrincipalEntityType, ConfigurationSource.DataAnnotation);
+            relationshipBuilder = relationshipBuilder.RelatedEntityTypes(
+                relationshipBuilder.Metadata.DeclaringEntityType,
+                relationshipBuilder.Metadata.PrincipalEntityType,
+                ConfigurationSource.DataAnnotation);
             Assert.Same(orderEntityBuilder.Metadata, relationshipBuilder.Metadata.DeclaringEntityType);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/NonRelationshipTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/NonRelationshipTestBase.cs
@@ -324,10 +324,9 @@ namespace Microsoft.EntityFrameworkCore.Tests
             }
 
             [Fact]
-            public virtual void Can_ignore_a_property_that_is_part_of_explicit_entity_key_throws()
+            public virtual void Can_ignore_a_property_that_is_part_of_explicit_entity_key()
             {
                 var modelBuilder = CreateModelBuilder();
-                var model = modelBuilder.Model;
 
                 var entityBuilder = modelBuilder.Entity<Customer>();
                 entityBuilder.HasKey(e => e.Id);
@@ -337,10 +336,9 @@ namespace Microsoft.EntityFrameworkCore.Tests
             }
 
             [Fact]
-            public virtual void Ignoring_shadow_properties_when_they_have_been_added_explicitly_throws()
+            public virtual void Can_ignore_shadow_properties_when_they_have_been_added_explicitly()
             {
                 var modelBuilder = CreateModelBuilder();
-                var model = modelBuilder.Model;
 
                 var entityBuilder = modelBuilder.Entity<Customer>();
                 entityBuilder.Property<string>("Shadow");

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/TestModel.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/TestModel.cs
@@ -226,7 +226,11 @@ namespace Microsoft.EntityFrameworkCore.Tests
 
         private class SpecialBookLabel : BookLabel
         {
-            public ICollection<BookLabel> BookLabels { get; set; }
+            public BookLabel BookLabel { get; set; }
+        }
+
+        private class ExtraSpecialBookLabel : SpecialBookLabel
+        {
         }
 
         private class AnotherBookLabel : BookLabel


### PR DESCRIPTION
Make InternalRelationshipBuilder.DependentEntityType() and InternalRelationshipBuilder.PrincipalEntityType() not try to invert the relationship
Add InternalRelationshipBuilder.RelatedEntityTypes() that handles inversion, as well as lifting of dependent or principal ends
  This avoids ambiguity between lifting and inverting relationships between types in the same hierarchy
Make ForeignKeyPropertyDiscoveryConvention match shadow properties that weren't added by convention