### PR TITLE
[SMALL] Fix framework reporting in benchmarks

### DIFF
--- a/test/Microsoft.EntityFrameworkCore.Microbenchmarks.Core/BenchmarkTestCaseRunner.cs
+++ b/test/Microsoft.EntityFrameworkCore.Microbenchmarks.Core/BenchmarkTestCaseRunner.cs
@@ -16,7 +16,6 @@ namespace Microsoft.EntityFrameworkCore.Microbenchmarks.Core
     public class BenchmarkTestCaseRunner : XunitTestCaseRunner
     {
         private static readonly string _machineName = GetMachineName();
-        private static readonly string _framework = GetFramework();
         private readonly IMessageSink _diagnosticMessageSink;
 
         public BenchmarkTestCaseRunner(
@@ -56,7 +55,7 @@ namespace Microsoft.EntityFrameworkCore.Microbenchmarks.Core
                 ProductReportingVersion = BenchmarkConfig.Instance.ProductReportingVersion,
                 RunStarted = DateTime.UtcNow,
                 MachineName = _machineName,
-                Framework = _framework,
+                Framework = PlatformServices.Default.Runtime.RuntimeType,
                 Architecture = IntPtr.Size > 4 ? "x64" : "x86",
                 WarmupIterations = TestCase.WarmupIterations,
                 Iterations = TestCase.Iterations,
@@ -119,12 +118,6 @@ namespace Microsoft.EntityFrameworkCore.Microbenchmarks.Core
                 BeforeAfterAttributes,
                 Aggregator,
                 CancellationTokenSource);
-        }
-
-        private static string GetFramework()
-        {
-            var env = PlatformServices.Default.Runtime;
-            return "DNX." + env.RuntimeType;
         }
 
         private static string GetMachineName()


### PR DESCRIPTION
We used to rely of conditional compilation to report Full .NET vs DNX,
but as part of moving to .NET CLI this was removed in
a80fd5277892dd1e9eee5c451df0b494ee98a9ff. We also no longer recompile
for each test run (we use central artifacts from CI build) - so
conditional compilation doesn't work anyway. Changing to just report CLR
vs CoreCLR and we can always report additional details via build
configuration parameters if needed.