### PR TITLE
Changed InternalEntityEntry to IUpdateEntry where logical.

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/OriginalValuesFactoryFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/OriginalValuesFactoryFactory.cs
@@ -3,10 +3,11 @@
 
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Update;
 
 namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 {
-    public class OriginalValuesFactoryFactory : SnapshotFactoryFactory<InternalEntityEntry>
+    public class OriginalValuesFactoryFactory : SnapshotFactoryFactory<IUpdateEntry>
     {
         protected override int GetPropertyIndex(IPropertyBase propertyBase)
             => (propertyBase as IProperty)?.GetOriginalValueIndex() ?? -1;

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/RelationshipSnapshotFactoryFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/RelationshipSnapshotFactoryFactory.cs
@@ -3,10 +3,11 @@
 
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Update;
 
 namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 {
-    public class RelationshipSnapshotFactoryFactory : SnapshotFactoryFactory<InternalEntityEntry>
+    public class RelationshipSnapshotFactoryFactory : SnapshotFactoryFactory<IUpdateEntry>
     {
         protected override int GetPropertyIndex(IPropertyBase propertyBase)
             => propertyBase.GetRelationshipIndex();

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityType.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityType.cs
@@ -11,6 +11,7 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Update;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
@@ -49,8 +50,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         // Warning: Never access these fields directly as access needs to be thread-safe
         private PropertyCounts _counts;
-        private Func<InternalEntityEntry, ISnapshot> _relationshipSnapshotFactory;
-        private Func<InternalEntityEntry, ISnapshot> _originalValuesFactory;
+        private Func<IUpdateEntry, ISnapshot> _relationshipSnapshotFactory;
+        private Func<IUpdateEntry, ISnapshot> _originalValuesFactory;
         private Func<ValueBuffer, ISnapshot> _shadowValuesFactory;
         private Func<ISnapshot> _emptyShadowValuesFactory;
 
@@ -1106,16 +1107,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         private PropertyCounts CalculateCounts() => EntityTypeExtensions.CalculateCounts(this);
 
-        public virtual Func<InternalEntityEntry, ISnapshot> RelationshipSnapshotFactory
+        public virtual Func<IUpdateEntry, ISnapshot> RelationshipSnapshotFactory
             => LazyInitializer.EnsureInitialized(ref _relationshipSnapshotFactory, CreateRelationshipSnapshotFactory);
 
-        private Func<InternalEntityEntry, ISnapshot> CreateRelationshipSnapshotFactory()
+        private Func<IUpdateEntry, ISnapshot> CreateRelationshipSnapshotFactory()
             => new RelationshipSnapshotFactoryFactory().Create(this);
 
-        public virtual Func<InternalEntityEntry, ISnapshot> OriginalValuesFactory
+        public virtual Func<IUpdateEntry, ISnapshot> OriginalValuesFactory
             => LazyInitializer.EnsureInitialized(ref _originalValuesFactory, CreateOriginalValuesFactory);
 
-        private Func<InternalEntityEntry, ISnapshot> CreateOriginalValuesFactory()
+        private Func<IUpdateEntry, ISnapshot> CreateOriginalValuesFactory()
             => new OriginalValuesFactoryFactory().Create(this);
 
         public virtual Func<ValueBuffer, ISnapshot> ShadowValuesFactory

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityTypeExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityTypeExtensions.cs
@@ -10,6 +10,7 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Update;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
@@ -131,7 +132,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 : new RelationshipSnapshotFactoryFactory().Create(entityType);
         }
 
-        public static Func<InternalEntityEntry, ISnapshot> GetOriginalValuesFactory([NotNull] this IEntityType entityType)
+        public static Func<IUpdateEntry, ISnapshot> GetOriginalValuesFactory([NotNull] this IEntityType entityType)
         {
             var source = entityType as ISnapshotFactorySource;
 

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ISnapshotFactorySource.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ISnapshotFactorySource.cs
@@ -4,13 +4,14 @@
 using System;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Update;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     public interface ISnapshotFactorySource
     {
-        Func<InternalEntityEntry, ISnapshot> OriginalValuesFactory { get; }
-        Func<InternalEntityEntry, ISnapshot> RelationshipSnapshotFactory { get; }
+        Func<IUpdateEntry, ISnapshot> OriginalValuesFactory { get; }
+        Func<IUpdateEntry, ISnapshot> RelationshipSnapshotFactory { get; }
         Func<ValueBuffer, ISnapshot> ShadowValuesFactory { get; }
         Func<ISnapshot> EmptyShadowValuesFactory { get; }
     }

--- a/src/Microsoft.EntityFrameworkCore/Update/IUpdateEntry.cs
+++ b/src/Microsoft.EntityFrameworkCore/Update/IUpdateEntry.cs
@@ -80,6 +80,12 @@ namespace Microsoft.EntityFrameworkCore.Update
         /// <param name="value"> The value to set. </param>
         void SetCurrentValue([NotNull] IPropertyBase propertyBase, [CanBeNull] object value);
 
+        object this[IPropertyBase propertyBase]
+        {
+            get;
+            set;
+        }
+
         /// <summary>
         ///     Gets an <see cref="EntityEntry" /> for the entity being saved. <see cref="EntityEntry" /> is an API optimized for
         ///     application developers and <see cref="IUpdateEntry" /> is optimized for database providers, but there may be instances


### PR DESCRIPTION
Made OriginalValues and StoredGeneratedValues structs public.
Added indexer to IUpdateEntry

This is so that custom Entity tracking can be created.