### PR TITLE
CLI Commands: Fix design-time assembly resolution

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Commands/Design/AssemblyLoader.cs
+++ b/src/Microsoft.EntityFrameworkCore.Commands/Design/AssemblyLoader.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Design
+{
+    public class AssemblyLoader
+    {
+        private readonly Func<AssemblyName, Assembly> _loadFunc;
+
+        public AssemblyLoader()
+            : this(Assembly.Load)
+        {
+        }
+
+        public AssemblyLoader([NotNull] Func<AssemblyName, Assembly> loadFunc)
+        {
+            Check.NotNull(loadFunc, nameof(loadFunc));
+
+            _loadFunc = loadFunc;
+        }
+
+        public virtual Assembly Load([NotNull] string assemblyName)
+            => _loadFunc(new AssemblyName(assemblyName));
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Commands/Design/DatabaseOperations.cs
+++ b/src/Microsoft.EntityFrameworkCore.Commands/Design/DatabaseOperations.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Threading;
@@ -50,14 +49,16 @@ namespace Microsoft.EntityFrameworkCore.Design
             [NotNull] string connectionString,
             [CanBeNull] string outputDir,
             [CanBeNull] string dbContextClassName,
-            [CanBeNull] List<string> schemas,
-            [CanBeNull] List<string> tables,
+            [NotNull] IEnumerable<string> schemas,
+            [NotNull] IEnumerable<string> tables,
             bool useDataAnnotations,
             bool overwriteFiles,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             Check.NotEmpty(provider, nameof(provider));
             Check.NotEmpty(connectionString, nameof(connectionString));
+            Check.NotNull(schemas, nameof(schemas));
+            Check.NotNull(tables, nameof(tables));
 
             var services = _servicesBuilder.Build(provider);
 

--- a/src/Microsoft.EntityFrameworkCore.Commands/Design/DatabaseOperations.cs
+++ b/src/Microsoft.EntityFrameworkCore.Commands/Design/DatabaseOperations.cs
@@ -23,15 +23,15 @@ namespace Microsoft.EntityFrameworkCore.Design
         private readonly DesignTimeServicesBuilder _servicesBuilder;
 
         public DatabaseOperations(
+            [NotNull] AssemblyLoader assemblyLoader,
             [NotNull] ILoggerProvider loggerProvider,
-            [NotNull] Assembly assembly,
             [NotNull] Assembly startupAssembly,
             [CanBeNull] string environment,
             [NotNull] string projectDir,
             [NotNull] string rootNamespace)
         {
+            Check.NotNull(assemblyLoader, nameof(assemblyLoader));
             Check.NotNull(loggerProvider, nameof(loggerProvider));
-            Check.NotNull(assembly, nameof(assembly));
             Check.NotNull(startupAssembly, nameof(startupAssembly));
             Check.NotNull(projectDir, nameof(projectDir));
             Check.NotNull(rootNamespace, nameof(rootNamespace));
@@ -41,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Design
             _rootNamespace = rootNamespace;
 
             var startup = new StartupInvoker(startupAssembly, environment);
-            _servicesBuilder = new DesignTimeServicesBuilder(startup);
+            _servicesBuilder = new DesignTimeServicesBuilder(assemblyLoader, startup);
         }
 
         public virtual Task<ReverseEngineerFiles> ReverseEngineerAsync(

--- a/src/Microsoft.EntityFrameworkCore.Commands/Design/DbContextOperations.cs
+++ b/src/Microsoft.EntityFrameworkCore.Commands/Design/DbContextOperations.cs
@@ -25,7 +25,6 @@ namespace Microsoft.EntityFrameworkCore.Design
         private readonly Assembly _startupAssembly;
         private readonly LazyRef<ILogger> _logger;
         private readonly IServiceProvider _runtimeServices;
-        private readonly DesignTimeServicesBuilder _servicesBuilder;
 
         public DbContextOperations(
             [NotNull] ILoggerProvider loggerProvider,
@@ -44,11 +43,9 @@ namespace Microsoft.EntityFrameworkCore.Design
 
             var startup = new StartupInvoker(startupAssembly, environment);
             _runtimeServices = startup.ConfigureServices();
-
-            _servicesBuilder = new DesignTimeServicesBuilder(startup);
         }
 
-        public virtual DbContext CreateContext([CanBeNull] string contextType) 
+        public virtual DbContext CreateContext([CanBeNull] string contextType)
             => CreateContext(FindContextType(contextType).Value);
 
         private DbContext CreateContext(Func<DbContext> factory)

--- a/src/Microsoft.EntityFrameworkCore.Commands/Design/MigrationsOperations.cs
+++ b/src/Microsoft.EntityFrameworkCore.Commands/Design/MigrationsOperations.cs
@@ -30,6 +30,7 @@ namespace Microsoft.EntityFrameworkCore.Design
         private readonly DbContextOperations _contextOperations;
 
         public MigrationsOperations(
+            [NotNull] AssemblyLoader assemblyLoader,
             [NotNull] ILoggerProvider loggerProvider,
             [NotNull] Assembly assembly,
             [NotNull] Assembly startupAssembly,
@@ -37,6 +38,7 @@ namespace Microsoft.EntityFrameworkCore.Design
             [NotNull] string projectDir,
             [NotNull] string rootNamespace)
         {
+            Check.NotNull(assemblyLoader, nameof(assemblyLoader));
             Check.NotNull(loggerProvider, nameof(loggerProvider));
             Check.NotNull(assembly, nameof(assembly));
             Check.NotNull(startupAssembly, nameof(startupAssembly));
@@ -58,7 +60,7 @@ namespace Microsoft.EntityFrameworkCore.Design
                 environment);
 
             var startup = new StartupInvoker(startupAssembly, environment);
-            _servicesBuilder = new DesignTimeServicesBuilder(startup);
+            _servicesBuilder = new DesignTimeServicesBuilder(assemblyLoader, startup);
         }
 
         public virtual MigrationFiles AddMigration(

--- a/src/Microsoft.EntityFrameworkCore.Commands/Design/OperationExecutor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Commands/Design/OperationExecutor.cs
@@ -290,8 +290,8 @@ namespace Microsoft.EntityFrameworkCore.Design
                 var provider = (string)args["provider"];
                 var outputDir = (string)args["outputDir"];
                 var dbContextClassName = (string)args["dbContextClassName"];
-                var schemaFilters = (string[])args["schemaFilters"] ?? new string[0];
-                var tableFilters = (string[])args["tableFilters"] ?? new string[0];
+                var schemaFilters = (IEnumerable<string>)args["schemaFilters"];
+                var tableFilters = (IEnumerable<string>)args["tableFilters"];
                 var useDataAnnotations = (bool)args["useDataAnnotations"];
                 var overwriteFiles = (bool)args["overwriteFiles"];
 
@@ -306,8 +306,8 @@ namespace Microsoft.EntityFrameworkCore.Design
             [NotNull] string connectionString,
             [CanBeNull] string outputDir,
             [CanBeNull] string dbContextClassName,
-            [NotNull] string[] schemaFilters,
-            [NotNull] string[] tableFilters,
+            [NotNull] IEnumerable<string> schemaFilters,
+            [NotNull] IEnumerable<string> tableFilters,
             bool useDataAnnotations,
             bool overwriteFiles)
         {
@@ -318,7 +318,7 @@ namespace Microsoft.EntityFrameworkCore.Design
 
             var files = _databaseOperations.Value.ReverseEngineerAsync(
                     provider, connectionString, outputDir, dbContextClassName,
-                    schemaFilters.ToList(), tableFilters.ToList(), useDataAnnotations, overwriteFiles).Result;
+                    schemaFilters, tableFilters, useDataAnnotations, overwriteFiles).Result;
 
             // NOTE: First file will be opened in VS
             yield return files.ContextFile;

--- a/src/Microsoft.EntityFrameworkCore.Commands/Design/OperationExecutor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Commands/Design/OperationExecutor.cs
@@ -35,12 +35,13 @@ namespace Microsoft.EntityFrameworkCore.Design
             var projectDir = (string)args["projectDir"];
             var rootNamespace = (string)args["rootNamespace"];
 
-            var startupAssembly = Assembly.Load(new AssemblyName(startupTargetName));
+            var assemblyLoader = new AssemblyLoader();
+            var startupAssembly = assemblyLoader.Load(startupTargetName);
 
             Assembly assembly;
             try
             {
-                assembly = Assembly.Load(new AssemblyName(targetName));
+                assembly = assemblyLoader.Load(targetName);
             }
             catch (Exception ex)
             {
@@ -55,14 +56,15 @@ namespace Microsoft.EntityFrameworkCore.Design
                     environment));
             _databaseOperations = new LazyRef<DatabaseOperations>(
                 () => new DatabaseOperations(
+                    assemblyLoader,
                     loggerProvider,
-                    assembly,
                     startupAssembly,
                     environment,
                     projectDir,
                     rootNamespace));
             _migrationsOperations = new LazyRef<MigrationsOperations>(
                 () => new MigrationsOperations(
+                    assemblyLoader,
                     loggerProvider,
                     assembly,
                     startupAssembly,

--- a/src/Microsoft.EntityFrameworkCore.Commands/tools/EntityFramework.psm1
+++ b/src/Microsoft.EntityFrameworkCore.Commands/tools/EntityFramework.psm1
@@ -359,7 +359,7 @@ Register-TabExpansion Scaffold-DbContext @{
 .PARAMETER Provider
     Specifies the provider to use. For example, Microsoft.EntityFrameworkCore.SqlServer.
 
-.PARAMETER OutputDirectory
+.PARAMETER OutputDir
     Specifies the directory to use to output the classes. If omitted, the top-level project directory is used.
 
 .PARAMETER Context
@@ -396,10 +396,10 @@ function Scaffold-DbContext {
         [string] $Connection,
         [Parameter(Position = 1, Mandatory = $true)]
         [string] $Provider,
-        [string] $OutputDirectory,
-        [string] $ContextClassName,
-        [string[]] $Schemas,
-        [string[]] $Tables,
+        [string] $OutputDir,
+        [string] $Context,
+        [string[]] $Schemas = @(),
+        [string[]] $Tables = @(),
         [switch] $DataAnnotations,
         [switch] $Force,
         [string] $Project,
@@ -413,8 +413,8 @@ function Scaffold-DbContext {
     $artifacts = InvokeOperation $dteStartupProject $Environment $dteProject ReverseEngineer @{
         connectionString = $Connection
         provider = $Provider
-        outputDir = $OutputDirectory
-        dbContextClassName = $ContextClassName
+        outputDir = $OutputDir
+        dbContextClassName = $Context
         schemaFilters = $Schemas
         tableFilters = $Tables
         useDataAnnotations = [bool]$DataAnnotations

--- a/src/Microsoft.EntityFrameworkCore.Relational.Design/TableSelectionSet.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Design/TableSelectionSet.cs
@@ -13,19 +13,22 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding
         public static readonly TableSelectionSet All = new TableSelectionSet();
 
         public TableSelectionSet()
-            : this(null, null)
+            : this(Enumerable.Empty<string>(), Enumerable.Empty<string>())
         {
         }
 
-        public TableSelectionSet([CanBeNull] IReadOnlyList<string> tables)
-            : this(tables, null)
+        public TableSelectionSet([NotNull] IEnumerable<string> tables)
+            : this(tables, Enumerable.Empty<string>())
         {
         }
 
-        public TableSelectionSet([CanBeNull] IReadOnlyList<string> tables, [CanBeNull] IReadOnlyList<string> schemas)
+        public TableSelectionSet([NotNull] IEnumerable<string> tables, [NotNull] IEnumerable<string> schemas)
         {
-            Schemas = schemas?.Select(schema => new Selection(schema)).ToList().AsReadOnly() ?? new List<Selection>().AsReadOnly();
-            Tables = tables?.Select(table => new Selection(table)).ToList().AsReadOnly() ?? new List<Selection>().AsReadOnly();
+            Check.NotNull(tables, nameof(tables));
+            Check.NotNull(schemas, nameof(schemas));
+
+            Schemas = schemas.Select(schema => new Selection(schema)).ToList();
+            Tables = tables.Select(table => new Selection(table)).ToList();
         }
 
         public virtual IReadOnlyList<Selection> Schemas { get; }

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Properties/AssemblyInfo.cs
@@ -8,5 +8,6 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 [assembly: NeutralResourcesLanguage("en-US")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
 [assembly: DesignTimeProviderServices(
-    fullyQualifiedTypeName: "Microsoft.EntityFrameworkCore.Scaffolding.SqlServerDesignTimeServices, Microsoft.EntityFrameworkCore.SqlServer.Design",
+    typeName: "Microsoft.EntityFrameworkCore.Scaffolding.SqlServerDesignTimeServices",
+    assemblyName: "Microsoft.EntityFrameworkCore.SqlServer.Design, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60",
     packageName: "Microsoft.EntityFrameworkCore.SqlServer.Design")]

--- a/src/Microsoft.EntityFrameworkCore.Sqlite/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite/Properties/AssemblyInfo.cs
@@ -8,5 +8,6 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 [assembly: NeutralResourcesLanguage("en-US")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
 [assembly: DesignTimeProviderServices(
-    fullyQualifiedTypeName: "Microsoft.EntityFrameworkCore.Scaffolding.SqliteDesignTimeServices, Microsoft.EntityFrameworkCore.Sqlite.Design",
+    typeName: "Microsoft.EntityFrameworkCore.Scaffolding.SqliteDesignTimeServices",
+    assemblyName: "Microsoft.EntityFrameworkCore.Sqlite.Design, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60",
     packageName: "Microsoft.EntityFrameworkCore.Sqlite.Design")]

--- a/src/Microsoft.EntityFrameworkCore/Infrastructure/DesignTimeProviderServicesAttribute.cs
+++ b/src/Microsoft.EntityFrameworkCore/Infrastructure/DesignTimeProviderServicesAttribute.cs
@@ -11,16 +11,19 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
     public sealed class DesignTimeProviderServicesAttribute : Attribute
     {
         public DesignTimeProviderServicesAttribute(
-            [NotNull] string fullyQualifiedTypeName, [NotNull] string packageName)
+            [NotNull] string typeName, [NotNull] string assemblyName, [NotNull] string packageName)
         {
-            Check.NotEmpty(fullyQualifiedTypeName, nameof(fullyQualifiedTypeName));
+            Check.NotEmpty(typeName, nameof(typeName));
+            Check.NotEmpty(assemblyName, nameof(assemblyName));
             Check.NotEmpty(packageName, nameof(packageName));
 
-            FullyQualifiedTypeName = fullyQualifiedTypeName;
+            TypeName = typeName;
+            AssemblyName = assemblyName;
             PackageName = packageName;
         }
 
-        public string FullyQualifiedTypeName { get; }
+        public string TypeName { get; }
+        public string AssemblyName { get; }
         public string PackageName { get; }
     }
 }

--- a/src/dotnet-ef/DatabaseUpdateCommand.cs
+++ b/src/dotnet-ef/DatabaseUpdateCommand.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Commands
                 "-c|--context <context>",
                 "The DbContext to use. If omitted, the default DbContext is used");
             var startupProject = command.Option(
-                "-s|--startupProject <project>",
+                "-s|--startup-project <project>",
                 "The startup project to use. If omitted, the current project is used.");
             var environment = command.Option(
                 "-e|--environment <environment>",

--- a/src/dotnet-ef/DbContextListCommand.cs
+++ b/src/dotnet-ef/DbContextListCommand.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Commands
             command.Description = "List your DbContext types";
 
             var startupProject = command.Option(
-                "-s|--startupProject <project>",
+                "-s|--startup-project <project>",
                 "The startup project to use. If omitted, the current project is used.");
             var environment = command.Option(
                 "-e|--environment <environment>",

--- a/src/dotnet-ef/DbContextScaffoldCommand.cs
+++ b/src/dotnet-ef/DbContextScaffoldCommand.cs
@@ -45,7 +45,7 @@ namespace Microsoft.EntityFrameworkCore.Commands
                 "Selects a table for which to generate classes.",
                 CommandOptionType.MultipleValue);
             var startupProject = command.Option(
-                "-s|--startupProject <project>",
+                "-s|--startup-project <project>",
                 "The startup project to use. If omitted, the current project is used.");
             var environment = command.Option(
                 "-e|--environment <environment>",
@@ -92,8 +92,8 @@ namespace Microsoft.EntityFrameworkCore.Commands
             string context,
             bool force,
             string outputDir,
-            List<string> schemas,
-            List<string> tables,
+            IEnumerable<string> schemas,
+            IEnumerable<string> tables,
             string startupProject,
             string environment)
         {

--- a/src/dotnet-ef/MigrationsAddCommand.cs
+++ b/src/dotnet-ef/MigrationsAddCommand.cs
@@ -22,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Commands
                 "-c|--context <context>",
                 "The DbContext to use. If omitted, the default DbContext is used");
             var startupProject = command.Option(
-                "-s|--startupProject <project>",
+                "-s|--startup-project <project>",
                 "The startup project to use. If omitted, the current project is used.");
             var environment = command.Option(
                 "-e|--environment <environment>",

--- a/src/dotnet-ef/MigrationsListCommand.cs
+++ b/src/dotnet-ef/MigrationsListCommand.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Commands
                 "-c|--context <context>",
                 "The DbContext to use. If omitted, the default DbContext is used");
             var startupProject = command.Option(
-                "-s|--startupProject <project>",
+                "-s|--startup-project <project>",
                 "The startup project to use. If omitted, the current project is used.");
             var environment = command.Option(
                 "-e|--environment <environment>",

--- a/src/dotnet-ef/MigrationsRemoveCommand.cs
+++ b/src/dotnet-ef/MigrationsRemoveCommand.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Commands
                 "-c|--context <context>",
                 "The DbContext to use. If omitted, the default DbContext is used");
             var startupProject = command.Option(
-                "-s|--startupProject <project>",
+                "-s|--startup-project <project>",
                 "The startup project to use. If omitted, the current project is used.");
             var environment = command.Option(
                 "-e|--environment <environment>",

--- a/src/dotnet-ef/MigrationsScriptCommand.cs
+++ b/src/dotnet-ef/MigrationsScriptCommand.cs
@@ -31,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Commands
                 "-c|--context <context>",
                 "The DbContext to use. If omitted, the default DbContext is used");
             var startupProject = command.Option(
-                "-s|--startupProject <project>",
+                "-s|--startup-project <project>",
                 "The startup project to use. If omitted, the current project is used.");
             var environment = command.Option(
                 "-e|--environment <environment>",

--- a/src/dotnet-ef/OperationExecutor.cs
+++ b/src/dotnet-ef/OperationExecutor.cs
@@ -63,6 +63,7 @@ namespace Microsoft.EntityFrameworkCore.Commands
             var projectDir = projectFile.ProjectDirectory;
             var rootNamespace = projectFile.Name;
             var assemblyLoadContext = startupProjectContext.CreateLoadContext();
+            var assemblyLoader = new AssemblyLoader(assemblyLoadContext.LoadFromAssemblyName);
 
             var startupAssembly = assemblyLoadContext.LoadFromAssemblyName(startupAssemblyName);
 
@@ -86,14 +87,15 @@ namespace Microsoft.EntityFrameworkCore.Commands
                     environment));
             _databaseOperations = new LazyRef<DatabaseOperations>(
                 () => new DatabaseOperations(
+                    assemblyLoader,
                     new LoggerProvider(name => new ConsoleCommandLogger(name)),
-                    assembly,
                     startupAssembly,
                     environment,
                     projectDir,
                     rootNamespace));
             _migrationsOperations = new LazyRef<MigrationsOperations>(
                 () => new MigrationsOperations(
+                    assemblyLoader,
                     new LoggerProvider(name => new ConsoleCommandLogger(name)),
                     assembly,
                     startupAssembly,

--- a/src/dotnet-ef/OperationExecutor.cs
+++ b/src/dotnet-ef/OperationExecutor.cs
@@ -132,8 +132,8 @@ namespace Microsoft.EntityFrameworkCore.Commands
             [NotNull] string connectionString,
             [CanBeNull] string outputDir,
             [CanBeNull] string dbContextClassName,
-            [CanBeNull] List<string> schemas,
-            [CanBeNull] List<string> tables,
+            [NotNull] IEnumerable<string> schemas,
+            [NotNull] IEnumerable<string> tables,
             bool useDataAnnotations,
             bool overwriteFiles,
             CancellationToken cancellationToken = default(CancellationToken))

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Design.Tests/SqlServerTableSelectionSetExtensionsTests.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Design.Tests/SqlServerTableSelectionSetExtensionsTests.cs
@@ -99,7 +99,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Design
                 "schema0.table1", "[schema0].[table1]", "[schema0].table1", "schema0.[table1]",
                 "schema1.table0", "[schema1].[table0]", "[schema1].table0", "schema1.[table0]"
             };
-            var tableSelectionSet = new TableSelectionSet(tableNames, null);
+            var tableSelectionSet = new TableSelectionSet(tableNames);
 
             Assert.Equal(0, tableSelectionSet.Schemas.Count);
             Assert.Equal(12, tableSelectionSet.Tables.Count);

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Design.Tests/SqliteTableSelectionSetExtensionsTests.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Design.Tests/SqliteTableSelectionSetExtensionsTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Design
         public void Allows_updates_IsMatched_for_matching_selections()
         {
             var tableNames = new List<string> { "table0", "table1", "table2" };
-            var tableSelectionSet = new TableSelectionSet(tableNames, null);
+            var tableSelectionSet = new TableSelectionSet(tableNames);
 
             Assert.Equal(3, tableSelectionSet.Tables.Count);
 


### PR DESCRIPTION
Resolves #3925

**Provider writers beware**, this splits `DesignTimeProviderServicesAttribute.FullyQualifiedTypeName` into `TypeName` and `AssemblyName`. (cc @rowanmiller)

This should also fix #3862