### PR TITLE
Fix #4875 - EF.Property<T> throws in certain generic usages

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/Query/EntityQueryModelVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/EntityQueryModelVisitor.cs
@@ -1186,9 +1186,18 @@ namespace Microsoft.EntityFrameworkCore.Query
                     || querySource == null
                     || querySource == querySourceReferenceExpression.ReferencedQuerySource)
                 {
+                    var entityExpression = methodCallExpression.Arguments[0];
+
+                    if ((entityExpression.NodeType == ExpressionType.Convert
+                        || entityExpression.NodeType == ExpressionType.ConvertChecked)
+                            && ((UnaryExpression)entityExpression).Type == typeof(object))
+                    {
+                        entityExpression = ((UnaryExpression)entityExpression).Operand;
+                    }
+
                     var entityType
                         = QueryCompilationContext.Model
-                            .FindEntityType(methodCallExpression.Arguments[0].Type);
+                            .FindEntityType(entityExpression.Type);
 
                     if (entityType != null)
                     {

--- a/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/MemberAccessBindingExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/MemberAccessBindingExpressionVisitor.cs
@@ -154,7 +154,13 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             if (EntityQueryModelVisitor.IsPropertyMethod(node.Method))
             {
                 var newArguments
-                    = VisitAndConvert(node.Arguments, "VisitMethodCall");
+                    = VisitAndConvert(
+                        new List<Expression>
+                        {
+                            node.Arguments[0].RemoveConvert(),
+                            node.Arguments[1]
+                        }.AsReadOnly(),
+                        "VisitMethodCall");
 
                 if (newArguments[0].Type == typeof(ValueBuffer))
                 {

--- a/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/ParameterExtractingExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/ParameterExtractingExpressionVisitor.cs
@@ -106,7 +106,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
                     if (parameterInfos[i].GetCustomAttribute<NotParameterizedAttribute>() != null)
                     {
-                        var parameter = newArgument as ParameterExpression;
+                        var parameter = newArgument.RemoveConvert() as ParameterExpression;
 
                         if (parameter != null)
                         {

--- a/test/Microsoft.EntityFrameworkCore.FunctionalTests/InheritanceTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.FunctionalTests/InheritanceTestBase.cs
@@ -296,6 +296,21 @@ namespace Microsoft.EntityFrameworkCore.FunctionalTests
         }
 
         [Fact]
+        public virtual void Discriminator_with_cast_in_shadow_property()
+        {
+            using (var context = CreateContext())
+            {
+                var preditors
+                    = context.Set<Animal>()
+                        .Where(b => "Kiwi" == EF.Property<string>(b, "Discriminator"))
+                        .Select(k => new { Preditor = EF.Property<string>((Bird)k, "EagleId") })
+                        .ToArray();
+
+                Assert.Equal(1, preditors.Length);
+            }
+        }
+
+        [Fact]
         public virtual void Discriminator_used_when_projection_over_of_type()
         {
             using (var context = CreateContext())

--- a/test/Microsoft.EntityFrameworkCore.FunctionalTests/QueryTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.FunctionalTests/QueryTestBase.cs
@@ -4702,6 +4702,27 @@ namespace Microsoft.EntityFrameworkCore.FunctionalTests
         }
 
         [ConditionalFact]
+        public virtual void Select_Property_when_shaow_unconstrained_generic_method()
+        {
+            AssertQuery<Employee>(es =>
+                ShadowPropertySelect<Employee, string>(es, "Title"));
+        }
+
+        [ConditionalFact]
+        public virtual void Where_Property_when_shaow_unconstrained_generic_method()
+        {
+            AssertQuery<Employee>(es =>
+                ShadowPropertyWhere(es, "Title", "Sales Representative"),
+                entryCount: 6);
+        }
+
+        protected IQueryable<TOut> ShadowPropertySelect<TIn, TOut>(IQueryable<TIn> source, object column)
+            => source.Select(e => EF.Property<TOut>(e, (string)column));
+
+        protected IQueryable<T> ShadowPropertyWhere<T>(IQueryable<T> source, object column, string value)
+            => source.Where(e => EF.Property<string>(e, (string)column) == value);
+
+        [ConditionalFact]
         public virtual void Where_Property_shadow_closure()
         {
             var propertyName = "Title";

--- a/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/InheritanceInMemoryTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/InheritanceInMemoryTest.cs
@@ -18,6 +18,14 @@ namespace Microsoft.EntityFrameworkCore.InMemory.FunctionalTests
                     base.Discriminator_used_when_projection_over_derived_type2()).Message);
         }
 
+        public override void Discriminator_with_cast_in_shadow_property()
+        {
+            Assert.Equal(
+                CoreStrings.PropertyNotFound("Discriminator", "Animal"),
+                Assert.Throws<InvalidOperationException>(() =>
+                    base.Discriminator_with_cast_in_shadow_property()).Message);
+        }
+
         public InheritanceInMemoryTest(InheritanceInMemoryFixture fixture)
             : base(fixture)
         {


### PR DESCRIPTION
Linq adds an extra Convert to object for boxing when EF.Property<T> is called in a method without generic constraints on the entity type.

Adding a step to query compilation to update the Expression before the QueryModel is generated but after caching.

cc @anpete @maumar 