### PR TITLE
Refix fixes to build break so they won't break again

### DIFF
--- a/test/Microsoft.EntityFrameworkCore.Microbenchmarks.Core/BenchmarkTestCaseBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Microbenchmarks.Core/BenchmarkTestCaseBase.cs
@@ -7,13 +7,16 @@ using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
+
+#if NETSTANDARDAPP1_5
 using TestMethodDisplay = Xunit.Sdk.TestMethodDisplay;
+#endif
 
 namespace Microsoft.EntityFrameworkCore.Microbenchmarks.Core
 {
     public abstract class BenchmarkTestCaseBase : XunitTestCase
     {
-        public BenchmarkTestCaseBase(
+        protected BenchmarkTestCaseBase(
             string variation,
             IMessageSink diagnosticMessageSink,
             ITestMethod testMethod,
@@ -69,9 +72,7 @@ namespace Microsoft.EntityFrameworkCore.Microbenchmarks.Core
             return reasons.Count > 0 ? string.Join(Environment.NewLine, reasons) : null;
         }
 
-        protected override string GetUniqueID()
-        {
-            return $"{TestMethod.TestClass.TestCollection.TestAssembly.Assembly.Name}{TestMethod.TestClass.Class.Name}{TestMethod.Method.Name}{Variation}";
-        }
+        protected override string GetUniqueID() 
+            => $"{TestMethod.TestClass.TestCollection.TestAssembly.Assembly.Name}{TestMethod.TestClass.Class.Name}{TestMethod.Method.Name}{Variation}";
     }
 }

--- a/test/Microsoft.EntityFrameworkCore.Microbenchmarks.Core/BenchmarkTestCaseRunner.cs
+++ b/test/Microsoft.EntityFrameworkCore.Microbenchmarks.Core/BenchmarkTestCaseRunner.cs
@@ -5,12 +5,13 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-#if NETSTANDARDAPP1_5
-using Microsoft.Extensions.Configuration;
-#endif
 using Microsoft.Extensions.PlatformAbstractions;
 using Xunit.Abstractions;
 using Xunit.Sdk;
+
+#if NETSTANDARDAPP1_5
+using Microsoft.Extensions.Configuration;
+#endif
 
 namespace Microsoft.EntityFrameworkCore.Microbenchmarks.Core
 {

--- a/test/Microsoft.EntityFrameworkCore.Relational.Design.FunctionalTests/TestUtilities/BuildReference.cs
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Design.FunctionalTests/TestUtilities/BuildReference.cs
@@ -3,12 +3,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using Microsoft.CodeAnalysis;
 
 #if NETSTANDARDAPP1_5
 using Microsoft.Extensions.DependencyModel;
+using System.Linq;
 #endif
 
 namespace Microsoft.EntityFrameworkCore.Relational.Design.FunctionalTests.TestUtilities

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/SqliteE2ETestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/ReverseEngineering/SqliteE2ETestBase.cs
@@ -4,9 +4,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-#if NETSTANDARDAPP1_5
-using System.Reflection;
-#endif
 using Microsoft.EntityFrameworkCore.FunctionalTests.TestUtilities.Xunit;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Relational.Design.FunctionalTests.ReverseEngineering;
@@ -17,6 +14,10 @@ using Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 using Xunit.Abstractions;
+
+#if NETSTANDARDAPP1_5
+using System.Reflection;
+#endif
 
 namespace Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests.ReverseEngineering
 {


### PR DESCRIPTION
Use ifdefs to prevent R# from removing unused stuff on code cleanup