### PR TITLE
Ensure relationship snapshot is kept up-to-date when query loads navigations

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -396,6 +396,12 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             _relationshipsSnapshot.AddToCollection(propertyBase, addedEntity);
         }
 
+        public virtual void AddRangeToCollectionSnapshot([NotNull] IPropertyBase propertyBase, [NotNull] IEnumerable<object> addedEntities)
+        {
+            EnsureRelationshipSnapshot();
+            _relationshipsSnapshot.AddRangeToCollection(propertyBase, addedEntities);
+        }
+
         public virtual object this[[NotNull] IPropertyBase propertyBase]
         {
             get

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/NavigationFixer.cs
@@ -720,19 +720,18 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         {
             if (navigation != null)
             {
-                if (!collectionAccessor.Contains(entry.Entity, value))
+                _changeDetector.Suspend();
+                try
                 {
-                    _changeDetector.Suspend();
-                    try
+                    if (collectionAccessor.Add(entry.Entity, value))
                     {
-                        collectionAccessor.Add(entry.Entity, value);
-                    }
-                    finally
-                    {
-                        _changeDetector.Resume();
+                        entry.AddToCollectionSnapshot(navigation, value);
                     }
                 }
-                entry.AddToCollectionSnapshot(navigation, value);
+                finally
+                {
+                    _changeDetector.Resume();
+                }
             }
         }
 

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/RelationshipsSnapshot.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/RelationshipsSnapshot.cs
@@ -51,6 +51,23 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             public void AddToCollection(IPropertyBase propertyBase, object addedEntity)
             {
+                var snapshot = GetOrCreateCollection(propertyBase);
+
+                snapshot.Add(addedEntity);
+            }
+
+            public void AddRangeToCollection(IPropertyBase propertyBase, IEnumerable<object> addedEntities)
+            {
+                var snapshot = GetOrCreateCollection(propertyBase);
+
+                foreach (var addedEntity in addedEntities)
+                {
+                    snapshot.Add(addedEntity);
+                }
+            }
+
+            private HashSet<object> GetOrCreateCollection(IPropertyBase propertyBase)
+            {
                 var index = propertyBase.GetRelationshipIndex();
 
                 var snapshot = (HashSet<object>)_values[index];
@@ -60,7 +77,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     _values[index] = snapshot;
                 }
 
-                snapshot.Add(addedEntity);
+                return snapshot;
             }
 
             public bool IsEmpty => _values == null;

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrICollectionAccessor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrICollectionAccessor.cs
@@ -34,8 +34,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             _createCollection = createCollection;
         }
 
-        public virtual void Add(object instance, object value)
-            => GetOrCreateCollection(instance).Add((TElement)value);
+        public virtual bool Add(object instance, object value)
+        {
+            var collection = GetOrCreateCollection(instance);
+            var element = (TElement)value;
+
+            if (!collection.Contains(element))
+            {
+                collection.Add(element);
+                return true;
+            }
+            return false;
+        }
 
         public virtual void AddRange(object instance, IEnumerable<object> values)
         {

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/IClrCollectionAccessor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/IClrCollectionAccessor.cs
@@ -9,7 +9,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     public interface IClrCollectionAccessor
     {
-        void Add([NotNull] object instance, [NotNull] object value);
+        bool Add([NotNull] object instance, [NotNull] object value);
         void AddRange([NotNull] object instance, [NotNull] IEnumerable<object> values);
         bool Contains([NotNull] object instance, [NotNull] object value);
         void Remove([NotNull] object instance, [NotNull] object value);


### PR DESCRIPTION
Issue #4853

The issue here is when the second TestClass was loaded the relationship snapshot on the inverse was not updated, which in turn caused DetectChanges to misbehave. Rather than attempt to do any kind of diff at the end of query the fix is to update the relationship snapshot at the same time that query is setting or populating the actual navigation property.