### PR TITLE
Update exception message for invalid property expression in Include & ThenInclude

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/Extensions/Internal/ExpressionExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/Internal/ExpressionExtensions.cs
@@ -77,11 +77,11 @@ namespace System.Linq.Expressions
             var newExpression
                 = RemoveConvert(lambdaExpression.Body) as NewExpression;
 
+            var parameterExpression
+                = lambdaExpression.Parameters.Single();
+
             if (newExpression != null)
             {
-                var parameterExpression
-                    = lambdaExpression.Parameters.Single();
-
                 var propertyInfos
                     = newExpression
                         .Arguments
@@ -93,7 +93,7 @@ namespace System.Linq.Expressions
             }
 
             var propertyPath
-                = propertyMatcher(lambdaExpression.Body, lambdaExpression.Parameters.Single());
+                = propertyMatcher(lambdaExpression.Body, parameterExpression);
 
             return propertyPath != null ? new[] { propertyPath } : null;
         }
@@ -114,22 +114,13 @@ namespace System.Linq.Expressions
                 = propertyAccessExpression
                     .Parameters
                     .Single()
-                    .MatchComplexPropertyAccess(propertyAccessExpression.Body);
+                    .MatchPropertyAccess(propertyAccessExpression.Body);
 
             if (propertyPath == null)
             {
                 throw new ArgumentException(
-                    CoreStrings.InvalidPropertiesExpression(propertyAccessExpression),
-                    nameof(propertyAccessExpression));
+                    CoreStrings.InvalidComplexPropertyExpression(propertyAccessExpression));
             }
-
-            return propertyPath;
-        }
-
-        private static PropertyInfo[] MatchComplexPropertyAccess(
-            this Expression parameterExpression, Expression propertyAccessExpression)
-        {
-            var propertyPath = MatchPropertyAccess(parameterExpression, propertyAccessExpression);
 
             return propertyPath;
         }

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
@@ -1132,6 +1132,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
             return string.Format(CultureInfo.CurrentCulture, GetString("AmbiguousOneToOneRelationship", "dependentToPrincipalNavigationSpecification", "principalToDependentNavigationSpecification"), dependentToPrincipalNavigationSpecification, principalToDependentNavigationSpecification);
         }
 
+        /// <summary>
+        /// The property expression '{propertyAccessExpression}' is not valid. The expression should represent a property access: 't =&gt; t.MyProperty'. For more information on including related data, see http://go.microsoft.com/fwlink/?LinkID=746393.
+        /// </summary>
+        public static string InvalidComplexPropertyExpression([CanBeNull] object propertyAccessExpression)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("InvalidComplexPropertyExpression", "propertyAccessExpression"), propertyAccessExpression);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
@@ -537,4 +537,7 @@
   <data name="AmbiguousOneToOneRelationship" xml:space="preserve">
     <value>The child/dependent side could not be determined for the one-to-one relationship that was detected between '{dependentToPrincipalNavigationSpecification}' and '{principalToDependentNavigationSpecification}'. To identify the child/dependent side of the relationship, configure the foreign key property. See http://go.microsoft.com/fwlink/?LinkId=724062 for more details.</value>
   </data>
+  <data name="InvalidComplexPropertyExpression" xml:space="preserve">
+    <value>The property expression '{propertyAccessExpression}' is not valid. The expression should represent a property access: 't =&gt; t.MyProperty'. For more information on including related data, see http://go.microsoft.com/fwlink/?LinkID=746393.</value>
+  </data>
 </root>

--- a/src/Microsoft.EntityFrameworkCore/Query/ResultOperators/Internal/IncludeExpressionNode.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/ResultOperators/Internal/IncludeExpressionNode.cs
@@ -1,10 +1,12 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
 using Remotion.Linq.Clauses;
 using Remotion.Linq.Parsing.Structure.IntermediateModel;
 
@@ -30,10 +32,16 @@ namespace Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal
         protected override ResultOperatorBase CreateResultOperator(ClauseGenerationContext clauseGenerationContext)
         {
             var navigationPropertyPath
-                = (MemberExpression)Source.Resolve(
+                = Source.Resolve(
                     _navigationPropertyPathLambda.Parameters[0],
                     _navigationPropertyPathLambda.Body,
-                    clauseGenerationContext);
+                    clauseGenerationContext) as MemberExpression;
+
+            if (navigationPropertyPath == null)
+            {
+                throw new ArgumentException(
+                    CoreStrings.InvalidComplexPropertyExpression(_navigationPropertyPathLambda));
+            }
 
             var includeResultOperator = new IncludeResultOperator(navigationPropertyPath);
 

--- a/test/Microsoft.EntityFrameworkCore.FunctionalTests/IncludeTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.FunctionalTests/IncludeTestBase.cs
@@ -38,6 +38,41 @@ namespace Microsoft.EntityFrameworkCore.FunctionalTests
         }
 
         [Fact]
+        public virtual void Include_property_expression_invalid()
+        {
+            Assert.Equal(
+                CoreStrings.InvalidComplexPropertyExpression("o => new <>f__AnonymousType104`2(Customer = o.Customer, OrderDetails = o.OrderDetails)"),
+                Assert.Throws<ArgumentException>(
+                    () =>
+                    {
+                        using (var context = CreateContext())
+                        {
+                            var query = context.Set<Order>()
+                                .Include(o => new { o.Customer, o.OrderDetails })
+                                .ToList();
+                        }
+                    }).Message);
+        }
+
+        [Fact]
+        public virtual void Then_include_property_expression_invalid()
+        {
+            Assert.Equal(
+                CoreStrings.InvalidComplexPropertyExpression("o => new <>f__AnonymousType104`2(Customer = o.Customer, OrderDetails = o.OrderDetails)"),
+                Assert.Throws<ArgumentException>(
+                    () =>
+                    {
+                        using (var context = CreateContext())
+                        {
+                            var query = context.Set<Customer>()
+                                .Include(o => o.Orders)
+                                .ThenInclude(o => new { o.Customer, o.OrderDetails })
+                                .ToList();
+                        }
+                    }).Message);
+        }
+
+        [Fact]
         public virtual void Include_closes_reader()
         {
             using (var context = CreateContext())
@@ -1259,7 +1294,7 @@ namespace Microsoft.EntityFrameworkCore.FunctionalTests
         {
             using (var context = CreateContext())
             {
-                var customers 
+                var customers
                     = context.Set<Customer>()
                         .OrderByDescending(c => c.City)
                         .Include(c => c.Orders)


### PR DESCRIPTION
resolves #4058 
Exception messages will be like this for `Include` & `ThenInclude` both
````
System.ArgumentException : The expression 'o => new <>f__AnonymousType103`2(Customer = o.Customer, OrderDetails = o.OrderDetails)' is not a valid property expression. The expression should represent a property access: 't => t.MyProperty'.
````