### PR TITLE
[TINY] Reorder parameters in exceptions thrown from PropertyMappingValidationConvention

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/PropertyMappingValidationConvention.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/PropertyMappingValidationConvention.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 if (unmappedProperty != null)
                 {
                     throw new InvalidOperationException(CoreStrings.PropertyNotMapped(
-                        unmappedProperty.Name, unmappedProperty.ClrType.DisplayName(fullName: false), entityType.DisplayName()));
+                        entityType.DisplayName(), unmappedProperty.Name, unmappedProperty.ClrType.DisplayName(fullName: false)));
                 }
 
                 if (entityType.HasClrType())
@@ -55,24 +55,24 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                                 if (!modelBuilder.IsIgnored(targetType.DisplayName(), ConfigurationSource.Convention))
                                 {
                                     throw new InvalidOperationException(CoreStrings.NavigationNotAdded(
-                                        actualProperty.Name, propertyType.DisplayName(fullName: false), entityType.DisplayName()));
+                                        entityType.DisplayName(), actualProperty.Name, propertyType.DisplayName(fullName: false)));
                                 }
                             }
                             else if (propertyType.IsPrimitive())
                             {
                                 throw new InvalidOperationException(CoreStrings.PropertyNotMapped(
-                                    actualProperty.Name, propertyType.DisplayName(fullName: false), entityType.DisplayName()));
+                                    entityType.DisplayName(), actualProperty.Name, propertyType.DisplayName(fullName: false)));
                             }
                             else if (propertyType.GetTypeInfo().IsInterface
                                      || (targetSequenceType != null && targetSequenceType.GetTypeInfo().IsInterface))
                             {
                                 throw new InvalidOperationException(CoreStrings.InterfacePropertyNotAdded(
-                                    actualProperty.Name, propertyType.DisplayName(fullName: false), entityType.DisplayName()));
+                                    entityType.DisplayName(), actualProperty.Name, propertyType.DisplayName(fullName: false)));
                             }
                             else
                             {
                                 throw new InvalidOperationException(CoreStrings.PropertyNotAdded(
-                                    actualProperty.Name, propertyType.DisplayName(fullName: false), entityType.DisplayName()));
+                                    entityType.DisplayName(), actualProperty.Name, propertyType.DisplayName(fullName: false)));
                             }
                         }
                     }

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Metadata/Conventions/Internal/RelationalPropertyMappingValidationConventionTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Metadata/Conventions/Internal/RelationalPropertyMappingValidationConventionTest.cs
@@ -19,7 +19,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Metadata.Conventions.In
             var entityTypeBuilder = modelBuilder.Entity(typeof(NonPrimitiveAsPropertyEntity), ConfigurationSource.Convention);
             entityTypeBuilder.Property("Property", typeof(long), ConfigurationSource.Convention);
 
-            Assert.Equal(CoreStrings.PropertyNotMapped("Property", typeof(long).DisplayName(fullName: false), typeof(NonPrimitiveAsPropertyEntity).DisplayName(fullName: false)),
+            Assert.Equal(CoreStrings.PropertyNotMapped(
+                typeof(NonPrimitiveAsPropertyEntity).DisplayName(fullName: false), "Property", typeof(long).DisplayName(fullName: false)),
                 Assert.Throws<InvalidOperationException>(() => CreateConvention().Apply(modelBuilder)).Message);
         }
 
@@ -30,7 +31,8 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Metadata.Conventions.In
             var entityTypeBuilder = modelBuilder.Entity(typeof(NonPrimitiveAsPropertyEntity), ConfigurationSource.Convention);
             entityTypeBuilder.Property("Property", typeof(long), ConfigurationSource.Convention).Relational(ConfigurationSource.Convention).HasColumnType("some_int_mapping");
 
-            Assert.Equal(CoreStrings.PropertyNotMapped("Property", typeof(long).DisplayName(fullName: false), typeof(NonPrimitiveAsPropertyEntity).DisplayName(fullName: false)),
+            Assert.Equal(CoreStrings.PropertyNotMapped(
+                typeof(NonPrimitiveAsPropertyEntity).DisplayName(fullName: false), "Property", typeof(long).DisplayName(fullName: false)),
                 Assert.Throws<InvalidOperationException>(() => CreateConvention().Apply(modelBuilder)).Message);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/PropertyMappingValidationConventionTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/PropertyMappingValidationConventionTest.cs
@@ -21,7 +21,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
             entityTypeBuilder.Property("Property", typeof(NavigationAsProperty), ConfigurationSource.Convention);
 
             Assert.Equal(CoreStrings.PropertyNotMapped(
-                "Property", typeof(NavigationAsProperty).DisplayName(fullName: false), typeof(NonPrimitiveAsPropertyEntity).DisplayName(fullName: false)),
+                typeof(NonPrimitiveAsPropertyEntity).DisplayName(fullName: false),
+                "Property",
+                typeof(NavigationAsProperty).DisplayName(fullName: false)),
                 Assert.Throws<InvalidOperationException>(() => CreateConvention().Apply(modelBuilder)).Message);
         }
 
@@ -32,7 +34,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
             var entityTypeBuilder = modelBuilder.Entity(typeof(PrimitivePropertyEntity), ConfigurationSource.Convention);
 
             Assert.Equal(
-                CoreStrings.PropertyNotMapped("Property", typeof(int).DisplayName(), typeof(PrimitivePropertyEntity).DisplayName(fullName: false)),
+                CoreStrings.PropertyNotMapped(
+                    typeof(PrimitivePropertyEntity).DisplayName(fullName: false), "Property", typeof(int).DisplayName()),
                 Assert.Throws<InvalidOperationException>(() => CreateConvention().Apply(modelBuilder)).Message);
         }
 
@@ -43,7 +46,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
             var entityTypeBuilder = modelBuilder.Entity(typeof(NonPrimitiveValueTypePropertyEntity), ConfigurationSource.Convention);
 
             Assert.Equal(
-                CoreStrings.PropertyNotAdded("Property", typeof(CancellationToken).Name, typeof(NonPrimitiveValueTypePropertyEntity).DisplayName(fullName: false)),
+                CoreStrings.PropertyNotAdded(
+                    typeof(NonPrimitiveValueTypePropertyEntity).DisplayName(fullName: false), "Property", typeof(CancellationToken).Name),
                 Assert.Throws<InvalidOperationException>(() => CreateConvention().Apply(modelBuilder)).Message);
         }
 
@@ -74,7 +78,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
             var entityTypeBuilder = modelBuilder.Entity(typeof(NavigationEntity), ConfigurationSource.Convention);
 
             Assert.Equal(
-                CoreStrings.NavigationNotAdded("Navigation", typeof(PrimitivePropertyEntity).Name, typeof(NavigationEntity).DisplayName(fullName: false)),
+                CoreStrings.NavigationNotAdded(typeof(NavigationEntity).DisplayName(fullName: false), "Navigation", typeof(PrimitivePropertyEntity).Name),
                 Assert.Throws<InvalidOperationException>(() => CreateConvention().Apply(modelBuilder)).Message);
         }
 
@@ -129,7 +133,9 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
             var entityTypeBuilder = modelBuilder.Entity(typeof(InterfaceNavigationEntity), ConfigurationSource.Convention);
 
             Assert.Equal(CoreStrings.InterfacePropertyNotAdded(
-                "Navigation", typeof(IList<INavigationEntity>).DisplayName(fullName: false), typeof(InterfaceNavigationEntity).DisplayName(fullName: false)),
+                typeof(InterfaceNavigationEntity).DisplayName(fullName: false),
+                "Navigation",
+                typeof(IList<INavigationEntity>).DisplayName(fullName: false)),
                 Assert.Throws<InvalidOperationException>(() => CreateConvention().Apply(modelBuilder)).Message);
         }
 


### PR DESCRIPTION
Fixes #4746