### PR TITLE
Add high-level cancellation token check to async queries

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/Query/Internal/AsyncLinqOperatorProvider.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/Internal/AsyncLinqOperatorProvider.cs
@@ -127,6 +127,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     try
                     {
                         _exceptionInterceptor._queryContext.ConcurrencyDetector.EnterCriticalSection();
+                        // TODO remove this when/if bug is resolved in Ix-Async https://github.com/Reactive-Extensions/Rx.NET/issues/166
+                        cancellationToken.ThrowIfCancellationRequested();
                         return await _innerEnumerator.MoveNext(cancellationToken);
                     }
                     catch (Exception exception)


### PR DESCRIPTION
This ensures partial results are never returned, as was found to be the case in #4317.

Close #4317

cc @anpete 