### PR TITLE
More x-plat testing

### DIFF
--- a/makefile.shade
+++ b/makefile.shade
@@ -32,3 +32,17 @@ k-standard-goals
         File.Copy(nupkg, Path.Combine(BUILD_DIR, Path.GetFileName(nupkg)), true);
     }
   }
+
+#publish-efci-artifacts target="test-compile" if='IsTeamCity'
+  @{
+    // produce .NET Core test artifacts for testing
+    var testProjects = Files.Include("test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/project.json")
+    .Include("test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/project.json");
+    var tfm = "netstandardapp1.5";
+    foreach (var projectFile in testProjects)
+    {
+      var projectName = Path.GetFileName(Path.GetDirectoryName(projectFile));
+      var output = Path.Combine(Directory.GetCurrentDirectory(), "artifacts/tests", projectName, tfm);
+      Dotnet(string.Format("publish --configuration Release --output {0} --framework {1} {2}", output, tfm, projectFile));
+    }
+  }


### PR DESCRIPTION
Extend test-compile target to publish .NET Core test apps for SQL Server testing

cc @divega will better enable testing .NET Core => Sql Azure. cref #2898