### PR TITLE
Use non-capturing lambdas for lazy initialization

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/Internal/NonCapturingLazyInitializer.cs
+++ b/src/Microsoft.EntityFrameworkCore/Internal/NonCapturingLazyInitializer.cs
@@ -1,0 +1,41 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Internal
+{
+    public static class NonCapturingLazyInitializer
+    {
+        public static TValue EnsureInitialized<TParam, TValue>(
+            [CanBeNull] ref TValue target,
+            [CanBeNull] TParam param,
+            [NotNull] Func<TParam, TValue> valueFactory) where TValue : class
+        {
+            if (Volatile.Read(ref target) != null)
+            {
+                return target;
+            }
+
+            Interlocked.CompareExchange(ref target, valueFactory(param), null);
+
+            return target;
+        }
+
+        public static TValue EnsureInitialized<TValue>(
+            [CanBeNull] ref TValue target,
+            [NotNull] TValue value) where TValue : class
+        {
+            if (Volatile.Read(ref target) != null)
+            {
+                return target;
+            }
+
+            Interlocked.CompareExchange(ref target, value, null);
+
+            return target;
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityType.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityType.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
-using System.Threading;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
@@ -1145,33 +1144,35 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             _counts = null;
         }
 
-        public virtual PropertyCounts Counts => LazyInitializer.EnsureInitialized(ref _counts, CalculateCounts);
+        public virtual PropertyCounts Counts 
+            => NonCapturingLazyInitializer.EnsureInitialized(ref _counts, this, CalculateCounts);
 
-        private PropertyCounts CalculateCounts() => EntityTypeExtensions.CalculateCounts(this);
+        private static PropertyCounts CalculateCounts(EntityType entityType) 
+            => entityType.CalculateCounts();
 
         public virtual Func<InternalEntityEntry, ISnapshot> RelationshipSnapshotFactory
-            => LazyInitializer.EnsureInitialized(ref _relationshipSnapshotFactory, CreateRelationshipSnapshotFactory);
+            => NonCapturingLazyInitializer.EnsureInitialized(ref _relationshipSnapshotFactory, this, CreateRelationshipSnapshotFactory);
 
-        private Func<InternalEntityEntry, ISnapshot> CreateRelationshipSnapshotFactory()
-            => new RelationshipSnapshotFactoryFactory().Create(this);
+        private static Func<InternalEntityEntry, ISnapshot> CreateRelationshipSnapshotFactory(EntityType entityType)
+            => new RelationshipSnapshotFactoryFactory().Create(entityType);
 
         public virtual Func<InternalEntityEntry, ISnapshot> OriginalValuesFactory
-            => LazyInitializer.EnsureInitialized(ref _originalValuesFactory, CreateOriginalValuesFactory);
+            => NonCapturingLazyInitializer.EnsureInitialized(ref _originalValuesFactory, this, CreateOriginalValuesFactory);
 
-        private Func<InternalEntityEntry, ISnapshot> CreateOriginalValuesFactory()
-            => new OriginalValuesFactoryFactory().Create(this);
+        private static Func<InternalEntityEntry, ISnapshot> CreateOriginalValuesFactory(EntityType entityType)
+            => new OriginalValuesFactoryFactory().Create(entityType);
 
         public virtual Func<ValueBuffer, ISnapshot> ShadowValuesFactory
-            => LazyInitializer.EnsureInitialized(ref _shadowValuesFactory, CreateShadowValuesFactory);
+            => NonCapturingLazyInitializer.EnsureInitialized(ref _shadowValuesFactory, this, CreateShadowValuesFactory);
 
-        private Func<ValueBuffer, ISnapshot> CreateShadowValuesFactory()
-            => new ShadowValuesFactoryFactory().Create(this);
+        private static Func<ValueBuffer, ISnapshot> CreateShadowValuesFactory(EntityType entityType)
+            => new ShadowValuesFactoryFactory().Create(entityType);
 
         public virtual Func<ISnapshot> EmptyShadowValuesFactory
-            => LazyInitializer.EnsureInitialized(ref _emptyShadowValuesFactory, CreateEmptyShadowValuesFactory);
+            => NonCapturingLazyInitializer.EnsureInitialized(ref _emptyShadowValuesFactory, this, CreateEmptyShadowValuesFactory);
 
-        private Func<ISnapshot> CreateEmptyShadowValuesFactory()
-            => new EmptyShadowValuesFactoryFactory().CreateEmpty(this);
+        private static Func<ISnapshot> CreateEmptyShadowValuesFactory(EntityType entityType)
+            => new EmptyShadowValuesFactoryFactory().CreateEmpty(entityType);
 
         #endregion
 

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Key.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Key.cs
@@ -5,9 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Threading;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -54,16 +54,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             => ((IKey)this).FindReferencingForeignKeys().Cast<ForeignKey>();
 
         public virtual Func<IIdentityMap> IdentityMapFactory
-            => LazyInitializer.EnsureInitialized(
-                ref _identityMapFactory, () => new IdentityMapFactoryFactory().Create(this));
+            => NonCapturingLazyInitializer.EnsureInitialized(
+                ref _identityMapFactory, this, k => new IdentityMapFactoryFactory().Create(k));
 
         public virtual Func<IWeakReferenceIdentityMap> WeakReferenceIdentityMapFactory
-            => LazyInitializer.EnsureInitialized(
-                ref _weakReferenceIdentityMap, () => new WeakReferenceIdentityMapFactoryFactory().Create(this));
+            => NonCapturingLazyInitializer.EnsureInitialized(
+                ref _weakReferenceIdentityMap, this, k => new WeakReferenceIdentityMapFactoryFactory().Create(k));
 
         public virtual IPrincipalKeyValueFactory<TKey> GetPrincipalKeyValueFactory<TKey>()
-            => (IPrincipalKeyValueFactory<TKey>)LazyInitializer.EnsureInitialized(
-                ref _principalKeyValueFactory, () => new KeyValueFactoryFactory().Create<TKey>(this));
+            => (IPrincipalKeyValueFactory<TKey>)NonCapturingLazyInitializer.EnsureInitialized(
+                ref _principalKeyValueFactory, this, k => new KeyValueFactoryFactory().Create<TKey>(k));
 
         IReadOnlyList<IProperty> IKey.Properties => Properties;
         IReadOnlyList<IMutableProperty> IMutableKey.Properties => Properties;

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Navigation.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Navigation.cs
@@ -5,7 +5,6 @@ using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
-using System.Threading;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -188,20 +187,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             => (EntityType)((INavigation)this).GetTargetType();
 
         public virtual IClrPropertyGetter Getter
-            => LazyInitializer.EnsureInitialized(ref _getter, () => new ClrPropertyGetterFactory().Create(this));
+            => NonCapturingLazyInitializer.EnsureInitialized(ref _getter, this, n => new ClrPropertyGetterFactory().Create(n));
 
         public virtual IClrPropertySetter Setter
-            => LazyInitializer.EnsureInitialized(ref _setter, () => new ClrPropertySetterFactory().Create(this));
+            => NonCapturingLazyInitializer.EnsureInitialized(ref _setter, this, n => new ClrPropertySetterFactory().Create(n));
 
         public virtual IClrCollectionAccessor CollectionAccessor
-            => LazyInitializer.EnsureInitialized(ref _collectionAccessor, () => new ClrCollectionAccessorFactory().Create(this));
+            => NonCapturingLazyInitializer.EnsureInitialized(ref _collectionAccessor, this, n => new ClrCollectionAccessorFactory().Create(n));
 
         public virtual PropertyAccessors Accessors
-            => LazyInitializer.EnsureInitialized(ref _accessors, () => new PropertyAccessorsFactory().Create(this));
+            => NonCapturingLazyInitializer.EnsureInitialized(ref _accessors, this, n => new PropertyAccessorsFactory().Create(n));
 
         public virtual PropertyIndexes PropertyIndexes
         {
-            get { return LazyInitializer.EnsureInitialized(ref _indexes, () => DeclaringEntityType.CalculateIndexes(this)); }
+            get { return NonCapturingLazyInitializer.EnsureInitialized(ref _indexes, this, n => DeclaringEntityType.CalculateIndexes(n)); }
 
             set
             {
@@ -213,7 +212,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
                 else
                 {
-                    LazyInitializer.EnsureInitialized(ref _indexes, () => value);
+                    NonCapturingLazyInitializer.EnsureInitialized(ref _indexes, this, n => value);
                 }
             }
         }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Property.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Property.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
-using System.Threading;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -418,17 +417,17 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         public virtual IClrPropertyGetter Getter
-            => LazyInitializer.EnsureInitialized(ref _getter, () => new ClrPropertyGetterFactory().Create(this));
+            => NonCapturingLazyInitializer.EnsureInitialized(ref _getter, this, p => new ClrPropertyGetterFactory().Create(p));
 
         public virtual IClrPropertySetter Setter
-            => LazyInitializer.EnsureInitialized(ref _setter, () => new ClrPropertySetterFactory().Create(this));
+            => NonCapturingLazyInitializer.EnsureInitialized(ref _setter, this, p => new ClrPropertySetterFactory().Create(p));
 
         public virtual PropertyAccessors Accessors
-            => LazyInitializer.EnsureInitialized(ref _accessors, () => new PropertyAccessorsFactory().Create(this));
+            => NonCapturingLazyInitializer.EnsureInitialized(ref _accessors, this, p => new PropertyAccessorsFactory().Create(p));
 
         public virtual PropertyIndexes PropertyIndexes
         {
-            get { return LazyInitializer.EnsureInitialized(ref _indexes, CalculateIndexes); }
+            get { return NonCapturingLazyInitializer.EnsureInitialized(ref _indexes, this, CalculateIndexes); }
 
             set
             {
@@ -440,7 +439,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
                 else
                 {
-                    LazyInitializer.EnsureInitialized(ref _indexes, () => value);
+                    NonCapturingLazyInitializer.EnsureInitialized(ref _indexes, value);
                 }
             }
         }
@@ -450,6 +449,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual IReadOnlyList<IForeignKey> ForeignKeys { get; [param: CanBeNull] set; }
         public virtual IReadOnlyList<IIndex> Indexes { get; [param: CanBeNull] set; }
 
-        private PropertyIndexes CalculateIndexes() => DeclaringEntityType.CalculateIndexes(this);
+        private static PropertyIndexes CalculateIndexes(Property property) 
+            => property.DeclaringEntityType.CalculateIndexes(property);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
+++ b/src/Microsoft.EntityFrameworkCore/Microsoft.EntityFrameworkCore.csproj
@@ -208,6 +208,7 @@
     <Compile Include="Internal\LoggingModelValidator.cs" />
     <Compile Include="Internal\ModelValidator.cs" />
     <Compile Include="Internal\Multigraph.cs" />
+    <Compile Include="Internal\NonCapturingLazyInitializer.cs" />
     <Compile Include="Internal\ProductInfo.cs" />
     <Compile Include="Internal\ReferenceEnumerableEqualityComparer.cs" />
     <Compile Include="Internal\ReferenceEqualityComparer.cs" />


### PR DESCRIPTION
See issue #4789

This requires a new initializer class since the BCL LazyInitializer doesn't support passing parameters to the creation delegate.