### PR TITLE
Stop registering DbContext as an internal service

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Commands/Design/Internal/DesignTimeServicesBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore.Commands/Design/Internal/DesignTimeServicesBuilder.cs
@@ -79,7 +79,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             [NotNull] IServiceCollection services)
             => services
                 .AddTransient<MigrationsScaffolder>()
-                .AddTransient(_ => contextServices.GetService<DbContext>())
+                .AddTransient(_ => contextServices.GetService<ICurrentDbContext>())
                 .AddTransient(_ => contextServices.GetService<IDatabaseProviderServices>())
                 .AddTransient(_ => contextServices.GetService<IDbContextOptions>())
                 .AddTransient(_ => contextServices.GetService<IHistoryRepository>())

--- a/src/Microsoft.EntityFrameworkCore.Commands/Design/MigrationsOperations.cs
+++ b/src/Microsoft.EntityFrameworkCore.Commands/Design/MigrationsOperations.cs
@@ -168,7 +168,7 @@ namespace Microsoft.EntityFrameworkCore.Design
 
             var assemblyName = _assembly.GetName();
             var options = services.GetRequiredService<IDbContextOptions>();
-            var contextType = services.GetRequiredService<DbContext>().GetType();
+            var contextType = services.GetRequiredService<ICurrentDbContext>().Context.GetType();
             var migrationsAssemblyName = RelationalOptionsExtension.Extract(options).MigrationsAssembly
                 ?? contextType.GetTypeInfo().Assembly.GetName().Name;
             if (assemblyName.Name != migrationsAssemblyName

--- a/src/Microsoft.EntityFrameworkCore.Commands/Migrations/Design/MigrationsScaffolder.cs
+++ b/src/Microsoft.EntityFrameworkCore.Commands/Migrations/Design/MigrationsScaffolder.cs
@@ -32,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         private readonly string _activeProvider;
 
         public MigrationsScaffolder(
-            [NotNull] DbContext context,
+            [NotNull] ICurrentDbContext currentContext,
             [NotNull] IModel model,
             [NotNull] IMigrationsAssembly migrationsAssembly,
             [NotNull] IMigrationsModelDiffer modelDiffer,
@@ -42,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             [NotNull] ILoggerFactory loggerFactory,
             [NotNull] IDatabaseProviderServices providerServices)
         {
-            Check.NotNull(context, nameof(context));
+            Check.NotNull(currentContext, nameof(currentContext));
             Check.NotNull(model, nameof(model));
             Check.NotNull(migrationsAssembly, nameof(migrationsAssembly));
             Check.NotNull(modelDiffer, nameof(modelDiffer));
@@ -52,7 +52,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             Check.NotNull(loggerFactory, nameof(loggerFactory));
             Check.NotNull(providerServices, nameof(providerServices));
 
-            _contextType = context.GetType();
+            _contextType = currentContext.Context.GetType();
             _model = model;
             _migrationsAssembly = migrationsAssembly;
             _modelDiffer = modelDiffer;

--- a/src/Microsoft.EntityFrameworkCore.Relational/Metadata/Conventions/Internal/RelationalConventionSetBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Metadata/Conventions/Internal/RelationalConventionSetBuilder.cs
@@ -18,13 +18,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
         protected RelationalConventionSetBuilder(
             [NotNull] IRelationalTypeMapper typeMapper,
-            [CanBeNull] DbContext context, 
+            [CanBeNull] ICurrentDbContext currentContext, 
             [CanBeNull] IDbSetFinder setFinder)
         {
             Check.NotNull(typeMapper, nameof(typeMapper));
 
             _typeMapper = typeMapper;
-            _context = context;
+            _context = currentContext?.Context;
             _setFinder = setFinder;
         }
 

--- a/src/Microsoft.EntityFrameworkCore.Relational/Migrations/Internal/MigrationsAssembly.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Migrations/Internal/MigrationsAssembly.cs
@@ -19,15 +19,15 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
         private readonly LazyRef<ModelSnapshot> _modelSnapshot;
 
         public MigrationsAssembly(
-            [NotNull] DbContext context,
+            [NotNull] ICurrentDbContext currentContext,
             [NotNull] IDbContextOptions options,
             [NotNull] IMigrationsIdGenerator idGenerator)
         {
-            Check.NotNull(context, nameof(context));
+            Check.NotNull(currentContext, nameof(currentContext));
             Check.NotNull(options, nameof(options));
             Check.NotNull(idGenerator, nameof(idGenerator));
 
-            var contextType = context.GetType();
+            var contextType = currentContext.Context.GetType();
 
             var assemblyName = RelationalOptionsExtension.Extract(options)?.MigrationsAssembly;
             Assembly = assemblyName == null

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalCompiledQueryCacheKeyGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalCompiledQueryCacheKeyGenerator.cs
@@ -4,6 +4,7 @@
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -15,9 +16,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
         public RelationalCompiledQueryCacheKeyGenerator(
             [NotNull] IModel model,
-            [NotNull] DbContext context,
+            [NotNull] ICurrentDbContext currentContext,
             [NotNull] IDbContextOptions contextOptions)
-            : base(model, context)
+            : base(model, currentContext)
         {
             Check.NotNull(contextOptions, nameof(contextOptions));
 

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryCompilationContextFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/RelationalQueryCompilationContextFactory.cs
@@ -3,6 +3,7 @@
 
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors;
 using Microsoft.EntityFrameworkCore.Query.Internal;
@@ -20,13 +21,13 @@ namespace Microsoft.EntityFrameworkCore.Query
             [NotNull] IEntityQueryModelVisitorFactory entityQueryModelVisitorFactory,
             [NotNull] IRequiresMaterializationExpressionVisitorFactory requiresMaterializationExpressionVisitorFactory,
             [NotNull] MethodInfoBasedNodeTypeRegistry methodInfoBasedNodeTypeRegistry,
-            [NotNull] DbContext context)
+            [NotNull] ICurrentDbContext currentContext)
             : base(
                 Check.NotNull(model, nameof(model)),
                 Check.NotNull(logger, nameof(logger)),
                 Check.NotNull(entityQueryModelVisitorFactory, nameof(entityQueryModelVisitorFactory)),
                 Check.NotNull(requiresMaterializationExpressionVisitorFactory, nameof(requiresMaterializationExpressionVisitorFactory)),
-                Check.NotNull(context, nameof(context)))
+                Check.NotNull(currentContext, nameof(currentContext)))
         {
             methodInfoBasedNodeTypeRegistry
                 .Register(FromSqlExpressionNode.SupportedMethods, typeof(FromSqlExpressionNode));

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Metadata/Conventions/SqlServerConventionSetBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Metadata/Conventions/SqlServerConventionSetBuilder.cs
@@ -14,9 +14,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
     {
         public SqlServerConventionSetBuilder(
             [NotNull] IRelationalTypeMapper typeMapper,
-            [CanBeNull] DbContext context,
+            [CanBeNull] ICurrentDbContext currentContext,
             [CanBeNull] IDbSetFinder setFinder)
-            : base(typeMapper, context, setFinder)
+            : base(typeMapper, currentContext, setFinder)
         {
         }
 

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Query/Internal/SqlServerCompiledQueryCacheKeyGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Query/Internal/SqlServerCompiledQueryCacheKeyGenerator.cs
@@ -5,6 +5,7 @@ using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Infrastructure.Internal;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -16,9 +17,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
         public SqlServerCompiledQueryCacheKeyGenerator(
             [NotNull] IModel model,
-            [NotNull] DbContext context,
+            [NotNull] ICurrentDbContext currentContext,
             [NotNull] IDbContextOptions contextOptions)
-            : base(model, context, contextOptions)
+            : base(model, currentContext, contextOptions)
         {
             Check.NotNull(contextOptions, nameof(contextOptions));
 

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Query/Internal/SqlServerQueryCompilationContextFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Query/Internal/SqlServerQueryCompilationContextFactory.cs
@@ -3,6 +3,7 @@
 
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -18,14 +19,14 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             [NotNull] IEntityQueryModelVisitorFactory entityQueryModelVisitorFactory,
             [NotNull] IRequiresMaterializationExpressionVisitorFactory requiresMaterializationExpressionVisitorFactory,
             [NotNull] MethodInfoBasedNodeTypeRegistry methodInfoBasedNodeTypeRegistry,
-            [NotNull] DbContext context)
+            [NotNull] ICurrentDbContext currentContext)
             : base(
                 Check.NotNull(model, nameof(model)),
                 Check.NotNull(logger, nameof(logger)),
                 Check.NotNull(entityQueryModelVisitorFactory, nameof(entityQueryModelVisitorFactory)),
                 Check.NotNull(requiresMaterializationExpressionVisitorFactory, nameof(requiresMaterializationExpressionVisitorFactory)),
                 Check.NotNull(methodInfoBasedNodeTypeRegistry, nameof(methodInfoBasedNodeTypeRegistry)),
-                Check.NotNull(context, nameof(context)))
+                Check.NotNull(currentContext, nameof(currentContext)))
         {
         }
 

--- a/src/Microsoft.EntityFrameworkCore.Sqlite/Metadata/Conventions/SqliteConventionSetBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite/Metadata/Conventions/SqliteConventionSetBuilder.cs
@@ -13,9 +13,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
     {
         public SqliteConventionSetBuilder(
             [NotNull] IRelationalTypeMapper typeMapper,
-            [CanBeNull] DbContext context,
+            [CanBeNull] ICurrentDbContext currentContext,
             [CanBeNull] IDbSetFinder setFinder)
-            : base(typeMapper, context, setFinder)
+            : base(typeMapper, currentContext, setFinder)
         {
         }
 

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/ChangeTrackerFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/ChangeTrackerFactory.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
 
 namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 {
@@ -16,12 +17,12 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             [NotNull] IStateManager stateManager,
             [NotNull] IChangeDetector changeDetector,
             [NotNull] IEntityEntryGraphIterator graphIterator,
-            [NotNull] DbContext context)
+            [NotNull] ICurrentDbContext currentContext)
         {
             _stateManager = stateManager;
             _changeDetector = changeDetector;
             _graphIterator = graphIterator;
-            _context = context;
+            _context = currentContext.Context;
         }
 
         public virtual ChangeTracker Create()

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/StateManager.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/StateManager.cs
@@ -42,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             [NotNull] IModel model,
             [NotNull] IDatabase database,
             [NotNull] IConcurrencyDetector concurrencyDetector,
-            [NotNull] DbContext context)
+            [NotNull] ICurrentDbContext currentContext)
         {
             _factory = factory;
             _subscriber = subscriber;
@@ -51,7 +51,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             _model = model;
             _database = database;
             _concurrencyDetector = concurrencyDetector;
-            Context = context;
+            Context = currentContext.Context;
         }
 
         public virtual bool? SingleQueryMode { get; set; }

--- a/src/Microsoft.EntityFrameworkCore/DbContext.cs
+++ b/src/Microsoft.EntityFrameworkCore/DbContext.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
@@ -15,7 +14,6 @@ using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -126,9 +124,9 @@ namespace Microsoft.EntityFrameworkCore
                 OnConfiguring(optionsBuilder);
 
                 var options = optionsBuilder.Options;
-                
+
                 var serviceProvider = options.FindExtension<CoreOptionsExtension>()?.InternalServiceProvider
-                    ?? ServiceProviderCache.Instance.GetOrAdd(options);
+                                      ?? ServiceProviderCache.Instance.GetOrAdd(options);
 
                 _serviceScope = serviceProvider
                     .GetRequiredService<IServiceScopeFactory>()
@@ -345,6 +343,12 @@ namespace Microsoft.EntityFrameworkCore
         {
             _disposed = true;
             _serviceScope?.Dispose();
+            _setInitializer = null;
+            _changeTracker = null;
+            _stateManager = null;
+            _changeDetector = null;
+            _graphAttacher = null;
+            _model = null;
         }
 
         /// <summary>

--- a/src/Microsoft.EntityFrameworkCore/Infrastructure/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Infrastructure/EntityFrameworkServiceCollectionExtensions.cs
@@ -109,7 +109,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 .AddScoped(typeof(ISensitiveDataLogger<>), typeof(SensitiveDataLogger<>))
                 .AddScoped(typeof(ILogger<>), typeof(InterceptingLogger<>))
                 .AddScoped(p => GetContextServices(p).Model)
-                .AddScoped(p => GetContextServices(p).Context)
+                .AddScoped(p => GetContextServices(p).CurrentContext)
                 .AddScoped(p => GetContextServices(p).ContextOptions)
                 .AddScoped(p => GetContextServices(p).DatabaseProviderServices)
                 .AddScoped(p => GetProviderServices(p).Database)

--- a/src/Microsoft.EntityFrameworkCore/Internal/CurrentDbContext.cs
+++ b/src/Microsoft.EntityFrameworkCore/Internal/CurrentDbContext.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Internal
+{
+    public class CurrentDbContext : ICurrentDbContext
+    {
+        public CurrentDbContext([NotNull] DbContext context)
+        {
+            Context = context;
+        }
+
+        public virtual DbContext Context { get; }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/Internal/DbContextServices.cs
+++ b/src/Microsoft.EntityFrameworkCore/Internal/DbContextServices.cs
@@ -17,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
     {
         private IServiceProvider _provider;
         private IDbContextOptions _contextOptions;
-        private DbContext _context;
+        private ICurrentDbContext _currentContext;
         private LazyRef<IModel> _modelFromSource;
         private LazyRef<IDatabaseProviderServices> _providerServices;
         private bool _inOnModelCreating;
@@ -33,7 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
 
             _provider = scopedProvider;
             _contextOptions = contextOptions;
-            _context = context;
+            _currentContext = new CurrentDbContext(context);
 
             _providerServices = new LazyRef<IDatabaseProviderServices>(() =>
                 _provider.GetRequiredService<IDatabaseProviderSelector>().SelectServices());
@@ -55,7 +55,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 _inOnModelCreating = true;
 
                 return _providerServices.Value.ModelSource.GetModel(
-                    _context,
+                    _currentContext.Context,
                     _providerServices.Value.ConventionSetBuilder,
                     _providerServices.Value.ModelValidator);
             }
@@ -65,7 +65,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
             }
         }
 
-        public virtual DbContext Context => _context;
+        public virtual ICurrentDbContext CurrentContext => _currentContext;
 
         public virtual IModel Model => CoreOptions?.Model ?? _modelFromSource.Value;
 

--- a/src/Microsoft.EntityFrameworkCore/Internal/ICurrentDbContext.cs
+++ b/src/Microsoft.EntityFrameworkCore/Internal/ICurrentDbContext.cs
@@ -1,0 +1,10 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Internal
+{
+    public interface ICurrentDbContext
+    {
+        DbContext Context { get; }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/Internal/IDbContextServices.cs
+++ b/src/Microsoft.EntityFrameworkCore/Internal/IDbContextServices.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
             [NotNull] IDbContextOptions contextOptions,
             [NotNull] DbContext context);
 
-        DbContext Context { get; }
+        ICurrentDbContext CurrentContext { get; }
         IModel Model { get; }
         ILoggerFactory LoggerFactory { get; }
         IMemoryCache MemoryCache { get; }

--- a/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
+++ b/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
@@ -182,6 +182,8 @@
     <Compile Include="Infrastructure\ModelSource.cs" />
     <Compile Include="Infrastructure\SensitiveDataLogger.cs" />
     <Compile Include="Internal\ConcurrencyDetector.cs" />
+    <Compile Include="Internal\CurrentDbContext.cs" />
+    <Compile Include="Internal\ICurrentDbContext.cs" />
     <Compile Include="Internal\InterceptingLogger.cs" />
     <Compile Include="Internal\CoreOptionsExtension.cs" />
     <Compile Include="Internal\DatabaseProviderSelector.cs" />

--- a/src/Microsoft.EntityFrameworkCore/Query/CompiledQueryCacheKeyGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/CompiledQueryCacheKeyGenerator.cs
@@ -3,6 +3,7 @@
 
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -14,13 +15,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         private readonly IModel _model;
         private readonly DbContext _context;
 
-        public CompiledQueryCacheKeyGenerator([NotNull] IModel model, [NotNull] DbContext context)
+        public CompiledQueryCacheKeyGenerator([NotNull] IModel model, [NotNull] ICurrentDbContext currentContext)
         {
             Check.NotNull(model, nameof(model));
-            Check.NotNull(context, nameof(context));
+            Check.NotNull(currentContext, nameof(currentContext));
 
             _model = model;
-            _context = context;
+            _context = currentContext.Context;
         }
 
         public virtual object GenerateCacheKey(Expression query, bool async)

--- a/src/Microsoft.EntityFrameworkCore/Query/Internal/QueryCompilationContextFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/Internal/QueryCompilationContextFactory.cs
@@ -3,6 +3,7 @@
 
 using System;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -19,12 +20,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             [NotNull] ILogger<QueryCompilationContextFactory> logger,
             [NotNull] IEntityQueryModelVisitorFactory entityQueryModelVisitorFactory,
             [NotNull] IRequiresMaterializationExpressionVisitorFactory requiresMaterializationExpressionVisitorFactory,
-            [NotNull] DbContext context)
+            [NotNull] ICurrentDbContext currentContext)
         {
             Check.NotNull(logger, nameof(logger));
             Check.NotNull(entityQueryModelVisitorFactory, nameof(entityQueryModelVisitorFactory));
             Check.NotNull(requiresMaterializationExpressionVisitorFactory, nameof(requiresMaterializationExpressionVisitorFactory));
-            Check.NotNull(context, nameof(context));
+            Check.NotNull(currentContext, nameof(currentContext));
 
             Model = model;
             Logger = logger;
@@ -32,7 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             EntityQueryModelVisitorFactory = entityQueryModelVisitorFactory;
             RequiresMaterializationExpressionVisitorFactory = requiresMaterializationExpressionVisitorFactory;
 
-            _context = context;
+            _context = currentContext.Context;
         }
 
         protected virtual IModel Model { get; }

--- a/src/Microsoft.EntityFrameworkCore/Query/Internal/QueryCompiler.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/Internal/QueryCompiler.cs
@@ -51,14 +51,14 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             [NotNull] IDatabase database,
             [NotNull] ISensitiveDataLogger<QueryCompiler> logger,
             [NotNull] MethodInfoBasedNodeTypeRegistry methodInfoBasedNodeTypeRegistry,
-            [NotNull] DbContext context)
+            [NotNull] ICurrentDbContext currentContext)
         {
             Check.NotNull(queryContextFactory, nameof(queryContextFactory));
             Check.NotNull(compiledQueryCache, nameof(compiledQueryCache));
             Check.NotNull(compiledQueryCacheKeyGenerator, nameof(compiledQueryCacheKeyGenerator));
             Check.NotNull(database, nameof(database));
             Check.NotNull(logger, nameof(logger));
-            Check.NotNull(context, nameof(context));
+            Check.NotNull(currentContext, nameof(currentContext));
 
             _queryContextFactory = queryContextFactory;
             _compiledQueryCache = compiledQueryCache;
@@ -66,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             _database = database;
             _logger = logger;
             _methodInfoBasedNodeTypeRegistry = methodInfoBasedNodeTypeRegistry;
-            _contextType = context.GetType();
+            _contextType = currentContext.Context.GetType();
         }
 
         protected virtual IDatabase Database => _database;

--- a/test/Microsoft.EntityFrameworkCore.Commands.Tests/Migrations/Design/MigrationScaffolderTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Commands.Tests/Migrations/Design/MigrationScaffolderTest.cs
@@ -48,15 +48,15 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         private MigrationsScaffolder CreateMigrationScaffolder<TContext>()
             where TContext : DbContext, new()
         {
-            var context = new TContext();
+            var currentContext = new CurrentDbContext(new TContext());
             var idGenerator = new MigrationsIdGenerator();
             var code = new CSharpHelper();
 
             return new MigrationsScaffolder(
-                context,
+                currentContext,
                 new Model(),
                 new MigrationsAssembly(
-                    context,
+                    currentContext,
                     new DbContextOptions<TContext>().WithExtension(new MockRelationalOptionsExtension()),
                     idGenerator),
                 new MigrationsModelDiffer(

--- a/test/Microsoft.EntityFrameworkCore.FunctionalTests/ThrowingMonsterStateManager.cs
+++ b/test/Microsoft.EntityFrameworkCore.FunctionalTests/ThrowingMonsterStateManager.cs
@@ -22,8 +22,8 @@ namespace Microsoft.EntityFrameworkCore.FunctionalTests
             IModel model,
             IDatabase database,
             IConcurrencyDetector concurrencyDetector,
-            DbContext context)
-            : base(factory, subscriber, notifier, valueGeneration, model, database, concurrencyDetector, context)
+            ICurrentDbContext currentContext)
+            : base(factory, subscriber, notifier, valueGeneration, model, database, concurrencyDetector, currentContext)
         {
         }
 

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Migrations/Internal/MigrationsAssemblyTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Migrations/Internal/MigrationsAssemblyTest.cs
@@ -40,7 +40,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Migrations.Internal
 
         private IMigrationsAssembly CreateMigrationsAssembly()
             => new MigrationsAssembly(
-                new Context(),
+                new CurrentDbContext(new Context()),
                 new DbContextOptions<DbContext>(
                     new Dictionary<Type, IDbContextOptionsExtension>
                     {

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/TestConventionalSetBuilder.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/TestConventionalSetBuilder.cs
@@ -11,9 +11,9 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests
     public class TestConventionalSetBuilder : RelationalConventionSetBuilder
     {
         public TestConventionalSetBuilder(IRelationalTypeMapper typeMapper,
-            DbContext context,
+            ICurrentDbContext currentContext,
             IDbSetFinder setFinder)
-            : base(typeMapper, context, setFinder)
+            : base(typeMapper, currentContext, setFinder)
         {
         }
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/DbContextTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/DbContextTest.cs
@@ -3387,6 +3387,629 @@ namespace Microsoft.EntityFrameworkCore.Tests
         }
 
         [Fact]
+        public void Can_add_non_derived_context_with_options()
+        {
+            var appServiceProivder = new ServiceCollection()
+                .AddDbContext<DbContext>(b => b.UseInMemoryDatabase())
+                .BuildServiceProvider();
+
+            var singleton = new object[4];
+
+            using (var serviceScope = appServiceProivder
+                .GetRequiredService<IServiceScopeFactory>()
+                .CreateScope())
+            {
+                var context = serviceScope.ServiceProvider.GetService<DbContext>();
+
+                Assert.NotNull(singleton[0] = context.GetService<IInMemoryStore>());
+                Assert.NotNull(singleton[1] = context.GetService<ILoggerFactory>());
+                Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
+                Assert.NotNull(singleton[3] = context.GetService<IDbContextOptions>());
+
+                Assert.NotNull(context.GetService<ILogger<Random>>());
+            }
+
+            using (var serviceScope = appServiceProivder
+                .GetRequiredService<IServiceScopeFactory>()
+                .CreateScope())
+            {
+                var context = serviceScope.ServiceProvider.GetService<DbContext>();
+
+                Assert.Same(singleton[0], context.GetService<IInMemoryStore>());
+                Assert.Same(singleton[1], context.GetService<ILoggerFactory>());
+                Assert.Same(singleton[2], context.GetService<IMemoryCache>());
+                Assert.Same(singleton[3], context.GetService<IDbContextOptions>());
+            }
+        }
+
+        [Fact]
+        public void Can_add_non_derived_context_with_options_and_external_services()
+        {
+            var appServiceProivder = new ServiceCollection()
+                .AddDbContext<DbContext>(
+                    (p, b) => b.UseInMemoryDatabase()
+                        .UseMemoryCache(p.GetService<IMemoryCache>())
+                        .UseLoggerFactory(p.GetService<ILoggerFactory>()))
+                .BuildServiceProvider();
+
+            var loggerFactory = appServiceProivder.GetService<ILoggerFactory>();
+            var memoryCache = appServiceProivder.GetService<IMemoryCache>();
+
+            IDbContextOptions options;
+            IInMemoryStore singleton;
+
+            using (var serviceScope = appServiceProivder
+                .GetRequiredService<IServiceScopeFactory>()
+                .CreateScope())
+            {
+                var context = serviceScope.ServiceProvider.GetService<DbContext>();
+
+                Assert.NotNull(singleton = context.GetService<IInMemoryStore>());
+                Assert.Same(loggerFactory, context.GetService<IDbContextServices>().LoggerFactory);
+                Assert.Same(memoryCache, context.GetService<IDbContextServices>().MemoryCache);
+                Assert.NotNull(options = context.GetService<IDbContextOptions>());
+
+                Assert.NotNull(context.GetService<ILogger<Random>>());
+            }
+
+            using (var serviceScope = appServiceProivder
+                .GetRequiredService<IServiceScopeFactory>()
+                .CreateScope())
+            {
+                var context = serviceScope.ServiceProvider.GetService<DbContext>();
+
+                Assert.Same(singleton, context.GetService<IInMemoryStore>());
+                Assert.Same(loggerFactory, context.GetService<IDbContextServices>().LoggerFactory);
+                Assert.Same(memoryCache, context.GetService<IDbContextServices>().MemoryCache);
+                Assert.Same(options, context.GetService<IDbContextOptions>());
+            }
+        }
+
+        [Fact]
+        public void Can_add_non_derived_context_controlling_internal_services_with_options()
+        {
+            var appServiceProivder = new ServiceCollection()
+                .AddEntityFrameworkInMemoryDatabase()
+                .AddDbContext<DbContext>((p, b) => b.UseInMemoryDatabase().UseInternalServiceProvider(p))
+                .BuildServiceProvider();
+
+            var singleton = new object[4];
+
+            using (var serviceScope = appServiceProivder
+                .GetRequiredService<IServiceScopeFactory>()
+                .CreateScope())
+            {
+                var context = serviceScope.ServiceProvider.GetService<DbContext>();
+
+                Assert.NotNull(singleton[0] = context.GetService<IInMemoryStore>());
+                Assert.NotNull(singleton[1] = context.GetService<ILoggerFactory>());
+                Assert.NotNull(singleton[2] = context.GetService<IMemoryCache>());
+                Assert.NotNull(singleton[3] = context.GetService<IDbContextOptions>());
+
+                Assert.NotNull(context.GetService<ILogger<Random>>());
+            }
+
+            using (var serviceScope = appServiceProivder
+                .GetRequiredService<IServiceScopeFactory>()
+                .CreateScope())
+            {
+                var context = serviceScope.ServiceProvider.GetService<DbContext>();
+
+                Assert.Same(singleton[0], context.GetService<IInMemoryStore>());
+                Assert.Same(singleton[1], context.GetService<ILoggerFactory>());
+                Assert.Same(singleton[2], context.GetService<IMemoryCache>());
+                Assert.Same(singleton[3], context.GetService<IDbContextOptions>());
+            }
+        }
+
+        [Fact]
+        public void Can_add_non_derived_context_controlling_internal_services_with_options_and_external_services()
+        {
+            var appServiceProivder = new ServiceCollection()
+                .AddEntityFrameworkInMemoryDatabase()
+                .AddDbContext<DbContext>(
+                    (p, b) => b.UseInMemoryDatabase()
+                        .UseMemoryCache(p.GetService<IMemoryCache>())
+                        .UseLoggerFactory(p.GetService<ILoggerFactory>())
+                        .UseInternalServiceProvider(p))
+                .BuildServiceProvider();
+
+            var loggerFactory = appServiceProivder.GetService<ILoggerFactory>();
+            var memoryCache = appServiceProivder.GetService<IMemoryCache>();
+
+            IDbContextOptions options;
+            IInMemoryStore singleton;
+
+            using (var serviceScope = appServiceProivder
+                .GetRequiredService<IServiceScopeFactory>()
+                .CreateScope())
+            {
+                var context = serviceScope.ServiceProvider.GetService<DbContext>();
+
+                Assert.NotNull(singleton = context.GetService<IInMemoryStore>());
+                Assert.Same(loggerFactory, context.GetService<IDbContextServices>().LoggerFactory);
+                Assert.Same(memoryCache, context.GetService<IDbContextServices>().MemoryCache);
+                Assert.NotNull(options = context.GetService<IDbContextOptions>());
+
+                Assert.NotNull(context.GetService<ILogger<Random>>());
+            }
+
+            using (var serviceScope = appServiceProivder
+                .GetRequiredService<IServiceScopeFactory>()
+                .CreateScope())
+            {
+                var context = serviceScope.ServiceProvider.GetService<DbContext>();
+
+                Assert.Same(singleton, context.GetService<IInMemoryStore>());
+                Assert.Same(loggerFactory, context.GetService<IDbContextServices>().LoggerFactory);
+                Assert.Same(memoryCache, context.GetService<IDbContextServices>().MemoryCache);
+                Assert.Same(options, context.GetService<IDbContextOptions>());
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Can_add_derived_context_as_singleton(bool addSingletonFirst)
+        {
+            var appServiceProivder = addSingletonFirst
+                ? new ServiceCollection()
+                    .AddSingleton<ConstructorTestContextWithOC1A>()
+                    .AddDbContext<ConstructorTestContextWithOC1A>()
+                    .BuildServiceProvider()
+                : new ServiceCollection()
+                    .AddDbContext<ConstructorTestContextWithOC1A>()
+                    .AddSingleton<ConstructorTestContextWithOC1A>()
+                    .BuildServiceProvider();
+
+            var singleton = new object[3];
+            DbContext context1;
+            DbContext context2;
+
+            using (var serviceScope = appServiceProivder
+                .GetRequiredService<IServiceScopeFactory>()
+                .CreateScope())
+            {
+                context1 = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC1A>();
+
+                Assert.NotNull(singleton[0] = context1.GetService<IInMemoryStore>());
+                Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
+                Assert.NotNull(singleton[2] = context1.GetService<IMemoryCache>());
+
+                Assert.NotNull(context1.GetService<ILogger<Random>>());
+            }
+
+            Assert.NotNull(context1.Model);
+
+            using (var serviceScope = appServiceProivder
+                .GetRequiredService<IServiceScopeFactory>()
+                .CreateScope())
+            {
+                context2 = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC1A>();
+
+                Assert.Same(singleton[0], context2.GetService<IInMemoryStore>());
+                Assert.Same(singleton[1], context2.GetService<ILoggerFactory>());
+                Assert.Same(singleton[2], context2.GetService<IMemoryCache>());
+            }
+
+            Assert.Same(context1, context2);
+            Assert.Same(context1.Model, context2.Model);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Can_add_derived_context_as_singleton_controlling_internal_services(bool addSingletonFirst)
+        {
+            var appServiceProivder = addSingletonFirst
+                ? new ServiceCollection()
+                .AddEntityFrameworkInMemoryDatabase()
+                    .AddSingleton<ConstructorTestContextWithOC1A>()
+                    .AddDbContext<ConstructorTestContextWithOC1A>((p, b) => b.UseInternalServiceProvider(p))
+                    .BuildServiceProvider()
+                : new ServiceCollection()
+                .AddEntityFrameworkInMemoryDatabase()
+                    .AddDbContext<ConstructorTestContextWithOC1A>((p, b) => b.UseInternalServiceProvider(p))
+                    .AddSingleton<ConstructorTestContextWithOC1A>()
+                    .BuildServiceProvider();
+
+            var singleton = new object[3];
+            DbContext context1;
+            DbContext context2;
+
+            using (var serviceScope = appServiceProivder
+                .GetRequiredService<IServiceScopeFactory>()
+                .CreateScope())
+            {
+                context1 = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC1A>();
+
+                Assert.NotNull(singleton[0] = context1.GetService<IInMemoryStore>());
+                Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
+                Assert.NotNull(singleton[2] = context1.GetService<IMemoryCache>());
+
+                Assert.NotNull(context1.GetService<ILogger<Random>>());
+            }
+
+            Assert.NotNull(context1.Model);
+
+            using (var serviceScope = appServiceProivder
+                .GetRequiredService<IServiceScopeFactory>()
+                .CreateScope())
+            {
+                context2 = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC1A>();
+
+                Assert.Same(singleton[0], context2.GetService<IInMemoryStore>());
+                Assert.Same(singleton[1], context2.GetService<ILoggerFactory>());
+                Assert.Same(singleton[2], context2.GetService<IMemoryCache>());
+            }
+
+            Assert.Same(context1, context2);
+            Assert.Same(context1.Model, context2.Model);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Can_add_derived_context_as_transient(bool addTransientFirst)
+        {
+            var appServiceProivder = addTransientFirst
+                ? new ServiceCollection()
+                    .AddTransient<ConstructorTestContextWithOC1A>()
+                    .AddDbContext<ConstructorTestContextWithOC1A>()
+                    .BuildServiceProvider()
+                : new ServiceCollection()
+                    .AddDbContext<ConstructorTestContextWithOC1A>()
+                    .AddTransient<ConstructorTestContextWithOC1A>()
+                    .BuildServiceProvider();
+
+            var singleton = new object[3];
+
+            using (var serviceScope = appServiceProivder
+                .GetRequiredService<IServiceScopeFactory>()
+                .CreateScope())
+            {
+                var context1 = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC1A>();
+                var context2 = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC1A>();
+
+                Assert.NotSame(context1, context2);
+
+                Assert.NotNull(singleton[0] = context1.GetService<IInMemoryStore>());
+                Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
+                Assert.NotNull(singleton[2] = context1.GetService<IMemoryCache>());
+
+                Assert.NotNull(context1.GetService<ILogger<Random>>());
+
+                context1.Dispose();
+                Assert.Throws<ObjectDisposedException>(() => context1.Model);
+                Assert.NotNull(context2.Model);
+
+                context2.Dispose();
+                Assert.Throws<ObjectDisposedException>(() => context2.Model);
+
+            }
+
+            using (var serviceScope = appServiceProivder
+                .GetRequiredService<IServiceScopeFactory>()
+                .CreateScope())
+            {
+                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC1A>();
+
+                Assert.Same(singleton[0], context.GetService<IInMemoryStore>());
+                Assert.Same(singleton[1], context.GetService<ILoggerFactory>());
+                Assert.Same(singleton[2], context.GetService<IMemoryCache>());
+
+                context.Dispose();
+                Assert.Throws<ObjectDisposedException>(() => context.Model);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Can_add_derived_context_as_transient_controlling_internal_services(bool addTransientFirst)
+        {
+            var appServiceProivder = addTransientFirst
+                ? new ServiceCollection()
+                    .AddEntityFrameworkInMemoryDatabase()
+                    .AddTransient<ConstructorTestContextWithOC1A>()
+                    .AddDbContext<ConstructorTestContextWithOC1A>((p, b) => b.UseInternalServiceProvider(p))
+                    .BuildServiceProvider()
+                : new ServiceCollection()
+                    .AddEntityFrameworkInMemoryDatabase()
+                    .AddDbContext<ConstructorTestContextWithOC1A>((p, b) => b.UseInternalServiceProvider(p))
+                    .AddTransient<ConstructorTestContextWithOC1A>()
+                    .BuildServiceProvider();
+
+            var singleton = new object[3];
+
+            using (var serviceScope = appServiceProivder
+                .GetRequiredService<IServiceScopeFactory>()
+                .CreateScope())
+            {
+                var context1 = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC1A>();
+                var context2 = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC1A>();
+
+                Assert.NotSame(context1, context2);
+
+                Assert.NotNull(singleton[0] = context1.GetService<IInMemoryStore>());
+                Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
+                Assert.NotNull(singleton[2] = context1.GetService<IMemoryCache>());
+
+                Assert.NotNull(context1.GetService<ILogger<Random>>());
+
+                context1.Dispose();
+                Assert.Throws<ObjectDisposedException>(() => context1.Model);
+                Assert.NotNull(context2.Model);
+
+                context2.Dispose();
+                Assert.Throws<ObjectDisposedException>(() => context2.Model);
+
+            }
+
+            using (var serviceScope = appServiceProivder
+                .GetRequiredService<IServiceScopeFactory>()
+                .CreateScope())
+            {
+                var context = serviceScope.ServiceProvider.GetService<ConstructorTestContextWithOC1A>();
+
+                Assert.Same(singleton[0], context.GetService<IInMemoryStore>());
+                Assert.Same(singleton[1], context.GetService<ILoggerFactory>());
+                Assert.Same(singleton[2], context.GetService<IMemoryCache>());
+
+                context.Dispose();
+                Assert.Throws<ObjectDisposedException>(() => context.Model);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Can_add_non_derived_context_as_singleton(bool addSingletonFirst)
+        {
+            var appServiceProivder = addSingletonFirst
+                ? new ServiceCollection()
+                    .AddSingleton<DbContext>()
+                    .AddDbContext<DbContext>(b => b.UseInMemoryDatabase())
+                    .BuildServiceProvider()
+                : new ServiceCollection()
+                    .AddDbContext<DbContext>(b => b.UseInMemoryDatabase())
+                    .AddSingleton<DbContext>()
+                    .BuildServiceProvider();
+
+            var singleton = new object[3];
+            DbContext context1;
+            DbContext context2;
+
+            using (var serviceScope = appServiceProivder
+                .GetRequiredService<IServiceScopeFactory>()
+                .CreateScope())
+            {
+                context1 = serviceScope.ServiceProvider.GetService<DbContext>();
+
+                Assert.NotNull(singleton[0] = context1.GetService<IInMemoryStore>());
+                Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
+                Assert.NotNull(singleton[2] = context1.GetService<IMemoryCache>());
+
+                Assert.NotNull(context1.GetService<ILogger<Random>>());
+            }
+
+            Assert.NotNull(context1.Model);
+
+            using (var serviceScope = appServiceProivder
+                .GetRequiredService<IServiceScopeFactory>()
+                .CreateScope())
+            {
+                context2 = serviceScope.ServiceProvider.GetService<DbContext>();
+
+                Assert.Same(singleton[0], context2.GetService<IInMemoryStore>());
+                Assert.Same(singleton[1], context2.GetService<ILoggerFactory>());
+                Assert.Same(singleton[2], context2.GetService<IMemoryCache>());
+            }
+
+            Assert.Same(context1, context2);
+            Assert.Same(context1.Model, context2.Model);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        public void Can_add_non_derived_context_as_singleton_controlling_internal_services(bool addSingletonFirst, bool addEfFirst)
+        {
+            var serviceCollection = new ServiceCollection();
+
+            if (addEfFirst)
+            {
+                serviceCollection.AddEntityFrameworkInMemoryDatabase();
+            }
+
+            if (addSingletonFirst)
+            {
+                serviceCollection
+                    .AddSingleton<DbContext>()
+                    .AddDbContext<DbContext>((p, b) => b.UseInMemoryDatabase().UseInternalServiceProvider(p));
+            }
+            else
+            {
+                serviceCollection
+                    .AddDbContext<DbContext>((p, b) => b.UseInMemoryDatabase().UseInternalServiceProvider(p))
+                    .AddSingleton<DbContext>();
+            }
+
+            if (!addEfFirst)
+            {
+                serviceCollection.AddEntityFrameworkInMemoryDatabase();
+            }
+
+            var appServiceProivder = serviceCollection.BuildServiceProvider();
+
+            var singleton = new object[3];
+            DbContext context1;
+            DbContext context2;
+
+            using (var serviceScope = appServiceProivder
+                .GetRequiredService<IServiceScopeFactory>()
+                .CreateScope())
+            {
+                context1 = serviceScope.ServiceProvider.GetService<DbContext>();
+
+                Assert.NotNull(singleton[0] = context1.GetService<IInMemoryStore>());
+                Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
+                Assert.NotNull(singleton[2] = context1.GetService<IMemoryCache>());
+
+                Assert.NotNull(context1.GetService<ILogger<Random>>());
+            }
+
+            Assert.NotNull(context1.Model);
+
+            using (var serviceScope = appServiceProivder
+                .GetRequiredService<IServiceScopeFactory>()
+                .CreateScope())
+            {
+                context2 = serviceScope.ServiceProvider.GetService<DbContext>();
+
+                Assert.Same(singleton[0], context2.GetService<IInMemoryStore>());
+                Assert.Same(singleton[1], context2.GetService<ILoggerFactory>());
+                Assert.Same(singleton[2], context2.GetService<IMemoryCache>());
+            }
+
+            Assert.Same(context1, context2);
+            Assert.Same(context1.Model, context2.Model);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Can_add_non_derived_context_as_transient(bool addTransientFirst)
+        {
+            var appServiceProivder = addTransientFirst
+                ? new ServiceCollection()
+                    .AddTransient<DbContext>()
+                    .AddDbContext<DbContext>(b => b.UseInMemoryDatabase())
+                    .BuildServiceProvider()
+                : new ServiceCollection()
+                    .AddDbContext<DbContext>(b => b.UseInMemoryDatabase())
+                    .AddTransient<DbContext>()
+                    .BuildServiceProvider();
+
+            var singleton = new object[3];
+
+            using (var serviceScope = appServiceProivder
+                .GetRequiredService<IServiceScopeFactory>()
+                .CreateScope())
+            {
+                var context1 = serviceScope.ServiceProvider.GetService<DbContext>();
+                var context2 = serviceScope.ServiceProvider.GetService<DbContext>();
+
+                Assert.NotSame(context1, context2);
+
+                Assert.NotNull(singleton[0] = context1.GetService<IInMemoryStore>());
+                Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
+                Assert.NotNull(singleton[2] = context1.GetService<IMemoryCache>());
+
+                Assert.NotNull(context1.GetService<ILogger<Random>>());
+
+                context1.Dispose();
+                Assert.Throws<ObjectDisposedException>(() => context1.Model);
+                Assert.NotNull(context2.Model);
+
+                context2.Dispose();
+                Assert.Throws<ObjectDisposedException>(() => context2.Model);
+
+            }
+
+            using (var serviceScope = appServiceProivder
+                .GetRequiredService<IServiceScopeFactory>()
+                .CreateScope())
+            {
+                var context = serviceScope.ServiceProvider.GetService<DbContext>();
+
+                Assert.Same(singleton[0], context.GetService<IInMemoryStore>());
+                Assert.Same(singleton[1], context.GetService<ILoggerFactory>());
+                Assert.Same(singleton[2], context.GetService<IMemoryCache>());
+
+                context.Dispose();
+                Assert.Throws<ObjectDisposedException>(() => context.Model);
+            }
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        public void Can_add_non_derived_context_as_transient_controlling_internal_services(bool addTransientFirst, bool addEfFirst)
+        {
+            var serviceCollection = new ServiceCollection();
+
+            if (addEfFirst)
+            {
+                serviceCollection.AddEntityFrameworkInMemoryDatabase();
+            }
+
+            if (addTransientFirst)
+            {
+                serviceCollection
+                    .AddTransient<DbContext>()
+                    .AddDbContext<DbContext>((p, b) => b.UseInMemoryDatabase().UseInternalServiceProvider(p));
+            }
+            else
+            {
+                serviceCollection
+                    .AddDbContext<DbContext>((p, b) => b.UseInMemoryDatabase().UseInternalServiceProvider(p))
+                    .AddTransient<DbContext>();
+            }
+
+            if (!addEfFirst)
+            {
+                serviceCollection.AddEntityFrameworkInMemoryDatabase();
+            }
+
+            var appServiceProivder = serviceCollection.BuildServiceProvider();
+
+            var singleton = new object[3];
+
+            using (var serviceScope = appServiceProivder
+                .GetRequiredService<IServiceScopeFactory>()
+                .CreateScope())
+            {
+                var context1 = serviceScope.ServiceProvider.GetService<DbContext>();
+                var context2 = serviceScope.ServiceProvider.GetService<DbContext>();
+
+                Assert.NotSame(context1, context2);
+
+                Assert.NotNull(singleton[0] = context1.GetService<IInMemoryStore>());
+                Assert.NotNull(singleton[1] = context1.GetService<ILoggerFactory>());
+                Assert.NotNull(singleton[2] = context1.GetService<IMemoryCache>());
+
+                Assert.NotNull(context1.GetService<ILogger<Random>>());
+
+                context1.Dispose();
+                Assert.Throws<ObjectDisposedException>(() => context1.Model);
+                Assert.NotNull(context2.Model);
+
+                context2.Dispose();
+                Assert.Throws<ObjectDisposedException>(() => context2.Model);
+
+            }
+
+            using (var serviceScope = appServiceProivder
+                .GetRequiredService<IServiceScopeFactory>()
+                .CreateScope())
+            {
+                var context = serviceScope.ServiceProvider.GetService<DbContext>();
+
+                Assert.Same(singleton[0], context.GetService<IInMemoryStore>());
+                Assert.Same(singleton[1], context.GetService<ILoggerFactory>());
+                Assert.Same(singleton[2], context.GetService<IMemoryCache>());
+
+                context.Dispose();
+                Assert.Throws<ObjectDisposedException>(() => context.Model);
+            }
+        }
+
+        [Fact]
         public void Throws_with_new_when_no_EF_services()
         {
             var options = new DbContextOptionsBuilder<ConstructorTestContext1A>()

--- a/test/Microsoft.EntityFrameworkCore.Tests/EntityFrameworkServiceCollectionExtensionsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/EntityFrameworkServiceCollectionExtensionsTest.cs
@@ -68,7 +68,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
             VerifyScoped<ValueGeneratorSelector>();
 
             VerifyScoped<IModel>();
-            VerifyScoped<DbContext>();
+            VerifyScoped<ICurrentDbContext>();
             VerifyScoped<IDbContextOptions>();
             VerifyScoped<IDatabaseProviderServices>();
             VerifyScoped<IDatabase>();


### PR DESCRIPTION
Because when people use the same service provider for both the application and our internal services and don't create a derived DbContext class, then the two registrations can often collide. See #4750.

The fix is to use the type ICurrentDbContext internally which wraps the context for the current scope.