### PR TITLE
Fix #4998 - NotImplementedException thrown on Where TypeIs cache key generation

### DIFF
--- a/src/Microsoft.EntityFrameworkCore/Query/Internal/ExpressionEqualityComparer.cs
+++ b/src/Microsoft.EntityFrameworkCore/Query/Internal/ExpressionEqualityComparer.cs
@@ -83,6 +83,15 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                         break;
                     }
+                    case ExpressionType.TypeIs:
+                    {
+                        var typeBinaryExpression = (TypeBinaryExpression)obj;
+
+                        hashCode += (hashCode * 397) ^ GetHashCode(typeBinaryExpression.Expression);
+                        hashCode += (hashCode * 397) ^ typeBinaryExpression.TypeOperand.GetHashCode();
+
+                        break;
+                    }
                     case ExpressionType.Constant:
                     {
                         var constantExpression = (ConstantExpression)obj;

--- a/test/Microsoft.EntityFrameworkCore.FunctionalTests/InheritanceTestBase.cs
+++ b/test/Microsoft.EntityFrameworkCore.FunctionalTests/InheritanceTestBase.cs
@@ -28,6 +28,17 @@ namespace Microsoft.EntityFrameworkCore.FunctionalTests
         }
 
         [Fact]
+        public virtual void Can_use_is_kiwi()
+        {
+            using (var context = CreateContext())
+            {
+                var kiwis = context.Set<Animal>().Where(a => a is Kiwi).ToList();
+
+                Assert.Equal(1, kiwis.Count);
+            }
+        }
+
+        [Fact]
         public virtual void Can_use_of_type_bird()
         {
             using (var context = CreateContext())

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/InheritanceSqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/InheritanceSqlServerTest.cs
@@ -23,6 +23,17 @@ ORDER BY [t].[Species]",
                 Sql);
         }
 
+        public override void Can_use_is_kiwi()
+        {
+            base.Can_use_is_kiwi();
+
+            Assert.Equal(
+                @"SELECT [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
+FROM [Animal] AS [a]
+WHERE [a].[Discriminator] IN (N'Kiwi', N'Eagle')",
+                Sql);
+        }
+
         public override void Can_use_of_type_bird()
         {
             base.Can_use_of_type_bird();


### PR DESCRIPTION
Adds hash code generation for expression type that was not covered by the existing implementation.
@anpete @divega 