### PR TITLE
Split storage of default value SQL and computed value SQL

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Commands/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Commands/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -247,12 +247,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
 
             GenerateFluentApiForAnnotation(ref annotations, RelationalFullAnnotationNames.Instance.ColumnName, nameof(RelationalPropertyBuilderExtensions.HasColumnName), stringBuilder);
             GenerateFluentApiForAnnotation(ref annotations, RelationalFullAnnotationNames.Instance.ColumnType, nameof(RelationalPropertyBuilderExtensions.HasColumnType), stringBuilder);
-            GenerateFluentApiForAnnotation(ref annotations,
-                RelationalFullAnnotationNames.Instance.GeneratedValueSql,
-                property.ValueGenerated == ValueGenerated.OnAdd
-                    ? nameof(RelationalPropertyBuilderExtensions.HasDefaultValueSql)
-                    : nameof(RelationalPropertyBuilderExtensions.HasComputedColumnSql),
-                stringBuilder);
+            GenerateFluentApiForAnnotation(ref annotations, RelationalFullAnnotationNames.Instance.DefaultValueSql, nameof(RelationalPropertyBuilderExtensions.HasDefaultValueSql), stringBuilder);
+            GenerateFluentApiForAnnotation(ref annotations, RelationalFullAnnotationNames.Instance.ComputedValueSql, nameof(RelationalPropertyBuilderExtensions.HasComputedColumnSql), stringBuilder);
             GenerateFluentApiForAnnotation(ref annotations, RelationalFullAnnotationNames.Instance.DefaultValue, nameof(RelationalPropertyBuilderExtensions.HasDefaultValue), stringBuilder);
 
             GenerateAnnotations(annotations, stringBuilder);

--- a/src/Microsoft.EntityFrameworkCore.Commands/Scaffolding/Internal/Configuration/ModelConfiguration.cs
+++ b/src/Microsoft.EntityFrameworkCore.Commands/Scaffolding/Internal/Configuration/ModelConfiguration.cs
@@ -353,6 +353,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal.Configuration
             AddMaxLengthConfiguration(propertyConfiguration);
             AddDefaultValueConfiguration(propertyConfiguration);
             AddDefaultExpressionConfiguration(propertyConfiguration);
+            AddComputedExpressionConfiguration(propertyConfiguration);
             AddValueGeneratedConfiguration(propertyConfiguration);
         }
 
@@ -419,7 +420,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal.Configuration
                     if (_keyConvention.FindValueGeneratedOnAddProperty(
                         new List<Property> { (Property)propertyConfiguration.Property },
                         (EntityType)propertyConfiguration.EntityConfiguration.EntityType) == null
-                        && ExtensionsProvider.For(propertyConfiguration.Property).GeneratedValueSql == null)
+                        && ExtensionsProvider.For(propertyConfiguration.Property).DefaultValueSql == null)
                     {
                         propertyConfiguration.FluentApiConfigurations.Add(
                             _configurationFactory.CreateFluentApiConfiguration(
@@ -527,14 +528,30 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal.Configuration
         {
             Check.NotNull(propertyConfiguration, nameof(propertyConfiguration));
 
-            if (ExtensionsProvider.For(propertyConfiguration.Property).GeneratedValueSql != null)
+            if (ExtensionsProvider.For(propertyConfiguration.Property).DefaultValueSql != null)
             {
                 propertyConfiguration.FluentApiConfigurations.Add(
                     _configurationFactory.CreateFluentApiConfiguration(
                         /* hasAttributeEquivalent */ false,
                         nameof(RelationalPropertyBuilderExtensions.HasDefaultValueSql),
                         CSharpUtilities.DelimitString(
-                            ExtensionsProvider.For(propertyConfiguration.Property).GeneratedValueSql)));
+                            ExtensionsProvider.For(propertyConfiguration.Property).DefaultValueSql)));
+            }
+        }
+
+        public virtual void AddComputedExpressionConfiguration(
+            [NotNull] PropertyConfiguration propertyConfiguration)
+        {
+            Check.NotNull(propertyConfiguration, nameof(propertyConfiguration));
+
+            if (ExtensionsProvider.For(propertyConfiguration.Property).ComputedValueSql != null)
+            {
+                propertyConfiguration.FluentApiConfigurations.Add(
+                    _configurationFactory.CreateFluentApiConfiguration(
+                        /* hasAttributeEquivalent */ false,
+                        nameof(RelationalPropertyBuilderExtensions.HasComputedColumnSql),
+                        CSharpUtilities.DelimitString(
+                            ExtensionsProvider.For(propertyConfiguration.Property).ComputedValueSql)));
             }
         }
 

--- a/src/Microsoft.EntityFrameworkCore.Relational/Metadata/IRelationalPropertyAnnotations.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Metadata/IRelationalPropertyAnnotations.cs
@@ -7,7 +7,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
     {
         string ColumnName { get; }
         string ColumnType { get; }
-        string GeneratedValueSql { get; }
+        string DefaultValueSql { get; }
+        string ComputedValueSql { get; }
         object DefaultValue { get; }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Metadata/Internal/RelationalAnnotationNames.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Metadata/Internal/RelationalAnnotationNames.cs
@@ -8,7 +8,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public const string Prefix = "Relational:";
         public const string ColumnName = "ColumnName";
         public const string ColumnType = "ColumnType";
-        public const string GeneratedValueSql = "GeneratedValueSql";
+        public const string DefaultValueSql = "DefaultValueSql";
+        public const string ComputedValueSql = "ComputedValueSql";
         public const string DefaultValue = "DefaultValue";
         public const string DatabaseName = "DatabaseName";
         public const string TableName = "TableName";

--- a/src/Microsoft.EntityFrameworkCore.Relational/Metadata/Internal/RelationalFullAnnotationNames.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Metadata/Internal/RelationalFullAnnotationNames.cs
@@ -9,7 +9,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         {
             ColumnName = prefix + RelationalAnnotationNames.ColumnName;
             ColumnType = prefix + RelationalAnnotationNames.ColumnType;
-            GeneratedValueSql = prefix + RelationalAnnotationNames.GeneratedValueSql;
+            DefaultValueSql = prefix + RelationalAnnotationNames.DefaultValueSql;
+            ComputedValueSql = prefix + RelationalAnnotationNames.ComputedValueSql;
             DefaultValue = prefix + RelationalAnnotationNames.DefaultValue;
             DatabaseName = prefix + RelationalAnnotationNames.DatabaseName;
             TableName = prefix + RelationalAnnotationNames.TableName;
@@ -25,7 +26,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         public readonly string ColumnName;
         public readonly string ColumnType;
-        public readonly string GeneratedValueSql;
+        public readonly string DefaultValueSql;
+        public readonly string ComputedValueSql;
         public readonly string DefaultValue;
         public readonly string DatabaseName;
         public readonly string TableName;

--- a/src/Microsoft.EntityFrameworkCore.Relational/Metadata/Internal/RelationalPropertyBuilderAnnotations.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Metadata/Internal/RelationalPropertyBuilderAnnotations.cs
@@ -19,7 +19,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         public virtual bool HasColumnType([CanBeNull] string value) => SetColumnType(value);
 
-        public virtual bool HasGeneratedValueSql([CanBeNull] string value) => SetGeneratedValueSql(value);
+        public virtual bool HasDefaultValueSql([CanBeNull] string value) => SetDefaultValueSql(value);
+
+        public virtual bool HasComputedValueSql([CanBeNull] string value) => SetComputedValueSql(value);
 
         public virtual bool HasDefaultValue([CanBeNull] object value) => SetDefaultValue(value);
     }

--- a/src/Microsoft.EntityFrameworkCore.Relational/Metadata/RelationalPropertyAnnotations.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Metadata/RelationalPropertyAnnotations.cs
@@ -66,21 +66,39 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                 ProviderFullAnnotationNames?.ColumnType,
                 Check.NullButNotEmpty(value, nameof(value)));
 
-        public virtual string GeneratedValueSql
+        public virtual string DefaultValueSql
         {
             get
             {
                 return (string)Annotations.GetAnnotation(
-                    RelationalFullAnnotationNames.Instance.GeneratedValueSql,
-                    ProviderFullAnnotationNames?.GeneratedValueSql);
+                    RelationalFullAnnotationNames.Instance.DefaultValueSql,
+                    ProviderFullAnnotationNames?.DefaultValueSql);
             }
-            [param: CanBeNull] set { SetGeneratedValueSql(value); }
+            [param: CanBeNull] set { SetDefaultValueSql(value); }
         }
 
-        protected virtual bool SetGeneratedValueSql([CanBeNull] string value)
+        protected virtual bool SetDefaultValueSql([CanBeNull] string value)
             => Annotations.SetAnnotation(
-                RelationalFullAnnotationNames.Instance.GeneratedValueSql,
-                ProviderFullAnnotationNames?.GeneratedValueSql,
+                RelationalFullAnnotationNames.Instance.DefaultValueSql,
+                ProviderFullAnnotationNames?.DefaultValueSql,
+                Check.NullButNotEmpty(value, nameof(value)));
+
+        public virtual string ComputedValueSql
+        {
+            get
+            {
+                return (string)Annotations.GetAnnotation(
+                    RelationalFullAnnotationNames.Instance.ComputedValueSql,
+                    ProviderFullAnnotationNames?.ComputedValueSql);
+            }
+            [param: CanBeNull]
+            set { SetComputedValueSql(value); }
+        }
+
+        protected virtual bool SetComputedValueSql([CanBeNull] string value)
+            => Annotations.SetAnnotation(
+                RelationalFullAnnotationNames.Instance.ComputedValueSql,
+                ProviderFullAnnotationNames?.ComputedValueSql,
                 Check.NullButNotEmpty(value, nameof(value)));
 
         public virtual object DefaultValue

--- a/src/Microsoft.EntityFrameworkCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -446,7 +446,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
 
             if (isNullableChanged
                 || columnTypeChanged
-                || (sourceAnnotations.GeneratedValueSql != targetAnnotations.GeneratedValueSql)
+                || sourceAnnotations.DefaultValueSql != targetAnnotations.DefaultValueSql
+                || sourceAnnotations.ComputedValueSql != targetAnnotations.ComputedValueSql
                 || !Equals(sourceAnnotations.DefaultValue, targetAnnotations.DefaultValue)
                 || HasDifferences(MigrationsAnnotations.For(source), targetMigrationsAnnotations))
             {
@@ -463,8 +464,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     ColumnType = targetAnnotations.ColumnType,
                     IsNullable = isTargetColumnNullable,
                     DefaultValue = targetAnnotations.DefaultValue,
-                    DefaultValueSql = target.ValueGenerated == ValueGenerated.OnAdd ? targetAnnotations.GeneratedValueSql : null,
-                    ComputedColumnSql = target.ValueGenerated == ValueGenerated.OnAddOrUpdate ? targetAnnotations.GeneratedValueSql : null,
+                    DefaultValueSql = targetAnnotations.DefaultValueSql,
+                    ComputedColumnSql = targetAnnotations.ComputedValueSql,
                     IsDestructiveChange = isDestructiveChange
                 };
                 CopyAnnotations(targetMigrationsAnnotations, alterColumnOperation);
@@ -490,8 +491,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                                ?? (inline || target.IsColumnNullable()
                                    ? null
                                    : GetDefaultValue(target.ClrType)),
-                DefaultValueSql = target.ValueGenerated == ValueGenerated.OnAdd ? targetAnnotations.GeneratedValueSql : null,
-                ComputedColumnSql = target.ValueGenerated == ValueGenerated.OnAddOrUpdate ? targetAnnotations.GeneratedValueSql : null
+                DefaultValueSql = targetAnnotations.DefaultValueSql,
+                ComputedColumnSql = targetAnnotations.ComputedValueSql
             };
             CopyAnnotations(MigrationsAnnotations.For(target), operation);
 

--- a/src/Microsoft.EntityFrameworkCore.Relational/RelationalPropertyBuilderExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/RelationalPropertyBuilderExtensions.cs
@@ -61,7 +61,7 @@ namespace Microsoft.EntityFrameworkCore
                 property.SetValueGenerated(ValueGenerated.OnAdd, ConfigurationSource.Convention);
             }
 
-            propertyBuilder.GetInfrastructure<InternalPropertyBuilder>().Relational(ConfigurationSource.Explicit).HasGeneratedValueSql(sql);
+            propertyBuilder.GetInfrastructure<InternalPropertyBuilder>().Relational(ConfigurationSource.Explicit).HasDefaultValueSql(sql);
 
             return propertyBuilder;
         }
@@ -84,7 +84,7 @@ namespace Microsoft.EntityFrameworkCore
                 property.SetValueGenerated(ValueGenerated.OnAddOrUpdate, ConfigurationSource.Convention);
             }
 
-            propertyBuilder.GetInfrastructure<InternalPropertyBuilder>().Relational(ConfigurationSource.Explicit).HasGeneratedValueSql(sql);
+            propertyBuilder.GetInfrastructure<InternalPropertyBuilder>().Relational(ConfigurationSource.Explicit).HasComputedValueSql(sql);
 
             return propertyBuilder;
         }

--- a/src/Microsoft.EntityFrameworkCore.SqlServer.Design/SqlServerScaffoldingModelFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer.Design/SqlServerScaffoldingModelFactory.cs
@@ -214,7 +214,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding
             if (column.DefaultValue != null)
             {
                 ((Property)propertyBuilder.Metadata).SetValueGenerated(null, ConfigurationSource.Explicit);
-                propertyBuilder.Metadata.Relational().GeneratedValueSql = null;
+                propertyBuilder.Metadata.Relational().DefaultValueSql = null;
 
                 var defaultExpression = ConvertSqlServerDefaultValue(column.DefaultValue);
                 if (defaultExpression != null)

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Extensions/SqlServerPropertyBuilderExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Extensions/SqlServerPropertyBuilderExtensions.cs
@@ -60,7 +60,7 @@ namespace Microsoft.EntityFrameworkCore
                 property.SetValueGenerated(ValueGenerated.OnAdd, ConfigurationSource.Convention);
             }
 
-            propertyBuilder.Metadata.SqlServer().GeneratedValueSql = sql;
+            propertyBuilder.Metadata.SqlServer().DefaultValueSql = sql;
 
             return propertyBuilder;
         }
@@ -105,7 +105,7 @@ namespace Microsoft.EntityFrameworkCore
                 property.SetValueGenerated(ValueGenerated.OnAddOrUpdate, ConfigurationSource.Convention);
             }
 
-            propertyBuilder.Metadata.SqlServer().GeneratedValueSql = sql;
+            propertyBuilder.Metadata.SqlServer().ComputedValueSql = sql;
 
             return propertyBuilder;
         }

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Metadata/Internal/SqlServerPropertyBuilderAnnotations.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Metadata/Internal/SqlServerPropertyBuilderAnnotations.cs
@@ -19,7 +19,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         public new virtual bool ColumnType([CanBeNull] string value) => SetColumnType(value);
 
-        public new virtual bool GeneratedValueSql([CanBeNull] string value) => SetGeneratedValueSql(value);
+        public new virtual bool DefaultValueSql([CanBeNull] string value) => SetDefaultValueSql(value);
+
+        public new virtual bool ComputedValueSql([CanBeNull] string value) => SetComputedValueSql(value);
 
         public new virtual bool DefaultValue([CanBeNull] object value) => SetDefaultValue(value);
 

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Metadata/SqlServerPropertyAnnotations.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Metadata/SqlServerPropertyAnnotations.cs
@@ -49,9 +49,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         {
             get
             {
-                if ((Property.ValueGenerated != ValueGenerated.OnAdd)
+                if (Property.ValueGenerated != ValueGenerated.OnAdd
                     || !Property.ClrType.UnwrapNullableType().IsInteger()
-                    || (Property.SqlServer().GeneratedValueSql != null))
+                    || Property.SqlServer().DefaultValueSql != null)
                 {
                     return null;
                 }
@@ -71,10 +71,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             {
                 var propertyType = Property.ClrType;
 
-                if ((value == SqlServerValueGenerationStrategy.IdentityColumn)
+                if (value == SqlServerValueGenerationStrategy.IdentityColumn
                     && (!propertyType.IsInteger()
-                        || (propertyType == typeof(byte))
-                        || (propertyType == typeof(byte?))))
+                        || propertyType == typeof(byte)
+                        || propertyType == typeof(byte?)))
                 {
                     throw new ArgumentException(SqlServerStrings.IdentityBadType(
                         Property.Name, Property.DeclaringEntityType.Name, propertyType.Name));

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/ValueGeneration/Internal/SqlServerValueGeneratorSelector.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/ValueGeneration/Internal/SqlServerValueGeneratorSelector.cs
@@ -53,8 +53,8 @@ namespace Microsoft.EntityFrameworkCore.ValueGeneration.Internal
             Check.NotNull(entityType, nameof(entityType));
 
             return property.ClrType.UnwrapNullableType() == typeof(Guid)
-                ? (property.ValueGenerated == ValueGenerated.Never)
-                  || (property.SqlServer().GeneratedValueSql != null)
+                ? property.ValueGenerated == ValueGenerated.Never
+                  || property.SqlServer().DefaultValueSql != null
                     ? _tempraryGuidFactory.Create(property)
                     : _sequentialGuidFactory.Create(property)
                 : base.Create(property, entityType);

--- a/src/Microsoft.EntityFrameworkCore.Sqlite/Metadata/Builders/SqlitePropertyBuilderExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite/Metadata/Builders/SqlitePropertyBuilderExtensions.cs
@@ -56,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore
                 property.SetValueGenerated(ValueGenerated.OnAdd, ConfigurationSource.Convention);
             }
 
-            propertyBuilder.Metadata.Sqlite().GeneratedValueSql = sql;
+            propertyBuilder.Metadata.Sqlite().DefaultValueSql = sql;
 
             return propertyBuilder;
         }

--- a/test/Microsoft.EntityFrameworkCore.Commands.FunctionalTests/Migrations/ModelSnapshotTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Commands.FunctionalTests/Migrations/ModelSnapshotTest.cs
@@ -887,7 +887,7 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Commands.Migrations.ModelSnapshot
         b.ToTable(""EntityWithTwoProperties"");
     });
 ",
-                o => { Assert.Equal("SQL", o.GetEntityTypes().First().FindProperty("AlternateId")["Relational:GeneratedValueSql"]); });
+                o => { Assert.Equal("SQL", o.GetEntityTypes().First().FindProperty("AlternateId")["Relational:DefaultValueSql"]); });
         }
 
         [ConditionalFact]
@@ -910,7 +910,7 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Commands.Migrations.ModelSnapshot
         b.ToTable(""EntityWithTwoProperties"");
     });
 ",
-                o => { Assert.Equal("SQL", o.GetEntityTypes().First().FindProperty("AlternateId")["Relational:GeneratedValueSql"]); });
+                o => { Assert.Equal("SQL", o.GetEntityTypes().First().FindProperty("AlternateId")["Relational:ComputedValueSql"]); });
         }
 
         [ConditionalFact]

--- a/test/Microsoft.EntityFrameworkCore.Relational.Design.Tests/RelationalScaffoldingModelFactoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Design.Tests/RelationalScaffoldingModelFactoryTest.cs
@@ -138,7 +138,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Design
                         Assert.Equal(typeof(string), col3.ClrType);
                         Assert.False(col3.IsColumnNullable());
                         Assert.Null(col3.GetMaxLength());
-                        Assert.Equal("\"dev\"", col3.Relational().GeneratedValueSql);
+                        Assert.Equal("\"dev\"", col3.Relational().DefaultValueSql);
                     },
                 col4 =>
                     {

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Metadata/InternalRelationalMetadataBuilderExtensionsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Metadata/InternalRelationalMetadataBuilderExtensionsTest.cs
@@ -89,29 +89,35 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Metadata
             Assert.True(propertyBuilder.Relational(ConfigurationSource.Convention).HasColumnName("Splew"));
             Assert.True(propertyBuilder.Relational(ConfigurationSource.Convention).HasColumnType("int"));
             Assert.True(propertyBuilder.Relational(ConfigurationSource.Convention).HasDefaultValue(1));
-            Assert.True(propertyBuilder.Relational(ConfigurationSource.Convention).HasGeneratedValueSql("2"));
+            Assert.True(propertyBuilder.Relational(ConfigurationSource.Convention).HasDefaultValueSql("2"));
+            Assert.True(propertyBuilder.Relational(ConfigurationSource.Convention).HasComputedValueSql("3"));
             Assert.Equal("Splew", propertyBuilder.Metadata.Relational().ColumnName);
             Assert.Equal("int", propertyBuilder.Metadata.Relational().ColumnType);
             Assert.Equal(1, propertyBuilder.Metadata.Relational().DefaultValue);
-            Assert.Equal("2", propertyBuilder.Metadata.Relational().GeneratedValueSql);
+            Assert.Equal("2", propertyBuilder.Metadata.Relational().DefaultValueSql);
+            Assert.Equal("3", propertyBuilder.Metadata.Relational().ComputedValueSql);
 
             Assert.True(propertyBuilder.Relational(ConfigurationSource.DataAnnotation).HasColumnName("Splow"));
             Assert.True(propertyBuilder.Relational(ConfigurationSource.DataAnnotation).HasColumnType("varchar"));
             Assert.True(propertyBuilder.Relational(ConfigurationSource.DataAnnotation).HasDefaultValue(0));
-            Assert.True(propertyBuilder.Relational(ConfigurationSource.DataAnnotation).HasGeneratedValueSql("NULL"));
+            Assert.True(propertyBuilder.Relational(ConfigurationSource.DataAnnotation).HasDefaultValueSql("NULL"));
+            Assert.True(propertyBuilder.Relational(ConfigurationSource.DataAnnotation).HasComputedValueSql("runthis()"));
             Assert.Equal("Splow", propertyBuilder.Metadata.Relational().ColumnName);
             Assert.Equal("varchar", propertyBuilder.Metadata.Relational().ColumnType);
             Assert.Equal(0, propertyBuilder.Metadata.Relational().DefaultValue);
-            Assert.Equal("NULL", propertyBuilder.Metadata.Relational().GeneratedValueSql);
+            Assert.Equal("NULL", propertyBuilder.Metadata.Relational().DefaultValueSql);
+            Assert.Equal("runthis()", propertyBuilder.Metadata.Relational().ComputedValueSql);
 
             Assert.False(propertyBuilder.Relational(ConfigurationSource.Convention).HasColumnName("Splod"));
             Assert.False(propertyBuilder.Relational(ConfigurationSource.Convention).HasColumnType("int"));
             Assert.False(propertyBuilder.Relational(ConfigurationSource.Convention).HasDefaultValue(1));
-            Assert.False(propertyBuilder.Relational(ConfigurationSource.Convention).HasGeneratedValueSql("2"));
+            Assert.False(propertyBuilder.Relational(ConfigurationSource.Convention).HasDefaultValueSql("2"));
+            Assert.False(propertyBuilder.Relational(ConfigurationSource.Convention).HasComputedValueSql("3"));
             Assert.Equal("Splow", propertyBuilder.Metadata.Relational().ColumnName);
             Assert.Equal("varchar", propertyBuilder.Metadata.Relational().ColumnType);
             Assert.Equal(0, propertyBuilder.Metadata.Relational().DefaultValue);
-            Assert.Equal("NULL", propertyBuilder.Metadata.Relational().GeneratedValueSql);
+            Assert.Equal("NULL", propertyBuilder.Metadata.Relational().DefaultValueSql);
+            Assert.Equal("runthis()", propertyBuilder.Metadata.Relational().ComputedValueSql);
         }
 
         [Fact]

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Metadata/RelationalBuilderExtensionsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Metadata/RelationalBuilderExtensionsTest.cs
@@ -56,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Metadata
 
             var property = modelBuilder.Model.FindEntityType(typeof(Customer)).FindProperty("Name");
 
-            Assert.Equal("CherryCoke", property.Relational().GeneratedValueSql);
+            Assert.Equal("CherryCoke", property.Relational().DefaultValueSql);
             Assert.Equal(ValueGenerated.OnAdd, property.ValueGenerated);
         }
 
@@ -73,7 +73,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Metadata
 
             var property = modelBuilder.Model.FindEntityType(typeof(Customer)).FindProperty("Name");
 
-            Assert.Equal("CherryCoke", property.Relational().GeneratedValueSql);
+            Assert.Equal("CherryCoke", property.Relational().DefaultValueSql);
             Assert.Equal(ValueGenerated.OnAddOrUpdate, property.ValueGenerated);
         }
 
@@ -89,7 +89,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Metadata
 
             var property = modelBuilder.Model.FindEntityType(typeof(Customer)).FindProperty("Name");
 
-            Assert.Equal("CherryCoke", property.Relational().GeneratedValueSql);
+            Assert.Equal("CherryCoke", property.Relational().ComputedValueSql);
             Assert.Equal(ValueGenerated.OnAddOrUpdate, property.ValueGenerated);
         }
 
@@ -106,7 +106,7 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Metadata
 
             var property = modelBuilder.Model.FindEntityType(typeof(Customer)).FindProperty("Name");
 
-            Assert.Equal("CherryCoke", property.Relational().GeneratedValueSql);
+            Assert.Equal("CherryCoke", property.Relational().ComputedValueSql);
             Assert.Equal(ValueGenerated.Never, property.ValueGenerated);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/Metadata/RelationalMetadataExtensionsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/Metadata/RelationalMetadataExtensionsTest.cs
@@ -128,15 +128,36 @@ namespace Microsoft.EntityFrameworkCore.Relational.Tests.Metadata
                 .Property(e => e.Name)
                 .Metadata;
 
-            Assert.Null(property.Relational().GeneratedValueSql);
+            Assert.Null(property.Relational().DefaultValueSql);
 
-            property.Relational().GeneratedValueSql = "newsequentialid()";
+            property.Relational().DefaultValueSql = "newsequentialid()";
 
-            Assert.Equal("newsequentialid()", property.Relational().GeneratedValueSql);
+            Assert.Equal("newsequentialid()", property.Relational().DefaultValueSql);
 
-            property.Relational().GeneratedValueSql = null;
+            property.Relational().DefaultValueSql = null;
 
-            Assert.Null(property.Relational().GeneratedValueSql);
+            Assert.Null(property.Relational().DefaultValueSql);
+        }
+
+        [Fact]
+        public void Can_get_and_set_column_computed_expression()
+        {
+            var modelBuilder = new ModelBuilder(new ConventionSet());
+
+            var property = modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .Metadata;
+
+            Assert.Null(property.Relational().ComputedValueSql);
+
+            property.Relational().ComputedValueSql = "newsequentialid()";
+
+            Assert.Equal("newsequentialid()", property.Relational().ComputedValueSql);
+
+            property.Relational().ComputedValueSql = null;
+
+            Assert.Null(property.Relational().ComputedValueSql);
         }
 
         [Fact]

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Metadata/SqlServerBuilderExtensionsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Metadata/SqlServerBuilderExtensionsTest.cs
@@ -76,8 +76,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests.Metadata
                 .Property(e => e.Name)
                 .HasDefaultValueSql("CherryCoke");
 
-            Assert.Equal("CherryCoke", property.Relational().GeneratedValueSql);
-            Assert.Equal("VanillaCoke", property.SqlServer().GeneratedValueSql);
+            Assert.Equal("CherryCoke", property.Relational().DefaultValueSql);
+            Assert.Equal("VanillaCoke", property.SqlServer().DefaultValueSql);
             Assert.Equal(ValueGenerated.OnAdd, property.ValueGenerated);
         }
 
@@ -101,8 +101,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests.Metadata
                 .Property(e => e.Name)
                 .HasDefaultValueSql("CherryCoke");
 
-            Assert.Equal("CherryCoke", property.Relational().GeneratedValueSql);
-            Assert.Equal("VanillaCoke", property.SqlServer().GeneratedValueSql);
+            Assert.Equal("CherryCoke", property.Relational().DefaultValueSql);
+            Assert.Equal("VanillaCoke", property.SqlServer().DefaultValueSql);
             Assert.Equal(ValueGenerated.Never, property.ValueGenerated);
         }
 
@@ -125,8 +125,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests.Metadata
                 .Property(e => e.Name)
                 .HasComputedColumnSql("CherryCoke");
 
-            Assert.Equal("CherryCoke", property.Relational().GeneratedValueSql);
-            Assert.Equal("VanillaCoke", property.SqlServer().GeneratedValueSql);
+            Assert.Equal("CherryCoke", property.Relational().ComputedValueSql);
+            Assert.Equal("VanillaCoke", property.SqlServer().ComputedValueSql);
             Assert.Equal(ValueGenerated.OnAddOrUpdate, property.ValueGenerated);
         }
 
@@ -150,8 +150,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests.Metadata
                 .Property(e => e.Name)
                 .HasComputedColumnSql("CherryCoke");
 
-            Assert.Equal("CherryCoke", property.Relational().GeneratedValueSql);
-            Assert.Equal("VanillaCoke", property.SqlServer().GeneratedValueSql);
+            Assert.Equal("CherryCoke", property.Relational().ComputedValueSql);
+            Assert.Equal("VanillaCoke", property.SqlServer().ComputedValueSql);
             Assert.Equal(ValueGenerated.Never, property.ValueGenerated);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Metadata/SqlServerMetadataExtensionsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/Metadata/SqlServerMetadataExtensionsTest.cs
@@ -163,27 +163,60 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests.Metadata
                 .Property(e => e.Name)
                 .Metadata;
 
-            Assert.Null(property.Relational().GeneratedValueSql);
-            Assert.Null(property.SqlServer().GeneratedValueSql);
-            Assert.Null(((IProperty)property).SqlServer().GeneratedValueSql);
+            Assert.Null(property.Relational().DefaultValueSql);
+            Assert.Null(property.SqlServer().DefaultValueSql);
+            Assert.Null(((IProperty)property).SqlServer().DefaultValueSql);
 
-            property.Relational().GeneratedValueSql = "newsequentialid()";
+            property.Relational().DefaultValueSql = "newsequentialid()";
 
-            Assert.Equal("newsequentialid()", property.Relational().GeneratedValueSql);
-            Assert.Equal("newsequentialid()", property.SqlServer().GeneratedValueSql);
-            Assert.Equal("newsequentialid()", ((IProperty)property).SqlServer().GeneratedValueSql);
+            Assert.Equal("newsequentialid()", property.Relational().DefaultValueSql);
+            Assert.Equal("newsequentialid()", property.SqlServer().DefaultValueSql);
+            Assert.Equal("newsequentialid()", ((IProperty)property).SqlServer().DefaultValueSql);
 
-            property.SqlServer().GeneratedValueSql = "expressyourself()";
+            property.SqlServer().DefaultValueSql = "expressyourself()";
 
-            Assert.Equal("newsequentialid()", property.Relational().GeneratedValueSql);
-            Assert.Equal("expressyourself()", property.SqlServer().GeneratedValueSql);
-            Assert.Equal("expressyourself()", ((IProperty)property).SqlServer().GeneratedValueSql);
+            Assert.Equal("newsequentialid()", property.Relational().DefaultValueSql);
+            Assert.Equal("expressyourself()", property.SqlServer().DefaultValueSql);
+            Assert.Equal("expressyourself()", ((IProperty)property).SqlServer().DefaultValueSql);
 
-            property.SqlServer().GeneratedValueSql = null;
+            property.SqlServer().DefaultValueSql = null;
 
-            Assert.Equal("newsequentialid()", property.Relational().GeneratedValueSql);
-            Assert.Equal("newsequentialid()", property.SqlServer().GeneratedValueSql);
-            Assert.Equal("newsequentialid()", ((IProperty)property).SqlServer().GeneratedValueSql);
+            Assert.Equal("newsequentialid()", property.Relational().DefaultValueSql);
+            Assert.Equal("newsequentialid()", property.SqlServer().DefaultValueSql);
+            Assert.Equal("newsequentialid()", ((IProperty)property).SqlServer().DefaultValueSql);
+        }
+
+        [Fact]
+        public void Can_get_and_set_column_computed_expression()
+        {
+            var modelBuilder = new ModelBuilder(new ConventionSet());
+
+            var property = modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .Metadata;
+
+            Assert.Null(property.Relational().ComputedValueSql);
+            Assert.Null(property.SqlServer().ComputedValueSql);
+            Assert.Null(((IProperty)property).SqlServer().ComputedValueSql);
+
+            property.Relational().ComputedValueSql = "newsequentialid()";
+
+            Assert.Equal("newsequentialid()", property.Relational().ComputedValueSql);
+            Assert.Equal("newsequentialid()", property.SqlServer().ComputedValueSql);
+            Assert.Equal("newsequentialid()", ((IProperty)property).SqlServer().ComputedValueSql);
+
+            property.SqlServer().ComputedValueSql = "expressyourself()";
+
+            Assert.Equal("newsequentialid()", property.Relational().ComputedValueSql);
+            Assert.Equal("expressyourself()", property.SqlServer().ComputedValueSql);
+            Assert.Equal("expressyourself()", ((IProperty)property).SqlServer().ComputedValueSql);
+
+            property.SqlServer().ComputedValueSql = null;
+
+            Assert.Equal("newsequentialid()", property.Relational().ComputedValueSql);
+            Assert.Equal("newsequentialid()", property.SqlServer().ComputedValueSql);
+            Assert.Equal("newsequentialid()", ((IProperty)property).SqlServer().ComputedValueSql);
         }
 
         [Fact]

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerValueGeneratorSelectorTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Tests/SqlServerValueGeneratorSelectorTest.cs
@@ -46,7 +46,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Tests
             var model = BuildModel();
             var entityType = model.FindEntityType(typeof(AnEntity));
 
-            entityType.FindProperty("Guid").SqlServer().GeneratedValueSql = "newid()";
+            entityType.FindProperty("Guid").SqlServer().DefaultValueSql = "newid()";
 
             var selector = SqlServerTestHelpers.Instance.CreateContextServices(model).GetRequiredService<IValueGeneratorSelector>();
 

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/SqliteScaffoldingModelFactoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/SqliteScaffoldingModelFactoryTest.cs
@@ -71,11 +71,11 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests
 
             Assert.NotNull(entityType);
 
-            Assert.Equal("\"dev\"", entityType.FindProperty("occupation").Sqlite().GeneratedValueSql);
-            Assert.Equal("2", entityType.FindProperty("pay").Sqlite().GeneratedValueSql);
-            Assert.Equal("current_timestamp", entityType.FindProperty("hiredate").Sqlite().GeneratedValueSql);
-            Assert.Equal("100 + 19.4", entityType.FindProperty("iq").Sqlite().GeneratedValueSql);
-            Assert.Null(entityType.FindProperty("name").Sqlite().GeneratedValueSql);
+            Assert.Equal("\"dev\"", entityType.FindProperty("occupation").Sqlite().DefaultValueSql);
+            Assert.Equal("2", entityType.FindProperty("pay").Sqlite().DefaultValueSql);
+            Assert.Equal("current_timestamp", entityType.FindProperty("hiredate").Sqlite().DefaultValueSql);
+            Assert.Equal("100 + 19.4", entityType.FindProperty("iq").Sqlite().DefaultValueSql);
+            Assert.Null(entityType.FindProperty("name").Sqlite().DefaultValueSql);
         }
 
         [Fact]

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Tests/Metadata/Builders/SqliteBuilderExtensionsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Tests/Metadata/Builders/SqliteBuilderExtensionsTest.cs
@@ -77,7 +77,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Tests.Metadata.Builders
                 .ForSqliteHasDefaultValueSql("VanillaCoke")
                 .Metadata;
 
-            Assert.Equal("VanillaCoke", property.Sqlite().GeneratedValueSql);
+            Assert.Equal("VanillaCoke", property.Sqlite().DefaultValueSql);
             Assert.Equal(ValueGenerated.OnAdd, property.ValueGenerated);
         }
 
@@ -92,7 +92,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Tests.Metadata.Builders
                 .ForSqliteHasDefaultValueSql("VanillaCoke")
                 .Metadata;
 
-            Assert.Equal("VanillaCoke", property.Sqlite().GeneratedValueSql);
+            Assert.Equal("VanillaCoke", property.Sqlite().DefaultValueSql);
             Assert.Equal(ValueGenerated.OnAdd, property.ValueGenerated);
         }
 
@@ -108,7 +108,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Tests.Metadata.Builders
                 .ForSqliteHasDefaultValueSql("VanillaCoke")
                 .Metadata;
 
-            Assert.Equal("VanillaCoke", property.Sqlite().GeneratedValueSql);
+            Assert.Equal("VanillaCoke", property.Sqlite().DefaultValueSql);
             Assert.Equal(ValueGenerated.Never, property.ValueGenerated);
         }
 
@@ -124,7 +124,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Tests.Metadata.Builders
                 .ForSqliteHasDefaultValueSql("VanillaCoke")
                 .Metadata;
 
-            Assert.Equal("VanillaCoke", property.Sqlite().GeneratedValueSql);
+            Assert.Equal("VanillaCoke", property.Sqlite().DefaultValueSql);
             Assert.Equal(ValueGenerated.Never, property.ValueGenerated);
         }
 

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Tests/Metadata/SqliteMetadataExtensionsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Tests/Metadata/SqliteMetadataExtensionsTest.cs
@@ -123,23 +123,23 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Tests.Metadata
                 .Property(e => e.Name)
                 .Metadata;
 
-            Assert.Null(property.Sqlite().GeneratedValueSql);
-            Assert.Null(((IProperty)property).Sqlite().GeneratedValueSql);
+            Assert.Null(property.Sqlite().DefaultValueSql);
+            Assert.Null(((IProperty)property).Sqlite().DefaultValueSql);
 
-            property.Relational().GeneratedValueSql = "newsequentialid()";
+            property.Relational().DefaultValueSql = "newsequentialid()";
 
-            Assert.Equal("newsequentialid()", property.Sqlite().GeneratedValueSql);
-            Assert.Equal("newsequentialid()", ((IProperty)property).Sqlite().GeneratedValueSql);
+            Assert.Equal("newsequentialid()", property.Sqlite().DefaultValueSql);
+            Assert.Equal("newsequentialid()", ((IProperty)property).Sqlite().DefaultValueSql);
 
-            property.Sqlite().GeneratedValueSql = "expressyourself()";
+            property.Sqlite().DefaultValueSql = "expressyourself()";
 
-            Assert.Equal("expressyourself()", property.Sqlite().GeneratedValueSql);
-            Assert.Equal("expressyourself()", ((IProperty)property).Sqlite().GeneratedValueSql);
+            Assert.Equal("expressyourself()", property.Sqlite().DefaultValueSql);
+            Assert.Equal("expressyourself()", ((IProperty)property).Sqlite().DefaultValueSql);
 
-            property.Sqlite().GeneratedValueSql = null;
+            property.Sqlite().DefaultValueSql = null;
 
-            Assert.Equal("newsequentialid()", property.Sqlite().GeneratedValueSql);
-            Assert.Equal("newsequentialid()", ((IProperty)property).Sqlite().GeneratedValueSql);
+            Assert.Equal("newsequentialid()", property.Sqlite().DefaultValueSql);
+            Assert.Equal("newsequentialid()", ((IProperty)property).Sqlite().DefaultValueSql);
         }
 
         [Fact]


### PR DESCRIPTION
Because not all provider support both concepts we were storing these things as a single string and then letting other metadata determine how to use the value. However, for cases like that in issue #4501 Migrations assumes a computed column because it doesn't know that the value specified is actually a default and not computed expression. The fix is to stop combining the metadata.