### PR TITLE
Fix/supress ReSharper warnings for Microsoft.EntityFrameworkCore

### DIFF
--- a/EntityFramework.sln.DotSettings
+++ b/EntityFramework.sln.DotSettings
@@ -1,12 +1,13 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeAttributes/@EntryIndexedValue">WARNING</s:String>
-	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeMissingParentheses/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeMissingParentheses/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeModifiersOrder/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeRedundantParentheses/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeTypeMemberModifiers/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeTypeModifiers/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=BuiltInTypeReferenceStyle/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertMethodToExpressionBody/@EntryIndexedValue">SUGGESTION</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=LoopCanBeConvertedToQuery/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantArgumentName/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantArgumentNameForLiteralExpression/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=StringEndsWithIsCultureSpecific/@EntryIndexedValue">WARNING</s:String>
@@ -25,6 +26,7 @@
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ALIGN_MULTILINE_PARAMETER/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ALIGN_MULTLINE_TYPE_PARAMETER_CONSTRAINS/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ANONYMOUS_METHOD_DECLARATION_BRACES/@EntryValue">NEXT_LINE_SHIFTED_2</s:String>
+	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/BLANK_LINES_AROUND_NAMESPACE/@EntryValue">0</s:Int64>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_ATTRIBUTE_STYLE/@EntryValue">SEPARATE</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_CHOP_COMPOUND_DO_EXPRESSION/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_CHOP_COMPOUND_IF_EXPRESSION/@EntryValue">True</s:Boolean>

--- a/src/Microsoft.EntityFrameworkCore.Relational/Extensions/RelationalExpressionExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Extensions/RelationalExpressionExtensions.cs
@@ -1,37 +1,15 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
-using Microsoft.EntityFrameworkCore.Utilities;
 
 // ReSharper disable once CheckNamespace
-
-namespace System.Linq.Expressions
+namespace Microsoft.EntityFrameworkCore.Internal
 {
-    public static class ExpressionExtensions
+    public static class RelationalExpressionExtensions
     {
-        public static bool IsLogicalOperation([NotNull] this Expression expression)
-        {
-            Check.NotNull(expression, nameof(expression));
-
-            return (expression.NodeType == ExpressionType.AndAlso)
-                   || (expression.NodeType == ExpressionType.OrElse);
-        }
-
-        public static bool IsComparisonOperation([NotNull] this Expression expression)
-        {
-            Check.NotNull(expression, nameof(expression));
-
-            return (expression.NodeType == ExpressionType.Equal)
-                || (expression.NodeType == ExpressionType.NotEqual)
-                || (expression.NodeType == ExpressionType.LessThan)
-                || (expression.NodeType == ExpressionType.LessThanOrEqual)
-                || (expression.NodeType == ExpressionType.GreaterThan)
-                || (expression.NodeType == ExpressionType.GreaterThanOrEqual)
-                || (expression.NodeType == ExpressionType.Not);
-        }
-
         public static ColumnExpression TryGetColumnExpression([NotNull] this Expression expression)
             => expression as ColumnExpression ?? (expression as AliasExpression)?.TryGetColumnExpression();
 

--- a/src/Microsoft.EntityFrameworkCore.Relational/Microsoft.EntityFrameworkCore.Relational.csproj
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Microsoft.EntityFrameworkCore.Relational.csproj
@@ -65,8 +65,8 @@
       <Link>StringBuilderExtensions.cs</Link>
     </Compile>
     <Compile Include="Extensions\DbCommandLogData.cs" />
-    <Compile Include="Extensions\ExpressionExtensions.cs" />
     <Compile Include="Extensions\MethodInfoExtensions.cs" />
+    <Compile Include="Extensions\RelationalExpressionExtensions.cs" />
     <Compile Include="Extensions\RelationalLoggerExtensions.cs" />
     <Compile Include="Extensions\TaskExtensions.cs" />
     <Compile Include="Infrastructure\Internal\RelationalModelSource.cs" />

--- a/src/Microsoft.EntityFrameworkCore.Relational/Migrations/Operations/Builders/CreateTableBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Migrations/Operations/Builders/CreateTableBuilder.cs
@@ -7,6 +7,8 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Migrations.Operations.Builders

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionTranslators/StringConcatTranslator.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionTranslators/StringConcatTranslator.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 
 namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/EqualityPredicateExpandingVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/EqualityPredicateExpandingVisitor.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Internal;
 using Remotion.Linq.Parsing;
 
 namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/EqualityPredicateInExpressionOptimizer.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/EqualityPredicateInExpressionOptimizer.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Remotion.Linq.Parsing;

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/IncludeExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/IncludeExpressionVisitor.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.Internal;
@@ -15,7 +16,6 @@ using Microsoft.EntityFrameworkCore.Utilities;
 using Remotion.Linq.Clauses;
 
 // ReSharper disable ImplicitlyCapturedClosure
-
 namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 {
     public class IncludeExpressionVisitor : ExpressionVisitorBase

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/IsNullExpressionBuildingVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/IsNullExpressionBuildingVisitor.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Remotion.Linq.Parsing;
 

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/PredicateReductionExpressionOptimizer.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/PredicateReductionExpressionOptimizer.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Internal;
 using Remotion.Linq.Parsing;
 
 namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/Shaper.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/Internal/Shaper.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
 using Remotion.Linq.Clauses;
 
 namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/RelationalProjectionExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/RelationalProjectionExpressionVisitor.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Storage;

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Expressions/SelectExpression.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query.Sql;
 using Microsoft.EntityFrameworkCore.Utilities;

--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Query.Expressions;

--- a/src/Microsoft.EntityFrameworkCore.Relational/RelationalEntityTypeBuilderExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/RelationalEntityTypeBuilderExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Query/Internal/SqlServerQueryModelVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Query/Internal/SqlServerQueryModelVisitor.cs
@@ -6,6 +6,7 @@ using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Infrastructure.Internal;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Query.Expressions;

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/Query/Sql/Internal/SqlServerQuerySqlGenerator.cs
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/Query/Sql/Internal/SqlServerQuerySqlGenerator.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.Expressions.Internal;
 using Microsoft.EntityFrameworkCore.Storage;

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/CompositePrincipalKeyValueFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/CompositePrincipalKeyValueFactory.cs
@@ -99,6 +99,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             {
                 var hashCode = 0;
 
+                // ReSharper disable once ForCanBeConvertedToForeach
+                // ReSharper disable once LoopCanBeConvertedToQuery
                 for (var i = 0; i < obj.Length; i++)
                 {
                     hashCode = (hashCode * 397) ^ (obj[i] != null ? obj[i].GetHashCode() : 0);
@@ -140,6 +142,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             {
                 var hashCode = 0;
 
+                // ReSharper disable once ForCanBeConvertedToForeach
+                // ReSharper disable once LoopCanBeConvertedToQuery
                 for (var i = 0; i < obj.Length; i++)
                 {
                     hashCode = (hashCode * 397) ^ _structuralEqualityComparer.GetHashCode(obj[i]);

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/IDependentKeyValueFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/IDependentKeyValueFactory.cs
@@ -8,9 +8,16 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 {
     public interface IDependentKeyValueFactory<TKey>
     {
+        [ContractAnnotation("=>true, key:notnull; =>false, key:null")]
         bool TryCreateFromBuffer(ValueBuffer valueBuffer, [CanBeNull] out TKey key);
+
+        [ContractAnnotation("=>true, key:notnull; =>false, key:null")]
         bool TryCreateFromCurrentValues([NotNull] InternalEntityEntry entry, [CanBeNull] out TKey key);
+
+        [ContractAnnotation("=>true, key:notnull; =>false, key:null")]
         bool TryCreateFromOriginalValues([NotNull] InternalEntityEntry entry, [CanBeNull] out TKey key);
+
+        [ContractAnnotation("=>true, key:notnull; =>false, key:null")]
         bool TryCreateFromRelationshipSnapshot([NotNull] InternalEntityEntry entry, [CanBeNull] out TKey key);
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/IEntityStateListener.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/IEntityStateListener.cs
@@ -5,7 +5,7 @@ using JetBrains.Annotations;
 
 namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 {
-    // TODO: Consider which of listerners/events/interceptors/etc is better here
+    // TODO: Consider which of listeners/events/interceptors/etc is better here
     // See issue #737
     public interface IEntityStateListener
     {

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -14,7 +14,6 @@ using Microsoft.EntityFrameworkCore.Update;
 
 namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 {
-    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public abstract partial class InternalEntityEntry : IUpdateEntry
     {
         private StateData _stateData;
@@ -517,7 +516,6 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             }
             else if (EntityState == EntityState.Modified)
             {
-
                 IProperty modifiedProperty = null;
                 foreach (var property in EntityType.GetProperties())
                 {

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/KeyPropagator.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/KeyPropagator.cs
@@ -48,7 +48,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 {
                     if (property == foreignKey.Properties[propertyIndex])
                     {
-                        object valueToPropagte = null;
+                        object valueToPropagate = null;
 
                         foreach (var navigation in entityType.GetNavigations()
                             .Concat(foreignKey.PrincipalEntityType.GetNavigations())
@@ -65,15 +65,15 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                                 var principalValue = principalEntry[principalProperty];
                                 if (!principalProperty.ClrType.IsDefaultValue(principalValue))
                                 {
-                                    valueToPropagte = principalValue;
+                                    valueToPropagate = principalValue;
                                     break;
                                 }
                             }
                         }
 
-                        if (valueToPropagte != null)
+                        if (valueToPropagate != null)
                         {
-                            entry[property] = valueToPropagte;
+                            entry[property] = valueToPropagate;
                             return true;
                         }
                     }

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/NavigationFixer.cs
@@ -216,7 +216,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     {
                         _inFixup = true;
 
-                        // For a dpendent added to the collection, remove it from the collection of
+                        // For a dependent added to the collection, remove it from the collection of
                         // the principal entity that it was previously part of
                         var oldPrincipalEntry = stateManager.GetPrincipal(newTargetEntry, foreignKey);
                         if (oldPrincipalEntry != null)
@@ -306,17 +306,17 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                                 // and navigation property. A.k.a. reference stealing.
                                 // However, if the FK has already been changed or the reference is already set to point
                                 // to something else, then don't change it.
-                                var vicitmDependentEntry
+                                var targetDependentEntry
                                     = stateManager.GetDependentsUsingRelationshipSnapshot(newPrincipalEntry, foreignKey).FirstOrDefault();
 
-                                if (vicitmDependentEntry != null
-                                    && vicitmDependentEntry != entry)
+                                if (targetDependentEntry != null
+                                    && targetDependentEntry != entry)
                                 {
-                                    ConditionallyNullForeignKeyProperties(vicitmDependentEntry, newPrincipalEntry, foreignKey);
+                                    ConditionallyNullForeignKeyProperties(targetDependentEntry, newPrincipalEntry, foreignKey);
 
-                                    if (ReferenceEquals(vicitmDependentEntry[dependentToPrincipal], newPrincipalEntry.Entity))
+                                    if (ReferenceEquals(targetDependentEntry[dependentToPrincipal], newPrincipalEntry.Entity))
                                     {
-                                        SetNavigation(vicitmDependentEntry, dependentToPrincipal, null);
+                                        SetNavigation(targetDependentEntry, dependentToPrincipal, null);
                                     }
                                 }
                             }
@@ -580,7 +580,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     DelayedFixup(danglerEntry.Item2, danglerEntry.Item1, entry);
                 }
 
-                // Esnure current value is snapshotted for all keys and FKs
+                // Ensure current value is snapshotted for all keys and FKs
                 foreach (var property in entityType.GetProperties().Where(p => p.GetRelationshipIndex() >= 0))
                 {
                     entry.SetRelationshipSnapshotValue(property, entry[property]);
@@ -673,8 +673,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             var principalProperties = foreignKey.PrincipalKey.Properties;
             var dependentProperties = foreignKey.Properties;
 
-            if (principalEntry == null
-                || principalEntry.EntityState != EntityState.Detached)
+            if (principalEntry != null
+                && principalEntry.EntityState != EntityState.Detached)
             {
                 for (var i = 0; i < foreignKey.Properties.Count; i++)
                 {

--- a/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/StateData.cs
+++ b/src/Microsoft.EntityFrameworkCore/ChangeTracking/Internal/StateData.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Linq;
-
 namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 {
     public abstract partial class InternalEntityEntry

--- a/src/Microsoft.EntityFrameworkCore/DbSet`.cs
+++ b/src/Microsoft.EntityFrameworkCore/DbSet`.cs
@@ -15,7 +15,6 @@ using System.ComponentModel;
 using Microsoft.EntityFrameworkCore.Internal;
 
 #endif
-
 namespace Microsoft.EntityFrameworkCore
 {
     /// <summary>

--- a/src/Microsoft.EntityFrameworkCore/EntityFrameworkQueryableExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/EntityFrameworkQueryableExtensions.cs
@@ -17,7 +17,6 @@ using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 // ReSharper disable once CheckNamespace
-
 namespace Microsoft.EntityFrameworkCore
 {
     public static class EntityFrameworkQueryableExtensions

--- a/src/Microsoft.EntityFrameworkCore/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/EntityFrameworkServiceCollectionExtensions.cs
@@ -11,7 +11,6 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 
 // ReSharper disable once CheckNamespace
-
 namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>

--- a/src/Microsoft.EntityFrameworkCore/Extensions/EntityTypeExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/EntityTypeExtensions.cs
@@ -9,6 +9,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+// ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {
     /// <summary>

--- a/src/Microsoft.EntityFrameworkCore/Extensions/Internal/CoreLoggerExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/Internal/CoreLoggerExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.Logging;
 
+// ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore.Internal
 {
     internal static class CoreLoggerExtensions

--- a/src/Microsoft.EntityFrameworkCore/Extensions/Internal/ExpressionExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/Internal/ExpressionExtensions.cs
@@ -1,15 +1,17 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
 
 // ReSharper disable once CheckNamespace
-
-namespace System.Linq.Expressions
+namespace Microsoft.EntityFrameworkCore.Internal
 {
     [DebuggerStepThrough]
     public static class ExpressionExtensions
@@ -174,6 +176,27 @@ namespace System.Linq.Expressions
             }
 
             return expression as TExpression;
+        }
+
+        public static bool IsLogicalOperation([NotNull] this Expression expression)
+        {
+            Check.NotNull(expression, nameof(expression));
+
+            return (expression.NodeType == ExpressionType.AndAlso)
+                   || (expression.NodeType == ExpressionType.OrElse);
+        }
+
+        public static bool IsComparisonOperation([NotNull] this Expression expression)
+        {
+            Check.NotNull(expression, nameof(expression));
+
+            return (expression.NodeType == ExpressionType.Equal)
+                   || (expression.NodeType == ExpressionType.NotEqual)
+                   || (expression.NodeType == ExpressionType.LessThan)
+                   || (expression.NodeType == ExpressionType.LessThanOrEqual)
+                   || (expression.NodeType == ExpressionType.GreaterThan)
+                   || (expression.NodeType == ExpressionType.GreaterThanOrEqual)
+                   || (expression.NodeType == ExpressionType.Not);
         }
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Extensions/Internal/ListExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/Internal/ListExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+// ReSharper disable once CheckNamespace
 namespace System.Collections.Generic
 {
     internal static class ListExtensions

--- a/src/Microsoft.EntityFrameworkCore/Extensions/KeyExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/KeyExtensions.cs
@@ -8,6 +8,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+// ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {
     /// <summary>

--- a/src/Microsoft.EntityFrameworkCore/Extensions/ModelExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/ModelExtensions.cs
@@ -8,6 +8,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+// ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {
     /// <summary>

--- a/src/Microsoft.EntityFrameworkCore/Extensions/MutableAnnotatableExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/MutableAnnotatableExtensions.cs
@@ -5,6 +5,7 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 
+// ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {
     /// <summary>

--- a/src/Microsoft.EntityFrameworkCore/Extensions/MutableEntityTypeExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/MutableEntityTypeExtensions.cs
@@ -11,6 +11,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+// ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {
     /// <summary>
@@ -333,6 +334,12 @@ namespace Microsoft.EntityFrameworkCore
         {
             Check.NotNull(entityType, nameof(entityType));
             Check.NotNull(propertyInfo, nameof(propertyInfo));
+
+            if (propertyInfo.DeclaringType == null)
+            {
+                // TODO: Add exception message
+                throw new ArgumentException();
+            }
 
             if (entityType.HasClrType()
                 && !propertyInfo.DeclaringType.GetTypeInfo().IsAssignableFrom(entityType.ClrType.GetTypeInfo()))

--- a/src/Microsoft.EntityFrameworkCore/Extensions/MutableKeyExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/MutableKeyExtensions.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
 
+// ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {
     /// <summary>

--- a/src/Microsoft.EntityFrameworkCore/Extensions/MutableModelExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/MutableModelExtensions.cs
@@ -8,6 +8,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+// ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {
     /// <summary>

--- a/src/Microsoft.EntityFrameworkCore/Extensions/MutableNavigationExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/MutableNavigationExtensions.cs
@@ -4,6 +4,7 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
 
+// ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {
     /// <summary>

--- a/src/Microsoft.EntityFrameworkCore/Extensions/MutablePropertyExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/MutablePropertyExtensions.cs
@@ -9,6 +9,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+// ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {
     /// <summary>

--- a/src/Microsoft.EntityFrameworkCore/Extensions/NavigationExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/NavigationExtensions.cs
@@ -5,6 +5,7 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+// ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {
     /// <summary>

--- a/src/Microsoft.EntityFrameworkCore/Extensions/PropertyExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Extensions/PropertyExtensions.cs
@@ -8,6 +8,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+// ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {
     /// <summary>

--- a/src/Microsoft.EntityFrameworkCore/Infrastructure/DatabaseFacade.cs
+++ b/src/Microsoft.EntityFrameworkCore/Infrastructure/DatabaseFacade.cs
@@ -98,7 +98,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// </summary>
         /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
         /// <returns>
-        ///     A task that represents the asynchronus transaction initialization. The task result contains a <see cref="IDbContextTransaction" />
+        ///     A task that represents the asynchronous transaction initialization. The task result contains a <see cref="IDbContextTransaction" />
         ///     that represents the started transaction.
         /// </returns>
         public virtual Task<IDbContextTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default(CancellationToken))

--- a/src/Microsoft.EntityFrameworkCore/Infrastructure/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Infrastructure/EntityFrameworkServiceCollectionExtensions.cs
@@ -21,7 +21,6 @@ using Remotion.Linq.Parsing.Structure.NodeTypeProviders;
 
 // Intentionally in this namespace since this is for use by other relational providers rather than
 // by top-level app developers.
-
 namespace Microsoft.EntityFrameworkCore.Infrastructure
 {
     /// <summary>

--- a/src/Microsoft.EntityFrameworkCore/Internal/DbSetSource.cs
+++ b/src/Microsoft.EntityFrameworkCore/Internal/DbSetSource.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         public virtual object Create(DbContext context, Type type)
             => _cache.GetOrAdd(
                 type,
-                t => (Func<DbContext, object>)_genericCreate.MakeGenericMethod(type).Invoke(null, null))(context);
+                t => (Func<DbContext, object>)_genericCreate.MakeGenericMethod(t).Invoke(null, null))(context);
 
         [UsedImplicitly]
         private static Func<DbContext, object> CreateConstructor<TEntity>() where TEntity : class

--- a/src/Microsoft.EntityFrameworkCore/Internal/InternalDbSet.cs
+++ b/src/Microsoft.EntityFrameworkCore/Internal/InternalDbSet.cs
@@ -56,15 +56,19 @@ namespace Microsoft.EntityFrameworkCore.Internal
             => _context.Update(Check.NotNull(entity, nameof(entity)));
 
         public override void AddRange(params TEntity[] entities)
+            // ReSharper disable once CoVariantArrayConversion
             => _context.AddRange(Check.NotNull(entities, nameof(entities)));
 
         public override void AttachRange(params TEntity[] entities)
+            // ReSharper disable once CoVariantArrayConversion
             => _context.AttachRange(Check.NotNull(entities, nameof(entities)));
 
         public override void RemoveRange(params TEntity[] entities)
+            // ReSharper disable once CoVariantArrayConversion
             => _context.RemoveRange(Check.NotNull(entities, nameof(entities)));
 
         public override void UpdateRange(params TEntity[] entities)
+            // ReSharper disable once CoVariantArrayConversion
             => _context.UpdateRange(Check.NotNull(entities, nameof(entities)));
 
         public override void AddRange(IEnumerable<TEntity> entities)

--- a/src/Microsoft.EntityFrameworkCore/Internal/Multigraph.cs
+++ b/src/Microsoft.EntityFrameworkCore/Internal/Multigraph.cs
@@ -33,8 +33,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
         public virtual void AddVertex([NotNull] TVertex vertex)
             => _vertices.Add(vertex);
 
-        public virtual void AddVertices([NotNull] IEnumerable<TVertex> verticies)
-            => _vertices.UnionWith(verticies);
+        public virtual void AddVertices([NotNull] IEnumerable<TVertex> vertices)
+            => _vertices.UnionWith(vertices);
 
         public virtual void AddEdge([NotNull] TVertex from, [NotNull] TVertex to, [NotNull] TEdge edge)
             => AddEdges(@from, to, new[] { edge });
@@ -66,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
             }
 
             edgeList.AddRange(edges);
-            _edges.UnionWith(edges);
+            _edges.UnionWith(edgeList);
         }
 
         public virtual IReadOnlyList<TVertex> TopologicalSort() => TopologicalSort(null, null);

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/CollectionNavigationBuilder`.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/CollectionNavigationBuilder`.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/EntityTypeBuilder`.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/EntityTypeBuilder`.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/ReferenceCollectionBuilder`.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/ReferenceCollectionBuilder`.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/ReferenceNavigationBuilder`.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/ReferenceNavigationBuilder`.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Builders/ReferenceReferenceBuilder`.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Builders/ReferenceReferenceBuilder`.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/ForeignKeyPropertyDiscoveryConvention.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Conventions/Internal/ForeignKeyPropertyDiscoveryConvention.cs
@@ -189,7 +189,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 }
             }
 
-            // Don't match with only Id since it is ambigious. PK in dependent entity used as FK is matched elsewhere
+            // Don't match with only Id since it is ambiguous. PK in dependent entity used as FK is matched elsewhere
             if ((foreignKeyProperties.Count == 1)
                 && (foreignKeyProperties.Single().Name == "Id"))
             {

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrCollectionAccessorFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrCollectionAccessorFactory.cs
@@ -22,8 +22,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         public virtual IClrCollectionAccessor Create([NotNull] INavigation navigation)
         {
+            // ReSharper disable once SuspiciousTypeConversion.Global
             var accessor = navigation as IClrCollectionAccessor;
-
             if (accessor != null)
             {
                 return accessor;
@@ -108,7 +108,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         [UsedImplicitly]
         private static TCollection CreateCollection<TCollection, TConcreteCollection>()
             where TCollection : class
-            where TConcreteCollection : TCollection, new() 
+            where TConcreteCollection : TCollection, new()
             => new TConcreteCollection();
     }
 }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrPropertySetterFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ClrPropertySetterFactory.cs
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
@@ -19,15 +21,17 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var setterProperty = property;
             while (setterProperty.SetMethod == null)
             {
-                setterProperty = setterProperty.DeclaringType.GetProperty(property.Name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                var declaringType = setterProperty.DeclaringType;
+                Debug.Assert(declaringType != null);
+                setterProperty = declaringType.GetProperty(property.Name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
                 if (setterProperty.SetMethod != null)
                 {
                     break;
                 }
-                setterProperty = setterProperty.DeclaringType.GetTypeInfo().BaseType.GetProperty(property.Name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                setterProperty = declaringType.GetTypeInfo().BaseType?.GetProperty(property.Name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
                 if (setterProperty == null)
                 {
-                    throw new InvalidOperationException($"Could not find setter for property {property.Name}");
+                    throw new InvalidOperationException(CoreStrings.NoClrSetter(property.Name));
                 }
             }
 

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ConfigurationSourceExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ConfigurationSourceExtensions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using JetBrains.Annotations;
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     public static class ConfigurationSourceExtensions
@@ -35,6 +37,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             return true;
         }
 
+        [ContractAnnotation("left:notnull => notnull;right:notnull => notnull")]
         public static ConfigurationSource? Max(this ConfigurationSource? left, ConfigurationSource? right)
         {
             if (!right.HasValue

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityType.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityType.cs
@@ -78,6 +78,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
 #if DEBUG
+        [UsedImplicitly]
         private string DebugName { get; set; }
 #endif
 
@@ -169,8 +170,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     throw new InvalidOperationException(CoreStrings.DerivedEntityCannotHaveKeys(Name));
                 }
 
-                var propertyCollisions = entityType.GetProperties().Select(p => p.Name)
-                    .SelectMany(FindPropertiesInHierarchy);
+                var propertyCollisions = entityType.GetProperties()
+                    .Select(p => p.Name)
+                    .SelectMany(FindPropertiesInHierarchy)
+                    .ToList();
                 if (propertyCollisions.Any())
                 {
                     throw new InvalidOperationException(
@@ -180,8 +183,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                             string.Join(", ", propertyCollisions.Select(p => p.Name))));
                 }
 
-                var navigationCollisions = entityType.GetNavigations().Select(p => p.Name)
-                    .SelectMany(FindNavigationsInHierarchy);
+                var navigationCollisions = entityType.GetNavigations()
+                    .Select(p => p.Name)
+                    .SelectMany(FindNavigationsInHierarchy)
+                    .ToList();
                 if (navigationCollisions.Any())
                 {
                     throw new InvalidOperationException(
@@ -471,6 +476,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 : null;
         }
 
+        // ReSharper disable once MethodOverloadWithOptionalParameter
         public virtual Key RemoveKey([NotNull] IReadOnlyList<IProperty> properties, bool runConventions = true)
         {
             Check.NotEmpty(properties, nameof(properties));
@@ -731,6 +737,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             [NotNull] IReadOnlyList<IProperty> properties,
             [NotNull] IKey principalKey,
             [NotNull] IEntityType principalEntityType,
+            // ReSharper disable once MethodOverloadWithOptionalParameter
             bool runConventions = true)
         {
             Check.NotEmpty(properties, nameof(properties));
@@ -1043,6 +1050,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         public virtual Property AddProperty(
             [NotNull] string name,
+            // ReSharper disable once MethodOverloadWithOptionalParameter
             ConfigurationSource configurationSource = ConfigurationSource.Explicit,
             bool runConventions = true)
         {

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityTypeExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/EntityTypeExtensions.cs
@@ -96,7 +96,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         {
             var properties = entityType.GetDeclaredProperties().ToList();
 
-            var propertyCount = properties.Count();
+            var propertyCount = properties.Count;
             var navigationCount = entityType.GetDeclaredNavigations().Count();
             var originalValueCount = properties.Count(p => p.RequiresOriginalValue());
             var shadowCount = properties.Count(p => p.IsShadowProperty);

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ForeignKey.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/ForeignKey.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
@@ -105,6 +106,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         public virtual Navigation HasDependentToPrincipal(
             [CanBeNull] string name,
+            // ReSharper disable once MethodOverloadWithOptionalParameter
             ConfigurationSource configurationSource = ConfigurationSource.Explicit,
             bool runConventions = true)
         {
@@ -117,6 +119,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             if (oldNavigation != null)
             {
+                Debug.Assert(oldNavigation.Name != null);
                 DeclaringEntityType.RemoveNavigation(oldNavigation.Name);
             }
 
@@ -133,6 +136,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             {
                 if (oldNavigation != null)
                 {
+                    Debug.Assert(oldNavigation.Name != null);
                     DeclaringEntityType.Model.ConventionDispatcher.OnNavigationRemoved(
                         DeclaringEntityType.Builder,
                         PrincipalEntityType.Builder,
@@ -158,6 +162,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         public virtual Navigation HasPrincipalToDependent(
             [CanBeNull] string name,
+            // ReSharper disable once MethodOverloadWithOptionalParameter
             ConfigurationSource configurationSource = ConfigurationSource.Explicit,
             bool runConventions = true)
         {
@@ -170,6 +175,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             if (oldNavigation != null)
             {
+                Debug.Assert(oldNavigation.Name != null);
                 PrincipalEntityType.RemoveNavigation(oldNavigation.Name);
             }
 
@@ -186,6 +192,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             {
                 if (oldNavigation != null)
                 {
+                    Debug.Assert(oldNavigation.Name != null);
                     DeclaringEntityType.Model.ConventionDispatcher.OnNavigationRemoved(
                         PrincipalEntityType.Builder,
                         DeclaringEntityType.Builder,
@@ -393,7 +400,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         public static bool CanPropertiesBeRequired(
-            [NotNull] IEnumerable<Property> properties,
+            [NotNull] IReadOnlyList<Property> properties,
             bool? required,
             [NotNull] EntityType entityType,
             bool shouldThrow)

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -546,6 +546,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     var propertyBuilder = propertyToDetach.Builder;
                     var removedConfigurationSource = entityTypeBuilder
                         .RemoveProperty(propertyToDetach, ConfigurationSource.Explicit);
+                    Debug.Assert(removedConfigurationSource.HasValue);
                     detachedProperties.Add(Tuple.Create(propertyBuilder, removedConfigurationSource.Value));
                 }
             }
@@ -1001,7 +1002,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             var newRelationship = Relationship(principalEntityTypeBuilder, principalKey, configurationSource);
             var relationship = newRelationship.HasForeignKey(dependentProperties, configurationSource);
-            if (relationship == null 
+            if (relationship == null
                 && newRelationship.Metadata.Builder != null)
             {
                 RemoveForeignKey(newRelationship.Metadata, configurationSource);
@@ -1157,31 +1158,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 isUnique: toSourceCanBeNonUnique || toTargetCanBeNonUnique ? true : (bool?)null);
         }
 
-        public virtual InternalRelationshipBuilder Relationship(
-            [NotNull] EntityType principalEntityType,
-            ConfigurationSource configurationSource,
-            bool setPrincipalEnd = true)
-            => Relationship(principalEntityType.Builder, configurationSource, setPrincipalEnd);
-
-        public virtual InternalRelationshipBuilder Relationship(
-            [NotNull] InternalEntityTypeBuilder principalEntityTypeBuilder,
-            ConfigurationSource configurationSource,
-            bool setPrincipalEnd = true)
-        {
-            var relationship = CreateForeignKey(
-                principalEntityTypeBuilder,
-                null,
-                null,
-                null,
-                null,
-                configurationSource,
-                runConventions: true);
-
-            return setPrincipalEnd
-                ? relationship?.RelatedEntityTypes(principalEntityTypeBuilder.Metadata, Metadata, configurationSource)
-                : relationship;
-        }
-
         private InternalRelationshipBuilder Relationship(
             InternalEntityTypeBuilder principalEntityTypeBuilder,
             string navigationToPrincipalName,
@@ -1262,7 +1238,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         public virtual InternalRelationshipBuilder Relationship(
             [NotNull] EntityType principalEntityType,
-            [NotNull] Key principalKey,
+            [CanBeNull] Key principalKey,
             ConfigurationSource configurationSource)
             => RelationshipInternal(principalEntityType.Builder, principalKey, configurationSource);
 
@@ -1273,7 +1249,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         public virtual InternalRelationshipBuilder Relationship(
             [NotNull] InternalEntityTypeBuilder principalEntityTypeBuilder,
-            [NotNull] Key principalKey,
+            [CanBeNull] Key principalKey,
             ConfigurationSource configurationSource)
             => RelationshipInternal(principalEntityTypeBuilder, principalKey, configurationSource);
 
@@ -1300,7 +1276,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 ?.HasPrincipalKey(principalKey.Properties, configurationSource);
 
             if (newRelationship == null
-                && relationship.Metadata.Builder != null)
+                && relationship?.Metadata.Builder != null)
             {
                 relationship.Metadata.DeclaringEntityType.Builder.RemoveForeignKey(relationship.Metadata, configurationSource);
                 return null;
@@ -1563,7 +1539,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             private InternalRelationshipBuilder Relationship { get; }
             private ConfigurationSource RelationshipConfigurationSource { get; }
 
-            public InternalRelationshipBuilder Attach()
+            public void Attach()
                 => Relationship.Attach(RelationshipConfigurationSource);
         }
     }

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalPropertyBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalPropertyBuilder.cs
@@ -159,41 +159,49 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             newPropertyBuilder.MergeAnnotationsFrom(this);
 
-            if (Metadata.GetClrTypeConfigurationSource().HasValue)
+            var oldClrTypeConfigurationSource = Metadata.GetClrTypeConfigurationSource();
+            if (oldClrTypeConfigurationSource.HasValue)
             {
-                newPropertyBuilder.HasClrType(Metadata.ClrType, Metadata.GetClrTypeConfigurationSource().Value);
+                newPropertyBuilder.HasClrType(Metadata.ClrType, oldClrTypeConfigurationSource.Value);
             }
-            if (Metadata.GetIsReadOnlyAfterSaveConfigurationSource().HasValue)
+            var oldIsReadOnlyAfterSaveConfigurationSource = Metadata.GetIsReadOnlyAfterSaveConfigurationSource();
+            if (oldIsReadOnlyAfterSaveConfigurationSource.HasValue)
             {
                 newPropertyBuilder.ReadOnlyAfterSave(Metadata.IsReadOnlyAfterSave,
-                    Metadata.GetIsReadOnlyAfterSaveConfigurationSource().Value);
+                    oldIsReadOnlyAfterSaveConfigurationSource.Value);
             }
-            if (Metadata.GetIsReadOnlyBeforeSaveConfigurationSource().HasValue)
+            var oldIsReadOnlyBeforeSaveConfigurationSource = Metadata.GetIsReadOnlyBeforeSaveConfigurationSource();
+            if (oldIsReadOnlyBeforeSaveConfigurationSource.HasValue)
             {
                 newPropertyBuilder.ReadOnlyBeforeSave(Metadata.IsReadOnlyBeforeSave,
-                    Metadata.GetIsReadOnlyBeforeSaveConfigurationSource().Value);
+                    oldIsReadOnlyBeforeSaveConfigurationSource.Value);
             }
-            if (Metadata.GetIsNullableConfigurationSource().HasValue)
+            var oldIsNullableConfigurationSource = Metadata.GetIsNullableConfigurationSource();
+            if (oldIsNullableConfigurationSource.HasValue)
             {
-                newPropertyBuilder.IsRequired(!Metadata.IsNullable, Metadata.GetIsNullableConfigurationSource().Value);
+                newPropertyBuilder.IsRequired(!Metadata.IsNullable, oldIsNullableConfigurationSource.Value);
             }
-            if (Metadata.GetIsConcurrencyTokenConfigurationSource().HasValue)
+            var oldIsConcurrencyTokenConfigurationSource = Metadata.GetIsConcurrencyTokenConfigurationSource();
+            if (oldIsConcurrencyTokenConfigurationSource.HasValue)
             {
                 newPropertyBuilder.IsConcurrencyToken(Metadata.IsConcurrencyToken,
-                    Metadata.GetIsConcurrencyTokenConfigurationSource().Value);
+                    oldIsConcurrencyTokenConfigurationSource.Value);
             }
-            if (Metadata.GetIsShadowPropertyConfigurationSource().HasValue)
+            var oldIsShadowPropertyConfigurationSource = Metadata.GetIsShadowPropertyConfigurationSource();
+            if (oldIsShadowPropertyConfigurationSource.HasValue)
             {
-                newPropertyBuilder.IsShadow(Metadata.IsShadowProperty, Metadata.GetIsShadowPropertyConfigurationSource().Value);
+                newPropertyBuilder.IsShadow(Metadata.IsShadowProperty, oldIsShadowPropertyConfigurationSource.Value);
             }
-            if (Metadata.GetRequiresValueGeneratorConfigurationSource().HasValue)
+            var oldRequiresValueGeneratorConfigurationSource = Metadata.GetRequiresValueGeneratorConfigurationSource();
+            if (oldRequiresValueGeneratorConfigurationSource.HasValue)
             {
                 newPropertyBuilder.RequiresValueGenerator(Metadata.RequiresValueGenerator,
-                    Metadata.GetRequiresValueGeneratorConfigurationSource().Value);
+                    oldRequiresValueGeneratorConfigurationSource.Value);
             }
-            if (Metadata.GetValueGeneratedConfigurationSource().HasValue)
+            var oldValueGeneratedConfigurationSource = Metadata.GetValueGeneratedConfigurationSource();
+            if (oldValueGeneratedConfigurationSource.HasValue)
             {
-                newPropertyBuilder.ValueGenerated(Metadata.ValueGenerated, Metadata.GetValueGeneratedConfigurationSource().Value);
+                newPropertyBuilder.ValueGenerated(Metadata.ValueGenerated, oldValueGeneratedConfigurationSource.Value);
             }
 
             return newPropertyBuilder;

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalRelationshipBuilder.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/InternalRelationshipBuilder.cs
@@ -132,6 +132,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 return null;
             }
 
+            Debug.Assert(configurationSource.HasValue);
+
             var builder = this;
             if (removeOppositeNavigation)
             {
@@ -361,7 +363,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         private static bool CanSetRequiredOnProperties(
-            IEnumerable<Property> properties,
+            IReadOnlyList<Property> properties,
             bool? isRequired,
             EntityType entityType,
             ConfigurationSource? configurationSource,
@@ -379,7 +381,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
 
             var nullableProperties = properties.Where(p => p.ClrType.IsNullableType());
-
             return isRequired.Value
                 ? nullableProperties.All(property => property.Builder.CanSetRequired(true, configurationSource))
                 : nullableProperties.Any(property => property.Builder.CanSetRequired(false, configurationSource));
@@ -701,10 +702,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual InternalRelationshipBuilder HasForeignKey(
             [CanBeNull] IReadOnlyList<Property> properties, ConfigurationSource? configurationSource, bool runConventions)
         {
-            if (properties == null
-                && configurationSource.HasValue)
+            if (properties == null)
             {
-                return !configurationSource.Value.Overrides(Metadata.GetForeignKeyPropertiesConfigurationSource())
+                return !configurationSource.HasValue
+                       || !configurationSource.Value.Overrides(Metadata.GetForeignKeyPropertiesConfigurationSource())
                     ? null
                     : ReplaceForeignKey(configurationSource,
                         dependentProperties: new Property[0],
@@ -873,7 +874,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         private InternalRelationshipBuilder HasPrincipalKey(
             IReadOnlyList<Property> properties, ConfigurationSource configurationSource, bool runConventions)
         {
-            if (properties == null)
+            bool resetDependent;
+            if (!CanSetPrincipalKey(properties, configurationSource, out resetDependent))
             {
                 return null;
             }
@@ -897,39 +899,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 return builder;
             }
 
-            if (!configurationSource.Overrides(Metadata.GetPrincipalKeyConfigurationSource()))
-            {
-                return null;
-            }
-
-            Property[] dependentProperties = null;
-            if (Metadata.GetForeignKeyPropertiesConfigurationSource().HasValue
-                && !ForeignKey.AreCompatible(
-                    properties,
-                    Metadata.Properties,
-                    Metadata.PrincipalEntityType,
-                    Metadata.DeclaringEntityType,
-                    shouldThrow: false))
-            {
-                if (!configurationSource.Overrides(Metadata.GetForeignKeyPropertiesConfigurationSource()))
-                {
-                    return null;
-                }
-
-                dependentProperties = new Property[0];
-            }
-
             return ReplaceForeignKey(
                 configurationSource,
                 principalProperties: properties,
-                dependentProperties: dependentProperties,
+                dependentProperties: resetDependent ? new Property[0] : null,
                 runConventions: runConventions);
         }
 
         private bool CanSetPrincipalKey(
             IReadOnlyList<Property> properties,
-            ConfigurationSource? configurationSource)
+            ConfigurationSource? configurationSource,
+            out bool resetDependent)
         {
+            resetDependent = false;
             if (properties == null)
             {
                 return false;
@@ -946,15 +928,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 return false;
             }
 
-            if (!configurationSource.Value.Overrides(Metadata.GetForeignKeyPropertiesConfigurationSource())
-                && !ForeignKey.AreCompatible(
+            if (!ForeignKey.AreCompatible(
                     properties,
                     Metadata.Properties,
                     Metadata.PrincipalEntityType,
                     Metadata.DeclaringEntityType,
                     shouldThrow: false))
             {
-                return false;
+                if (!configurationSource.Value.Overrides(Metadata.GetForeignKeyPropertiesConfigurationSource()))
+                {
+                    return false;
+                }
+
+                resetDependent = true;
             }
 
             return true;

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/MemberMapper.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/MemberMapper.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
@@ -33,6 +34,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 MemberInfo memberInfo = null;
                 foreach (var propertyInfo in entityType.ClrType.GetPropertiesInHierarchy(propertyName))
                 {
+                    Debug.Assert(propertyInfo.DeclaringType != null);
                     // TODO: Handle cases where backing field is declared in a different class than the property
                     // Issue #758
                     Dictionary<string, FieldInfo> fields;

--- a/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Model.cs
+++ b/src/Microsoft.EntityFrameworkCore/Metadata/Internal/Model.cs
@@ -42,7 +42,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual IEnumerable<EntityType> GetEntityTypes() => _entityTypes.Values;
 
         public virtual EntityType AddEntityType(
-            [NotNull] string name, [CanBeNull] Type type = null, ConfigurationSource configurationSource = ConfigurationSource.Explicit)
+            [NotNull] string name,
+            // ReSharper disable once MethodOverloadWithOptionalParameter
+            [CanBeNull] Type type = null,
+            // ReSharper disable once MethodOverloadWithOptionalParameter
+            ConfigurationSource configurationSource = ConfigurationSource.Explicit)
         {
             Check.NotEmpty(name, nameof(name));
 

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.Designer.cs
@@ -1149,7 +1149,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
-        /// The corresponding CLR type for entity type '{entityType}' is abstract and there is no derived entity type in the model that corresponds to a concrete CLR type.
+        /// The corresponding CLR type for entity type '{entityType}' is not instantiable and there is no derived entity type in the model that corresponds to a concrete CLR type.
         /// </summary>
         public static string AbstractLeafEntityType([CanBeNull] object entityType)
         {
@@ -1157,11 +1157,11 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         /// <summary>
-        /// The discriminator value for '{entityType1}' is '{discriminatorValue}' which is the same for '{entityType2}'. Every concrete entity type in the hierarchy needs to have a unique discriminator value.
+        /// Could not find setter for property {property}
         /// </summary>
-        public static string DuplicateDiscriminatorValue([CanBeNull] object entityType1, [CanBeNull] object discriminatorValue, [CanBeNull] object entityType2)
+        public static string NoClrSetter([CanBeNull] object property)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("DuplicateDiscriminatorValue", "entityType1", "discriminatorValue", "entityType2"), entityType1, discriminatorValue, entityType2);
+            return string.Format(CultureInfo.CurrentCulture, GetString("NoClrSetter", "property"), property);
         }
 
         private static string GetString(string name, params string[] formatterNames)

--- a/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
+++ b/src/Microsoft.EntityFrameworkCore/Properties/CoreStrings.resx
@@ -352,7 +352,7 @@
     <value>The key {key} on entity type '{entityType}' contains properties in shadow state - {shadowProperties}.</value>
   </data>
   <data name="ExpressionParameterizationException" xml:space="preserve">
-    <value>An exception was thrown while attempting to evaluate a LINQ query parameter expression. To show aditional information call EnableSensitiveDataLogging() when overriding DbContext.OnConfiguring.</value>
+    <value>An exception was thrown while attempting to evaluate a LINQ query parameter expression. To show additional information call EnableSensitiveDataLogging() when overriding DbContext.OnConfiguring.</value>
   </data>
   <data name="InvalidValueGeneratorFactoryProperty" xml:space="preserve">
     <value>The '{factory}' cannot create a value generator for property '{property}' on entity type '{entityType}'. Only integer properties are supported.</value>
@@ -545,5 +545,8 @@
   </data>
   <data name="AbstractLeafEntityType" xml:space="preserve">
     <value>The corresponding CLR type for entity type '{entityType}' is not instantiable and there is no derived entity type in the model that corresponds to a concrete CLR type.</value>
+  </data>
+  <data name="NoClrSetter" xml:space="preserve">
+    <value>Could not find setter for property {property}</value>
   </data>
 </root>

--- a/src/Microsoft.EntityFrameworkCore/Query/EntityQueryModelVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/EntityQueryModelVisitor.cs
@@ -811,7 +811,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     inProjection: true);
 
             if ((selector.Type != sequenceType
-                || !(selectClause.Selector is QuerySourceReferenceExpression))
+                 || !(selectClause.Selector is QuerySourceReferenceExpression))
                 && !queryModel.ResultOperators
                     .Select(ro => ro.GetType())
                     .Any(t =>

--- a/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/MemberAccessBindingExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/MemberAccessBindingExpressionVisitor.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage;
 using Remotion.Linq.Clauses;

--- a/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
@@ -775,14 +775,14 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                             .ToArray()));
         }
 
-        private static readonly MethodInfo PropertyMethodInfo
+        private static readonly MethodInfo _propertyMethodInfo
             = typeof(EF).GetTypeInfo().GetDeclaredMethod(nameof(Property));
 
         private static Expression CreatePropertyExpression(Expression target, IProperty property, bool addNullCheck)
         {
             var propertyExpression = (Expression)Expression.Call(
                 null,
-                PropertyMethodInfo.MakeGenericMethod(property.ClrType),
+                _propertyMethodInfo.MakeGenericMethod(property.ClrType),
                 target,
                 Expression.Constant(property.Name));
 
@@ -851,6 +851,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 .GetTypeInfo().GetDeclaredMethod(nameof(_CreateEntityQueryable));
 
         [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
         private static EntityQueryable<TResult> _CreateEntityQueryable<TResult>(IAsyncQueryProvider entityQueryProvider)
             => new EntityQueryable<TResult>(entityQueryProvider);
 
@@ -924,7 +925,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                     _queryModelVisitor = queryModelVisitor;
                 }
 
-                protected override Expression VisitSubQuery(SubQueryExpression expression) 
+                protected override Expression VisitSubQuery(SubQueryExpression expression)
                     => expression;
 
                 protected override Expression VisitMember(MemberExpression node)
@@ -950,9 +951,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 {
                     var targetType = collectionNavigation.GetTargetType().ClrType;
                     var mainFromClause = new MainFromClause(targetType.Name.Substring(0, 1).ToLower(), targetType, expression);
-                    var selecor = new QuerySourceReferenceExpression(mainFromClause);
+                    var selector = new QuerySourceReferenceExpression(mainFromClause);
 
-                    var subqueryModel = new QueryModel(mainFromClause, new SelectClause(selecor));
+                    var subqueryModel = new QueryModel(mainFromClause, new SelectClause(selector));
                     var subqueryExpression = new SubQueryExpression(subqueryModel);
 
                     var resultCollectionType = collectionNavigation.GetCollectionAccessor().CollectionType;
@@ -970,6 +971,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                     = typeof(SubqueryInjector).GetTypeInfo()
                         .GetDeclaredMethod(nameof(MaterializeCollectionNavigation));
 
+                [UsedImplicitly]
                 private static ICollection<TEntity> MaterializeCollectionNavigation<TEntity>(INavigation navigation, IEnumerable<object> elements)
                 {
                     var collection = navigation.GetCollectionAccessor().Create(elements);

--- a/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/RequiresMaterializationExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/ExpressionVisitors/Internal/RequiresMaterializationExpressionVisitor.cs
@@ -225,6 +225,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             }
 
             var unionOperator = resultOperator as UnionResultOperator;
+            // ReSharper disable once UseNullPropagation
             if (unionOperator != null)
             {
                 return unionOperator.Source2;

--- a/src/Microsoft.EntityFrameworkCore/Query/Internal/AsyncLinqOperatorProvider.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/Internal/AsyncLinqOperatorProvider.cs
@@ -29,6 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 .GetTypeInfo().GetDeclaredMethod(nameof(_ToEnumerable));
 
         [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
         private static EnumerableAdapter<TResult> _ToEnumerable<TResult>(IAsyncEnumerable<TResult> results)
             => new EnumerableAdapter<TResult>(results);
 
@@ -55,6 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 .GetTypeInfo().GetDeclaredMethod(nameof(_ToOrdered));
 
         [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
         private static OrderedEnumerableAdapter<TResult> _ToOrdered<TResult>(IAsyncEnumerable<TResult> results)
             => new OrderedEnumerableAdapter<TResult>(results);
 
@@ -84,6 +86,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 .GetTypeInfo().GetDeclaredMethod(nameof(_InterceptExceptions));
 
         [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
         private static IAsyncEnumerable<T> _InterceptExceptions<T>(
             IAsyncEnumerable<T> source, Type contextType, ILogger logger, QueryContext queryContext)
             => new ExceptionInterceptor<T>(source, contextType, logger, queryContext);
@@ -157,6 +160,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 .GetTypeInfo().GetDeclaredMethod(nameof(_TrackEntities));
 
         [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
         private static IAsyncEnumerable<TOut> _TrackEntities<TOut, TIn>(
             IAsyncEnumerable<TOut> results,
             QueryContext queryContext,
@@ -204,6 +208,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 .GetTypeInfo().GetDeclaredMethod(nameof(_TrackGroupedEntities));
 
         [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
         private static IAsyncEnumerable<TrackingGrouping<TKey, TOut, TIn>> _TrackGroupedEntities<TKey, TOut, TIn>(
             IAsyncEnumerable<IGrouping<TKey, TOut>> groupings,
             QueryContext queryContext,
@@ -275,6 +280,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 .GetTypeInfo().GetDeclaredMethod(nameof(_ToSequence));
 
         [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
         private static IAsyncEnumerable<T> _ToSequence<T>(T element)
             => new AsyncEnumerableAdapter<T>(new[] { element });
 
@@ -285,6 +291,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 .GetTypeInfo().GetDeclaredMethod(nameof(_ToQueryable));
 
         [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
         private static IOrderedQueryable<TSource> _ToQueryable<TSource>(IAsyncEnumerable<TSource> source)
             => new AsyncQueryableAdapter<TSource>(source);
 
@@ -321,6 +328,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 .GetTypeInfo().GetDeclaredMethod(nameof(_SelectMany));
 
         [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
         private static IAsyncEnumerable<TResult> _SelectMany<TSource, TCollection, TResult>(
             IAsyncEnumerable<TSource> source,
             Func<TSource, IAsyncEnumerable<TCollection>> collectionSelector,
@@ -334,6 +342,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 .GetTypeInfo().GetDeclaredMethod(nameof(_Join));
 
         [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
         private static IAsyncEnumerable<TResult> _Join<TOuter, TInner, TKey, TResult>(
             IAsyncEnumerable<TOuter> outer,
             IAsyncEnumerable<TInner> inner,
@@ -349,6 +358,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 .GetTypeInfo().GetDeclaredMethod(nameof(_GroupJoin));
 
         [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
         private static IAsyncEnumerable<TResult> _GroupJoin<TOuter, TInner, TKey, TResult>(
             IAsyncEnumerable<TOuter> outer,
             IAsyncEnumerable<TInner> inner,
@@ -364,6 +374,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 .GetTypeInfo().GetDeclaredMethod(nameof(_Select));
 
         [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
         private static IAsyncEnumerable<TResult> _Select<TSource, TResult>(
             IAsyncEnumerable<TSource> source, Func<TSource, TResult> selector)
             => source.Select(selector);
@@ -375,6 +386,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 .GetTypeInfo().GetDeclaredMethod(nameof(_OrderBy));
 
         [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
         private static IOrderedAsyncEnumerable<TSource> _OrderBy<TSource, TKey>(
             IAsyncEnumerable<TSource> source, Func<TSource, TKey> expression, OrderingDirection orderingDirection)
             => orderingDirection == OrderingDirection.Asc
@@ -388,6 +400,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 .GetTypeInfo().GetDeclaredMethod(nameof(_ThenBy));
 
         [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
         private static IOrderedAsyncEnumerable<TSource> _ThenBy<TSource, TKey>(
             IOrderedAsyncEnumerable<TSource> source, Func<TSource, TKey> expression, OrderingDirection orderingDirection)
             => orderingDirection == OrderingDirection.Asc
@@ -401,6 +414,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 .GetTypeInfo().GetDeclaredMethod(nameof(_Where));
 
         [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
         private static IAsyncEnumerable<TSource> _Where<TSource>(
             IAsyncEnumerable<TSource> source, Func<TSource, bool> predicate) => source.Where(predicate);
 
@@ -435,6 +449,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             = typeof(AsyncLinqOperatorProvider).GetTypeInfo().GetDeclaredMethod(nameof(_GroupBy));
 
         [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
         private static IAsyncEnumerable<IGrouping<TKey, TElement>> _GroupBy<TSource, TKey, TElement>(
             IAsyncEnumerable<TSource> source,
             Func<TSource, TKey> keySelector,
@@ -596,7 +611,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             }
         }
 
-
         // Set operations
         private static readonly MethodInfo _concat = GetMethod("Concat", 1);
         private static readonly MethodInfo _except = GetMethod("Except", 1);
@@ -607,7 +621,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         public virtual MethodInfo Except => _except;
         public virtual MethodInfo Intersect => _intersect;
         public virtual MethodInfo Union => _union;
-
 
         private static MethodInfo GetMethod(string name, int parameterCount = 0)
         {

--- a/src/Microsoft.EntityFrameworkCore/Query/Internal/ExpressionEqualityComparer.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/Internal/ExpressionEqualityComparer.cs
@@ -10,7 +10,6 @@ using System.Reflection;
 // ReSharper disable SwitchStatementMissingSomeCases
 // ReSharper disable ForCanBeConvertedToForeach
 // ReSharper disable LoopCanBeConvertedToQuery
-
 namespace Microsoft.EntityFrameworkCore.Query.Internal
 {
     public class ExpressionEqualityComparer : IEqualityComparer<Expression>

--- a/src/Microsoft.EntityFrameworkCore/Query/Internal/ExpressionPrinter.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/Internal/ExpressionPrinter.cs
@@ -180,8 +180,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 {
                     UnhandledExpressionType(node.NodeType);
                 }
-
-                _stringBuilder.Append(operand);
+                else
+                {
+                    _stringBuilder.Append(operand);
+                }
 
                 Visit(node.Right);
             }
@@ -509,8 +511,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             return processedPlan;
         }
 
-        //throw new NotSupportedException(CoreStrings.UnhandledExpressionType(expressionType));
-        private void UnhandledExpressionType(ExpressionType expressionType) 
+        private void UnhandledExpressionType(ExpressionType expressionType)
             => _stringBuilder.AppendLine(CoreStrings.UnhandledExpressionType(expressionType));
 
         protected interface IConstantPrinter

--- a/src/Microsoft.EntityFrameworkCore/Query/Internal/LinqOperatorProvider.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/Internal/LinqOperatorProvider.cs
@@ -27,6 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
         [UsedImplicitly]
         // ReSharper disable once PossibleMultipleEnumeration
+        // ReSharper disable once InconsistentNaming
         private static IEnumerable<TResult> _ToEnumerable<TResult>(IEnumerable<TResult> results) => results;
 
         public virtual MethodInfo ToOrdered => _toOrdered;
@@ -36,6 +37,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 .GetTypeInfo().GetDeclaredMethod(nameof(_ToOrdered));
 
         [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
         private static OrderedEnumerableAdapter<TResult> _ToOrdered<TResult>(IEnumerable<TResult> results)
             => new OrderedEnumerableAdapter<TResult>(results);
 
@@ -63,6 +65,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 .GetTypeInfo().GetDeclaredMethod(nameof(_InterceptExceptions));
 
         [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
         private static IEnumerable<T> _InterceptExceptions<T>(
             IEnumerable<T> source, Type contextType, ILogger logger, QueryContext queryContext)
             => new ExceptionInterceptor<T>(source, contextType, logger, queryContext);
@@ -137,6 +140,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 .GetTypeInfo().GetDeclaredMethod(nameof(_TrackEntities));
 
         [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
         private static IEnumerable<TOut> _TrackEntities<TOut, TIn>(
             IEnumerable<TOut> results,
             QueryContext queryContext,
@@ -184,6 +188,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 .GetTypeInfo().GetDeclaredMethod(nameof(_TrackGroupedEntities));
 
         [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
         private static IEnumerable<IGrouping<TKey, TOut>> _TrackGroupedEntities<TKey, TOut, TIn>(
             IEnumerable<IGrouping<TKey, TOut>> groupings,
             QueryContext queryContext,
@@ -255,6 +260,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 .GetTypeInfo().GetDeclaredMethod(nameof(_ToSequence));
 
         [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
         private static IEnumerable<T> _ToSequence<T>(T element) => new[] { element };
 
         public virtual MethodInfo ToSequence => _toSequence;
@@ -264,6 +270,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 .GetTypeInfo().GetDeclaredMethod(nameof(_ToQueryable));
 
         [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
         private static IOrderedQueryable<TSource> _ToQueryable<TSource>(IEnumerable<TSource> source)
             => new EnumerableQuery<TSource>(source);
 
@@ -274,6 +281,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 .GetTypeInfo().GetDeclaredMethod(nameof(_SelectMany));
 
         [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
         private static IEnumerable<TResult> _SelectMany<TSource, TCollection, TResult>(
             IEnumerable<TSource> source,
             Func<TSource, IEnumerable<TCollection>> collectionSelector,
@@ -287,6 +295,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 .GetTypeInfo().GetDeclaredMethod(nameof(_Join));
 
         [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
         private static IEnumerable<TResult> _Join<TOuter, TInner, TKey, TResult>(
             IEnumerable<TOuter> outer,
             IEnumerable<TInner> inner,
@@ -302,6 +311,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 .GetTypeInfo().GetDeclaredMethod(nameof(_GroupJoin));
 
         [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
         private static IEnumerable<TResult> _GroupJoin<TOuter, TInner, TKey, TResult>(
             IEnumerable<TOuter> outer,
             IEnumerable<TInner> inner,
@@ -317,6 +327,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 .GetTypeInfo().GetDeclaredMethod(nameof(_Select));
 
         [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
         private static IEnumerable<TResult> _Select<TSource, TResult>(
             IEnumerable<TSource> source, Func<TSource, TResult> selector)
             => source.Select(selector);
@@ -328,6 +339,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 .GetTypeInfo().GetDeclaredMethod(nameof(_OrderBy));
 
         [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
         private static IOrderedEnumerable<TSource> _OrderBy<TSource, TKey>(
             IEnumerable<TSource> source, Func<TSource, TKey> expression, OrderingDirection orderingDirection)
             => orderingDirection == OrderingDirection.Asc
@@ -341,6 +353,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 .GetTypeInfo().GetDeclaredMethod(nameof(_ThenBy));
 
         [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
         private static IOrderedEnumerable<TSource> _ThenBy<TSource, TKey>(
             IOrderedEnumerable<TSource> source, Func<TSource, TKey> expression, OrderingDirection orderingDirection)
             => orderingDirection == OrderingDirection.Asc
@@ -354,6 +367,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 .GetTypeInfo().GetDeclaredMethod(nameof(_Where));
 
         [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
         private static IEnumerable<TSource> _Where<TSource>(
             IEnumerable<TSource> source, Func<TSource, bool> predicate) => source.Where(predicate);
 
@@ -387,6 +401,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             = typeof(LinqOperatorProvider).GetTypeInfo().GetDeclaredMethod(nameof(_GroupBy));
 
         [UsedImplicitly]
+        // ReSharper disable once InconsistentNaming
         private static IEnumerable<IGrouping<TKey, TElement>> _GroupBy<TSource, TKey, TElement>(
             IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector)
             => source.GroupBy(keySelector, elementSelector);

--- a/src/Microsoft.EntityFrameworkCore/Query/ResultOperatorHandler.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/ResultOperatorHandler.cs
@@ -117,10 +117,10 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         private static Expression HandleConcat(
             EntityQueryModelVisitor entityQueryModelVisitor,
-            ConcatResultOperator concateResultOperator)
+            ConcatResultOperator concatResultOperator)
             => HandleSetOperation(
                 entityQueryModelVisitor,
-                concateResultOperator.Source2,
+                concatResultOperator.Source2,
                 entityQueryModelVisitor.LinqOperatorProvider.Concat);
 
         private static Expression HandleCount(EntityQueryModelVisitor entityQueryModelVisitor)
@@ -314,14 +314,13 @@ namespace Microsoft.EntityFrameworkCore.Query
             MethodInfo setMethodInfo)
         {
             var source2 = entityQueryModelVisitor
-               .ReplaceClauseReferences(secondSource);
+                .ReplaceClauseReferences(secondSource);
 
             return Expression.Call(
                 setMethodInfo.MakeGenericMethod(entityQueryModelVisitor.Expression.Type.GetSequenceType()),
                 entityQueryModelVisitor.Expression,
                 source2);
         }
-
 
         private static Expression HandleAggregate(EntityQueryModelVisitor entityQueryModelVisitor, string methodName)
             => CallWithPossibleCancellationToken(

--- a/src/Microsoft.EntityFrameworkCore/Query/ResultOperators/Internal/ThenIncludeExpressionNode.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/ResultOperators/Internal/ThenIncludeExpressionNode.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
 using Remotion.Linq;
 using Remotion.Linq.Clauses;
 using Remotion.Linq.Parsing.Structure.IntermediateModel;

--- a/src/Shared/PropertyInfoExtensions.cs
+++ b/src/Shared/PropertyInfoExtensions.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics;
 
 // ReSharper disable once CheckNamespace
-
 namespace System.Reflection
 {
     [DebuggerStepThrough]
@@ -18,7 +17,7 @@ namespace System.Reflection
                && propertyInfo.GetIndexParameters().Length == 0
                && propertyInfo.CanRead
                && (!needsWrite || propertyInfo.CanWrite)
-               && (propertyInfo.GetMethod != null && propertyInfo.GetMethod.IsPublic);
+               && propertyInfo.GetMethod != null && propertyInfo.GetMethod.IsPublic;
 
         public static Type FindCandidateNavigationPropertyType(this PropertyInfo propertyInfo, Func<Type, bool> isPrimitiveProperty)
         {

--- a/src/Shared/SharedTypeExtensions.cs
+++ b/src/Shared/SharedTypeExtensions.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Reflection;
 
 // ReSharper disable once CheckNamespace
-
 namespace System
 {
     [DebuggerStepThrough]

--- a/test/Microsoft.EntityFrameworkCore.FunctionalTests/TestModels/Northwind/NorthwindData.cs
+++ b/test/Microsoft.EntityFrameworkCore.FunctionalTests/TestModels/Northwind/NorthwindData.cs
@@ -9,6 +9,7 @@ using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors;
 using Microsoft.EntityFrameworkCore.Query.Internal;

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/ConventionDispatcherTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/ConventionDispatcherTest.cs
@@ -642,7 +642,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
             {
                 Assert.Null(
                     dependentEntityBuilder
-                        .Relationship(entityBuilder, ConfigurationSource.Convention, setPrincipalEnd: false)
+                        .Relationship(entityBuilder, ConfigurationSource.Convention)
                         .HasPrincipalKey(entityBuilder.Metadata.FindPrimaryKey().Properties, ConfigurationSource.Convention));
             }
             else

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/ForeignKeyPropertyDiscoveryConventionTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Conventions/Internal/ForeignKeyPropertyDiscoveryConventionTest.cs
@@ -333,7 +333,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
         {
             DependentType.PrimaryKey(new[] { DependentEntity.PrincipalEntityPeEKaYProperty }, ConfigurationSource.Explicit);
 
-            var relationshipBuilder = DependentType.Relationship(PrincipalType, ConfigurationSource.Convention, setPrincipalEnd: false)
+            var relationshipBuilder = DependentType.Relationship(PrincipalType, ConfigurationSource.Convention)
                 .IsUnique(false, ConfigurationSource.Convention);
 
             Assert.Same(relationshipBuilder, new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder));
@@ -366,7 +366,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
         [Fact]
         public void Does_not_match_dependent_PK_for_self_ref()
         {
-            var relationshipBuilder = PrincipalType.Relationship(PrincipalType, ConfigurationSource.Convention, setPrincipalEnd: false)
+            var relationshipBuilder = PrincipalType.Relationship(PrincipalType, ConfigurationSource.Convention)
                 .IsUnique(true, ConfigurationSource.DataAnnotation);
 
             Assert.Same(relationshipBuilder, new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder));
@@ -562,7 +562,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
         {
             var fkProperty = DependentType.Property(DependentEntity.PeEKaYProperty, ConfigurationSource.Convention).Metadata;
 
-            var relationshipBuilder = DependentType.Relationship(PrincipalType, ConfigurationSource.Convention, setPrincipalEnd: false)
+            var relationshipBuilder = DependentType.Relationship(PrincipalType, ConfigurationSource.Convention)
                 .IsUnique(true, ConfigurationSource.Convention);
 
             var newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder);
@@ -584,7 +584,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
         {
             var fkProperty = DependentType.Property(DependentEntity.PeEKaYProperty, ConfigurationSource.Convention).Metadata;
 
-            var relationshipBuilder = DependentType.Relationship(PrincipalType, ConfigurationSource.Convention, setPrincipalEnd: false)
+            var relationshipBuilder = DependentType.Relationship(PrincipalType, ConfigurationSource.Convention)
                 .IsUnique(true, ConfigurationSource.Convention);
 
             var newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder);
@@ -607,7 +607,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
             DependentType.Property(DependentEntity.PeEKaYProperty, ConfigurationSource.Convention);
             PrincipalType.Property(PrincipalEntity.DependentEntityKayPeeProperty, ConfigurationSource.Convention);
 
-            var relationshipBuilder = DependentType.Relationship(PrincipalType, ConfigurationSource.Convention, setPrincipalEnd: false)
+            var relationshipBuilder = DependentType.Relationship(PrincipalType, ConfigurationSource.Convention)
                 .IsUnique(true, ConfigurationSource.Convention);
 
             var newRelationshipBuilder = new ForeignKeyPropertyDiscoveryConvention().Apply(relationshipBuilder);
@@ -620,14 +620,14 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Conventions.Internal
             Assert.False(fk.IsRequired);
         }
 
-        // TODO: Issue#4440 For non-required FK, nullable property should be matched over any other
+        // TODO: Issue #4440 For non-required FK, nullable property should be matched over any other
         // [Fact]
         public void Inverts_if_principal_entity_type_can_have_nullable_fk_property_for_non_required_relationship()
         {
             DependentType.Property(DependentEntity.PeEKaYProperty, ConfigurationSource.Convention);
             var fkProperty = PrincipalType.Property(PrincipalEntity.DependentEntityKayPeeProperty, ConfigurationSource.Convention).Metadata;
 
-            var relationshipBuilder = DependentType.Relationship(PrincipalType, ConfigurationSource.Convention, setPrincipalEnd: false)
+            var relationshipBuilder = DependentType.Relationship(PrincipalType, ConfigurationSource.Convention)
                 .IsUnique(true, ConfigurationSource.Convention)
                 .IsRequired(false, ConfigurationSource.DataAnnotation);
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/InternalRelationshipBuilderTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Metadata/Internal/InternalRelationshipBuilderTest.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
             var relationshipBuilder = dependentEntityBuilder.Relationship(
-                principalEntityBuilder, ConfigurationSource.Convention, setPrincipalEnd: false);
+                principalEntityBuilder, ConfigurationSource.Convention);
 
             var fk = relationshipBuilder.Metadata;
             Assert.Equal(ConfigurationSource.Convention, fk.GetConfigurationSource());
@@ -71,7 +71,7 @@ namespace Microsoft.EntityFrameworkCore.Tests.Metadata.Internal
             var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
 
             var foreignKey = dependentEntityBuilder.Relationship(
-                principalEntityBuilder, ConfigurationSource.Explicit, setPrincipalEnd: false).Metadata;
+                principalEntityBuilder, ConfigurationSource.Explicit).Metadata;
 
             foreignKey.UpdateForeignKeyPropertiesConfigurationSource(ConfigurationSource.Explicit);
             foreignKey.UpdatePrincipalKeyConfigurationSource(ConfigurationSource.Explicit);

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderGenericRelationshipStringTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderGenericRelationshipStringTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 // ReSharper disable once CheckNamespace

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderGenericRelationshipTypeTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderGenericRelationshipTypeTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 // ReSharper disable once CheckNamespace

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderNonGenericStringTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderNonGenericStringTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Xunit;
 

--- a/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderNonGenericTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/ModelBuilderTest/ModelBuilderNonGenericTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Xunit;

--- a/test/Microsoft.EntityFrameworkCore.Tests/Utilities/ExpressionExtensionsTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tests/Utilities/ExpressionExtensionsTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Query;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Tests.Utilities

--- a/tools/Resources.cs
+++ b/tools/Resources.cs
@@ -1,4 +1,0 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-
-

--- a/tools/Resources.tt
+++ b/tools/Resources.tt
@@ -4,7 +4,6 @@
 <#@ assembly name="Microsoft.VisualStudio.Shell.Interop.8.0" #>
 <#@ assembly name="EnvDTE" #>
 <#@ assembly name="EnvDTE80" #>
-<#@ import namespace="System" #>
 <#@ import namespace="System.Collections" #>
 <#@ import namespace="System.Collections.Generic" #>
 <#@ import namespace="System.IO" #>
@@ -12,9 +11,6 @@
 <#@ import namespace="System.Resources" #>
 <#@ import namespace="System.Text" #>
 <#@ import namespace="System.Text.RegularExpressions" #>
-<#@ import namespace="Microsoft.VisualStudio.Shell.Interop" #>
-<#@ import namespace="EnvDTE" #>
-<#@ import namespace="EnvDTE80" #>
 <#
     var hostServiceProvider = (IServiceProvider)Host;
     var dte = (EnvDTE.DTE)hostServiceProvider.GetService(typeof(EnvDTE.DTE));
@@ -151,18 +147,15 @@ namespace {0}
     }
 
     private static void RenderProperty(StringBuilder builder, ResourceData resourceString)
-    {
-        builder.AppendFormat("        public static string {0}", resourceString.Name)
+        => builder.AppendFormat("        public static string {0}", resourceString.Name)
             .AppendLine()
             .AppendLine("        {")
             .AppendFormat(@"            get {{ return GetString(""{0}""); }}", resourceString.Name)
             .AppendLine()
             .AppendLine("        }");
-    }
 
     private static void RenderFormatMethod(StringBuilder builder, ResourceData resourceString)
-    {
-        builder.AppendFormat("        public static string {0}({1})", resourceString.Name, resourceString.Parameters)
+        => builder.AppendFormat("        public static string {0}({1})", resourceString.Name, resourceString.Parameters)
             .AppendLine()
             .AppendLine("        {")
             .AppendFormat(
@@ -172,7 +165,6 @@ namespace {0}
                 resourceString.ArgumentNames)
             .AppendLine()
             .AppendLine("        }");
-    }
 
     private class ResourceData
     {
@@ -182,24 +174,12 @@ namespace {0}
 
         public bool UsingNamedArgs { get; set; }
 
-        public string FormatArguments
-        {
-            get { return string.Join(", ", Arguments.Select(a => "\"" + a + "\"")); }
-        }
+        public string FormatArguments => string.Join(", ", Arguments.Select(a => "\"" + a + "\""));
 
-        public string ArgumentNames
-        {
-            get { return string.Join(", ", Arguments.Select(GetArgName)); }
-        }
+        public string ArgumentNames => string.Join(", ", Arguments.Select(GetArgName));
 
-        public string Parameters
-        {
-            get { return string.Join(", ", Arguments.Select(a => "[CanBeNull] object " + GetArgName(a))); }
-        }
+        public string Parameters => string.Join(", ", Arguments.Select(a => "[CanBeNull] object " + GetArgName(a)));
 
-        public string GetArgName(string name)
-        {
-            return UsingNamedArgs ? name : 'p' + name;
-        }
+        private string GetArgName(string name) => UsingNamedArgs ? name : 'p' + name;
     }
 #>


### PR DESCRIPTION
Move ExpressionExtensions to Microsoft.EntityFrameworkCore.Internal