### PR TITLE
Merge conditions when ternary operator used in Where Clause to select…

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Extensions/ExpressionExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Extensions/ExpressionExtensions.cs
@@ -23,12 +23,13 @@ namespace System.Linq.Expressions
         {
             Check.NotNull(expression, nameof(expression));
 
-            return expression.NodeType == ExpressionType.Equal
-                   || expression.NodeType == ExpressionType.NotEqual
-                   || expression.NodeType == ExpressionType.LessThan
-                   || expression.NodeType == ExpressionType.LessThanOrEqual
-                   || expression.NodeType == ExpressionType.GreaterThan
-                   || expression.NodeType == ExpressionType.GreaterThanOrEqual;
+            return (expression.NodeType == ExpressionType.Equal)
+                || (expression.NodeType == ExpressionType.NotEqual)
+                || (expression.NodeType == ExpressionType.LessThan)
+                || (expression.NodeType == ExpressionType.LessThanOrEqual)
+                || (expression.NodeType == ExpressionType.GreaterThan)
+                || (expression.NodeType == ExpressionType.GreaterThanOrEqual)
+                || (expression.NodeType == ExpressionType.Not);
         }
 
         public static ColumnExpression TryGetColumnExpression([NotNull] this Expression expression)

--- a/src/Microsoft.EntityFrameworkCore.Relational/Microsoft.EntityFrameworkCore.Relational.csproj
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Microsoft.EntityFrameworkCore.Relational.csproj
@@ -239,6 +239,7 @@
     <Compile Include="Query\ExpressionVisitors\Internal\IShaper.cs" />
     <Compile Include="Query\ExpressionVisitors\Internal\IsNullExpressionBuildingVisitor.cs" />
     <Compile Include="Query\ExpressionVisitors\Internal\MaterializerFactory.cs" />
+    <Compile Include="Query\ExpressionVisitors\Internal\PredicateReductionExpressionOptimizer.cs" />
     <Compile Include="Query\ExpressionVisitors\Internal\PredicateNegationExpressionOptimizer.cs" />
     <Compile Include="Query\ExpressionVisitors\Internal\QueryFlattener.cs" />
     <Compile Include="Query\ExpressionVisitors\Internal\QueryFlattenerFactory.cs" />

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/CompositePredicateExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/CompositePredicateExpressionVisitor.cs
@@ -30,6 +30,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
                 expression = predicateNegationExpressionOptimizer.Visit(expression);
 
+                expression = new PredicateReductionExpressionOptimizer().Visit(expression);
+
                 if (_useRelationalNulls)
                 {
                     expression = new NotNullableExpression(expression);

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/PredicateReductionExpressionOptimizer.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/PredicateReductionExpressionOptimizer.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq.Expressions;
+using Remotion.Linq.Parsing;
+
+namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
+{
+    public class PredicateReductionExpressionOptimizer : RelinqExpressionVisitor
+    {
+        protected override Expression VisitBinary(BinaryExpression node)
+        {
+            if (node.IsLogicalOperation())
+            {
+                var newLeft = Visit(node.Left);
+                var newRight = Visit(node.Right);
+                var constantLeft = newLeft as ConstantExpression;
+                var constantRight = newRight as ConstantExpression;
+
+                if (node.NodeType == ExpressionType.AndAlso)
+                {
+                    if ((constantLeft != null)
+                        && (constantLeft.Type == typeof(bool)))
+                    {
+                        // true && a => a
+                        // false && a => false
+                        return (bool)constantLeft.Value ? newRight : newLeft;
+                    }
+
+                    if ((constantRight != null)
+                       && (constantRight.Type == typeof(bool)))
+                    {
+                        // a && true => a
+                        // a && false => false
+                        return (bool)constantRight.Value ? newLeft : newRight;
+                    }
+                }
+
+                if (node.NodeType == ExpressionType.OrElse)
+                {
+                    if ((constantLeft != null)
+                        && (constantLeft.Type == typeof(bool)))
+                    {
+                        // true || a => true
+                        // false || a => a
+                        return (bool)constantLeft.Value ? newLeft : newRight;
+                    }
+
+                    if ((constantRight != null)
+                       && (constantRight.Type == typeof(bool)))
+                    {
+                        // a || true => true
+                        // a || false => a
+                        return (bool)constantRight.Value ? newRight : newLeft;
+                    }
+                }
+            }
+
+            return base.VisitBinary(node);
+        }
+    }
+}

--- a/test/Microsoft.EntityFrameworkCore.FunctionalTests/QueryTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.FunctionalTests/QueryTestBase.cs
@@ -1494,6 +1494,38 @@ namespace Microsoft.EntityFrameworkCore.FunctionalTests
         }
 
         [ConditionalFact]
+        public virtual void Where_ternary_boolean_condition()
+        {
+            var flag = new Random().Next(0, 2) == 1;
+
+            AssertQuery<Product>(ps => ps
+                .Where(p => flag ? p.UnitsInStock >= 20 : p.UnitsInStock < 20),
+                    entryCount: flag ? 51 : 26);
+        }
+
+        [ConditionalFact]
+        public virtual void Where_ternary_boolean_condition_with_another_condition()
+        {
+            var flag = true;
+            var productId = 15;
+
+            AssertQuery<Product>(ps => ps
+                .Where(p => p.ProductID < productId
+                    && (flag ? p.UnitsInStock >= 20 : p.UnitsInStock < 20)),
+                    entryCount: 9);
+        }
+
+        [ConditionalFact]
+        public virtual void Where_ternary_boolean_condition_with_false_as_result()
+        {
+            var flag = new Random().Next(0, 2) == 1;
+
+            AssertQuery<Product>(ps => ps
+                .Where(p => flag ? p.UnitsInStock >= 20 : false),
+                    entryCount: flag ? 51 : 0);
+        }
+
+        [ConditionalFact]
         public virtual void Select_bool_closure()
         {
             var boolean = false;

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -3077,6 +3077,42 @@ WHERE 1 = 0",
                 Sql);
         }
 
+        public override void Where_ternary_boolean_condition()
+        {
+            base.Where_ternary_boolean_condition();
+
+            Assert.Contains(
+                    @"SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitsInStock]
+FROM [Products] AS [p]
+WHERE ((@__flag_0 = 1) AND ([p].[UnitsInStock] >= 20)) OR ((@__flag_0 <> 1) AND ([p].[UnitsInStock] < 20))",
+                    Sql);
+        }
+
+        public override void Where_ternary_boolean_condition_with_another_condition()
+        {
+            base.Where_ternary_boolean_condition_with_another_condition();
+
+            Assert.Equal(
+                    @"@__productId_0: 15
+@__flag_1: True
+
+SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitsInStock]
+FROM [Products] AS [p]
+WHERE ([p].[ProductID] < @__productId_0) AND (((@__flag_1 = 1) AND ([p].[UnitsInStock] >= 20)) OR ((@__flag_1 <> 1) AND ([p].[UnitsInStock] < 20)))",
+                    Sql);
+        }
+
+        public override void Where_ternary_boolean_condition_with_false_as_result()
+        {
+            base.Where_ternary_boolean_condition_with_false_as_result();
+
+            Assert.Contains(
+                    @"SELECT [p].[ProductID], [p].[Discontinued], [p].[ProductName], [p].[UnitsInStock]
+FROM [Products] AS [p]
+WHERE (@__flag_0 = 1) AND ([p].[UnitsInStock] >= 20)",
+                    Sql);
+        }
+
         public override void Where_concat_string_int_comparison1()
         {
             base.Where_concat_string_int_comparison1();


### PR DESCRIPTION
… filtering condition
fix for #4868 
Issue: While C# supports selecting condition based on another condition (in ternary operator) that is not supported by T-Sql since the Case Block needs to return single value.
Solution:
In the most simplest form of solution the conditions which are results (IfTrue, IfFalse) of another conditional, should be expanded to return true or false and then compare it to true or false as shown in https://github.com/aspnet/EntityFramework/issues/4868#issuecomment-202626010
Such logic can be simplified using Boolean logic rules. i.e.
`cond1 ? cond2 : cond3` translates to `(cond1 && cond2) || (!cond1 && cond3)` which generates a very concise Sql.