### PR TITLE
Fixes/improvements to ConcurrencyDetector:

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/RelationalDatabaseFacadeExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/RelationalDatabaseFacadeExtensions.cs
@@ -47,18 +47,12 @@ namespace Microsoft.EntityFrameworkCore
 
             var concurrencyDetector = databaseFacade.GetService<IConcurrencyDetector>();
 
-            try
+            using (concurrencyDetector.EnterCriticalSection())
             {
-                concurrencyDetector.EnterCriticalSection();
-
                 return databaseFacade
                     .GetService<IRawSqlCommandBuilder>()
                     .Build(sql, parameters)
                     .ExecuteNonQuery(GetRelationalConnection(databaseFacade));
-            }
-            finally
-            {
-                concurrencyDetector.ExitCriticalSection();
             }
         }
 
@@ -72,18 +66,12 @@ namespace Microsoft.EntityFrameworkCore
 
             var concurrencyDetector = databaseFacade.GetService<IConcurrencyDetector>();
 
-            try
+            using (concurrencyDetector.EnterCriticalSection())
             {
-                concurrencyDetector.EnterCriticalSection();
-
                 return await databaseFacade
                     .GetService<IRawSqlCommandBuilder>()
                     .Build(sql, parameters)
                     .ExecuteNonQueryAsync(GetRelationalConnection(databaseFacade), cancellationToken: cancellationToken);
-            }
-            finally
-            {
-                concurrencyDetector.ExitCriticalSection();
             }
         }
 

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/StateManager.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/StateManager.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -111,7 +110,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             return newEntry;
         }
 
-        public virtual InternalEntityEntry TryGetEntry(IKey key, ValueBuffer valueBuffer, bool throwOnNullKey) 
+        public virtual InternalEntityEntry TryGetEntry(IKey key, ValueBuffer valueBuffer, bool throwOnNullKey)
             => GetOrCreateIdentityMap(key).TryGetEntry(valueBuffer, throwOnNullKey);
 
         public virtual InternalEntityEntry TryGetEntry(object entity)
@@ -181,7 +180,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             }
 
             IIdentityMap identityMap;
-            if (_identityMaps == null 
+            if (_identityMaps == null
                 || !_identityMaps.TryGetValue(key, out identityMap))
             {
                 return null;
@@ -281,10 +280,10 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             return Enumerable.Empty<Tuple<INavigation, InternalEntityEntry>>();
         }
 
-        public virtual InternalEntityEntry GetPrincipal(InternalEntityEntry dependentEntry, IForeignKey foreignKey) 
+        public virtual InternalEntityEntry GetPrincipal(InternalEntityEntry dependentEntry, IForeignKey foreignKey)
             => FindIdentityMap(foreignKey.PrincipalKey)?.TryGetEntry(foreignKey, dependentEntry);
 
-        public virtual InternalEntityEntry GetPrincipalUsingRelationshipSnapshot(InternalEntityEntry dependentEntry, IForeignKey foreignKey) 
+        public virtual InternalEntityEntry GetPrincipalUsingRelationshipSnapshot(InternalEntityEntry dependentEntry, IForeignKey foreignKey)
             => FindIdentityMap(foreignKey.PrincipalKey)?.TryGetEntryUsingRelationshipSnapshot(foreignKey, dependentEntry);
 
         public virtual void UpdateIdentityMap(InternalEntityEntry entry, IKey key)
@@ -320,8 +319,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             InternalEntityEntry principalEntry, IForeignKey foreignKey)
         {
             var dependentIdentityMap = FindIdentityMap(foreignKey.DeclaringEntityType.FindPrimaryKey());
-            return dependentIdentityMap != null 
-                ? dependentIdentityMap.GetDependentsMap(foreignKey).GetDependents(principalEntry) 
+            return dependentIdentityMap != null
+                ? dependentIdentityMap.GetDependentsMap(foreignKey).GetDependents(principalEntry)
                 : Enumerable.Empty<InternalEntityEntry>();
         }
 
@@ -393,7 +392,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         {
             foreach (var entry in Entries.Where(
                 e => e.EntityState != EntityState.Detached
-                && e.HasConceptualNull).ToList())
+                     && e.HasConceptualNull).ToList())
             {
                 entry.HandleConceptualNulls();
             }
@@ -404,7 +403,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             }
 
             return Entries
-                .Where(e => (e.EntityState == EntityState.Added)
+                .Where(e => e.EntityState == EntityState.Added
                             || e.EntityState == EntityState.Modified
                             || e.EntityState == EntityState.Deleted)
                 .Select(e => e.PrepareToSave())
@@ -444,14 +443,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         protected virtual int SaveChanges(
             [NotNull] IReadOnlyList<InternalEntityEntry> entriesToSave)
         {
-            try
+            using (_concurrencyDetector.EnterCriticalSection())
             {
-                _concurrencyDetector.EnterCriticalSection();
                 return _database.SaveChanges(entriesToSave);
-            }
-            finally
-            {
-                _concurrencyDetector.ExitCriticalSection();
             }
         }
 
@@ -459,23 +453,18 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             [NotNull] IReadOnlyList<InternalEntityEntry> entriesToSave,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            try
+            using (_concurrencyDetector.EnterCriticalSection())
             {
-                _concurrencyDetector.EnterCriticalSection();
                 return await _database.SaveChangesAsync(entriesToSave, cancellationToken);
-            }
-            finally
-            {
-                _concurrencyDetector.ExitCriticalSection();
             }
         }
 
         public virtual void AcceptAllChanges()
         {
             var changedEntries = Entries
-                .Where(e => (e.EntityState == EntityState.Added)
-                            || (e.EntityState == EntityState.Modified)
-                            || (e.EntityState == EntityState.Deleted))
+                .Where(e => e.EntityState == EntityState.Added
+                            || e.EntityState == EntityState.Modified
+                            || e.EntityState == EntityState.Deleted)
                 .ToList();
 
             AcceptAllChanges(changedEntries);

--- a/src/Microsoft.EntityFrameworkCore/Internal/IConcurrencyDetector.cs
+++ b/src/Microsoft.EntityFrameworkCore/Internal/IConcurrencyDetector.cs
@@ -1,12 +1,12 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.EntityFrameworkCore.Internal
 {
     public interface IConcurrencyDetector
     {
-        void EnterCriticalSection();
-
-        void ExitCriticalSection();
+        IDisposable EnterCriticalSection();
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Query/Internal/LinqOperatorProvider.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/Internal/LinqOperatorProvider.cs
@@ -107,25 +107,23 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                 public bool MoveNext()
                 {
-                    try
+                    using (_exceptionInterceptor._queryContext.ConcurrencyDetector.EnterCriticalSection())
                     {
-                        _exceptionInterceptor._queryContext.ConcurrencyDetector.EnterCriticalSection();
-                        return _innerEnumerator.MoveNext();
-                    }
-                    catch (Exception exception)
-                    {
-                        _exceptionInterceptor._logger
-                            .LogError(
-                                CoreLoggingEventId.DatabaseError,
-                                () => new DatabaseErrorLogState(_exceptionInterceptor._contextType),
-                                exception,
-                                e => CoreStrings.LogExceptionDuringQueryIteration(Environment.NewLine, e));
+                        try
+                        {
+                            return _innerEnumerator.MoveNext();
+                        }
+                        catch (Exception exception)
+                        {
+                            _exceptionInterceptor._logger
+                                .LogError(
+                                    CoreLoggingEventId.DatabaseError,
+                                    () => new DatabaseErrorLogState(_exceptionInterceptor._contextType),
+                                    exception,
+                                    e => CoreStrings.LogExceptionDuringQueryIteration(Environment.NewLine, e));
 
-                        throw;
-                    }
-                    finally
-                    {
-                        _exceptionInterceptor._queryContext.ConcurrencyDetector.ExitCriticalSection();
+                            throw;
+                        }
                     }
                 }
 

--- a/test/Microsoft.EntityFrameworkCore.FunctionalTests/QueryTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.FunctionalTests/QueryTestBase.cs
@@ -4744,7 +4744,7 @@ namespace Microsoft.EntityFrameworkCore.FunctionalTests
 
                 Assert.Equal(
                     CoreStrings.ConcurrentMethodInvocation,
-                    Assert.Throws<NotSupportedException>(
+                    Assert.Throws<InvalidOperationException>(
                     () => context.Customers.ToList()).Message);
             }
         }
@@ -4758,7 +4758,7 @@ namespace Microsoft.EntityFrameworkCore.FunctionalTests
 
                 Assert.Equal(
                     CoreStrings.ConcurrentMethodInvocation,
-                    Assert.Throws<NotSupportedException>(
+                    Assert.Throws<InvalidOperationException>(
                         () => context.Customers.First()).Message);
             }
         }

--- a/test/Microsoft.EntityFrameworkCore.Relational.FunctionalTests/SqlExecutorTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.FunctionalTests/SqlExecutorTestBase.cs
@@ -42,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore.FunctionalTests
 
                 Assert.Equal(
                     CoreStrings.ConcurrentMethodInvocation,
-                    Assert.Throws<NotSupportedException>(
+                    Assert.Throws<InvalidOperationException>(
                         () => context.Database.ExecuteSqlCommand(@"SELECT * FROM ""Customers""")).Message);
             }
         }
@@ -74,7 +74,7 @@ namespace Microsoft.EntityFrameworkCore.FunctionalTests
 
                 Assert.Equal(
                     CoreStrings.ConcurrentMethodInvocation,
-                    (await Assert.ThrowsAsync<NotSupportedException>(
+                    (await Assert.ThrowsAsync<InvalidOperationException>(
                         async () => await context.Database.ExecuteSqlCommandAsync(@"SELECT * FROM ""Customers"""))).Message);
             }
         }


### PR DESCRIPTION
1) Fixed race-condition in EnterCriticalSection.
2) Switched to Disposable pattern to streamline usage.
3) Use InvalidOperationException instead of NotSupportedException. see #4730

cc @mikary 