### PR TITLE
Throw a better exception when a property was not discovered, but could be a primitive property

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Metadata/Conventions/Internal/RelationalPropertyMappingValidationConvention.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Metadata/Conventions/Internal/RelationalPropertyMappingValidationConvention.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -21,12 +20,5 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         }
 
         public override bool IsMappedPrimitiveProperty(Type clrType) => _typeMapper.IsTypeMapped(clrType);
-
-        public override Type FindCandidateNavigationPropertyType(PropertyInfo propertyInfo)
-        {
-            Check.NotNull(propertyInfo, nameof(propertyInfo));
-
-            return propertyInfo.FindCandidateNavigationPropertyType(_typeMapper.IsTypeMapped);
-        }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
@@ -613,7 +613,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
-        /// The key {key} contains properties in shadow state and is referenced by a relationship from  '{referencingEntityTypeWithNavigation}' to '{referencedEntityTypeWithNavigation}'. Configure a non-shadow principal key for this relationship.
+        /// The key {key} contains properties in shadow state and is referenced by a relationship from '{referencingEntityTypeWithNavigation}' to '{referencedEntityTypeWithNavigation}'. Configure a non-shadow principal key for this relationship.
         /// </summary>
         public static string ReferencedShadowKey([CanBeNull] object key, [CanBeNull] object referencingEntityTypeWithNavigation, [CanBeNull] object referencedEntityTypeWithNavigation)
         {
@@ -941,27 +941,35 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
-        /// The navigation '{navigation}' on entity type '{entityType}' has not been added to the model, or ignored, or target entityType ignored.
+        /// Unable to determine the relationship represented by navigation property '{entityType}.{navigation} of type '{propertyType}'. Either manually configure the relationship, or ignore this property from the model.
         /// </summary>
-        public static string NavigationNotAdded([CanBeNull] object navigation, [CanBeNull] object entityType)
+        public static string NavigationNotAdded([CanBeNull] object entityType, [CanBeNull] object navigation, [CanBeNull] object propertyType)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("NavigationNotAdded", "navigation", "entityType"), navigation, entityType);
+            return string.Format(CultureInfo.CurrentCulture, GetString("NavigationNotAdded", "entityType", "navigation", "propertyType"), entityType, navigation, propertyType);
         }
 
         /// <summary>
-        /// The property '{property}' on entity type '{entityType}' has not been added to the model or ignored.
+        /// The property '{entityType}.{property}' could not be mapped, because it is of type '{propertyType}' which is not a supported primitive type or a valid entity type. Either explicitly map this property, or ignore it.
         /// </summary>
-        public static string PropertyNotAdded([CanBeNull] object property, [CanBeNull] object entityType)
+        public static string PropertyNotAdded([CanBeNull] object entityType, [CanBeNull] object property, [CanBeNull] object propertyType)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("PropertyNotAdded", "property", "entityType"), property, entityType);
+            return string.Format(CultureInfo.CurrentCulture, GetString("PropertyNotAdded", "entityType", "property", "propertyType"), entityType, property, propertyType);
         }
 
         /// <summary>
-        /// The property '{property}' on entity type '{entityType}' has CLR type which is not supported by current provider and it has not been configured to use any supported column type.
+        /// The property '{entityType}.{property}' is of type '{propertyType}' which is not supported by current database provider. Either change the property CLR type or manually configure the database type for it.
         /// </summary>
-        public static string PropertyNotMapped([CanBeNull] object property, [CanBeNull] object entityType)
+        public static string PropertyNotMapped([CanBeNull] object entityType, [CanBeNull] object property, [CanBeNull] object propertyType)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("PropertyNotMapped", "property", "entityType"), property, entityType);
+            return string.Format(CultureInfo.CurrentCulture, GetString("PropertyNotMapped", "entityType", "property", "propertyType"), entityType, property, propertyType);
+        }
+
+        /// <summary>
+        /// The property '{entityType}.{navigation}' is of an interface type ('{propertyType}'). If it is a navigation property manually configure the relationship for this property by casting it to a mapped entity type, otherwise ignore the property from the model.
+        /// </summary>
+        public static string InterfacePropertyNotAdded([CanBeNull] object entityType, [CanBeNull] object navigation, [CanBeNull] object propertyType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("InterfacePropertyNotAdded", "entityType", "navigation", "propertyType"), entityType, navigation, propertyType);
         }
 
         /// <summary>

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
@@ -466,13 +466,16 @@
     <value>The entity type '{entityType}' cannot be removed because '{derivedEntityType}' is derived from it. All derived entity types must be removed or redefined before the entity type can be removed.</value>
   </data>
   <data name="NavigationNotAdded" xml:space="preserve">
-    <value>The navigation '{navigation}' on entity type '{entityType}' has not been added to the model, or ignored, or target entityType ignored.</value>
+    <value>Unable to determine the relationship represented by navigation property '{entityType}.{navigation} of type '{propertyType}'. Either manually configure the relationship, or ignore this property from the model.</value>
   </data>
   <data name="PropertyNotAdded" xml:space="preserve">
-    <value>The property '{property}' on entity type '{entityType}' has not been added to the model or ignored.</value>
+    <value>The property '{entityType}.{property}' could not be mapped, because it is of type '{propertyType}' which is not a supported primitive type or a valid entity type. Either explicitly map this property, or ignore it.</value>
   </data>
   <data name="PropertyNotMapped" xml:space="preserve">
-    <value>The property '{property}' on entity type '{entityType}' has CLR type which is not supported by current provider and it has not been configured to use any supported column type.</value>
+    <value>The property '{entityType}.{property}' is of type '{propertyType}' which is not supported by current database provider. Either change the property CLR type or manually configure the database type for it.</value>
+  </data>
+  <data name="InterfacePropertyNotAdded" xml:space="preserve">
+    <value>The property '{entityType}.{navigation}' is of an interface type ('{propertyType}'). If it is a navigation property manually configure the relationship for this property by casting it to a mapped entity type, otherwise ignore the property from the model.</value>
   </data>
   <data name="NavigationForWrongForeignKey" xml:space="preserve">
     <value>The navigation property '{navigation}' on entity type '{entityType}' cannot be associated with foreign key {targetFk} because it was created for foreign key {actualFk}.</value>

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Metadata/Conventions/Internal/RelationalPropertyMappingValidationConventionTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Metadata/Conventions/Internal/RelationalPropertyMappingValidationConventionTest.cs
@@ -5,11 +5,12 @@ using System;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Relational.Tests.Metadata.Conventions.Internal
 {
-    public class RelationalPropertyMappingValidationConventionTest
+    public class RelationalPropertyMappingValidationConventionTest : PropertyMappingValidationConventionTest
     {
         [Fact]
         public void Throws_when_added_property_is_not_mapped_to_store()
@@ -18,8 +19,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Metadata.Conventions.In
             var entityTypeBuilder = modelBuilder.Entity(typeof(NonPrimitiveAsPropertyEntity), ConfigurationSource.Convention);
             entityTypeBuilder.Property("Property", typeof(long), ConfigurationSource.Convention);
 
-            Assert.Equal(CoreStrings.PropertyNotMapped("Property", typeof(NonPrimitiveAsPropertyEntity).FullName),
-                Assert.Throws<InvalidOperationException>(() => new RelationalPropertyMappingValidationConvention(new TestRelationalTypeMapper()).Apply(modelBuilder)).Message);
+            Assert.Equal(CoreStrings.PropertyNotMapped("Property", typeof(long).DisplayName(fullName: false), typeof(NonPrimitiveAsPropertyEntity).DisplayName(fullName: false)),
+                Assert.Throws<InvalidOperationException>(() => CreateConvention().Apply(modelBuilder)).Message);
         }
 
         [Fact]
@@ -29,129 +30,11 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Metadata.Conventions.In
             var entityTypeBuilder = modelBuilder.Entity(typeof(NonPrimitiveAsPropertyEntity), ConfigurationSource.Convention);
             entityTypeBuilder.Property("Property", typeof(long), ConfigurationSource.Convention).Relational(ConfigurationSource.Convention).ColumnType("some_int_mapping");
 
-            Assert.Equal(CoreStrings.PropertyNotMapped("Property", typeof(NonPrimitiveAsPropertyEntity).FullName),
-                Assert.Throws<InvalidOperationException>(() => new RelationalPropertyMappingValidationConvention(new TestRelationalTypeMapper()).Apply(modelBuilder)).Message);
+            Assert.Equal(CoreStrings.PropertyNotMapped("Property", typeof(long).DisplayName(fullName: false), typeof(NonPrimitiveAsPropertyEntity).DisplayName(fullName: false)),
+                Assert.Throws<InvalidOperationException>(() => CreateConvention().Apply(modelBuilder)).Message);
         }
 
-        [Fact]
-        public void Throws_when_primitive_type_is_not_added_or_ignored()
-        {
-            var modelBuilder = new InternalModelBuilder(new Model());
-            var entityTypeBuilder = modelBuilder.Entity(typeof(PrimitivePropertyEntity), ConfigurationSource.Convention);
-
-            Assert.Equal(CoreStrings.PropertyNotAdded("Property", typeof(PrimitivePropertyEntity).FullName),
-                Assert.Throws<InvalidOperationException>(() => new RelationalPropertyMappingValidationConvention(new TestRelationalTypeMapper()).Apply(modelBuilder)).Message);
-        }
-
-        [Fact]
-        public void Does_not_throw_when_primitive_type_is_added()
-        {
-            var modelBuilder = new InternalModelBuilder(new Model());
-            var entityTypeBuilder = modelBuilder.Entity(typeof(PrimitivePropertyEntity), ConfigurationSource.Convention);
-            entityTypeBuilder.Property("Property", typeof(int), ConfigurationSource.Convention);
-
-            new RelationalPropertyMappingValidationConvention(new TestRelationalTypeMapper()).Apply(modelBuilder);
-        }
-
-        [Fact]
-        public void Does_not_throw_when_primitive_type_is_ignored()
-        {
-            var modelBuilder = new InternalModelBuilder(new Model());
-            var entityTypeBuilder = modelBuilder.Entity(typeof(PrimitivePropertyEntity), ConfigurationSource.Convention);
-            entityTypeBuilder.Ignore("Property", ConfigurationSource.Convention);
-
-            new RelationalPropertyMappingValidationConvention(new TestRelationalTypeMapper()).Apply(modelBuilder);
-        }
-
-        [Fact]
-        public void Throws_when_navigation_is_not_added_or_ignored()
-        {
-            var modelBuilder = new InternalModelBuilder(new Model());
-            var entityTypeBuilder = modelBuilder.Entity(typeof(NavigationEntity), ConfigurationSource.Convention);
-
-            Assert.Equal(CoreStrings.NavigationNotAdded("Navigation", typeof(NavigationEntity).FullName),
-                Assert.Throws<InvalidOperationException>(() => new RelationalPropertyMappingValidationConvention(new TestRelationalTypeMapper()).Apply(modelBuilder)).Message);
-        }
-
-        [Fact]
-        public void Does_not_throw_when_navigation_is_added()
-        {
-            var modelBuilder = new InternalModelBuilder(new Model());
-            var entityTypeBuilder = modelBuilder.Entity(typeof(NavigationEntity), ConfigurationSource.Convention);
-            var referencedEntityTypeBuilder = modelBuilder.Entity(typeof(PrimitivePropertyEntity), ConfigurationSource.Convention);
-            referencedEntityTypeBuilder.Ignore("Property", ConfigurationSource.Convention);
-            entityTypeBuilder.Relationship(referencedEntityTypeBuilder, "Navigation", null, ConfigurationSource.Convention);
-
-            new RelationalPropertyMappingValidationConvention(new TestRelationalTypeMapper()).Apply(modelBuilder);
-        }
-
-        [Fact]
-        public void Does_not_throw_when_navigation_is_ignored()
-        {
-            var modelBuilder = new InternalModelBuilder(new Model());
-            var entityTypeBuilder = modelBuilder.Entity(typeof(NavigationEntity), ConfigurationSource.Convention);
-            entityTypeBuilder.Ignore("Navigation", ConfigurationSource.Convention);
-
-            new RelationalPropertyMappingValidationConvention(new TestRelationalTypeMapper()).Apply(modelBuilder);
-        }
-
-        [Fact]
-        public void Does_not_throw_when_navigation_target_entity_is_ignored()
-        {
-            var modelBuilder = new InternalModelBuilder(new Model());
-            var entityTypeBuilder = modelBuilder.Entity(typeof(NavigationEntity), ConfigurationSource.Convention);
-            modelBuilder.Ignore(typeof(PrimitivePropertyEntity), ConfigurationSource.Convention);
-
-            new RelationalPropertyMappingValidationConvention(new TestRelationalTypeMapper()).Apply(modelBuilder);
-        }
-
-        [Fact]
-        public void Does_not_throw_when_interface_or_non_candidate_property_is_not_added()
-        {
-            var modelBuilder = new InternalModelBuilder(new Model());
-            var entityTypeBuilder = modelBuilder.Entity(typeof(NonCandidatePropertyEntity), ConfigurationSource.Convention);
-
-            new RelationalPropertyMappingValidationConvention(new TestRelationalTypeMapper()).Apply(modelBuilder);
-        }
-
-        [Fact]
-        public void Does_not_throw_when_clr_type_is_not_set_for_shadow_property()
-        {
-            var modelBuilder = new InternalModelBuilder(new Model());
-            var entityTypeBuilder = modelBuilder.Entity(typeof(NavigationAsProperty), ConfigurationSource.Convention);
-            entityTypeBuilder.Property("ShadowPropertyOfNullType", ConfigurationSource.Convention);
-
-            new RelationalPropertyMappingValidationConvention(new TestRelationalTypeMapper()).Apply(modelBuilder);
-        }
-
-        private class NonPrimitiveAsPropertyEntity
-        {
-            public NavigationAsProperty Property { get; set; }
-        }
-
-        private class NavigationAsProperty
-        {
-        }
-
-        private class PrimitivePropertyEntity
-        {
-            public int Property { get; set; }
-        }
-
-        private class NavigationEntity
-        {
-            public PrimitivePropertyEntity Navigation { get; set; }
-        }
-
-        private class NonCandidatePropertyEntity
-        {
-            public static int StaticProperty { get; set; }
-
-            public int _writeOnlyField = 1;
-            public int WriteOnlyProperty
-            {
-                set { _writeOnlyField = value; }
-            }
-        }
+        protected override PropertyMappingValidationConvention CreateConvention()
+            => new RelationalPropertyMappingValidationConvention(new TestRelationalTypeMapper());
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/PropertyMappingValidationConventionTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/PropertyMappingValidationConventionTest.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Threading;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
@@ -12,58 +14,72 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
     public class PropertyMappingValidationConventionTest
     {
         [Fact]
-        public void Throws_when_added_property_is_not_primitive_type()
+        public virtual void Throws_when_added_property_is_not_of_primitive_type()
         {
             var modelBuilder = new InternalModelBuilder(new Model());
             var entityTypeBuilder = modelBuilder.Entity(typeof(NonPrimitiveAsPropertyEntity), ConfigurationSource.Convention);
             entityTypeBuilder.Property("Property", typeof(NavigationAsProperty), ConfigurationSource.Convention);
 
-            Assert.Equal(CoreStrings.PropertyNotMapped("Property", typeof(NonPrimitiveAsPropertyEntity).FullName),
-                Assert.Throws<InvalidOperationException>(() => new PropertyMappingValidationConvention().Apply(modelBuilder)).Message);
+            Assert.Equal(CoreStrings.PropertyNotMapped(
+                "Property", typeof(NavigationAsProperty).DisplayName(fullName: false), typeof(NonPrimitiveAsPropertyEntity).DisplayName(fullName: false)),
+                Assert.Throws<InvalidOperationException>(() => CreateConvention().Apply(modelBuilder)).Message);
         }
 
         [Fact]
-        public void Throws_when_primitive_type_is_not_added_or_ignored()
+        public virtual void Throws_when_primitive_type_property_is_not_added_or_ignored()
         {
             var modelBuilder = new InternalModelBuilder(new Model());
             var entityTypeBuilder = modelBuilder.Entity(typeof(PrimitivePropertyEntity), ConfigurationSource.Convention);
 
-            Assert.Equal(CoreStrings.PropertyNotAdded("Property", typeof(PrimitivePropertyEntity).FullName),
-                Assert.Throws<InvalidOperationException>(() => new PropertyMappingValidationConvention().Apply(modelBuilder)).Message);
+            Assert.Equal(
+                CoreStrings.PropertyNotMapped("Property", typeof(int).DisplayName(), typeof(PrimitivePropertyEntity).DisplayName(fullName: false)),
+                Assert.Throws<InvalidOperationException>(() => CreateConvention().Apply(modelBuilder)).Message);
         }
 
         [Fact]
-        public void Does_not_throw_when_primitive_type_is_added()
+        public virtual void Throws_when_nonprimitive_value_type_property_is_not_added_or_ignored()
+        {
+            var modelBuilder = new InternalModelBuilder(new Model());
+            var entityTypeBuilder = modelBuilder.Entity(typeof(NonPrimitiveValueTypePropertyEntity), ConfigurationSource.Convention);
+
+            Assert.Equal(
+                CoreStrings.PropertyNotAdded("Property", typeof(CancellationToken).Name, typeof(NonPrimitiveValueTypePropertyEntity).DisplayName(fullName: false)),
+                Assert.Throws<InvalidOperationException>(() => CreateConvention().Apply(modelBuilder)).Message);
+        }
+
+        [Fact]
+        public virtual void Does_not_throw_when_primitive_type_property_is_added()
         {
             var modelBuilder = new InternalModelBuilder(new Model());
             var entityTypeBuilder = modelBuilder.Entity(typeof(PrimitivePropertyEntity), ConfigurationSource.Convention);
             entityTypeBuilder.Property("Property", typeof(int), ConfigurationSource.Convention);
 
-            new PropertyMappingValidationConvention().Apply(modelBuilder);
+            CreateConvention().Apply(modelBuilder);
         }
 
         [Fact]
-        public void Does_not_throw_when_primitive_type_is_ignored()
+        public virtual void Does_not_throw_when_primitive_type_property_is_ignored()
         {
             var modelBuilder = new InternalModelBuilder(new Model());
             var entityTypeBuilder = modelBuilder.Entity(typeof(PrimitivePropertyEntity), ConfigurationSource.Convention);
             entityTypeBuilder.Ignore("Property", ConfigurationSource.Convention);
 
-            new PropertyMappingValidationConvention().Apply(modelBuilder);
+            CreateConvention().Apply(modelBuilder);
         }
 
         [Fact]
-        public void Throws_when_navigation_is_not_added_or_ignored()
+        public virtual void Throws_when_navigation_is_not_added_or_ignored()
         {
             var modelBuilder = new InternalModelBuilder(new Model());
             var entityTypeBuilder = modelBuilder.Entity(typeof(NavigationEntity), ConfigurationSource.Convention);
 
-            Assert.Equal(CoreStrings.NavigationNotAdded("Navigation", typeof(NavigationEntity).FullName),
-                Assert.Throws<InvalidOperationException>(() => new PropertyMappingValidationConvention().Apply(modelBuilder)).Message);
+            Assert.Equal(
+                CoreStrings.NavigationNotAdded("Navigation", typeof(PrimitivePropertyEntity).Name, typeof(NavigationEntity).DisplayName(fullName: false)),
+                Assert.Throws<InvalidOperationException>(() => CreateConvention().Apply(modelBuilder)).Message);
         }
 
         [Fact]
-        public void Does_not_throw_when_navigation_is_added()
+        public virtual void Does_not_throw_when_navigation_is_added()
         {
             var modelBuilder = new InternalModelBuilder(new Model());
             var entityTypeBuilder = modelBuilder.Entity(typeof(NavigationEntity), ConfigurationSource.Convention);
@@ -71,68 +87,98 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
             referencedEntityTypeBuilder.Ignore("Property", ConfigurationSource.Convention);
             entityTypeBuilder.Relationship(referencedEntityTypeBuilder, "Navigation", null, ConfigurationSource.Convention);
 
-            new PropertyMappingValidationConvention().Apply(modelBuilder);
+            CreateConvention().Apply(modelBuilder);
         }
 
         [Fact]
-        public void Does_not_throw_when_navigation_is_ignored()
+        public virtual void Does_not_throw_when_navigation_is_ignored()
         {
             var modelBuilder = new InternalModelBuilder(new Model());
             var entityTypeBuilder = modelBuilder.Entity(typeof(NavigationEntity), ConfigurationSource.Convention);
             entityTypeBuilder.Ignore("Navigation", ConfigurationSource.Convention);
 
-            new PropertyMappingValidationConvention().Apply(modelBuilder);
+            CreateConvention().Apply(modelBuilder);
         }
 
         [Fact]
-        public void Does_not_throw_when_navigation_target_entity_is_ignored()
+        public virtual void Does_not_throw_when_navigation_target_entity_is_ignored()
         {
             var modelBuilder = new InternalModelBuilder(new Model());
             var entityTypeBuilder = modelBuilder.Entity(typeof(NavigationEntity), ConfigurationSource.Convention);
             modelBuilder.Ignore(typeof(PrimitivePropertyEntity), ConfigurationSource.Convention);
 
-            new PropertyMappingValidationConvention().Apply(modelBuilder);
+            CreateConvention().Apply(modelBuilder);
         }
 
         [Fact]
-        public void Does_not_throw_when_non_candidate_property_is_not_added()
+        public virtual void Does_not_throw_when_explicit_navigation_is_not_added()
+        {
+            var modelBuilder = new InternalModelBuilder(new Model());
+            var entityTypeBuilder = modelBuilder.Entity(typeof(ExplicitNavigationEntity), ConfigurationSource.Convention);
+            var referencedEntityTypeBuilder = modelBuilder.Entity(typeof(PrimitivePropertyEntity), ConfigurationSource.Convention);
+            referencedEntityTypeBuilder.Ignore("Property", ConfigurationSource.Convention);
+            entityTypeBuilder.Relationship(referencedEntityTypeBuilder, "Navigation", null, ConfigurationSource.Convention);
+
+            CreateConvention().Apply(modelBuilder);
+        }
+
+        [Fact]
+        public virtual void Throws_when_interface_type_property_is_not_added_or_ignored()
+        {
+            var modelBuilder = new InternalModelBuilder(new Model());
+            var entityTypeBuilder = modelBuilder.Entity(typeof(InterfaceNavigationEntity), ConfigurationSource.Convention);
+
+            Assert.Equal(CoreStrings.InterfacePropertyNotAdded(
+                "Navigation", typeof(IList<INavigationEntity>).DisplayName(fullName: false), typeof(InterfaceNavigationEntity).DisplayName(fullName: false)),
+                Assert.Throws<InvalidOperationException>(() => CreateConvention().Apply(modelBuilder)).Message);
+        }
+
+        [Fact]
+        public virtual void Does_not_throw_when_non_candidate_property_is_not_added()
         {
             var modelBuilder = new InternalModelBuilder(new Model());
             var entityTypeBuilder = modelBuilder.Entity(typeof(NonCandidatePropertyEntity), ConfigurationSource.Convention);
 
-            new PropertyMappingValidationConvention().Apply(modelBuilder);
+            CreateConvention().Apply(modelBuilder);
         }
 
         [Fact]
-        public void Does_not_throw_when_clr_type_is_not_set_for_shadow_property()
+        public virtual void Does_not_throw_when_clr_type_is_not_set_for_shadow_property()
         {
             var modelBuilder = new InternalModelBuilder(new Model());
             var entityTypeBuilder = modelBuilder.Entity(typeof(NavigationAsProperty), ConfigurationSource.Convention);
             entityTypeBuilder.Property("ShadowPropertyOfNullType", ConfigurationSource.Convention);
 
-            new PropertyMappingValidationConvention().Apply(modelBuilder);
+            CreateConvention().Apply(modelBuilder);
         }
 
-        private class NonPrimitiveAsPropertyEntity
+        protected virtual PropertyMappingValidationConvention CreateConvention() => new PropertyMappingValidationConvention();
+
+        protected class NonPrimitiveAsPropertyEntity
         {
             public NavigationAsProperty Property { get; set; }
         }
 
-        private class NavigationAsProperty
+        protected class NavigationAsProperty
         {
         }
 
-        private class PrimitivePropertyEntity
+        protected class PrimitivePropertyEntity
         {
             public int Property { get; set; }
         }
 
-        private class NavigationEntity
+        protected class NonPrimitiveValueTypePropertyEntity
+        {
+            public CancellationToken Property { get; set; }
+        }
+
+        protected class NavigationEntity
         {
             public PrimitivePropertyEntity Navigation { get; set; }
         }
 
-        private class NonCandidatePropertyEntity
+        protected class NonCandidatePropertyEntity
         {
             public static int StaticProperty { get; set; }
 
@@ -142,6 +188,23 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
             {
                 set { _writeOnlyField = value; }
             }
+        }
+
+        protected interface INavigationEntity
+        {
+            PrimitivePropertyEntity Navigation { get; set; }
+        }
+
+        protected class ExplicitNavigationEntity : INavigationEntity
+        {
+            PrimitivePropertyEntity INavigationEntity.Navigation { get; set; }
+
+            public PrimitivePropertyEntity Navigation { get; set; }
+        }
+
+        protected class InterfaceNavigationEntity
+        {
+            public IList<INavigationEntity> Navigation { get; set; }
         }
     }
 }


### PR DESCRIPTION
Throw a better exception when a property of interface type was not discovered

Resolves #4484, #4627