### PR TITLE
Ensure entities from query are tracked as correct type

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/IStateManager.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/IStateManager.cs
@@ -15,7 +15,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
     {
         InternalEntityEntry GetOrCreateEntry([NotNull] object entity);
 
-        InternalEntityEntry StartTrackingFromQuery([NotNull] IEntityType entityType, [NotNull] object entity, ValueBuffer valueBuffer);
+        InternalEntityEntry StartTrackingFromQuery([NotNull] IEntityType baseEntityType, [NotNull] object entity, ValueBuffer valueBuffer);
 
         void BeginTrackingQuery();
 

--- a/src/Microsoft.EntityFrameworkCore/Extensions/EntityTypeExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/EntityTypeExtensions.cs
@@ -28,8 +28,8 @@ namespace Microsoft.EntityFrameworkCore
             // ReSharper disable once LoopCanBeConvertedToQuery
             foreach (var derivedType in entityType.Model.GetEntityTypes())
             {
-                if ((derivedType.BaseType != null)
-                    && (derivedType != entityType)
+                if (derivedType.BaseType != null
+                    && derivedType != entityType
                     && entityType.IsAssignableFrom(derivedType))
                 {
                     yield return derivedType;

--- a/src/Microsoft.EntityFrameworkCore/Extensions/ModelExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/ModelExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore
@@ -24,7 +25,11 @@ namespace Microsoft.EntityFrameworkCore
         {
             Check.NotNull(type, nameof(type));
 
-            return model.FindEntityType(type.DisplayName());
+            var canFindEntityType = model as ICanFindEntityType;
+
+            return canFindEntityType != null
+                ? canFindEntityType.FindEntityType(type)
+                : model.FindEntityType(type.DisplayName());
         }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Extensions/MutableModelExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/MutableModelExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore
@@ -44,8 +45,14 @@ namespace Microsoft.EntityFrameworkCore
             Check.NotNull(model, nameof(model));
             Check.NotNull(type, nameof(type));
 
-            var entityType = model.AddEntityType(type.DisplayName());
+            var canFindEntityType = model as ICanFindEntityType;
+
+            var entityType = canFindEntityType != null
+                ? canFindEntityType.AddEntityType(type.DisplayName(), type) :
+                model.AddEntityType(type.DisplayName());
+
             entityType.ClrType = type;
+
             return entityType;
         }
 

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ICanFindEntityType.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ICanFindEntityType.cs
@@ -1,0 +1,14 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    public interface ICanFindEntityType
+    {
+        IEntityType FindEntityType([NotNull] Type type);
+        IMutableEntityType AddEntityType([NotNull] string name, [CanBeNull] Type type);
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalModelBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalModelBuilder.cs
@@ -31,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             {
                 Metadata.Unignore(name);
 
-                entityType = Metadata.AddEntityType(name, configurationSource);
+                entityType = Metadata.AddEntityType(name, null, configurationSource);
             }
             else
             {

--- a/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
+++ b/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
@@ -320,6 +320,7 @@
     <Compile Include="Metadata\Internal\IEntityMaterializer.cs" />
     <Compile Include="Metadata\Internal\IEntityMaterializerSource.cs" />
     <Compile Include="Metadata\Internal\IFieldMatcher.cs" />
+    <Compile Include="Metadata\Internal\ICanFindEntityType.cs" />
     <Compile Include="Metadata\Internal\IIdentityMapFactorySource.cs" />
     <Compile Include="Metadata\Internal\IMemberMapper.cs" />
     <Compile Include="Metadata\Internal\INavigationAccessors.cs" />

--- a/test/Microsoft.EntityFrameworkCore.FunctionalTests/TestModels/InheritanceRelationships/DerivedCollectionOnBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.FunctionalTests/TestModels/InheritanceRelationships/DerivedCollectionOnBase.cs
@@ -5,5 +5,6 @@ namespace Microsoft.EntityFrameworkCore.FunctionalTests.TestModels.InheritanceRe
 {
     public class DerivedCollectionOnBase : BaseCollectionOnBase
     {
+        public int DerivedProperty { get; set; }
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.FunctionalTests/TestModels/InheritanceRelationships/InheritanceRelationshipsModelInitializer.cs
+++ b/test/Microsoft.EntityFrameworkCore.FunctionalTests/TestModels/InheritanceRelationships/InheritanceRelationshipsModelInitializer.cs
@@ -72,14 +72,14 @@ namespace Microsoft.EntityFrameworkCore.FunctionalTests.TestModels.InheritanceRe
 
             context.BaseCollectionsOnBase.AddRange(bcob11, bcob12, bcob21, bcob31, bcob32);
 
-            var dcob11 = new DerivedCollectionOnBase { Name = "DCOB11", NestedReference = nrd2, NestedCollection = new List<NestedCollectionBase> { ncd21 } };
-            var dcob12 = new DerivedCollectionOnBase { Name = "DCOB12", NestedReference = nrb3, NestedCollection = new List<NestedCollectionBase> { ncb31 } };
-            var dcob21 = new DerivedCollectionOnBase { Name = "DCOB21" };
-            var dcob31 = new DerivedCollectionOnBase { Name = "DCOB31", NestedReference = nrd3, NestedCollection = new List<NestedCollectionBase> { ncd31, ncd32 } };
-            var dcob32 = new DerivedCollectionOnBase { Name = "DCOB32" };
-            var dcob41 = new DerivedCollectionOnBase { Name = "DCOB41" };
-            var dcob51 = new DerivedCollectionOnBase { Name = "DCOB51 (dangling)", NestedReference = nrd4, NestedCollection = new List<NestedCollectionBase> { ncd41, ncd42 } };
-            var dcob52 = new DerivedCollectionOnBase { Name = "DCOB52 (dangling)" };
+            var dcob11 = new DerivedCollectionOnBase { Name = "DCOB11", NestedReference = nrd2, NestedCollection = new List<NestedCollectionBase> { ncd21 }, DerivedProperty = 1 };
+            var dcob12 = new DerivedCollectionOnBase { Name = "DCOB12", NestedReference = nrb3, NestedCollection = new List<NestedCollectionBase> { ncb31 }, DerivedProperty = 2 };
+            var dcob21 = new DerivedCollectionOnBase { Name = "DCOB21", DerivedProperty = 3 };
+            var dcob31 = new DerivedCollectionOnBase { Name = "DCOB31", NestedReference = nrd3, NestedCollection = new List<NestedCollectionBase> { ncd31, ncd32 }, DerivedProperty = 4 };
+            var dcob32 = new DerivedCollectionOnBase { Name = "DCOB32", DerivedProperty = 5 };
+            var dcob41 = new DerivedCollectionOnBase { Name = "DCOB41", DerivedProperty = 6 };
+            var dcob51 = new DerivedCollectionOnBase { Name = "DCOB51 (dangling)", NestedReference = nrd4, NestedCollection = new List<NestedCollectionBase> { ncd41, ncd42 }, DerivedProperty = 7 };
+            var dcob52 = new DerivedCollectionOnBase { Name = "DCOB52 (dangling)", DerivedProperty = 8 };
 
             context.BaseCollectionsOnBase.AddRange(dcob11, dcob12, dcob21, dcob31, dcob32, dcob41, dcob51, dcob52);
 

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/InheritanceRelationshipsQuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/InheritanceRelationshipsQuerySqlServerTest.cs
@@ -193,7 +193,7 @@ FROM [BaseInheritanceRelationshipEntity] AS [e]
 WHERE [e].[Discriminator] IN (N'DerivedInheritanceRelationshipEntity', N'BaseInheritanceRelationshipEntity')
 ORDER BY [e].[Id]
 
-SELECT [b].[Id], [b].[BaseParentId], [b].[Discriminator], [b].[Name]
+SELECT [b].[Id], [b].[BaseParentId], [b].[Discriminator], [b].[Name], [b].[DerivedProperty]
 FROM [BaseCollectionOnBase] AS [b]
 INNER JOIN (
     SELECT DISTINCT [e].[Id]
@@ -219,7 +219,7 @@ ORDER BY [e0].[Id]",
             base.Include_collection_with_inheritance_reverse();
 
             Assert.Equal(
-                @"SELECT [e].[Id], [e].[BaseParentId], [e].[Discriminator], [e].[Name], [b].[Id], [b].[Discriminator], [b].[Name], [b].[BaseId]
+                @"SELECT [e].[Id], [e].[BaseParentId], [e].[Discriminator], [e].[Name], [e].[DerivedProperty], [b].[Id], [b].[Discriminator], [b].[Name], [b].[BaseId]
 FROM [BaseCollectionOnBase] AS [e]
 LEFT JOIN (
     SELECT [b].*
@@ -240,7 +240,7 @@ FROM [BaseInheritanceRelationshipEntity] AS [e]
 WHERE [e].[Discriminator] IN (N'DerivedInheritanceRelationshipEntity', N'BaseInheritanceRelationshipEntity') AND (([e].[Name] <> N'Bar') OR [e].[Name] IS NULL)
 ORDER BY [e].[Id]
 
-SELECT [b].[Id], [b].[BaseParentId], [b].[Discriminator], [b].[Name]
+SELECT [b].[Id], [b].[BaseParentId], [b].[Discriminator], [b].[Name], [b].[DerivedProperty]
 FROM [BaseCollectionOnBase] AS [b]
 INNER JOIN (
     SELECT DISTINCT [e].[Id]
@@ -266,7 +266,7 @@ ORDER BY [e0].[Id]",
             base.Include_collection_with_inheritance_with_filter_reverse();
 
             Assert.Equal(
-                @"SELECT [e].[Id], [e].[BaseParentId], [e].[Discriminator], [e].[Name], [b].[Id], [b].[Discriminator], [b].[Name], [b].[BaseId]
+                @"SELECT [e].[Id], [e].[BaseParentId], [e].[Discriminator], [e].[Name], [e].[DerivedProperty], [b].[Id], [b].[Discriminator], [b].[Name], [b].[BaseId]
 FROM [BaseCollectionOnBase] AS [e]
 LEFT JOIN (
     SELECT [b].*
@@ -545,7 +545,7 @@ FROM [BaseInheritanceRelationshipEntity] AS [e]
 WHERE [e].[Discriminator] = N'DerivedInheritanceRelationshipEntity'
 ORDER BY [e].[Id]
 
-SELECT [b].[Id], [b].[BaseParentId], [b].[Discriminator], [b].[Name]
+SELECT [b].[Id], [b].[BaseParentId], [b].[Discriminator], [b].[Name], [b].[DerivedProperty]
 FROM [BaseCollectionOnBase] AS [b]
 INNER JOIN (
     SELECT DISTINCT [e].[Id]
@@ -807,7 +807,7 @@ FROM [BaseInheritanceRelationshipEntity] AS [e]
 WHERE [e].[Discriminator] IN (N'DerivedInheritanceRelationshipEntity', N'BaseInheritanceRelationshipEntity')
 ORDER BY [e].[Id]
 
-SELECT [b].[Id], [b].[BaseParentId], [b].[Discriminator], [b].[Name], [n].[Id], [n].[Discriminator], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId]
+SELECT [b].[Id], [b].[BaseParentId], [b].[Discriminator], [b].[Name], [b].[DerivedProperty], [n].[Id], [n].[Discriminator], [n].[Name], [n].[ParentCollectionId], [n].[ParentReferenceId]
 FROM [BaseCollectionOnBase] AS [b]
 INNER JOIN (
     SELECT DISTINCT [e].[Id]
@@ -856,7 +856,7 @@ ORDER BY [e0].[Id]",
             base.Nested_include_with_inheritance_collection_reference_reverse();
 
             Assert.Equal(
-                @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[ParentCollectionId], [e].[ParentReferenceId], [b].[Id], [b].[BaseParentId], [b].[Discriminator], [b].[Name], [b0].[Id], [b0].[Discriminator], [b0].[Name], [b0].[BaseId]
+                @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[ParentCollectionId], [e].[ParentReferenceId], [b].[Id], [b].[BaseParentId], [b].[Discriminator], [b].[Name], [b].[DerivedProperty], [b0].[Id], [b0].[Discriminator], [b0].[Name], [b0].[BaseId]
 FROM [NestedReferenceBase] AS [e]
 LEFT JOIN (
     SELECT [b].*
@@ -882,7 +882,7 @@ FROM [BaseInheritanceRelationshipEntity] AS [e]
 WHERE [e].[Discriminator] IN (N'DerivedInheritanceRelationshipEntity', N'BaseInheritanceRelationshipEntity')
 ORDER BY [e].[Id]
 
-SELECT [b].[Id], [b].[BaseParentId], [b].[Discriminator], [b].[Name]
+SELECT [b].[Id], [b].[BaseParentId], [b].[Discriminator], [b].[Name], [b].[DerivedProperty]
 FROM [BaseCollectionOnBase] AS [b]
 INNER JOIN (
     SELECT DISTINCT [e].[Id]
@@ -941,7 +941,7 @@ ORDER BY [b0].[Id], [b0].[Id0]",
             base.Nested_include_with_inheritance_collection_collection_reverse();
 
             Assert.Equal(
-                @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[ParentCollectionId], [e].[ParentReferenceId], [b].[Id], [b].[BaseParentId], [b].[Discriminator], [b].[Name], [b0].[Id], [b0].[Discriminator], [b0].[Name], [b0].[BaseId]
+                @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[ParentCollectionId], [e].[ParentReferenceId], [b].[Id], [b].[BaseParentId], [b].[Discriminator], [b].[Name], [b].[DerivedProperty], [b0].[Id], [b0].[Discriminator], [b0].[Name], [b0].[BaseId]
 FROM [NestedCollectionBase] AS [e]
 LEFT JOIN (
     SELECT [b].*

--- a/test/Microsoft.EntityFrameworkCore.Tests/DbContextTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/DbContextTest.cs
@@ -288,7 +288,7 @@ namespace Microsoft.EntityFrameworkCore.Tests
             }
 
             public InternalEntityEntry StartTrackingFromQuery(
-                IEntityType entityType,
+                IEntityType baseEntityType,
                 object entity,
                 ValueBuffer valueBuffer)
             {


### PR DESCRIPTION
Issue #4817

The problem was that query was passing in the base type to the state manager since the actual type varies by row. It would likely be possible to flow the actual type through from the materializer but this would require significant changes and would not be used in a lot of cases. Instead the state manager now looks up the entity type if it is not the base type, with some optimizations to that lookup made in metadata.