### PR TITLE
Make Attach never have side effect of setting dependent entities as Modified

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/NavigationFixer.cs
@@ -512,6 +512,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                         var navigationValue = entry[principalToDependent];
                         if (navigationValue != null)
                         {
+                            var setModified = entry.EntityState != EntityState.Unchanged;
+
                             if (principalToDependent.IsCollection())
                             {
                                 var dependents = ((IEnumerable)navigationValue).Cast<object>();
@@ -527,7 +529,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                                     }
                                     else
                                     {
-                                        FixupToDependent(entry, dependentEntry, foreignKey, setModified: true);
+                                        FixupToDependent(entry, dependentEntry, foreignKey, setModified);
                                     }
                                 }
                             }
@@ -543,7 +545,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                                 }
                                 else
                                 {
-                                    FixupToDependent(entry, dependentEntry, foreignKey, setModified: true);
+                                    FixupToDependent(entry, dependentEntry, foreignKey, setModified);
                                 }
                             }
                         }
@@ -595,10 +597,10 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             if (navigationValue != null)
             {
+                var setModified = referencedEntry.EntityState != EntityState.Unchanged;
+
                 if (!navigation.IsDependentToPrincipal())
                 {
-                    var setModified = referencedEntry.EntityState != EntityState.Unchanged;
-
                     if (navigation.IsCollection())
                     {
                         if (navigation.GetCollectionAccessor().Contains(entry.Entity, referencedEntry.Entity))
@@ -613,7 +615,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 }
                 else if (referencedEntry.Entity == navigationValue)
                 {
-                    FixupToPrincipal(entry, referencedEntry, navigation.ForeignKey, setModified: true);
+                    FixupToPrincipal(entry, referencedEntry, navigation.ForeignKey, setModified);
                 }
             }
         }

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/FixupTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/FixupTest.cs
@@ -55,12 +55,6 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 Assert.Same(principal, dependent.Category);
                 Assert.Equal(new[] { dependent }.ToList(), principal.Products);
                 Assert.Equal(entityState, context.Entry(principal).State);
-
-                if (entityState == EntityState.Unchanged)
-                {
-                    // Dependent FK gets modified when principal is attached 
-                    entityState = EntityState.Modified;
-                }
                 Assert.Equal(entityState, context.Entry(dependent).State);
             }
         }
@@ -151,12 +145,6 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 Assert.Same(principal, dependent.Category);
                 Assert.Equal(new[] { dependent }.ToList(), principal.Products);
                 Assert.Equal(entityState, context.Entry(principal).State);
-
-                if (entityState == EntityState.Unchanged)
-                {
-                    // Dependent FK gets modified when principal is attached 
-                    entityState = EntityState.Modified;
-                }
                 Assert.Equal(entityState, context.Entry(dependent).State);
             }
         }
@@ -179,12 +167,6 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 Assert.Same(principal, dependent.Category);
                 Assert.Equal(new[] { dependent }.ToList(), principal.Products);
                 Assert.Equal(entityState, context.Entry(principal).State);
-
-                if (entityState == EntityState.Unchanged)
-                {
-                    // Dependent FK gets modified when principal is attached 
-                    entityState = EntityState.Modified;
-                }
                 Assert.Equal(entityState, context.Entry(dependent).State);
             }
         }
@@ -429,12 +411,6 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 Assert.Equal(principal.Id, dependent.CategoryId);
                 Assert.Equal(new[] { dependent }.ToList(), principal.Products);
                 Assert.Equal(entityState, context.Entry(principal).State);
-
-                if (entityState == EntityState.Unchanged)
-                {
-                    // Dependent FK gets modified when principal is attached 
-                    entityState = EntityState.Modified;
-                }
                 Assert.Equal(entityState, context.Entry(dependent).State);
             }
         }
@@ -542,12 +518,6 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 Assert.Equal(principal.Id, dependent.CategoryId);
                 Assert.Same(principal, dependent.Category);
                 Assert.Equal(entityState, context.Entry(principal).State);
-
-                if (entityState == EntityState.Unchanged)
-                {
-                    // Dependent FK gets modified when principal is attached 
-                    entityState = EntityState.Modified;
-                }
                 Assert.Equal(entityState, context.Entry(dependent).State);
             }
         }
@@ -698,12 +668,6 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 Assert.Same(principal, dependent.Parent);
                 Assert.Same(dependent, principal.Child);
                 Assert.Equal(entityState, context.Entry(principal).State);
-
-                if (entityState == EntityState.Unchanged)
-                {
-                    // Dependent FK gets modified when principal is attached 
-                    entityState = EntityState.Modified;
-                }
                 Assert.Equal(entityState, context.Entry(dependent).State);
             }
         }
@@ -794,12 +758,6 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 Assert.Same(principal, dependent.Parent);
                 Assert.Same(dependent, principal.Child);
                 Assert.Equal(entityState, context.Entry(principal).State);
-
-                if (entityState == EntityState.Unchanged)
-                {
-                    // Dependent FK gets modified when principal is attached 
-                    entityState = EntityState.Modified;
-                }
                 Assert.Equal(entityState, context.Entry(dependent).State);
             }
         }
@@ -822,12 +780,6 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 Assert.Same(principal, dependent.Parent);
                 Assert.Same(dependent, principal.Child);
                 Assert.Equal(entityState, context.Entry(principal).State);
-
-                if (entityState == EntityState.Unchanged)
-                {
-                    // Dependent FK gets modified when principal is attached 
-                    entityState = EntityState.Modified;
-                }
                 Assert.Equal(entityState, context.Entry(dependent).State);
             }
         }
@@ -1072,12 +1024,6 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 Assert.Equal(principal.Id, dependent.ParentId);
                 Assert.Same(dependent, principal.Child);
                 Assert.Equal(entityState, context.Entry(principal).State);
-
-                if (entityState == EntityState.Unchanged)
-                {
-                    // Dependent FK gets modified when principal is attached 
-                    entityState = EntityState.Modified;
-                }
                 Assert.Equal(entityState, context.Entry(dependent).State);
             }
         }
@@ -1185,12 +1131,6 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 Assert.Equal(principal.Id, dependent.ParentId);
                 Assert.Same(principal, dependent.Parent);
                 Assert.Equal(entityState, context.Entry(principal).State);
-
-                if (entityState == EntityState.Unchanged)
-                {
-                    // Dependent FK gets modified when principal is attached 
-                    entityState = EntityState.Modified;
-                }
                 Assert.Equal(entityState, context.Entry(dependent).State);
             }
         }

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/ShadowFkFixupTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/ShadowFkFixupTest.cs
@@ -56,12 +56,6 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 Assert.Same(principal, dependent.Category);
                 Assert.Equal(new[] { dependent }.ToList(), principal.Products);
                 Assert.Equal(entityState, context.Entry(principal).State);
-
-                if (entityState == EntityState.Unchanged)
-                {
-                    // Dependent FK gets modified when principal is attached 
-                    entityState = EntityState.Modified;
-                }
                 Assert.Equal(entityState, context.Entry(dependent).State);
             }
         }
@@ -158,12 +152,6 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 Assert.Same(principal, dependent.Category);
                 Assert.Equal(new[] { dependent }.ToList(), principal.Products);
                 Assert.Equal(entityState, context.Entry(principal).State);
-
-                if (entityState == EntityState.Unchanged)
-                {
-                    // Dependent FK gets modified when principal is attached 
-                    entityState = EntityState.Modified;
-                }
                 Assert.Equal(entityState, context.Entry(dependent).State);
             }
         }
@@ -186,12 +174,6 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 Assert.Same(principal, dependent.Category);
                 Assert.Equal(new[] { dependent }.ToList(), principal.Products);
                 Assert.Equal(entityState, context.Entry(principal).State);
-
-                if (entityState == EntityState.Unchanged)
-                {
-                    // Dependent FK gets modified when principal is attached 
-                    entityState = EntityState.Modified;
-                }
                 Assert.Equal(entityState, context.Entry(dependent).State);
             }
         }
@@ -450,12 +432,6 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
                 Assert.Equal(new[] { dependent }.ToList(), principal.Products);
                 Assert.Equal(entityState, context.Entry(principal).State);
-
-                if (entityState == EntityState.Unchanged)
-                {
-                    // Dependent FK gets modified when principal is attached 
-                    entityState = EntityState.Modified;
-                }
                 Assert.Equal(entityState, context.Entry(dependent).State);
             }
         }
@@ -569,12 +545,6 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 Assert.Equal(principal.Id, context.Entry(dependent).Property("CategoryId").CurrentValue);
                 Assert.Same(principal, dependent.Category);
                 Assert.Equal(entityState, context.Entry(principal).State);
-
-                if (entityState == EntityState.Unchanged)
-                {
-                    // Dependent FK gets modified when principal is attached 
-                    entityState = EntityState.Modified;
-                }
                 Assert.Equal(entityState, context.Entry(dependent).State);
             }
         }
@@ -735,12 +705,6 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 Assert.Same(principal, dependent.Parent);
                 Assert.Same(dependent, principal.Child);
                 Assert.Equal(entityState, context.Entry(principal).State);
-
-                if (entityState == EntityState.Unchanged)
-                {
-                    // Dependent FK gets modified when principal is attached 
-                    entityState = EntityState.Modified;
-                }
                 Assert.Equal(entityState, context.Entry(dependent).State);
             }
         }
@@ -837,12 +801,6 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 Assert.Same(principal, dependent.Parent);
                 Assert.Same(dependent, principal.Child);
                 Assert.Equal(entityState, context.Entry(principal).State);
-
-                if (entityState == EntityState.Unchanged)
-                {
-                    // Dependent FK gets modified when principal is attached 
-                    entityState = EntityState.Modified;
-                }
                 Assert.Equal(entityState, context.Entry(dependent).State);
             }
         }
@@ -865,12 +823,6 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 Assert.Same(principal, dependent.Parent);
                 Assert.Same(dependent, principal.Child);
                 Assert.Equal(entityState, context.Entry(principal).State);
-
-                if (entityState == EntityState.Unchanged)
-                {
-                    // Dependent FK gets modified when principal is attached 
-                    entityState = EntityState.Modified;
-                }
                 Assert.Equal(entityState, context.Entry(dependent).State);
             }
         }
@@ -1129,12 +1081,6 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
                 Assert.Same(dependent, principal.Child);
                 Assert.Equal(entityState, context.Entry(principal).State);
-
-                if (entityState == EntityState.Unchanged)
-                {
-                    // Dependent FK gets modified when principal is attached 
-                    entityState = EntityState.Modified;
-                }
                 Assert.Equal(entityState, context.Entry(dependent).State);
             }
         }
@@ -1248,12 +1194,6 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 Assert.Equal(principal.Id, context.Entry(dependent).Property("ParentId").CurrentValue);
                 Assert.Same(principal, dependent.Parent);
                 Assert.Equal(entityState, context.Entry(principal).State);
-
-                if (entityState == EntityState.Unchanged)
-                {
-                    // Dependent FK gets modified when principal is attached 
-                    entityState = EntityState.Modified;
-                }
                 Assert.Equal(entityState, context.Entry(dependent).State);
             }
         }

--- a/test/Microsoft.EntityFrameworkCore.Tests/DbContextTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/DbContextTest.cs
@@ -1018,8 +1018,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.Same(product, category.Products.Single());
                 Assert.Same(category, product.Category);
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
-                // Product ends up modified because when category is attached the FK of product is changed
-                Assert.Equal(EntityState.Modified, context.Entry(product).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
 
                 context.Attach(category);
 
@@ -1027,7 +1026,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.Same(product, category.Products.Single());
                 Assert.Same(category, product.Category);
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
-                Assert.Equal(EntityState.Modified, context.Entry(product).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
             }
         }
 
@@ -1073,8 +1072,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.Same(product, category.Products.Single());
                 Assert.Same(category, product.Category);
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
-                // Product ends up modified because when category is attached the FK of product is changed
-                Assert.Equal(EntityState.Modified, context.Entry(product).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
 
                 context.Attach(category);
 
@@ -1082,7 +1080,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.Same(product, category.Products.Single());
                 Assert.Same(category, product.Category);
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
-                Assert.Equal(EntityState.Modified, context.Entry(product).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
             }
         }
 
@@ -1136,8 +1134,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.Same(product, category.Products.Single());
                 Assert.Same(category, product.Category);
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
-                // Product ends up modified because when category is attached the FK of product is changed
-                Assert.Equal(EntityState.Modified, context.Entry(product).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
             }
         }
 
@@ -1193,8 +1190,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.Same(product, category.Products.Single());
                 Assert.Same(category, product.Category);
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
-                // Product ends up modified because when category is attached the FK of product is changed
-                Assert.Equal(EntityState.Modified, context.Entry(product).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
             }
         }
 
@@ -1248,8 +1244,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.Same(product, category.Products.Single());
                 Assert.Same(category, product.Category);
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
-                // Product ends up modified because when category is attached the FK of product is changed
-                Assert.Equal(EntityState.Modified, context.Entry(product).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
             }
         }
 
@@ -1303,8 +1298,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.Same(product, category.Products.Single());
                 Assert.Same(category, product.Category);
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
-                // Product ends up modified because when category is attached the FK of product is changed
-                Assert.Equal(EntityState.Modified, context.Entry(product).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
             }
         }
 
@@ -1366,8 +1360,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.Same(product, category.Products.Single());
                 Assert.Same(category, product.Category);
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
-                // Product ends up modified because when category is attached the FK of product is changed
-                Assert.Equal(EntityState.Modified, context.Entry(product).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
             }
         }
 
@@ -1490,8 +1483,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.Same(product, category.Products.Single());
                 Assert.Same(category, product.Category);
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
-                // Product ends up modified because when category is attached the FK of product is changed
-                Assert.Equal(EntityState.Modified, context.Entry(product).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
             }
         }
 
@@ -1552,8 +1544,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.Same(product, category.Products.Single());
                 Assert.Same(category, product.Category);
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
-                // Product ends up modified because when category is attached the FK of product is changed
-                Assert.Equal(EntityState.Modified, context.Entry(product).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
             }
         }
 
@@ -1676,8 +1667,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
                 Assert.Same(product, category.Products.Single());
                 Assert.Same(category, product.Category);
                 Assert.Equal(EntityState.Unchanged, context.Entry(category).State);
-                // Product ends up modified because when category is attached the FK of product is changed
-                Assert.Equal(EntityState.Modified, context.Entry(product).State);
+                Assert.Equal(EntityState.Unchanged, context.Entry(product).State);
             }
         }
 


### PR DESCRIPTION
This means that graph Attach calls behave as expected no matter which entity is attached first or which mechanism is used, and work correctly with shadow FKs.

It also means that re-parenting an attached dependent cannot be done by setting a new principal to point to it, and then attaching that principal. But attaching the principal and then setting the navigation property will work.

/cc @divega @rowanmiller 