### PR TITLE
Allow inverting non-unique relationships

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Metadata/Conventions/Internal/RelationalConventionSetBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Metadata/Conventions/Internal/RelationalConventionSetBuilder.cs
@@ -32,6 +32,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             ReplaceConvention(conventionSet.ForeignKeyAddedConventions, (ForeignKeyAttributeConvention)new RelationalForeignKeyAttributeConvention(_typeMapper));
 
+            ReplaceConvention(conventionSet.NavigationAddedConventions, relationshipDiscoveryConvention);
+
             ReplaceConvention(conventionSet.NavigationRemovedConventions, relationshipDiscoveryConvention);
 
             ReplaceConvention(conventionSet.ModelBuiltConventions, (PropertyMappingValidationConvention)new RelationalPropertyMappingValidationConvention(_typeMapper));

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/EntityTypeBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/EntityTypeBuilder.cs
@@ -334,17 +334,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> The newly created builder. </returns>
         protected virtual InternalRelationshipBuilder ReferenceBuilder(
             [NotNull] EntityType relatedEntityType, [CanBeNull] string navigationName)
-        {
-            var relationship = Builder.ModelBuilder.Entity(Metadata.Name, ConfigurationSource.Explicit)
-                .Relationship(relatedEntityType, ConfigurationSource.Explicit);
-
-            if (relationship.Metadata.IsSelfReferencing())
-            {
-                relationship = relationship.PrincipalEntityType(relatedEntityType, ConfigurationSource.Explicit);
-            }
-
-            return relationship.DependentToPrincipal(navigationName, ConfigurationSource.Explicit);
-        }
+            => Builder.Navigation(
+                relatedEntityType.Builder,
+                navigationName,
+                ConfigurationSource.Explicit,
+                strictPrincipalEnd: relatedEntityType == Metadata);
 
         /// <summary>
         ///     Creates a relationship builder for a relationship that has a collection navigation property on this entity.
@@ -359,7 +353,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             [NotNull] EntityType relatedEntityType, [CanBeNull] string navigationName)
             => Builder.ModelBuilder.Entity(relatedEntityType.Name, ConfigurationSource.Explicit)
                 .Relationship(Builder, ConfigurationSource.Explicit)
-                .RelatedEntityTypes(Builder.Metadata, relatedEntityType, ConfigurationSource.Explicit)
                 .IsUnique(false, ConfigurationSource.Explicit)
                 .PrincipalToDependent(navigationName, ConfigurationSource.Explicit);
 

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
@@ -61,6 +61,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             conventionSet.NavigationAddedConventions.Add(new RequiredNavigationAttributeConvention());
             conventionSet.NavigationAddedConventions.Add(foreignKeyPropertyDiscoveryConvention);
+            conventionSet.NavigationAddedConventions.Add(relationshipDiscoveryConvention);
 
             conventionSet.NavigationRemovedConventions.Add(relationshipDiscoveryConvention);
 

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/ForeignKeyPropertyDiscoveryConvention.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/ForeignKeyPropertyDiscoveryConvention.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
@@ -14,42 +13,28 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         public virtual InternalRelationshipBuilder Apply(InternalRelationshipBuilder relationshipBuilder)
         {
             var foreignKey = relationshipBuilder.Metadata;
-            if (!foreignKey.Properties.All(fk => fk.IsShadowProperty))
+            var foreignKeyProperties = FindCandidateForeignKeyProperties(foreignKey, onDependent: true);
+            if (foreignKeyProperties == null)
             {
-                return relationshipBuilder;
-            }
-
-            var foreignKeyProperties = FindCandidateForeignKeyProperties(
-                foreignKey, onDependent: true);
-
-            if (foreignKey.IsUnique
-                && !foreignKey.IsSelfPrimaryKeyReferencing())
-            {
-                var candidatePropertiesOnPrincipal = FindCandidateForeignKeyProperties(
-                    foreignKey, onDependent: false);
-
-                if (candidatePropertiesOnPrincipal != null)
+                // Try to invert if one to one or can be converted to one to one
+                if (foreignKey.IsUnique
+                    || (foreignKey.PrincipalToDependent == null))
                 {
-                    if ((foreignKeyProperties == null)
-                        && relationshipBuilder.CanInvert(candidatePropertiesOnPrincipal, ConfigurationSource.Convention))
+                    var candidatePropertiesOnPrincipal = FindCandidateForeignKeyProperties(foreignKey, onDependent: false);
+                    if (candidatePropertiesOnPrincipal != null
+                        && !foreignKey.PrincipalEntityType.FindForeignKeysInHierarchy(candidatePropertiesOnPrincipal).Any())
                     {
-                        // Invert only if principal side has matching property & dependent does not have
-                        relationshipBuilder = relationshipBuilder
-                            .RelatedEntityTypes(foreignKey.DeclaringEntityType, foreignKey.PrincipalEntityType, ConfigurationSource.Convention)
-                            .HasForeignKey(candidatePropertiesOnPrincipal, ConfigurationSource.Convention);
+                        var invertedRelationshipBuilder = relationshipBuilder
+                            .RelatedEntityTypes(foreignKey.DeclaringEntityType, foreignKey.PrincipalEntityType, ConfigurationSource.Convention);
 
-                        Debug.Assert(relationshipBuilder != null);
-                        return relationshipBuilder;
+                        return invertedRelationshipBuilder ?? relationshipBuilder;
                     }
-
-                    // Return if both sides have matching property
-                    return relationshipBuilder;
                 }
 
-                // Only match with PK if the principal end is set
-                if ((!ConfigurationSource.Convention.Overrides(foreignKey.GetPrincipalEndConfigurationSource())
-                     || !ConfigurationSource.Convention.Overrides(foreignKey.GetPrincipalKeyConfigurationSource()))
-                    && (foreignKeyProperties == null))
+                // Try to use PK properties if principal end is not ambiguous
+                if (foreignKey.IsUnique
+                    && !foreignKey.IsSelfReferencing()
+                    && !ConfigurationSource.Convention.Overrides(foreignKey.GetPrincipalEndConfigurationSource()))
                 {
                     foreignKeyProperties = GetCompatiblePrimaryKeyProperties(
                         foreignKey.DeclaringEntityType,
@@ -57,34 +42,26 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                         foreignKey.PrincipalKey.Properties);
                 }
             }
-            else if ((foreignKey.DependentToPrincipal != null)
-                     && !foreignKey.DependentToPrincipal.IsCollection()
-                     && (foreignKey.PrincipalToDependent == null))
-            {
-                // Single reference navigation which can be converted to one to one
-                var candidatePropertiesOnPrincipal = FindCandidateForeignKeyProperties(
-                    foreignKey, onDependent: false);
-
-                if (candidatePropertiesOnPrincipal != null)
-                {
-                    if ((foreignKeyProperties == null)
-                        && relationshipBuilder.CanInvert(candidatePropertiesOnPrincipal, ConfigurationSource.Convention))
-                    {
-                        // Invert and set one to one if principal side has matching property & dependent side does not have
-                        relationshipBuilder = relationshipBuilder
-                            .RelatedEntityTypes(foreignKey.DeclaringEntityType, foreignKey.PrincipalEntityType, ConfigurationSource.Convention)
-                            .HasForeignKey(candidatePropertiesOnPrincipal, ConfigurationSource.Convention);
-
-                        Debug.Assert(relationshipBuilder != null);
-                        return relationshipBuilder;
-                    }
-                }
-            }
 
             if ((foreignKeyProperties == null)
-                || (foreignKey.DeclaringEntityType.FindForeignKey(foreignKeyProperties, foreignKey.PrincipalKey, foreignKey.PrincipalEntityType) != null))
+                || foreignKey.DeclaringEntityType.FindForeignKeysInHierarchy(foreignKeyProperties).Any())
             {
                 return relationshipBuilder;
+            }
+
+            if (ConfigurationSource.Convention.Overrides(foreignKey.GetPrincipalEndConfigurationSource()))
+            {
+                var candidatePropertiesOnPrincipal = FindCandidateForeignKeyProperties(foreignKey, onDependent: false);
+                if (candidatePropertiesOnPrincipal != null
+                    && !foreignKey.PrincipalEntityType.FindForeignKeysInHierarchy(candidatePropertiesOnPrincipal).Any())
+                {
+                    // Ambiguous principal end
+                    if (relationshipBuilder.Metadata.GetPrincipalEndConfigurationSource() == ConfigurationSource.Convention)
+                    {
+                        relationshipBuilder.Metadata.SetPrincipalEndConfigurationSource(null);
+                    }
+                    return relationshipBuilder;
+                }
             }
 
             var newRelationshipBuilder = relationshipBuilder.HasForeignKey(foreignKeyProperties, ConfigurationSource.Convention);
@@ -226,7 +203,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             foreach (var property in entityType.GetProperties())
             {
                 if (property.Name.Equals(name, StringComparison.OrdinalIgnoreCase)
-                    && (!property.IsShadowProperty || !ConfigurationSource.Convention.Overrides(property.GetConfigurationSource())) 
+                    && (!property.IsShadowProperty || !ConfigurationSource.Convention.Overrides(property.GetConfigurationSource()))
                     && (property.ClrType.UnwrapNullableType() == type))
                 {
                     return property;

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/NavigationAttributeNavigationConvention.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/NavigationAttributeNavigationConvention.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
@@ -18,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Check.NotNull(relationshipBuilder, nameof(relationshipBuilder));
             Check.NotNull(navigation, nameof(navigation));
 
-            var attributes = navigation.DeclaringEntityType?.ClrType?.GetRuntimeProperties().FirstOrDefault(pi => pi.Name == navigation.Name)?.GetCustomAttributes<TAttribute>(true);
+            var attributes = GetAttributes<TAttribute>(navigation.DeclaringEntityType, navigation.Name);
 
             if (attributes != null)
             {
@@ -35,5 +36,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         }
 
         public abstract InternalRelationshipBuilder Apply([NotNull] InternalRelationshipBuilder relationshipBuilder, [NotNull] Navigation navigation, [NotNull] TAttribute attribute);
+
+        protected static IEnumerable<TCustomAttribute> GetAttributes<TCustomAttribute>([NotNull] EntityType entityType, [NotNull] string propertyName)
+            where TCustomAttribute : Attribute
+        {
+            Check.NotNull(entityType, nameof(entityType));
+            Check.NotNull(propertyName, nameof(propertyName));
+
+            return entityType.ClrType?.GetRuntimeProperties().FirstOrDefault(p => p.Name == propertyName)
+                ?.GetCustomAttributes<TCustomAttribute>(true);
+        }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/RelationshipDiscoveryConvention.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/RelationshipDiscoveryConvention.cs
@@ -11,7 +11,7 @@ using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 {
-    public class RelationshipDiscoveryConvention : IEntityTypeConvention, IBaseTypeConvention, INavigationRemovedConvention, IEntityTypeMemberIgnoredConvention
+    public class RelationshipDiscoveryConvention : IEntityTypeConvention, IBaseTypeConvention, INavigationRemovedConvention, IEntityTypeMemberIgnoredConvention, INavigationConvention
     {
         public virtual InternalEntityTypeBuilder Apply(InternalEntityTypeBuilder entityTypeBuilder)
         {
@@ -373,6 +373,17 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             public InternalEntityTypeBuilder TargetTypeBuilder { get; }
             public HashSet<PropertyInfo> NavigationProperties { get; }
             public HashSet<PropertyInfo> InverseProperties { get; }
+        }
+
+        public virtual InternalRelationshipBuilder Apply(InternalRelationshipBuilder relationshipBuilder, Navigation navigation)
+        {
+            var entityTypeBuilder = Apply(navigation.DeclaringEntityType.Builder);
+            if (relationshipBuilder.Metadata.Builder == null)
+            {
+                relationshipBuilder = entityTypeBuilder.Metadata.FindNavigation(navigation.Name)?.ForeignKey?.Builder;
+            }
+
+            return relationshipBuilder;
         }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/RelationshipValidationConvention.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/RelationshipValidationConvention.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -19,9 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 foreach (var foreignKey in entityType.GetDeclaredForeignKeys())
                 {
                     if (foreignKey.IsUnique
-                        && !foreignKey.IsSelfPrimaryKeyReferencing()
-                        && (foreignKey.GetForeignKeyPropertiesConfigurationSource() == null)
-                            && (foreignKey.GetPrincipalKeyConfigurationSource() == null))
+                        && foreignKey.GetPrincipalEndConfigurationSource() == null)
                     {
                         throw new InvalidOperationException(CoreStrings.AmbiguousOneToOneRelationship(
                             foreignKey.DeclaringEntityType.DisplayName() + (foreignKey.DependentToPrincipal == null ? "" : "." + foreignKey.DependentToPrincipal.Name),

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ConfigurationSourceExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ConfigurationSourceExtensions.cs
@@ -35,15 +35,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             return true;
         }
 
-        public static ConfigurationSource Max(this ConfigurationSource left, ConfigurationSource? right)
+        public static ConfigurationSource? Max(this ConfigurationSource? left, ConfigurationSource? right)
         {
             if (!right.HasValue
-                || left.Overrides(right.Value))
+                || (left.HasValue
+                    && left.Value.Overrides(right.Value)))
             {
                 return left;
             }
 
             return right.Value;
         }
+
+        public static ConfigurationSource Max(this ConfigurationSource left, ConfigurationSource? right)
+            => Max((ConfigurationSource?)left, right).Value;
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityType.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityType.cs
@@ -603,7 +603,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             if (runConventions)
             {
                 var builder = Model.ConventionDispatcher.OnForeignKeyAdded(foreignKey.Builder);
-                if (builder != null)
+                if (builder != null
+                    && configurationSource.HasValue)
                 {
                     builder = Model.ConventionDispatcher.OnPrincipalEndSet(builder);
                 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ForeignKey.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ForeignKey.cs
@@ -95,6 +95,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         public virtual ConfigurationSource? GetPrincipalEndConfigurationSource() => _principalEndConfigurationSource;
 
+        public virtual void SetPrincipalEndConfigurationSource(ConfigurationSource? configurationSource)
+            => _principalEndConfigurationSource = configurationSource;
+
         public virtual void UpdatePrincipalEndConfigurationSource(ConfigurationSource configurationSource)
             => _principalEndConfigurationSource = configurationSource.Max(_principalEndConfigurationSource);
 
@@ -257,7 +260,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         public virtual ConfigurationSource? GetIsRequiredConfigurationSource() => _isRequiredConfigurationSource;
 
-        private void UpdateIsRequiredConfigurationSource(ConfigurationSource configurationSource)
+        public virtual void SetIsRequiredConfigurationSource(ConfigurationSource? configurationSource)
+            => _isRequiredConfigurationSource = configurationSource;
+
+        public virtual void UpdateIsRequiredConfigurationSource(ConfigurationSource configurationSource)
             => _isRequiredConfigurationSource = configurationSource.Max(_isRequiredConfigurationSource);
 
         public virtual DeleteBehavior DeleteBehavior

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalModelBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalModelBuilder.cs
@@ -121,7 +121,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var entityTypeBuilder = entityType.Builder;
             foreach (var foreignKey in entityType.GetDeclaredForeignKeys().ToList())
             {
-                var removed = entityTypeBuilder.RemoveForeignKey(foreignKey, configurationSource, runConventions: false);
+                var removed = entityTypeBuilder.RemoveForeignKey(foreignKey, configurationSource);
                 Debug.Assert(removed.HasValue);
             }
 

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalPropertyBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalPropertyBuilder.cs
@@ -35,9 +35,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             return false;
         }
 
-        public virtual bool CanSetRequired(bool isRequired, ConfigurationSource configurationSource)
-            => (configurationSource.Overrides(Metadata.GetIsNullableConfigurationSource())
-                || (Metadata.IsNullable == !isRequired))
+        public virtual bool CanSetRequired(bool isRequired, ConfigurationSource? configurationSource)
+            => ((Metadata.IsNullable == !isRequired)
+                || (configurationSource.HasValue &&
+                    configurationSource.Value.Overrides(Metadata.GetIsNullableConfigurationSource())))
                && (isRequired
                    || Metadata.ClrType.IsNullableType()
                    || (configurationSource == ConfigurationSource.Explicit)); // let it throw for Explicit

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalRelationshipBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalRelationshipBuilder.cs
@@ -47,9 +47,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             bool _;
             if (!CanSetRelatedTypes(Metadata.PrincipalEntityType,
                 Metadata.DeclaringEntityType,
-                navigationToPrincipalName,
-                navigationToDependentName,
+                navigationToPrincipalName ?? "",
+                navigationToDependentName ?? "",
                 configurationSource,
+                false,
                 configurationSource == ConfigurationSource.Explicit,
                 out _,
                 out _,
@@ -66,9 +67,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             if (newRelationshipBuilder != null
                 && newRelationshipBuilder.Metadata.Builder == null)
             {
-                return FindForeignKey(
+                newRelationshipBuilder = FindForeignKey(
                     navigationToPrincipalName,
                     navigationToDependentName);
+            }
+
+            if (newRelationshipBuilder == null
+                || ((navigationToPrincipalName != newRelationshipBuilder.Metadata.DependentToPrincipal?.Name
+                     || navigationToDependentName != newRelationshipBuilder.Metadata.PrincipalToDependent?.Name)
+                    && (navigationToDependentName != newRelationshipBuilder.Metadata.DependentToPrincipal?.Name
+                        || navigationToPrincipalName != newRelationshipBuilder.Metadata.PrincipalToDependent?.Name)))
+            {
+                return null;
             }
 
             return newRelationshipBuilder;
@@ -77,127 +87,46 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         private InternalRelationshipBuilder Navigation(
             [CanBeNull] string navigationName,
             bool pointsToPrincipal,
-            ConfigurationSource configurationSource,
+            ConfigurationSource? configurationSource,
             bool runConventions)
         {
             var oldNavigation = pointsToPrincipal ? Metadata.DependentToPrincipal : Metadata.PrincipalToDependent;
             if (navigationName == oldNavigation?.Name)
             {
-                Metadata.UpdateConfigurationSource(configurationSource);
+                if (configurationSource.HasValue)
+                {
+                    Metadata.UpdateConfigurationSource(configurationSource.Value);
 
-                if (pointsToPrincipal)
-                {
-                    Metadata.HasDependentToPrincipal(navigationName, configurationSource, runConventions);
-                }
-                else
-                {
-                    Metadata.HasPrincipalToDependent(navigationName, configurationSource, runConventions);
+                    if (pointsToPrincipal)
+                    {
+                        Metadata.HasDependentToPrincipal(navigationName, configurationSource.Value, runConventions);
+                    }
+                    else
+                    {
+                        Metadata.HasPrincipalToDependent(navigationName, configurationSource.Value, runConventions);
+                    }
                 }
                 return this;
             }
 
-            if (pointsToPrincipal
-                && !configurationSource.Overrides(Metadata.GetDependentToPrincipalConfigurationSource()))
+            bool removeOppositeNavigation;
+            bool? shouldBeUnique;
+            if (!CanSetNavigation(
+                navigationName,
+                pointsToPrincipal,
+                configurationSource,
+                shouldThrow: configurationSource == ConfigurationSource.Explicit,
+                overrideSameSource: true,
+                shouldBeUnique: out shouldBeUnique,
+                removeOppositeNavigation: out removeOppositeNavigation))
             {
                 return null;
             }
-
-            if (!pointsToPrincipal
-                && !configurationSource.Overrides(Metadata.GetPrincipalToDependentConfigurationSource()))
-            {
-                return null;
-            }
-
-            var entityType = pointsToPrincipal ? Metadata.DeclaringEntityType : Metadata.PrincipalEntityType;
-            var entityTypeBuilder = entityType.Builder;
-
-            var strictPrincipal = false;
-            bool? shouldBeUnique = null;
-            var uniquenessConfigurationSource = ConfigurationSource.Convention;
-            if (navigationName != null)
-            {
-                if (entityTypeBuilder.IsIgnored(navigationName, configurationSource))
-                {
-                    return null;
-                }
-
-                if (!pointsToPrincipal)
-                {
-                    var canBeUnique = Internal.Navigation.IsCompatible(
-                        navigationName,
-                        Metadata.PrincipalEntityType,
-                        Metadata.DeclaringEntityType,
-                        shouldBeCollection: false,
-                        shouldThrow: false);
-                    var canBeNonUnique = Internal.Navigation.IsCompatible(
-                        navigationName,
-                        Metadata.PrincipalEntityType,
-                        Metadata.DeclaringEntityType,
-                        shouldBeCollection: true,
-                        shouldThrow: false);
-
-                    if (canBeUnique != canBeNonUnique)
-                    {
-                        if (!configurationSource.Overrides(Metadata.GetIsUniqueConfigurationSource())
-                            && (Metadata.IsUnique != canBeUnique))
-                        {
-                            return null;
-                        }
-
-                        shouldBeUnique = canBeUnique;
-                        if (canBeUnique)
-                        {
-                            uniquenessConfigurationSource = (Metadata.GetPrincipalEndConfigurationSource() ?? ConfigurationSource.Convention)
-                                .Max(Metadata.GetIsUniqueConfigurationSource());
-                        }
-                        else
-                        {
-                            strictPrincipal = true;
-                            uniquenessConfigurationSource = configurationSource;
-                        }
-                    }
-                    else if (!canBeUnique)
-                    {
-                        Internal.Navigation.IsCompatible(
-                            navigationName,
-                            Metadata.PrincipalEntityType,
-                            Metadata.DeclaringEntityType,
-                            shouldBeCollection: false,
-                            shouldThrow: configurationSource == ConfigurationSource.Explicit);
-
-                        return null;
-                    }
-                }
-                else if (!Internal.Navigation.IsCompatible(
-                    navigationName,
-                    Metadata.DeclaringEntityType,
-                    Metadata.PrincipalEntityType,
-                    shouldBeCollection: false,
-                    shouldThrow: configurationSource == ConfigurationSource.Explicit))
-                {
-                    return null;
-                }
-            }
-
-            var conflictingNavigation = navigationName == null
-                ? null
-                : entityTypeBuilder.Metadata.FindNavigationsInHierarchy(navigationName).FirstOrDefault();
 
             var builder = this;
-            if (conflictingNavigation?.ForeignKey == Metadata)
+            if (removeOppositeNavigation)
             {
-                Debug.Assert(conflictingNavigation.IsDependentToPrincipal() != pointsToPrincipal);
-
-                builder = builder.Navigation(null, conflictingNavigation.IsDependentToPrincipal(), configurationSource, runConventions);
-            }
-            else
-            {
-                Debug.Assert((conflictingNavigation == null) || runConventions);
-            }
-
-            if (shouldBeUnique.HasValue)
-            {
-                builder = builder.IsUnique(shouldBeUnique.Value, uniquenessConfigurationSource, runConventions);
+                builder = builder.Navigation(null, !pointsToPrincipal, configurationSource, runConventions);
             }
 
             if (runConventions)
@@ -207,21 +136,29 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     configurationSource,
                     navigationToPrincipalName: pointsToPrincipal ? navigationName : null,
                     navigationToDependentName: pointsToPrincipal ? null : navigationName,
-                    strictPrincipal: strictPrincipal);
+                    isUnique: shouldBeUnique);
+            }
+
+            if (shouldBeUnique.HasValue)
+            {
+                builder = builder.IsUnique(shouldBeUnique.Value, configurationSource.Value, false);
             }
 
             if (navigationName != null)
             {
+                var entityTypeBuilder = pointsToPrincipal
+                    ? Metadata.DeclaringEntityType.Builder
+                    : Metadata.PrincipalEntityType.Builder;
                 entityTypeBuilder.Unignore(navigationName);
             }
 
             if (pointsToPrincipal)
             {
-                builder.Metadata.HasDependentToPrincipal(navigationName, configurationSource, runConventions);
+                builder.Metadata.HasDependentToPrincipal(navigationName, configurationSource.Value, runConventions: false);
             }
             else
             {
-                builder.Metadata.HasPrincipalToDependent(navigationName, configurationSource, runConventions);
+                builder.Metadata.HasPrincipalToDependent(navigationName, configurationSource.Value, runConventions: false);
             }
 
             return builder;
@@ -230,22 +167,54 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual bool CanSetNavigation(
             [CanBeNull] string navigationName,
             bool pointsToPrincipal,
-            ConfigurationSource configurationSource)
+            ConfigurationSource? configurationSource,
+            bool overrideSameSource = true)
         {
+            bool? _;
+            bool __;
+            return CanSetNavigation(
+                navigationName,
+                pointsToPrincipal,
+                configurationSource,
+                false,
+                overrideSameSource,
+                out _,
+                out __);
+        }
+
+        private bool CanSetNavigation(
+            string navigationName,
+            bool pointsToPrincipal,
+            ConfigurationSource? configurationSource,
+            bool shouldThrow,
+            bool overrideSameSource,
+            out bool? shouldBeUnique,
+            out bool removeOppositeNavigation)
+        {
+            shouldBeUnique = null;
+            removeOppositeNavigation = false;
+
             var existingNavigation = pointsToPrincipal ? Metadata.DependentToPrincipal : Metadata.PrincipalToDependent;
             if (navigationName == existingNavigation?.Name)
             {
                 return true;
             }
 
+            if (!configurationSource.HasValue)
+            {
+                return false;
+            }
+
             if (pointsToPrincipal
-                && !configurationSource.Overrides(Metadata.GetDependentToPrincipalConfigurationSource()))
+                && (!configurationSource.Value.Overrides(Metadata.GetDependentToPrincipalConfigurationSource())
+                    || (!overrideSameSource && configurationSource.Value == Metadata.GetDependentToPrincipalConfigurationSource())))
             {
                 return false;
             }
 
             if (!pointsToPrincipal
-                && !configurationSource.Overrides(Metadata.GetPrincipalToDependentConfigurationSource()))
+                && (!configurationSource.Value.Overrides(Metadata.GetPrincipalToDependentConfigurationSource())
+                    || (!overrideSameSource && configurationSource.Value == Metadata.GetPrincipalToDependentConfigurationSource())))
             {
                 return false;
             }
@@ -254,68 +223,55 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 ? Metadata.DeclaringEntityType.Builder
                 : Metadata.PrincipalEntityType.Builder;
 
-            if (navigationName != null)
+            if (navigationName == null)
             {
-                if (entityTypeBuilder.IsIgnored(navigationName, configurationSource))
-                {
-                    return false;
-                }
-
-                if (!pointsToPrincipal)
-                {
-                    var canBeUnique = Internal.Navigation.IsCompatible(
-                        navigationName,
-                        Metadata.PrincipalEntityType,
-                        Metadata.DeclaringEntityType,
-                        shouldBeCollection: false,
-                        shouldThrow: false);
-                    var canBeNonUnique = Internal.Navigation.IsCompatible(
-                        navigationName,
-                        Metadata.PrincipalEntityType,
-                        Metadata.DeclaringEntityType,
-                        shouldBeCollection: true,
-                        shouldThrow: false);
-
-                    if (canBeUnique != canBeNonUnique)
-                    {
-                        if (!configurationSource.Overrides(Metadata.GetIsUniqueConfigurationSource())
-                            && (Metadata.IsUnique != canBeUnique))
-                        {
-                            return false;
-                        }
-                    }
-                    else if (!canBeUnique)
-                    {
-                        return false;
-                    }
-                }
-                else if (!Internal.Navigation.IsCompatible(
-                    navigationName,
-                    Metadata.DeclaringEntityType,
-                    Metadata.PrincipalEntityType,
-                    shouldBeCollection: false,
-                    shouldThrow: false))
-                {
-                    return false;
-                }
+                return true;
             }
 
-            var conflictingNavigation = navigationName == null
-                ? null
-                : entityTypeBuilder.Metadata.FindNavigation(navigationName);
-            if (conflictingNavigation != null)
+            if (entityTypeBuilder.IsIgnored(navigationName, configurationSource.Value))
+            {
+                return false;
+            }
+
+            if (!Internal.Navigation.IsCompatible(
+                navigationName,
+                pointsToPrincipal,
+                Metadata.DeclaringEntityType,
+                Metadata.PrincipalEntityType,
+                shouldThrow,
+                out shouldBeUnique))
+            {
+                return false;
+            }
+
+            if (shouldBeUnique.HasValue
+                && (Metadata.IsUnique != shouldBeUnique)
+                && !configurationSource.Value.Overrides(Metadata.GetIsUniqueConfigurationSource()))
+            {
+                return false;
+            }
+
+            foreach (var conflictingNavigation in entityTypeBuilder.Metadata.FindNavigationsInHierarchy(navigationName))
             {
                 if (conflictingNavigation.ForeignKey == Metadata)
                 {
-                    if (!CanSetNavigation(null, conflictingNavigation.IsDependentToPrincipal(), configurationSource))
+                    Debug.Assert(conflictingNavigation.IsDependentToPrincipal() != pointsToPrincipal);
+
+                    if (!pointsToPrincipal
+                        && !configurationSource.Value.Overrides(Metadata.GetDependentToPrincipalConfigurationSource())
+                        || (!overrideSameSource && configurationSource.Value == Metadata.GetDependentToPrincipalConfigurationSource()))
                     {
                         return false;
                     }
-                }
-                else if (!conflictingNavigation.ForeignKey.DeclaringEntityType.Builder
-                    .CanRemoveForeignKey(conflictingNavigation.ForeignKey, configurationSource))
-                {
-                    return false;
+
+                    if (pointsToPrincipal
+                        && !configurationSource.Value.Overrides(Metadata.GetPrincipalToDependentConfigurationSource())
+                        || (!overrideSameSource && configurationSource.Value == Metadata.GetPrincipalToDependentConfigurationSource()))
+                    {
+                        return false;
+                    }
+
+                    removeOppositeNavigation = true;
                 }
             }
 
@@ -338,7 +294,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 return null;
             }
 
-            if (!CanSetRequiredOnProperties(Metadata.Properties, isRequired, configurationSource, shouldThrow: false))
+            if (!CanSetRequiredOnProperties(
+                Metadata.Properties,
+                isRequired,
+                Metadata.DeclaringEntityType,
+                configurationSource,
+                shouldThrow: false))
             {
                 if (!configurationSource.Overrides(Metadata.GetForeignKeyPropertiesConfigurationSource()))
                 {
@@ -363,20 +324,26 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             return this;
         }
 
-        private bool CanSetRequired(bool isRequired, ConfigurationSource configurationSource)
+        public virtual bool CanSetRequired(bool isRequired, ConfigurationSource? configurationSource)
         {
             if (Metadata.IsRequired == isRequired)
             {
                 return true;
             }
 
-            if (!configurationSource.Overrides(Metadata.GetIsRequiredConfigurationSource()))
+            if (!configurationSource.HasValue
+                || !configurationSource.Value.Overrides(Metadata.GetIsRequiredConfigurationSource()))
             {
                 return false;
             }
 
-            if (!configurationSource.Overrides(Metadata.GetForeignKeyPropertiesConfigurationSource())
-                && !CanSetRequiredOnProperties(Metadata.Properties, isRequired, configurationSource, shouldThrow: false))
+            if (!configurationSource.Value.Overrides(Metadata.GetForeignKeyPropertiesConfigurationSource())
+                && !CanSetRequiredOnProperties(
+                    Metadata.Properties,
+                    isRequired,
+                    Metadata.DeclaringEntityType,
+                    configurationSource,
+                    shouldThrow: false))
             {
                 return false;
             }
@@ -384,19 +351,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             return true;
         }
 
-        private bool CanSetRequiredOnProperties(IEnumerable<Property> properties, bool? isRequired, ConfigurationSource configurationSource, bool shouldThrow)
-            => CanSetRequiredOnProperties(
-                properties,
-                isRequired,
-                Metadata.DeclaringEntityType,
-                configurationSource,
-                shouldThrow);
-
         private static bool CanSetRequiredOnProperties(
             IEnumerable<Property> properties,
             bool? isRequired,
             EntityType entityType,
-            ConfigurationSource configurationSource,
+            ConfigurationSource? configurationSource,
             bool shouldThrow)
         {
             if ((isRequired == null)
@@ -434,14 +393,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             return this;
         }
 
-        public virtual bool CanSetDeleteBehavior(DeleteBehavior deleteBehavior, ConfigurationSource configurationSource)
+        public virtual bool CanSetDeleteBehavior(DeleteBehavior deleteBehavior, ConfigurationSource? configurationSource)
         {
             if (Metadata.DeleteBehavior == deleteBehavior)
             {
                 return true;
             }
 
-            if (!configurationSource.Overrides(Metadata.GetDeleteBehaviorConfigurationSource()))
+            if (!configurationSource.HasValue
+                || !configurationSource.Value.Overrides(Metadata.GetDeleteBehaviorConfigurationSource()))
             {
                 return false;
             }
@@ -490,20 +450,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             return builder;
         }
 
-        private bool CanSetUnique(bool isUnique, ConfigurationSource configurationSource)
+        private bool CanSetUnique(bool isUnique, ConfigurationSource? configurationSource)
         {
             if (Metadata.IsUnique == isUnique)
             {
                 return true;
             }
 
-            if (!configurationSource.Overrides(Metadata.GetIsUniqueConfigurationSource()))
+            if (!configurationSource.HasValue
+                || !configurationSource.Value.Overrides(Metadata.GetIsUniqueConfigurationSource()))
             {
                 return false;
             }
 
             if ((Metadata.PrincipalToDependent != null)
-                && !configurationSource.Overrides(Metadata.GetPrincipalToDependentConfigurationSource())
+                && !configurationSource.Value.Overrides(Metadata.GetPrincipalToDependentConfigurationSource())
                 && !Internal.Navigation.IsCompatible(
                     Metadata.PrincipalToDependent.Name,
                     Metadata.PrincipalEntityType,
@@ -543,10 +504,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var builder = this;
             if (Metadata.DeclaringEntityType.IsAssignableFrom(dependentEntityType))
             {
-                Metadata.UpdatePrincipalEndConfigurationSource(configurationSource);
-                if (runConventions)
+                if (Metadata.GetPrincipalEndConfigurationSource()?.Overrides(configurationSource) != true)
                 {
-                    builder = ModelBuilder.Metadata.ConventionDispatcher.OnPrincipalEndSet(builder);
+                    Metadata.UpdatePrincipalEndConfigurationSource(configurationSource);
+                    if (runConventions)
+                    {
+                        builder = ModelBuilder.Metadata.ConventionDispatcher.OnPrincipalEndSet(builder);
+                    }
                 }
 
                 return builder;
@@ -557,7 +521,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             {
                 return RelatedEntityTypes(Metadata.PrincipalEntityType, dependentEntityType, configurationSource, runConventions);
             }
-            
+
             return null;
         }
 
@@ -588,10 +552,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var builder = this;
             if (Metadata.PrincipalEntityType.IsAssignableFrom(principalEntityType))
             {
-                Metadata.UpdatePrincipalEndConfigurationSource(configurationSource);
-                if (runConventions)
+                if (Metadata.GetPrincipalEndConfigurationSource()?.Overrides(configurationSource) != true)
                 {
-                    builder = ModelBuilder.Metadata.ConventionDispatcher.OnPrincipalEndSet(builder);
+                    Metadata.UpdatePrincipalEndConfigurationSource(configurationSource);
+                    if (runConventions)
+                    {
+                        builder = ModelBuilder.Metadata.ConventionDispatcher.OnPrincipalEndSet(builder);
+                    }
                 }
 
                 return builder;
@@ -602,14 +569,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             {
                 return RelatedEntityTypes(principalEntityType, Metadata.DeclaringEntityType, configurationSource, runConventions);
             }
-            
+
             return null;
         }
 
         public virtual InternalRelationshipBuilder RelatedEntityTypes(
             [NotNull] EntityType principalEntityType,
             [NotNull] EntityType dependentEntityType,
-            ConfigurationSource configurationSource,
+            ConfigurationSource? configurationSource,
             bool runConventions = true)
         {
             bool shouldInvert;
@@ -620,7 +587,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             if (!CanSetRelatedTypes(
                 principalEntityType,
                 dependentEntityType,
-                !CanInvert(configurationSource),
+                ConfigurationSource.Explicit,
                 null,
                 null,
                 configurationSource,
@@ -638,8 +605,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var builder = this;
             if (shouldInvert)
             {
-                Debug.Assert(configurationSource.Overrides(Metadata.GetForeignKeyPropertiesConfigurationSource()));
-                Debug.Assert(configurationSource.Overrides(Metadata.GetPrincipalKeyConfigurationSource()));
+                Debug.Assert(!configurationSource.HasValue
+                             || configurationSource.Value.Overrides(Metadata.GetForeignKeyPropertiesConfigurationSource()));
+                Debug.Assert(!configurationSource.HasValue
+                             || configurationSource.Value.Overrides(Metadata.GetPrincipalKeyConfigurationSource()));
 
                 principalEntityType = principalEntityType.LeastDerivedType(Metadata.DeclaringEntityType);
                 dependentEntityType = dependentEntityType.LeastDerivedType(Metadata.PrincipalEntityType);
@@ -657,11 +626,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                                  && !shouldResetPrincipalProperties
                                  && !shouldResetDependentProperties);
 
-                    builder.Metadata.UpdatePrincipalEndConfigurationSource(configurationSource);
-
-                    if (runConventions)
+                    if (configurationSource.HasValue
+                        && Metadata.GetPrincipalEndConfigurationSource()?.Overrides(configurationSource) != true)
                     {
-                        builder = ModelBuilder.Metadata.ConventionDispatcher.OnPrincipalEndSet(builder);
+                        builder.Metadata.UpdatePrincipalEndConfigurationSource(configurationSource.Value);
+                        if (runConventions)
+                        {
+                            builder = ModelBuilder.Metadata.ConventionDispatcher.OnPrincipalEndSet(builder);
+                        }
                     }
 
                     return builder;
@@ -676,7 +648,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 navigationToDependentName: shouldResetToDependent ? "" : null,
                 dependentProperties: shouldResetDependentProperties ? new Property[0] : null,
                 principalProperties: shouldResetPrincipalProperties ? new Property[0] : null,
-                isUnique: shouldInvert ? true : (bool?)null,
                 strictPrincipal: true,
                 oldRelationshipInverted: shouldInvert,
                 runConventions: runConventions);
@@ -688,14 +659,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                && ((newForeignKeyProperties == null)
                    || CanSetForeignKey(newForeignKeyProperties, Metadata.PrincipalEntityType, configurationSource));
 
-        private bool CanInvert(ConfigurationSource configurationSource)
+        private bool CanInvert(ConfigurationSource? configurationSource)
         {
-            if (!CanSetUnique(true, configurationSource))
-            {
-                return false;
-            }
-
-            if (!configurationSource.Overrides(Metadata.GetPrincipalEndConfigurationSource()))
+            if (configurationSource == null
+                || !configurationSource.Value.Overrides(Metadata.GetPrincipalEndConfigurationSource()))
             {
                 return false;
             }
@@ -723,31 +690,38 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 GetExistingProperties(properties, Metadata.DeclaringEntityType), configurationSource, runConventions: true);
 
         public virtual InternalRelationshipBuilder HasForeignKey(
-            [CanBeNull] IReadOnlyList<Property> properties, ConfigurationSource configurationSource, bool runConventions)
+            [CanBeNull] IReadOnlyList<Property> properties, ConfigurationSource? configurationSource, bool runConventions)
         {
-            if (properties == null)
+            if (properties == null
+                && configurationSource.HasValue)
             {
-                return !configurationSource.Overrides(Metadata.GetForeignKeyPropertiesConfigurationSource())
+                return !configurationSource.Value.Overrides(Metadata.GetForeignKeyPropertiesConfigurationSource())
                     ? null
                     : ReplaceForeignKey(configurationSource,
                         dependentProperties: new Property[0],
                         runConventions: runConventions);
             }
 
+            var builder = this;
             if (Metadata.Properties.SequenceEqual(properties))
             {
-                var builder = this;
-                builder.Metadata.UpdateForeignKeyPropertiesConfigurationSource(configurationSource);
-                builder.Metadata.UpdateConfigurationSource(configurationSource);
+                if (!configurationSource.HasValue)
+                {
+                    return this;
+                }
+
+                builder.Metadata.UpdateForeignKeyPropertiesConfigurationSource(configurationSource.Value);
+                builder.Metadata.UpdateConfigurationSource(configurationSource.Value);
 
                 foreach (var property in properties)
                 {
-                    property.UpdateConfigurationSource(configurationSource);
+                    property.UpdateConfigurationSource(configurationSource.Value);
                 }
 
-                if (!Metadata.IsSelfReferencing())
+                if (!Metadata.IsSelfReferencing()
+                    && Metadata.GetPrincipalEndConfigurationSource()?.Overrides(configurationSource) != true)
                 {
-                    Metadata.UpdatePrincipalEndConfigurationSource(configurationSource);
+                    Metadata.UpdatePrincipalEndConfigurationSource(configurationSource.Value);
                     if (runConventions)
                     {
                         builder = ModelBuilder.Metadata.ConventionDispatcher.OnPrincipalEndSet(builder);
@@ -757,10 +731,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 return builder;
             }
 
-            if (!configurationSource.Overrides(Metadata.GetForeignKeyPropertiesConfigurationSource()))
+            bool resetIsRequired;
+            bool resetPrincipalKey;
+            if (!CanSetForeignKey(properties, Metadata.DeclaringEntityType, configurationSource, out resetIsRequired, out resetPrincipalKey))
             {
                 return null;
             }
+
+            Debug.Assert(configurationSource.HasValue);
 
             if ((Metadata.DeclaringEntityType.BaseType != null)
                 && (configurationSource != ConfigurationSource.Explicit) // let it throw for explicit
@@ -769,57 +747,46 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 return null;
             }
 
-            var resetIsRequired = false;
-            if (!CanSetRequiredOnProperties(properties, Metadata.IsRequired, configurationSource, shouldThrow: false))
+            if (resetIsRequired)
             {
-                if (!configurationSource.Overrides(Metadata.GetIsRequiredConfigurationSource()))
-                {
-                    return null;
-                }
-                resetIsRequired = true;
+                Metadata.SetIsRequiredConfigurationSource(null);
             }
 
-            Property[] principalProperties = null;
-            if (Metadata.GetForeignKeyPropertiesConfigurationSource().HasValue
-                && !ForeignKey.AreCompatible(
-                    Metadata.PrincipalKey.Properties,
-                    properties,
-                    Metadata.PrincipalEntityType,
-                    Metadata.DeclaringEntityType,
-                    shouldThrow: false))
-            {
-                if (!configurationSource.Overrides(Metadata.GetPrincipalKeyConfigurationSource()))
-                {
-                    return null;
-                }
-
-                principalProperties = new Property[0];
-            }
-
-            if (resetIsRequired
-                && Metadata.GetIsRequiredConfigurationSource().HasValue)
-            {
-                // ReSharper disable once PossibleInvalidOperationException
-                Metadata.SetIsRequired(!Metadata.IsRequired, Metadata.GetIsRequiredConfigurationSource().Value);
-            }
-
-            return ReplaceForeignKey(
+            return builder.ReplaceForeignKey(
                 configurationSource,
                 dependentProperties: properties,
-                principalProperties: principalProperties,
+                principalProperties: resetPrincipalKey ? new Property[0] : null,
                 runConventions: runConventions);
         }
 
         private bool CanSetForeignKey(
-            IReadOnlyList<Property> properties, EntityType dependentEntityType, ConfigurationSource configurationSource)
+            IReadOnlyList<Property> properties,
+            EntityType dependentEntityType,
+            ConfigurationSource? configurationSource)
         {
+            bool _;
+            return CanSetForeignKey(properties, dependentEntityType, configurationSource, out _, out _);
+        }
+
+        private bool CanSetForeignKey(
+            IReadOnlyList<Property> properties,
+            EntityType dependentEntityType,
+            ConfigurationSource? configurationSource,
+            out bool resetIsRequired,
+            out bool resetPrincipalKey,
+            bool overrideSameSource = true)
+        {
+            resetIsRequired = false;
+            resetPrincipalKey = false;
             if (properties != null
                 && Metadata.Properties.SequenceEqual(properties))
             {
                 return true;
             }
 
-            if (!configurationSource.Overrides(Metadata.GetForeignKeyPropertiesConfigurationSource()))
+            if (!configurationSource.HasValue
+                || !configurationSource.Value.Overrides(Metadata.GetForeignKeyPropertiesConfigurationSource())
+                || (!overrideSameSource && configurationSource.Value == Metadata.GetForeignKeyPropertiesConfigurationSource()))
             {
                 return false;
             }
@@ -829,14 +796,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 return true;
             }
 
-            if (!configurationSource.Overrides(Metadata.GetIsRequiredConfigurationSource())
-                && !CanSetRequiredOnProperties(properties, Metadata.IsRequired, configurationSource, shouldThrow: false))
+            if (!CanSetRequiredOnProperties(
+                properties,
+                Metadata.IsRequired,
+                Metadata.DeclaringEntityType,
+                configurationSource,
+                shouldThrow: false))
             {
-                return false;
+                if (!configurationSource.Value.Overrides(Metadata.GetIsRequiredConfigurationSource()))
+                {
+                    return false;
+                }
+                resetIsRequired = true;
             }
 
-            if (!configurationSource.Overrides(Metadata.GetPrincipalKeyConfigurationSource())
-                && (dependentEntityType == Metadata.DeclaringEntityType)
+            if (Metadata.GetForeignKeyPropertiesConfigurationSource().HasValue
                 && !ForeignKey.AreCompatible(
                     Metadata.PrincipalKey.Properties,
                     properties,
@@ -844,12 +818,22 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     Metadata.DeclaringEntityType,
                     shouldThrow: false))
             {
-                return false;
+                if (!configurationSource.Value.Overrides(Metadata.GetPrincipalKeyConfigurationSource()))
+                {
+                    return false;
+                }
+
+                resetPrincipalKey = true;
             }
 
-            var conflictingForeignKey = dependentEntityType.FindForeignKeys(properties).SingleOrDefault();
-            if ((conflictingForeignKey != null)
-                && !conflictingForeignKey.DeclaringEntityType.Builder.CanRemoveForeignKey(conflictingForeignKey, configurationSource))
+            if (!configurationSource.Value.Overrides(Metadata.GetPrincipalKeyConfigurationSource())
+                && (dependentEntityType == Metadata.DeclaringEntityType)
+                && !ForeignKey.AreCompatible(
+                    Metadata.PrincipalKey.Properties,
+                    properties,
+                    Metadata.PrincipalEntityType,
+                    Metadata.DeclaringEntityType,
+                    shouldThrow: false))
             {
                 return false;
             }
@@ -889,7 +873,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 builder.Metadata.UpdatePrincipalKeyConfigurationSource(configurationSource);
                 builder.Metadata.PrincipalKey.UpdateConfigurationSource(configurationSource);
 
-                if (!Metadata.IsSelfReferencing())
+                if (!Metadata.IsSelfReferencing()
+                    && Metadata.GetPrincipalEndConfigurationSource()?.Overrides(configurationSource) != true)
                 {
                     Metadata.UpdatePrincipalEndConfigurationSource(configurationSource);
                     if (runConventions)
@@ -930,7 +915,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 runConventions: runConventions);
         }
 
-        private bool CanSetPrincipalKey(IReadOnlyList<Property> properties, ConfigurationSource configurationSource)
+        private bool CanSetPrincipalKey(IReadOnlyList<Property> properties, ConfigurationSource? configurationSource)
         {
             if (properties == null)
             {
@@ -942,12 +927,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 return true;
             }
 
-            if (!configurationSource.Overrides(Metadata.GetPrincipalKeyConfigurationSource()))
+            if (!configurationSource.HasValue
+                || !configurationSource.Value.Overrides(Metadata.GetPrincipalKeyConfigurationSource()))
             {
                 return false;
             }
 
-            if (!configurationSource.Overrides(Metadata.GetForeignKeyPropertiesConfigurationSource())
+            if (!configurationSource.Value.Overrides(Metadata.GetForeignKeyPropertiesConfigurationSource())
                 && !ForeignKey.AreCompatible(
                     properties,
                     Metadata.Properties,
@@ -962,7 +948,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         private InternalRelationshipBuilder ReplaceForeignKey(
-            ConfigurationSource configurationSource,
+            ConfigurationSource? configurationSource,
             InternalEntityTypeBuilder principalEntityTypeBuilder = null,
             InternalEntityTypeBuilder dependentEntityTypeBuilder = null,
             string navigationToPrincipalName = null,
@@ -1026,22 +1012,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             dependentProperties = dependentProperties ??
                                   ((Metadata.GetForeignKeyPropertiesConfigurationSource()?.Overrides(configurationSource) ?? false)
                                    && !oldRelationshipInverted
-                                   // To find matching property when adding navigation. Both sides can have matching propery, one of them being matching with navigation name
-                                   && (!settingNewNavigation || !ConfigurationSource.Convention.Overrides(Metadata.GetForeignKeyPropertiesConfigurationSource()))
                                       ? Metadata.Properties
                                       : null);
-            dependentProperties = dependentProperties?.Count == 0
-                ? null
-                : dependentProperties;
 
             principalProperties = principalProperties ??
                                   ((Metadata.GetPrincipalKeyConfigurationSource()?.Overrides(configurationSource) ?? false)
                                    && !oldRelationshipInverted
                                       ? Metadata.PrincipalKey.Properties
                                       : null);
-            principalProperties = principalProperties?.Count == 0
-                ? null
-                : principalProperties;
 
             isUnique = isUnique ??
                        ((Metadata.GetIsUniqueConfigurationSource()?.Overrides(configurationSource) ?? false)
@@ -1058,11 +1036,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                                  ? Metadata.DeleteBehavior
                                  : (DeleteBehavior?)null);
 
-            strictPrincipal = strictPrincipal
-                              || (Metadata.GetPrincipalEndConfigurationSource()?.Overrides(configurationSource) ?? false)
-                              || ((principalEntityTypeBuilder.Metadata != dependentEntityTypeBuilder.Metadata)
-                                  && ((principalProperties != null)
-                                      || (dependentProperties != null)));
+            var principalEndConfigurationSource =
+                strictPrincipal
+                || (principalProperties != null)
+                || (dependentProperties != null)
+                || ((navigationToDependentName != null) && (isUnique == false))
+                    ? configurationSource
+                    : null;
+            principalEndConfigurationSource = principalEndConfigurationSource.Max(Metadata.GetPrincipalEndConfigurationSource());
 
             return ReplaceForeignKey(
                 principalEntityTypeBuilder,
@@ -1074,8 +1055,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 isUnique,
                 isRequired,
                 deleteBehavior,
-                strictPrincipal,
                 oldRelationshipInverted,
+                principalEndConfigurationSource,
                 configurationSource,
                 runConventions);
         }
@@ -1090,9 +1071,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             bool? isUnique,
             bool? isRequired,
             DeleteBehavior? deleteBehavior,
-            bool strictPrincipal,
             bool oldRelationshipInverted,
-            ConfigurationSource configurationSource,
+            ConfigurationSource? principalEndConfigurationSource,
+            ConfigurationSource? configurationSource,
             bool runConventions)
         {
             Check.NotNull(principalEntityTypeBuilder, nameof(principalEntityTypeBuilder));
@@ -1102,136 +1083,54 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 dependentEntityTypeBuilder.Metadata,
                 navigationToPrincipalName == "" ? null : navigationToPrincipalName,
                 navigationToDependentName == "" ? null : navigationToDependentName,
-                dependentProperties,
-                principalProperties,
+                dependentProperties != null && dependentProperties.Any() ? dependentProperties : null,
+                principalProperties != null && principalProperties.Any() ? principalProperties : null,
                 isUnique,
                 isRequired,
                 configurationSource));
 
+            var newRelationshipConfigurationSource = Metadata.GetConfigurationSource();
+            if ((dependentProperties != null && dependentProperties.Any())
+                || !string.IsNullOrEmpty(navigationToPrincipalName)
+                || !string.IsNullOrEmpty(navigationToDependentName))
+            {
+                newRelationshipConfigurationSource = newRelationshipConfigurationSource.Max(configurationSource);
+            }
+
             var dependentEntityType = dependentEntityTypeBuilder.Metadata;
             var principalEntityType = principalEntityTypeBuilder.Metadata;
-            var matchingRelationships = dependentEntityTypeBuilder.GetRelationshipBuilders(
-                principalEntityType,
-                navigationToPrincipalName == "" ? null : navigationToPrincipalName,
-                navigationToDependentName == "" ? null : navigationToDependentName,
-                dependentProperties);
-
-            var existingRelationshipInverted = false;
-            matchingRelationships = matchingRelationships.Distinct().Where(r => r.Metadata != Metadata).ToList();
-            var newRelationshipBuilder = matchingRelationships.FirstOrDefault(r =>
-                r.CanSet(principalEntityType,
-                    dependentEntityType,
-                    navigationToPrincipalName == "" ? null : navigationToPrincipalName,
-                    navigationToDependentName == "" ? null : navigationToDependentName,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    strictPrincipal,
-                    configurationSource,
-                    false,
-                    out existingRelationshipInverted));
-
-            var conflictingRelationships = matchingRelationships.Where(r => r != newRelationshipBuilder).ToList();
-            var addedForeignKeys = new List<InternalRelationshipBuilder>();
-            if (conflictingRelationships.Any(relationshipBuilder =>
-                !relationshipBuilder.Metadata.DeclaringEntityType.Builder
-                    .CanRemoveForeignKey(relationshipBuilder.Metadata, configurationSource)))
-            {
-                if (dependentProperties == null)
-                {
-                    return null;
-                }
-
-                var conflictingForeignKeyWithSameProperties = conflictingRelationships.FirstOrDefault(r => r.Metadata.Properties.SequenceEqual(dependentProperties));
-                if (conflictingForeignKeyWithSameProperties == null
-                    || !conflictingForeignKeyWithSameProperties.CanSetForeignKey(null, conflictingForeignKeyWithSameProperties.Metadata.DeclaringEntityType, configurationSource))
-                {
-                    return null;
-                }
-
-                conflictingRelationships.Remove(conflictingForeignKeyWithSameProperties);
-                if (conflictingRelationships.Count > 0)
-                {
-                    return null;
-                }
-                conflictingForeignKeyWithSameProperties = conflictingForeignKeyWithSameProperties.HasForeignKey(null, configurationSource, runConventions: false);
-                addedForeignKeys.Add(conflictingForeignKeyWithSameProperties);
-            }
-
-            var shouldUpgradeSource = (dependentProperties != null)
-                                      || !string.IsNullOrEmpty(navigationToPrincipalName)
-                                      || !string.IsNullOrEmpty(navigationToDependentName);
-
-            var newRelationshipConfigurationSource = shouldUpgradeSource
-                ? configurationSource
-                : ConfigurationSource.Convention;
-
             var removedNavigations = new Dictionary<string, Tuple<InternalEntityTypeBuilder, InternalEntityTypeBuilder, string>>();
             var removedForeignKeys = new List<Tuple<InternalEntityTypeBuilder, ForeignKey>>();
-            if (Metadata.DeclaringEntityType.GetDeclaredForeignKeys().Contains(Metadata))
-            {
-                var oldDependentEntityTypeBuilder = Metadata.DeclaringEntityType.Builder;
-                var oldPrincipalEntityTypeBuilder = Metadata.PrincipalEntityType.Builder;
-                var oldNavigationToPrincipalName = Metadata.DependentToPrincipal?.Name;
-                if (oldNavigationToPrincipalName != null)
-                {
-                    removedNavigations[Metadata.DeclaringEntityType.Name + oldNavigationToPrincipalName] = Tuple.Create(
-                        oldDependentEntityTypeBuilder, oldPrincipalEntityTypeBuilder, oldNavigationToPrincipalName);
-                }
-                var oldNavigationToDependentName = Metadata.PrincipalToDependent?.Name;
-                if (oldNavigationToDependentName != null)
-                {
-                    removedNavigations[Metadata.PrincipalEntityType.Name + oldNavigationToDependentName] = Tuple.Create(
-                        oldPrincipalEntityTypeBuilder, oldDependentEntityTypeBuilder, oldNavigationToDependentName);
-                }
-
-                var fkOwner = Metadata.DeclaringEntityType.Builder;
-                var replacedConfigurationSource = fkOwner.RemoveForeignKey(Metadata, ConfigurationSource.Explicit, runConventions: false);
-                Debug.Assert(replacedConfigurationSource.HasValue);
-
-                removedForeignKeys.Add(Tuple.Create(fkOwner, Metadata));
-                newRelationshipConfigurationSource = newRelationshipConfigurationSource.Max(replacedConfigurationSource.Value);
-            }
-
-            foreach (var relationshipBuilder in conflictingRelationships)
-            {
-                var foreignKey = relationshipBuilder.Metadata;
-                var oldDependentEntityTypeBuilder = foreignKey.DeclaringEntityType.Builder;
-                var oldPrincipalEntityTypeBuilder = foreignKey.PrincipalEntityType.Builder;
-                if (foreignKey.DependentToPrincipal != null)
-                {
-                    removedNavigations[foreignKey.DeclaringEntityType.Name + foreignKey.DependentToPrincipal.Name] = Tuple.Create(
-                        oldDependentEntityTypeBuilder, oldPrincipalEntityTypeBuilder, foreignKey.DependentToPrincipal.Name);
-                }
-                if (foreignKey.PrincipalToDependent != null)
-                {
-                    removedNavigations[foreignKey.PrincipalEntityType.Name + foreignKey.PrincipalToDependent.Name] = Tuple.Create(
-                        oldPrincipalEntityTypeBuilder, oldDependentEntityTypeBuilder, foreignKey.PrincipalToDependent.Name);
-                }
-                var fkOwner = foreignKey.DeclaringEntityType.Builder;
-                var removed = fkOwner.RemoveForeignKey(foreignKey, configurationSource, runConventions: false);
-                Debug.Assert(removed.HasValue);
-
-                removedForeignKeys.Add(Tuple.Create(fkOwner, foreignKey));
-            }
+            var addedForeignKeys = new List<InternalRelationshipBuilder>();
+            var existingRelationshipInverted = false;
+            var newRelationshipBuilder = GetOrCreateRelationshipBuilder(
+                principalEntityType,
+                dependentEntityType,
+                navigationToPrincipalName,
+                navigationToDependentName,
+                dependentProperties != null && dependentProperties.Any() ? dependentProperties : null,
+                principalProperties != null && principalProperties.Any() ? principalProperties : null,
+                isRequired,
+                principalEndConfigurationSource,
+                configurationSource,
+                removedNavigations,
+                removedForeignKeys,
+                addedForeignKeys,
+                out existingRelationshipInverted);
 
             if (newRelationshipBuilder == null)
             {
-                newRelationshipBuilder = dependentEntityTypeBuilder.CreateForeignKey(
-                    principalEntityTypeBuilder,
-                    dependentProperties,
-                    principalProperties,
-                    navigationToPrincipalName == "" ? null : navigationToPrincipalName,
-                    isRequired,
-                    newRelationshipConfigurationSource,
-                    runConventions: false);
+                return null;
             }
-            else if (existingRelationshipInverted
-                     && !strictPrincipal)
+
+            var existingPrincipalEndConfigurationSource = newRelationshipBuilder.Metadata.GetPrincipalEndConfigurationSource();
+            var strictPrincipal = principalEndConfigurationSource.HasValue
+                                  && principalEndConfigurationSource.Value.Overrides(existingPrincipalEndConfigurationSource);
+            if (existingRelationshipInverted
+                && !strictPrincipal)
             {
                 oldRelationshipInverted = !oldRelationshipInverted;
+                existingRelationshipInverted = false;
 
                 var entityTypeBuilder = principalEntityTypeBuilder;
                 principalEntityTypeBuilder = dependentEntityTypeBuilder;
@@ -1242,16 +1141,58 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 navigationToDependentName = navigationName;
             }
 
-            var newForeignKey = newRelationshipBuilder.Metadata;
-            if (newForeignKey.DependentToPrincipal != null)
+            if (newRelationshipBuilder.Metadata.DependentToPrincipal != null)
             {
-                removedNavigations[newForeignKey.DeclaringEntityType.Name + newForeignKey.DependentToPrincipal.Name] = Tuple.Create(
-                    dependentEntityTypeBuilder, principalEntityTypeBuilder, newForeignKey.DependentToPrincipal.Name);
+                var newForeignKey = newRelationshipBuilder.Metadata;
+                removedNavigations[newForeignKey.DeclaringEntityType.Name + "." + newForeignKey.DependentToPrincipal.Name] =
+                    Tuple.Create(
+                        newForeignKey.DeclaringEntityType.Builder,
+                        newForeignKey.PrincipalEntityType.Builder,
+                        newForeignKey.DependentToPrincipal.Name);
+                if ((!existingRelationshipInverted
+                     && navigationToPrincipalName != null
+                     && navigationToPrincipalName != newRelationshipBuilder.Metadata.DependentToPrincipal.Name)
+                    || (existingRelationshipInverted
+                        && navigationToDependentName != null
+                        && navigationToDependentName != newRelationshipBuilder.Metadata.DependentToPrincipal.Name))
+                {
+                    newRelationshipBuilder = newRelationshipBuilder.Navigation(
+                        null,
+                        pointsToPrincipal: true,
+                        configurationSource: configurationSource,
+                        runConventions: false)
+                                             ?? newRelationshipBuilder;
+                }
             }
-            if (newForeignKey.PrincipalToDependent != null)
+            if (newRelationshipBuilder.Metadata.PrincipalToDependent != null)
             {
-                removedNavigations[newForeignKey.PrincipalEntityType.Name + newForeignKey.PrincipalToDependent.Name] = Tuple.Create(
-                    principalEntityTypeBuilder, dependentEntityTypeBuilder, newForeignKey.PrincipalToDependent.Name);
+                var newForeignKey = newRelationshipBuilder.Metadata;
+                removedNavigations[newForeignKey.PrincipalEntityType.Name + "." + newForeignKey.PrincipalToDependent.Name] =
+                    Tuple.Create(
+                        newForeignKey.PrincipalEntityType.Builder,
+                        newForeignKey.DeclaringEntityType.Builder,
+                        newForeignKey.PrincipalToDependent.Name);
+                if ((!existingRelationshipInverted
+                     && navigationToDependentName != null
+                     && navigationToDependentName != newRelationshipBuilder.Metadata.PrincipalToDependent.Name)
+                    || (existingRelationshipInverted
+                        && navigationToPrincipalName != null
+                        && navigationToPrincipalName != newRelationshipBuilder.Metadata.PrincipalToDependent.Name))
+                {
+                    newRelationshipBuilder = newRelationshipBuilder.Navigation(
+                        null,
+                        pointsToPrincipal: false,
+                        configurationSource: configurationSource,
+                        runConventions: false)
+                                             ?? newRelationshipBuilder;
+                }
+            }
+            if (newRelationshipBuilder.Metadata.GetForeignKeyPropertiesConfigurationSource() != null
+                && dependentProperties != null
+                && !dependentProperties.SequenceEqual(newRelationshipBuilder.Metadata.Properties))
+            {
+                newRelationshipBuilder = newRelationshipBuilder.HasForeignKey(null, configurationSource, runConventions: false)
+                                         ?? newRelationshipBuilder;
             }
 
             newRelationshipBuilder.Metadata.UpdateConfigurationSource(newRelationshipConfigurationSource);
@@ -1259,21 +1200,24 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             newRelationshipBuilder = newRelationshipBuilder.RelatedEntityTypes(
                 principalEntityTypeBuilder.Metadata,
                 dependentEntityTypeBuilder.Metadata,
-                strictPrincipal ? configurationSource : ConfigurationSource.Convention, runConventions: false);
+                principalEndConfigurationSource,
+                runConventions: false);
 
-            if (dependentProperties != null)
+            if (dependentProperties != null
+                && dependentProperties.Any())
             {
                 newRelationshipBuilder = newRelationshipBuilder.HasForeignKey(
                     dependentProperties,
-                    configurationSource.Max(oldRelationshipInverted ? null : Metadata.GetForeignKeyPropertiesConfigurationSource()),
+                    configurationSource.Max(oldRelationshipInverted ? null : Metadata.GetForeignKeyPropertiesConfigurationSource()).Value,
                     runConventions: false)
                                          ?? newRelationshipBuilder;
             }
-            if (principalProperties != null)
+            if (principalProperties != null
+                && principalProperties.Any())
             {
                 newRelationshipBuilder = newRelationshipBuilder.HasPrincipalKey(
                     principalProperties,
-                    configurationSource.Max(oldRelationshipInverted ? null : Metadata.GetPrincipalKeyConfigurationSource()),
+                    configurationSource.Max(oldRelationshipInverted ? null : Metadata.GetPrincipalKeyConfigurationSource()).Value,
                     runConventions: false)
                                          ?? newRelationshipBuilder;
             }
@@ -1281,7 +1225,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             {
                 newRelationshipBuilder = newRelationshipBuilder.IsUnique(
                     isUnique.Value,
-                    configurationSource.Max(Metadata.GetIsUniqueConfigurationSource()),
+                    configurationSource.Max(Metadata.GetIsUniqueConfigurationSource()).Value,
                     runConventions: false)
                                          ?? newRelationshipBuilder;
             }
@@ -1289,7 +1233,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             {
                 newRelationshipBuilder = newRelationshipBuilder.IsRequired(
                     isRequired.Value,
-                    configurationSource.Max(Metadata.GetIsRequiredConfigurationSource()),
+                    configurationSource.Max(Metadata.GetIsRequiredConfigurationSource()).Value,
                     runConventions: false)
                                          ?? newRelationshipBuilder;
             }
@@ -1297,7 +1241,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             {
                 newRelationshipBuilder = newRelationshipBuilder.DeleteBehavior(
                     deleteBehavior.Value,
-                    configurationSource.Max(Metadata.GetDeleteBehaviorConfigurationSource()))
+                    configurationSource.Max(Metadata.GetDeleteBehaviorConfigurationSource()).Value)
                                          ?? newRelationshipBuilder;
             }
             if (navigationToPrincipalName != null)
@@ -1307,7 +1251,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     pointsToPrincipal: true,
                     configurationSource: configurationSource.Max(oldRelationshipInverted
                         ? Metadata.GetPrincipalToDependentConfigurationSource()
-                        : Metadata.GetDependentToPrincipalConfigurationSource()),
+                        : Metadata.GetDependentToPrincipalConfigurationSource()).Value,
                     runConventions: false)
                                          ?? newRelationshipBuilder;
             }
@@ -1318,7 +1262,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     pointsToPrincipal: false,
                     configurationSource: configurationSource.Max(oldRelationshipInverted
                         ? Metadata.GetDependentToPrincipalConfigurationSource()
-                        : Metadata.GetPrincipalToDependentConfigurationSource()),
+                        : Metadata.GetPrincipalToDependentConfigurationSource()).Value,
                     runConventions: false)
                                          ?? newRelationshipBuilder;
             }
@@ -1336,7 +1280,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 var oldDependentProperties = GetExistingProperties(
                     Metadata.Properties, newRelationshipBuilder.Metadata.DeclaringEntityType);
                 if (oldDependentProperties != null
-                    && CanSetRequiredOnProperties(oldDependentProperties, newRelationshipBuilder.Metadata.IsRequired, Metadata.GetForeignKeyPropertiesConfigurationSource().Value, shouldThrow: false)
+                    && CanSetRequiredOnProperties(
+                        oldDependentProperties,
+                        newRelationshipBuilder.Metadata.IsRequired,
+                        Metadata.DeclaringEntityType,
+                        Metadata.GetForeignKeyPropertiesConfigurationSource().Value,
+                        shouldThrow: false)
                     && ForeignKey.AreCompatible(
                         newRelationshipBuilder.Metadata.PrincipalKey.Properties,
                         oldDependentProperties,
@@ -1377,7 +1326,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             if (!isRequired.HasValue
                 && Metadata.GetIsRequiredConfigurationSource().HasValue
                 && CanSetRequiredOnProperties(
-                    newRelationshipBuilder.Metadata.Properties, Metadata.IsRequired, configurationSource, shouldThrow: false))
+                    newRelationshipBuilder.Metadata.Properties,
+                    Metadata.IsRequired,
+                    Metadata.DeclaringEntityType,
+                    configurationSource,
+                    shouldThrow: false))
             {
                 newRelationshipBuilder = newRelationshipBuilder.IsRequired(
                     Metadata.IsRequired, Metadata.GetIsRequiredConfigurationSource().Value, runConventions: false)
@@ -1452,20 +1405,22 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 if (newRelationshipBuilder.Metadata.DependentToPrincipal != null)
                 {
                     dependentToPrincipalIsNew = !removedNavigations.Remove(
-                        newRelationshipBuilder.Metadata.DeclaringEntityType.Name + newRelationshipBuilder.Metadata.DependentToPrincipal.Name);
+                        newRelationshipBuilder.Metadata.DeclaringEntityType.Name + "." +
+                        newRelationshipBuilder.Metadata.DependentToPrincipal.Name);
                 }
 
                 var principalToDependentIsNew = false;
                 if (newRelationshipBuilder.Metadata.PrincipalToDependent != null)
                 {
                     principalToDependentIsNew = !removedNavigations.Remove(
-                        newRelationshipBuilder.Metadata.PrincipalEntityType.Name + newRelationshipBuilder.Metadata.PrincipalToDependent.Name);
+                        newRelationshipBuilder.Metadata.PrincipalEntityType.Name + "." +
+                        newRelationshipBuilder.Metadata.PrincipalToDependent.Name);
                 }
 
-                foreach (var removedNavigation in removedNavigations)
+                foreach (var removedNavigation in removedNavigations.Values)
                 {
                     ModelBuilder.Metadata.ConventionDispatcher.OnNavigationRemoved(
-                        removedNavigation.Value.Item1, removedNavigation.Value.Item2, removedNavigation.Value.Item3);
+                        removedNavigation.Item1, removedNavigation.Item2, removedNavigation.Item3);
                 }
 
                 foreach (var removedForeignKey in removedForeignKeys)
@@ -1473,16 +1428,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     ModelBuilder.Metadata.ConventionDispatcher.OnForeignKeyRemoved(removedForeignKey.Item1, removedForeignKey.Item2);
                 }
 
+                if (newRelationshipBuilder == null)
+                {
+                    return null;
+                }
+
                 if (newRelationshipBuilder.Metadata.Builder == null)
                 {
                     newRelationshipBuilder = FindForeignKey(navigationToPrincipalName,
                         navigationToDependentName,
                         dependentProperties);
-                }
-
-                if (newRelationshipBuilder == null)
-                {
-                    return null;
                 }
 
                 newRelationshipBuilder = ModelBuilder.Metadata.ConventionDispatcher.OnForeignKeyAdded(newRelationshipBuilder);
@@ -1497,25 +1452,49 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     return null;
                 }
 
-                newRelationshipBuilder = ModelBuilder.Metadata.ConventionDispatcher.OnPrincipalEndSet(newRelationshipBuilder);
+                if (newRelationshipBuilder.Metadata.Builder == null)
+                {
+                    newRelationshipBuilder = FindForeignKey(navigationToPrincipalName,
+                        navigationToDependentName,
+                        dependentProperties);
+                }
+
+                if (strictPrincipal
+                    && existingPrincipalEndConfigurationSource != principalEndConfigurationSource)
+                {
+                    newRelationshipBuilder = ModelBuilder.Metadata.ConventionDispatcher.OnPrincipalEndSet(newRelationshipBuilder);
+                }
 
                 if (newRelationshipBuilder == null)
                 {
                     return null;
+                }
+
+                if (newRelationshipBuilder.Metadata.Builder == null)
+                {
+                    newRelationshipBuilder = FindForeignKey(navigationToPrincipalName,
+                        navigationToDependentName,
+                        dependentProperties);
                 }
 
                 var inverted = newRelationshipBuilder.Metadata.DeclaringEntityType != dependentEntityType;
                 if ((dependentToPrincipalIsNew && !inverted)
-                    || (principalToDependentIsNew && inverted)
-                    // RequiredNavigationAttributeConvention only work on DependentToPrincipal. So when inverting relationship, run the convention regardless of it being new/old
-                    || ((newRelationshipBuilder.Metadata.DependentToPrincipal != null) && inverted))
+                    || (principalToDependentIsNew && inverted))
                 {
                     newRelationshipBuilder = ModelBuilder.Metadata.ConventionDispatcher.OnNavigationAdded(
                         newRelationshipBuilder, newRelationshipBuilder.Metadata.DependentToPrincipal);
                 }
+
                 if (newRelationshipBuilder == null)
                 {
                     return null;
+                }
+
+                if (newRelationshipBuilder.Metadata.Builder == null)
+                {
+                    newRelationshipBuilder = FindForeignKey(navigationToPrincipalName,
+                        navigationToDependentName,
+                        dependentProperties);
                 }
 
                 if ((principalToDependentIsNew && !inverted)
@@ -1524,9 +1503,386 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     newRelationshipBuilder = ModelBuilder.Metadata.ConventionDispatcher.OnNavigationAdded(
                         newRelationshipBuilder, newRelationshipBuilder.Metadata.PrincipalToDependent);
                 }
+
+                if (newRelationshipBuilder == null)
+                {
+                    return null;
+                }
+
+                if (newRelationshipBuilder.Metadata.Builder == null)
+                {
+                    newRelationshipBuilder = FindForeignKey(navigationToPrincipalName,
+                        navigationToDependentName,
+                        dependentProperties);
+                }
             }
 
             return newRelationshipBuilder;
+        }
+
+        private InternalRelationshipBuilder GetOrCreateRelationshipBuilder(
+            EntityType principalEntityType,
+            EntityType dependentEntityType,
+            string navigationToPrincipalName,
+            string navigationToDependentName,
+            IReadOnlyList<Property> dependentProperties,
+            IReadOnlyList<Property> principalProperties,
+            bool? isRequired,
+            ConfigurationSource? principalEndConfigurationSource,
+            ConfigurationSource? configurationSource,
+            Dictionary<string, Tuple<InternalEntityTypeBuilder, InternalEntityTypeBuilder, string>> removedNavigations,
+            List<Tuple<InternalEntityTypeBuilder, ForeignKey>> removedForeignKeys,
+            List<InternalRelationshipBuilder> addedForeignKeys,
+            out bool existingRelationshipInverted)
+        {
+            existingRelationshipInverted = false;
+            var matchingRelationships = FindConflictingRelationshipBuilders(
+                dependentEntityType,
+                principalEntityType,
+                navigationToPrincipalName,
+                navigationToDependentName,
+                dependentProperties);
+            matchingRelationships = matchingRelationships.Distinct().Where(r => r.Metadata != Metadata).ToList();
+
+            var unresolvableRelationships = new List<InternalRelationshipBuilder>();
+            var resolvableRelationships = new List<Tuple<InternalRelationshipBuilder, bool, Resolution>>();
+            foreach (var matchingRelationship in matchingRelationships)
+            {
+                var resolvable = true;
+                var goodMatch = true;
+                var resolution = Resolution.None;
+                if (!string.IsNullOrEmpty(navigationToPrincipalName))
+                {
+                    if ((navigationToPrincipalName == matchingRelationship.Metadata.DependentToPrincipal?.Name)
+                        && dependentEntityType.IsSameHierarchy(matchingRelationship.Metadata.DependentToPrincipal.DeclaringEntityType))
+                    {
+                        if (matchingRelationship.CanSetNavigation(null, true, configurationSource, overrideSameSource: false))
+                        {
+                            resolution |= Resolution.ResetToPrincipal;
+                            goodMatch = false;
+                        }
+                        else if (matchingRelationship.CanSetNavigation(null, true, configurationSource))
+                        {
+                            resolution |= Resolution.ResetToPrincipal;
+                        }
+                        else
+                        {
+                            resolvable = false;
+                        }
+                    }
+                    else if ((navigationToPrincipalName == matchingRelationship.Metadata.PrincipalToDependent?.Name)
+                             && dependentEntityType.IsSameHierarchy(matchingRelationship.Metadata.PrincipalToDependent.DeclaringEntityType))
+                    {
+                        if (matchingRelationship.CanSetNavigation(null, false, configurationSource, overrideSameSource: false))
+                        {
+                            resolution |= Resolution.ResetToDependent;
+                            goodMatch = false;
+                        }
+                        else if (matchingRelationship.CanSetNavigation(null, false, configurationSource))
+                        {
+                            resolution |= Resolution.ResetToDependent;
+                        }
+                        else
+                        {
+                            resolvable = false;
+                        }
+                    }
+                }
+
+                if (!string.IsNullOrEmpty(navigationToDependentName))
+                {
+                    if ((navigationToDependentName == matchingRelationship.Metadata.PrincipalToDependent?.Name)
+                        && principalEntityType.IsSameHierarchy(matchingRelationship.Metadata.PrincipalToDependent.DeclaringEntityType))
+                    {
+                        if (matchingRelationship.CanSetNavigation(null, false, configurationSource, overrideSameSource: false))
+                        {
+                            resolution |= Resolution.ResetToDependent;
+                            goodMatch = false;
+                        }
+                        else if (matchingRelationship.CanSetNavigation(null, false, configurationSource))
+                        {
+                            resolution |= Resolution.ResetToDependent;
+                        }
+                        else
+                        {
+                            resolvable = false;
+                        }
+                    }
+                    else if ((navigationToDependentName == matchingRelationship.Metadata.DependentToPrincipal?.Name)
+                             && principalEntityType.IsSameHierarchy(matchingRelationship.Metadata.DependentToPrincipal.DeclaringEntityType))
+                    {
+                        if (matchingRelationship.CanSetNavigation(null, true, configurationSource, overrideSameSource: false))
+                        {
+                            resolution |= Resolution.ResetToPrincipal;
+                            goodMatch = false;
+                        }
+                        else if (matchingRelationship.CanSetNavigation(null, true, configurationSource))
+                        {
+                            resolution |= Resolution.ResetToPrincipal;
+                        }
+                        else
+                        {
+                            resolvable = false;
+                        }
+                    }
+                }
+
+                if ((dependentProperties != null)
+                    && matchingRelationship.Metadata.Properties.SequenceEqual(dependentProperties))
+                {
+                    bool _;
+                    if (matchingRelationship.CanSetForeignKey(
+                        null, matchingRelationship.Metadata.DeclaringEntityType, configurationSource, out _, out _, overrideSameSource: false))
+                    {
+                        resolution |= Resolution.ResetDependentProperties;
+                        goodMatch = false;
+                    }
+                    if (matchingRelationship.CanSetForeignKey(
+                        null, matchingRelationship.Metadata.DeclaringEntityType, configurationSource, out _, out _))
+                    {
+                        resolution |= Resolution.ResetDependentProperties;
+                    }
+                    else
+                    {
+                        resolvable = false;
+                    }
+                }
+
+                if (resolvable)
+                {
+                    if (goodMatch
+                        && configurationSource.HasValue
+                        && matchingRelationship.Metadata.DeclaringEntityType.Builder
+                            .CanRemoveForeignKey(matchingRelationship.Metadata, configurationSource.Value))
+                    {
+                        resolution |= Resolution.Remove;
+                    }
+
+                    resolvableRelationships.Add(Tuple.Create(matchingRelationship, goodMatch, resolution));
+                }
+                else
+                {
+                    unresolvableRelationships.Add(matchingRelationship);
+                }
+            }
+
+            var candidates = unresolvableRelationships.Concat(
+                resolvableRelationships.Where(r => r.Item2).Concat(
+                    resolvableRelationships.Where(r => !r.Item2 && !r.Item1.Metadata.GetConfigurationSource().Overrides(configurationSource)))
+                    .Select(r => r.Item1))
+                .ToList();
+            InternalRelationshipBuilder newRelationshipBuilder = null;
+            foreach (var candidateRelationship in candidates)
+            {
+                bool _;
+                if (candidateRelationship.CanSetRelatedTypes(
+                    principalEntityType,
+                    dependentEntityType,
+                    principalEndConfigurationSource,
+                    navigationToPrincipalName,
+                    navigationToDependentName,
+                    configurationSource,
+                    false,
+                    out existingRelationshipInverted,
+                    out _,
+                    out _,
+                    out _,
+                    out _))
+                {
+                    newRelationshipBuilder = candidateRelationship;
+                    break;
+                }
+            }
+
+            if (unresolvableRelationships.Any(r => r != newRelationshipBuilder))
+            {
+                return null;
+            }
+
+            // This workaround prevents the properties to be cleaned away before the new FK is created,
+            // this should be replaced with reference counting
+            // Issue #214
+            var temporaryProperties = dependentProperties?.Where(p => p.GetConfigurationSource() == ConfigurationSource.Convention
+                                                                      && p.IsShadowProperty).ToList() ?? new List<Property>();
+            foreach (var temporaryProperty in temporaryProperties)
+            {
+                temporaryProperty.UpdateConfigurationSource(ConfigurationSource.DataAnnotation);
+            }
+
+            if (Metadata.Builder != null)
+            {
+                RemoveForeignKey(Metadata, removedNavigations, removedForeignKeys);
+            }
+
+            foreach (var relationshipWithResolution in resolvableRelationships)
+            {
+                var resolvableRelationship = relationshipWithResolution.Item1;
+                if (resolvableRelationship == newRelationshipBuilder)
+                {
+                    continue;
+                }
+
+                var resolution = relationshipWithResolution.Item3;
+                if (resolution.HasFlag(Resolution.Remove))
+                {
+                    // TODO: Merge non-conflicting aspects from the removed relationships
+                    RemoveForeignKey(resolvableRelationship.Metadata, removedNavigations, removedForeignKeys);
+                    continue;
+                }
+
+                if (resolution.HasFlag(Resolution.ResetToPrincipal))
+                {
+                    var foreignKey = resolvableRelationship.Metadata;
+                    removedNavigations[foreignKey.DeclaringEntityType.Name + "." + foreignKey.DependentToPrincipal.Name] =
+                        Tuple.Create(
+                            foreignKey.DeclaringEntityType.Builder,
+                            foreignKey.PrincipalEntityType.Builder,
+                            foreignKey.DependentToPrincipal.Name);
+                    resolvableRelationship = resolvableRelationship.Navigation(null, true, foreignKey.GetConfigurationSource(), runConventions: false);
+                }
+
+                if (resolution.HasFlag(Resolution.ResetToDependent))
+                {
+                    var foreignKey = resolvableRelationship.Metadata;
+                    removedNavigations[foreignKey.PrincipalEntityType.Name + "." + foreignKey.PrincipalToDependent.Name] =
+                        Tuple.Create(
+                            foreignKey.PrincipalEntityType.Builder,
+                            foreignKey.DeclaringEntityType.Builder,
+                            foreignKey.PrincipalToDependent.Name);
+                    resolvableRelationship = resolvableRelationship.Navigation(null, false, foreignKey.GetConfigurationSource(), runConventions: false);
+                }
+
+                if (resolvableRelationship.Metadata.Builder == null)
+                {
+                    continue;
+                }
+
+                var navigationLessForeignKey = resolvableRelationship.Metadata;
+                if (navigationLessForeignKey.DependentToPrincipal == null
+                    && navigationLessForeignKey.PrincipalToDependent == null)
+                {
+                    var extraForeignKeyOwner = navigationLessForeignKey.DeclaringEntityType.Builder;
+                    if (extraForeignKeyOwner.RemoveForeignKey(navigationLessForeignKey, ConfigurationSource.Convention, runConventions: false).HasValue)
+                    {
+                        removedForeignKeys.Add(Tuple.Create(extraForeignKeyOwner, navigationLessForeignKey));
+                        continue;
+                    }
+                }
+
+                if (resolution.HasFlag(Resolution.ResetDependentProperties))
+                {
+                    var foreignKey = resolvableRelationship.Metadata;
+                    removedForeignKeys.Add(Tuple.Create(foreignKey.DeclaringEntityType.Builder, foreignKey));
+                    resolvableRelationship = resolvableRelationship.HasForeignKey(null, foreignKey.GetConfigurationSource(), runConventions: false);
+                    addedForeignKeys.Add(resolvableRelationship);
+                }
+            }
+
+            if (configurationSource == ConfigurationSource.Convention)
+            {
+                foreach (var temporaryProperty in temporaryProperties)
+                {
+                    temporaryProperty.SetConfigurationSource(ConfigurationSource.Convention);
+                }
+            }
+
+            if (newRelationshipBuilder == null)
+            {
+                newRelationshipBuilder = dependentEntityType.Builder.CreateForeignKey(
+                    principalEntityType.Builder,
+                    dependentProperties,
+                    principalProperties,
+                    navigationToPrincipalName,
+                    isRequired,
+                    ConfigurationSource.Convention,
+                    runConventions: false);
+                existingRelationshipInverted = false;
+            }
+            else if (!string.IsNullOrEmpty(navigationToPrincipalName)
+                     && newRelationshipBuilder.Metadata.DependentToPrincipal == null
+                     && dependentProperties == null
+                     && newRelationshipBuilder.Metadata.GetForeignKeyPropertiesConfigurationSource() == null
+                     && !existingRelationshipInverted)
+            {
+                // TODO: Also handle the case where existing relationship cannot be inverted,
+                // so the new nav to principal will be specified nav to dependent
+                newRelationshipBuilder = newRelationshipBuilder.ReplaceForeignKey(
+                    principalEntityType.Builder,
+                    dependentEntityType.Builder,
+                    navigationToPrincipalName,
+                    null,
+                    dependentProperties,
+                    principalProperties,
+                    null,
+                    isRequired,
+                    null,
+                    false,
+                    null,
+                    configurationSource,
+                    runConventions: false);
+            }
+
+            return newRelationshipBuilder;
+        }
+
+        private void RemoveForeignKey(
+            ForeignKey foreignKey,
+            Dictionary<string, Tuple<InternalEntityTypeBuilder, InternalEntityTypeBuilder, string>> removedNavigations,
+            List<Tuple<InternalEntityTypeBuilder, ForeignKey>> removedForeignKeys)
+        {
+            var dependentEntityTypeBuilder = foreignKey.DeclaringEntityType.Builder;
+            var principalEntityTypeBuilder = foreignKey.PrincipalEntityType.Builder;
+            var navigationToPrincipalName = foreignKey.DependentToPrincipal?.Name;
+            if (navigationToPrincipalName != null)
+            {
+                removedNavigations[foreignKey.DeclaringEntityType.Name + "." + navigationToPrincipalName] =
+                    Tuple.Create(dependentEntityTypeBuilder, principalEntityTypeBuilder, navigationToPrincipalName);
+            }
+
+            var navigationToDependentName = foreignKey.PrincipalToDependent?.Name;
+            if (navigationToDependentName != null)
+            {
+                removedNavigations[foreignKey.PrincipalEntityType.Name + "." + navigationToDependentName] =
+                    Tuple.Create(principalEntityTypeBuilder, dependentEntityTypeBuilder, navigationToDependentName);
+            }
+
+            var foreignKeyOwner = foreignKey.DeclaringEntityType.Builder;
+            var replacedConfigurationSource = foreignKeyOwner.RemoveForeignKey(foreignKey, ConfigurationSource.Explicit, runConventions: false);
+            Debug.Assert(replacedConfigurationSource.HasValue);
+
+            removedForeignKeys.Add(Tuple.Create(foreignKeyOwner, foreignKey));
+        }
+
+        private static IReadOnlyList<InternalRelationshipBuilder> FindConflictingRelationshipBuilders(
+            [NotNull] EntityType dependentEntityType,
+            [NotNull] EntityType principalEntityType,
+            [CanBeNull] string navigationToPrincipalName,
+            [CanBeNull] string navigationToDependentName,
+            [CanBeNull] IReadOnlyList<Property> dependentProperties)
+        {
+            var existingRelationships = new List<InternalRelationshipBuilder>();
+            if (!string.IsNullOrEmpty(navigationToPrincipalName))
+            {
+                existingRelationships.AddRange(dependentEntityType
+                    .FindNavigationsInHierarchy(navigationToPrincipalName)
+                    .Select(n => n.ForeignKey.Builder));
+            }
+
+            if (!string.IsNullOrEmpty(navigationToDependentName))
+            {
+                existingRelationships.AddRange(principalEntityType
+                    .FindNavigationsInHierarchy(navigationToDependentName)
+                    .Select(n => n.ForeignKey.Builder));
+            }
+
+            if (dependentProperties != null)
+            {
+                existingRelationships.AddRange(dependentEntityType
+                    .FindForeignKeysInHierarchy(dependentProperties)
+                    .Select(fk => fk.Builder));
+            }
+
+            return existingRelationships;
         }
 
         private InternalRelationshipBuilder FindForeignKey(
@@ -1538,7 +1894,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 Metadata.PrincipalEntityType,
                 navigationToPrincipalName == "" ? null : navigationToPrincipalName,
                 navigationToDependentName == "" ? null : navigationToDependentName,
-                dependentProperties);
+                dependentProperties != null && dependentProperties.Any() ? dependentProperties : null);
 
             matchingRelationships = matchingRelationships.Distinct().ToList();
 
@@ -1605,7 +1961,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             [CanBeNull] IReadOnlyList<Property> principalProperties,
             bool? isUnique,
             bool? isRequired,
-            ConfigurationSource configurationSource)
+            ConfigurationSource? configurationSource)
         {
             var shouldThrow = configurationSource == ConfigurationSource.Explicit;
             if ((dependentProperties != null)
@@ -1641,39 +1997,36 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             bool? isUnique,
             bool? isRequired,
             DeleteBehavior? deleteBehavior,
-            bool strictPrincipal,
-            ConfigurationSource configurationSource,
+            ConfigurationSource? principalEndConfigurationSource,
+            ConfigurationSource? configurationSource,
             bool shouldThrow,
             out bool shouldInvert)
         {
             Debug.Assert(AreCompatible(
                 principalEntityType,
                 dependentEntityType,
-                navigationToPrincipalName,
-                navigationToDependentName,
+                navigationToPrincipalName == "" ? null : navigationToPrincipalName,
+                navigationToDependentName == "" ? null : navigationToDependentName,
                 dependentProperties,
                 principalProperties,
                 isUnique,
                 isRequired,
                 configurationSource));
 
-            bool shouldResetToPrincipal;
-            bool shouldResetToDependent;
-            bool shouldResetPrincipalProperties;
-            bool shouldResetDependentProperties;
+            bool _;
             if (!CanSetRelatedTypes(
                 principalEntityType,
                 dependentEntityType,
-                strictPrincipal && !CanInvert(configurationSource),
+                principalEndConfigurationSource,
                 navigationToPrincipalName,
                 navigationToDependentName,
                 configurationSource,
                 shouldThrow,
                 out shouldInvert,
-                out shouldResetToPrincipal,
-                out shouldResetToDependent,
-                out shouldResetPrincipalProperties,
-                out shouldResetDependentProperties))
+                out _,
+                out _,
+                out _,
+                out _))
             {
                 return false;
             }
@@ -1682,7 +2035,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 && !CanSetForeignKey(
                     dependentProperties,
                     configurationSource: configurationSource,
-                    dependentEntityType: shouldInvert ? dependentEntityType : principalEntityType))
+                    dependentEntityType: dependentEntityType))
             {
                 return false;
             }
@@ -1717,10 +2070,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         private bool CanSetRelatedTypes(
             EntityType principalEntityType,
             EntityType dependentEntityType,
-            bool strictPrincipal,
+            ConfigurationSource? principalEndConfigurationSource,
             string navigationToPrincipalName,
             string navigationToDependentName,
-            ConfigurationSource configurationSource,
+            ConfigurationSource? configurationSource,
             bool shouldThrow,
             out bool shouldInvert,
             out bool shouldResetToPrincipal,
@@ -1749,6 +2102,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     navigationToDependentName,
                     configurationSource,
                     false,
+                    false,
                     out shouldResetToPrincipal,
                     out shouldResetToDependent,
                     out shouldResetPrincipalProperties,
@@ -1762,16 +2116,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 someAspectsFitNonInverted = true;
             }
 
+            var strictPrincipal = principalEndConfigurationSource.HasValue
+                                  && principalEndConfigurationSource.Value.Overrides(Metadata.GetPrincipalEndConfigurationSource());
+            var canInvert = CanInvert(configurationSource);
             bool invertedShouldResetToPrincipal;
             bool invertedShouldResetToDependent;
             bool _;
-            if (!strictPrincipal
+            if ((!strictPrincipal
+                 || canInvert)
                 && CanSetRelatedTypes(
                     dependentEntityType,
                     principalEntityType,
                     navigationToDependentName,
                     navigationToPrincipalName,
                     configurationSource,
+                    strictPrincipal,
                     false,
                     out invertedShouldResetToPrincipal,
                     out invertedShouldResetToDependent,
@@ -1805,7 +2164,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             EntityType dependentEntityType,
             string navigationToPrincipalName,
             string navigationToDependentName,
-            ConfigurationSource configurationSource,
+            ConfigurationSource? configurationSource,
+            bool inverted,
             bool shouldThrow,
             out bool shouldResetToPrincipal,
             out bool shouldResetToDependent,
@@ -1827,55 +2187,86 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 return false;
             }
 
+            bool? _;
+            bool __;
             if (navigationToPrincipalName != null)
             {
-                if (!CanSetNavigation(navigationToPrincipalName, true, configurationSource))
+                if (!configurationSource.HasValue
+                    || !CanSetNavigation(
+                        navigationToPrincipalName == "" ? null : navigationToPrincipalName,
+                        true,
+                        configurationSource.Value,
+                        shouldThrow,
+                        true,
+                        out _,
+                        out __))
                 {
                     return false;
                 }
             }
-            else if ((Metadata.DependentToPrincipal != null)
-                     && !Internal.Navigation.IsCompatible(
-                         Metadata.DependentToPrincipal.Name,
-                         dependentEntityType,
-                         principalEntityType,
-                         shouldBeCollection: null,
-                         shouldThrow: shouldThrow))
+            else
             {
-                if (!CanSetNavigation(null, true, configurationSource))
+                navigationToPrincipalName = Metadata.DependentToPrincipal?.Name;
+                if ((navigationToPrincipalName != null)
+                    && !Internal.Navigation.IsCompatible(
+                        navigationToPrincipalName,
+                        !inverted,
+                        inverted ? principalEntityType : dependentEntityType,
+                        inverted ? dependentEntityType : principalEntityType,
+                        shouldThrow,
+                        out _))
                 {
-                    return false;
-                }
+                    if (!configurationSource.HasValue
+                        || !CanSetNavigation(null, true, configurationSource.Value))
+                    {
+                        return false;
+                    }
 
-                shouldResetToPrincipal = true;
+                    shouldResetToPrincipal = true;
+                }
             }
 
             if (navigationToDependentName != null)
             {
-                if (!CanSetNavigation(navigationToDependentName, false, configurationSource))
+                if (!configurationSource.HasValue
+                    || !CanSetNavigation(
+                        navigationToDependentName == "" ? null : navigationToDependentName,
+                        false,
+                        configurationSource.Value,
+                        shouldThrow,
+                        true,
+                        out _,
+                        out __))
                 {
                     return false;
                 }
             }
-            else if ((Metadata.PrincipalToDependent != null)
-                     && !Internal.Navigation.IsCompatible(
-                         Metadata.PrincipalToDependent.Name,
-                         principalEntityType,
-                         dependentEntityType,
-                         shouldBeCollection: null,
-                         shouldThrow: shouldThrow))
+            else
             {
-                if (!CanSetNavigation(null, false, configurationSource))
+                navigationToDependentName = Metadata.PrincipalToDependent?.Name;
+                if ((navigationToDependentName != null)
+                    && !Internal.Navigation.IsCompatible(
+                        navigationToDependentName,
+                        inverted,
+                        inverted ? principalEntityType : dependentEntityType,
+                        inverted ? dependentEntityType : principalEntityType,
+                        shouldThrow,
+                        out _))
                 {
-                    return false;
-                }
+                    if (!configurationSource.HasValue
+                        || !CanSetNavigation(null, false, configurationSource.Value))
+                    {
+                        return false;
+                    }
 
-                shouldResetToDependent = true;
+                    shouldResetToDependent = true;
+                }
             }
 
             if (!Property.AreCompatible(Metadata.PrincipalKey.Properties, principalEntityType))
             {
-                if (!configurationSource.Overrides(Metadata.GetPrincipalKeyConfigurationSource()))
+                if (!configurationSource.HasValue
+                    || !configurationSource.Value.Overrides(Metadata.GetPrincipalKeyConfigurationSource()))
                 {
                     return false;
                 }
@@ -1885,7 +2276,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             if (!Property.AreCompatible(Metadata.Properties, dependentEntityType))
             {
-                if (!configurationSource.Overrides(Metadata.GetForeignKeyPropertiesConfigurationSource()))
+                if (!configurationSource.HasValue
+                    || !configurationSource.Value.Overrides(Metadata.GetForeignKeyPropertiesConfigurationSource()))
                 {
                     return false;
                 }
@@ -1894,6 +2286,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
 
             return true;
+        }
+
+        [Flags]
+        private enum Resolution
+        {
+            None = 0,
+            Remove = 1 << 0,
+            ResetToPrincipal = 1 << 1,
+            ResetToDependent = 1 << 2,
+            ResetDependentProperties = 1 << 3
         }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Navigation.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Navigation.cs
@@ -42,6 +42,42 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public override string ToString() => DeclaringEntityType + "." + Name;
 
         public static bool IsCompatible(
+            [NotNull] string navigationName,
+            bool pointsToPrincipal,
+            [NotNull] EntityType dependentType,
+            [NotNull] EntityType principalType,
+            bool shouldThrow,
+            out bool? shouldBeUnique)
+        {
+            shouldBeUnique = null;
+            if (!pointsToPrincipal)
+            {
+                var canBeUnique = IsCompatible(navigationName, principalType, dependentType, shouldBeCollection: false, shouldThrow: false);
+                var canBeNonUnique = IsCompatible(navigationName, principalType, dependentType, shouldBeCollection: true, shouldThrow: false);
+
+                if (canBeUnique != canBeNonUnique)
+                {
+                    shouldBeUnique = canBeUnique;
+                }
+                else if (!canBeUnique)
+                {
+                    if (shouldThrow)
+                    {
+                        IsCompatible(navigationName, principalType, dependentType, shouldBeCollection: false, shouldThrow: true);
+                    }
+
+                    return false;
+                }
+            }
+            else if (!IsCompatible(navigationName, dependentType, principalType, shouldBeCollection: false, shouldThrow: shouldThrow))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        public static bool IsCompatible(
             [NotNull] string navigationPropertyName,
             [NotNull] EntityType sourceType,
             [NotNull] EntityType targetType,

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Property.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Property.cs
@@ -59,11 +59,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual void UpdateConfigurationSource(ConfigurationSource configurationSource)
             => _configurationSource = _configurationSource.Max(configurationSource);
 
+        // Needed for a workaround before reference counting is implemented
+        // Issue #214
+        public virtual void SetConfigurationSource(ConfigurationSource configurationSource)
+            => _configurationSource = configurationSource;
+
         public virtual Type ClrType
         {
             get { return _clrType ?? DefaultClrType; }
-            [param: NotNull]
-            set { HasClrType(value, ConfigurationSource.Explicit); }
+            [param: NotNull] set { HasClrType(value, ConfigurationSource.Explicit); }
         }
 
         public virtual void HasClrType([NotNull] Type type, ConfigurationSource configurationSource)
@@ -193,7 +197,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             get
             {
                 bool value;
-                return TryGetFlag(PropertyFlags.IsReadOnlyAfterSave, out value) ? value  : DefaultIsReadOnlyAfterSave;
+                return TryGetFlag(PropertyFlags.IsReadOnlyAfterSave, out value) ? value : DefaultIsReadOnlyAfterSave;
             }
             set { SetIsReadOnlyAfterSave(value, ConfigurationSource.Explicit); }
         }
@@ -434,8 +438,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         public virtual IKey PrimaryKey { get; [param: CanBeNull] set; }
-        public virtual IReadOnlyList<IKey> Keys { get;[param: CanBeNull] set; }
-        public virtual IReadOnlyList<IForeignKey> ForeignKeys { get;[param: CanBeNull] set; }
+        public virtual IReadOnlyList<IKey> Keys { get; [param: CanBeNull] set; }
+        public virtual IReadOnlyList<IForeignKey> ForeignKeys { get; [param: CanBeNull] set; }
 
         private PropertyIndexes CalculateIndexes() => DeclaringEntityType.CalculateIndexes(this);
     }

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
@@ -493,7 +493,7 @@
     <value>Unhandled node type: {nodeType}</value>
   </data>
   <data name="InvalidKeyValue" xml:space="preserve">
-    <value>Unable to create or track an entity of type '{entityType}' because it has an null primary or alternate key value.</value>
+    <value>Unable to create or track an entity of type '{entityType}' because it has a null primary or alternate key value.</value>
   </data>
   <data name="SensitiveDataLoggingEnabled" xml:space="preserve">
     <value>Sensitive data logging is enabled. Log entries and exception messages may include sensitive application data, this mode should only be enabled during development.</value>

--- a/test/Microsoft.EntityFrameworkCore.FunctionalTests/DataAnnotationFixtureBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.FunctionalTests/DataAnnotationFixtureBase.cs
@@ -17,9 +17,6 @@ namespace Microsoft.EntityFrameworkCore.FunctionalTests
 
         protected virtual void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.Entity<One>();
-            modelBuilder.Entity<Two>();
-            modelBuilder.Entity<Book>();
         }
     }
 
@@ -38,6 +35,7 @@ namespace Microsoft.EntityFrameworkCore.FunctionalTests
 
         public DbSet<BookDetail> BookDetails { get; set; }
 
+        public DbSet<AdditionalBookDetail> AdditionalBookDetails { get; set; }
     }
 
     [Table("Sample")]
@@ -97,8 +95,18 @@ namespace Microsoft.EntityFrameworkCore.FunctionalTests
 
         public string BookId { get; set; }
 
+        public int? AdditionalBookDetailId { get; set; }
+
         [Required]
         public virtual Book Book { get; set; }
+    }
+
+    public class AdditionalBookDetail
+    {
+        public int Id { get; set; }
+        
+        [Required]
+        public virtual BookDetail BookDetail { get; set; }
     }
 
     public class UselessBookDetails

--- a/test/Microsoft.EntityFrameworkCore.FunctionalTests/DataAnnotationTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.FunctionalTests/DataAnnotationTestBase.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using Microsoft.EntityFrameworkCore.Internal;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.FunctionalTests
@@ -121,6 +122,18 @@ namespace Microsoft.EntityFrameworkCore.FunctionalTests
 
                 Assert.Equal("An error occurred while updating the entries. See the inner exception for details.",
                     Assert.Throws<DbUpdateException>(() => context.SaveChanges()).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void RequiredAttribute_does_nothing_when_specified_on_nav_to_dependent_per_convention()
+        {
+            using (var context = CreateContext())
+            {
+                var relationship = context.Model.FindEntityType(typeof(AdditionalBookDetail))
+                    .FindNavigation(nameof(AdditionalBookDetail.BookDetail)).ForeignKey;
+                Assert.Equal(typeof(AdditionalBookDetail), relationship.PrincipalEntityType.ClrType);
+                Assert.False(relationship.IsRequired);
             }
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerFixture.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.FunctionalTests;
 using Microsoft.EntityFrameworkCore.FunctionalTests.TestModels.ComplexNavigationsModel;
 using Microsoft.Extensions.DependencyInjection;

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
@@ -96,23 +96,12 @@ WHERE @@ROWCOUNT = 1 AND [UniqueNo] = scope_identity();",
         {
             base.RequiredAttribute_for_navigation_throws_while_inserting_null_value();
 
-            Assert.Equal(@"@p0: Book1
+            Assert.Contains(@"@p1: Book1
+",
+                Sql);
 
-SET NOCOUNT ON;
-INSERT INTO [BookDetail] ([BookId])
-VALUES (@p0);
-SELECT [Id]
-FROM [BookDetail]
-WHERE @@ROWCOUNT = 1 AND [Id] = scope_identity();
-
-@p0: 
-
-SET NOCOUNT ON;
-INSERT INTO [BookDetail] ([BookId])
-VALUES (@p0);
-SELECT [Id]
-FROM [BookDetail]
-WHERE @@ROWCOUNT = 1 AND [Id] = scope_identity();",
+            Assert.Contains(@"@p1: 
+",
                 Sql);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/DataAnnotationSqliteTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/DataAnnotationSqliteTest.cs
@@ -77,22 +77,12 @@ WHERE changes() = 1 AND ""UniqueNo"" = last_insert_rowid();",
         {
             base.RequiredAttribute_for_navigation_throws_while_inserting_null_value();
 
-            Assert.Contains(@"@p0: Book1
-
-INSERT INTO ""BookDetail"" (""BookId"")
-VALUES (@p0);
-SELECT ""Id""
-FROM ""BookDetail""
-WHERE changes() = 1 AND ""Id"" = last_insert_rowid();",
+            Assert.Contains(@"@p1: Book1
+",
                 Sql);
 
-            Assert.Contains(@"@p0: 
-
-INSERT INTO ""BookDetail"" (""BookId"")
-VALUES (@p0);
-SELECT ""Id""
-FROM ""BookDetail""
-WHERE changes() = 1 AND ""Id"" = last_insert_rowid();",
+            Assert.Contains(@"@p1: 
+",
                 Sql);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/NavigationFixerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/NavigationFixerTest.cs
@@ -969,7 +969,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
         }
 
         [Fact]
-        public void Nulls_one_to_one_navigation_to_principal_after_after_deletion()
+        public void Nulls_one_to_one_navigation_to_principal_after_deletion()
         {
             var model = BuildModel();
             var contextServices = CreateContextServices(model);

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/ConventionDispatcherTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/ConventionDispatcherTest.cs
@@ -642,7 +642,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions
             {
                 Assert.Null(
                     dependentEntityBuilder
-                        .Relationship(entityBuilder, ConfigurationSource.Convention)
+                        .Relationship(entityBuilder, ConfigurationSource.Convention, setPrincipalEnd: false)
                         .HasPrincipalKey(entityBuilder.Metadata.FindPrimaryKey().Properties, ConfigurationSource.Convention));
             }
             else

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/ForeignKeyPropertyDiscoveryConventionTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/ForeignKeyPropertyDiscoveryConventionTest.cs
@@ -333,7 +333,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions
         {
             DependentType.PrimaryKey(new[] { DependentEntity.PrincipalEntityPeEKaYProperty }, ConfigurationSource.Explicit);
 
-            var relationshipBuilder = DependentType.Relationship(PrincipalType, ConfigurationSource.Convention)
+            var relationshipBuilder = DependentType.Relationship(PrincipalType, ConfigurationSource.Convention, setPrincipalEnd: false)
                 .IsUnique(false, ConfigurationSource.Convention);
 
             Assert.Same(relationshipBuilder, new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder));
@@ -350,7 +350,6 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions
             var fkProperty = DependentType.Metadata.FindPrimaryKey().Properties.Single();
 
             var relationshipBuilder = DependentType.Relationship(PrincipalType, ConfigurationSource.Convention)
-                .PrincipalEntityType(PrincipalType, ConfigurationSource.DataAnnotation)
                 .IsUnique(true, ConfigurationSource.DataAnnotation)
                 .IsRequired(false, ConfigurationSource.DataAnnotation);
 
@@ -367,7 +366,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions
         [Fact]
         public void Does_not_match_dependent_PK_for_self_ref()
         {
-            var relationshipBuilder = PrincipalType.Relationship(PrincipalType, ConfigurationSource.Convention)
+            var relationshipBuilder = PrincipalType.Relationship(PrincipalType, ConfigurationSource.Convention, setPrincipalEnd: false)
                 .IsUnique(true, ConfigurationSource.DataAnnotation);
 
             Assert.Same(relationshipBuilder, new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder));
@@ -470,8 +469,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions
             var fkProperty1 = DependentTypeWithCompositeKey.Metadata.FindPrimaryKey().Properties[0];
             DependentTypeWithCompositeKey.PrimaryKey(new[] { fkProperty1.Name }, ConfigurationSource.Explicit);
 
-            var relationshipBuilder = DependentTypeWithCompositeKey.Relationship(
-                PrincipalTypeWithCompositeKey, ConfigurationSource.Convention)
+            var relationshipBuilder = DependentTypeWithCompositeKey.Relationship(PrincipalTypeWithCompositeKey, ConfigurationSource.Convention)
                 .HasPrincipalKey(PrincipalTypeWithCompositeKey.Metadata.FindPrimaryKey().Properties, ConfigurationSource.DataAnnotation)
                 .IsUnique(true, ConfigurationSource.DataAnnotation);
 
@@ -564,7 +562,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions
         {
             var fkProperty = DependentType.Property(DependentEntity.PeEKaYProperty, ConfigurationSource.Convention).Metadata;
 
-            var relationshipBuilder = DependentType.Relationship(PrincipalType, ConfigurationSource.Convention)
+            var relationshipBuilder = DependentType.Relationship(PrincipalType, ConfigurationSource.Convention, setPrincipalEnd: false)
                 .IsUnique(true, ConfigurationSource.Convention);
 
             var newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder);
@@ -586,7 +584,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions
         {
             var fkProperty = DependentType.Property(DependentEntity.PeEKaYProperty, ConfigurationSource.Convention).Metadata;
 
-            var relationshipBuilder = DependentType.Relationship(PrincipalType, ConfigurationSource.Convention)
+            var relationshipBuilder = DependentType.Relationship(PrincipalType, ConfigurationSource.Convention, setPrincipalEnd: false)
                 .IsUnique(true, ConfigurationSource.Convention);
 
             var newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder);
@@ -609,8 +607,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions
             DependentType.Property(DependentEntity.PeEKaYProperty, ConfigurationSource.Convention);
             PrincipalType.Property(PrincipalEntity.DependentEntityKayPeeProperty, ConfigurationSource.Convention);
 
-            var relationshipBuilder = DependentType.Relationship(
-                PrincipalType, ConfigurationSource.Convention)
+            var relationshipBuilder = DependentType.Relationship(PrincipalType, ConfigurationSource.Convention, setPrincipalEnd: false)
                 .IsUnique(true, ConfigurationSource.Convention);
 
             var newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder);
@@ -630,8 +627,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions
             DependentType.Property(DependentEntity.PeEKaYProperty, ConfigurationSource.Convention);
             var fkProperty = PrincipalType.Property(PrincipalEntity.DependentEntityKayPeeProperty, ConfigurationSource.Convention).Metadata;
 
-            var relationshipBuilder = DependentType.Relationship(
-                PrincipalType, ConfigurationSource.Convention)
+            var relationshipBuilder = DependentType.Relationship(PrincipalType, ConfigurationSource.Convention, setPrincipalEnd: false)
                 .IsUnique(true, ConfigurationSource.Convention)
                 .IsRequired(false, ConfigurationSource.DataAnnotation);
 
@@ -705,6 +701,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions
 
             var property = DependentType.Property(DependentEntity.SomeNavIDProperty, ConfigurationSource.Convention);
 
+            Assert.Same(property, new ForeignKeyPropertyDiscoveryConvention().Apply(property));
             Assert.Same(property, new ForeignKeyPropertyDiscoveryConvention().Apply(property));
 
             var newFk = DependentType.Metadata.GetForeignKeys().Single();

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/NavigationAttributeConventionTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/NavigationAttributeConventionTest.cs
@@ -161,7 +161,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 principalEntityTypeBuilder,
                 nameof(Dependent.Principal),
                 nameof(Principal.Dependent),
-                ConfigurationSource.Convention);
+                ConfigurationSource.Convention)
+                .RelatedEntityTypes(principalEntityTypeBuilder.Metadata, dependentEntityTypeBuilder.Metadata, ConfigurationSource.Convention);
 
             var navigation = principalEntityTypeBuilder.Metadata.FindNavigation(nameof(Principal.Dependent));
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/NavigationExtensionsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/NavigationExtensionsTest.cs
@@ -98,8 +98,16 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata
             var builder = TestHelpers.Instance.CreateConventionBuilder();
             var model = builder.Model;
 
-            builder.Entity<Product>();
-            builder.Entity<Category>();
+            builder.Entity<Product>(e =>
+                {
+                    e.Ignore(p => p.Category);
+                    e.Ignore(p => p.FeaturedProductCategory);
+                });
+            builder.Entity<Category>(e =>
+                {
+                    e.Ignore(c => c.Products);
+                    e.Ignore(c => c.FeaturedProduct);
+                });
 
             var categoryType = model.FindEntityType(typeof(Category));
             var productType = model.FindEntityType(typeof(Product));

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/DataAnnotationsTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/DataAnnotationsTestBase.cs
@@ -137,11 +137,18 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 var model = modelBuilder.Model;
                 modelBuilder.Entity<Author>();
 
-                Assert.Null(model.FindEntityType(typeof(AuthorDetails)).FindNavigation("Author").ForeignKey.PrincipalToDependent);
-                Assert.Equal("AuthorId", model.FindEntityType(typeof(AuthorDetails)).FindNavigation("Author").ForeignKey.Properties.First().Name);
+                var authorDetails = model.FindEntityType(typeof(AuthorDetails));
+                var firstFk = authorDetails.FindNavigation(nameof(AuthorDetails.Author)).ForeignKey;
+                Assert.Equal(typeof(AuthorDetails), firstFk.DeclaringEntityType.ClrType);
+                Assert.Equal("AuthorId", firstFk.Properties.First().Name);
 
-                Assert.Null(model.FindEntityType(typeof(Author)).FindNavigation("AuthorDetails").ForeignKey.PrincipalToDependent);
-                Assert.Equal("AuthorDetailsId", model.FindEntityType(typeof(Author)).FindNavigation("AuthorDetails").ForeignKey.Properties.First().Name);
+                var author = model.FindEntityType(typeof(Author));
+                var secondFk = author.FindNavigation(nameof(Author.AuthorDetails)).ForeignKey;
+                Assert.Equal(typeof(Author), secondFk.DeclaringEntityType.ClrType);
+                Assert.Equal("AuthorDetailsIdByAttribute", secondFk.Properties.First().Name);
+
+                AssertEqual(new[] { "AuthorId", "Id" }, authorDetails.GetProperties().Select(p => p.Name));
+                AssertEqual(new[] { "AuthorDetailsIdByAttribute", "Id", "PostId" }, author.GetProperties().Select(p => p.Name));
             }
 
             [Fact]

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/InheritanceTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/InheritanceTestBase.cs
@@ -169,7 +169,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.Equal(typeof(SpecialBookLabel), relationshipBuilder.Metadata.PrincipalEntityType.ClrType);
                 Assert.Equal(nameof(BookLabel.SpecialBookLabel), relationshipBuilder.Metadata.DependentToPrincipal.Name);
                 Assert.Equal(nameof(SpecialBookLabel.BookLabel), relationshipBuilder.Metadata.PrincipalToDependent.Name);
-                Assert.Equal("SpecialBookLabelId", relationshipBuilder.Metadata.Properties.Single().Name);
+                Assert.Equal(nameof(SpecialBookLabel.Id), relationshipBuilder.Metadata.PrincipalKey.Properties.Single().Name);
             }
 
             [Fact]

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/TestModel.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/TestModel.cs
@@ -267,7 +267,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
             [ForeignKey("PostId")]
             public Post Post { get; set; }
 
-            [ForeignKey("AuthorDetailsId")]
+            [ForeignKey("AuthorDetailsIdByAttribute")]
             public AuthorDetails AuthorDetails { get; set; }
         }
 


### PR DESCRIPTION
Discover fk properties if principal end is configured by convention (not ambiguous)
Make RequiredAttribute configure the principal end when specified on only one navigation and principal end wasn't configured by convention

Fixes #3006