### PR TITLE
Fix to #4547 - Query :: query source materialized as ValueBuffer rather than entity for some complex cases involving subqueries and conditional operator - causes NRE/InvalidCast

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/Query/EntityQueryModelVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/EntityQueryModelVisitor.cs
@@ -699,8 +699,16 @@ namespace Microsoft.EntityFrameworkCore.Query
                     innerSequenceExpression.Type.GetSequenceType(),
                     groupJoinClause.JoinClause.ItemName);
 
-            _queryCompilationContext.QuerySourceMapping
-                .AddMapping(groupJoinClause.JoinClause, innerItemParameter);
+            if (!_queryCompilationContext.QuerySourceMapping.ContainsMapping(groupJoinClause.JoinClause))
+            {
+                _queryCompilationContext.QuerySourceMapping
+                    .AddMapping(groupJoinClause.JoinClause, innerItemParameter);
+            }
+            else
+            {
+                _queryCompilationContext.QuerySourceMapping
+                    .ReplaceMapping(groupJoinClause.JoinClause, innerItemParameter);
+            }
 
             var innerKeySelectorExpression
                 = ReplaceClauseReferences(groupJoinClause.JoinClause.InnerKeySelector, groupJoinClause);

--- a/test/Microsoft.EntityFrameworkCore.FunctionalTests/ComplexNavigationsQueryTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.FunctionalTests/ComplexNavigationsQueryTestBase.cs
@@ -560,8 +560,7 @@ namespace Microsoft.EntityFrameworkCore.FunctionalTests
             }
         }
 
-        // issue 4547
-        ////[ConditionalFact]
+        [ConditionalFact]
         public virtual void Join_navigation_translated_to_subquery_nested()
         {
             List<Level1> levelOnes;
@@ -594,8 +593,7 @@ namespace Microsoft.EntityFrameworkCore.FunctionalTests
             }
         }
 
-        // issue 4547
-        ////[ConditionalFact]
+        [ConditionalFact]
         public virtual void Join_navigation_translated_to_subquery_deeply_nested_non_key_join()
         {
             List<Level1> levelOnes;
@@ -1985,7 +1983,7 @@ namespace Microsoft.EntityFrameworkCore.FunctionalTests
             }
         }
 
-        ////[ConditionalFact]
+        [ConditionalFact]
         public virtual void Query_source_materialization_bug_4547()
         {
             using (var context = CreateContext())

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/ComplexNavigationsQuerySqlServerTest.cs
@@ -286,15 +286,16 @@ INNER JOIN [Level1] AS [e2] ON [e1].[Id] = (
         {
             base.Join_navigation_translated_to_subquery_nested();
 
-            Assert.Equal(
-                @"SELECT [e3].[Id], [e1].[Id]
-FROM [Level3] AS [e3]
-INNER JOIN [Level1] AS [e1] ON [e3].[Id] = (
-    SELECT TOP(1) [subQuery.OneToOne_Optional_FK0].[Id]
-    FROM [Level2] AS [subQuery0]
-    INNER JOIN [Level3] AS [subQuery.OneToOne_Optional_FK0] ON [subQuery0].[Id] = [subQuery.OneToOne_Optional_FK0].[Level2_Optional_Id]
-    WHERE [subQuery0].[Level1_Required_Id] = [e1].[Id]
-)",
+            Assert.Contains(
+                @"SELECT [e1].[Id]
+FROM [Level1] AS [e1]",
+                Sql);
+
+            Assert.Contains(
+                @"SELECT [subQuery].[Id], [subQuery].[Level1_Optional_Id], [subQuery].[Level1_Required_Id], [subQuery].[Name], [subQuery].[OneToMany_Optional_InverseId], [subQuery].[OneToMany_Optional_Self_InverseId], [subQuery].[OneToMany_Required_InverseId], [subQuery].[OneToMany_Required_Self_InverseId], [subQuery].[OneToOne_Optional_PK_InverseId], [subQuery].[OneToOne_Optional_SelfId], [subQuery.OneToOne_Optional_FK].[Id], [subQuery.OneToOne_Optional_FK].[Level2_Optional_Id], [subQuery.OneToOne_Optional_FK].[Level2_Required_Id], [subQuery.OneToOne_Optional_FK].[Name], [subQuery.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [subQuery.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [subQuery.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [subQuery.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [subQuery.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [subQuery.OneToOne_Optional_FK].[OneToOne_Optional_SelfId]
+FROM [Level2] AS [subQuery]
+LEFT JOIN [Level3] AS [subQuery.OneToOne_Optional_FK] ON [subQuery].[Id] = [subQuery.OneToOne_Optional_FK].[Level2_Optional_Id]
+ORDER BY [subQuery].[Id]",
                 Sql);
         }
 
@@ -302,16 +303,21 @@ INNER JOIN [Level1] AS [e1] ON [e3].[Id] = (
         {
             base.Join_navigation_translated_to_subquery_deeply_nested_non_key_join();
 
-            Assert.Equal(
-                @"SELECT [e4].[Id], [e4].[Name], [e1].[Id], [e1].[Name]
-FROM [Level4] AS [e4]
-INNER JOIN [Level1] AS [e1] ON [e4].[Name] = (
-    SELECT TOP(1) [subQuery.OneToOne_Optional_FK.OneToOne_Required_PK0].[Name]
-    FROM [Level2] AS [subQuery0]
-    INNER JOIN [Level3] AS [subQuery.OneToOne_Optional_FK0] ON [subQuery0].[Id] = [subQuery.OneToOne_Optional_FK0].[Level2_Optional_Id]
-    INNER JOIN [Level4] AS [subQuery.OneToOne_Optional_FK.OneToOne_Required_PK0] ON [subQuery.OneToOne_Optional_FK0].[Id] = [subQuery.OneToOne_Optional_FK.OneToOne_Required_PK0].[Id]
-    WHERE [subQuery0].[Level1_Required_Id] = [e1].[Id]
-)",
+            Assert.Contains(
+                @"SELECT [e1].[Id], [e1].[Name]
+FROM [Level1] AS [e1]", 
+                Sql);
+
+            Assert.Contains(
+                @"SELECT [subQuery.OneToOne_Optional_FK.OneToOne_Required_PK].[Id], [subQuery.OneToOne_Optional_FK.OneToOne_Required_PK].[Level3_Optional_Id], [subQuery.OneToOne_Optional_FK.OneToOne_Required_PK].[Level3_Required_Id], [subQuery.OneToOne_Optional_FK.OneToOne_Required_PK].[Name], [subQuery.OneToOne_Optional_FK.OneToOne_Required_PK].[OneToMany_Optional_InverseId], [subQuery.OneToOne_Optional_FK.OneToOne_Required_PK].[OneToMany_Optional_Self_InverseId], [subQuery.OneToOne_Optional_FK.OneToOne_Required_PK].[OneToMany_Required_InverseId], [subQuery.OneToOne_Optional_FK.OneToOne_Required_PK].[OneToMany_Required_Self_InverseId], [subQuery.OneToOne_Optional_FK.OneToOne_Required_PK].[OneToOne_Optional_PK_InverseId], [subQuery.OneToOne_Optional_FK.OneToOne_Required_PK].[OneToOne_Optional_SelfId]
+FROM [Level4] AS [subQuery.OneToOne_Optional_FK.OneToOne_Required_PK]",
+                Sql);
+
+            Assert.Contains(
+                @"SELECT [subQuery].[Id], [subQuery].[Level1_Optional_Id], [subQuery].[Level1_Required_Id], [subQuery].[Name], [subQuery].[OneToMany_Optional_InverseId], [subQuery].[OneToMany_Optional_Self_InverseId], [subQuery].[OneToMany_Required_InverseId], [subQuery].[OneToMany_Required_Self_InverseId], [subQuery].[OneToOne_Optional_PK_InverseId], [subQuery].[OneToOne_Optional_SelfId], [subQuery.OneToOne_Optional_FK].[Id], [subQuery.OneToOne_Optional_FK].[Level2_Optional_Id], [subQuery.OneToOne_Optional_FK].[Level2_Required_Id], [subQuery.OneToOne_Optional_FK].[Name], [subQuery.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [subQuery.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [subQuery.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [subQuery.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [subQuery.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [subQuery.OneToOne_Optional_FK].[OneToOne_Optional_SelfId]
+FROM [Level2] AS [subQuery]
+LEFT JOIN [Level3] AS [subQuery.OneToOne_Optional_FK] ON [subQuery].[Id] = [subQuery.OneToOne_Optional_FK].[Level2_Optional_Id]
+ORDER BY [subQuery].[Id]",
                 Sql);
         }
 
@@ -944,8 +950,19 @@ ORDER BY [e2].[Id]",
         {
             base.Query_source_materialization_bug_4547();
 
-            Assert.Equal(
-                @"",
+            Assert.StartsWith(
+                @"SELECT [e1].[Id]
+FROM [Level1] AS [e1]
+
+SELECT [subQuery2].[Id], [subQuery2].[Level1_Optional_Id], [subQuery2].[Level1_Required_Id], [subQuery2].[Name], [subQuery2].[OneToMany_Optional_InverseId], [subQuery2].[OneToMany_Optional_Self_InverseId], [subQuery2].[OneToMany_Required_InverseId], [subQuery2].[OneToMany_Required_Self_InverseId], [subQuery2].[OneToOne_Optional_PK_InverseId], [subQuery2].[OneToOne_Optional_SelfId], [subQuery3].[Id], [subQuery3].[Level2_Optional_Id], [subQuery3].[Level2_Required_Id], [subQuery3].[Name], [subQuery3].[OneToMany_Optional_InverseId], [subQuery3].[OneToMany_Optional_Self_InverseId], [subQuery3].[OneToMany_Required_InverseId], [subQuery3].[OneToMany_Required_Self_InverseId], [subQuery3].[OneToOne_Optional_PK_InverseId], [subQuery3].[OneToOne_Optional_SelfId]
+FROM [Level2] AS [subQuery2]
+LEFT JOIN [Level3] AS [subQuery3] ON [subQuery2].[Id] = [subQuery3].[Level2_Optional_Id]
+ORDER BY [subQuery2].[Id]
+
+SELECT [subQuery2].[Id], [subQuery2].[Level1_Optional_Id], [subQuery2].[Level1_Required_Id], [subQuery2].[Name], [subQuery2].[OneToMany_Optional_InverseId], [subQuery2].[OneToMany_Optional_Self_InverseId], [subQuery2].[OneToMany_Required_InverseId], [subQuery2].[OneToMany_Required_Self_InverseId], [subQuery2].[OneToOne_Optional_PK_InverseId], [subQuery2].[OneToOne_Optional_SelfId], [subQuery3].[Id], [subQuery3].[Level2_Optional_Id], [subQuery3].[Level2_Required_Id], [subQuery3].[Name], [subQuery3].[OneToMany_Optional_InverseId], [subQuery3].[OneToMany_Optional_Self_InverseId], [subQuery3].[OneToMany_Required_InverseId], [subQuery3].[OneToMany_Required_Self_InverseId], [subQuery3].[OneToOne_Optional_PK_InverseId], [subQuery3].[OneToOne_Optional_SelfId]
+FROM [Level2] AS [subQuery2]
+LEFT JOIN [Level3] AS [subQuery3] ON [subQuery2].[Id] = [subQuery3].[Level2_Optional_Id]
+ORDER BY [subQuery2].[Id]",
                 Sql);
         }
 


### PR DESCRIPTION
Issue is that some queries reference result of SelectMany-GroupJoin-DefaultIfEmpty in a subquery scenario but those underlying query sources were not marked for materialization.
Fix is to add those additional sources to the list of queries to be materialized, similar to what we do for the non-subquery case.