### PR TITLE
Validate properties mapped to same column has same type mapping.

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -357,11 +357,11 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
-        /// Cannot use column name '{columnName}' in entity '{entityType}' for property '{property}' since it is being used for another property.
+        /// '{entityType1}.{property1}' and '{entityType2}.{property2}' are both mapped to column '{columnName}' in '{table}' but are configured to use different data types ('{dataType1}' and '{dataType2}').
         /// </summary>
-        public static string DuplicateColumnName([CanBeNull] object columnName, [CanBeNull] object entityType, [CanBeNull] object property)
+        public static string DuplicateColumnName([CanBeNull] object entityType1, [CanBeNull] object property1, [CanBeNull] object entityType2, [CanBeNull] object property2, [CanBeNull] object columnName, [CanBeNull] object table, [CanBeNull] object dataType1, [CanBeNull] object dataType2)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("DuplicateColumnName", "columnName", "entityType", "property"), columnName, entityType, property);
+            return string.Format(CultureInfo.CurrentCulture, GetString("DuplicateColumnName", "entityType1", "property1", "entityType2", "property2", "columnName", "table", "dataType1", "dataType2"), entityType1, property1, entityType2, property2, columnName, table, dataType1, dataType2);
         }
 
         /// <summary>

--- a/src/Microsoft.EntityFrameworkCore.Relational/Properties/RelationalStrings.resx
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Properties/RelationalStrings.resx
@@ -248,7 +248,7 @@
     <value>Executed DbCommand ({elapsed}ms) [Parameters=[{parameters}], CommandType='{commandType}', CommandTimeout='{commandTimeout}']{newLine}{commandText}</value>
   </data>
   <data name="DuplicateColumnName" xml:space="preserve">
-    <value>Cannot use column name '{columnName}' in entity '{entityType}' for property '{property}' since it is being used for another property.</value>
+    <value>'{entityType1}.{property1}' and '{entityType2}.{property2}' are both mapped to column '{columnName}' in '{table}' but are configured to use different data types ('{dataType1}' and '{dataType2}').</value>
   </data>
   <data name="NoActiveTransaction" xml:space="preserve">
     <value>The connection does not have any active transactions.</value>

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerModelValidatorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerModelValidatorTest.cs
@@ -11,7 +11,6 @@ using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Tests;
 using Microsoft.EntityFrameworkCore.Tests.TestUtilities;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
@@ -24,7 +23,17 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
             modelBuilder.Entity<Product>();
             modelBuilder.Entity<Product>().Property(b => b.Name).ForSqlServerHasColumnName("Id");
 
-            VerifyError(RelationalStrings.DuplicateColumnName("Id", typeof(Product).FullName, "Name"), modelBuilder.Model);
+            VerifyError(RelationalStrings.DuplicateColumnName(typeof(Product).Name, "Id", typeof(Product).Name, "Name", "Id", ".Product", "int", "nvarchar(max)"), modelBuilder.Model);
+        }
+
+        public override void Detects_duplicate_columns_in_derived_types_with_different_types()
+        {
+            var modelBuilder = new ModelBuilder(TestConventionalSetBuilder.Build());
+            modelBuilder.Entity<Animal>();
+            modelBuilder.Entity<Cat>();
+            modelBuilder.Entity<Dog>();
+
+            VerifyError(RelationalStrings.DuplicateColumnName(typeof(Cat).Name, "Type", typeof(Dog).Name, "Type", "Type", ".Animal", "nvarchar(max)", "int"), modelBuilder.Model);
         }
 
         private class Product

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Tests/SqliteModelValidatorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Tests/SqliteModelValidatorTest.cs
@@ -25,13 +25,17 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Tests
             modelBuilder.Entity<Product>();
             modelBuilder.Entity<Product>().Property(b => b.Name).ForSqliteHasColumnName("Id");
 
-            VerifyError(RelationalStrings.DuplicateColumnName("Id", typeof(Product).FullName, "Name"), modelBuilder.Model);
+            VerifyError(RelationalStrings.DuplicateColumnName(typeof(Product).Name, "Id", typeof(Product).Name, "Name", "Id", ".Product", "INTEGER", "TEXT"), modelBuilder.Model);
         }
 
-        private class Product
+        public override void Detects_duplicate_columns_in_derived_types_with_different_types()
         {
-            public int Id { get; set; }
-            public string Name { get; set; }
+            var modelBuilder = new ModelBuilder(TestConventionalSetBuilder.Build());
+            modelBuilder.Entity<Animal>();
+            modelBuilder.Entity<Cat>();
+            modelBuilder.Entity<Dog>();
+
+            VerifyError(RelationalStrings.DuplicateColumnName(typeof(Cat).Name, "Type", typeof(Dog).Name, "Type", "Type", ".Animal", "TEXT", "INTEGER"), modelBuilder.Model);
         }
 
         protected override ModelValidator CreateModelValidator()


### PR DESCRIPTION
Resolves #4251 
If the properties which are being added to single table has same name and different type mapping then throw exception.