### PR TITLE
Introduce an Unknown state for property values

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/InternalMixedEntityEntry.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/InternalMixedEntityEntry.cs
@@ -20,6 +20,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         {
             Entity = entity;
             _shadowValues = entityType.GetEmptyShadowValuesFactory()();
+
+            // ReSharper disable once DoNotCallOverridableMethodsInConstructor
+            MarkShadowPropertiesNotSet(entityType);
         }
 
         public InternalMixedEntityEntry(

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/InternalShadowEntityEntry.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/InternalShadowEntityEntry.cs
@@ -21,6 +21,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             : base(stateManager, entityType)
         {
             _propertyValues = entityType.GetEmptyShadowValuesFactory()();
+
+            // ReSharper disable once DoNotCallOverridableMethodsInConstructor
+            MarkShadowPropertiesNotSet(entityType);
         }
 
         public InternalShadowEntityEntry(

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/StateData.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/StateData.cs
@@ -10,7 +10,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         internal enum PropertyFlag
         {
             TemporaryOrModified = 0,
-            Null = 1
+            Null = 1,
+            Unknown = 2
         }
 
         internal struct StateData
@@ -18,11 +19,12 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             private const int BitsPerInt = 32;
             private const int BitsForEntityState = 3;
             private const int BitsForEntityFlags = 1;
-            private const int BitsForPropertyFlags = 2;
+            private const int BitsForPropertyFlags = 4;
             private const int BitsForAdditionalState = BitsForEntityState + BitsForEntityFlags;
             private const int EntityStateMask = 0x07;
             private const int UnusedStateMask = 0x08; // So entity state uses even number of bits
             private const int AdditionalStateMask = EntityStateMask | UnusedStateMask;
+            private const int PropertyFlagMask = 0x11111111;
 
             private readonly int[] _bits;
 
@@ -77,7 +79,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             private static int CreateMaskForRead(int i, PropertyFlag propertyFlag)
             {
-                var mask = 0x55555555 << (int)propertyFlag;
+                var mask = PropertyFlagMask << (int)propertyFlag;
                 if (i == 0)
                 {
                     mask &= ~AdditionalStateMask;
@@ -92,7 +94,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
                 if (i == _bits.Length - 1)
                 {
-                    var overlay = 0x55555555 << (int)propertyFlag;
+                    var overlay = PropertyFlagMask << (int)propertyFlag;
                     var shift = (propertyCount * BitsForPropertyFlags + BitsForAdditionalState) % BitsPerInt;
                     overlay = shift != 0 ? overlay << shift : 0;
                     mask &= ~overlay;

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/InternalEntityEntryTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/InternalEntityEntryTestBase.cs
@@ -95,7 +95,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
             entry.SetEntityState(EntityState.Modified);
 
             Assert.False(entry.IsModified(keyProperty));
-            Assert.True(entry.IsModified(nonKeyProperty));
+            Assert.NotEqual(nonKeyProperty.IsShadowProperty, entry.IsModified(nonKeyProperty));
 
             entry.SetEntityState(EntityState.Unchanged, true);
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/StateDataTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ChangeTracking/Internal/StateDataTest.cs
@@ -16,7 +16,8 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 PropertyManipulation(
                     i,
                     InternalEntityEntry.PropertyFlag.TemporaryOrModified,
-                    InternalEntityEntry.PropertyFlag.Null);
+                    InternalEntityEntry.PropertyFlag.Null,
+                    InternalEntityEntry.PropertyFlag.Unknown);
             }
         }
 
@@ -28,19 +29,35 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 PropertyManipulation(
                     i,
                     InternalEntityEntry.PropertyFlag.Null,
-                    InternalEntityEntry.PropertyFlag.TemporaryOrModified);
+                    InternalEntityEntry.PropertyFlag.TemporaryOrModified,
+                    InternalEntityEntry.PropertyFlag.Unknown);
+            }
+        }
+
+        [Fact]
+        public void Can_read_and_manipulate_not_set_flags()
+        {
+            for (var i = 0; i < 70; i++)
+            {
+                PropertyManipulation(
+                    i,
+                    InternalEntityEntry.PropertyFlag.Unknown,
+                    InternalEntityEntry.PropertyFlag.TemporaryOrModified,
+                    InternalEntityEntry.PropertyFlag.Null);
             }
         }
 
         private void PropertyManipulation(
             int propertyCount,
             InternalEntityEntry.PropertyFlag propertyFlag,
-            InternalEntityEntry.PropertyFlag unusedFlag)
+            InternalEntityEntry.PropertyFlag unusedFlag1,
+            InternalEntityEntry.PropertyFlag unusedFlag2)
         {
             var data = new InternalEntityEntry.StateData(propertyCount);
 
             Assert.False(data.AnyPropertiesFlagged(propertyFlag));
-            Assert.False(data.AnyPropertiesFlagged(unusedFlag));
+            Assert.False(data.AnyPropertiesFlagged(unusedFlag1));
+            Assert.False(data.AnyPropertiesFlagged(unusedFlag2));
 
             for (var i = 0; i < propertyCount; i++)
             {
@@ -49,11 +66,13 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 for (var j = 0; j < propertyCount; j++)
                 {
                     Assert.Equal(j <= i, data.IsPropertyFlagged(j, propertyFlag));
-                    Assert.False(data.IsPropertyFlagged(j, unusedFlag));
+                    Assert.False(data.IsPropertyFlagged(j, unusedFlag1));
+                    Assert.False(data.IsPropertyFlagged(j, unusedFlag2));
                 }
 
                 Assert.True(data.AnyPropertiesFlagged(propertyFlag));
-                Assert.False(data.AnyPropertiesFlagged(unusedFlag));
+                Assert.False(data.AnyPropertiesFlagged(unusedFlag1));
+                Assert.False(data.AnyPropertiesFlagged(unusedFlag2));
             }
 
             for (var i = 0; i < propertyCount; i++)
@@ -63,39 +82,46 @@ namespace Microsoft.EntityFrameworkCore.Tests.ChangeTracking.Internal
                 for (var j = 0; j < propertyCount; j++)
                 {
                     Assert.Equal(j > i, data.IsPropertyFlagged(j, propertyFlag));
-                    Assert.False(data.IsPropertyFlagged(j, unusedFlag));
+                    Assert.False(data.IsPropertyFlagged(j, unusedFlag1));
+                    Assert.False(data.IsPropertyFlagged(j, unusedFlag2));
                 }
 
                 Assert.Equal(i < propertyCount - 1, data.AnyPropertiesFlagged(propertyFlag));
-                Assert.False(data.AnyPropertiesFlagged(unusedFlag));
+                Assert.False(data.AnyPropertiesFlagged(unusedFlag1));
+                Assert.False(data.AnyPropertiesFlagged(unusedFlag2));
             }
 
             for (var i = 0; i < propertyCount; i++)
             {
                 Assert.False(data.IsPropertyFlagged(i, propertyFlag));
-                Assert.False(data.IsPropertyFlagged(i, unusedFlag));
+                Assert.False(data.IsPropertyFlagged(i, unusedFlag1));
+                Assert.False(data.IsPropertyFlagged(i, unusedFlag2));
             }
 
             data.FlagAllProperties(propertyCount, propertyFlag, flagged: true);
 
             Assert.Equal(propertyCount > 0, data.AnyPropertiesFlagged(propertyFlag));
-            Assert.False(data.AnyPropertiesFlagged(unusedFlag));
+            Assert.False(data.AnyPropertiesFlagged(unusedFlag1));
+            Assert.False(data.AnyPropertiesFlagged(unusedFlag2));
 
             for (var i = 0; i < propertyCount; i++)
             {
                 Assert.True(data.IsPropertyFlagged(i, propertyFlag));
-                Assert.False(data.IsPropertyFlagged(i, unusedFlag));
+                Assert.False(data.IsPropertyFlagged(i, unusedFlag1));
+                Assert.False(data.IsPropertyFlagged(i, unusedFlag2));
             }
 
             data.FlagAllProperties(propertyCount, propertyFlag, flagged: false);
 
             Assert.False(data.AnyPropertiesFlagged(propertyFlag));
-            Assert.False(data.AnyPropertiesFlagged(unusedFlag));
+            Assert.False(data.AnyPropertiesFlagged(unusedFlag1));
+            Assert.False(data.AnyPropertiesFlagged(unusedFlag2));
 
             for (var i = 0; i < propertyCount; i++)
             {
                 Assert.False(data.IsPropertyFlagged(i, propertyFlag));
-                Assert.False(data.IsPropertyFlagged(i, unusedFlag));
+                Assert.False(data.IsPropertyFlagged(i, unusedFlag1));
+                Assert.False(data.IsPropertyFlagged(i, unusedFlag2));
             }
         }
 


### PR DESCRIPTION
Shadow properties get this state when entities are first attached. These properties are then not considered modified even if the entire entity is marked as modified and so the values for these properties are not saved. The properties are only considered as modified or not when an actual value is set.

See #4474