### PR TITLE
Tiny: Move DbContextOptions to root namespace

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/DbContextOptions.cs
+++ b/src/Microsoft.EntityFrameworkCore/DbContextOptions.cs
@@ -4,10 +4,11 @@
 using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
-namespace Microsoft.EntityFrameworkCore.Infrastructure
+namespace Microsoft.EntityFrameworkCore
 {
     /// <summary>
     ///     The options to be used by a <see cref="DbContext" />. You normally override

--- a/src/Microsoft.EntityFrameworkCore/DbContextOptions`.cs
+++ b/src/Microsoft.EntityFrameworkCore/DbContextOptions`.cs
@@ -5,9 +5,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Utilities;
 
-namespace Microsoft.EntityFrameworkCore.Infrastructure
+namespace Microsoft.EntityFrameworkCore
 {
     /// <summary>
     ///     The options to be used by a <see cref="DbContext" />. You normally override

--- a/src/Microsoft.EntityFrameworkCore/Infrastructure/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Infrastructure/EntityFrameworkServiceCollectionExtensions.cs
@@ -49,7 +49,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///     <para>
         ///         For derived contexts to be registered in the <see cref="IServiceProvider" /> and resolve their services
         ///         from the <see cref="IServiceProvider" /> you must chain a call to the
-        ///         <see cref="AddDbContext{TContext}(IServiceCollection, Action{Microsoft.EntityFrameworkCore.DbContextOptionsBuilder})" />
+        ///         <see cref="Extensions.DependencyInjection.EntityFrameworkServiceCollectionExtensions.AddDbContext{TContext}(IServiceCollection, Action{DbContextOptionsBuilder})" />
         ///         method on the returned <see cref="IServiceCollection" />.
         ///     </para>
         /// </remarks>

--- a/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
+++ b/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
@@ -130,8 +130,10 @@
     <Compile Include="ChangeTracking\PropertyEntry.cs" />
     <Compile Include="ChangeTracking\PropertyEntry`.cs" />
     <Compile Include="DbContext.cs" />
+    <Compile Include="DbContextOptions.cs" />
     <Compile Include="DbContextOptionsBuilder.cs" />
     <Compile Include="DbContextOptionsBuilder`.cs" />
+    <Compile Include="DbContextOptions`.cs" />
     <Compile Include="DbSet`.cs" />
     <Compile Include="DbUpdateConcurrencyException.cs" />
     <Compile Include="DbUpdateException.cs" />
@@ -160,8 +162,6 @@
     <Compile Include="Infrastructure\CoreLoggingEventId.cs" />
     <Compile Include="Infrastructure\DatabaseFacade.cs" />
     <Compile Include="Infrastructure\DbContextAttribute.cs" />
-    <Compile Include="Infrastructure\DbContextOptions.cs" />
-    <Compile Include="Infrastructure\DbContextOptions`.cs" />
     <Compile Include="Infrastructure\DesignTimeProviderServicesAttribute.cs" />
     <Compile Include="Infrastructure\EntityFrameworkServiceCollectionExtensions.cs" />
     <Compile Include="Infrastructure\IAccessor.cs" />


### PR DESCRIPTION
Since it will now be referenced very commonly by applications.