### PR TITLE
Avoid re-ordering of projections in case of complex projections

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/RelationalProjectionExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/RelationalProjectionExpressionVisitor.cs
@@ -98,6 +98,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                 && !(node is ConstantExpression)
                 && (selectExpression != null))
             {
+                var existingProjectionsCount = selectExpression.Projection.Count;
+
                 var sqlExpression
                     = _sqlTranslatingExpressionVisitorFactory
                         .Create(QueryModelVisitor, selectExpression, inProjection: true)
@@ -112,6 +114,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                 }
                 else
                 {
+                    selectExpression.RemoveRangeFromProjection(existingProjectionsCount);
+
                     if (!(node is NewExpression))
                     {
                         AliasExpression aliasExpression;

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/SelectExpression.cs
@@ -351,11 +351,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
                 return AddToProjection(aliasExpression);
             }
 
-            if (expression is SelectExpression)
-            {
-                ClearColumnProjections();
-            }
-
             _projection.Add(expression);
 
             if (resetProjectStar)

--- a/test/Microsoft.EntityFrameworkCore.FunctionalTests/QueryTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.FunctionalTests/QueryTestBase.cs
@@ -4148,7 +4148,7 @@ namespace Microsoft.EntityFrameworkCore.FunctionalTests
                 asserter:
                     (l2oResults, efResults) =>
                     {
-                         Assert.Equal(l2oResults.Count, efResults.Count);
+                        Assert.Equal(l2oResults.Count, efResults.Count);
                     });
         }
 
@@ -4762,17 +4762,17 @@ namespace Microsoft.EntityFrameworkCore.FunctionalTests
             {
                 var orders
                     = (from o in context.Orders.Take(2)
-                      // ReSharper disable once UseMethodAny.0
-                      where (from od in context.OrderDetails.Take(2)
-                             where (from c in context.Set<Customer>()
-                                    where c.CustomerID == o.CustomerID
-                                    select c).First().Country
-                                   == (from o2 in context.Set<Order>()
-                                       join c in context.Set<Customer>() on o2.CustomerID equals c.CustomerID
-                                       where o2.OrderID == od.OrderID
-                                       select c).First().Country
-                             select od).Count() > 0
-                      select o).ToList();
+                           // ReSharper disable once UseMethodAny.0
+                       where (from od in context.OrderDetails.Take(2)
+                              where (from c in context.Set<Customer>()
+                                     where c.CustomerID == o.CustomerID
+                                     select c).First().Country
+                                    == (from o2 in context.Set<Order>()
+                                        join c in context.Set<Customer>() on o2.CustomerID equals c.CustomerID
+                                        where o2.OrderID == od.OrderID
+                                        select c).First().Country
+                              select od).Count() > 0
+                       select o).ToList();
 
                 Assert.Equal(1, orders.Count);
             }
@@ -4803,6 +4803,24 @@ namespace Microsoft.EntityFrameworkCore.FunctionalTests
                     CoreStrings.ConcurrentMethodInvocation,
                     Assert.Throws<InvalidOperationException>(
                         () => context.Customers.First()).Message);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Does_not_change_ordering_of_projection_with_complex_projections()
+        {
+            using (var context = CreateContext())
+            {
+                var q = from c in context.Customers.Include(e => e.Orders).Where(c => c.ContactTitle == "Owner")
+                        select new
+                        {
+                            Id = c.CustomerID,
+                            TotalOrders = c.Orders.Count
+                        };
+
+                var result = q.Where(e => e.TotalOrders > 2).ToList();
+
+                Assert.Equal(15, result.Count);
             }
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QueryNavigationsSqlServerTest.cs
@@ -447,7 +447,7 @@ FROM [Customers] AS [c]",
     SELECT COUNT(*)
     FROM [Order Details] AS [o2]
     WHERE [o].[OrderID] = [o2].[OrderID]
-), (
+), [o].[OrderDate], (
     SELECT CASE
         WHEN EXISTS (
             SELECT 1
@@ -470,7 +470,7 @@ END, [o].[OrderID], (
     SELECT COUNT_BIG(*)
     FROM [Order Details] AS [o3]
     WHERE [o].[OrderID] = [o3].[OrderID]
-), [o].[OrderDate]
+)
 FROM [Orders] AS [o]
 WHERE [o].[CustomerID] LIKE N'A' + N'%'",
                 Sql);

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -4723,6 +4723,24 @@ ORDER BY COALESCE([c].[Region], N'ZZ')",
                 Sql);
         }
 
+        public override void Does_not_change_ordering_of_projection_with_complex_projections()
+        {
+            base.Does_not_change_ordering_of_projection_with_complex_projections();
+
+            Assert.StartsWith(
+                @"SELECT [e].[CustomerID], (
+    SELECT COUNT(*)
+    FROM [Orders] AS [o1]
+    WHERE [e].[CustomerID] = [o1].[CustomerID]
+)
+FROM [Customers] AS [e]
+WHERE [e].[ContactTitle] = N'Owner'
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]",
+                Sql);
+        }
+
         private static string FileLineEnding = @"
 ";
 


### PR DESCRIPTION
resolves #4094
The issue: When we added complex projection to the Sql, we removed the scalar projections from it. They get re-added while binding but this changes the order in which projections appear. In the case of #4094, we had to do filter on client eval, due to re-ordering the filter condition still used old index which was wrong. Based on the type of the projection at that index, it threw InvalidCastException or gave incorrect results.

Fix:When we visit the SelectClause we record the present projection count. These projections are already present and required by WhereClause. Then we visit the Selector and if we lift the query we remove additional projections added while visiting the selector using previously recorded count.