### PR TITLE
[TINY] Fixing small issue in SqlTranslatingExpressionVisitor 

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
@@ -88,7 +88,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                         var left = Visit(expression.Left);
                         var right = Visit(expression.Right);
 
-                        return new AliasExpression(expression.Update(left, expression.Conversion, right));
+                        return left != null && right != null
+                            ? new AliasExpression(expression.Update(left, expression.Conversion, right))
+                            : null;
                     }
 
                 case ExpressionType.Equal:
@@ -547,7 +549,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                         {
                             var aliasExpression = (AliasExpression)VisitMember(memberItem);
 
-                            return new InExpression(aliasExpression, new[] { fromExpression });
+                            return aliasExpression != null
+                                ? new InExpression(aliasExpression, new[] { fromExpression })
+                                : null;
                         }
 
                         var methodCallItem = contains.Item as MethodCallExpression;


### PR DESCRIPTION
...when we would get null argument exception when trying to translate coalesce expression whose arguments were not translatable to sql (i.e. needed to be client eval-ed)