### PR TITLE
Throw helpful exceptions when services or provider are not configured

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/DbContext.cs
+++ b/src/Microsoft.EntityFrameworkCore/DbContext.cs
@@ -136,9 +136,14 @@ namespace Microsoft.EntityFrameworkCore
 
                 var scopedServiceProvider = _serviceScope.ServiceProvider;
 
-                var contextServices = scopedServiceProvider
-                    .GetRequiredService<IDbContextServices>()
-                    .Initialize(scopedServiceProvider, options, this);
+                var contextServices = scopedServiceProvider.GetService<IDbContextServices>();
+
+                if (contextServices == null)
+                {
+                    throw new InvalidOperationException(CoreStrings.NoEfServices);
+                }
+
+                contextServices.Initialize(scopedServiceProvider, options, this);
 
                 _logger = scopedServiceProvider.GetRequiredService<ILogger<DbContext>>();
 

--- a/src/Microsoft.EntityFrameworkCore/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/EntityFrameworkServiceCollectionExtensions.cs
@@ -89,12 +89,10 @@ namespace Microsoft.Extensions.DependencyInjection
             [CanBeNull] Action<IServiceProvider, DbContextOptionsBuilder> optionsAction)
             where TContext : DbContext
         {
-            var options = new DbContextOptions<TContext>(new Dictionary<Type, IDbContextOptionsExtension>());
-
-            var builder = new DbContextOptionsBuilder<TContext>(options);
-
-            builder.UseMemoryCache(applicationServiceProvider.GetService<IMemoryCache>());
-            builder.UseLoggerFactory(applicationServiceProvider.GetService<ILoggerFactory>());
+            var builder = new DbContextOptionsBuilder<TContext>(
+                new DbContextOptions<TContext>(new Dictionary<Type, IDbContextOptionsExtension>()))
+                .UseMemoryCache(applicationServiceProvider.GetService<IMemoryCache>())
+                .UseLoggerFactory(applicationServiceProvider.GetService<ILoggerFactory>());
 
             optionsAction?.Invoke(applicationServiceProvider, builder);
 

--- a/src/Microsoft.EntityFrameworkCore/Infrastructure/AccessorExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Infrastructure/AccessorExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -41,7 +42,17 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <param name="accessor"> The object exposing the service provider. </param>
         /// <returns> The requested service. </returns>
         public static TService GetService<TService>([NotNull] this IInfrastructure<IServiceProvider> accessor)
-            => Check.NotNull(accessor, nameof(accessor)).Instance.GetRequiredService<TService>();
+        {
+            Check.NotNull(accessor, nameof(accessor));
+
+            var service = accessor.Instance.GetService<TService>();
+            if (service == null)
+            {
+                throw new InvalidOperationException(CoreStrings.NoProviderConfigured);
+            }
+
+            return service;
+        }
 
         /// <summary>
         ///     <para>

--- a/src/Microsoft.EntityFrameworkCore/Internal/DatabaseProviderSelector.cs
+++ b/src/Microsoft.EntityFrameworkCore/Internal/DatabaseProviderSelector.cs
@@ -40,11 +40,6 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 throw new InvalidOperationException(CoreStrings.MultipleProvidersConfigured(BuildDatabaseNamesString(configured)));
             }
 
-            if (_providers.Length == 0)
-            {
-                throw new InvalidOperationException(CoreStrings.NoProviderConfigured);
-            }
-
             if (_providers.Length > 1)
             {
                 throw new InvalidOperationException(CoreStrings.MultipleProvidersAvailable(BuildDatabaseNamesString(_providers)));

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
@@ -197,7 +197,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
-        /// A database has not been configured for this context. If you are not using dependency injection, override the OnConfiguring method in your context class to configure the database. If you are using dependency injection, use the AddDbContext method to register your context as a service and configure the database. In ASP.NET Core this is done in the ConfigureServices method of your Startup class. Also ensure that you are resolving the context from services and are not directly creating instances of it.
+        /// No database provider has been configured for this DbContext. A provider can be configured by overriding the DbContext.OnConfiguring method or by using AddDbContext on the application service provider. If AddDbContext is used, then also ensure that your DbContext type accepts a DbContextOptions object in its constructor.
         /// </summary>
         public static string NoProviderConfigured
         {
@@ -205,11 +205,11 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
-        /// No database providers are available. Ensure that database provider services are added inside the call to AddEntityFramework on your ServiceCollection.
+        /// Entity Framework services have not been added to the internal service provider. Either remove the call to UseInternalServiceProvider so that EF will manage its own internal services, or use the method from your database provider to add the required services to the service provider (e.g. AddEntityFrameworkSqlServer).
         /// </summary>
-        public static string NoProviderServices
+        public static string NoEfServices
         {
-            get { return GetString("NoProviderServices"); }
+            get { return GetString("NoEfServices"); }
         }
 
         /// <summary>

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
@@ -187,10 +187,10 @@
     <value>The database providers {storeNames}are configured. A context can only be configured to use a single database provider.</value>
   </data>
   <data name="NoProviderConfigured" xml:space="preserve">
-    <value>A database has not been configured for this context. If you are not using dependency injection, override the OnConfiguring method in your context class to configure the database. If you are using dependency injection, use the AddDbContext method to register your context as a service and configure the database. In ASP.NET Core this is done in the ConfigureServices method of your Startup class. Also ensure that you are resolving the context from services and are not directly creating instances of it.</value>
+    <value>No database provider has been configured for this DbContext. A provider can be configured by overriding the DbContext.OnConfiguring method or by using AddDbContext on the application service provider. If AddDbContext is used, then also ensure that your DbContext type accepts a DbContextOptions object in its constructor.</value>
   </data>
-  <data name="NoProviderServices" xml:space="preserve">
-    <value>No database providers are available. Ensure that database provider services are added inside the call to AddEntityFramework on your ServiceCollection.</value>
+  <data name="NoEfServices" xml:space="preserve">
+    <value>Entity Framework services have not been added to the internal service provider. Either remove the call to UseInternalServiceProvider so that EF will manage its own internal services, or use the method from your database provider to add the required services to the service provider (e.g. AddEntityFrameworkSqlServer).</value>
   </data>
   <data name="MultipleProvidersAvailable" xml:space="preserve">
     <value>The database providers {storeNames}are available. A context can only be configured to use a single database provider. Configure a database provider by overriding OnConfiguring in your DbContext class or in the AddDbContext method when setting up services.</value>

--- a/test/Microsoft.EntityFrameworkCore.CrossStore.FunctionalTests/EndToEndTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.CrossStore.FunctionalTests/EndToEndTest.cs
@@ -9,7 +9,6 @@ using Microsoft.EntityFrameworkCore.FunctionalTests.TestUtilities.Xunit;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.InMemory.FunctionalTests;
 using Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests;
-using Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests;
 using Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests.Utilities;
 using Xunit;
 

--- a/test/Microsoft.EntityFrameworkCore.CrossStore.FunctionalTests/Microsoft.EntityFrameworkCore.CrossStore.FunctionalTests.csproj
+++ b/test/Microsoft.EntityFrameworkCore.CrossStore.FunctionalTests/Microsoft.EntityFrameworkCore.CrossStore.FunctionalTests.csproj
@@ -79,6 +79,7 @@
     <Compile Include="CrossStoreFixture.cs" />
     <Compile Include="EndToEndTest.cs" />
     <Compile Include="InMemoryCrossStoreFixture.cs" />
+    <Compile Include="ProviderSpecificServicesTest.cs" />
     <Compile Include="SharedCrossStoreFixture.cs" />
     <Compile Include="SqliteCrossStoreFixture.cs" />
     <Compile Include="SqlServerCrossStoreFixture.cs" />

--- a/test/Microsoft.EntityFrameworkCore.CrossStore.FunctionalTests/ProviderSpecificServicesTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.CrossStore.FunctionalTests/ProviderSpecificServicesTest.cs
@@ -1,0 +1,63 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.CrossStore.FunctionalTests
+{
+    public class ProviderSpecificServicesTest
+    {
+        [Fact]
+        public void Throws_with_new_when_non_relational_provider_in_use1110938893()
+        {
+            var options = new DbContextOptionsBuilder<ConstructorTestContext1A>()
+                .UseInternalServiceProvider(
+                    new ServiceCollection()
+                        .AddEntityFrameworkSqlServer()
+                        .AddEntityFrameworkInMemoryDatabase()
+                        .BuildServiceProvider())
+                .UseInMemoryDatabase()
+                .Options;
+
+            using (var context = new ConstructorTestContext1A(options))
+            {
+                Assert.Equal(
+                    RelationalStrings.RelationalNotInUse,
+                    Assert.Throws<InvalidOperationException>(() => context.Database.GetDbConnection()).Message);
+            }
+        }
+
+        [Fact]
+        public void Throws_with_add_when_non_relational_provider_in_use547424486()
+        {
+            var appServiceProivder = new ServiceCollection()
+                .AddEntityFrameworkSqlServer()
+                .AddEntityFrameworkInMemoryDatabase()
+                .AddDbContext<ConstructorTestContext1A>(
+                    (p, b) => b.UseInMemoryDatabase().UseInternalServiceProvider(p))
+                .BuildServiceProvider();
+
+            using (var serviceScope = appServiceProivder
+                .GetRequiredService<IServiceScopeFactory>()
+                .CreateScope())
+            {
+                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>();
+
+                Assert.Equal(
+                    RelationalStrings.RelationalNotInUse,
+                    Assert.Throws<InvalidOperationException>(() => context.Database.GetDbConnection()).Message);
+            }
+        }
+
+        private class ConstructorTestContext1A : DbContext
+        {
+            public ConstructorTestContext1A(DbContextOptions options)
+                : base(options)
+            {
+            }
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/RelationalConnectionTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/RelationalConnectionTest.cs
@@ -9,12 +9,126 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Relational.Tests.TestUtilities.FakeProvider;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Relational.Tests
 {
     public class RelationalConnectionTest
     {
+        [Fact]
+        public void Throws_with_new_when_no_EF_services_use_Database()
+        {
+            var options = new DbContextOptionsBuilder<ConstructorTestContext1A>()
+                .UseInternalServiceProvider(new ServiceCollection().BuildServiceProvider())
+                .Options;
+
+            using (var context = new ConstructorTestContext1A(options))
+            {
+                Assert.Equal(
+                    CoreStrings.NoEfServices,
+                    Assert.Throws<InvalidOperationException>(() => context.Database.GetDbConnection()).Message);
+            }
+        }
+
+        [Fact]
+        public void Throws_with_add_when_no_EF_services_use_Database()
+        {
+            var appServiceProivder = new ServiceCollection()
+                .AddDbContext<ConstructorTestContext1A>(
+                    (p, b) => b.UseInternalServiceProvider(p))
+                .BuildServiceProvider();
+
+            using (var serviceScope = appServiceProivder
+                .GetRequiredService<IServiceScopeFactory>()
+                .CreateScope())
+            {
+                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>();
+
+                Assert.Equal(
+                    CoreStrings.NoEfServices,
+                    Assert.Throws<InvalidOperationException>(() => context.Database.GetDbConnection()).Message);
+            }
+        }
+
+        [Fact]
+        public void Throws_with_new_when_no_provider_use_Database()
+        {
+            var options = new DbContextOptionsBuilder<ConstructorTestContext1A>()
+                .UseInternalServiceProvider(new ServiceCollection().AddEntityFramework().BuildServiceProvider())
+                .Options;
+
+            using (var context = new ConstructorTestContext1A(options))
+            {
+                Assert.Equal(
+                    CoreStrings.NoProviderConfigured,
+                    Assert.Throws<InvalidOperationException>(() => context.Database.GetDbConnection()).Message);
+            }
+        }
+
+        [Fact]
+        public void Throws_with_add_when_no_provider_use_Database()
+        {
+            var appServiceProivder = new ServiceCollection()
+                .AddEntityFramework()
+                .AddDbContext<ConstructorTestContext1A>(
+                    (p, b) => b.UseInternalServiceProvider(p))
+                .BuildServiceProvider();
+
+            using (var serviceScope = appServiceProivder
+                .GetRequiredService<IServiceScopeFactory>()
+                .CreateScope())
+            {
+                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>();
+
+                Assert.Equal(
+                    CoreStrings.NoProviderConfigured,
+                    Assert.Throws<InvalidOperationException>(() => context.Database.GetDbConnection()).Message);
+            }
+        }
+
+        [Fact]
+        public void Throws_with_new_when_no_EF_services_because_parameterless_constructor_use_Database()
+        {
+            using (var context = new ConstructorTestContextNoConfiguration())
+            {
+                Assert.Equal(
+                    CoreStrings.NoProviderConfigured,
+                    Assert.Throws<InvalidOperationException>(() => context.Database.GetDbConnection()).Message);
+            }
+        }
+
+        [Fact]
+        public void Throws_with_add_when_no_EF_services_because_parameterless_constructor_use_Database()
+        {
+            var appServiceProivder = new ServiceCollection()
+                .AddDbContext<ConstructorTestContextNoConfiguration>()
+                .BuildServiceProvider();
+
+            using (var serviceScope = appServiceProivder
+                .GetRequiredService<IServiceScopeFactory>()
+                .CreateScope())
+            {
+                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextNoConfiguration>();
+
+                Assert.Equal(
+                    CoreStrings.NoProviderConfigured,
+                    Assert.Throws<InvalidOperationException>(() => context.Database.GetDbConnection()).Message);
+            }
+        }
+
+        private class ConstructorTestContext1A : DbContext
+        {
+            public ConstructorTestContext1A(DbContextOptions options)
+                : base(options)
+            {
+            }
+        }
+
+        private class ConstructorTestContextNoConfiguration : DbContext
+        {
+        }
+
         [Fact]
         public void Can_create_new_connection_lazily_using_given_connection_string()
         {

--- a/test/Microsoft.EntityFrameworkCore.Tests/DbContextTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/DbContextTest.cs
@@ -3386,6 +3386,208 @@ namespace Microsoft.EntityFrameworkCore.Tests
             }
         }
 
+        [Fact]
+        public void Throws_with_new_when_no_EF_services()
+        {
+            var options = new DbContextOptionsBuilder<ConstructorTestContext1A>()
+                .UseInternalServiceProvider(new ServiceCollection().BuildServiceProvider())
+                .Options;
+
+            using (var context = new ConstructorTestContextWithSets(options))
+            {
+                Assert.Equal(
+                    CoreStrings.NoEfServices,
+                    Assert.Throws<InvalidOperationException>(() => context.Model).Message);
+            }
+        }
+
+        [Fact]
+        public void Throws_with_add_when_no_EF_services()
+        {
+            var appServiceProivder = new ServiceCollection()
+                .AddDbContext<ConstructorTestContextWithSets>(
+                    (p, b) => b.UseInternalServiceProvider(p))
+                .BuildServiceProvider();
+
+            using (var serviceScope = appServiceProivder
+                .GetRequiredService<IServiceScopeFactory>()
+                .CreateScope())
+            {
+                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithSets>();
+
+                Assert.Equal(
+                    CoreStrings.NoEfServices,
+                    Assert.Throws<InvalidOperationException>(() => context.Model).Message);
+            }
+        }
+
+        [Fact]
+        public void Throws_with_new_when_no_EF_services_and_no_sets()
+        {
+            var options = new DbContextOptionsBuilder<ConstructorTestContext1A>()
+                .UseInternalServiceProvider(new ServiceCollection().BuildServiceProvider())
+                .Options;
+
+            using (var context = new ConstructorTestContext1A(options))
+            {
+                Assert.Equal(
+                    CoreStrings.NoEfServices,
+                    Assert.Throws<InvalidOperationException>(() => context.Model).Message);
+            }
+        }
+
+        [Fact]
+        public void Throws_with_add_when_no_EF_services_and_no_sets()
+        {
+            var appServiceProivder = new ServiceCollection()
+                .AddDbContext<ConstructorTestContext1A>(
+                    (p, b) => b.UseInternalServiceProvider(p))
+                .BuildServiceProvider();
+
+            using (var serviceScope = appServiceProivder
+                .GetRequiredService<IServiceScopeFactory>()
+                .CreateScope())
+            {
+                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>();
+
+                Assert.Equal(
+                    CoreStrings.NoEfServices,
+                    Assert.Throws<InvalidOperationException>(() => context.Model).Message);
+            }
+        }
+
+        [Fact]
+        public void Throws_with_new_when_no_provider()
+        {
+            var options = new DbContextOptionsBuilder<ConstructorTestContext1A>()
+                .UseInternalServiceProvider(new ServiceCollection().AddEntityFramework().BuildServiceProvider())
+                .Options;
+
+            using (var context = new ConstructorTestContextWithSets(options))
+            {
+                Assert.Equal(
+                    CoreStrings.NoProviderConfigured,
+                    Assert.Throws<InvalidOperationException>(() => context.Model).Message);
+            }
+        }
+
+        [Fact]
+        public void Throws_with_add_when_no_provider()
+        {
+            var appServiceProivder = new ServiceCollection()
+                .AddEntityFramework()
+                .AddDbContext<ConstructorTestContextWithSets>(
+                    (p, b) => b.UseInternalServiceProvider(p))
+                .BuildServiceProvider();
+
+            using (var serviceScope = appServiceProivder
+                .GetRequiredService<IServiceScopeFactory>()
+                .CreateScope())
+            {
+                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithSets>();
+
+                Assert.Equal(
+                    CoreStrings.NoProviderConfigured,
+                    Assert.Throws<InvalidOperationException>(() => context.Model).Message);
+            }
+        }
+
+        [Fact]
+        public void Throws_with_new_when_no_provider_and_no_sets()
+        {
+            var options = new DbContextOptionsBuilder<ConstructorTestContext1A>()
+                .UseInternalServiceProvider(new ServiceCollection().AddEntityFramework().BuildServiceProvider())
+                .Options;
+
+            using (var context = new ConstructorTestContext1A(options))
+            {
+                Assert.Equal(
+                    CoreStrings.NoProviderConfigured,
+                    Assert.Throws<InvalidOperationException>(() => context.Model).Message);
+            }
+        }
+
+        [Fact]
+        public void Throws_with_add_when_no_provider_and_no_sets()
+        {
+            var appServiceProivder = new ServiceCollection()
+                .AddEntityFramework()
+                .AddDbContext<ConstructorTestContext1A>(
+                    (p, b) => b.UseInternalServiceProvider(p))
+                .BuildServiceProvider();
+
+            using (var serviceScope = appServiceProivder
+                .GetRequiredService<IServiceScopeFactory>()
+                .CreateScope())
+            {
+                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContext1A>();
+
+                Assert.Equal(
+                    CoreStrings.NoProviderConfigured,
+                    Assert.Throws<InvalidOperationException>(() => context.Model).Message);
+            }
+        }
+
+        [Fact]
+        public void Throws_with_new_when_no_EF_services_because_parameterless_constructor()
+        {
+            using (var context = new ConstructorTestContextNoConfigurationWithSets())
+            {
+                Assert.Equal(
+                    CoreStrings.NoProviderConfigured,
+                    Assert.Throws<InvalidOperationException>(() => context.Model).Message);
+            }
+        }
+
+        [Fact]
+        public void Throws_with_add_when_no_EF_services_because_parameterless_constructor()
+        {
+            var appServiceProivder = new ServiceCollection()
+                .AddDbContext<ConstructorTestContextNoConfigurationWithSets>()
+                .BuildServiceProvider();
+
+            using (var serviceScope = appServiceProivder
+                .GetRequiredService<IServiceScopeFactory>()
+                .CreateScope())
+            {
+                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextNoConfigurationWithSets>();
+
+                Assert.Equal(
+                    CoreStrings.NoProviderConfigured,
+                    Assert.Throws<InvalidOperationException>(() => context.Model).Message);
+            }
+        }
+
+        [Fact]
+        public void Throws_with_new_when_no_EF_services_and_no_sets_because_parameterless_constructor()
+        {
+            using (var context = new ConstructorTestContextNoConfiguration())
+            {
+                Assert.Equal(
+                    CoreStrings.NoProviderConfigured,
+                    Assert.Throws<InvalidOperationException>(() => context.Model).Message);
+            }
+        }
+
+        [Fact]
+        public void Throws_with_add_when_no_EF_services_and_no_sets_because_parameterless_constructor()
+        {
+            var appServiceProivder = new ServiceCollection()
+                .AddDbContext<ConstructorTestContextNoConfiguration>()
+                .BuildServiceProvider();
+
+            using (var serviceScope = appServiceProivder
+                .GetRequiredService<IServiceScopeFactory>()
+                .CreateScope())
+            {
+                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextNoConfiguration>();
+
+                Assert.Equal(
+                    CoreStrings.NoProviderConfigured,
+                    Assert.Throws<InvalidOperationException>(() => context.Model).Message);
+            }
+        }
+
         private class WrappingLoggerFactory : ILoggerFactory
         {
             private readonly ILoggerFactory _loggerFactory;
@@ -3411,11 +3613,30 @@ namespace Microsoft.EntityFrameworkCore.Tests
 
         private class ConstructorTestContext1A : DbContext
         {
-            public ConstructorTestContext1A(
-                DbContextOptions options)
+            public ConstructorTestContext1A(DbContextOptions options)
                 : base(options)
             {
             }
+        }
+
+        private class ConstructorTestContextWithSets : DbContext
+        {
+            public ConstructorTestContextWithSets(DbContextOptions options)
+                : base(options)
+            {
+            }
+
+            public DbSet<Product> Products { get; set; }
+        }
+
+
+        private class ConstructorTestContextNoConfiguration : DbContext
+        {
+        }
+
+        private class ConstructorTestContextNoConfigurationWithSets : DbContext
+        {
+            public DbSet<Product> Products { get; set; }
         }
 
         private class ConstructorTestContextWithOCBase : DbContext
@@ -3449,19 +3670,6 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 IMemoryCache memoryCache = null)
                 : base(options)
             {
-                _loggerFactory = loggerFactory;
-                _memoryCache = memoryCache;
-                _isConfigured = true;
-            }
-
-            protected ConstructorTestContextWithOCBase(
-                IServiceProvider internalServicesProvider,
-                DbContextOptions options,
-                ILoggerFactory loggerFactory = null,
-                IMemoryCache memoryCache = null)
-                : base(options)
-            {
-                _internalServicesProvider = internalServicesProvider;
                 _loggerFactory = loggerFactory;
                 _memoryCache = memoryCache;
                 _isConfigured = true;


### PR DESCRIPTION
The common case here is a context that does not have OnConfiguring and does not pass in a DbContextOptions to its constructor, or the DbContextOptions passed does has not had any providers configured on it.

It is also possible to get no EF services at all, but this now requires making a call to UseInternalServiceProvider with a service provider that does not have EF services in it.

Also fixes #4665.

@rowanmiller for exception message wording