### PR TITLE
Remove-Migration -Force

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Commands/Design/MigrationsOperations.cs
+++ b/src/Microsoft.EntityFrameworkCore.Commands/Design/MigrationsOperations.cs
@@ -141,7 +141,7 @@ namespace Microsoft.EntityFrameworkCore.Design
         }
 
         public virtual MigrationFiles RemoveMigration(
-            [CanBeNull] string contextType)
+            [CanBeNull] string contextType, bool force)
         {
             using (var context = _contextOperations.CreateContext(contextType))
             {
@@ -150,7 +150,7 @@ namespace Microsoft.EntityFrameworkCore.Design
 
                 var scaffolder = services.GetRequiredService<MigrationsScaffolder>();
 
-                var files = scaffolder.RemoveMigration(_projectDir, _rootNamespace);
+                var files = scaffolder.RemoveMigration(_projectDir, _rootNamespace, force);
 
                 _logger.Value.LogInformation(CommandsStrings.Done);
 

--- a/src/Microsoft.EntityFrameworkCore.Commands/Design/OperationExecutor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Commands/Design/OperationExecutor.cs
@@ -195,15 +195,16 @@ namespace Microsoft.EntityFrameworkCore.Design
                 Check.NotNull(args, nameof(args));
 
                 var contextType = (string)args["contextType"];
+                var force = args.Contains("force") && (bool)args["force"];
 
-                Execute(() => executor.RemoveMigrationImpl(contextType));
+                Execute(() => executor.RemoveMigrationImpl(contextType, force));
             }
         }
 
-        private IEnumerable<string> RemoveMigrationImpl([CanBeNull] string contextType)
+        private IEnumerable<string> RemoveMigrationImpl([CanBeNull] string contextType, bool force)
         {
             var files = _migrationsOperations.Value
-                .RemoveMigration(contextType);
+                .RemoveMigration(contextType, force);
 
             if (files.MigrationFile != null)
             {

--- a/src/Microsoft.EntityFrameworkCore.Commands/Migrations/Design/MigrationsScaffolder.cs
+++ b/src/Microsoft.EntityFrameworkCore.Commands/Migrations/Design/MigrationsScaffolder.cs
@@ -188,7 +188,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                     : @namespace;
 
         // TODO: DRY (file names)
-        public virtual MigrationFiles RemoveMigration([NotNull] string projectDir, [NotNull] string rootNamespace)
+        public virtual MigrationFiles RemoveMigration([NotNull] string projectDir, [NotNull] string rootNamespace, bool force)
         {
             Check.NotEmpty(projectDir, nameof(projectDir));
             Check.NotEmpty(rootNamespace, nameof(rootNamespace));
@@ -214,7 +214,11 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
 
                 if (!_modelDiffer.HasDifferences(model, modelSnapshot.Model))
                 {
-                    if (_historyRepository.GetAppliedMigrations().Any(
+                    if (force)
+                    {
+                        _logger.Value.LogWarning(CommandsStrings.ForceRemoveMigration(migration.GetId()));
+                    }
+                    else if (_historyRepository.GetAppliedMigrations().Any(
                         e => e.MigrationId.Equals(migration.GetId(), StringComparison.OrdinalIgnoreCase)))
                     {
                         throw new InvalidOperationException(CommandsStrings.UnapplyMigration(migration.GetId()));

--- a/src/Microsoft.EntityFrameworkCore.Commands/Properties/CommandsStrings.Designer.cs
+++ b/src/Microsoft.EntityFrameworkCore.Commands/Properties/CommandsStrings.Designer.cs
@@ -301,7 +301,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
-        /// Your target project '{assembly}' doesn't match your migrations assembly '{migrationsAssembly}'. Change your target project to the migrations project by using the Package Manager Console's Default project drop-down list or by using the '--targetProject' option for DNX commands. Change your migrations assembly by using DbContextOptionsBuilder. E.g. options.UseSqlServer(connection, b => b.MigrationsAssembly("{assembly}"))
+        /// Your target project '{assembly}' doesn't match your migrations assembly '{migrationsAssembly}'. Change your target project to the migrations project by using the Package Manager Console's Default project drop-down list or by using the '--targetProject' option for DNX commands. Change your migrations assembly by using DbContextOptionsBuilder. E.g. options.UseSqlServer(connection, b =&gt; b.MigrationsAssembly("{assembly}"))
         /// </summary>
         public static string MigrationsAssemblyMismatch([CanBeNull] object assembly, [CanBeNull] object migrationsAssembly)
         {
@@ -314,6 +314,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
         public static string SensitiveInformationWarning
         {
             get { return GetString("SensitiveInformationWarning"); }
+        }
+
+        /// <summary>
+        /// Removing migration '{name}' without checking the database. If this migration has been applied to the database, you will need to manually reverse the changes it made.
+        /// </summary>
+        public static string ForceRemoveMigration([CanBeNull] object name)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("ForceRemoveMigration", "name"), name);
         }
 
         private static string GetString(string name, params string[] formatterNames)

--- a/src/Microsoft.EntityFrameworkCore.Commands/Properties/CommandsStrings.resx
+++ b/src/Microsoft.EntityFrameworkCore.Commands/Properties/CommandsStrings.resx
@@ -232,4 +232,7 @@
     <value>To protect potentially sensitive information in your connection string, you should move it out of source code. See http://go.microsoft.com/fwlink/?LinkId=723263 for guidance on storing connection strings.</value>
     <comment>Localize the URL if we have localized docs.</comment>
   </data>
+  <data name="ForceRemoveMigration" xml:space="preserve">
+    <value>Removing migration '{name}' without checking the database. If this migration has been applied to the database, you will need to manually reverse the changes it made.</value>
+  </data>
 </root>

--- a/src/dotnet-ef/MigrationsRemoveCommand.cs
+++ b/src/dotnet-ef/MigrationsRemoveCommand.cs
@@ -21,6 +21,10 @@ namespace Microsoft.EntityFrameworkCore.Commands
             var environment = command.Option(
                 "-e|--environment <environment>",
                 "The environment to use. If omitted, \"Development\" is used.");
+            var force = command.Option(
+                "-f|--force",
+                "Removes the last migration without checking the database. If the last migration has been applied to the database, you will need to manually reverse the changes it made.",
+                CommandOptionType.NoValue);
             command.HelpOption();
             command.VerboseOption();
 
@@ -28,13 +32,14 @@ namespace Microsoft.EntityFrameworkCore.Commands
                 () => Execute(
                     context.Value(),
                     startupProject.Value(),
-                    environment.Value()));
+                    environment.Value(),
+                    force.HasValue()));
         }
 
-        private static int Execute(string context, string startupProject, string environment)
+        private static int Execute(string context, string startupProject, string environment, bool force)
         {
             new OperationExecutor(startupProject, environment)
-                .RemoveMigration(context);
+                .RemoveMigration(context, force);
 
             return 0;
         }

--- a/src/dotnet-ef/OperationExecutor.cs
+++ b/src/dotnet-ef/OperationExecutor.cs
@@ -135,8 +135,8 @@ namespace Microsoft.EntityFrameworkCore.Commands
             [CanBeNull] string contextType)
             => _migrationsOperations.Value.ScriptMigration(fromMigration, toMigration, idempotent, contextType);
 
-        public virtual MigrationFiles RemoveMigration([CanBeNull] string contextType)
-            => _migrationsOperations.Value.RemoveMigration(contextType);
+        public virtual MigrationFiles RemoveMigration([CanBeNull] string contextType, bool force)
+            => _migrationsOperations.Value.RemoveMigration(contextType, force);
 
         public virtual IEnumerable<Type> GetContextTypes()
             => _contextOperations.Value.GetContextTypes();


### PR DESCRIPTION
cc @bricelam 
Fix https://github.com/aspnet/EntityFramework/issues/4812.
Allows user to force remove the last migration, skipping over database check.