### PR TITLE
Fix #4605 - Do not cache commands with Contains on Enumerable parameter.

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -66,6 +66,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
             SelectExpression = selectExpression;
         }
 
+        public virtual bool IsCacheable { get; private set; }
+
         protected virtual SelectExpression SelectExpression { get; }
 
         protected virtual ISqlGenerationHelper SqlGenerator => _sqlGenerationHelper;
@@ -80,6 +82,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
             _parameterNameGenerator = _parameterNameGeneratorFactory.Create();
 
             _parametersValues = parameterValues;
+            IsCacheable = true;
 
             Visit(SelectExpression);
 
@@ -636,6 +639,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
                         if (_parametersValues.TryGetValue(inParameter.Name, out parameterValue))
                         {
                             AddInExpressionValues(parameterValue, inConstants, inParameter);
+
+                            IsCacheable = false;
                         }
                     }
                     else

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Sql/IQuerySqlGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Sql/IQuerySqlGenerator.cs
@@ -12,6 +12,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
     {
         IRelationalCommand GenerateSql([NotNull] IReadOnlyDictionary<string, object> parameterValues);
 
+        bool IsCacheable { get; }
+
         IRelationalValueBufferFactory CreateValueBufferFactory(
             [NotNull] IRelationalValueBufferFactoryFactory relationalValueBufferFactoryFactory,
             [NotNull] DbDataReader dataReader);

--- a/test/Microsoft.EntityFrameworkCore.FunctionalTests/QueryTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.FunctionalTests/QueryTestBase.cs
@@ -1270,7 +1270,7 @@ namespace Microsoft.EntityFrameworkCore.FunctionalTests
 
         [ConditionalFact]
         public virtual void Where_subquery_expression()
-        { 
+        {
             AssertQuery<Order, Order>((o1, o2) =>
                 {
                     var firstOrder = o1.First();
@@ -1278,7 +1278,7 @@ namespace Microsoft.EntityFrameworkCore.FunctionalTests
                     return o1.Where(x => o2.Where(expr).Any());
                 });
         }
-        
+
         [ConditionalFact]
         public virtual void Where_subquery_expression_same_parametername()
         {
@@ -4314,6 +4314,26 @@ namespace Microsoft.EntityFrameworkCore.FunctionalTests
             AssertQuery<Customer>(cs =>
                 cs.Where(c => ids.Contains(c.CustomerID)));
         }
+
+        [ConditionalFact]
+        public virtual void Contains_with_subquery_and_local_array_closure()
+        {
+            var ids = new[] { "London", "Buenos Aires" };
+
+            AssertQuery<Customer>(cs =>
+                cs.Where(c =>
+                    cs.Where(c1 => ids.Contains(c1.City)).Any(e => e.CustomerID == c.CustomerID)),
+                    entryCount: 9);
+
+
+            ids = new[] { "London" };
+
+            AssertQuery<Customer>(cs =>
+                cs.Where(c =>
+                    cs.Where(c1 => ids.Contains(c1.City)).Any(e => e.CustomerID == c.CustomerID)),
+                    entryCount: 6);
+        }
+
 
         [ConditionalFact]
         public virtual void Contains_with_local_int_array_closure()

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -4383,6 +4383,27 @@ WHERE [c].[CustomerID] IN (N'ABCDE')",
                 Sql);
         }
 
+        public override void Contains_with_subquery_and_local_array_closure()
+        {
+            base.Contains_with_subquery_and_local_array_closure();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE EXISTS (
+    SELECT 1
+    FROM [Customers] AS [c1]
+    WHERE [c1].[City] IN (N'London', N'Buenos Aires') AND ([c1].[CustomerID] = [c].[CustomerID]))
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE EXISTS (
+    SELECT 1
+    FROM [Customers] AS [c1]
+    WHERE [c1].[City] IN (N'London') AND ([c1].[CustomerID] = [c].[CustomerID]))",
+                Sql);
+        }
+
         public override void Contains_with_local_array_inline()
         {
             base.Contains_with_local_array_inline();


### PR DESCRIPTION
May need to revisit the `CommandCacheKey` comparison after  #4575 is merged
@anpete 