### PR TITLE
Small: fix missed cancellation Token when migrate async

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Migrations/HistoryRepository.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Migrations/HistoryRepository.cs
@@ -149,7 +149,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             {
                 var command = _rawSqlCommandBuilder.Build(GetAppliedMigrationsSql);
 
-                using (var reader = await command.ExecuteReaderAsync(_connection))
+                using (var reader = await command.ExecuteReaderAsync(_connection, cancellationToken: cancellationToken))
                 {
                     while (await reader.DbDataReader.ReadAsync(cancellationToken))
                     {


### PR DESCRIPTION
This is small fix.
I noticed that in history repository missed cancellation token for async command reader. 