### PR TITLE
:bug: Conventions should only discover relationships targeting exact type

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/RelationshipDiscoveryConvention.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/RelationshipDiscoveryConvention.cs
@@ -68,7 +68,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 {
                     var inverseTargetType = FindCandidateNavigationPropertyType(inversePropertyInfo);
                     if ((inverseTargetType == null)
-                        || !inverseTargetType.GetTypeInfo().IsAssignableFrom(entityType.ClrType.GetTypeInfo())
+                        || (inverseTargetType != entityType.ClrType)
                         || (navigationPropertyInfo == inversePropertyInfo)
                         || candidateTargetEntityTypeBuilder.IsIgnored(inversePropertyInfo.Name, ConfigurationSource.Convention))
                     {

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalRelationshipBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalRelationshipBuilder.cs
@@ -1403,6 +1403,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         principalProperties);
                 }
 
+                if (newRelationshipBuilder == null)
+                {
+                    return null;
+                }
+
                 newRelationshipBuilder = ModelBuilder.Metadata.ConventionDispatcher.OnForeignKeyAdded(newRelationshipBuilder);
 
                 foreach (var addedForeignKey in addedForeignKeys)

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/TestModel.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/TestModel.cs
@@ -80,7 +80,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
             public Whoopper Whoopper { get; set; }
         }
 
-        private class Customer
+        protected class Customer
         {
             public static readonly PropertyInfo IdProperty = typeof(Customer).GetProperty("Id");
             public static readonly PropertyInfo NameProperty = typeof(Customer).GetProperty("Name");
@@ -95,12 +95,12 @@ namespace Microsoft.EntityFrameworkCore.Tests
             public CustomerDetails Details { get; set; }
         }
 
-        private class SpecialCustomer : Customer
+        protected class SpecialCustomer : Customer
         {
             public ICollection<SpecialOrder> SpecialOrders { get; set; }
         }
 
-        private class CustomerDetails
+        protected class CustomerDetails
         {
             public int Id { get; set; }
             public int CustomerId { get; set; }
@@ -108,7 +108,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
             public Customer Customer { get; set; }
         }
 
-        private class Order
+        protected class Order
         {
             public int OrderId { get; set; }
 
@@ -116,18 +116,34 @@ namespace Microsoft.EntityFrameworkCore.Tests
             public Guid AnotherCustomerId { get; set; }
             public Customer Customer { get; set; }
 
+            public OrderCombination OrderCombination  { get; set; }
+
             public OrderDetails Details { get; set; }
         }
 
-        private class SpecialOrder : Order
+        protected class SpecialOrder : Order
         {
+            public BackOrder BackOrder { get; set; }
+            public OrderCombination SpecialOrderCombination { get; set; }
         }
 
-        private class BackOrder : Order
+        protected class BackOrder : Order
         {
+            public int SpecialOrderId { get; set; }
+            public SpecialOrder SpecialOrder { get; set; }
         }
 
-        private class OrderDetails
+        [NotMapped]
+        protected class OrderCombination
+        {
+            public int Id { get; set; }
+            public int OrderId { get; set; }
+            public Order Order { get; set; }
+            public int SpecialOrderId { get; set; }
+            public SpecialOrder SpecialOrder { get; set; }
+        }
+
+        protected class OrderDetails
         {
             public static readonly PropertyInfo OrderIdProperty = typeof(OrderDetails).GetProperty("OrderId");
 


### PR DESCRIPTION
resolves #4715 
Convention used to discover relationships to derived type based on the navigation targeting to base type. Due to this if there is relationship with base type and base type relationships are not built yet then derived types will try to use the same pairs and the inverse navigation becomes null for one of them throwing exception.
Fixes:
- Discover relationship by convention to exact type match only.
- Add extra check if we cannot find relationship builder then return null.

Tests:
Issue surfaces in existing tests after changing model so it is already covered.