### PR TITLE
:bug: Process all relationship candidates

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/RelationshipDiscoveryConvention.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/RelationshipDiscoveryConvention.cs
@@ -276,7 +276,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                             .RemoveForeignKey(existingForeignKey, ConfigurationSource.Convention);
                     }
 
-                    break;
+                    continue;
                 }
 
                 foreach (var navigation in relationshipCandidate.NavigationProperties)

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderGenericTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderGenericTest.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Reflection;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/OneToManyTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/OneToManyTestBase.cs
@@ -1901,6 +1901,17 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.Null(fk.PrincipalToDependent);
                 Assert.True(fk.Properties.Single().IsShadowProperty);
             }
+
+            [Fact]
+            public virtual void Ambiguous_relationship_candidate_does_not_block_creating_further_relationships()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var theta = modelBuilder.Entity<Theta>().Metadata;
+
+                Assert.NotNull(theta.FindNavigation("NavTheta"));
+                Assert.NotNull(theta.FindNavigation("InverseNavThetas"));
+                Assert.Same(theta.FindNavigation("NavTheta").ForeignKey, theta.FindNavigation("InverseNavThetas").ForeignKey);
+            }
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/TestModel.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/TestModel.cs
@@ -409,6 +409,18 @@ namespace Microsoft.EntityFrameworkCore.Tests
             public int Id { get; set; }
 
             public Alpha Alpha { get; set; }
+
+            public Theta NavTheta { get; set; }
+            public IList<Theta> InverseNavThetas { get; set; }
+            public IList<Iota> AllIotas { get; set; }
+        }
+
+        protected class Iota
+        {
+            public int Id { get; set; }
+
+            public Theta FirstTheta { get; set; }
+            public Theta SecondTheta { get; set; }
         }
 
         protected interface IEntityBase


### PR DESCRIPTION
resolves #4682 
Issue: When we encountered multiple relationship candidates, we were falling out of the loop if find ambiguous candidate. Therefore rest of candidates were not being process to build relationships. The issue did not surfaced so far because such missing relationships are found by the relationship discovery convention running on the other side. Which fails for self-ref relationship.