### PR TITLE
Tiny: Only resolve ILogger<> and ISensitiveDataLogger<> from scoped services

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.InMemory/Storage/Internal/IInMemoryStore.cs
+++ b/src/Microsoft.EntityFrameworkCore.InMemory/Storage/Internal/IInMemoryStore.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Update;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Internal
 {
@@ -22,6 +23,6 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
 
         IReadOnlyList<InMemoryTableSnapshot> GetTables([NotNull] IEntityType entityType);
 
-        int ExecuteTransaction([NotNull] IEnumerable<IUpdateEntry> entries);
+        int ExecuteTransaction([NotNull] IEnumerable<IUpdateEntry> entries, [NotNull] ILogger<InMemoryDatabase> logger);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.InMemory/Storage/Internal/InMemoryStore.cs
+++ b/src/Microsoft.EntityFrameworkCore.InMemory/Storage/Internal/InMemoryStore.cs
@@ -18,18 +18,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
     public class InMemoryStore : IInMemoryStore
     {
         private readonly IInMemoryTableFactory _tableFactory;
-        private readonly ILogger _logger;
 
         private readonly object _lock = new object();
 
         private Lazy<Dictionary<IEntityType, IInMemoryTable>> _tables = CreateTables();
 
-        public InMemoryStore(
-            [NotNull] IInMemoryTableFactory tableFactory,
-            [NotNull] ILogger<InMemoryStore> logger)
+        public InMemoryStore([NotNull] IInMemoryTableFactory tableFactory)
         {
             _tableFactory = tableFactory;
-            _logger = logger;
         }
 
         /// <summary>
@@ -93,7 +89,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             return data;
         }
 
-        public virtual int ExecuteTransaction(IEnumerable<IUpdateEntry> entries)
+        public virtual int ExecuteTransaction(IEnumerable<IUpdateEntry> entries, ILogger<InMemoryDatabase> logger)
         {
             var rowsAffected = 0;
 
@@ -128,13 +124,12 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                 }
             }
 
-            _logger.LogInformation<object>(
+            logger.LogInformation<object>(
                 InMemoryLoggingEventId.SavedChanges,
                 rowsAffected,
                 InMemoryStrings.LogSavedChanges);
 
             return rowsAffected;
         }
-
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/EntityFrameworkServiceCollectionExtensions.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddSingleton<ICoreConventionSetBuilder, CoreConventionSetBuilder>()
                 .AddSingleton<IModelCustomizer, ModelCustomizer>()
                 .AddSingleton<IModelCacheKeyFactory, ModelCacheKeyFactory>()
-                .AddSingleton<LoggingModelValidator>()
+                .AddScoped<LoggingModelValidator>()
                 .AddScoped<IKeyPropagator, KeyPropagator>()
                 .AddScoped<INavigationFixer, NavigationFixer>()
                 .AddScoped<IStateManager, StateManager>()

--- a/test/Microsoft.EntityFrameworkCore.Tests/EntityFrameworkServiceCollectionExtensionsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/EntityFrameworkServiceCollectionExtensionsTest.cs
@@ -51,8 +51,8 @@ namespace Microsoft.EntityFrameworkCore.Tests
             VerifySingleton<IFieldMatcher>();
             VerifySingleton<ILoggerFactory>();
             VerifySingleton<ICoreConventionSetBuilder>();
-            VerifySingleton<LoggingModelValidator>();
 
+            VerifyScoped<LoggingModelValidator>();
             VerifyScoped<IKeyPropagator>();
             VerifyScoped<INavigationFixer>();
             VerifyScoped<IStateManager>();


### PR DESCRIPTION
This clears the way for a logger or logger provider to be set at the context level, either through the constructor or some other sugar mechanism. This may be needed for proposed changes in the way we use D.I. but even if it isn't it will be useful for logging sugar.