### PR TITLE
Workaround for CLI issue where restore fails with

### DIFF
--- a/test/Microsoft.EntityFrameworkCore.Relational.Design.FunctionalTests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Design.FunctionalTests/project.json
@@ -38,13 +38,7 @@
         "System.Dynamic.Runtime": {
           "type": "build"
         },
-        "System.IO": {
-          "type": "build"
-        },
         "System.Reflection.Primitives": {
-          "type": "build"
-        },
-        "System.Resources.ResourceManager": {
           "type": "build"
         },
         "System.Runtime.InteropServices": {
@@ -60,9 +54,6 @@
           "type": "build"
         },
         "System.Text.Encoding.Extensions": {
-          "type": "build"
-        },
-        "System.Threading": {
           "type": "build"
         },
         "System.Threading.Tasks.Parallel": {


### PR DESCRIPTION
An item with the same key has already been added. Key: System.Threading
Unspecified exception.