### PR TITLE
Use DbSet property name as table names

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Infrastructure/Internal/RelationalModelSource.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Infrastructure/Internal/RelationalModelSource.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Infrastructure.Internal
+{
+    public class RelationalModelSource : ModelSource
+    {
+        public RelationalModelSource(
+            [NotNull] IDbSetFinder setFinder,
+            [NotNull] ICoreConventionSetBuilder coreConventionSetBuilder,
+            [NotNull] IModelCustomizer modelCustomizer,
+            [NotNull] IModelCacheKeyFactory modelCacheKeyFactory)
+            : base(setFinder, coreConventionSetBuilder, modelCustomizer, modelCacheKeyFactory)
+        {
+        }
+
+        protected override void FindSets(ModelBuilder modelBuilder, DbContext context)
+        {
+            base.FindSets(modelBuilder, context);
+
+            var sets = SetFinder.CreateClrTypeDbSetMapping(context);
+
+            foreach (var entityType in modelBuilder.Model.GetEntityTypes().Cast<EntityType>())
+            {
+                if (entityType.BaseType == null
+                    && sets.ContainsKey(entityType.ClrType))
+                {
+                    entityType.Builder.Relational(ConfigurationSource.Convention).TableName = sets[entityType.ClrType].Name;
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Relational/Metadata/Conventions/Internal/DiscriminatorConvention.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Metadata/Conventions/Internal/DiscriminatorConvention.cs
@@ -11,8 +11,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     {
         public virtual bool Apply(InternalEntityTypeBuilder entityTypeBuilder, EntityType oldBaseType)
         {
-            if ((oldBaseType != null)
-                && (oldBaseType.BaseType == null)
+            if (oldBaseType != null
+                && oldBaseType.BaseType == null
                 && !oldBaseType.GetDerivedTypes().Any())
             {
                 var oldBaseTypeBuilder = oldBaseType.Builder;

--- a/src/Microsoft.EntityFrameworkCore.Relational/Metadata/Conventions/Internal/RelationalConventionSetBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Metadata/Conventions/Internal/RelationalConventionSetBuilder.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -12,12 +13,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     public abstract class RelationalConventionSetBuilder : IConventionSetBuilder
     {
         private readonly IRelationalTypeMapper _typeMapper;
+        private readonly DbContext _context;
+        private readonly IDbSetFinder _setFinder;
 
-        protected RelationalConventionSetBuilder([NotNull] IRelationalTypeMapper typeMapper)
+        protected RelationalConventionSetBuilder(
+            [NotNull] IRelationalTypeMapper typeMapper,
+            [CanBeNull] DbContext context, 
+            [CanBeNull] IDbSetFinder setFinder)
         {
             Check.NotNull(typeMapper, nameof(typeMapper));
 
             _typeMapper = typeMapper;
+            _context = context;
+            _setFinder = setFinder;
         }
 
         public virtual ConventionSet AddConventions(ConventionSet conventionSet)
@@ -43,6 +51,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             conventionSet.EntityTypeAddedConventions.Add(new RelationalTableAttributeConvention());
 
             conventionSet.BaseEntityTypeSetConventions.Add(new DiscriminatorConvention());
+
+            conventionSet.BaseEntityTypeSetConventions.Add(new TableNameFromDbSetConvention(_context, _setFinder));
 
             return conventionSet;
         }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Metadata/Conventions/Internal/TableNameFromDbSetConvention.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Metadata/Conventions/Internal/TableNameFromDbSetConvention.cs
@@ -1,0 +1,44 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
+{
+    public class TableNameFromDbSetConvention : IBaseTypeConvention
+    {
+        private readonly IDictionary<Type, DbSetProperty> _sets;
+
+        public TableNameFromDbSetConvention([CanBeNull] DbContext context, [CanBeNull] IDbSetFinder setFinder)
+        {
+            // ReSharper disable once AssignNullToNotNullAttribute
+            _sets = setFinder?.CreateClrTypeDbSetMapping(context);
+        }
+
+        public virtual bool Apply(InternalEntityTypeBuilder entityTypeBuilder, EntityType oldBaseType)
+        {
+            if (_sets != null)
+            {
+                var entityType = entityTypeBuilder.Metadata;
+
+                if (oldBaseType == null
+                    && entityType.BaseType != null)
+                {
+                    entityTypeBuilder.Relational(ConfigurationSource.Convention).TableName = null;
+                }
+                else if (oldBaseType != null
+                         && entityType.BaseType == null
+                         && _sets.ContainsKey(entityType.ClrType))
+                {
+                    entityTypeBuilder.Relational(ConfigurationSource.Convention).TableName
+                        = _sets[entityType.ClrType].Name;
+                }
+            }
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Relational/Microsoft.EntityFrameworkCore.Relational.csproj
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Microsoft.EntityFrameworkCore.Relational.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Extensions\MethodInfoExtensions.cs" />
     <Compile Include="Extensions\RelationalLoggerExtensions.cs" />
     <Compile Include="Extensions\TaskExtensions.cs" />
+    <Compile Include="Infrastructure\Internal\RelationalModelSource.cs" />
     <Compile Include="Infrastructure\ModelSnapshot.cs" />
     <Compile Include="Infrastructure\RelationalCommandListBuilder.cs" />
     <Compile Include="Infrastructure\RelationalDbContextOptionsBuilder.cs" />
@@ -89,6 +90,7 @@
     <Compile Include="Metadata\Conventions\Internal\RelationalPropertyMappingValidationConvention.cs" />
     <Compile Include="Metadata\Conventions\Internal\RelationalRelationshipDiscoveryConvention.cs" />
     <Compile Include="Metadata\Conventions\Internal\RelationalTableAttributeConvention.cs" />
+    <Compile Include="Metadata\Conventions\Internal\TableNameFromDbSetConvention.cs" />
     <Compile Include="Metadata\Internal\RelationalAnnotationNames.cs" />
     <Compile Include="Metadata\Internal\RelationalAnnotationsBuilder.cs" />
     <Compile Include="Metadata\Internal\RelationalEntityTypeBuilderAnnotations.cs" />

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Infrastructure/Internal/SqlServerModelSource.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Infrastructure/Internal/SqlServerModelSource.cs
@@ -7,9 +7,13 @@ using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Infrastructure.Internal
 {
-    public class SqlServerModelSource : ModelSource
+    public class SqlServerModelSource : RelationalModelSource
     {
-        public SqlServerModelSource([NotNull] IDbSetFinder setFinder, [NotNull] ICoreConventionSetBuilder coreConventionSetBuilder, [NotNull] IModelCustomizer modelCustomizer, [NotNull] IModelCacheKeyFactory modelCacheKeyFactory)
+        public SqlServerModelSource(
+            [NotNull] IDbSetFinder setFinder,
+            [NotNull] ICoreConventionSetBuilder coreConventionSetBuilder,
+            [NotNull] IModelCustomizer modelCustomizer,
+            [NotNull] IModelCacheKeyFactory modelCacheKeyFactory)
             : base(setFinder, coreConventionSetBuilder, modelCustomizer, modelCacheKeyFactory)
         {
         }

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Metadata/Conventions/SqlServerConventionSetBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Metadata/Conventions/SqlServerConventionSetBuilder.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
@@ -11,8 +12,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 {
     public class SqlServerConventionSetBuilder : RelationalConventionSetBuilder
     {
-        public SqlServerConventionSetBuilder([NotNull] IRelationalTypeMapper typeMapper)
-            : base(typeMapper)
+        public SqlServerConventionSetBuilder(
+            [NotNull] IRelationalTypeMapper typeMapper,
+            [CanBeNull] DbContext context,
+            [CanBeNull] IDbSetFinder setFinder)
+            : base(typeMapper, context, setFinder)
         {
         }
 
@@ -28,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         }
 
         public static ConventionSet Build()
-            => new SqlServerConventionSetBuilder(new SqlServerTypeMapper())
+            => new SqlServerConventionSetBuilder(new SqlServerTypeMapper(), null, null)
                 .AddConventions(new CoreConventionSetBuilder().CreateConventionSet());
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Sqlite/Infrastructure/Internal/SqliteModelSource.cs
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite/Infrastructure/Internal/SqliteModelSource.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Infrastructure.Internal
 {
-    public class SqliteModelSource : ModelSource
+    public class SqliteModelSource : RelationalModelSource
     {
         public SqliteModelSource([NotNull] IDbSetFinder setFinder, [NotNull] ICoreConventionSetBuilder coreConventionSetBuilder, [NotNull] IModelCustomizer modelCustomizer, [NotNull] IModelCacheKeyFactory modelCacheKeyFactory)
             : base(setFinder, coreConventionSetBuilder, modelCustomizer, modelCacheKeyFactory)

--- a/src/Microsoft.EntityFrameworkCore.Sqlite/Metadata/Conventions/SqliteConventionSetBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite/Metadata/Conventions/SqliteConventionSetBuilder.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
@@ -10,13 +11,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 {
     public class SqliteConventionSetBuilder : RelationalConventionSetBuilder
     {
-        public SqliteConventionSetBuilder([NotNull] IRelationalTypeMapper typeMapper)
-            : base(typeMapper)
+        public SqliteConventionSetBuilder(
+            [NotNull] IRelationalTypeMapper typeMapper,
+            [CanBeNull] DbContext context,
+            [CanBeNull] IDbSetFinder setFinder)
+            : base(typeMapper, context, setFinder)
         {
         }
 
         public static ConventionSet Build()
-            => new SqliteConventionSetBuilder(new SqliteTypeMapper())
+            => new SqliteConventionSetBuilder(new SqliteTypeMapper(), null, null)
                 .AddConventions(new CoreConventionSetBuilder().CreateConventionSet());
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Infrastructure/ModelSource.cs
+++ b/src/Microsoft.EntityFrameworkCore/Infrastructure/ModelSource.cs
@@ -110,10 +110,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         {
             foreach (var setInfo in SetFinder.FindSets(context))
             {
-                modelBuilder.Entity(setInfo.EntityType);
+                modelBuilder.Entity(setInfo.ClrType);
             }
         }
-
     }
 }
-

--- a/src/Microsoft.EntityFrameworkCore/Internal/DbSetFinder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Internal/DbSetFinder.cs
@@ -15,7 +15,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
         private readonly ConcurrentDictionary<Type, IReadOnlyList<DbSetProperty>> _cache
             = new ConcurrentDictionary<Type, IReadOnlyList<DbSetProperty>>();
 
-        public virtual IReadOnlyList<DbSetProperty> FindSets(DbContext context) => _cache.GetOrAdd(context.GetType(), FindSets);
+        public virtual IReadOnlyList<DbSetProperty> FindSets(DbContext context) 
+            => _cache.GetOrAdd(context.GetType(), FindSets);
 
         private static DbSetProperty[] FindSets(Type contextType)
         {
@@ -25,17 +26,15 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 .Where(
                     p => !p.IsStatic()
                          && !p.GetIndexParameters().Any()
-                         && (p.DeclaringType != typeof(DbContext))
+                         && p.DeclaringType != typeof(DbContext)
                          && p.PropertyType.GetTypeInfo().IsGenericType
-                         && (p.PropertyType.GetGenericTypeDefinition() == typeof(DbSet<>)))
+                         && p.PropertyType.GetGenericTypeDefinition() == typeof(DbSet<>))
                 .OrderBy(p => p.Name)
-                .Select(p =>
-                    {
-                        return new DbSetProperty(
-                            p.Name,
-                            p.PropertyType.GetTypeInfo().GenericTypeArguments.Single(),
-                            p.SetMethod == null ? null : factory.Create(p));
-                    })
+                .Select(
+                    p => new DbSetProperty(
+                        p.Name,
+                        p.PropertyType.GetTypeInfo().GenericTypeArguments.Single(),
+                        p.SetMethod == null ? null : factory.Create(p)))
                 .ToArray();
         }
     }

--- a/src/Microsoft.EntityFrameworkCore/Internal/DbSetFinderExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Internal/DbSetFinderExtensions.cs
@@ -1,0 +1,33 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Internal
+{
+    public static class DbSetFinderExtensions
+    {
+        public static IDictionary<Type, DbSetProperty> CreateClrTypeDbSetMapping(
+            [NotNull] this IDbSetFinder setFinder, [NotNull] DbContext context)
+        {
+            var sets = new Dictionary<Type, DbSetProperty>();
+            var alreadySeen = new HashSet<Type>();
+            foreach (var set in setFinder.FindSets(context))
+            {
+                if (!alreadySeen.Contains(set.ClrType))
+                {
+                    alreadySeen.Add(set.ClrType);
+                    sets.Add(set.ClrType, set);
+                }
+                else
+                {
+                    sets.Remove(set.ClrType);
+                }
+            }
+
+            return sets;
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/Internal/DbSetInitializer.cs
+++ b/src/Microsoft.EntityFrameworkCore/Internal/DbSetInitializer.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         {
             foreach (var setInfo in _setFinder.FindSets(context).Where(p => p.Setter != null))
             {
-                setInfo.Setter.SetClrValue(context, _setSource.Create(context, setInfo.EntityType));
+                setInfo.Setter.SetClrValue(context, _setSource.Create(context, setInfo.ClrType));
             }
         }
 

--- a/src/Microsoft.EntityFrameworkCore/Internal/DbSetProperty.cs
+++ b/src/Microsoft.EntityFrameworkCore/Internal/DbSetProperty.cs
@@ -11,17 +11,17 @@ namespace Microsoft.EntityFrameworkCore.Internal
     {
         public DbSetProperty(
             [NotNull] string name,
-            [NotNull] Type entityType,
+            [NotNull] Type clrType,
             [CanBeNull] IClrPropertySetter setter)
         {
             Name = name;
-            EntityType = entityType;
+            ClrType = clrType;
             Setter = setter;
         }
 
         public string Name { get; }
 
-        public Type EntityType { get; }
+        public Type ClrType { get; }
 
         public IClrPropertySetter Setter { get; }
     }

--- a/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
+++ b/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
@@ -187,6 +187,7 @@
     <Compile Include="Internal\DbContextActivator.cs" />
     <Compile Include="Internal\DbContextServices.cs" />
     <Compile Include="Internal\DbSetFinder.cs" />
+    <Compile Include="Internal\DbSetFinderExtensions.cs" />
     <Compile Include="Internal\DbSetInitializer.cs" />
     <Compile Include="Internal\DbSetProperty.cs" />
     <Compile Include="Internal\DbSetSource.cs" />

--- a/test/Microsoft.EntityFrameworkCore.Microbenchmarks/Query/RawSqlQueryTests.cs
+++ b/test/Microsoft.EntityFrameworkCore.Microbenchmarks/Query/RawSqlQueryTests.cs
@@ -1,10 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Linq;
 using Microsoft.EntityFrameworkCore.Microbenchmarks.Core;
 using Microsoft.EntityFrameworkCore.Microbenchmarks.Models.Orders;
-using Microsoft.EntityFrameworkCore;
-using System.Linq;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Microbenchmarks.Query
@@ -27,7 +26,7 @@ namespace Microsoft.EntityFrameworkCore.Microbenchmarks.Query
             using (var context = _fixture.CreateContext())
             {
                 var query = context.Products
-                    .FromSql("SELECT * FROM dbo.Product")
+                    .FromSql("SELECT * FROM dbo.Products")
                     .ApplyTracking(tracking);
 
                 using (collector.StartCollection())
@@ -51,7 +50,7 @@ namespace Microsoft.EntityFrameworkCore.Microbenchmarks.Query
             using (var context = _fixture.CreateContext())
             {
                 var query = context.Products
-                    .FromSql("SELECT * FROM dbo.Product WHERE CurrentPrice >= @p0 AND CurrentPrice <= @p1", 10, 14)
+                    .FromSql("SELECT * FROM dbo.Products WHERE CurrentPrice >= @p0 AND CurrentPrice <= @p1", 10, 14)
                     .ApplyTracking(tracking);
 
                 using (collector.StartCollection())
@@ -75,7 +74,7 @@ namespace Microsoft.EntityFrameworkCore.Microbenchmarks.Query
             using (var context = _fixture.CreateContext())
             {
                 var query = context.Products
-                    .FromSql("SELECT * FROM dbo.Product")
+                    .FromSql("SELECT * FROM dbo.Products")
                     .ApplyTracking(tracking)
                     .Where(p => p.CurrentPrice >= 10 && p.CurrentPrice <= 14)
                     .OrderBy(p => p.Name);
@@ -121,19 +120,18 @@ namespace Microsoft.EntityFrameworkCore.Microbenchmarks.Query
         {
             public RawSqlQueryFixture()
                 : base("Perf_Query_RawSql", 1000, 1000, 2, 2)
-            { }
+            {
+            }
 
             protected override void OnDatabaseCreated(OrdersContext context)
-            {
-                context.Database.ExecuteSqlCommand(
+                => context.Database.ExecuteSqlCommand(
                     @"CREATE PROCEDURE dbo.SearchProducts
                         @minPrice decimal(18, 2),
                         @maxPrice decimal(18, 2)
                     AS
                     BEGIN
-                        SELECT * FROM dbo.Product WHERE CurrentPrice >= @minPrice AND CurrentPrice <= @maxPrice
+                        SELECT * FROM dbo.Products WHERE CurrentPrice >= @minPrice AND CurrentPrice <= @maxPrice
                     END");
-            }
         }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/DbSetAsTableNameTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/DbSetAsTableNameTest.cs
@@ -1,0 +1,199 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Tests
+{
+    public abstract class DbSetAsTableNameTest
+    {
+        [Fact]
+        public void DbSet_names_are_used_as_table_names()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal("Cheeses", GetTableName<Cheese>(context));
+            }
+        }
+
+        [Fact]
+        public void DbSet_name_of_base_type_is_used_as_table_name_for_TPH()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal("Chocolates", GetTableName<Chocolate>(context));
+                Assert.Equal("Chocolates", GetTableName<Galaxy>(context));
+                Assert.Equal("Chocolates", GetTableName<DairyMilk>(context));
+            }
+        }
+
+        [Fact]
+        public void Type_name_of_base_type_is_used_as_table_name_for_TPH_if_not_added_as_set()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal("Fruit", GetTableName<Fruit>(context));
+                Assert.Equal("Fruit", GetTableName<Apple>(context));
+                Assert.Equal("Fruit", GetTableName<Banana>(context));
+            }
+        }
+
+        [Fact]
+        public void DbSet_names_of_derived_types_are_used_as_table_names_when_base_type_not_mapped()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal("Triskets", GetTableName<Trisket>(context));
+                Assert.Equal("WheatThins", GetTableName<WheatThin>(context));
+            }
+        }
+
+        [Fact]
+        public void Name_of_duplicate_DbSet_is_not_used_as_table_name()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal("Marmite", GetTableName<Marmite>(context));
+            }
+        }
+
+        [Fact]
+        public void Explicit_names_can_be_used_as_table_names()
+        {
+            using (var context = CreateNamedTablesContext())
+            {
+                Assert.Equal("YummyCheese", GetTableName<Cheese>(context));
+            }
+        }
+
+        [Fact]
+        public void Explicit_name_of_base_type_can_be_used_as_table_name_for_TPH()
+        {
+            using (var context = CreateNamedTablesContext())
+            {
+                Assert.Equal("YummyChocolate", GetTableName<Chocolate>(context));
+                Assert.Equal("YummyChocolate", GetTableName<Galaxy>(context));
+                Assert.Equal("YummyChocolate", GetTableName<DairyMilk>(context));
+            }
+        }
+
+        [Fact]
+        public void Explicit_name_of_base_type_can_be_used_as_table_name_for_TPH_if_not_added_as_set()
+        {
+            using (var context = CreateNamedTablesContext())
+            {
+                Assert.Equal("YummyFruit", GetTableName<Fruit>(context));
+                Assert.Equal("YummyFruit", GetTableName<Apple>(context));
+                Assert.Equal("YummyFruit", GetTableName<Banana>(context));
+            }
+        }
+
+        [Fact]
+        public void Explicit_names_of_derived_types_can_be_used_as_table_names_when_base_type_not_mapped()
+        {
+            using (var context = CreateNamedTablesContext())
+            {
+                Assert.Equal("YummyTriskets", GetTableName<Trisket>(context));
+                Assert.Equal("YummyWheatThins", GetTableName<WheatThin>(context));
+            }
+        }
+
+        [Fact]
+        public void Explicit_name_can_be_used_for_type_with_duplicated_sets()
+        {
+            using (var context = CreateNamedTablesContext())
+            {
+                Assert.Equal("YummyMarmite", GetTableName<Marmite>(context));
+            }
+        }
+
+        protected abstract string GetTableName<TEntity>(DbContext context);
+
+        protected abstract SetsContext CreateContext();
+
+        protected abstract class SetsContext : DbContext
+        {
+            public DbSet<Cheese> Cheeses { get; set; }
+            public DbSet<Chocolate> Chocolates { get; set; }
+            public DbSet<Galaxy> Galaxies { get; set; }
+            public DbSet<DairyMilk> DairyMilks { get; set; }
+            public DbSet<Apple> Apples { get; set; }
+            public DbSet<Trisket> Triskets { get; set; }
+            public DbSet<WheatThin> WheatThins { get; set; }
+            public DbSet<Marmite> Food { get; set; }
+            public DbSet<Marmite> Beverage { get; set; }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<Fruit>();
+                modelBuilder.Entity<Banana>();
+            }
+        }
+
+        protected abstract SetsContext CreateNamedTablesContext();
+
+        protected abstract class NamedTablesContext : SetsContext
+        {
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                base.OnModelCreating(modelBuilder);
+
+                modelBuilder.Entity<Cheese>().ToTable("YummyCheese");
+                modelBuilder.Entity<Chocolate>().ToTable("YummyChocolate");
+                modelBuilder.Entity<Fruit>().ToTable("YummyFruit");
+                modelBuilder.Entity<Trisket>().ToTable("YummyTriskets");
+                modelBuilder.Entity<WheatThin>().ToTable("YummyWheatThins");
+                modelBuilder.Entity<Marmite>().ToTable("YummyMarmite");
+            }
+        }
+
+        protected class Cheese
+        {
+            public int Id { get; set; }
+        }
+
+        protected class Chocolate
+        {
+            public int Id { get; set; }
+        }
+
+        protected class Galaxy : Chocolate
+        {
+        }
+
+        protected class DairyMilk : Chocolate
+        {
+        }
+
+        protected class Fruit
+        {
+            public int Id { get; set; }
+        }
+
+        protected class Apple : Fruit
+        {
+        }
+
+        protected class Banana : Fruit
+        {
+        }
+
+        protected class Cracker
+        {
+            public int Id { get; set; }
+        }
+
+        protected class Trisket : Cracker
+        {
+        }
+
+        protected class WheatThin : Cracker
+        {
+        }
+
+        protected class Marmite
+        {
+            public int Id { get; set; }
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Microsoft.EntityFrameworkCore.Relational.Tests.csproj
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Microsoft.EntityFrameworkCore.Relational.Tests.csproj
@@ -36,6 +36,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ApiConsistencyTest.cs" />
+    <Compile Include="DbSetAsTableNameTest.cs" />
     <Compile Include="Metadata\Conventions\Internal\DiscriminatorConventionTest.cs" />
     <Compile Include="Metadata\Conventions\Internal\RelationalPropertyMappingValidationConventionTest.cs" />
     <Compile Include="Metadata\InternalRelationalMetadataBuilderExtensionsTest.cs" />

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/TestConventionalSetBuilder.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/TestConventionalSetBuilder.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -9,13 +10,15 @@ namespace Microsoft.EntityFrameworkCore.Tests
 {
     public class TestConventionalSetBuilder : RelationalConventionSetBuilder
     {
-        public TestConventionalSetBuilder(IRelationalTypeMapper typeMapper)
-            : base(typeMapper)
+        public TestConventionalSetBuilder(IRelationalTypeMapper typeMapper,
+            DbContext context,
+            IDbSetFinder setFinder)
+            : base(typeMapper, context, setFinder)
         {
         }
 
         public static ConventionSet Build()
-            => new TestConventionalSetBuilder(new TestRelationalTypeMapper())
+            => new TestConventionalSetBuilder(new TestRelationalTypeMapper(), null, null)
                 .AddConventions(new CoreConventionSetBuilder().CreateConventionSet());
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/CompositeKeyEndToEndTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/CompositeKeyEndToEndTest.cs
@@ -200,20 +200,26 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
             protected override void OnModelCreating(ModelBuilder modelBuilder)
             {
-                modelBuilder.Entity<Pegasus>().HasKey(e => new { e.Id1, e.Id2 });
+                modelBuilder.Entity<Pegasus>(b =>
+                    {
+                        b.ToTable("Pegasus");
+                        b.HasKey(e => new { e.Id1, e.Id2 });
+                    });
 
                 modelBuilder.Entity<Unicorn>(b =>
                     {
+                        b.ToTable("Unicorn");
                         b.HasKey(e => new { e.Id1, e.Id2, e.Id3 });
                         b.Property(e => e.Id1).UseSqlServerIdentityColumn();
                         b.Property(e => e.Id3).ValueGeneratedOnAdd();
                     });
 
                 modelBuilder.Entity<EarthPony>(b =>
-                {
-                    b.HasKey(e => new { e.Id1, e.Id2});
-                    b.Property(e => e.Id1).UseSqlServerIdentityColumn();
-                });
+                    {
+                        b.ToTable("EarthPony");
+                        b.HasKey(e => new { e.Id1, e.Id2 });
+                        b.Property(e => e.Id1).UseSqlServerIdentityColumn();
+                    });
             }
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryBugsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryBugsTest.cs
@@ -52,6 +52,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
                 => optionsBuilder.UseSqlServer(_connectionString);
 
+            protected override void OnModelCreating(ModelBuilder modelBuilder) 
+                => modelBuilder.Entity<ZeroKey>().ToTable("ZeroKey");
+
             public DbSet<ZeroKey> ZeroKeys { get; set; }
 
             public class ZeroKey
@@ -118,6 +121,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
                 => optionsBuilder.UseSqlServer(SqlServerTestStore.CreateConnectionString("Repro603"));
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+                => modelBuilder.Entity<Product>().ToTable("Product");
         }
 
         [Fact]
@@ -249,9 +255,12 @@ LEFT JOIN [Customer] AS [c] ON ([o].[CustomerFirstName] = [c].[FirstName]) AND (
             {
                 modelBuilder.Entity<Customer>(m =>
                     {
+                        m.ToTable("Customer");
                         m.HasKey(c => new { c.FirstName, c.LastName });
                         m.HasMany(c => c.Orders).WithOne(o => o.Customer);
                     });
+
+                modelBuilder.Entity<Order>().ToTable("Order");
             }
         }
 
@@ -307,8 +316,8 @@ LEFT JOIN [Customer] AS [c] ON ([o].[CustomerFirstName] = [c].[FirstName]) AND (
             using (var ctx = new MyContext963(_fixture.ServiceProvider))
             {
                 (from t in ctx.Targaryens
-                    join d in ctx.Dragons on t.Id equals d.MotherId
-                    select d).ToList();
+                 join d in ctx.Dragons on t.Id equals d.MotherId
+                 select d).ToList();
             }
         }
 
@@ -327,10 +336,10 @@ LEFT JOIN [Customer] AS [c] ON ([o].[CustomerFirstName] = [c].[FirstName]) AND (
 
                         var aerys = new Targaryen { Name = "Aerys II" };
                         var details = new Details
-                            {
-                                FullName = @"Daenerys Stormborn of the House Targaryen, the First of Her Name, the Unburnt, Queen of Meereen, 
+                        {
+                            FullName = @"Daenerys Stormborn of the House Targaryen, the First of Her Name, the Unburnt, Queen of Meereen, 
 Queen of the Andals and the Rhoynar and the First Men, Khaleesi of the Great Grass Sea, Breaker of Chains, and Mother of Dragons"
-                            };
+                        };
 
                         var daenerys = new Targaryen { Name = "Daenerys", Details = details, Dragons = new List<Dragon> { drogon, rhaegal, viserion } };
                         context.Targaryens.AddRange(daenerys, aerys);
@@ -386,10 +395,13 @@ Queen of the Andals and the Rhoynar and the First Men, Khaleesi of the Great Gra
             {
                 modelBuilder.Entity<Targaryen>(m =>
                     {
+                        m.ToTable("Targaryen");
                         m.HasKey(t => t.Id);
                         m.HasMany(t => t.Dragons).WithOne(d => d.Mother).HasForeignKey(d => d.MotherId);
                         m.HasOne(t => t.Details).WithOne(d => d.Targaryen).HasForeignKey<Details>(d => d.TargaryenId);
                     });
+
+                modelBuilder.Entity<Dragon>().ToTable("Dragon");
             }
         }
 
@@ -501,10 +513,17 @@ WHERE ([c].[FirstName] = @__firstName_0) AND ([c].[LastName] = @__8__locals1_det
 
             protected override void OnModelCreating(ModelBuilder modelBuilder)
             {
-                modelBuilder.Entity<Customer3758>().HasMany(e => e.Orders1).WithOne();
-                modelBuilder.Entity<Customer3758>().HasMany(e => e.Orders2).WithOne();
-                modelBuilder.Entity<Customer3758>().HasMany(e => e.Orders3).WithOne();
-                modelBuilder.Entity<Customer3758>().HasMany(e => e.Orders4).WithOne();
+                modelBuilder.Entity<Customer3758>(b =>
+                    {
+                        b.ToTable("Customer3758");
+
+                        b.HasMany(e => e.Orders1).WithOne();
+                        b.HasMany(e => e.Orders2).WithOne();
+                        b.HasMany(e => e.Orders3).WithOne();
+                        b.HasMany(e => e.Orders4).WithOne();
+                    });
+
+                modelBuilder.Entity<Order3758>().ToTable("Order3758");
             }
         }
 
@@ -547,54 +566,54 @@ WHERE ([c].[FirstName] = @__firstName_0) AND ([c].[LastName] = @__8__locals1_det
                 _fixture.ServiceProvider,
                 (sp, co) => new MyContext3758(sp),
                 context =>
-                {
-                    var o111 = new Order3758 { Name = "O111" };
-                    var o112 = new Order3758 { Name = "O112" };
-                    var o121 = new Order3758 { Name = "O121" };
-                    var o122 = new Order3758 { Name = "O122" };
-                    var o131 = new Order3758 { Name = "O131" };
-                    var o132 = new Order3758 { Name = "O132" };
-                    var o141 = new Order3758 { Name = "O141" };
-
-                    var o211 = new Order3758 { Name = "O211" };
-                    var o212 = new Order3758 { Name = "O212" };
-                    var o221 = new Order3758 { Name = "O221" };
-                    var o222 = new Order3758 { Name = "O222" };
-                    var o231 = new Order3758 { Name = "O231" };
-                    var o232 = new Order3758 { Name = "O232" };
-                    var o241 = new Order3758 { Name = "O241" };
-
-                    var c1 = new Customer3758
                     {
-                        Name = "C1",
-                        Orders1 = new List<Order3758> { o111, o112 },
-                        Orders2 = new MyGenericCollection3758<Order3758>(),
-                        Orders3 = new MyNonGenericCollection3758(),
-                        Orders4 = new MyInvalidCollection3758<Order3758>(42),
-                    };
+                        var o111 = new Order3758 { Name = "O111" };
+                        var o112 = new Order3758 { Name = "O112" };
+                        var o121 = new Order3758 { Name = "O121" };
+                        var o122 = new Order3758 { Name = "O122" };
+                        var o131 = new Order3758 { Name = "O131" };
+                        var o132 = new Order3758 { Name = "O132" };
+                        var o141 = new Order3758 { Name = "O141" };
 
-                    c1.Orders2.AddRange(new[] { o121, o122 });
-                    c1.Orders3.AddRange(new[] { o131, o132 });
-                    c1.Orders4.Add(o141);
+                        var o211 = new Order3758 { Name = "O211" };
+                        var o212 = new Order3758 { Name = "O212" };
+                        var o221 = new Order3758 { Name = "O221" };
+                        var o222 = new Order3758 { Name = "O222" };
+                        var o231 = new Order3758 { Name = "O231" };
+                        var o232 = new Order3758 { Name = "O232" };
+                        var o241 = new Order3758 { Name = "O241" };
 
-                    var c2 = new Customer3758
-                    {
-                        Name = "C2",
-                        Orders1 = new List<Order3758> { o211, o212 },
-                        Orders2 = new MyGenericCollection3758<Order3758>(),
-                        Orders3 = new MyNonGenericCollection3758(),
-                        Orders4 = new MyInvalidCollection3758<Order3758>(42),
-                    };
+                        var c1 = new Customer3758
+                        {
+                            Name = "C1",
+                            Orders1 = new List<Order3758> { o111, o112 },
+                            Orders2 = new MyGenericCollection3758<Order3758>(),
+                            Orders3 = new MyNonGenericCollection3758(),
+                            Orders4 = new MyInvalidCollection3758<Order3758>(42)
+                        };
 
-                    c2.Orders2.AddRange(new[] { o221, o222 });
-                    c2.Orders3.AddRange(new[] { o231, o232 });
-                    c2.Orders4.Add(o241);
+                        c1.Orders2.AddRange(new[] { o121, o122 });
+                        c1.Orders3.AddRange(new[] { o131, o132 });
+                        c1.Orders4.Add(o141);
 
-                    context.Customers.AddRange(c1, c2);
-                    context.Orders.AddRange(o111, o112, o121, o122, o131, o132, o141, o211, o212, o221, o222, o231, o232, o241);
+                        var c2 = new Customer3758
+                        {
+                            Name = "C2",
+                            Orders1 = new List<Order3758> { o211, o212 },
+                            Orders2 = new MyGenericCollection3758<Order3758>(),
+                            Orders3 = new MyNonGenericCollection3758(),
+                            Orders4 = new MyInvalidCollection3758<Order3758>(42)
+                        };
 
-                    context.SaveChanges();
-                });
+                        c2.Orders2.AddRange(new[] { o221, o222 });
+                        c2.Orders3.AddRange(new[] { o231, o232 });
+                        c2.Orders4.Add(o241);
+
+                        context.Customers.AddRange(c1, c2);
+                        context.Orders.AddRange(o111, o112, o121, o122, o131, o132, o141, o211, o212, o221, o222, o231, o232, o241);
+
+                        context.SaveChanges();
+                    });
         }
 
         private static void CreateTestStore<TContext>(

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SqlServerDatabaseCreationTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SqlServerDatabaseCreationTest.cs
@@ -231,30 +231,30 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
                 var tables = await testStore.QueryAsync<string>("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = 'BASE TABLE'");
                 Assert.Equal(1, tables.Count());
-                Assert.Equal("Blog", tables.Single());
+                Assert.Equal("Blogs", tables.Single());
 
                 var columns = (await testStore.QueryAsync<string>(
-                    "SELECT TABLE_NAME + '.' + COLUMN_NAME + ' (' + DATA_TYPE + ')' FROM INFORMATION_SCHEMA.COLUMNS  WHERE TABLE_NAME = 'Blog' ORDER BY TABLE_NAME, COLUMN_NAME")).ToArray();
+                    "SELECT TABLE_NAME + '.' + COLUMN_NAME + ' (' + DATA_TYPE + ')' FROM INFORMATION_SCHEMA.COLUMNS  WHERE TABLE_NAME = 'Blogs' ORDER BY TABLE_NAME, COLUMN_NAME")).ToArray();
                 Assert.Equal(15, columns.Length);
 
                 Assert.Equal(
                     new[]
                     {
-                        "Blog.AndChew (varbinary)",
-                        "Blog.AndRow (timestamp)",
-                        "Blog.Cheese (nvarchar)",
-                        "Blog.CupOfChar (int)",
-                        "Blog.ErMilan (int)",
-                        "Blog.Fuse (smallint)",
-                        "Blog.George (bit)",
-                        "Blog.Key1 (nvarchar)",
-                        "Blog.Key2 (varbinary)",
-                        "Blog.NotFigTime (datetime2)",
-                        "Blog.On (real)",
-                        "Blog.OrNothing (float)",
-                        "Blog.TheGu (uniqueidentifier)",
-                        "Blog.ToEat (tinyint)",
-                        "Blog.WayRound (bigint)"
+                        "Blogs.AndChew (varbinary)",
+                        "Blogs.AndRow (timestamp)",
+                        "Blogs.Cheese (nvarchar)",
+                        "Blogs.CupOfChar (int)",
+                        "Blogs.ErMilan (int)",
+                        "Blogs.Fuse (smallint)",
+                        "Blogs.George (bit)",
+                        "Blogs.Key1 (nvarchar)",
+                        "Blogs.Key2 (varbinary)",
+                        "Blogs.NotFigTime (datetime2)",
+                        "Blogs.On (real)",
+                        "Blogs.OrNothing (float)",
+                        "Blogs.TheGu (uniqueidentifier)",
+                        "Blogs.ToEat (tinyint)",
+                        "Blogs.WayRound (bigint)"
                     },
                     columns);
             }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SqlServerDatabaseCreatorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SqlServerDatabaseCreatorTest.cs
@@ -250,12 +250,12 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
                     var tables = await testDatabase.QueryAsync<string>("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = 'BASE TABLE'");
                     Assert.Equal(1, tables.Count());
-                    Assert.Equal("Blog", tables.Single());
+                    Assert.Equal("Blogs", tables.Single());
 
-                    var columns = await testDatabase.QueryAsync<string>("SELECT TABLE_NAME + '.' + COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'Blog'");
+                    var columns = await testDatabase.QueryAsync<string>("SELECT TABLE_NAME + '.' + COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'Blogs'");
                     Assert.Equal(2, columns.Count());
-                    Assert.True(columns.Any(c => c == "Blog.Id"));
-                    Assert.True(columns.Any(c => c == "Blog.Name"));
+                    Assert.True(columns.Any(c => c == "Blogs.Id"));
+                    Assert.True(columns.Any(c => c == "Blogs.Name"));
                 }
             }
         }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SqlServerTriggersTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/SqlServerTriggersTest.cs
@@ -121,43 +121,43 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests
 
                     testStore.ExecuteNonQuery(@"
 CREATE TRIGGER TRG_InsertProduct
-ON Product
+ON Products
 AFTER INSERT AS
 BEGIN
 	if @@ROWCOUNT = 0
 		return
 	set nocount on;
 
-    INSERT INTO ProductBackup
+    INSERT INTO ProductBackups
     SELECT * FROM INSERTED;
 END");
 
                     testStore.ExecuteNonQuery(@"
 CREATE TRIGGER TRG_UpdateProduct
-ON Product
+ON Products
 AFTER UPDATE AS
 BEGIN
 	if @@ROWCOUNT = 0
 		return
 	set nocount on;
 
-    DELETE FROM ProductBackup
+    DELETE FROM ProductBackups
     WHERE Id IN(SELECT DELETED.Id FROM DELETED);
 
-    INSERT INTO ProductBackup
+    INSERT INTO ProductBackups
     SELECT * FROM INSERTED;
 END");
 
                     testStore.ExecuteNonQuery(@"
 CREATE TRIGGER TRG_DeleteProduct
-ON Product
+ON Products
 AFTER DELETE AS
 BEGIN
 	if @@ROWCOUNT = 0
 		return
 	set nocount on;
 
-    DELETE FROM ProductBackup
+    DELETE FROM ProductBackups
     WHERE Id IN(SELECT DELETED.Id FROM DELETED);
 END");
                 }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/DbSetAsTableNameSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/DbSetAsTableNameSqlServerTest.cs
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Tests;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
+{
+    public class DbSetAsTableNameSqlServerTest : DbSetAsTableNameTest
+    {
+        protected override string GetTableName<TEntity>(DbContext context)
+            => context.Model.FindEntityType(typeof(TEntity)).SqlServer().TableName;
+
+        protected override SetsContext CreateContext() => new SqlServerSetsContext();
+
+        protected override SetsContext CreateNamedTablesContext() => new SqlServerNamedTablesContextContext();
+
+        protected class SqlServerSetsContext : SetsContext
+        {
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder.UseSqlServer("Database = Dummy");
+        }
+
+        protected class SqlServerNamedTablesContextContext : NamedTablesContext
+        {
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder.UseSqlServer("Database = Dummy");
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Microsoft.EntityFrameworkCore.SqlServer.Tests.csproj
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Microsoft.EntityFrameworkCore.SqlServer.Tests.csproj
@@ -37,6 +37,7 @@
   <ItemGroup>
     <Compile Include="ApiConsistencyTest.cs" />
     <Compile Include="CommandConfigurationTests.cs" />
+    <Compile Include="DbSetAsTableNameSqlServerTest.cs" />
     <Compile Include="Metadata\Conventions\SqlServerConventionSetBuilderTests.cs" />
     <Compile Include="Metadata\Conventions\SqlServerValueGenerationStrategyConventionTest.cs" />
     <Compile Include="Metadata\SqlServerBuilderExtensionsTest.cs" />

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/CompositeKeyEndToEndTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/CompositeKeyEndToEndTest.cs
@@ -130,17 +130,20 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
             public DbSet<Pegasus> Pegasuses { get; set; }
             public DbSet<EarthPony> EarthPonies { get; set; }
 
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-            {
-                optionsBuilder.UseSqlite(SqliteTestStore.CreateConnectionString(_databaseName));
-            }
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder) 
+                => optionsBuilder.UseSqlite(SqliteTestStore.CreateConnectionString(_databaseName));
 
             protected override void OnModelCreating(ModelBuilder modelBuilder)
             {
-                modelBuilder.Entity<Pegasus>().HasKey(e => new { e.Id1, e.Id2 });
+                modelBuilder.Entity<Pegasus>(b =>
+                    {
+                        b.ToTable("Pegasus");
+                        b.HasKey(e => new { e.Id1, e.Id2 });
+                    });
 
                 modelBuilder.Entity<EarthPony>(b =>
                     {
+                        b.ToTable("EarthPony");
                         b.HasKey(e => new { e.Id1, e.Id2 });
                         b.Property(e => e.Id1);
                     });

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/SqliteForeignKeyTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/SqliteForeignKeyTest.cs
@@ -3,9 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Xunit;
-using System.Linq;
 
 namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
 {
@@ -17,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests
         {
             _testStore = SqliteTestStore.CreateScratch();
         }
-        
+
         public void Dispose() => _testStore.Dispose();
 
         [Theory]
@@ -115,47 +115,45 @@ CREATE TABLE Comment (
                 var comment = context.Comments.Include(u => u.User).Single();
                 Assert.Equal(id, comment.User.Id);
             }
-
         }
     }
 
-
-    class BloggingContext : DbContext
+    internal class BloggingContext : DbContext
     {
         public BloggingContext(DbContextOptions options)
             : base(options)
         {
         }
+
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder.Entity<Comment>(entity =>
-            {
-                entity.HasOne(d => d.User)
-                    .WithMany(p => p.Comments)
-                    .HasPrincipalKey(p => p.AltId)
-                    .HasForeignKey(d => d.UserAltId);
-            });
+                {
+                    entity.ToTable("Comment");
 
-            modelBuilder.Entity<User>(entity =>
-            {
-                entity.HasAlternateKey(e => e.AltId);
-            });
+                    entity.HasOne(d => d.User)
+                        .WithMany(p => p.Comments)
+                        .HasPrincipalKey(p => p.AltId)
+                        .HasForeignKey(d => d.UserAltId);
+                });
+
+            modelBuilder.Entity<User>(entity => { entity.HasAlternateKey(e => e.AltId); });
         }
 
         public virtual DbSet<Comment> Comments { get; set; }
         public virtual DbSet<User> User { get; set; }
     }
-    class Comment
+
+    internal class Comment
     {
         public long Id { get; set; }
-
 
         public int UserAltId { get; set; }
 
         public virtual User User { get; set; }
     }
 
-    class User
+    internal class User
     {
         public long Id { get; set; }
 
@@ -163,5 +161,4 @@ CREATE TABLE Comment (
 
         public virtual ICollection<Comment> Comments { get; set; }
     }
-
 }

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Tests/DbSetAsTableNameSqliteTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Tests/DbSetAsTableNameSqliteTest.cs
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Tests;
+
+namespace Microsoft.EntityFrameworkCore.Sqlite.Tests
+{
+    public class DbSetAsTableNameSqliteTest : DbSetAsTableNameTest
+    {
+        protected override string GetTableName<TEntity>(DbContext context)
+            => context.Model.FindEntityType(typeof(TEntity)).Sqlite().TableName;
+
+        protected override SetsContext CreateContext() => new SqliteSetsContext();
+
+        protected override SetsContext CreateNamedTablesContext() => new SqliteNamedTablesContextContext();
+
+        protected class SqliteSetsContext : SetsContext
+        {
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder.UseSqlite("Database = Dummy");
+        }
+
+        protected class SqliteNamedTablesContextContext : NamedTablesContext
+        {
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder.UseSqlite("Database = Dummy");
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Tests/Microsoft.EntityFrameworkCore.Sqlite.Tests.csproj
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Tests/Microsoft.EntityFrameworkCore.Sqlite.Tests.csproj
@@ -32,6 +32,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ApiConsistencyTest.cs" />
+    <Compile Include="DbSetAsTableNameSqliteTest.cs" />
     <Compile Include="Infrastructure\SqliteEntityFrameworkServicesBuilderExtensionsTest.cs" />
     <Compile Include="Metadata\Builders\SqliteBuilderExtensionsTest.cs" />
     <Compile Include="Metadata\Conventions\SqliteConventionSetBuilderTests.cs" />

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Tests/SqliteModelValidatorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Tests/SqliteModelValidatorTest.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Linq;
 using Microsoft.EntityFrameworkCore.Infrastructure.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Internal.Tests;
@@ -11,6 +13,7 @@ using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Tests;
 using Microsoft.EntityFrameworkCore.Tests.TestUtilities;
 using Microsoft.Extensions.Logging;
+using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Sqlite.Tests
 {

--- a/test/Microsoft.EntityFrameworkCore.Tests/EntitySetFinderTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/EntitySetFinderTest.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
 
                 Assert.Equal(
                     new[] { typeof(Better), typeof(Brandy), typeof(Drinking), typeof(Stop), typeof(You) },
-                    sets.Select(s => s.EntityType).ToArray());
+                    sets.Select(s => s.ClrType).ToArray());
 
                 Assert.Equal(
                     new[] { true, true, true, false, true },


### PR DESCRIPTION
Issue #4540

The DbSet property name from the context is used as the name of the table mapped to by that entity type.

If the table name is specified explicitly with ToTable, then this is used instead.

The entity type name is used as the table name for entity types in the model that do not have a corresponding DbSet property. If there is more than one DbSet property for the same entity type, then we fall back to using the entity type name.