### PR TITLE
Query: Relational: Fix #4412 - Ensure discriminator filtering is app…

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/MaterializerFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/MaterializerFactory.cs
@@ -62,8 +62,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                     .CreateMaterializeExpression(
                         concreteEntityTypes[0], valueBufferParameter, indexMap);
 
-            if ((concreteEntityTypes.Length == 1)
-                && (concreteEntityTypes[0].RootType() == concreteEntityTypes[0]))
+            if (concreteEntityTypes.Length == 1
+                && concreteEntityTypes[0].RootType() == concreteEntityTypes[0])
             {
                 return Expression.Lambda<Func<ValueBuffer, object>>(materializer, valueBufferParameter);
             }

--- a/test/Microsoft.EntityFrameworkCore.FunctionalTests/InheritanceTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.FunctionalTests/InheritanceTestBase.cs
@@ -256,6 +256,49 @@ namespace Microsoft.EntityFrameworkCore.FunctionalTests
         }
 
         [Fact]
+        public virtual void Discriminator_used_when_projection_over_derived_type()
+        {
+            using (var context = CreateContext())
+            {
+                var kiwis
+                    = context.Set<Kiwi>()
+                        .Select(k => k.FoundOn)
+                        .ToArray();
+
+                Assert.Equal(1, kiwis.Length);
+            }
+        }
+
+        [Fact]
+        public virtual void Discriminator_used_when_projection_over_derived_type2()
+        {
+            using (var context = CreateContext())
+            {
+                var birds
+                    = context.Set<Bird>()
+                        .Select(b => new { b.IsFlightless, Discriminator = EF.Property<string>(b, "Discriminator") })
+                        .ToArray();
+
+                Assert.Equal(2, birds.Length);
+            }
+        }
+
+        [Fact]
+        public virtual void Discriminator_used_when_projection_over_of_type()
+        {
+            using (var context = CreateContext())
+            {
+                var birds
+                    = context.Set<Animal>()
+                        .OfType<Kiwi>()
+                        .Select(k => k.FoundOn)
+                        .ToArray();
+
+                Assert.Equal(1, birds.Length);
+            }
+        }
+
+        [Fact]
         public virtual void Can_insert_update_delete()
         {
             using (var context = CreateContext())
@@ -303,10 +346,7 @@ namespace Microsoft.EntityFrameworkCore.FunctionalTests
             }
         }
 
-        protected InheritanceContext CreateContext()
-        {
-            return Fixture.CreateContext();
-        }
+        protected InheritanceContext CreateContext() => Fixture.CreateContext();
 
         protected TFixture Fixture { get; }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/GearsOfWarQuerySqlServerTest.cs
@@ -841,8 +841,9 @@ FROM [Gear] AS [g]
 INNER JOIN [CogTag] AS [t] ON [g].[FullName] = (
     SELECT TOP(1) [subQuery0].[FullName]
     FROM [Gear] AS [subQuery0]
-    WHERE ([subQuery0].[Nickname] = [t].[GearNickName]) AND ([subQuery0].[SquadId] = [t].[GearSquadId])
-)",
+    WHERE (([subQuery0].[Discriminator] = N'Officer') OR ([subQuery0].[Discriminator] = N'Gear')) AND (([subQuery0].[Nickname] = [t].[GearNickName]) AND ([subQuery0].[SquadId] = [t].[GearSquadId]))
+)
+WHERE ([g].[Discriminator] = N'Officer') OR ([g].[Discriminator] = N'Gear')",
                 Sql);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/InheritanceSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/InheritanceSqlServerTest.cs
@@ -218,6 +218,42 @@ ORDER BY [c0].[Name], [c0].[Id]",
                 Sql);
         }
 
+        public override void Discriminator_used_when_projection_over_derived_type()
+        {
+            base.Discriminator_used_when_projection_over_derived_type();
+
+            Assert.Equal(
+                @"SELECT [k].[FoundOn]
+FROM [Animal] AS [k]
+WHERE [k].[Discriminator] = N'Kiwi'",
+                Sql);
+        }
+
+        public override void Discriminator_used_when_projection_over_derived_type2()
+        {
+            base.Discriminator_used_when_projection_over_derived_type2();
+
+            Assert.Equal(
+                @"SELECT [b].[IsFlightless], [b].[Discriminator]
+FROM [Animal] AS [b]
+WHERE ([b].[Discriminator] = N'Kiwi') OR ([b].[Discriminator] = N'Eagle')",
+                Sql);
+        }
+
+        public override void Discriminator_used_when_projection_over_of_type()
+        {
+            base.Discriminator_used_when_projection_over_of_type();
+
+            Assert.Equal(
+                @"SELECT [t].[FoundOn]
+FROM (
+    SELECT [a0].[Species], [a0].[CountryId], [a0].[Discriminator], [a0].[Name], [a0].[EagleId], [a0].[IsFlightless], [a0].[Group], [a0].[FoundOn]
+    FROM [Animal] AS [a0]
+    WHERE [a0].[Discriminator] = N'Kiwi'
+) AS [t]",
+                Sql);
+        }
+
         public override void Can_insert_update_delete()
         {
             base.Can_insert_update_delete();


### PR DESCRIPTION
…lied for projection queries against inherited entities.