### PR TITLE
Adds Timestamps, InstanceId and Duration to Diagnostic Source events

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Internal/RelationalDiagnosticSourceAfterMessage.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Internal/RelationalDiagnosticSourceAfterMessage.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Data.Common;
+
+namespace Microsoft.EntityFrameworkCore.Internal
+{
+    // TODO revert to anonymous types when https://github.com/dotnet/corefx/issues/4672 is fixed
+    internal class RelationalDiagnosticSourceAfterMessage
+    {
+        public DbCommand Command { get; set; }
+        public string ExecuteMethod { get; set; }
+        public bool IsAsync { get; set; }
+        public Guid InstanceId { get; set; }
+        public long Timestamp { get; set; }
+        public long Duration { get; set; }
+        public Exception Exception { get; set; }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Relational/Internal/RelationalDiagnosticSourceBeforeMessage.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Internal/RelationalDiagnosticSourceBeforeMessage.cs
@@ -7,11 +7,12 @@ using System.Data.Common;
 namespace Microsoft.EntityFrameworkCore.Internal
 {
     // TODO revert to anonymous types when https://github.com/dotnet/corefx/issues/4672 is fixed
-    internal class RelationalDiagnosticSourceMessage
+    internal class RelationalDiagnosticSourceBeforeMessage
     {
         public DbCommand Command { get; set; }
         public string ExecuteMethod { get; set; }
         public bool IsAsync { get; set; }
-        public Exception Exception { get; set; }
+        public Guid InstanceId { get; set; }
+        public long Timestamp { get; set; }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Microsoft.EntityFrameworkCore.Relational.csproj
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Microsoft.EntityFrameworkCore.Relational.csproj
@@ -77,7 +77,8 @@
     <Compile Include="Infrastructure\RelationalLoggingEventId.cs" />
     <Compile Include="Infrastructure\RelationalOptionsExtension.cs" />
     <Compile Include="Internal\RelationalDiagnostics.cs" />
-    <Compile Include="Internal\RelationalDiagnosticSourceMessage.cs" />
+    <Compile Include="Internal\RelationalDiagnosticSourceAfterMessage.cs" />
+    <Compile Include="Internal\RelationalDiagnosticSourceBeforeMessage.cs" />
     <Compile Include="Internal\RelationalModelValidator.cs" />
     <Compile Include="Metadata\Builders\DiscriminatorBuilder.cs" />
     <Compile Include="Metadata\Builders\DiscriminatorBuilder`.cs" />

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Storage/RelationalCommandTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Storage/RelationalCommandTest.cs
@@ -1022,8 +1022,8 @@ Logged Command",
             Assert.Equal(RelationalDiagnostics.BeforeExecuteCommand, diagnostic[0].Item1);
             Assert.Equal(RelationalDiagnostics.AfterExecuteCommand, diagnostic[1].Item1);
 
-            var beforeData = (RelationalDiagnosticSourceMessage)diagnostic[0].Item2;
-            var afterData = (RelationalDiagnosticSourceMessage)diagnostic[1].Item2;
+            var beforeData = (RelationalDiagnosticSourceBeforeMessage)diagnostic[0].Item2;
+            var afterData = (RelationalDiagnosticSourceAfterMessage)diagnostic[1].Item2;
 
             Assert.Equal(fakeConnection.DbConnections[0].DbCommands[0], beforeData.Command);
             Assert.Equal(fakeConnection.DbConnections[0].DbCommands[0], afterData.Command);
@@ -1090,8 +1090,8 @@ Logged Command",
             Assert.Equal(RelationalDiagnostics.BeforeExecuteCommand, diagnostic[0].Item1);
             Assert.Equal(RelationalDiagnostics.CommandExecutionError, diagnostic[1].Item1);
 
-            var beforeData = (RelationalDiagnosticSourceMessage)diagnostic[0].Item2;
-            var afterData = (RelationalDiagnosticSourceMessage)diagnostic[1].Item2;
+            var beforeData = (RelationalDiagnosticSourceBeforeMessage)diagnostic[0].Item2;
+            var afterData = (RelationalDiagnosticSourceAfterMessage)diagnostic[1].Item2;
 
             Assert.Equal(fakeDbConnection.DbCommands[0], beforeData.Command);
             Assert.Equal(fakeDbConnection.DbCommands[0], afterData.Command);


### PR DESCRIPTION
This brings DiagnosticSource usage inline with what we have been doing elsewhere. 
 - **Timing**: usage has been converted from using a new instance of `StopWatch` to using `Stopwatch.GetTimestamp()`. This has been well [documented](https://github.com/aspnet/Hosting/pull/543) to have better performance than other alternatives. 
 - **TimeStamp**: `timestamp` has ben added to the begin/end payloads so that all consumers of logging and DiagnosticSource will be showing the same times when using EF based events
 - **Correlation**: `InstanceId` has ben added to the payload so that consumers can correlate begin and end messages together in a deterministic way without haven't to maintain state across events
     - Note: Strictly speaking other areas where we are using this, the Id is "global" to the instance of the object. In this case that dosn't work as technically the command object can be used multiple times. Semantically, that means that the Id is unique to the call not the instance of the containing object, but I *think?* the still holds given that its the instance of the command being executed.
 - **Duration**: `duration` has ben added to the payload so that consumers don't have to listen to both the begin and end message to easily be able to determine how long a request took... this has the potential to make the whole system more performant as it means that less people should have the need to tap the begin message
     - Note: I removing the `RelationalDiagnosticSourceMessage` and creating the `RelationalDiagnosticSourceBeforeMessage`/`RelationalDiagnosticSourceAfterMessage` instead. Strictly speaking I didn't need to do this, but it seemed weird to have `duration` on the begin message.
     - Note: I updated the centralized logging implementation to access the start/end timestamp instead of `elapsedMilliseconds` so that the calculations of the milliseconds would only occur as needed when logging is enabled. 

Note: I changed the position of when the events get run to be slightly more consistent with other areas where we are doing this with Try/Catch blocks. In these cases, we have been running the end event as the last thing inside of the try block... In this case doing that means that means that the main semantic difference is that we would be running the event before a potential connection close. That meant that I shifted the begin event to after the potential connection open. Given that the timing data we are looking at is around command execution time, this seemed liked a ok change.

Let me know if there is any feedback.

@anpete @divega