### PR TITLE
Fix to #3889 - Query: [Nav Prop Translation] SelectMany generates wrong SQL

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
+++ b/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
@@ -372,6 +372,7 @@
     <Compile Include="Query\EntityQueryModelVisitor.cs" />
     <Compile Include="Query\EntityQueryModelVisitorFactory.cs" />
     <Compile Include="Query\ExpressionVisitors\EntityQueryableExpressionVisitor.cs" />
+    <Compile Include="Query\ExpressionVisitors\ExpressionTransformingQueryModelVisitor.cs" />
     <Compile Include="Query\ExpressionVisitors\ExpressionVisitorBase.cs" />
     <Compile Include="Query\ExpressionVisitors\IEntityQueryableExpressionVisitorFactory.cs" />
     <Compile Include="Query\ExpressionVisitors\IEntityResultFindingExpressionVisitorFactory.cs" />

--- a/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/ExpressionTransformingQueryModelVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/ExpressionTransformingQueryModelVisitor.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Utilities;
+using JetBrains.Annotations;
+using Remotion.Linq;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Parsing;
+
+namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
+{
+    public class ExpressionTransformingQueryModelVisitor : QueryModelVisitorBase
+    {
+        protected RelinqExpressionVisitor TransformingVisitor { get; private set; }
+
+        public ExpressionTransformingQueryModelVisitor([NotNull] RelinqExpressionVisitor transformingVisitor)
+        {
+            Check.NotNull(transformingVisitor, nameof(transformingVisitor));
+
+            TransformingVisitor = transformingVisitor;
+        }
+
+        public override void VisitMainFromClause(MainFromClause fromClause, QueryModel queryModel)
+            => fromClause.TransformExpressions(TransformingVisitor.Visit);
+
+        public override void VisitAdditionalFromClause(AdditionalFromClause fromClause, QueryModel queryModel, int index)
+            => fromClause.TransformExpressions(TransformingVisitor.Visit);
+
+        public override void VisitJoinClause(JoinClause joinClause, QueryModel queryModel, int index)
+            => joinClause.TransformExpressions(TransformingVisitor.Visit);
+
+        public override void VisitJoinClause(JoinClause joinClause, QueryModel queryModel, GroupJoinClause groupJoinClause)
+            => joinClause.TransformExpressions(TransformingVisitor.Visit);
+
+        public override void VisitWhereClause(WhereClause whereClause, QueryModel queryModel, int index)
+            => whereClause.TransformExpressions(TransformingVisitor.Visit);
+
+        public override void VisitOrderByClause(OrderByClause orderByClause, QueryModel queryModel, int index)
+            => orderByClause.TransformExpressions(TransformingVisitor.Visit);
+
+        public override void VisitOrdering(Ordering ordering, QueryModel queryModel, OrderByClause orderByClause, int index)
+            => ordering.TransformExpressions(TransformingVisitor.Visit);
+
+        public override void VisitSelectClause(SelectClause selectClause, QueryModel queryModel)
+            => selectClause.TransformExpressions(TransformingVisitor.Visit);
+
+        public override void VisitResultOperator(ResultOperatorBase resultOperator, QueryModel queryModel, int index)
+            => resultOperator.TransformExpressions(TransformingVisitor.Visit);
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.FunctionalTests/ComplexNavigationsQueryTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.FunctionalTests/ComplexNavigationsQueryTestBase.cs
@@ -2012,5 +2012,245 @@ namespace Microsoft.EntityFrameworkCore.FunctionalTests
                 var result = query.ToList();
             }
         }
+
+        [ConditionalFact]
+        public virtual void SelectMany_navigation_property()
+        {
+            var expected = new List<int>();
+            using (var context = CreateContext())
+            {
+                expected = context.LevelOne
+                    .Include(e => e.OneToMany_Optional)
+                    .ToList()
+                    .SelectMany(e => e.OneToMany_Optional).Select(e => e.Id)
+                    .ToList();
+            }
+
+            ClearLog();
+
+            using (var context = CreateContext())
+            {
+                var query = context.LevelOne.SelectMany(l1 => l1.OneToMany_Optional);
+
+                var result = query.ToList();
+
+                Assert.Equal(expected.Count, result.Count);
+                for (var i = 0; i < result.Count; i++)
+                {
+                    Assert.True(expected.Contains(result[i].Id));
+                }
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void SelectMany_navigation_property_and_projection()
+        {
+            var expected = new List<string>();
+            using (var context = CreateContext())
+            {
+                expected = context.LevelOne
+                    .Include(e => e.OneToMany_Optional)
+                    .ToList()
+                    .SelectMany(e => e.OneToMany_Optional).Select(e => e.Name)
+                    .ToList();
+            }
+
+            ClearLog();
+
+            using (var context = CreateContext())
+            {
+                var query = context.LevelOne.SelectMany(l1 => l1.OneToMany_Optional).Select(e => e.Name);
+
+                var result = query.ToList();
+
+                Assert.Equal(expected.Count, result.Count);
+                for (var i = 0; i < result.Count; i++)
+                {
+                    Assert.True(expected.Contains(result[i]));
+                }
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void SelectMany_navigation_property_and_filter_before()
+        {
+            var expected = new List<int>();
+            using (var context = CreateContext())
+            {
+                expected = context.LevelOne
+                    .Include(e => e.OneToMany_Optional)
+                    .ToList()
+                    .Where(e => e.Id == 1)
+                    .SelectMany(e => e.OneToMany_Optional).Select(e => e.Id)
+                    .ToList();
+            }
+
+            ClearLog();
+
+            using (var context = CreateContext())
+            {
+                var query = context.LevelOne
+                    .Where(e => e.Id == 1)
+                    .SelectMany(l1 => l1.OneToMany_Optional);
+
+                var result = query.ToList();
+
+                Assert.Equal(expected.Count, result.Count);
+                for (var i = 0; i < result.Count; i++)
+                {
+                    Assert.True(expected.Contains(result[i].Id));
+                }
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void SelectMany_navigation_property_and_filter_after()
+        {
+            var expected = new List<int>();
+            using (var context = CreateContext())
+            {
+                expected = context.LevelOne
+                    .Include(e => e.OneToMany_Optional)
+                    .ToList()
+                    .SelectMany(e => e.OneToMany_Optional).Select(e => e.Id)
+                    .Where(e => e != 6)
+                    .ToList();
+            }
+
+            ClearLog();
+
+            using (var context = CreateContext())
+            {
+                var query = context.LevelOne
+                    .SelectMany(l1 => l1.OneToMany_Optional)
+                    .Where(e => e.Id != 6);
+
+                var result = query.ToList();
+
+                Assert.Equal(expected.Count, result.Count);
+                for (var i = 0; i < result.Count; i++)
+                {
+                    Assert.True(expected.Contains(result[i].Id));
+                }
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void SelectMany_nested_navigation_property_required()
+        {
+            var expected = new List<int>();
+            using (var context = CreateContext())
+            {
+                expected = context.LevelOne
+                    .Include(e => e.OneToOne_Required_FK.OneToMany_Optional)
+                    .ToList()
+                    .SelectMany(e => e.OneToOne_Required_FK.OneToMany_Optional).Select(e => e.Id)
+                    .ToList();
+            }
+
+            ClearLog();
+
+            using (var context = CreateContext())
+            {
+                var query = context.LevelOne.SelectMany(l1 => l1.OneToOne_Required_FK.OneToMany_Optional);
+
+                var result = query.ToList();
+
+                Assert.Equal(expected.Count, result.Count);
+                for (var i = 0; i < result.Count; i++)
+                {
+                    Assert.True(expected.Contains(result[i].Id));
+                }
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void SelectMany_nested_navigation_property_optional_and_projection()
+        {
+            var expected = new List<string>();
+            using (var context = CreateContext())
+            {
+                expected = context.LevelOne
+                    .Include(e => e.OneToOne_Optional_FK.OneToMany_Optional)
+                    .ToList()
+                    .Where(e => e.OneToOne_Optional_FK != null)
+                    .SelectMany(e => e.OneToOne_Optional_FK.OneToMany_Optional).Select(e => e.Name)
+                    .ToList();
+            }
+
+            ClearLog();
+
+            using (var context = CreateContext())
+            {
+                var query = context.LevelOne.SelectMany(l1 => l1.OneToOne_Optional_FK.OneToMany_Optional).Select(e => e.Name);
+
+                var result = query.ToList();
+
+                Assert.Equal(expected.Count, result.Count);
+                for (var i = 0; i < result.Count; i++)
+                {
+                    Assert.True(expected.Contains(result[i]));
+                }
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Multiple_SelectMany_calls()
+        {
+            var expected = new List<string>();
+            using (var context = CreateContext())
+            {
+                expected = context.LevelOne
+                    .Include(e => e.OneToMany_Optional).ThenInclude(e => e.OneToMany_Optional)
+                    .ToList()
+                    .SelectMany(e => e.OneToMany_Optional)
+                    .SelectMany(e => e.OneToMany_Optional)
+                    .Select(e => e.Name)
+                    .ToList();
+            }
+
+            ClearLog();
+
+            using (var context = CreateContext())
+            {
+                var query = context.LevelOne.SelectMany(e => e.OneToMany_Optional).SelectMany(e => e.OneToMany_Optional);
+                var result = query.ToList();
+
+                Assert.Equal(expected.Count, result.Count);
+                for (var i = 0; i < result.Count; i++)
+                {
+                    Assert.True(expected.Contains(result[i].Name));
+                }
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void SelectMany_navigation_property_with_another_navigation_in_subquery()
+        {
+            var expected = new List<string>();
+            using (var context = CreateContext())
+            {
+                expected = context.LevelOne
+                    .Include(e => e.OneToMany_Optional).ThenInclude(e => e.OneToOne_Optional_FK)
+                    .ToList()
+                    .SelectMany(e => e.OneToMany_Optional.Select(l2 => l2.OneToOne_Optional_FK))
+                    .Select(e => e?.Name)
+                    .ToList();
+            }
+
+            ClearLog();
+
+            using (var context = CreateContext())
+            {
+                var query = context.LevelOne.SelectMany(l1 => l1.OneToMany_Optional.Select(l2 => l2.OneToOne_Optional_FK));
+                var result = query.ToList();
+
+                Assert.Equal(expected.Count, result.Count);
+                for (var i = 0; i < result.Count; i++)
+                {
+                    Assert.True(expected.Contains(result[i]?.Name));
+                }
+            }
+        }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -949,6 +949,100 @@ ORDER BY [e2].[Id]",
                 Sql);
         }
 
+        public override void SelectMany_navigation_property()
+        {
+            base.SelectMany_navigation_property();
+
+            Assert.Equal(
+                @"SELECT [l1.OneToMany_Optional].[Id], [l1.OneToMany_Optional].[Level1_Optional_Id], [l1.OneToMany_Optional].[Level1_Required_Id], [l1.OneToMany_Optional].[Name], [l1.OneToMany_Optional].[OneToMany_Optional_InverseId], [l1.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [l1.OneToMany_Optional].[OneToMany_Required_InverseId], [l1.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [l1.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [l1.OneToMany_Optional].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l1]
+INNER JOIN [Level2] AS [l1.OneToMany_Optional] ON [l1].[Id] = [l1.OneToMany_Optional].[OneToMany_Optional_InverseId]",
+                Sql);
+        }
+
+        public override void SelectMany_navigation_property_and_projection()
+        {
+            base.SelectMany_navigation_property_and_projection();
+
+            Assert.Equal(
+                @"SELECT [l1.OneToMany_Optional].[Name]
+FROM [Level1] AS [l1]
+INNER JOIN [Level2] AS [l1.OneToMany_Optional] ON [l1].[Id] = [l1.OneToMany_Optional].[OneToMany_Optional_InverseId]",
+                Sql);
+        }
+
+        public override void SelectMany_navigation_property_and_filter_before()
+        {
+            base.SelectMany_navigation_property_and_filter_before();
+
+            Assert.Equal(
+                @"SELECT [e.OneToMany_Optional].[Id], [e.OneToMany_Optional].[Level1_Optional_Id], [e.OneToMany_Optional].[Level1_Required_Id], [e.OneToMany_Optional].[Name], [e.OneToMany_Optional].[OneToMany_Optional_InverseId], [e.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [e.OneToMany_Optional].[OneToMany_Required_InverseId], [e.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [e.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [e.OneToMany_Optional].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [e]
+INNER JOIN [Level2] AS [e.OneToMany_Optional] ON [e].[Id] = [e.OneToMany_Optional].[OneToMany_Optional_InverseId]
+WHERE [e].[Id] = 1",
+                Sql);
+        }
+
+        public override void SelectMany_navigation_property_and_filter_after()
+        {
+            base.SelectMany_navigation_property_and_filter_after();
+
+            Assert.Equal(
+                @"SELECT [l1.OneToMany_Optional].[Id], [l1.OneToMany_Optional].[Level1_Optional_Id], [l1.OneToMany_Optional].[Level1_Required_Id], [l1.OneToMany_Optional].[Name], [l1.OneToMany_Optional].[OneToMany_Optional_InverseId], [l1.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [l1.OneToMany_Optional].[OneToMany_Required_InverseId], [l1.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [l1.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [l1.OneToMany_Optional].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l1]
+INNER JOIN [Level2] AS [l1.OneToMany_Optional] ON [l1].[Id] = [l1.OneToMany_Optional].[OneToMany_Optional_InverseId]
+WHERE [l1.OneToMany_Optional].[Id] <> 6",
+                Sql);
+        }
+
+        public override void SelectMany_nested_navigation_property_required()
+        {
+            base.SelectMany_nested_navigation_property_required();
+
+            Assert.Equal(
+                @"SELECT [l1.OneToOne_Required_FK.OneToMany_Optional].[Id], [l1.OneToOne_Required_FK.OneToMany_Optional].[Level2_Optional_Id], [l1.OneToOne_Required_FK.OneToMany_Optional].[Level2_Required_Id], [l1.OneToOne_Required_FK.OneToMany_Optional].[Name], [l1.OneToOne_Required_FK.OneToMany_Optional].[OneToMany_Optional_InverseId], [l1.OneToOne_Required_FK.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Required_FK.OneToMany_Optional].[OneToMany_Required_InverseId], [l1.OneToOne_Required_FK.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Required_FK.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Required_FK.OneToMany_Optional].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l1]
+INNER JOIN [Level2] AS [l1.OneToOne_Required_FK] ON [l1].[Id] = [l1.OneToOne_Required_FK].[Level1_Required_Id]
+INNER JOIN [Level3] AS [l1.OneToOne_Required_FK.OneToMany_Optional] ON [l1.OneToOne_Required_FK].[Id] = [l1.OneToOne_Required_FK.OneToMany_Optional].[OneToMany_Optional_InverseId]",
+                Sql);
+        }
+
+        public override void SelectMany_nested_navigation_property_optional_and_projection()
+        {
+            base.SelectMany_nested_navigation_property_optional_and_projection();
+
+            Assert.Equal(
+                @"SELECT [l1.OneToOne_Optional_FK.OneToMany_Optional].[Name]
+FROM [Level1] AS [l1]
+INNER JOIN [Level2] AS [l1.OneToOne_Optional_FK] ON [l1].[Id] = [l1.OneToOne_Optional_FK].[Level1_Optional_Id]
+INNER JOIN [Level3] AS [l1.OneToOne_Optional_FK.OneToMany_Optional] ON [l1.OneToOne_Optional_FK].[Id] = [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_InverseId]",
+                Sql);
+        }
+
+        public override void Multiple_SelectMany_calls()
+        {
+            base.Multiple_SelectMany_calls();
+
+            Assert.Equal(
+                @"SELECT [e.OneToMany_Optional.OneToMany_Optional].[Id], [e.OneToMany_Optional.OneToMany_Optional].[Level2_Optional_Id], [e.OneToMany_Optional.OneToMany_Optional].[Level2_Required_Id], [e.OneToMany_Optional.OneToMany_Optional].[Name], [e.OneToMany_Optional.OneToMany_Optional].[OneToMany_Optional_InverseId], [e.OneToMany_Optional.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [e.OneToMany_Optional.OneToMany_Optional].[OneToMany_Required_InverseId], [e.OneToMany_Optional.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [e.OneToMany_Optional.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [e.OneToMany_Optional.OneToMany_Optional].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [e]
+INNER JOIN [Level2] AS [e.OneToMany_Optional] ON [e].[Id] = [e.OneToMany_Optional].[OneToMany_Optional_InverseId]
+INNER JOIN [Level3] AS [e.OneToMany_Optional.OneToMany_Optional] ON [e.OneToMany_Optional].[Id] = [e.OneToMany_Optional.OneToMany_Optional].[OneToMany_Optional_InverseId]",
+                Sql);
+        }
+
+        public override void SelectMany_navigation_property_with_another_navigation_in_subquery()
+        {
+            base.SelectMany_navigation_property_with_another_navigation_in_subquery();
+
+            Assert.Equal(
+                @"SELECT [l1.OneToMany_Optional].[Id], [l1.OneToMany_Optional].[Level1_Optional_Id], [l1.OneToMany_Optional].[Level1_Required_Id], [l1.OneToMany_Optional].[Name], [l1.OneToMany_Optional].[OneToMany_Optional_InverseId], [l1.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [l1.OneToMany_Optional].[OneToMany_Required_InverseId], [l1.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [l1.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [l1.OneToMany_Optional].[OneToOne_Optional_SelfId], [l1.OneToMany_Optional.OneToOne_Optional_FK].[Id], [l1.OneToMany_Optional.OneToOne_Optional_FK].[Level2_Optional_Id], [l1.OneToMany_Optional.OneToOne_Optional_FK].[Level2_Required_Id], [l1.OneToMany_Optional.OneToOne_Optional_FK].[Name], [l1.OneToMany_Optional.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [l1.OneToMany_Optional.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [l1.OneToMany_Optional.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [l1.OneToMany_Optional.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [l1.OneToMany_Optional.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [l1.OneToMany_Optional.OneToOne_Optional_FK].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l1]
+INNER JOIN [Level2] AS [l1.OneToMany_Optional] ON [l1].[Id] = [l1.OneToMany_Optional].[OneToMany_Optional_InverseId]
+LEFT JOIN [Level3] AS [l1.OneToMany_Optional.OneToOne_Optional_FK] ON [l1.OneToMany_Optional].[Id] = [l1.OneToMany_Optional.OneToOne_Optional_FK].[Level2_Optional_Id]
+ORDER BY [l1.OneToMany_Optional].[Id]",
+                Sql);
+        }
 
         // issue #3491
         //[Fact]


### PR DESCRIPTION
Issue was that we were applying our standard navigation expansion logic to SelectMany queries (e.g. customers.SelectMany(c => c.Orders)

This resulted in queries like:

SELECT * FROM Orders as o

which is correct for the basic case, however gives invalid SQL for slightly complex scenarios, e.g. with filter:
customers.Where(c => c.CustomerPK == 1).SelectMany(c => c.Orders)

SELECT * FROM Orders as o
WHERE o.CustomerPK = 1

Fix is to always translate the navigations inside SelectMany into inner joins instead.
This will produce queries like:

SELECT * FROM Customers as c
JOIN Orders as o ON c.Id = o.CustomerFK
WHERE c.CustomerPK = 1

This will have to be modified when Many-Many relationships are introduces, as some of the navigations will have to be translated into CROSS JOINs

Also added template visitor for transforming QueryModel as we now have two instances where this functionality is used.