### PR TITLE
Explicitly set UTF8 encoding on migration files output

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Commands/Migrations/Design/MigrationsScaffolder.cs
+++ b/src/Microsoft.EntityFrameworkCore.Commands/Migrations/Design/MigrationsScaffolder.cs
@@ -289,7 +289,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 }
 
                 _logger.Value.LogInformation(CommandsStrings.RevertingSnapshot);
-                File.WriteAllText(modelSnapshotFile, modelSnapshotCode);
+                File.WriteAllText(modelSnapshotFile, modelSnapshotCode, Encoding.UTF8);
             }
 
             return files;
@@ -310,12 +310,12 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
 
             _logger.Value.LogDebug(CommandsStrings.WritingMigration(migrationFile));
             Directory.CreateDirectory(migrationDirectory);
-            File.WriteAllText(migrationFile, migration.MigrationCode);
-            File.WriteAllText(migrationMetadataFile, migration.MetadataCode);
+            File.WriteAllText(migrationFile, migration.MigrationCode, Encoding.UTF8);
+            File.WriteAllText(migrationMetadataFile, migration.MetadataCode, Encoding.UTF8);
 
             _logger.Value.LogDebug(CommandsStrings.WritingSnapshot(modelSnapshotFile));
             Directory.CreateDirectory(modelSnapshotDirectory);
-            File.WriteAllText(modelSnapshotFile, migration.SnapshotCode);
+            File.WriteAllText(modelSnapshotFile, migration.SnapshotCode, Encoding.UTF8);
 
             return new MigrationFiles
             {

--- a/src/Microsoft.EntityFrameworkCore.Commands/Scaffolding/Internal/FileSystemFileService.cs
+++ b/src/Microsoft.EntityFrameworkCore.Commands/Scaffolding/Internal/FileSystemFileService.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
+using System.Text;
 using JetBrains.Annotations;
 
 namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
@@ -47,7 +48,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         {
             Directory.CreateDirectory(directoryName);
             var fullFileName = Path.Combine(directoryName, fileName);
-            File.WriteAllText(fullFileName, contents);
+            File.WriteAllText(fullFileName, contents, Encoding.UTF8);
 
             return fullFileName;
         }


### PR DESCRIPTION
Fix #4574
cc @bricelam 