### PR TITLE
Fix #4975 - EF.Property<T> property name shoud not be parameterized

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/EF.cs
+++ b/src/Microsoft.EntityFrameworkCore/EF.cs
@@ -4,6 +4,7 @@
 using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Query;
 
 namespace Microsoft.EntityFrameworkCore
 {
@@ -30,7 +31,9 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="entity"> The entity to access the property on. </param>
         /// <param name="propertyName"> The name of the property. </param>
         /// <returns> The value assigned to the property. </returns>
-        public static TProperty Property<TProperty>([NotNull] object entity, [NotNull] string propertyName)
+        public static TProperty Property<TProperty>(
+            [NotNull] object entity,
+            [NotNull] [NotParameterized] string propertyName)
         {
             throw new InvalidOperationException(CoreStrings.PropertyMethodInvoked);
         }

--- a/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/ParameterExtractingExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/ParameterExtractingExpressionVisitor.cs
@@ -69,8 +69,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             var methodInfo = methodCallExpression.Method;
             var declaringType = methodInfo.DeclaringType;
 
-            if (declaringType == typeof(EF)
-                || declaringType == typeof(DbContext))
+            if (declaringType == typeof(DbContext))
             {
                 return methodCallExpression;
             }

--- a/test/Microsoft.EntityFrameworkCore.FunctionalTests/QueryTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.FunctionalTests/QueryTestBase.cs
@@ -4689,6 +4689,24 @@ namespace Microsoft.EntityFrameworkCore.FunctionalTests
         }
 
         [ConditionalFact]
+        public virtual void Where_Property_shadow_closure()
+        {
+            var propertyName = "Title";
+            var value = "Sales Representative";
+
+            AssertQuery<Employee>(
+                es => es.Where(e => EF.Property<string>(e, propertyName) == value),
+                entryCount: 6);
+
+            propertyName = "FirstName";
+            value = "Steven";
+
+            AssertQuery<Employee>(
+                es => es.Where(e => EF.Property<string>(e, propertyName) == value),
+                entryCount: 1);
+        }
+
+        [ConditionalFact]
         public virtual void Selected_column_can_coalesce()
         {
             using (var context = CreateContext())

--- a/test/Microsoft.EntityFrameworkCore.FunctionalTests/TestModels/Northwind/NorthwindData.cs
+++ b/test/Microsoft.EntityFrameworkCore.FunctionalTests/TestModels/Northwind/NorthwindData.cs
@@ -121,8 +121,8 @@ namespace Microsoft.EntityFrameworkCore.FunctionalTests.TestModels.Northwind
             protected override Expression VisitMethodCall(MethodCallExpression expression)
                 => EntityQueryModelVisitor.IsPropertyMethod(expression.Method)
                     ? Expression.Property(
-                        expression.Arguments[0],
-                        (string)((ConstantExpression)expression.Arguments[1]).Value)
+                        expression.Arguments[0].RemoveConvert(),
+                        Expression.Lambda<Func<string>>(expression.Arguments[1]).Compile().Invoke())
                     : base.VisitMethodCall(expression);
         }
 


### PR DESCRIPTION
Implementing the solution proposed in #4975. Also includes minor change to `ParameterExtractingExpressionVisitor` because the attribute was not being checked due to a performance optimization.
@anpete @maumar 